### PR TITLE
docs: add doc comments and README table generation

### DIFF
--- a/lib/cosmic/doc.tl
+++ b/lib/cosmic/doc.tl
@@ -1,4 +1,5 @@
--- cosmic.doc: Extract documentation from .tl files and render as markdown
+--- Extract documentation from Teal files and render as markdown.
+--- Parses doc comments, records, functions, and examples from .tl files.
 
 local record Param
   name: string

--- a/lib/cosmic/doc_test.tl
+++ b/lib/cosmic/doc_test.tl
@@ -216,4 +216,40 @@ end
 end
 test_example_title()
 
+-- Test that actual library files have proper documentation
+-- These tests verify that our source files have doc comments
+local function test_embed_has_module_doc()
+  local ok, md = doc.render_file("lib/cosmic/embed.tl")
+  assert(ok, "should read embed.tl")
+  -- Module should have a description after the header
+  assert(md:find("# embed\n\n[^#]"), "embed.tl should have module description")
+end
+test_embed_has_module_doc()
+
+local function test_embed_has_type_descriptions()
+  local ok, md = doc.render_file("lib/cosmic/embed.tl")
+  assert(ok, "should read embed.tl")
+  -- EmbedResult should have a description, not just a bare header
+  assert(md:find("### EmbedResult\n\n[^#]"), "EmbedResult should have description")
+end
+test_embed_has_type_descriptions()
+
+local function test_spawn_has_type_descriptions()
+  local ok, md = doc.render_file("lib/cosmic/spawn.tl")
+  assert(ok, "should read spawn.tl")
+  -- SpawnHandle should have a description
+  assert(md:find("### SpawnHandle\n\n[^#]"), "SpawnHandle should have description")
+end
+test_spawn_has_type_descriptions()
+
+local function test_fetch_has_module_description()
+  local ok, md = doc.render_file("lib/cosmic/fetch.tl")
+  assert(ok, "should read fetch.tl")
+  -- Module should have a description after the header
+  assert(md:find("# fetch\n\n[^#]"), "fetch.tl should have module description")
+  -- Should describe what it does
+  assert(md:find("HTTP fetch"), "should describe HTTP fetching")
+end
+test_fetch_has_module_description()
+
 print("All doc tests passed!")

--- a/lib/cosmic/embed.tl
+++ b/lib/cosmic/embed.tl
@@ -1,9 +1,10 @@
--- cosmic.embed: embed files into cosmic executable
--- Creates a copy of the cosmic executable with files appended as a zip archive
+--- Embed files into cosmic executable.
+--- Creates a copy of the cosmic executable with files appended as a zip archive.
 
 local cosmo = require("cosmo")
 local zip = require("cosmo.zip")
 
+--- Result returned from embed operation.
 local record EmbedResult
   ok: boolean
   message: string

--- a/lib/cosmic/example.tl
+++ b/lib/cosmic/example.tl
@@ -1,5 +1,5 @@
--- cosmic.example: Go-style executable example testing
--- Parses Example_* functions from .tl files, runs them, and checks output
+--- Go-style executable example testing.
+--- Parses Example_* functions from Teal files, runs them, and verifies output.
 
 local record Example
   name: string

--- a/lib/cosmic/fetch.tl
+++ b/lib/cosmic/fetch.tl
@@ -1,23 +1,10 @@
--- cosmic.fetch: structured wrapper for cosmo.Fetch
---
--- Solves the problem of accidentally discarding error messages when using:
---   local status, _, body = cosmo.Fetch(url, opts)
---
--- Usage:
---   local fetch = require("cosmic.fetch")
---   local result = fetch.Fetch(url, opts)
---   if not result.ok then
---     return nil, result.error
---   end
---   -- use result.status, result.headers, result.body
---
--- With retry:
---   local result = fetch.Fetch(url, {max_attempts = 4})
---   local result = fetch.Fetch(url, {should_retry = function(r) return r.status >= 500 end})
+--- Structured HTTP fetch with optional retry.
+--- Wraps cosmo.Fetch with structured results to prevent accidentally discarding errors.
 
 local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
 
+--- Result from a fetch operation.
 local record Result
   ok: boolean
   status: number
@@ -53,9 +40,10 @@ local function do_fetch(url: string, opts?: Opts): Result
   }
 end
 
--- Fetch wraps cosmo.Fetch with structured results and optional retry.
--- Set max_attempts > 1 for retry with exponential backoff.
--- Set should_retry to control which results trigger retry.
+--- Fetch a URL and return structured result.
+--- @param url string URL to fetch
+--- @param opts Opts optional fetch options (retry, headers, etc.)
+--- @return Result fetch result with ok, status, headers, body, or error
 local function Fetch(url: string, opts?: Opts): Result
   local max_attempts = (opts and opts.max_attempts) or 1
   local max_delay = (opts and opts.max_delay) or 30

