### PR TITLE
docs: add comprehensive documentation for cosmo C modules

### DIFF
--- a/lib/types/cosmo/getopt.d.tl
+++ b/lib/types/cosmo/getopt.d.tl
@@ -1,12 +1,82 @@
--- type declarations for cosmo.getopt
+--- Command-line argument parsing.
+--- The getopt module provides POSIX-style command-line option parsing with support for both
+--- short options (-v) and long options (--verbose).
 
+--- Parser for iterating through command-line options.
 local record Parser
+  --- Get the next option from the parser.
+  ---
+  --- Returns the next option character or long name, along with its argument
+  --- if the option takes one. Returns nil when no more options remain.
+  ---
+  --- If the option is unknown, returns "?" as the option name and the unknown
+  --- option string as the argument.
+  ---
+  --- @return string|nil opt Option character or long name, or "?" for unknown, or nil when done
+  --- @return string|nil arg Option argument (for options that take arguments), or nil
   next: function(self): string, string
+
+  --- Get remaining non-option arguments after all options have been parsed.
+  ---
+  --- @return {string} remaining Non-option arguments
   remaining: function(self): {string}
 end
 
 local record getopt
+  --- Long option definition: {name, has_arg, short}
+  --- - name: the long option name (e.g., "help" for --help)
+  --- - has_arg: "none", "required", or "optional"
+  --- - short: the equivalent short option character (e.g., "h")
   type LongOpt = {string, string, string}
+
+  --- Create a new getopt parser for iterating through command-line options.
+  ---
+  --- The optstring uses standard getopt format:
+  --- - A letter means that option takes no argument (e.g., "v" for -v)
+  --- - A letter followed by : means it requires an argument (e.g., "o:" for -o file)
+  --- - A letter followed by :: means it takes an optional argument
+  ---
+  --- Example - Basic usage:
+  ---
+  ---     local getopt = require("cosmo.getopt")
+  ---     local parser = getopt.new(arg, "hvo:", {
+  ---       {"help",    "none",     "h"},
+  ---       {"verbose", "none",     "v"},
+  ---       {"output",  "required", "o"},
+  ---     })
+  ---
+  ---     while true do
+  ---       local opt, arg = parser:next()
+  ---       if not opt then break end
+  ---
+  ---       if opt == "h" or opt == "help" then
+  ---         print("Usage: ...")
+  ---       elseif opt == "v" or opt == "verbose" then
+  ---         verbose = true
+  ---       elseif opt == "o" or opt == "output" then
+  ---         output = arg
+  ---       end
+  ---     end
+  ---
+  ---     local remaining = parser:remaining()  -- non-option args
+  ---
+  --- Example - Handling repeated options:
+  ---
+  ---     local parser = getopt.new(arg, "e:", {})
+  ---     local excludes = {}
+  ---     while true do
+  ---       local opt, arg = parser:next()
+  ---       if not opt then break end
+  ---       if opt == "e" then
+  ---         table.insert(excludes, arg)
+  ---       end
+  ---     end
+  ---     -- Now excludes contains all -e values: {"foo", "bar", "spam"}
+  ---
+  --- @param args {string} Command-line arguments (typically `arg`)
+  --- @param shortopts string Short options string (e.g., "hvo:")
+  --- @param longopts {LongOpt} Long option definitions
+  --- @return Parser parser Parser object with next() and remaining() methods
   new: function(args: {string}, shortopts: string, longopts: {LongOpt}): Parser
 end
 

--- a/lib/types/cosmo/lsqlite3.d.tl
+++ b/lib/types/cosmo/lsqlite3.d.tl
@@ -1,21 +1,124 @@
--- type declarations for cosmo.lsqlite3
+--- SQLite database access.
+--- The lsqlite3 module provides a Lua binding to SQLite, allowing you to create,
+--- query, and manipulate SQLite databases.
 
+--- Prepared SQL statement for executing queries with parameters.
 local record Statement
+  --- Bind values to placeholders in the prepared statement.
+  ---
+  --- Binds values to ? placeholders in the SQL statement, in order.
+  ---
+  --- Example:
+  ---
+  ---     local stmt = db:prepare("INSERT INTO users (name, age) VALUES (?, ?)")
+  ---     stmt:bind_values("Alice", 30)
+  ---     stmt:step()
+  ---
+  --- @param ... any Values to bind to the statement placeholders
   bind_values: function(self: Statement, ...: any)
