### PR TITLE
sqlite: add ergonomic wrapper module

### DIFF
--- a/lib/cosmic/require_test.tl
+++ b/lib/cosmic/require_test.tl
@@ -39,9 +39,9 @@ end
 test_format_error_suggests_cosmic_prefix()
 
 local function test_format_error_fuzzy_sqlite()
-  -- "sqlite" should fuzzy match to "lsqlite3" (distance 2)
+  -- "sqlite" should match to "cosmic.sqlite" (exact suffix match)
   local err = require_mod.format_error("sqlite")
-  assert(err:match("lsqlite3"), "should suggest lsqlite3 for sqlite via fuzzy match, got: " .. err)
+  assert(err:match("cosmic%.sqlite"), "should suggest cosmic.sqlite for sqlite, got: " .. err)
 end
 test_format_error_fuzzy_sqlite()
 

--- a/lib/cosmic/sqlite.tl
+++ b/lib/cosmic/sqlite.tl
@@ -1,0 +1,299 @@
+--- Ergonomic SQLite wrapper with automatic cleanup and 1-indexed columns.
+--- Wraps lsqlite3 with proper error returns and resource management.
+
+local lsqlite3 = require("cosmo.lsqlite3")
+
+-- Raw lsqlite3 types (0-indexed, requires manual cleanup)
+local record RawStatement
+  bind_values: function(self: RawStatement, ...: any): number
+  step: function(self: RawStatement): number
+  reset: function(self: RawStatement)
+  finalize: function(self: RawStatement): number
+  get_value: function(self: RawStatement, n: number): any
+  columns: function(self: RawStatement): number
+  get_name: function(self: RawStatement, n: number): string
+end
+
+local record RawDatabase
+  close: function(self: RawDatabase): number
+  exec: function(self: RawDatabase, sql: string): number
+  prepare: function(self: RawDatabase, sql: string): RawStatement, number, string
+  last_insert_rowid: function(self: RawDatabase): number
+  changes: function(self: RawDatabase): number
+  errmsg: function(self: RawDatabase): string
+end
+
+local record RawSqlite3
+  OK: number
+  ROW: number
+  DONE: number
+  open: function(filename: string): RawDatabase, number, string
+end
+
+local sqlite3 = lsqlite3 as RawSqlite3
+
+--- Statement handle with automatic cleanup.
+local record Statement
+  bind: function(self: Statement, ...: any): boolean, string
+  rows: function(self: Statement): function(): {string:any}
+  values: function(self: Statement): function(): any...
+  exec: function(self: Statement): boolean, string
+  reset: function(self: Statement)
+  columns: function(self: Statement): number
+  column_name: function(self: Statement, n: number): string
+  close: function(self: Statement)
+end
+
+--- Database handle with automatic cleanup.
+local record Database
+  prepare: function(self: Database, sql: string): Statement, string
+  query: function(self: Database, sql: string, ...: any): function(): {string:any}
+  exec: function(self: Database, sql: string): boolean, string
+  last_insert_rowid: function(self: Database): number
+  changes: function(self: Database): number
+  close: function(self: Database)
+end
+
+local function make_statement(raw_stmt: RawStatement, raw_db: RawDatabase): Statement
+  local stmt: Statement = {}
+  local closed = false
+
+  function stmt:bind(...: any): boolean, string
+    raw_stmt:reset()
+    local args = {...}
+    local rc = raw_stmt:bind_values(table.unpack(args))
+    if rc ~= sqlite3.OK then
+      return false, raw_db:errmsg()
+    end
+    return true
+  end
+
+  function stmt:rows(): function(): {string:any}
+    local col_count = raw_stmt:columns()
+    local col_names: {integer:string}
+    local first_call = true
+
+    return function(): {string:any}
+      local rc = raw_stmt:step()
+      if rc == sqlite3.ROW then
+        -- Get column names on first row (requires step to be called first)
+        if first_call then
+          first_call = false
+          col_names = {}
+          for idx = 0, col_count - 1 do
+            col_names[(idx + 1) as integer] = raw_stmt:get_name(idx)
+          end
+        end
+        local row: {string:any} = {}
+        for idx = 0, col_count - 1 do
+          local name = col_names[(idx + 1) as integer]
+          row[name] = raw_stmt:get_value(idx)
+        end
+        return row
+      end
+      return nil
+    end
+  end
+
+  function stmt:values(): function(): any...
+    local col_count = raw_stmt:columns()
+
+    return function(): any...
+      local rc = raw_stmt:step()
+      if rc == sqlite3.ROW then
+        local vals: {integer:any} = {}
+        for idx = 0, col_count - 1 do
+          vals[(idx + 1) as integer] = raw_stmt:get_value(idx)
+        end
+        return table.unpack(vals)
+      end
+      return nil
+    end
+  end
+
+  function stmt:exec(): boolean, string
+    local rc = raw_stmt:step()
+    if rc ~= sqlite3.DONE and rc ~= sqlite3.ROW then
+      return false, raw_db:errmsg()
+    end
+    return true
+  end
+
+  stmt.reset = function(_: Statement)
+    raw_stmt:reset()
+  end
+
+  stmt.columns = function(_: Statement): number
+    return raw_stmt:columns()
+  end
+
+  stmt.column_name = function(_: Statement, n: number): string
+    return raw_stmt:get_name(n - 1)
+  end
+
+  stmt.close = function(_: Statement)
+    if not closed then
+      closed = true
+      local _ = raw_stmt:finalize()
+    end
+  end
+
+  return setmetatable(stmt, {
+    __close = function(self: Statement) self:close() end
+  }) as Statement
+end
+
+local function make_database(raw_db: RawDatabase): Database
+  local db: Database = {}
+  local closed = false
+
+  function db:prepare(sql: string): Statement, string
+    local raw_stmt, errcode, errmsg = raw_db:prepare(sql)
+    if not raw_stmt then
+      return nil, errmsg or ("error code " .. tostring(errcode))
+    end
+    return make_statement(raw_stmt, raw_db)
+  end
+
+  function db:query(sql: string, ...: any): function(): {string:any}
+    local stmt, err = self:prepare(sql)
+    if not stmt then
+      return function(): {string:any}
+        error("query failed: " .. (err or "unknown error"))
+      end
+    end
+
+    local args = {...}
+    if #args > 0 then
+      local ok, bind_err = stmt:bind(table.unpack(args))
+      if not ok then
+        stmt:close()
+        return function(): {string:any}
+          error("bind failed: " .. (bind_err or "unknown error"))
+        end
+      end
+    end
+
+    local raw_iter = stmt:rows()
+    local done = false
+    return function(): {string:any}
+      if done then
+        return nil
+      end
+      local row = raw_iter()
+      if row == nil then
+        done = true
+        stmt:close()
+        return nil
+      end
+      return row
+    end
+  end
+
+  function db:exec(sql: string): boolean, string
+    local rc = raw_db:exec(sql)
+    if rc ~= sqlite3.OK then
+      return false, raw_db:errmsg()
+    end
+    return true
+  end
+
+  function db:last_insert_rowid(): number
+    return raw_db:last_insert_rowid()
+  end
+
+  function db:changes(): number
+    return raw_db:changes()
+  end
+
+  db.close = function(_: Database)
+    if not closed then
+      closed = true
+      local _ = raw_db:close()
+    end
+  end
+
+  return setmetatable(db, {
+    __close = function(self: Database) self:close() end
+  }) as Database
+end
+
+--- Open or create an SQLite database.
+--- @param filename string Database path (use ":memory:" for in-memory)
+--- @return Database Database handle with __close support
+--- @return string Error message on failure
+local function open(filename: string): Database, string
+  local raw_db, errcode, errmsg = sqlite3.open(filename)
+  if not raw_db then
+    return nil, errmsg or ("error code " .. tostring(errcode))
+  end
+  return make_database(raw_db)
+end
+
+-- Example_open demonstrates opening an in-memory database
+local function Example_open()
+  local sqlite = require("cosmic.sqlite")
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE kv (k TEXT PRIMARY KEY, v TEXT)")
+  db:exec("INSERT INTO kv (k, v) VALUES ('hello', 'world')")
+  for row in db:query("SELECT * FROM kv") do
+    print(row.k, row.v)
+  end
+  db:close()
+  -- Output:
+  -- hello	world
+end
+
+-- Example_prepared demonstrates prepared statements
+local function Example_prepared()
+  local sqlite = require("cosmic.sqlite")
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+
+  local stmt = db:prepare("INSERT INTO users (name) VALUES (?)")
+  stmt:bind("Alice")
+  stmt:exec()
+  stmt:reset()
+  stmt:bind("Bob")
+  stmt:exec()
+  stmt:close()
+
+  for row in db:query("SELECT * FROM users ORDER BY id") do
+    print(row.id, row.name)
+  end
+  db:close()
+  -- Output:
+  -- 1	Alice
+  -- 2	Bob
+end
+
+-- Example_query_params demonstrates query with parameters
+local function Example_query_params()
+  local sqlite = require("cosmic.sqlite")
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE nums (n INTEGER)")
+  for i = 1, 5 do
+    db:exec("INSERT INTO nums (n) VALUES (" .. i .. ")")
+  end
+
+  for row in db:query("SELECT * FROM nums WHERE n > ?", 2) do
+    print(row.n)
+  end
+  db:close()
+  -- Output:
+  -- 3
+  -- 4
+  -- 5
+end
+
+local record sqlite
+  open: function(filename: string): Database, string
+  Database: Database
+  Statement: Statement
+end
+
+local M: sqlite = {
+  open = open,
+}
+
+return M