--- a/lib/cosmic/init.tl
+++ b/lib/cosmic/init.tl
@@ -1,5 +1,5 @@
--- cosmic: cosmopolitan lua utilities
--- require individual modules via require("cosmic.spawn"), require("cosmic.walk"), etc.
+--- Cosmopolitan Lua utilities.
+--- Main entry point and utilities for cosmic modules.
 
 local cosmo = require("cosmo")
 

--- a/lib/cosmic/spawn.tl
+++ b/lib/cosmic/spawn.tl
@@ -1,6 +1,8 @@
--- cosmic.spawn: process spawning utilities
+--- Process spawning utilities.
+--- Spawn external processes with control over stdin, stdout, and stderr.
 local unix = require("cosmo.unix")
 
+--- Pipe for reading/writing process I/O.
 local record Pipe
   fd: number
   write: function(self: Pipe, data: string): number
@@ -8,6 +10,7 @@ local record Pipe
   close: function(self: Pipe)
 end
 
+--- Handle for a spawned process.
 local record SpawnHandle
   pid: number
   stdin: Pipe
@@ -17,6 +20,7 @@ local record SpawnHandle
   read: function(self: SpawnHandle, size?: number): boolean | string, string, number
 end
 
+--- Options for spawning a process.
 local record SpawnOpts
   stdin: string | number
   stdout: number

--- a/lib/cosmic/teal.tl
+++ b/lib/cosmic/teal.tl
@@ -1,5 +1,5 @@
--- cosmic.teal: Teal compilation and type-checking for cosmic-lua
--- Provides --compile and --check functionality
+--- Teal compilation and type-checking.
+--- Provides --compile and --check functionality for cosmic-lua.
 
 local tl = require("tl")
 

--- a/lib/cosmic/walk.tl
+++ b/lib/cosmic/walk.tl
@@ -1,4 +1,5 @@
--- cosmic.walk: directory tree walking utilities
+--- Directory tree walking utilities.
+--- Recursively traverse directories with visitor pattern or glob matching.
 local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 

--- a/lib/docs/cook.mk
+++ b/lib/docs/cook.mk
@@ -2,3 +2,5 @@ modules += docs
 # no docs_tl - avoid inclusion in all_example_srcs (these are build tools, not library code)
 docs_publish := $(o)/lib/docs/publish.lua
 docs_files := $(docs_publish)
+docs_tests := lib/docs/publish_test.tl
+docs_deps := cosmic

--- a/lib/docs/publish.tl
+++ b/lib/docs/publish.tl
@@ -1,11 +1,110 @@
 -- docs-publish: publish generated docs to a git branch
 local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
+local path = require("cosmo.path")
 local spawn = require("cosmic.spawn")
 
 local record DirHandle
   read: function(DirHandle): string
   close: function(DirHandle)
