### PR TITLE
docs: add --docs examples and improve example discoverability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,10 +277,10 @@ doc-publish: $(all_docs) $(docs_publish) | $(bootstrap_cosmic)
 	@test -n "$(SOURCE_SHA)" || { echo "SOURCE_SHA required"; exit 1; }
 	@$(bootstrap_cosmic) -- $(docs_publish) $(SOURCE_SHA) $(o)/docs $(or $(DOCS_BRANCH),docs)
 
-ci_stages := teal test build
+ci_stages := teal test example build
 
 .PHONY: ci
-## Run full CI pipeline (teal, test, build)
+## Run full CI pipeline (teal, test, example, build)
 ci:
 	@rm -f $(o)/failed
 	@$(foreach s,$(ci_stages),\

--- a/lib/cosmic/docs.tl
+++ b/lib/cosmic/docs.tl
@@ -571,6 +571,84 @@ local function search(query: string): {SearchResult}
   return results
 end
 
+--- Entry for examples list.
+local record ExampleEntry
+  module_name: string
+  example_name: string
+  description: string
+end
+
+--- List all examples across all modules.
+--- @return {ExampleEntry} List of examples sorted by module then name
+local function list_all_examples(): {ExampleEntry}
+  local index, _ = load_index()
+  if not index then
+    return {}
+  end
+
+  local examples: {ExampleEntry} = {}
+  for mod_name, mod_doc in pairs(index.modules) do
+    if mod_doc.examples then
+      for _, ex in ipairs(mod_doc.examples) do
+        local display_name = ex.name:gsub("^Example_?", "")
+        table.insert(examples, {
+          module_name = mod_name,
+          example_name = display_name,
+          description = first_paragraph(ex.description or ""),
+        })
+      end
+    end
+  end
+
+  table.sort(examples, function(a: ExampleEntry, b: ExampleEntry): boolean
+    if a.module_name ~= b.module_name then
+      return a.module_name < b.module_name
+    end
+    return a.example_name < b.example_name
+  end)
+
+  return examples
+end
+
+--- Render examples list as CLI output.
+--- @param examples {ExampleEntry} List of examples
+--- @return string Formatted output
+local function render_examples_list(examples: {ExampleEntry}): string
+  local lines: {string} = {}
+
+  table.insert(lines, "All examples")
+  table.insert(lines, "")
+
+  if #examples == 0 then
+    table.insert(lines, "No examples found.")
+    return table.concat(lines, "\n")
+  end
+
+  -- Group by module
+  local current_module: string = nil
+  for _, ex in ipairs(examples) do
+    if ex.module_name ~= current_module then
+      current_module = ex.module_name
+      if #lines > 2 then
+        table.insert(lines, "")
+      end
+      local simple_name = current_module:match("([^%.]+)$") or current_module
+      table.insert(lines, simple_name .. ":")
+    end
+    local line = "  " .. ex.example_name
+    if ex.description and ex.description ~= "" then
+      line = line .. " - " .. ex.description
+    end
+    table.insert(lines, line)
+  end
+
+  table.insert(lines, "")
+  table.insert(lines, "Run examples with: cosmic --example <file.tl>")
+  table.insert(lines, "View module docs with: cosmic --docs <module>")
+
+  return table.concat(lines, "\n")
+end
+
 --- Render search results as CLI output.
 --- @param results {SearchResult} List of search results
 --- @param query string The original search query
@@ -701,6 +779,15 @@ local function run(query?: string): DocsResult
     return {
       ok = true,
       output = render_topic_list(topics),
+    }
+  end
+
+  -- Special query: list all examples
+  if query == "examples" then
+    local examples = list_all_examples()
+    return {
+      ok = true,
+      output = render_examples_list(examples),
     }
   end
 

--- a/lib/cosmic/example.tl
+++ b/lib/cosmic/example.tl
@@ -1,6 +1,8 @@
 --- Go-style executable example testing.
 --- Parses Example_* functions from Teal files, runs them, and verifies output.
 
+local tl = require("tl")
+
 --- A parsed example function with its expected output.
 local record Example
   name: string
@@ -197,13 +199,39 @@ local function run_example(example: Example, file_path: string): ExampleResult
   end
 
   -- Build a script that executes the example body
-  -- We need to set up require paths to match the original file's context
-  local dir = file_path:match("(.*/)")
+  -- Compile through Teal first to handle type annotations
+  local teal_source = example.body
+
+  -- Initialize Teal environment and process the source
+  local env = tl.init_env(true) -- lax mode
+  local tl_result, proc_err = tl.process_string(teal_source, true, env, "@" .. example.name)
+
+  if not tl_result then
+    result.error = "process error: " .. (proc_err or "unknown")
+    return result
+  end
+
+  if tl_result.syntax_errors and #tl_result.syntax_errors > 0 then
+    result.error = "syntax error: " .. tl_result.syntax_errors[1].msg
+    return result
+  end
+
+  local lua_code = tl.generate(tl_result.ast, {
+    gen_target = "5.4",
+    gen_compat = "off",
+  } as {string:any})
+
+  if not lua_code then
+    result.error = "compile error: code generation failed"
+    return result
+  end
+
+  -- Prepend tl loader for require statements
   local script = [[
 require("tl").loader()
-]] .. example.body
+]] .. lua_code
 