+
+  --- Execute one step of the prepared statement.
+  ---
+  --- Returns a status code:
+  --- - 100 (SQLITE_ROW): A row is available, call step() again to get more rows
+  --- - 101 (SQLITE_DONE): Statement completed successfully
+  --- - Other: Error occurred
+  ---
+  --- @return number status SQLite status code
   step: function(self: Statement): number
+
+  --- Return an iterator for rows returned by the statement.
+  ---
+  --- Each call to the iterator returns a table mapping column names to values.
+  --- Returns nil when no more rows are available.
+  ---
+  --- Example:
+  ---
+  ---     local stmt = db:prepare("SELECT name, age FROM users")
+  ---     for row in stmt:nrows() do
+  ---       print(row.name, row.age)
+  ---     end
+  ---
+  --- @return function iterator Iterator function that returns row tables
   nrows: function(self: Statement): function(): {string:any}
+
+  --- Finalize and release the prepared statement.
+  ---
+  --- This should be called when you're done with the statement to free resources.
   finalize: function(self: Statement)
+
+  --- Reset the statement to be executed again with new bindings.
+  ---
+  --- After reset, you can bind new values and execute the statement again.
   reset: function(self: Statement)
 end
 
+--- SQLite database connection.
 local record Database
+  --- Execute an SQL statement without returning results.
+  ---
+  --- Suitable for CREATE, INSERT, UPDATE, DELETE statements.
+  ---
+  --- Example:
+  ---
+  ---     db:exec("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)")
+  ---     db:exec("INSERT INTO users (name, age) VALUES ('Alice', 30)")
+  ---
+  --- @param sql string SQL statement to execute
+  --- @return number status SQLite status code (0 = success)
   exec: function(self: Database, sql: string): number
+
+  --- Prepare an SQL statement for execution.
+  ---
+  --- Returns a Statement object that can be executed multiple times with
+  --- different bound parameters.
+  ---
+  --- @param sql string SQL statement to prepare
+  --- @return Statement stmt Prepared statement object
   prepare: function(self: Database, sql: string): Statement
+
+  --- Execute a query and return an iterator for the results.
+  ---
+  --- Convenience method that combines prepare() and nrows().
+  ---
+  --- Example:
+  ---
+  ---     for row in db:nrows("SELECT name, age FROM users WHERE age > 25") do
+  ---       print(row.name, row.age)
+  ---     end
+  ---
+  --- @param sql string SQL query to execute
+  --- @return function iterator Iterator function that returns row tables
   nrows: function(self: Database, sql: string): function(): {string:any}
+
+  --- Close the database connection and release resources.
   close: function(self: Database)
 end
 
 local record lsqlite3
+  --- Open or create an SQLite database.
+  ---
+  --- Opens an existing database or creates a new one if it doesn't exist.
+  --- Use ":memory:" as the filename to create an in-memory database.
+  ---
+  --- Example - File database:
+  ---
+  ---     local lsqlite3 = require("cosmo.lsqlite3")
+  ---     local db = assert(lsqlite3.open("mydata.db"))
+  ---     db:exec("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT)")
+  ---     db:exec("INSERT INTO users (name) VALUES ('Alice')")
+  ---     for row in db:nrows("SELECT * FROM users") do
+  ---       print(row.id, row.name)
+  ---     end
+  ---     db:close()
+  ---
+  --- Example - In-memory database:
+  ---
+  ---     local db = lsqlite3.open(":memory:")
+  ---     db:exec("CREATE TABLE temp (data TEXT)")
+  ---
+  --- @param filename string Path to database file, or ":memory:" for in-memory database
+  --- @return Database db Database connection object
   open: function(filename: string): Database
 end
 

--- a/lib/types/cosmo/path.d.tl
+++ b/lib/types/cosmo/path.d.tl
@@ -1,9 +1,63 @@
--- type declarations for cosmo.path
+--- Path manipulation utilities.
+--- The path module provides functions for manipulating UNIX-style paths.
 
 local record path
