### PR TITLE
Complete documentation for cosmic project

### DIFF
--- a/lib/cosmic/doc.tl
+++ b/lib/cosmic/doc.tl
@@ -1,17 +1,20 @@
 --- Extract documentation from Teal files and render as markdown.
 --- Parses doc comments, records, functions, and examples from .tl files.
 
+--- A function parameter with type and description.
 local record Param
   name: string
   param_type: string
   description: string
 end
 
+--- A function return value with type and description.
 local record Return
   return_type: string
   description: string
 end
 
+--- Documentation for a function.
 local record FunctionDoc
   name: string
   description: string
@@ -22,6 +25,7 @@ local record FunctionDoc
   is_local: boolean
 end
 
+--- Documentation for a record type.
 local record RecordDoc
   name: string
   description: string
@@ -29,6 +33,7 @@ local record RecordDoc
   line: integer
 end
 
+--- Documentation for an example function.
 local record ExampleDoc
   name: string
   body: string
@@ -36,6 +41,7 @@ local record ExampleDoc
   line: integer
 end
 
+--- Complete documentation for a module.
 local record ModuleDoc
   file: string
   module_doc: string
@@ -44,7 +50,11 @@ local record ModuleDoc
   examples: {ExampleDoc}
 end
 
--- Extract leading doc comment (--- style) before a position
+--- Extract leading doc comment (--- style) before a position.
+--- Scans backwards from the given position to collect doc comment lines.
+--- @param source string The source code to search
+--- @param pos integer The position to search backwards from
+--- @return string The extracted doc comment, or nil if none found
 local function extract_doc_comment(source: string, pos: integer): string
   -- Find the start of the line containing pos
   local line_start = pos
@@ -86,7 +96,12 @@ local function extract_doc_comment(source: string, pos: integer): string
   return table.concat(doc_lines, "\n")
 end
 
--- Parse @param and @return annotations from doc comment
+--- Parse @param and @return annotations from doc comment.
+--- Extracts structured parameter and return information along with description.
+--- @param doc string The doc comment to parse
+--- @return {Param} List of parameters
+--- @return {Return} List of return values
+--- @return string The description text (non-annotation lines)
 local function parse_annotations(doc: string): {Param}, {Return}, string
   if not doc then
     return {}, {}, nil
@@ -122,7 +137,11 @@ local function parse_annotations(doc: string): {Param}, {Return}, string
   return params, returns, description
 end
 
