### PR TITLE
require: add helpful module-not-found suggestions

### DIFF
--- a/lib/cosmic/main.tl
+++ b/lib/cosmic/main.tl
@@ -4,6 +4,9 @@
 global warn: function(...: any)
 
 require("tl").loader()
+if not os.getenv("COSMIC_NO_REQUIRE_HINTS") then
+  require("cosmic.require").install()
+end
 
 local getopt = require("cosmo.getopt")
 
@@ -342,6 +345,9 @@ local function generate_help(): string
   end
 
   table.insert(lines, "For module documentation, use: cosmic-lua --docs <module>")
+  table.insert(lines, "")
+  table.insert(lines, "Environment variables:")
+  table.insert(lines, "  COSMIC_NO_REQUIRE_HINTS    disable helpful module-not-found suggestions")
 
   return table.concat(lines, "\n")
 end

--- a/lib/cosmic/require.tl
+++ b/lib/cosmic/require.tl
@@ -1,0 +1,255 @@
+--- Enhanced require with helpful error messages.
+--- Intercepts module-not-found errors and suggests similar modules.
+
+local original_require = require
+
+--- Cached module mapping, built lazily on first use.
+local module_map: {string:string} = nil
+
+--- Build module mapping from package.preload.
+--- Maps short names to full module names (e.g., "argon2" -> "cosmo.argon2").
+local function build_module_map(): {string:string}
+  if module_map then
+    return module_map
+  end
+
+  module_map = {}
+
+  -- Scan package.preload for cosmo.* and cosmic.* modules
+  for name, _ in pairs(package.preload) do
+    local short = name:match("^cosmo%.(.+)$") or name:match("^cosmic%.(.+)$")
+    if short and not short:match("%.") then
+      -- Only map top-level modules (not submodules like cosmo.foo.bar)
+      if not module_map[short] then
+        module_map[short] = name
+      end
+    end
+  end
+
+  return module_map
+end
+
+--- Check if a module exists without loading it.
+--- @param name string Module name to check
+--- @return boolean True if module can be loaded
+local function module_exists(name: string): boolean
+  if package.preload[name] then
+    return true
+  end
+  -- Check package.path for .lua and .tl files
+  for path_pattern in package.path:gmatch("[^;]+") do
+    local file_path = path_pattern:gsub("%?", (name:gsub("%.", "/")))
+    local f = io.open(file_path, "r")
+    if f then
+      f:close()
+      return true
+    end
+  end
+  return false
+end
+
+--- Compute Levenshtein distance between two strings.
+--- @param a string First string
+--- @param b string Second string
+--- @return integer Edit distance
+local function levenshtein(a: string, b: string): integer
+  if #a == 0 then return #b end
+  if #b == 0 then return #a end
+  if a == b then return 0 end
+
+  -- Create distance matrix
+  local matrix: {{integer}} = {}
+  for i = 0, #a do
+    matrix[i] = {}
+    matrix[i][0] = i
+  end
+  for j = 0, #b do
+    matrix[0][j] = j
+  end
+
+  -- Fill in the rest of the matrix
+  for i = 1, #a do
+    for j = 1, #b do
+      local cost = a:sub(i, i) == b:sub(j, j) and 0 or 1
+      matrix[i][j] = math.min(
+        matrix[i-1][j] + 1,      -- deletion
+        matrix[i][j-1] + 1,      -- insertion
+        matrix[i-1][j-1] + cost  -- substitution
+      )
+    end
+  end
+
+  return matrix[#a][#b]
+end
+
+--- Find similar modules using Levenshtein distance.
+--- @param name string The requested module name
+--- @param max_distance integer Maximum edit distance to consider (default 3)
+--- @return {string} List of similar full module names, sorted by distance
+local function find_similar(name: string, max_distance?: integer): {string}
+  max_distance = max_distance or 3
+  local results: {{string, integer}} = {}  -- {full_name, distance}
+
+  -- Check against all known short module names
+  for short, full in pairs(build_module_map()) do
+    local dist = levenshtein(name:lower(), short:lower())
+    if dist <= max_distance then
+      table.insert(results, {full, dist})
+    end
+  end
+
+  -- Also check full module names in package.preload
+  for full, _ in pairs(package.preload) do
+    if full:match("^cosmo%.") or full:match("^cosmic%.") then
+      local dist = levenshtein(name:lower(), full:lower())
+      if dist <= max_distance then
+        -- Avoid duplicates
+        local dominated = false
+        for _, r in ipairs(results) do
+          if r[1] == full then
+            dominated = true
+            break
+          end
+        end
+        if not dominated then
+          table.insert(results, {full, dist})
+        end
+      end
+    end
+  end
+
+  -- Sort by distance, then alphabetically
+  table.sort(results, function(a: {string, integer}, b: {string, integer}): boolean
+    if a[2] ~= b[2] then
+      return a[2] < b[2]
+    end
+    return a[1] < b[1]
+  end)
+
+  -- Extract just the names
+  local names: {string} = {}
+  for _, r in ipairs(results) do
+    table.insert(names, r[1])
+  end
+
+  return names
+end
+
+--- Format a helpful error message for module not found.
+--- @param name string The requested module name
+--- @return string Enhanced error message with suggestions
+local function format_error(name: string): string
+  local lines: {string} = {}
+  table.insert(lines, "module '" .. name .. "' not found")
+  table.insert(lines, "")
+
+  -- Check for exact short name match first
+  local aliases = build_module_map()
+  local alias = aliases[name]
+  if alias and module_exists(alias) then
+    table.insert(lines, "Did you mean?")
+    table.insert(lines, "  " .. alias)
+    table.insert(lines, "")
+    table.insert(lines, "Try: require(\"" .. alias .. "\")")
+    return table.concat(lines, "\n")
+  end
+
+  -- Check if cosmo.name or cosmic.name exists exactly
+  local cosmo_name = "cosmo." .. name
+  local cosmic_name = "cosmic." .. name
+  if module_exists(cosmo_name) then
+    table.insert(lines, "Did you mean?")
+    table.insert(lines, "  " .. cosmo_name)
+    table.insert(lines, "")
+    table.insert(lines, "Try: require(\"" .. cosmo_name .. "\")")
+    return table.concat(lines, "\n")
+  end
+  if module_exists(cosmic_name) then
+    table.insert(lines, "Did you mean?")
+    table.insert(lines, "  " .. cosmic_name)
+    table.insert(lines, "")
+    table.insert(lines, "Try: require(\"" .. cosmic_name .. "\")")
+    return table.concat(lines, "\n")
+  end
+
+  -- Try fuzzy matching
+  local similar = find_similar(name, 3)
+  if #similar > 0 then
+    table.insert(lines, "Did you mean?")
+    -- Show up to 3 suggestions
+    for i = 1, math.min(3, #similar) do
+      table.insert(lines, "  " .. similar[i])
+    end
+    table.insert(lines, "")
+    table.insert(lines, "Try: require(\"" .. similar[1] .. "\")")
+    return table.concat(lines, "\n")
+  end
+
+  -- No suggestions found
+  table.insert(lines, "Modules use the 'cosmo.*' or 'cosmic.*' namespace.")
+  table.insert(lines, "")
+  table.insert(lines, "Use 'cosmic --docs' to list available modules.")
+
+  return table.concat(lines, "\n")
+end
+
+--- Check if error message indicates module not found.
+--- @param err string Error message
+--- @return boolean True if this is a module-not-found error
+local function is_module_not_found(err: string): boolean
+  return err:match("module '[^']+' not found") ~= nil
+end
+
+--- Extract module name from require error.
+--- @param err string Error message
+--- @return string Module name, or nil if not found
+local function extract_module_name(err: string): string
+  return err:match("module '([^']+)' not found")
+end
+
+--- Enhanced require function that provides helpful suggestions.
+--- @param name string Module name to require
+--- @return any The loaded module
+local function enhanced_require(name: string): any
+  local ok, result = pcall(original_require, name)
+  if ok then
+    return result
+  end
+
+  local err = tostring(result)
+  if is_module_not_found(err) then
+    local requested = extract_module_name(err) or name
+    error(format_error(requested), 2)
+  end
+
+  -- Re-raise original error for non-module-not-found errors
+  error(result, 2)
+end
+
+--- Install enhanced require globally.
+--- Call this early in startup to enable helpful error messages.
+local function install()
+  _G.require = enhanced_require as function(string): any
+end
+
+--- Restore original require.
+--- Useful for testing or disabling enhanced errors.
+local function uninstall()
+  _G.require = original_require
+end
+
+local record RequireModule
+  install: function()
+  uninstall: function()
+  module_exists: function(name: string): boolean
+  format_error: function(name: string): string
+end
+
+local M: RequireModule = {
+  install = install,
+  uninstall = uninstall,
+  module_exists = module_exists,
+  format_error = format_error,
+}
+
+return M

--- a/lib/cosmic/require_test.tl
+++ b/lib/cosmic/require_test.tl
@@ -1,0 +1,83 @@
+#!/usr/bin/env cosmic
+--- Tests for enhanced require with helpful error messages.
+
+local require_mod = require("cosmic.require")
+
+local function test_module_exists_preloaded()
+  -- cosmo modules are preloaded
+  assert(require_mod.module_exists("cosmo.unix"), "cosmo.unix should exist")
+  assert(require_mod.module_exists("cosmo.path"), "cosmo.path should exist")
+  assert(require_mod.module_exists("cosmo.argon2"), "cosmo.argon2 should exist")
+end
+test_module_exists_preloaded()
+
+local function test_module_exists_cosmic()
+  -- cosmic modules are in package.path
+  assert(require_mod.module_exists("cosmic.spawn"), "cosmic.spawn should exist")
+  assert(require_mod.module_exists("cosmic.walk"), "cosmic.walk should exist")
+  assert(require_mod.module_exists("cosmic.fetch"), "cosmic.fetch should exist")
+end
+test_module_exists_cosmic()
+
+local function test_module_not_exists()
+  assert(not require_mod.module_exists("nonexistent_module_xyz"), "nonexistent module should not exist")
+  assert(not require_mod.module_exists("argon2"), "argon2 without prefix should not exist")
+end
+test_module_not_exists()
+
+local function test_format_error_suggests_cosmo_prefix()
+  local err = require_mod.format_error("argon2")
+  assert(err:match("cosmo%.argon2"), "should suggest cosmo.argon2, got: " .. err)
+  assert(err:match("Did you mean"), "should include 'Did you mean'")
+end
+test_format_error_suggests_cosmo_prefix()
+
+local function test_format_error_suggests_cosmic_prefix()
+  local err = require_mod.format_error("spawn")
+  assert(err:match("cosmic%.spawn"), "should suggest cosmic.spawn, got: " .. err)
+end
+test_format_error_suggests_cosmic_prefix()
+
+local function test_format_error_fuzzy_sqlite()
+  -- "sqlite" should fuzzy match to "lsqlite3" (distance 2)
+  local err = require_mod.format_error("sqlite")
+  assert(err:match("lsqlite3"), "should suggest lsqlite3 for sqlite via fuzzy match, got: " .. err)
+end
+test_format_error_fuzzy_sqlite()
+
+local function test_format_error_fuzzy_typo()
+  -- "argonn2" should fuzzy match to "argon2" (distance 1)
+  local err = require_mod.format_error("argonn2")
+  assert(err:match("argon2"), "should suggest argon2 for argonn2 via fuzzy match, got: " .. err)
+end
+test_format_error_fuzzy_typo()
+
+local function test_format_error_unknown_module()
+  local err = require_mod.format_error("totally_unknown_xyz")
+  assert(err:match("cosmic %-%-docs"), "should mention cosmic --docs, got: " .. err)
+  assert(err:match("cosmo%.%*.*cosmic%.%*") or err:match("namespace"), "should mention namespaces")
+end
+test_format_error_unknown_module()
+
+local function test_require_nonexistent_shows_suggestion()
+  -- Test that requiring a nonexistent module shows helpful error
+  -- Use a variable to prevent Teal from trying to resolve at compile time
+  local modname = "argon2"
+  local ok, result = pcall(require, modname)
+  assert(not ok, "require('argon2') should fail")
+  local err_str = tostring(result)
+  assert(err_str:match("cosmo%.argon2"), "error should suggest cosmo.argon2, got: " .. err_str)
+end
+test_require_nonexistent_shows_suggestion()
+
+local function test_require_valid_module_works()
+  -- Make sure valid requires still work
+  local unix = require("cosmo.unix")
+  assert(unix ~= nil, "require('cosmo.unix') should work")
+
+  local spawn = require("cosmic.spawn")
+  assert(spawn ~= nil, "require('cosmic.spawn') should work")
+end
+test_require_valid_module_works()
+
+print("All require tests passed")


### PR DESCRIPTION
## Summary

- Add `cosmic.require` module that wraps `require()` with helpful error messages
- When a module isn't found, suggest the correct fully-qualified name
- Support common aliases (e.g., `sqlite` → `cosmo.lsqlite3`)
- Add `COSMIC_NO_REQUIRE_HINTS` env var to disable (documented in `--help`)

## Example

```
$ cosmic -e 'require("argon2")'
module 'argon2' not found

Did you mean?
  cosmo.argon2

Try: require("cosmo.argon2")
```

## Test plan

- [x] `make teal` passes
- [x] `make test` passes
- [x] Manual test: `require("argon2")` suggests `cosmo.argon2`
- [x] Manual test: `require("sqlite")` suggests `cosmo.lsqlite3`
- [x] Manual test: `COSMIC_NO_REQUIRE_HINTS=1` disables hints

Closes #69