### PR TITLE
compile: preserve shebang from source file

### DIFF
--- a/lib/cosmic/teal.tl
+++ b/lib/cosmic/teal.tl
@@ -85,6 +85,15 @@ local function compile(input_path: string, opts: CompileOpts): CompileResult
   local input = f:read("*a")
   f:close()
 
+  -- Extract shebang if present (to preserve it in output)
+  local shebang: string = nil
+  if input:sub(1, 2) == "#!" then
+    local newline_pos = input:find("\n")
+    if newline_pos then
+      shebang = input:sub(1, newline_pos)
+    end
+  end
+
   -- Set up include directories for type definitions
   local include_dirs = opts.include_dirs or get_default_include_dirs()
 
@@ -163,6 +172,11 @@ local function compile(input_path: string, opts: CompileOpts): CompileResult
     gen_compat = opts.gen_compat or "off",
   }
   local lua_code = tl.generate(result.ast, gen_opts)
+
+  -- Prepend shebang if source had one
+  if shebang then
+    lua_code = shebang .. lua_code
+  end
 
   return {
     ok = true,

--- a/lib/cosmic/test_compile.tl
+++ b/lib/cosmic/test_compile.tl
@@ -124,4 +124,31 @@ print("read " .. #data .. " bytes")
 end
 test_compile_with_cosmic_types()
 
+-- Test shebang preservation
+local function test_compile_preserves_shebang()
+  local input = write_temp("shebang.tl", [[#!/usr/bin/env cosmic
+local x: number = 42
+print(x)
+]])
+
+  local ok, out = spawn({cosmic, "--compile", input}):read()
+  assert(ok, "cosmic --compile should succeed")
+  assert((out as string):sub(1, 21) == "#!/usr/bin/env cosmic", "shebang should be preserved at start of output")
+  assert((out as string):find("\nlocal x = 42"), "compiled Lua should follow shebang")
+end
+test_compile_preserves_shebang()
+
+-- Test file without shebang still works
+local function test_compile_no_shebang()
+  local input = write_temp("no_shebang.tl", [[local x: number = 42
+print(x)
+]])
+
+  local ok, out = spawn({cosmic, "--compile", input}):read()
+  assert(ok, "cosmic --compile should succeed")
+  assert((out as string):sub(1, 2) ~= "#!", "output should not have shebang if source didn't")
+  assert((out as string):find("local x = 42"), "output should contain compiled Lua")
+end
+test_compile_no_shebang()
+
 print("All compile tests passed!")


### PR DESCRIPTION
## Summary
- Extracts shebang line from source file if present during `--compile`
- Prepends the shebang to the generated Lua output
- Allows compiled scripts to remain directly executable

## Test plan
- [x] Added `test_compile_preserves_shebang` - verifies shebang is preserved
- [x] Added `test_compile_no_shebang` - verifies files without shebang work correctly
- [x] All existing tests pass