--- a/lib/cosmic/sqlite_test.tl
+++ b/lib/cosmic/sqlite_test.tl
@@ -1,0 +1,331 @@
+#!/usr/bin/env cosmic
+--- Tests for cosmic.sqlite wrapper module.
+
+local path = require("cosmo.path")
+local sqlite = require("cosmic.sqlite")
+
+local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
+
+-- Basic operations
+
+local function test_open_memory()
+  local db, err = sqlite.open(":memory:")
+  assert(db, "should open memory db: " .. tostring(err))
+  db:close()
+end
+test_open_memory()
+
+local function test_open_file()
+  local dbpath = path.join(TEST_TMPDIR, "test.db")
+  local db, err = sqlite.open(dbpath)
+  assert(db, "should open file db: " .. tostring(err))
+  db:close()
+end
+test_open_file()
+
+local function test_open_invalid_path()
+  local db, err = sqlite.open("/nonexistent/path/to/db.sqlite")
+  assert(db == nil, "should fail on invalid path")
+  assert(err, "should return error message")
+end
+test_open_invalid_path()
+
+-- Execution
+
+local function test_exec_create_table()
+  local db = sqlite.open(":memory:")
+  local ok, err = db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+  assert(ok, "exec should succeed: " .. tostring(err))
+  db:close()
+end
+test_exec_create_table()
+
+local function test_exec_invalid_sql()
+  local db = sqlite.open(":memory:")
+  local ok, err = db:exec("INVALID SQL SYNTAX")
+  assert(not ok, "exec should fail on invalid SQL")
+  assert(err, "should return error message")
+  db:close()
+end
+test_exec_invalid_sql()
+
+local function test_last_insert_rowid()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+  db:exec("INSERT INTO t (name) VALUES ('first')")
+  assert(db:last_insert_rowid() == 1, "first insert should have rowid 1")
+  db:exec("INSERT INTO t (name) VALUES ('second')")
+  assert(db:last_insert_rowid() == 2, "second insert should have rowid 2")
+  db:close()
+end
+test_last_insert_rowid()
+
+local function test_changes()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+  db:exec("INSERT INTO t (name) VALUES ('a'), ('b'), ('c')")
+  assert(db:changes() == 3, "should report 3 changes")
+  db:exec("DELETE FROM t WHERE id < 3")
+  assert(db:changes() == 2, "should report 2 changes after delete")
+  db:close()
+end
+test_changes()
+
+-- Prepared statements
+
+local function test_prepare_bind_exec()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+
+  local stmt = db:prepare("INSERT INTO t (name) VALUES (?)")
+  assert(stmt, "should prepare statement")
+
+  local ok, err = stmt:bind("test")
+  assert(ok, "bind should succeed: " .. tostring(err))
+
+  ok, err = stmt:exec()
+  assert(ok, "exec should succeed: " .. tostring(err))
+
+  assert(db:last_insert_rowid() == 1, "should have inserted row")
+  stmt:close()
+  db:close()
+end
+test_prepare_bind_exec()
+
+local function test_prepare_invalid_sql()
+  local db = sqlite.open(":memory:")
+  local stmt, err = db:prepare("INVALID SQL")
+  assert(stmt == nil, "should fail on invalid SQL")
+  assert(err, "should return error message")
+  db:close()
+end
+test_prepare_invalid_sql()
+
+local function test_statement_reset()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+
+  local stmt = db:prepare("INSERT INTO t (name) VALUES (?)")
+  stmt:bind("first")
+  stmt:exec()
+  stmt:reset()
+  stmt:bind("second")
+  stmt:exec()
+  stmt:close()
+
+  local count = 0
+  for _ in db:query("SELECT * FROM t") do
+    count = count + 1
+  end
+  assert(count == 2, "should have 2 rows after reset and reuse")
+  db:close()
+end
+test_statement_reset()
+
+-- Query iteration
+
+local function test_query_rows()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+  db:exec("INSERT INTO t (name) VALUES ('Alice'), ('Bob'), ('Carol')")
+
+  local names: {string} = {}
+  for row in db:query("SELECT * FROM t ORDER BY id") do
+    table.insert(names, row.name as string)
+  end
+
+  assert(#names == 3, "should get 3 rows")
+  assert(names[1] == "Alice", "first name should be Alice")
+  assert(names[2] == "Bob", "second name should be Bob")
+  assert(names[3] == "Carol", "third name should be Carol")
+  db:close()
+end
+test_query_rows()
+
+local function test_query_with_params()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+  db:exec("INSERT INTO t (name) VALUES ('Alice'), ('Bob'), ('Carol')")
+
+  local names: {string} = {}
+  for row in db:query("SELECT * FROM t WHERE id > ? ORDER BY id", 1) do
+    table.insert(names, row.name as string)
+  end
+
+  assert(#names == 2, "should get 2 rows")
+  assert(names[1] == "Bob", "first should be Bob")
+  assert(names[2] == "Carol", "second should be Carol")
+  db:close()
+end
+test_query_with_params()
+
+local function test_query_empty_results()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+
+  local count = 0
+  for _ in db:query("SELECT * FROM t") do
+    count = count + 1
+  end
+  assert(count == 0, "should get 0 rows from empty table")
+  db:close()
+end
+test_query_empty_results()
+
+local function test_statement_values()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (a TEXT, b INTEGER, c REAL)")
+  db:exec("INSERT INTO t VALUES ('hello', 42, 3.14)")
+
+  local stmt = db:prepare("SELECT * FROM t")
+  local iter = stmt:values()
+  local a, b, c = iter()
+
+  assert(a == "hello", "first value should be 'hello'")
+  assert(b == 42, "second value should be 42")
+  assert(math.abs((c as number) - 3.14) < 0.001, "third value should be ~3.14")
+  stmt:close()
+  db:close()
+end
+test_statement_values()
+
+-- Index conversion (1-indexed)
+
+local function test_column_name_1indexed()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (first_col TEXT, second_col INTEGER, third_col REAL)")
+  db:exec("INSERT INTO t VALUES ('a', 1, 1.0)")  -- Need a row to step to
+
+  local stmt = db:prepare("SELECT * FROM t")
+  assert(stmt:columns() == 3, "should have 3 columns")
+  -- column_name requires step() to be called first (lsqlite3 limitation)
+  stmt:exec()  -- Step to first row
+  assert(stmt:column_name(1) == "first_col", "column 1 should be 'first_col'")
+  assert(stmt:column_name(2) == "second_col", "column 2 should be 'second_col'")
+  assert(stmt:column_name(3) == "third_col", "column 3 should be 'third_col'")
+  stmt:close()
+  db:close()
+end
+test_column_name_1indexed()
+
+-- Resource cleanup
+
+local function test_manual_close()
+  local db = sqlite.open(":memory:")
+  assert(db, "should open db")
+  db:close()
+  -- second close should be safe (no error)
+  db:close()
+end
+test_manual_close()
+
+local function test_auto_close()
+  -- Test that db can be opened and closed without issue
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (id INTEGER)")
+  db:close()
+end
+test_auto_close()
+
+local function test_statement_close()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (id INTEGER)")
+  local stmt = db:prepare("SELECT * FROM t")
+  assert(stmt, "should prepare")
+  stmt:close()
+  db:close()
+end
+test_statement_close()
+
+local function test_double_close_safe()
+  local db = sqlite.open(":memory:")
+  local stmt, _ = db:prepare("SELECT 1")
+  stmt:close()
+  stmt:close()
+  db:close()
+  db:close()
+end
+test_double_close_safe()
+
+-- Integration tests
+
+local function test_transaction()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+
+  db:exec("BEGIN TRANSACTION")
+  db:exec("INSERT INTO t (name) VALUES ('inside tx')")
+  db:exec("ROLLBACK")
+
+  local count = 0
+  for _ in db:query("SELECT * FROM t") do
+    count = count + 1
+  end
+  assert(count == 0, "should have 0 rows after rollback")
+
+  db:exec("BEGIN TRANSACTION")
+  db:exec("INSERT INTO t (name) VALUES ('committed')")
+  db:exec("COMMIT")
+
+  count = 0
+  for _ in db:query("SELECT * FROM t") do
+    count = count + 1
+  end
+  assert(count == 1, "should have 1 row after commit")
+  db:close()
+end
+test_transaction()
+
+local function test_multiple_params()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (a TEXT, b INTEGER, c REAL)")
+
+  local stmt = db:prepare("INSERT INTO t (a, b, c) VALUES (?, ?, ?)")
+  stmt:bind("hello", 42, 3.14)
+  stmt:exec()
+  stmt:close()
+
+  for row in db:query("SELECT * FROM t") do
+    assert(row.a == "hello", "a should be 'hello'")
+    assert(row.b == 42, "b should be 42")
+    assert(math.abs((row.c as number) - 3.14) < 0.001, "c should be ~3.14")
+  end
+  db:close()
+end
+test_multiple_params()
+
+local function test_null_values()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+  db:exec("INSERT INTO t (name) VALUES (NULL)")
+
+  for row in db:query("SELECT * FROM t") do
+    assert(row.name == nil, "name should be nil")
+  end
+  db:close()
+end
+test_null_values()
+
+local function test_nested_queries()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE parents (id INTEGER PRIMARY KEY, name TEXT)")
+  db:exec("CREATE TABLE children (id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT)")
+  db:exec("INSERT INTO parents (name) VALUES ('Alice'), ('Bob')")
+  db:exec("INSERT INTO children (parent_id, name) VALUES (1, 'Child1'), (1, 'Child2'), (2, 'Child3')")
+
+  local results: {string} = {}
+  for parent in db:query("SELECT * FROM parents ORDER BY id") do
+    for child in db:query("SELECT * FROM children WHERE parent_id = ? ORDER BY id", parent.id) do
+      table.insert(results, (parent.name as string) .. "->" .. (child.name as string))
+    end
+  end
+
+  assert(#results == 3, "should get 3 parent-child pairs")
+  assert(results[1] == "Alice->Child1", "first pair")
+  assert(results[2] == "Alice->Child2", "second pair")
+  assert(results[3] == "Bob->Child3", "third pair")
+  db:close()
+end
+test_nested_queries()
+
+print("All sqlite tests passed")


### PR DESCRIPTION
## Summary

- Add `cosmic.sqlite` wrapper module with automatic cleanup and 1-indexed columns
- Wraps `cosmo.lsqlite3` with proper error returns (`nil, errmsg` pattern)
- Add comprehensive test suite covering all API methods

## Test plan

- [x] `make check` passes (type checking)
- [x] `make test` passes (22 test cases)
- [x] `./o/bin/cosmic --example lib/cosmic/sqlite.tl` passes (3 examples)

Closes #75