+  --- Joins path components into a single path.
+  ---
+  --- Concatenates path components intelligently, handling slashes appropriately:
+  --- - `/usr` + `lib` = `/usr/lib`
+  --- - `/usr/` + `lib` = `/usr/lib`
+  --- - `/usr/lib` + `/lib` = `/lib` (absolute path takes precedence)
+  ---
+  --- You may specify 1 or more arguments. If `nil` arguments are specified,
+  --- they're skipped. Empty strings behave similarly to `nil`, but may
+  --- coerce a trailing slash.
+  ---
+  --- Example:
+  ---
+  ---     local path = require("cosmo.path")
+  ---     assert(path.join("/usr", "local", "bin") == "/usr/local/bin")
+  ---
+  --- @return string The joined path
   join: function(...: string): string
+
+  --- Strips final component of path.
+  ---
+  --- Returns the directory component of a path:
+  --- - `.` returns `.`
+  --- - `..` returns `.`
+  --- - `/` returns `/`
+  --- - `usr` returns `.`
+  --- - `/usr/` returns `/`
+  --- - `/usr/lib` returns `/usr`
+  --- - `/usr/lib/` returns `/usr`
+  ---
+  --- @param p string The path to process
+  --- @return string The directory component
   dirname: function(p: string): string
+
+  --- Returns final component of path.
+  ---
+  --- Extracts the filename component from a path:
+  --- - `.` returns `.`
+  --- - `..` returns `..`
+  --- - `/` returns `/`
+  --- - `usr` returns `usr`
+  --- - `/usr/` returns `usr`
+  --- - `/usr/lib` returns `lib`
+  --- - `/usr/lib/` returns `lib`
+  ---
+  --- @param p string The path to process
+  --- @return string The filename component
   basename: function(p: string): string
+
+  --- Returns `true` if path exists.
+  ---
+  --- This function is inclusive of regular files, directories, and special files.
+  --- Symbolic links are followed and resolved. On error, `false` is returned.
+  ---
+  --- @param p string The path to check
+  --- @return boolean `true` if the path exists
   exists: function(p: string): boolean
 end
 

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -1,124 +1,532 @@
--- type declarations for cosmo.unix
+--- Low-level UNIX system call interface.
+--- This module exposes the System V system call interface and works on all supported platforms,
+--- including Windows NT where calls are emulated using native Windows APIs.
 
+--- File metadata returned by stat().
 local record Stat
+  --- Get the file mode (permissions and type).
+  --- @return number mode Unix file mode bits
   mode: function(self): number
+
+  --- Get the file size in bytes.
+  --- @return number size File size
   size: function(self): number
+
+  --- Get the modification time.
+  --- @return number mtime Modification time as Unix timestamp
   mtim: function(self): number
 end
 
+--- Directory handle for iterating through directory entries.
 local record DirHandle
+  --- Read the next directory entry.
+  --- @return string|nil name Entry name, or nil when no more entries
   read: function(self): string
+
+  --- Close the directory handle and release resources.
   close: function(self)
-  -- Allow iteration: for entry in handle do
+
+  --- Allow iteration: for entry in handle do
   metamethod __call: function(self: DirHandle): string
 end
 
 local record unix
-  -- process control
+  -- ============================================================================
+  -- PROCESS CONTROL
+  -- ============================================================================
+
+  --- Create a new process by duplicating the current process.
+  ---
+  --- Returns 0 in the child process, and the child's PID in the parent process.
+  --- This is useful for creating worker processes or handling concurrent requests.
+  ---
+  --- Example:
+  ---
+  ---     local unix = require("cosmo.unix")
+  ---     local pid = unix.fork()
+  ---     if pid == 0 then
+  ---       -- Child process
+  ---       print("I am the child")
+  ---       unix.exit(0)
+  ---     else
+  ---       -- Parent process
+  ---       print("Child PID:", pid)
+  ---       unix.wait(pid)
+  ---     end
+  ---
+  --- @return number pid 0 in child, child's PID in parent
   fork: function(): number
+
+  --- Replace the current process with a new program.
+  ---
+  --- Executes the program at `path` with the given arguments and environment.
+  --- This function never returns on success; it replaces the current process.
+  --- `path` must be an absolute path to the executable.
+  ---
+  --- Example:
+  ---
+  ---     unix.execve("/bin/ls", {"/bin/ls", "-la", "."}, {"PATH=/bin"})
+  ---     unix.exit(127)  -- Only reached if execve fails
+  ---
+  --- @param path string Absolute path to executable
+  --- @param argv {string} Argument vector (argv[1] should be the program name)
+  --- @param env {string} Environment variables as "KEY=value" strings
   execve: function(path: string, argv: {string}, env: {string})