+end
+
+local record DocInfo
+  path: string
+  name: string
+  description: string
+end
+
+-- Scan a directory recursively for .md files
+local function scan_docs(docs_dir: string): {DocInfo}
+  local docs: {DocInfo} = {}
+
+  local function scan(dir: string)
+    local handle = unix.opendir(dir) as DirHandle
+    if not handle then return end
+
+    while true do
+      local name = handle:read()
+      if not name then break end
+      if name ~= "." and name ~= ".." then
+        local full_path = path.join(dir, name)
+        local stat = unix.stat(full_path)
+        if stat then
+          if unix.S_ISDIR(stat:mode()) then
+            scan(full_path)
+          elseif name:match("%.md$") and name ~= "README.md" then
+            -- Read first paragraph after the header for description
+            local content = cosmo.Slurp(full_path)
+            local description = ""
+            if content then
+              -- Extract description: skip header line, take next non-empty paragraph
+              local after_header = content:match("^#[^\n]*\n+(.*)") or ""
+              local first_para = after_header:match("^([^\n]+)")
+              if first_para and not first_para:match("^#") then
+                description = first_para
+              end
+            end
+
+            -- Get relative path from docs_dir
+            local rel_path = full_path:sub(#docs_dir + 2)
+            local mod_name = name:gsub("%.md$", "")
+
+            table.insert(docs, {
+              path = rel_path,
+              name = mod_name,
+              description = description,
+            })
+          end
+        end
+      end
+    end
+    handle:close()
+  end
+
+  scan(docs_dir)
+
+  -- Sort by path for consistent output
+  table.sort(docs, function(a: DocInfo, b: DocInfo): boolean
+    return a.path < b.path
+  end)
+
+  return docs
+end
+
+-- Generate README.md content with links to docs
+local function make_readme(docs_dir: string): string
+  local docs = scan_docs(docs_dir)
+
+  local lines: {string} = {
+    "# Generated Documentation",
+    "",
+    "This branch contains auto-generated documentation from the cosmic-lua source code.",
+    "",
+    "## Documentation",
+    "",
+    "| Module | Description |",
+    "|--------|-------------|",
+  }
+
+  for _, doc in ipairs(docs) do
+    local link = "[" .. doc.name .. "](" .. doc.path .. ")"
+    table.insert(lines, "| " .. link .. " | " .. doc.description .. " |")
+  end
+
+  table.insert(lines, "")
+  table.insert(lines, "---")
+  table.insert(lines, "")
+  table.insert(lines, "Documentation is generated from Teal source files using `cosmic --doc`.")
+  table.insert(lines, "")
+  table.insert(lines, "To regenerate locally:")
+  table.insert(lines, "```bash")
+  table.insert(lines, "make docs")
+  table.insert(lines, "```")
+  table.insert(lines, "")
+  table.insert(lines, "*This branch is automatically updated by GitHub Actions. Do not edit manually.*")
+  table.insert(lines, "")
+
+  return table.concat(lines, "\n")
 end
 
 local function run(argv: {string}): boolean, string
@@ -72,27 +171,9 @@ local function main(source_sha: string, docs_dir: string, branch: string): boole
   unix.rmrf(temp_dir)
   if not ok then return nil, err end
 
-  -- write readme
-  local readme = io.open("README.md", "w")
-  if readme then
-    readme:write([[# Generated Documentation
-
-This branch contains auto-generated documentation from the cosmic-lua source code.
-
-## Contents
-
-Documentation is generated from Teal source files using `cosmic --doc`.
-
-To regenerate locally:
-```bash
-make doc
-```
-
----
-*This branch is automatically updated by GitHub Actions. Do not edit manually.*
-]])
-    readme:close()
-  end
+  -- write readme with doc table
+  local readme_content = make_readme(".")
+  cosmo.Barf("README.md", readme_content)
 
   -- stage all changes
   ok, err = run({"git", "add", "-A"})
@@ -116,6 +197,14 @@ make doc
   return true
 end
 
+local record PublishModule
+  make_readme: function(docs_dir: string): string
+end
+
+local M: PublishModule = {
+  make_readme = make_readme,
+}
+
 if cosmo.is_main() then
   local ok, err = main(arg[1], arg[2], arg[3])
   if not ok then
@@ -123,3 +212,5 @@ if cosmo.is_main() then
     os.exit(1)
   end
 end
+
+return M

--- a/lib/docs/publish_test.tl
+++ b/lib/docs/publish_test.tl
@@ -1,0 +1,51 @@
+#!/usr/bin/env cosmic
+-- test docs-publish readme generation
+
+local path = require("cosmo.path")
+local unix = require("cosmo.unix")
+local cosmo = require("cosmo")
+
+local tmpdir = os.getenv("TEST_TMPDIR")
+
+local record PublishModule
+  make_readme: function(docs_dir: string): string
+end
+
+-- Test that make_readme generates a table of doc links
+local function test_readme_has_doc_table()
+  local publish = require("lib.docs.publish") as PublishModule
+
+  -- Create some mock doc files
+  local docs_dir = path.join(tmpdir, "docs")
+  unix.makedirs(docs_dir .. "/lib/cosmic")
+
+  -- Write mock doc files with module descriptions
+  cosmo.Barf(path.join(docs_dir, "lib/cosmic/embed.md"), [[# embed
+
+Embed files into cosmic executable.
+
+## Types
+]])
+  cosmo.Barf(path.join(docs_dir, "lib/cosmic/spawn.md"), [[# spawn
+
+Process spawning utilities.
+
+## Types
+]])
+
+  local readme = publish.make_readme(docs_dir)
+
+  -- README should have a table section
+  assert(readme:find("## Documentation"), "should have Documentation section")
+
+  -- README should link to each doc file
+  assert(readme:find("%[embed%]"), "should link to embed.md")
+  assert(readme:find("%[spawn%]"), "should link to spawn.md")
+
+  -- README should include descriptions from the doc files
+  assert(readme:find("Embed files"), "should include embed description")
+  assert(readme:find("Process spawning"), "should include spawn description")
+end
+test_readme_has_doc_table()
+
+print("All publish tests passed!")


### PR DESCRIPTION
## Summary
- Add `---` doc comments to all cosmic library modules so generated docs have content
- Update `publish.tl` to generate README with a table linking to each doc file with descriptions
- Add tests for doc content quality and README table generation

## Test plan
- [x] `make test` passes (17/17 tests)
- [x] `make docs` generates markdown files with module descriptions
- [x] README table includes links and descriptions for all modules