--- Parse a .tl file and extract documentation
+--- Parse a .tl file and extract documentation.
+--- Extracts module docs, records, functions, and examples from source code.
+--- @param source string The source code to parse
+--- @param file_path string Path to the file being parsed
+--- @return ModuleDoc Complete documentation for the module
 local function parse(source: string, file_path: string): ModuleDoc
   local doc: ModuleDoc = {
     file = file_path,
@@ -379,7 +398,10 @@ local function parse(source: string, file_path: string): ModuleDoc
   return doc
 end
 
--- Render documentation as markdown
+--- Render documentation as markdown.
+--- Converts parsed documentation into formatted markdown with sections for types, functions, and examples.
+--- @param doc ModuleDoc The documentation to render
+--- @return string Formatted markdown documentation
 local function render(doc: ModuleDoc): string
   local lines: {string} = {}
 
@@ -500,7 +522,11 @@ local function render(doc: ModuleDoc): string
   return table.concat(lines, "\n")
 end
 
--- Main entry point: parse file and render markdown
+--- Main entry point: parse file and render markdown.
+--- Reads a Teal file, extracts documentation, and renders it as markdown.
+--- @param file_path string Path to the Teal file to document
+--- @return boolean Success status
+--- @return string Markdown documentation on success, error message on failure
 local function render_file(file_path: string): boolean, string
   local f, err = io.open(file_path, "r")
   if not f then

--- a/lib/cosmic/embed.tl
+++ b/lib/cosmic/embed.tl
@@ -11,10 +11,13 @@ local record EmbedResult
   file_count: integer
 end
 
--- Embed files into a copy of the cosmic executable
--- files: list of file paths to embed
--- output: output path (defaults to "cosmic")
--- exe_path: path to the executable to copy (defaults to arg[-1])
+--- Embed files into a copy of the cosmic executable.
+--- Creates a new executable with files appended as a zip archive.
+--- The original executable is copied and files are added to the end as a zip.
+--- @param files {string} List of file paths to embed
+--- @param output string Output path for the new executable (defaults to "cosmic")
+--- @param exe_path string Path to the executable to copy (defaults to arg[-1])
+--- @return EmbedResult Result with ok status, message, and file count
 local function run(files: {string}, output?: string, exe_path?: string): EmbedResult
   output = output or "cosmic"
   exe_path = exe_path or arg[-1]

--- a/lib/cosmic/example.tl
+++ b/lib/cosmic/example.tl
@@ -1,6 +1,7 @@
 --- Go-style executable example testing.
 --- Parses Example_* functions from Teal files, runs them, and verifies output.
 
+--- A parsed example function with its expected output.
 local record Example
   name: string
   body: string
@@ -8,6 +9,7 @@ local record Example
   line: integer
 end
 
+--- Result from running a single example.
 local record ExampleResult
   name: string
   passed: boolean
@@ -16,13 +18,17 @@ local record ExampleResult
   error: string
 end
 
+--- Result from running all examples in a file.
 local record RunResult
   exit_code: integer
   results: {ExampleResult}
   error: string
 end
 
--- Parse a .tl file and extract Example_* functions with their expected output
+--- Parse a .tl file and extract Example_* functions with their expected output.
+--- Finds all local functions named Example_* and extracts their code and -- Output: comments.
+--- @param source string The source code to parse
+--- @return {Example} List of parsed examples
 local function parse_examples(source: string): {Example}
   local examples: {Example} = {}
 
@@ -170,7 +176,11 @@ local function parse_examples(source: string): {Example}
   return examples
 end
 
--- Run a single example and capture its output
+--- Run a single example and capture its output.
+--- Executes the example code and compares actual output with expected output.
+--- @param example Example The example to run
+--- @param file_path string Path to the source file (for context)
+--- @return ExampleResult Result with pass/fail status and output comparison
 local function run_example(example: Example, file_path: string): ExampleResult
   local result: ExampleResult = {
     name = example.name,
@@ -247,8 +257,10 @@ require("tl").loader()
   return result
 end
 
--- Run all examples in a file
--- Returns exit code (0=pass, 1=fail) and results
+--- Run all examples in a file.
+--- Parses and executes all Example_* functions, returning aggregated results.
+--- @param file_path string Path to the Teal file containing examples
+--- @return RunResult Result with exit code (0=pass, 1=fail, 2=skip), results, and errors
 local function run(file_path: string): RunResult
   local f, err = io.open(file_path, "r")
   if not f then
@@ -291,7 +303,11 @@ local function run(file_path: string): RunResult
   }
 end
 
--- Format results for human-readable output
+--- Format results for human-readable output.
+--- Creates formatted test output showing PASS/FAIL/SKIP with expected vs actual output.
+--- @param file_path string Path to the file that was tested
+--- @param run_result RunResult Results from running examples
+--- @return string Formatted output for display
 local function format_results(file_path: string, run_result: RunResult): string
   local lines: {string} = {}
 

--- a/lib/cosmic/init.tl
+++ b/lib/cosmic/init.tl
@@ -3,13 +3,20 @@
 
 local cosmo = require("cosmo")
 
+--- Environment with standard output and error streams.
 local record Env
   stdout: FILE
   stderr: FILE
 end
 
+--- Main function signature for cosmic programs.
+--- Takes command-line arguments and environment, returns exit code and optional error message.
 local type MainFn = function(args: {string}, env: Env): number, string
 
+--- Run a main function and exit with its return code.
+--- Calls the provided function only if running as main script.
+--- Writes error message to stderr and exits with the returned code.
+--- @param fn MainFn The main function to execute
 local function main(fn: MainFn)
   if not cosmo.is_main() then return end
   local env: Env = {stderr = io.stderr, stdout = io.stdout}

--- a/lib/cosmic/teal.tl
+++ b/lib/cosmic/teal.tl
@@ -4,6 +4,7 @@
 
 local tl = require("tl")
 
+--- A compiler or type checker issue.
 local record Issue
   file: string
   line: integer
@@ -12,29 +13,35 @@ local record Issue
   severity: string  -- "error" or "warning"
 end
 
+--- Options for compiling Teal to Lua.
 local record CompileOpts
   include_dirs: {string}
   gen_target: string
   gen_compat: string
 end
 
+--- Options for type-checking Teal files.
 local record CheckOpts
   include_dirs: {string}
 end
 
+--- Result from compiling a Teal file.
 local record CompileResult
   ok: boolean
   code: string
   errors: {Issue}
 end
 
+--- Result from type-checking a Teal file.
 local record CheckResult
   ok: boolean
   warnings: {Issue}
   errors: {Issue}
 end
 
--- Default include directories for cosmic type definitions
+--- Get default include directories for cosmic type definitions.
+--- Returns paths to bundled and local type definition directories.
+--- @return {string} List of default include directory paths
 local function get_default_include_dirs(): {string}
   return {
     "/zip/.lua/types",       -- Bundled cosmic types (in binary)
@@ -43,6 +50,7 @@ local function get_default_include_dirs(): {string}
   }
 end
 
+--- Error from the Teal compiler.
 local record TlError
   msg: string
   filename: string
@@ -50,6 +58,7 @@ local record TlError
   x: integer
 end
 
+--- Result from Teal's process_string function.
 local record TlResult
   syntax_errors: {TlError}
   type_errors: {TlError}
@@ -57,14 +66,19 @@ local record TlResult
   ast: any
 end
 
+--- Internal result from processing a Teal file.
 local record ProcessResult
   tl_result: TlResult
   shebang: string
   error: Issue
 end
 
--- Process a Teal file: read, setup paths, run tl.process_string
--- Returns ProcessResult with tl_result on success, or error on failure
+--- Process a Teal file: read, setup paths, run tl.process_string.
+--- Returns ProcessResult with tl_result on success, or error on failure.
+--- @param input_path string Path to the Teal file to process
+--- @param include_dirs {string} Directories to search for type definitions
+--- @param lax boolean If true, use lax mode; if false, use strict mode
+--- @return ProcessResult Processing result with tl_result or error
 local function process_file(input_path: string, include_dirs: {string}, lax: boolean): ProcessResult
   local f, open_err = io.open(input_path, "r")
   if not f then
@@ -119,7 +133,11 @@ local function process_file(input_path: string, include_dirs: {string}, lax: boo
   return {tl_result = result as TlResult, shebang = shebang}
 end
 
--- Collect errors from tl result (syntax_errors and type_errors)
+--- Collect errors from tl result (syntax_errors and type_errors).
+--- Converts Teal's error format to cosmic's Issue format.
+--- @param result TlResult The result from tl.process_string
+--- @param input_path string Path to the source file for error reporting
+--- @return {Issue} List of issues converted from TlErrors
 local function collect_errors(result: TlResult, input_path: string): {Issue}
   local errors: {Issue} = {}
 
@@ -154,8 +172,11 @@ local function collect_errors(result: TlResult, input_path: string): {Issue}
   return errors
 end
 
--- Compile a Teal file to Lua code
--- Returns: CompileResult with ok, code (if successful), errors (if failed)
+--- Compile a Teal file to Lua code.
+--- Uses lax mode for permissive compilation. Preserves shebang if present.
+--- @param input_path string Path to the Teal file to compile
+--- @param opts CompileOpts Compilation options (include_dirs, gen_target, gen_compat)
+--- @return CompileResult Result with ok status, generated Lua code, and any errors
 local function compile(input_path: string, opts: CompileOpts): CompileResult
   opts = opts or {} as CompileOpts
 
@@ -182,8 +203,11 @@ local function compile(input_path: string, opts: CompileOpts): CompileResult
   return {ok = true, code = lua_code, errors = {}}
 end
 
--- Type-check a Teal file
--- Returns: CheckResult with ok, warnings, errors
+--- Type-check a Teal file.
+--- Uses strict mode for thorough type checking. Collects errors and warnings.
+--- @param input_path string Path to the Teal file to check
+--- @param opts CheckOpts Type-checking options (include_dirs)
+--- @return CheckResult Result with ok status, warnings, and errors
 local function check(input_path: string, opts: CheckOpts): CheckResult
   opts = opts or {} as CheckOpts
 
@@ -212,7 +236,10 @@ local function check(input_path: string, opts: CheckOpts): CheckResult
   return {ok = #errors == 0, warnings = warnings, errors = errors}
 end
 
--- Format issues for human-readable output
+--- Format issues for human-readable output.
+--- Creates formatted strings like "file.tl:10:5: error: message".
+--- @param issues {Issue} List of issues to format
+--- @return string Formatted issues, one per line
 local function format_issues(issues: {Issue}): string
   local lines: {string} = {}
   for _, issue in ipairs(issues) do

--- a/lib/cosmic/walk.tl
+++ b/lib/cosmic/walk.tl
@@ -3,23 +3,39 @@
 local unix = require("cosmo.unix")
 local path = require("cosmo.path")
 
+--- File or directory metadata.
 local record Stat
   mode: function(self): number
   size: function(self): number
   mtim: function(self): number
 end
 
+--- Handle for reading directory entries.
 local record DirHandle
   read: function(self): string
   close: function(self)
 end
 
+--- File information with Unix permissions.
 local record FileInfo
   mode: number
 end
 
+--- Visitor function type for directory traversal.
+--- Return false to skip recursion into subdirectories.
+--- @param full_path string The complete path to the file or directory
+--- @param entry string The basename of the file or directory
+--- @param stat Stat File metadata
+--- @param ctx any User-provided context passed through the walk
+--- @return boolean Return false to skip recursing into this directory
 local type Visitor = function(full_path: string, entry: string, stat: Stat, ctx: any): boolean
 
+--- Walk a directory tree, calling visitor for each entry.
+--- Recursively traverses subdirectories unless visitor returns false.
+--- @param dir string The directory to walk
+--- @param visitor Visitor Function called for each file and directory
+--- @param ctx T Optional context passed to visitor function
+--- @return T The context object, potentially modified by visitor
 local function walk<T>(dir: string, visitor: Visitor, ctx?: T): T
   ctx = ctx or {} as T
   local handle = unix.opendir(dir) as DirHandle
@@ -43,6 +59,11 @@ local function walk<T>(dir: string, visitor: Visitor, ctx?: T): T
   return ctx
 end
 
+--- Collect file paths matching a Lua pattern.
+--- Recursively walks directory tree and returns matching file paths.
+--- @param dir string The directory to search
+--- @param pattern string Lua pattern to match against file basenames
+--- @return {string} List of full paths to matching files
 local function collect(dir: string, pattern: string): {string}
   local results: {string} = {}
   walk(dir, function(full_path: string, entry: string, stat: Stat, ctx: {string}): boolean
@@ -54,6 +75,12 @@ local function collect(dir: string, pattern: string): {string}
   return results
 end
 
+--- Recursively collect all files with their Unix permissions.
+--- Returns a map of relative paths to file information.
+--- @param dir string The directory to walk
+--- @param base string Internal: relative path prefix (used during recursion)
+--- @param files {string:FileInfo} Internal: accumulator map (used during recursion)
+--- @return {string:FileInfo} Map of relative paths to file information
 local function collect_all(dir: string, base?: string, files?: {string:FileInfo}): {string:FileInfo}
   files = files or {}
   base = base or ""


### PR DESCRIPTION
Following the documentation style established in spawn.tl (commit 21dca9e), add doc comments with @param/@return annotations to all remaining modules:

- walk.tl: Document filesystem traversal functions (walk, collect, collect_all) and related types (Stat, DirHandle, FileInfo, Visitor)

- embed.tl: Document the run() function for embedding files into executables

- teal.tl: Document Teal compilation and type-checking functions (compile, check, format_issues, process_file, collect_errors, get_default_include_dirs) and types (Issue, CompileOpts, CheckOpts, CompileResult, CheckResult)

- example.tl: Document example testing functions (parse_examples, run_example, run, format_results) and types (Example, ExampleResult, RunResult)

- doc.tl: Document documentation extraction functions (extract_doc_comment, parse_annotations, parse, render, render_file) and types (Param, Return, FunctionDoc, RecordDoc, ExampleDoc, ModuleDoc)

- init.tl: Document main entry point function and types (Env, MainFn)

All functions now include:
- Function signatures with type annotations
- Parameter descriptions with @param tags
- Return value descriptions with @return tags
- Record/type doc comments

This completes the documentation initiative started in #23.