-  -- Execute using loadstring
+  -- Execute using load
   local chunk, load_err = load(script, example.name)
   if not chunk then
     result.error = "load error: " .. (load_err or "unknown")

--- a/lib/cosmic/fetch.tl
+++ b/lib/cosmic/fetch.tl
@@ -65,6 +65,28 @@ local function Fetch(url: string, opts?: Opts): Result
   return result
 end
 
+-- Example_get demonstrates a simple HTTP GET request
+local function Example_get()
+  local fetch = require("cosmic.fetch")
+  local result = fetch.Fetch("https://httpbin.org/get")
+  print("status:", result.status)
+  print("ok:", result.ok)
+  -- Output:
+  -- status:	200
+  -- ok:	true
+end
+
+-- Example_get_json demonstrates fetching and parsing JSON
+local function Example_get_json()
+  local fetch = require("cosmic.fetch")
+  local json = require("cosmic.json")
+  local result = fetch.Fetch("https://httpbin.org/json")
+  local data = json.decode(result.body) as {string:{string:string}}
+  print("title:", data.slideshow.title)
+  -- Output:
+  -- title:	Sample Slide Show
+end
+
 local record fetch
   Fetch: function(url: string, opts?: Opts): Result
   Opts: Opts

--- a/lib/cosmic/main.tl
+++ b/lib/cosmic/main.tl
@@ -294,7 +294,7 @@ local function generate_help(): string
   table.insert(lines, "  --output <file>             output file for --embed (default: cosmic)")
   table.insert(lines, "  --example <file.tl>         run Example_* functions, check output")
   table.insert(lines, "  --benchmark <file.tl[:pat]> run Benchmark_* functions, report timing")
-  table.insert(lines, "  --docs <query>              show docs; exact match or search")
+  table.insert(lines, "  --docs <query>              show docs; \"examples\" lists all examples")
   table.insert(lines, "  --help                      show this help message")
   table.insert(lines, "")
   table.insert(lines, "Standard lua options:")

--- a/lib/cosmic/walk.tl
+++ b/lib/cosmic/walk.tl
@@ -110,6 +110,65 @@ local function collect_all(dir: string, base?: string, files?: {string:FileInfo}
   return files
 end
 
+-- Example_collect demonstrates collecting files matching a pattern
+local function Example_collect()
+  local walk_m = require("cosmic.walk")
+  local unix_m = require("cosmo.unix")
+  local path_m = require("cosmo.path")
+
+  -- Create temp dir with test files
+  local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp/walk_example"
+  unix_m.makedirs(tmpdir)
+  local f1 = io.open(path_m.join(tmpdir, "a.lua"), "w")
+  if f1 then f1:write("-- a") f1:close() end
+  local f2 = io.open(path_m.join(tmpdir, "b.lua"), "w")
+  if f2 then f2:write("-- b") f2:close() end
+  local f3 = io.open(path_m.join(tmpdir, "c.txt"), "w")
+  if f3 then f3:write("text") f3:close() end
+
+  local files = walk_m.collect(tmpdir, "%.lua$")
+  table.sort(files)
+  print("found", #files, "lua files")
+  for _, file in ipairs(files) do
+    print(path_m.basename(file))
+  end
+
+  unix_m.rmrf(tmpdir)
+  -- Output:
+  -- found	2	lua files
+  -- a.lua
+  -- b.lua
+end
+
+-- Example_walk demonstrates walking a directory tree with a visitor
+local function Example_walk()
+  local walk_m = require("cosmic.walk")
+  local unix_m = require("cosmo.unix")
+  local path_m = require("cosmo.path")
+
+  -- Create temp dir with test structure
+  local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp/walk_example2"
+  unix_m.makedirs(path_m.join(tmpdir, "sub"))
+  local f1 = io.open(path_m.join(tmpdir, "root.txt"), "w")
+  if f1 then f1:write("root") f1:close() end
+  local f2 = io.open(path_m.join(tmpdir, "sub", "child.txt"), "w")
+  if f2 then f2:write("child") f2:close() end
+
+  local count = 0
+  walk_m.walk(tmpdir, function(_: string, _: string, s: any, _: any): boolean
+    local st = s as Stat
+    if not unix_m.S_ISDIR(st:mode()) then
+      count = count + 1
+    end
+    return true
+  end)
+  print("visited", count, "files")
+
+  unix_m.rmrf(tmpdir)
+  -- Output:
+  -- visited	2	files
+end
+
 local record WalkModule
   walk: function<T>(dir: string, visitor: Visitor, ctx?: T): T
   collect: function(dir: string, pattern: string): {string}


### PR DESCRIPTION
## Summary

- Add `--docs examples` command to list all examples across all modules
- Add examples to fetch.tl (Example_get, Example_get_json) and walk.tl (Example_collect, Example_walk)
- Fix example runner to compile Teal to Lua before execution, allowing full Teal syntax in examples

## Test plan

- [x] `make test` passes (24/24)
- [x] `cosmic --docs examples` lists all examples grouped by module
- [x] `cosmic --example lib/cosmic/fetch.tl` runs both examples
- [x] `cosmic --example lib/cosmic/walk.tl` runs both examples
- [x] Help text updated for --docs

Closes #70