### PR TITLE
Set release workflow default to prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ on:
         description: 'Mark release as pre-release'
         required: false
         type: boolean
-        default: false
+        default: true
 
 env:
-  PRERELEASE: false
+  PRERELEASE: true
 
 jobs:
   build:


### PR DESCRIPTION
Changes:
- Set workflow_dispatch prerelease input default to true
- Set PRERELEASE environment variable to true

This ensures both manual and scheduled releases default to prerelease.