+
+  --- Execute program with PATH search.
+  ---
+  --- Like execve() but searches for the program in directories listed in
+  --- the PATH environment variable. This function never returns on success.
+  ---
+  --- @param cmd string Program name or path
+  --- @param argv {string} Argument vector
   execvp: function(cmd: string, argv: {string})
+
+  --- Execute program with PATH search and custom environment.
+  ---
+  --- Combines execvp() and execve() - searches PATH and allows custom environment.
+  --- This function never returns on success.
+  ---
+  --- @param cmd string Program name or path
+  --- @param argv {string} Argument vector
+  --- @param env {string} Environment variables as "KEY=value" strings
   execvpe: function(cmd: string, argv: {string}, env: {string})
+
+  --- Wait for a child process to terminate.
+  ---
+  --- If pid is specified, waits for that specific child. Otherwise waits for
+  --- any child process. Returns the PID of the terminated process and its
+  --- exit status.
+  ---
+  --- Use WIFEXITED() and WEXITSTATUS() to interpret the status.
+  ---
+  --- @param pid number|nil Specific child PID, or nil for any child
+  --- @return number pid PID of terminated child
+  --- @return number status Exit status (use WIFEXITED/WEXITSTATUS to decode)
   wait: function(pid?: number): number, number
+
+  --- Terminate the current process.
+  ---
+  --- @param code number Exit code (0 = success, non-zero = failure)
   exit: function(code: number)
+
+  --- Send a signal to a process.
+  ---
+  --- @param pid number Process ID to signal
+  --- @param signal number Signal number (e.g., SIGTERM, SIGINT)
+  --- @return boolean success `true` on success
   kill: function(pid: number, signal: number): boolean
+
+  --- Get the current process ID.
+  ---
+  --- @return number pid Current process ID
   getpid: function(): number
+
+  --- Run the current process as a daemon (background service).
+  ---
+  --- Detaches from the controlling terminal and runs in the background.
+  ---
+  --- @param nochdir boolean If false, changes to root directory
+  --- @param noclose boolean If false, redirects stdin/stdout/stderr to /dev/null
+  --- @return boolean success `true` on success
   daemon: function(nochdir: boolean, noclose: boolean): boolean
 
-  -- pipes
+  -- ============================================================================
+  -- PIPES AND FILE DESCRIPTORS
+  -- ============================================================================
+
+  --- Create a pipe for inter-process communication.
+  ---
+  --- Returns two file descriptors: read end and write end.
+  --- Data written to the write end can be read from the read end.
+  ---
+  --- Example:
+  ---
+  ---     local read_fd, write_fd = unix.pipe()
+  ---     unix.write(write_fd, "Hello, pipe!")
+  ---     local data = unix.read(read_fd, 100)
+  ---     unix.close(read_fd)
+  ---     unix.close(write_fd)
+  ---
+  --- @return number read_fd File descriptor for reading
+  --- @return number write_fd File descriptor for writing
   pipe: function(): number, number
+
+  --- Duplicate a file descriptor.
+  ---
+  --- If newfd is specified, duplicates oldfd to that specific number.
+  --- Otherwise allocates the lowest available file descriptor.
+  ---
+  --- @param fd number File descriptor to duplicate
+  --- @param newfd number|nil Target file descriptor number
+  --- @return number fd New file descriptor
   dup: function(fd: number, newfd?: number): number
 
-  -- file operations
+  -- ============================================================================
+  -- FILE OPERATIONS
+  -- ============================================================================
+
+  --- Open a file and return a file descriptor.
+  ---
+  --- Flags should be a combination of O_RDONLY, O_WRONLY, O_RDWR, plus optional
+  --- flags like O_CREAT, O_TRUNC, O_APPEND. Mode specifies permissions when
+  --- creating a file (e.g., 0o644).
+  ---
+  --- Example:
+  ---
+  ---     local fd, err = unix.open("/tmp/test.txt",
+  ---       unix.O_WRONLY + unix.O_CREAT + unix.O_TRUNC, 0o644)
+  ---     if not fd then
+  ---       print("Error:", err)
+  ---       return
+  ---     end
+  ---     unix.write(fd, "Hello, World!")
+  ---     unix.close(fd)
+  ---
+  --- @param path string Path to file
+  --- @param flags number Open flags (O_RDONLY, O_WRONLY, O_RDWR, etc.)
+  --- @param mode number|nil File permissions when creating (e.g., 0o644)
+  --- @return number|nil fd File descriptor on success, nil on error
+  --- @return string|nil error Error message on failure
   open: function(path: string, flags: number, mode?: number): number, string
