### PR TITLE
Add documentation for cosmic.walk functions

### DIFF
--- a/lib/cosmic/doc.tl
+++ b/lib/cosmic/doc.tl
@@ -203,7 +203,7 @@ local function parse(source: string, file_path: string): ModuleDoc
 
   -- Find functions: local function name() or function name()
   -- Capture full signature including return types
-  for func_start, is_local, func_name in source:gmatch("()(local%s+)function%s+([%w_:]+)%s*%(") do
+  for func_start, is_local, func_name in source:gmatch("()(local%s+)function%s+([%w_:]+)<?[^>%(]*>?%s*%(") do
     update_line_num(func_start as integer)
 
     -- Skip if this is inside a comment
@@ -268,7 +268,7 @@ local function parse(source: string, file_path: string): ModuleDoc
   -- Also find non-local functions
   line_num = 1
   last_pos = 1
-  for func_start, func_name in source:gmatch("()function%s+([%w_:]+)%s*%(") do
+  for func_start, func_name in source:gmatch("()function%s+([%w_:]+)<?[^>%(]*>?%s*%(") do
     -- Skip if this is inside a comment
     local line_start = func_start as integer
     while line_start > 1 and source:sub(line_start - 1, line_start - 1) ~= "\n" do

--- a/lib/cosmic/walk.tl
+++ b/lib/cosmic/walk.tl
@@ -110,8 +110,16 @@ local function collect_all(dir: string, base?: string, files?: {string:FileInfo}
   return files
 end
 
-return {
+local record WalkModule
+  walk: function<T>(dir: string, visitor: Visitor, ctx?: T): T
+  collect: function(dir: string, pattern: string): {string}
+  collect_all: function(dir: string, base?: string, files?: {string:FileInfo}): {string:FileInfo}
+end
+
+local M: WalkModule = {
   walk = walk,
   collect = collect,
   collect_all = collect_all,
 }
+
+return M


### PR DESCRIPTION
This commit fixes the missing function documentation for cosmic.walk by:

1. Adding WalkModule record to walk.tl to declare the module's exported API, following the pattern established in spawn.tl and other modules. This allows the documentation generator to identify and include local functions that are exported through the module record.

2. Fixing the regex patterns in doc.tl to support generic functions like walk<T>(...). The patterns now match optional generic type parameters by including <?[^>%(]*>? after the function name, which matches <T>, <T,U>, or no generics at all.

The generated walk.md now includes complete documentation for all three exported functions:
- walk<T>: Walk a directory tree with a visitor function
- collect: Collect file paths matching a Lua pattern
- collect_all: Recursively collect all files with Unix permissions

Fixes the issue where cosmic.walk functions were missing from the generated documentation at https://github.com/whilp/cosmic/blob/docs/lib/cosmic/walk.md