### PR TITLE
Switch bootstrap to cosmic prerelease 2026-01-19-9452528

### DIFF
--- a/bin/cosmic
+++ b/bin/cosmic
@@ -4,7 +4,7 @@ set -e
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 COSMIC_LUA="${SCRIPT_DIR}/cosmic-lua"
-RELEASE_URL="https://github.com/whilp/world/releases/download/2026-01-15-34a060f/cosmic-lua"
+RELEASE_URL="https://github.com/whilp/cosmic/releases/download/2026-01-19-9452528/cosmic-lua"
 
 # Download cosmic-lua if it doesn't exist
 if [ ! -f "${COSMIC_LUA}" ]; then


### PR DESCRIPTION
Update bin/cosmic to use the validated prerelease from whilp/cosmic
instead of the older release from whilp/world.

Validated:
- Binary downloads successfully
- SHA256 checksum matches: 9db8b0f70d0e1111dc63798e91dc91b57554436b9837543a794f439c67a85d45
- Lua execution works correctly
- Binary is a valid cosmopolitan executable

This prerelease includes the workflow changes to make prerelease
the default state for the release workflow (#3).