+
+  --- Close a file descriptor.
+  ---
+  --- @param fd number File descriptor to close
+  --- @return boolean success `true` on success
   close: function(fd: number): boolean
+
+  --- Read data from a file descriptor.
+  ---
+  --- Reads up to `size` bytes from the file descriptor.
+  --- May return fewer bytes than requested.
+  ---
+  --- @param fd number File descriptor to read from
+  --- @param size number Maximum number of bytes to read
+  --- @return string data Data read from file descriptor
   read: function(fd: number, size: number): string
+
+  --- Write data to a file descriptor.
+  ---
+  --- @param fd number File descriptor to write to
+  --- @param data string Data to write
+  --- @return number bytes Number of bytes written
   write: function(fd: number, data: string): number
+
+  --- Reposition file offset.
+  ---
+  --- Changes the file offset for reading/writing.
+  --- whence can be SEEK_SET (from start), SEEK_CUR (from current),
+  --- or SEEK_END (from end).
+  ---
+  --- @param fd number File descriptor
+  --- @param offset number Offset in bytes
+  --- @param whence number SEEK_SET, SEEK_CUR, or SEEK_END
+  --- @return number position New file offset
   lseek: function(fd: number, offset: number, whence: number): number
+
+  --- Truncate a file to a specified length.
+  ---
+  --- @param fd number File descriptor
+  --- @param length number New file length in bytes
+  --- @return boolean success `true` on success
   ftruncate: function(fd: number, length: number): boolean
 
-  -- directory operations
+  -- ============================================================================
+  -- DIRECTORY OPERATIONS
+  -- ============================================================================
+
+  --- Open a directory for reading its entries.
+  ---
+  --- Returns a handle that can be used to iterate through directory entries.
+  ---
+  --- Example:
+  ---
+  ---     local dir = unix.opendir("/tmp")
+  ---     while true do
+  ---       local entry = dir:read()
+  ---       if not entry then break end
+  ---       print(entry)
+  ---     end
+  ---     dir:close()
+  ---
+  --- @param path string Directory path
+  --- @return DirHandle handle Directory handle
   opendir: function(path: string): DirHandle
+
+  --- Create a directory.
+  ---
+  --- @param path string Directory path
+  --- @param mode number Directory permissions (e.g., 0o755)
+  --- @return boolean success `true` on success
   mkdir: function(path: string, mode: number): boolean
+
+  --- Create a directory and all parent directories.
+  ---
+  --- Like `mkdir -p`, creates intermediate directories as needed.
+  ---
+  --- @param path string Directory path
+  --- @param mode number|nil Directory permissions (defaults to 0o755)
+  --- @return boolean success `true` on success
+  --- @return string|nil error Error message on failure
   makedirs: function(path: string, mode?: number): boolean, string
+
+  --- Create a temporary directory with a unique name.
+  ---
+  --- The template should end with "XXXXXX" which will be replaced with
+  --- random characters to ensure uniqueness.
+  ---
+  --- Example:
+  ---
+  ---     local tmpdir = unix.mkdtemp("/tmp/myapp-XXXXXX")
+  ---     -- Use tmpdir...
+  ---     unix.rmrf(tmpdir)
+  ---
+  --- @param template string Path template ending in "XXXXXX"
+  --- @return string path Created directory path
   mkdtemp: function(template: string): string
+
+  --- Recursively remove a directory and all its contents.
+  ---
+  --- Like `rm -rf`, removes directories and files recursively.
+  ---
+  --- @param path string Directory path
+  --- @return boolean success `true` on success
   rmrf: function(path: string): boolean
+
+  --- Rename or move a file or directory.
+  ---
+  --- @param src string Source path
+  --- @param dst string Destination path
+  --- @return boolean success `true` on success
   rename: function(src: string, dst: string): boolean
+
+  --- Remove a file or empty directory.
+  ---
+  --- @param path string File or directory path
+  --- @return boolean success `true` on success
   unlink: function(path: string): boolean
+
+  --- Create a symbolic link.
+  ---
+  --- @param target string Path the symlink points to
+  --- @param link_path string Path where the symlink will be created
+  --- @return boolean success `true` on success
   symlink: function(target: string, link_path: string): boolean
