### PR TITLE
friction: add duplicate checking, task list tracking, and source links

### DIFF
--- a/.claude/skills/friction/SKILL.md
+++ b/.claude/skills/friction/SKILL.md
@@ -22,7 +22,28 @@ Accept input in any of these formats:
 - **File path**: Read the markdown file directly
 - **Inline text**: User pastes the friction log content
 
-### 2. Analyze and categorize findings
+Record the source URL or file path for later reference.
+
+### 2. Check for existing issues
+
+Before creating new issues, search for existing issues that may already cover the friction points:
+
+```bash
+# Search open issues by keyword
+gh issue list --repo owner/repo --state open --search "keyword" --json number,title,state
+
+# List recent issues to check for duplicates
+gh issue list --repo owner/repo --limit 50 --json number,title,state
+
+# View a specific issue to check scope
+gh issue view 123 --repo owner/repo
+```
+
+If an existing issue covers a friction point:
+- Note it in the summary instead of creating a duplicate
+- Consider commenting on the existing issue with new context from the friction log
+
+### 3. Analyze and categorize findings
 
 Read through the friction log and identify:
 
@@ -42,7 +63,7 @@ Read through the friction log and identify:
 - Error messages
 - Discoverability
 
-### 3. Design the issue breakdown
+### 4. Design the issue breakdown
 
 Create a tiered structure based on dependencies:
 
@@ -64,7 +85,7 @@ Tier 4+: Refinements
   - Blocked by earlier tiers
 ```
 
-### 4. Write detailed issues
+### 5. Write detailed issues
 
 Each issue must include:
 
@@ -88,30 +109,84 @@ Each issue must include:
 - [ ] Tests pass: `make test`
 
 ## Blocked by
-- #N (if applicable)
+- [ ] #N description of blocking issue
+
+## Source
+- [Friction log title](URL to PR or file)
 ```
 
-### 5. Create issues in dependency order
+### 6. Create issues in dependency order
 
-Create issues starting from Tier 1, capturing issue numbers as you go:
+Create Tier 1 issues first (no blockers), then Tier 2+ issues that reference blockers.
+
+**Capturing issue numbers:**
+```bash
+# Create issue and capture the URL (contains issue number)
+gh issue create --repo owner/repo --title "Title" --body "Body"
+# Output: https://github.com/owner/repo/issues/123
+```
+
+**Using task list syntax for tracking:**
+
+GitHub tracks issues referenced in task lists. Use checkbox syntax for "Blocked by":
 
 ```bash
-# Create issue and capture number
-gh issue create --repo owner/repo --title "Title" --body "$(cat <<'EOF'
-Body content here...
+gh issue create --repo owner/repo --title "Add getpass wrapper" --body "$(cat <<'EOF'
+## Problem
+Users need a simple way to read passwords without echoing.
+
+## Solution
+Add unix.getpass() function.
 
 ## Blocked by
-- #45 (previously created issue)
+- [ ] #66 Add tcgetattr/tcsetattr (needed for terminal control)
+
+## Source
+- [Password vault friction report](https://github.com/owner/repo/pull/5)
 EOF
 )"
 ```
 
-### 6. Report summary
+This creates a tracked relationship - GitHub shows the blocking issue's status.
+
+**Full example with dependency chain:**
+
+```bash
+# Tier 1: No blockers
+gh issue create --repo owner/repo --title "Add Database record types" --body "$(cat <<'EOF'
+## Problem
+Database methods are undocumented.
+
+## Blocked by
+None - this is a foundation issue.
+
+## Source
+- [Friction report](https://github.com/owner/repo/pull/5)
+EOF
+)"
+# Returns: https://github.com/owner/repo/issues/65
+
+# Tier 2: References #65
+gh issue create --repo owner/repo --title "Index record methods in docs" --body "$(cat <<'EOF'
+## Problem
+Can't search for Database.exec in docs.
+
+## Blocked by
+- [ ] #65 Add Database record types (methods must exist before indexing)
+
+## Source
+- [Friction report](https://github.com/owner/repo/pull/5)
+EOF
+)"
+```
+
+### 7. Report summary
 
 After creating all issues, provide:
-- Table mapping plan items to issue numbers
+- Table mapping friction points to issue numbers
 - Dependency graph showing parallel work streams
-- Starting points (issues with no blockers)
+- Starting points (Tier 1 issues with no blockers)
+- Any existing issues that already covered friction points
 
 ## Issue writing guidelines
 
@@ -131,6 +206,14 @@ After creating all issues, provide:
 **Acceptance criteria**: Testable, specific
 - "cosmic-lua --docs Database finds cosmo.lsqlite3.Database"
 - "make test passes"
+
+**Blocked by**: Use task list format for GitHub tracking
+- `- [ ] #N description` - GitHub tracks this and shows status
+- Only reference direct blockers, not transitive dependencies
+
+**Source**: Always link to the friction log
+- Provides context and traceability
+- Helps reviewers understand the user's original pain
 
 ## Example issue
 
@@ -172,13 +255,19 @@ index["cosmo.lsqlite3.Database.exec"] = method_doc
 
 ## Blocked by
 
-- #46 (needs record definitions to exist)
+- [ ] #65 Add Database and Statement record types (methods must exist to be indexed)
+
+## Source
+
+- [Password vault friction report](https://github.com/whilp/cosmic-eval/pull/5)
 ```
 
 ## Tips
 
+- Always check for existing issues before creating new ones
 - Create issues that can be worked on independently
 - Keep implementation details specific enough to avoid ambiguity
-- Use "Blocked by" references to show dependencies clearly
+- Use task list (`- [ ] #N`) format for blockers - GitHub tracks these
 - Prefer smaller, focused issues over large omnibus issues
 - Include code snippets that match the project's style
+- Always include a Source link for traceability


### PR DESCRIPTION
## Summary

Improves the friction skill with three key additions:

1. **Check existing issues first** - Search for duplicates before creating new issues
2. **Task list tracking for blockers** - Use `- [ ] #N` format which GitHub tracks
3. **Source links** - Always link back to the friction log for traceability

## Changes

### Duplicate checking (new step 2)
```bash
# Search open issues by keyword
gh issue list --repo owner/repo --state open --search "keyword" --json number,title,state

# List recent issues to check for duplicates
gh issue list --repo owner/repo --limit 50 --json number,title,state
```

### Task list format for blockers
Instead of plain text "Blocked by #N", use GitHub's tracked task list:
```markdown
## Blocked by
- [ ] #65 Add Database record types (methods must exist to be indexed)
```

GitHub renders this with status tracking and shows the relationship in the issue sidebar.

### Source section
Every issue now includes:
```markdown
## Source
- [Friction report title](URL to PR or file)
```

This provides traceability from issues back to the original user feedback.

## Test plan
- [x] Skill file validates as markdown
- [x] Examples use correct gh CLI syntax