### PR TITLE
Separate example code into dedicated _example.tl files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,8 +189,8 @@ bootstrap: $(bootstrap_files)
 ## Build cosmic binary
 build: cosmic
 
-# Example testing - run Example_* functions in .tl files (exclude test files)
-all_example_srcs := $(call filter-only,$(foreach m,$(modules),$(filter-out $($(m)_tests),$($(m)_tl))))
+# Example testing - run Example_* functions in _example.tl files
+all_example_srcs := $(call filter-only,$(foreach m,$(modules),$($(m)_examples)))
 all_examples := $(patsubst %.tl,$(o)/%.tl.example.got,$(all_example_srcs))
 
 .PHONY: example
@@ -239,7 +239,9 @@ regen-types: | $(bootstrap_cosmic) $(cosmos_staged)
 	@echo "Type definitions regenerated from upstream cosmopolitan."
 
 # Documentation generation - render .tl files as markdown
-all_docs := $(patsubst %.tl,$(o)/docs/%.md,$(all_example_srcs))
+# Module sources for docs: all _tl files (excludes tests and examples)
+all_module_srcs := $(call filter-only,$(foreach m,$(modules),$($(m)_tl)))
+all_docs := $(patsubst %.tl,$(o)/docs/%.md,$(all_module_srcs))
 
 # Documentation from .d.tl type definition files (cosmo modules)
 dtl_files := $(wildcard lib/types/cosmo/*.d.tl)
@@ -259,7 +261,8 @@ $(o)/docs/cosmo/%.md: lib/types/cosmo/%.d.tl $(cosmic_bin) | $(bootstrap_files)
 	@$(cosmic_bin) lib/cosmic/gendoc.tl $< > $@
 
 # Generate serialized doc index for embedding (uses bootstrap cosmic to avoid circular dep)
-doc_index_srcs := $(all_example_srcs) $(dtl_files)
+# Include both module sources and example files for the index
+doc_index_srcs := $(all_module_srcs) $(all_example_srcs) $(dtl_files)
 doc_index := $(o)/docs/.index.lua
 doc_index_script := lib/cosmic/docindex.tl
 

--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -1,7 +1,8 @@
 modules += cosmic
 cosmic_srcs := $(wildcard lib/cosmic/*.tl)
 cosmic_tests := $(filter %_test.tl,$(cosmic_srcs))
-cosmic_tl := $(filter-out $(cosmic_tests) lib/cosmic/main.tl,$(cosmic_srcs))
+cosmic_examples := $(filter %_example.tl,$(cosmic_srcs))
+cosmic_tl := $(filter-out $(cosmic_tests) $(cosmic_examples) lib/cosmic/main.tl,$(cosmic_srcs))
 cosmic_main := $(o)/lib/cosmic/main.lua
 cosmic_args := lib/cosmic/.args
 cosmic_bin := $(o)/bin/cosmic

--- a/lib/cosmic/docindex.tl
+++ b/lib/cosmic/docindex.tl
@@ -10,11 +10,13 @@ local record DocIndexModule
 end
 
 --- Generate serialized documentation index from source files.
+--- Merges examples from _example.tl files into their corresponding modules.
 --- @param files List of .tl or .d.tl file paths to process
 --- @return Encoded Lua source for the index, or nil on error
 --- @return Error message if generation failed
 local function generate(files: {string}): string, string
   local modules: {string:any} = {}
+  local example_files: {string:any} = {}  -- Store example docs separately
 
   for i = 1, #files do
     local file_path = files[i]
@@ -36,7 +38,30 @@ local function generate(files: {string}): string, string
     local name = file_path:gsub("%.d%.tl$", ""):gsub("%.tl$", "")
     name = name:gsub("^lib/", ""):gsub("^types/", ""):gsub("/", ".")
 
-    modules[name] = module_doc
+    -- Check if this is an _example file
+    if name:match("_example$") then
+      -- Store example docs for later merging
+      local base_name = name:gsub("_example$", "")
+      example_files[base_name] = module_doc
+    else
+      modules[name] = module_doc
+    end
+  end
+
+  -- Merge examples from _example files into corresponding modules
+  for base_name, example_doc in pairs(example_files) do
+    local mod = modules[base_name]
+    if mod then
+      -- Merge examples into the module's examples
+      local mod_table = mod as {string:any}
+      local example_table = example_doc as {string:any}
+      if example_table.examples then
+        mod_table.examples = mod_table.examples or {}
+        for _, ex in ipairs(example_table.examples as {any}) do
+          table.insert(mod_table.examples as {any}, ex)
+        end
+      end
+    end
   end
 
   return cosmo.EncodeLua({ modules = modules })

--- a/lib/cosmic/json.tl
+++ b/lib/cosmic/json.tl
@@ -18,25 +18,6 @@ local function encode(value: any): string
   return cosmo.EncodeJson(value)
 end
 
--- Example_decode demonstrates JSON decoding
-local function Example_decode()
-  local json = require("cosmic.json")
-  local result = json.decode('{"a":1}')
-  -- result is now a Lua table
-  print(json.encode(result))
-  -- Output:
-  -- {"a":1}
-end
-
--- Example_encode demonstrates JSON encoding
-local function Example_encode()
-  local json = require("cosmic.json")
-  local result = json.encode({a = 1})
-  print(result)
-  -- Output:
-  -- {"a":1}
-end
-
 local record JsonModule
   decode: function(str: string): any
   encode: function(value: any): string

--- a/lib/cosmic/json_example.tl
+++ b/lib/cosmic/json_example.tl
@@ -1,0 +1,23 @@
+--- Examples for the cosmic.json module.
+--- Demonstrates JSON encoding and decoding.
+
+-- Example_decode demonstrates JSON decoding
+local function Example_decode()
+  local json = require("cosmic.json")
+  local result = json.decode('{"a":1}')
+  -- result is now a Lua table
+  print(json.encode(result))
+  -- Output:
+  -- {"a":1}
+end
+
+-- Example_encode demonstrates JSON encoding
+local function Example_encode()
+  local json = require("cosmic.json")
+  local result = json.encode({a = 1})
+  print(result)
+  -- Output:
+  -- {"a":1}
+end
+
+return {}

--- a/lib/cosmic/spawn.tl
+++ b/lib/cosmic/spawn.tl
@@ -237,36 +237,6 @@ local function spawn(argv: {string}, opts?: SpawnOpts): SpawnHandle, string
   return handle
 end
 
--- Example_spawn demonstrates basic process spawning
-local function Example_spawn()
-  local spawn = require("cosmic.spawn")
-  local h = spawn.spawn({"echo", "hello world"})
-  local ok, out = h:read()
-  print(out)
-  -- Output:
-  -- hello world
-end
-
--- Example_spawn_stdin demonstrates passing stdin to a process
-local function Example_spawn_stdin()
-  local spawn = require("cosmic.spawn")
-  local h = spawn.spawn({"cat"}, {stdin = "hello from stdin"})
-  local ok, out = h:read()
-  print(out)
-  -- Output:
-  -- hello from stdin
-end
-
--- Example_spawn_exit_code demonstrates checking exit codes
-local function Example_spawn_exit_code()
-  local spawn = require("cosmic.spawn")
-  local h = spawn.spawn({"sh", "-c", "exit 0"})
-  local code = h:wait()
-  print("exit code:", code)
-  -- Output:
-  -- exit code:	0
-end
-
 local record SpawnModule
   spawn: function(argv: {string}, opts?: SpawnOpts): SpawnHandle, string
   metamethod __call: function(self: SpawnModule, argv: {string}, opts?: SpawnOpts): SpawnHandle, string

--- a/lib/cosmic/spawn_example.tl
+++ b/lib/cosmic/spawn_example.tl
@@ -1,0 +1,34 @@
+--- Examples for the cosmic.spawn module.
+--- Demonstrates process spawning, stdin handling, and exit codes.
+
+-- Example_spawn demonstrates basic process spawning
+local function Example_spawn()
+  local spawn = require("cosmic.spawn")
+  local h = spawn.spawn({"echo", "hello world"})
+  local ok, out = h:read()
+  print(out)
+  -- Output:
+  -- hello world
+end
+
+-- Example_spawn_stdin demonstrates passing stdin to a process
+local function Example_spawn_stdin()
+  local spawn = require("cosmic.spawn")
+  local h = spawn.spawn({"cat"}, {stdin = "hello from stdin"})
+  local ok, out = h:read()
+  print(out)
+  -- Output:
+  -- hello from stdin
+end
+
+-- Example_spawn_exit_code demonstrates checking exit codes
+local function Example_spawn_exit_code()
+  local spawn = require("cosmic.spawn")
+  local h = spawn.spawn({"sh", "-c", "exit 0"})
+  local code = h:wait()
+  print("exit code:", code)
+  -- Output:
+  -- exit code:	0
+end
+
+return {}

--- a/lib/cosmic/sqlite.tl
+++ b/lib/cosmic/sqlite.tl
@@ -230,62 +230,6 @@ local function open(filename: string): Database, string
   return make_database(raw_db)
 end
 
--- Example_open demonstrates opening an in-memory database
-local function Example_open()
-  local sqlite = require("cosmic.sqlite")
-  local db = sqlite.open(":memory:")
-  db:exec("CREATE TABLE kv (k TEXT PRIMARY KEY, v TEXT)")
-  db:exec("INSERT INTO kv (k, v) VALUES ('hello', 'world')")
-  for row in db:query("SELECT * FROM kv") do
-    print(row.k, row.v)
-  end
-  db:close()
-  -- Output:
-  -- hello	world
-end
-
--- Example_prepared demonstrates prepared statements
-local function Example_prepared()
-  local sqlite = require("cosmic.sqlite")
-  local db = sqlite.open(":memory:")
-  db:exec("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
-
-  local stmt = db:prepare("INSERT INTO users (name) VALUES (?)")
-  stmt:bind("Alice")
-  stmt:exec()
-  stmt:reset()
-  stmt:bind("Bob")
-  stmt:exec()
-  stmt:close()
-
-  for row in db:query("SELECT * FROM users ORDER BY id") do
-    print(row.id, row.name)
-  end
-  db:close()
-  -- Output:
-  -- 1	Alice
-  -- 2	Bob
-end
-
--- Example_query_params demonstrates query with parameters
-local function Example_query_params()
-  local sqlite = require("cosmic.sqlite")
-  local db = sqlite.open(":memory:")
-  db:exec("CREATE TABLE nums (n INTEGER)")
-  for i = 1, 5 do
-    db:exec("INSERT INTO nums (n) VALUES (" .. i .. ")")
-  end
-
-  for row in db:query("SELECT * FROM nums WHERE n > ?", 2) do
-    print(row.n)
-  end
-  db:close()
-  -- Output:
-  -- 3
-  -- 4
-  -- 5
-end
-
 local record sqlite
   open: function(filename: string): Database, string
   Database: Database

--- a/lib/cosmic/sqlite_example.tl
+++ b/lib/cosmic/sqlite_example.tl
@@ -1,0 +1,60 @@
+--- Examples for the cosmic.sqlite module.
+--- Demonstrates database operations, prepared statements, and queries.
+
+-- Example_open demonstrates opening an in-memory database
+local function Example_open()
+  local sqlite = require("cosmic.sqlite")
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE kv (k TEXT PRIMARY KEY, v TEXT)")
+  db:exec("INSERT INTO kv (k, v) VALUES ('hello', 'world')")
+  for row in db:query("SELECT * FROM kv") do
+    print(row.k, row.v)
+  end
+  db:close()
+  -- Output:
+  -- hello	world
+end
+
+-- Example_prepared demonstrates prepared statements
+local function Example_prepared()
+  local sqlite = require("cosmic.sqlite")
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+
+  local stmt = db:prepare("INSERT INTO users (name) VALUES (?)")
+  stmt:bind("Alice")
+  stmt:exec()
+  stmt:reset()
+  stmt:bind("Bob")
+  stmt:exec()
+  stmt:close()
+
+  for row in db:query("SELECT * FROM users ORDER BY id") do
+    print(row.id, row.name)
+  end
+  db:close()
+  -- Output:
+  -- 1	Alice
+  -- 2	Bob
+end
+
+-- Example_query_params demonstrates query with parameters
+local function Example_query_params()
+  local sqlite = require("cosmic.sqlite")
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE nums (n INTEGER)")
+  for i = 1, 5 do
+    db:exec("INSERT INTO nums (n) VALUES (" .. i .. ")")
+  end
+
+  for row in db:query("SELECT * FROM nums WHERE n > ?", 2) do
+    print(row.n)
+  end
+  db:close()
+  -- Output:
+  -- 3
+  -- 4
+  -- 5
+end
+
+return {}


### PR DESCRIPTION
## Summary
Refactored the codebase to separate example functions from module implementations by moving them into dedicated `_example.tl` files. This improves code organization and allows examples to be managed independently while still being included in documentation.

## Key Changes

- **Created new example files**: Added `json_example.tl`, `spawn_example.tl`, and `sqlite_example.tl` containing the `Example_*` functions previously embedded in their respective modules
- **Updated module files**: Removed example functions from `json.tl`, `spawn.tl`, and `sqlite.tl` to keep modules focused on their core functionality
- **Updated build system** (`Makefile`):
  - Modified example source discovery to explicitly target `_example.tl` files via new `$(m)_examples` variable
  - Separated module sources (`all_module_srcs`) from example sources for documentation generation
  - Updated doc index generation to include both module and example sources, with logic to merge examples into their corresponding modules
- **Updated module configuration** (`lib/cosmic/cook.mk`): Added `cosmic_examples` filter to properly categorize example files alongside test files
- **Enhanced documentation indexing** (`lib/cosmic/docindex.tl`): Implemented logic to detect `_example.tl` files and merge their examples into the corresponding base module's documentation

## Implementation Details

The documentation system now intelligently merges examples from `_example.tl` files into their parent modules by:
1. Storing example documentation separately during initial processing
2. Matching example files to modules by stripping the `_example` suffix
3. Merging the examples array from example files into the corresponding module's documentation

This approach maintains backward compatibility with the documentation generation while providing cleaner separation of concerns in the source code.

https://claude.ai/code/session_01CQJAKg6rwnskvuRo88KXNL

fixes #82 