+
+  --- Read the target of a symbolic link.
+  ---
+  --- @param path string Path to symbolic link
+  --- @return string target Path the symlink points to
   readlink: function(path: string): string
 
-  -- path/directory functions
+  -- ============================================================================
+  -- PATH AND DIRECTORY FUNCTIONS
+  -- ============================================================================
+
+  --- Get the current working directory.
+  ---
+  --- @return string cwd Current working directory path
   getcwd: function(): string
+
+  --- Change the current working directory.
+  ---
+  --- @param path string New working directory path
+  --- @return boolean success `true` on success
   chdir: function(path: string): boolean
+
+  --- Resolve a path to its canonical absolute form.
+  ---
+  --- Resolves symbolic links and removes . and .. components.
+  ---
+  --- @param path string Path to resolve
+  --- @return string realpath Canonical absolute path
   realpath: function(path: string): string
+
+  --- Check file accessibility.
+  ---
+  --- Tests whether the file exists and has the requested permissions.
+  --- Use F_OK to test existence, R_OK for read permission, W_OK for write,
+  --- X_OK for execute.
+  ---
+  --- @param path string File path
+  --- @param mode number Access mode (F_OK, R_OK, W_OK, X_OK)
+  --- @return boolean accessible `true` if accessible
   access: function(path: string, mode: number): boolean
+
+  --- Change file permissions.
+  ---
+  --- @param path string File path
+  --- @param mode number New permissions (e.g., 0o644)
+  --- @return boolean success `true` on success
   chmod: function(path: string, mode: number): boolean
+
+  --- Get file metadata.
+  ---
+  --- Returns a Stat object with file information. Use flags to control
+  --- behavior (e.g., AT_SYMLINK_NOFOLLOW to not follow symlinks).
+  ---
+  --- @param path string File path
+  --- @param flags number|nil Stat flags (e.g., AT_SYMLINK_NOFOLLOW)
+  --- @return Stat stat File metadata
   stat: function(path: string, flags?: number): Stat
 
-  -- environment
+  -- ============================================================================
+  -- ENVIRONMENT
+  -- ============================================================================
+
+  --- Get all environment variables.
+  ---
+  --- Returns an array of "KEY=value" strings.
+  ---
+  --- @return {string} env Environment variables
   environ: function(): {string}
+
+  --- Set an environment variable.
+  ---
+  --- @param name string Variable name
+  --- @param value string Variable value
+  --- @return boolean success `true` on success
   setenv: function(name: string, value: string): boolean
+
+  --- Unset an environment variable.
+  ---
+  --- @param name string Variable name
+  --- @return boolean success `true` on success
   unsetenv: function(name: string): boolean
+
+  --- Search for a command in PATH.
+  ---
+  --- Returns the full path to the command if found in PATH.
+  ---
+  --- Example:
+  ---
+  ---     local ls = unix.commandv("ls")
+  ---     if ls then
+  ---       unix.execve(ls, {ls, "-la"}, unix.environ())
+  ---     end
+  ---
+  --- @param cmd string Command name
+  --- @return string path Full path to command
   commandv: function(cmd: string): string
+
+  --- Get the system hostname.
+  ---
+  --- @return string hostname System hostname
   gethostname: function(): string
 
-  -- time
+  -- ============================================================================
+  -- TIME
+  -- ============================================================================
+
+  --- Sleep for a specified time.
+  ---
+  --- @param sec number Seconds to sleep
+  --- @param nsec number Nanoseconds to sleep
   nanosleep: function(sec: number, nsec: number)
 
-  -- network
+  -- ============================================================================
+  -- NETWORK
+  -- ============================================================================
+
+  --- Create a network socket.
+  ---
+  --- @param family number Address family (e.g., AF_UNIX)
+  --- @param socktype number Socket type (e.g., SOCK_STREAM)
+  --- @return number fd Socket file descriptor
   socket: function(family: number, socktype: number): number
+
+  --- Connect a socket to an address.
+  ---
+  --- For AF_UNIX sockets, path is the socket file path.
+  ---
+  --- @param fd number Socket file descriptor
+  --- @param path string Address (e.g., socket path for AF_UNIX)
+  --- @return boolean success `true` on success
   connect: function(fd: number, path: string): boolean
 
