### PR TITLE
Remove types_deps assignment to fix build dependency

### DIFF
--- a/lib/types/cook.mk
+++ b/lib/types/cook.mk
@@ -1,4 +1,5 @@
 modules += types
 # Note: gentype_test.tl requires /zip/.lua/definitions.lua from cosmopolitan
 # and is not included in regular tests. Run manually with: cosmic lib/types/gentype_test.tl
-types_deps := cosmic
+# types_deps is intentionally not set - types_files are source files (.d.tl),
+# not built outputs. The regen-types target uses bootstrap_cosmic directly.


### PR DESCRIPTION
## Summary
This change removes the `types_deps := cosmic` assignment from the types build configuration and adds clarifying comments about why types files should not depend on the cosmic build target.

## Key Changes
- Removed `types_deps := cosmic` line that was creating an incorrect build dependency
- Added explanatory comments clarifying that:
  - `types_files` are source files (`.d.tl`), not built outputs
  - The `regen-types` target uses `bootstrap_cosmic` directly instead
  - This prevents unnecessary circular or incorrect dependency chains

## Implementation Details
The types module contains type definition source files that should not depend on the fully-built cosmic binary. By removing this dependency and using `bootstrap_cosmic` in the regen-types target, we ensure proper build ordering and avoid potential circular dependencies or redundant rebuilds.

https://claude.ai/code/session_01QgWZEQpWn6rzWN3VD8yEnT