### PR TITLE
json: return errors instead of throwing

### DIFF
--- a/lib/cosmic/json.tl
+++ b/lib/cosmic/json.tl
@@ -6,21 +6,25 @@ local cosmo = require("cosmo")
 --- Converts JSON strings, numbers, booleans, arrays, and objects into their Lua equivalents.
 --- @param str string The JSON string to decode
 --- @return any The decoded Lua value (table, string, number, boolean, or nil)
-local function decode(str: string): any
-  return cosmo.DecodeJson(str)
+--- @return string? Error message if decoding failed
+local function decode(str: string): any, string
+  local result, err = cosmo.DecodeJson(str)
+  return result, err as string
 end
 
 --- Encode a Lua value as a JSON string.
 --- Converts Lua tables, strings, numbers, booleans, and nil into JSON format.
 --- @param value any The Lua value to encode
 --- @return string The JSON string representation
-local function encode(value: any): string
-  return cosmo.EncodeJson(value)
+--- @return string? Error message if encoding failed
+local function encode(value: any): string, string
+  local result, err = cosmo.EncodeJson(value)
+  return result as string, err as string
 end
 
 local record JsonModule
-  decode: function(str: string): any
-  encode: function(value: any): string
+  decode: function(str: string): any, string
+  encode: function(value: any): string, string
 end
 
 local M: JsonModule = {

--- a/lib/cosmic/json_example.tl
+++ b/lib/cosmic/json_example.tl
@@ -6,7 +6,7 @@ local function Example_decode()
   local json = require("cosmic.json")
   local result = json.decode('{"a":1}')
   -- result is now a Lua table
-  print(json.encode(result))
+  print((json.encode(result)))
   -- Output:
   -- {"a":1}
 end
@@ -18,6 +18,28 @@ local function Example_encode()
   print(result)
   -- Output:
   -- {"a":1}
+end
+
+-- Example_decode_error demonstrates error handling for invalid JSON
+local function Example_decode_error()
+  local json = require("cosmic.json")
+  local result, err = json.decode("{invalid}")
+  if err then
+    print("decode error: " .. err)
+  end
+  -- Output:
+  -- decode error: illegal character
+end
+
+-- Example_encode_error demonstrates error handling for unencodable values
+local function Example_encode_error()
+  local json = require("cosmic.json")
+  local result, err = json.encode(function() end)
+  if err then
+    print("encode error: " .. err)
+  end
+  -- Output:
+  -- encode error: unsupported lua type
 end
 
 return {}

--- a/lib/cosmic/json_test.tl
+++ b/lib/cosmic/json_test.tl
@@ -56,3 +56,33 @@ local function test_roundtrip()
   assert(nested.flag == original.nested.flag, "nested flag mismatch")
 end
 test_roundtrip()
+
+local function test_decode_invalid_json()
+  local result, err = json.decode("{invalid json}")
+  assert(result == nil, "expected nil for invalid json")
+  assert(err ~= nil, "expected error message")
+  assert(type(err) == "string", "error should be a string")
+end
+test_decode_invalid_json()
+
+local function test_decode_truncated_json()
+  local result, err = json.decode('{"key":')
+  assert(result == nil, "expected nil for truncated json")
+  assert(err ~= nil, "expected error message for truncated json")
+end
+test_decode_truncated_json()
+
+local function test_decode_empty_string()
+  local result, err = json.decode("")
+  assert(result == nil, "expected nil for empty string")
+  assert(err ~= nil, "expected error message for empty string")
+end
+test_decode_empty_string()
+
+local function test_encode_invalid_value()
+  local result, err = json.encode(function() end)
+  assert(result == nil, "expected nil for function")
+  assert(err ~= nil, "expected error message for function")
+  assert(type(err) == "string", "error should be a string")
+end
+test_encode_invalid_value()

--- a/lib/types/cosmo.d.tl
+++ b/lib/types/cosmo.d.tl
@@ -13,8 +13,8 @@ local record cosmo
 
   -- encoding
   EncodeHex: function(data: string): string
-  EncodeJson: function(value: any): string
-  DecodeJson: function(json: string): any
+  EncodeJson: function(value: any): string, string
+  DecodeJson: function(json: string): any, string
   EncodeLua: function(value: any, opts?: {string:any}): string
 
   -- system info


### PR DESCRIPTION
## Summary

- Change `decode()` and `encode()` to return `(value, error)` instead of throwing
- Add error handling tests for invalid JSON, truncated JSON, empty strings, and unencodable values
- Add examples demonstrating error handling patterns

Backwards compatible - existing code that ignores the second return value continues to work.

Closes #94

## Test plan

- [x] `make test` passes
- [x] `make example` passes