-  -- signals
+  -- ============================================================================
+  -- SIGNALS
+  -- ============================================================================
+
+  --- Install a signal handler.
+  ---
+  --- @param signal number Signal number (e.g., SIGINT, SIGTERM)
+  --- @param handler function Handler function to call when signal is received
   sigaction: function(signal: number, handler: function())
 
-  -- file locking
+  -- ============================================================================
+  -- FILE LOCKING
+  -- ============================================================================
+
+  --- Manipulate file descriptor (including file locking).
+  ---
+  --- Used for advisory file locking. Set lock_type to F_WRLCK for write lock.
+  ---
+  --- @param fd number File descriptor
+  --- @param cmd number Command (e.g., F_SETLK)
+  --- @param lock_type number Lock type (e.g., F_WRLCK)
+  --- @param whence number|nil Lock start reference (SEEK_SET, SEEK_CUR, SEEK_END)
+  --- @param start number|nil Lock start offset
+  --- @param len number|nil Lock length (0 = to EOF)
+  --- @return number result Result code
   fcntl: function(fd: number, cmd: number, lock_type: number, whence?: number, start?: number, len?: number): number
 
-  -- file flags
-  O_RDONLY: number
-  O_WRONLY: number
-  O_RDWR: number
-  O_CREAT: number
-  O_EXCL: number
-  O_TRUNC: number
-  O_APPEND: number
+  -- ============================================================================
+  -- CONSTANTS
+  -- ============================================================================
 
-  -- file type tests
+  -- File flags
+  O_RDONLY: number    --- Open for reading only
+  O_WRONLY: number    --- Open for writing only
+  O_RDWR: number      --- Open for reading and writing
+  O_CREAT: number     --- Create file if it doesn't exist
+  O_EXCL: number      --- Fail if file exists (with O_CREAT)
+  O_TRUNC: number     --- Truncate file to 0 bytes
+  O_APPEND: number    --- Append mode
+
+  -- File type tests
+  --- Test if mode indicates a directory.
   S_ISDIR: function(mode: number): boolean
+
+  --- Test if mode indicates a regular file.
   S_ISREG: function(mode: number): boolean
+
+  --- Test if mode indicates a symbolic link.
   S_ISLNK: function(mode: number): boolean
 
-  -- process status
+  -- Process status
+  --- Test if child exited normally.
   WIFEXITED: function(status: number): boolean
+
+  --- Extract exit status if WIFEXITED is true.
   WEXITSTATUS: function(status: number): number
 
-  -- access modes
-  F_OK: number
-  X_OK: number
-  R_OK: number
-  W_OK: number
+  -- Access modes
+  F_OK: number        --- Test for file existence
+  X_OK: number        --- Test for execute permission
+  R_OK: number        --- Test for read permission
+  W_OK: number        --- Test for write permission
 
-  -- lock modes
-  F_SETLK: number
-  F_WRLCK: number
+  -- Lock modes
+  F_SETLK: number     --- Set lock (non-blocking)
+  F_WRLCK: number     --- Write lock
 
-  -- signals
-  SIGINT: integer
-  SIGTERM: integer
+  -- Signals
+  SIGINT: integer     --- Interrupt signal (Ctrl+C)
+  SIGTERM: integer    --- Termination signal
 
-  -- network constants
-  AF_UNIX: number
-  SOCK_STREAM: number
+  -- Network constants
+  AF_UNIX: number     --- Unix domain sockets
+  SOCK_STREAM: number --- Stream socket (TCP)
 
-  -- stat flags
-  AT_SYMLINK_NOFOLLOW: number
+  -- Stat flags
+  AT_SYMLINK_NOFOLLOW: number  --- Don't follow symbolic links
 
-  -- seek whence
-  SEEK_SET: number
-  SEEK_CUR: number
-  SEEK_END: number
+  -- Seek whence
+  SEEK_SET: number    --- Seek from beginning of file
+  SEEK_CUR: number    --- Seek from current position
+  SEEK_END: number    --- Seek from end of file
 end
 
 return unix

--- a/lib/types/cosmo/zip.d.tl
+++ b/lib/types/cosmo/zip.d.tl
@@ -1,28 +1,98 @@
--- Type definitions for cosmo.zip module
+--- ZIP archive reading and writing.
+--- The zip module provides functionality for creating and reading ZIP archives.
 
+--- Writer for adding files to a ZIP archive.
 local record ZipAppender
