### PR TITLE
Document missing function in cosmic.embed

### DIFF
--- a/lib/cosmic/doc.tl
+++ b/lib/cosmic/doc.tl
@@ -546,9 +546,27 @@ local function render(doc: ModuleDoc): string
   end
 
   -- Functions
+  -- Identify exported functions by checking the module record
+  local exported_names: {string:boolean} = {}
+
+  -- Find the module record (typically ends with "Module")
+  for _, rec in ipairs(doc.records) do
+    if rec.name:match("Module$") then
+      -- Extract function names from the module record fields
+      for _, field in ipairs(rec.fields) do
+        local field_name, field_type = field[1], field[2]
+        -- Check if this field is a function type
+        if field_type:match("^function") then
+          exported_names[field_name] = true
+        end
+      end
+    end
+  end
+
   local exported_functions: {FunctionDoc} = {}
   for _, func in ipairs(doc.functions) do
-    if not func.is_local then
+    -- Include if it's non-local OR if it's local but exported via module record
+    if not func.is_local or exported_names[func.name] then
       table.insert(exported_functions, func)
     end
   end


### PR DESCRIPTION
Previously, the documentation generator only included non-local functions in the "Functions" section, causing exported functions like cosmic.embed.run() and cosmic.spawn.spawn() to be missing from the generated docs.

This fix identifies functions that are exported through the module record (e.g., EmbedModule, SpawnModule) and includes them in the documentation even if they're defined as local functions.

The logic:
1. Scans all module records (records ending with "Module")
2. Extracts function field names from those records
3. Includes local functions in the docs if they appear in the module exports

Fixes missing documentation for cosmic.embed.run() and cosmic.spawn.spawn().