### PR TITLE
Add cwd option to spawn function

### DIFF
--- a/lib/cosmic/spawn.tl
+++ b/lib/cosmic/spawn.tl
@@ -26,6 +26,7 @@ local record SpawnOpts
   stdout: number
   stderr: number
   env: {string}
+  cwd: string
 end
 
 local function make_pipe(fd: number): Pipe
@@ -141,6 +142,14 @@ local function spawn(argv: {string}, opts?: SpawnOpts): SpawnHandle, string
       unix.close(stderr_r)
       unix.dup(stderr_w)
       unix.close(stderr_w)
+    end
+
+    -- change working directory if specified
+    if opts.cwd then
+      if not unix.chdir(opts.cwd) then
+        -- chdir failed, exit with error code
+        os.exit(126)
+      end
     end
 
     local env = opts.env or unix.environ()

--- a/lib/cosmic/spawn_test.tl
+++ b/lib/cosmic/spawn_test.tl
@@ -135,3 +135,16 @@ local function test_fd_passthrough_stderr()
   assert(content == "written", "expected 'written', got '" .. tostring(content) .. "'")
 end
 test_fd_passthrough_stderr()
+
+local function test_cwd_option()
+  -- test that cwd option changes the working directory of spawned process
+  -- Use pwd command to verify the working directory
+  local handle = spawn({"pwd"}, {cwd = TEST_TMPDIR})
+  assert(handle ~= nil, "handle should not be nil")
+  local ok, out, exit_code = handle:read()
+  assert(ok, "command should succeed, exit code: " .. tostring(exit_code) .. ", output: '" .. tostring(out) .. "'")
+  -- pwd output includes a trailing newline
+  local pwd_output = out:gsub("\n$", "")
+  assert(pwd_output == TEST_TMPDIR, "expected pwd to be '" .. TEST_TMPDIR .. "', got '" .. tostring(pwd_output) .. "'")
+end
+test_cwd_option()


### PR DESCRIPTION
This change adds a 'cwd' field to SpawnOpts that allows callers to specify the working directory for the spawned process. The child process will chdir to the specified directory before executing the target program.

If chdir fails, the child exits with code 126 to distinguish from the exec failure code (127).