+  --- Add a file to the ZIP archive.
+  ---
+  --- @param name string The path/filename within the ZIP archive
+  --- @param content string The file content to add
+  --- @return boolean success `true` on success
+  --- @return string|nil error Error message on failure
   add: function(self: ZipAppender, name: string, content: string): boolean, string
+
+  --- Close the ZIP archive and finalize all entries.
   close: function(self: ZipAppender)
 end
 
+--- File metadata within a ZIP archive.
 local record ZipStat
+  --- Uncompressed file size in bytes.
   size: integer
+
+  --- Compressed file size in bytes.
   compressed_size: integer
+
+  --- CRC32 checksum of uncompressed data.
   crc32: integer
+
+  --- Modification time as Unix timestamp.
   mtime: integer
+
+  --- Compression method (0=stored, 8=deflated).
   method: integer
+
+  --- Unix file mode/permissions.
   mode: integer
 end
 
+--- Reader for extracting files from a ZIP archive.
 local record ZipReader
+  --- List all files in the ZIP archive.
+  ---
+  --- @return {string} files Array of file paths in the archive
   list: function(self: ZipReader): {string}
+
+  --- Get metadata for a specific file in the archive.
+  ---
+  --- @param name string The file path within the archive
+  --- @return ZipStat stat File metadata
   stat: function(self: ZipReader, name: string): ZipStat
+
+  --- Read the contents of a file from the archive.
+  ---
+  --- @param name string The file path within the archive
+  --- @return string content The file contents
   read: function(self: ZipReader, name: string): string
+
+  --- Close the ZIP reader and release resources.
   close: function(self: ZipReader)
 end
 
 local record zip
+  --- Open a ZIP archive for reading or writing.
+  ---
+  --- For writing, creates a new archive or appends to an existing one.
+  ---
+  --- Example - Creating a ZIP archive:
+  ---
+  ---     local zip = require("cosmo.zip")
+  ---     local archive = assert(zip.open("output.zip", "w"))
+  ---     archive:add("hello.txt", "Hello, World!")
+  ---     archive:add("data/config.json", '{"key": "value"}')
+  ---     archive:close()
+  ---
+  --- Example - Reading a ZIP archive:
+  ---
+  ---     local archive = assert(zip.from(io.open("input.zip", "rb"):read("*a")))
+  ---     local files = archive:list()
+  ---     for _, name in ipairs(files) do
+  ---       local content = archive:read(name)
+  ---       print(name, #content)
+  ---     end
+  ---     archive:close()
+  ---
+  --- @param path string Path to the ZIP file
+  --- @param mode string Open mode: "r" for reading, "w" for writing, "a" for appending
+  --- @return ZipAppender|nil appender ZIP writer object on success
+  --- @return string|nil error Error message on failure
   open: function(path: string, mode: string): ZipAppender, string
+
+  --- Open a ZIP archive from in-memory data.
+  ---
+  --- @param data string ZIP file contents as a string
+  --- @return ZipReader|nil reader ZIP reader object on success
+  --- @return string|nil error Error message on failure
   from: function(data: string): ZipReader, string
 end
 


### PR DESCRIPTION
Add comprehensive documentation for all cosmo C modules in Teal definition files:

## Modules documented

- **cosmo.unix**: Low-level UNIX system call interface
  - Process control (fork, exec, wait, kill, daemon)
  - File operations (open, close, read, write, lseek)
  - Directory operations (opendir, mkdir, makedirs, mkdtemp, rmrf)
  - Pipes and file descriptors (pipe, dup)
  - Path functions (getcwd, chdir, realpath, access, stat)
  - Environment variables (environ, setenv, commandv)
  - Network (socket, connect)
  - Signals (sigaction)
  - File locking (fcntl)

- **cosmo.path**: Path manipulation utilities
  - join, dirname, basename, exists
  - Complete with examples and edge cases

- **cosmo.getopt**: Command-line argument parsing
  - POSIX-style short and long options
  - Complete usage examples

- **cosmo.zip**: ZIP archive operations
  - ZipAppender, ZipReader, ZipStat types
  - Examples for creating and reading archives

- **cosmo.lsqlite3**: SQLite database access
  - Database, Statement types with full method documentation
  - Examples for common database operations

## Documentation format

All modules include:
- Module-level descriptions
- Detailed type definitions with field documentation
- Function signatures with parameter and return documentation
- Usage examples for complex operations

## Additional changes

- Fix doc.tl function pattern matching to handle generic-style syntax
- Simplify walk.tl module export pattern