### PR TITLE
build: simplify compile rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ include 3p/teal-types/cook.mk
 .PHONY: help
 ## Show this help message
 help: $(build_files) | $(bootstrap_cosmic)
-	@$(bootstrap_cosmic) $(o)/bin/make-help.lua $(MAKEFILE_LIST)
+	@$(bootstrap_cosmic) $(build_help) $(MAKEFILE_LIST)
 
 ## Filter targets by pattern (make test only='teal')
 filter-only = $(if $(only),$(foreach f,$1,$(if $(findstring $(only),$(f)),$(f))),$1)
@@ -91,7 +91,7 @@ fetched: $(all_fetched)
 $(o)/%/.fetched: .PLEDGE = stdio rpath wpath cpath inet dns
 $(o)/%/.fetched: .UNVEIL = rx:$(o)/bootstrap r:3p rwc:$(o) r:/etc/resolv.conf r:/etc/ssl
 $(o)/%/.fetched: $(o)/%/.versioned $(build_files) | $(bootstrap_cosmic)
-	@$(build_fetch) $$(readlink $<) $(platform) $@
+	@$(bootstrap_cosmic) -- $(build_fetch) $$(readlink $<) $(platform) $@
 
 # versions get staged: o/module/.staged -> o/staged/module/<ver>-<sha>
 .PHONY: staged
@@ -101,7 +101,7 @@ staged: $(all_staged)
 $(o)/%/.staged: .PLEDGE = stdio rpath wpath cpath proc exec
 $(o)/%/.staged: .UNVEIL = rx:$(o)/bootstrap r:3p rwc:$(o) rx:/usr/bin
 $(o)/%/.staged: $(o)/%/.fetched $(build_files)
-	@$(build_stage) $$(readlink $(o)/$*/.versioned) $(platform) $< $@
+	@$(bootstrap_cosmic) -- $(build_stage) $$(readlink $(o)/$*/.versioned) $(platform) $< $@
 
 all_tests := $(call filter-only,$(foreach x,$(modules),$($(x)_tests)))
 all_tested := $(patsubst %,$(o)/%.test.got,$(all_tests))

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -1,19 +1,12 @@
 modules += build
-build_lua_dirs := $(o)/bin
-build_fetch := $(o)/bin/build-fetch.lua
-build_stage := $(o)/bin/build-stage.lua
-build_reporter := $(o)/bin/reporter.lua
-build_help := $(o)/bin/make-help.lua
+build_lua_dirs := $(o)/lib/build
+build_fetch := $(o)/lib/build/build-fetch.lua
+build_stage := $(o)/lib/build/build-stage.lua
+build_reporter := $(o)/lib/build/reporter.lua
+build_help := $(o)/lib/build/make-help.lua
 build_files := $(build_fetch) $(build_stage) $(build_reporter) $(build_help)
 build_tests := $(wildcard lib/build/test_*.tl)
 
-.PRECIOUS: $(build_files)
-
-# Build scripts: compile to o/bin/ and make executable
-$(build_files): $(o)/bin/%.lua: lib/build/%.tl | $(bootstrap_files)
-	@mkdir -p $(@D)
-	@$(bootstrap_cosmic) --compile $< > $@
-	@chmod +x $@
 reporter := $(bootstrap_cosmic) -- $(build_reporter)
 
 # test_reporter needs cosmic binary

--- a/lib/build/test_reporter.tl
+++ b/lib/build/test_reporter.tl
@@ -23,7 +23,8 @@ end
 
 local function run_reporter(...: string): integer, string, string
   local test_bin = os.getenv("TEST_BIN") or ""
-  local reporter = path.join(test_bin, "reporter.lua")
+  local test_o = os.getenv("TEST_O") or "o"
+  local reporter = path.join(test_o, "lib/build/reporter.lua")
   local spawn = require("cosmic.spawn").spawn
   local args: {string} = {path.join(test_bin, "cosmic"), "--", reporter}
   local varargs: {string} = {...}


### PR DESCRIPTION
## Summary

- Remove dead vpath and pattern rules for `o/bin/*.lua` that were never used
- Remove spurious `tl_staged` dependency from generic compile rule (cosmic has teal bundled)
- Unify build scripts to use the generic compile rule instead of a special one

The build system now has a single compile rule:
```makefile
$(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files)
	@$(bootstrap_cosmic) --compile $< > $@
```

## Test plan

- [x] `make clean test` passes
- [x] `make test; make test` (incremental build works)
- [x] `make help` works