### PR TITLE
cli: extend welcome to non-REPL execution paths

### DIFF
--- a/lib/cosmic/main.tl
+++ b/lib/cosmic/main.tl
@@ -556,6 +556,19 @@ local function main(): integer, string
     end
   end
 
+  -- Show welcome on first invocation for non-REPL execution (to stderr)
+  -- REPL mode handles its own welcome (to stdout) in run_repl()
+  local is_non_repl_execution = not opts.interactive and (opts.script or #opts.execute > 0 or #opts.load > 0)
+  if is_non_repl_execution then
+    local unix = require("cosmo.unix")
+    local welcome = require("cosmic.welcome")
+    local is_stderr_tty = unix.isatty(2)
+    if is_stderr_tty and not os.getenv("COSMIC_NO_WELCOME") and not welcome.was_shown() then
+      io.stderr:write(generate_welcome())
+      welcome.mark_shown()
+    end
+  end
+
   -- Load libraries
   for _, name in ipairs(opts.load) do
     require(name)


### PR DESCRIPTION
## Summary

Extends the welcome message (from #90) to show on first invocation for ALL code execution paths, not just REPL:
- `-e` (execute string)
- `-l` (load library)  
- script execution

## Changes

- Welcome goes to **stderr** for non-REPL modes (keeps stdout clean)
- REPL continues to show welcome to **stdout** via `run_repl()`
- Same state tracking via `welcome.was_shown()` / `mark_shown()`

## Motivation

Users who exclusively use `-e` mode never discovered `--docs` or `--help` because they never entered the REPL.

## Test plan

- [x] `make teal test` passes (49 type checks, 25 tests)
- [x] Existing welcome_test.tl covers the shared state tracking
- [x] Manual verification:
  - `cosmic -e 'print(1)'` shows welcome on stderr (first run, TTY)
  - `cosmic script.lua` shows welcome on stderr (first run, TTY)
  - `cosmic` (REPL) shows welcome on stdout (first run, TTY)
  - Second invocation does NOT show welcome (already shown)
  - Non-TTY stderr suppresses welcome
  - `COSMIC_NO_WELCOME=1` suppresses welcome