### PR TITLE
Add CLAUDE.md: error handling guidelines for cosmic library

### DIFF
--- a/lib/cosmic/CLAUDE.md
+++ b/lib/cosmic/CLAUDE.md
@@ -1,0 +1,183 @@
+# CLAUDE.md - cosmic library modules
+
+Guidelines for function signatures and error handling in `lib/cosmic/` modules.
+
+## Error Handling Patterns
+
+### Primary Pattern: Value + Error String
+
+Most functions should return `value, string` where the second return is an error message on failure:
+
+```teal
+--- Good: Returns value on success, nil + error on failure
+local function decode(str: string): any, string
+  local result, err = cosmo.DecodeJson(str)
+  return result, err as string
+end
+
+--- Good: Returns boolean success + error on failure
+function db:exec(sql: string): boolean, string
+  local rc = raw_db:exec(sql)
+  if rc ~= sqlite3.OK then
+    return false, raw_db:errmsg()
+  end
+  return true
+end
+
+--- Good: Prepare can fail, returns nil + error
+function db:prepare(sql: string): Statement, string
+  local raw_stmt, errcode, errmsg = raw_db:prepare(sql)
+  if not raw_stmt then
+    return nil, errmsg or ("error code " .. tostring(errcode))
+  end
+  return make_statement(raw_stmt, raw_db)
+end
+```
+
+Callers handle errors naturally:
+
+```teal
+local data, err = json.decode(input)
+if not data then
+  print("parse failed: " .. err)
+  return
+end
+```
+
+### Result Records: For Complex Operations
+
+Use a Result record when operations have multiple error states or rich success metadata:
+
+```teal
+--- Good: Result record for HTTP with status, headers, body
+local record Result
+  ok: boolean
+  status: number
+  headers: {string:string}
+  body: string
+  error: string
+end
+
+local function Fetch(url: string, opts?: Opts): Result
+  local status, headers_or_err, body = cosmo.Fetch(url, opts)
+
+  if not status then
+    return {ok = false, error = tostring(headers_or_err or "unknown error")}
+  end
+
+  return {
+    ok = true,
+    status = status,
+    headers = headers_or_err as {string:string},
+    body = body,
+  }
+end
+```
+
+Result records are appropriate when:
+- Success returns multiple related values (status + headers + body)
+- Multiple distinct error conditions need different handling
+- The API wraps an unreliable external service
+
+### Patterns to Avoid
+
+**Never throw exceptions from library code:**
+
+```teal
+--- Bad: Throws instead of returning error
+function db:query(sql: string): function(): {string:any}
+  local stmt, err = self:prepare(sql)
+  if not stmt then
+    error("query failed: " .. err)  -- Don't do this
+  end
+  ...
+end
+
+--- Good: Return error through the iterator or use prepare+rows pattern
+local stmt, err = db:prepare(sql)
+if not stmt then
+  print("query failed: " .. err)
+  return
+end
+for row in stmt:rows() do
+  ...
+end
+```
+
+**Never silently discard errors:**
+
+```teal
+--- Bad: Silent failure, caller can't tell what went wrong
+local function walk(dir: string): Context
+  local handle = io.open(dir)
+  if not handle then
+    return {}  -- Silently returns empty result
+  end
+  ...
+end
+
+--- Good: Return error as second value
+local function walk(dir: string): Context, string
+  local handle, err = io.open(dir)
+  if not handle then
+    return {}, "cannot open directory: " .. (err or dir)
+  end
+  ...
+end
+```
+
+**Never mix patterns in the same module:**
+
+```teal
+--- Bad: prepare() returns errors, query() throws, exec() returns boolean
+function db:prepare(sql: string): Statement, string     -- returns error
+function db:query(sql: string): function(): Row         -- throws error
+function db:exec(sql: string): boolean, string          -- returns error
+
+--- Good: All methods use the same pattern
+function db:prepare(sql: string): Statement, string
+function db:exec(sql: string): boolean, string
+-- For query, use prepare() + rows() so errors surface at prepare time
+```
+
+## Type Signatures
+
+Document error returns in the type signature:
+
+```teal
+--- Good: Type shows this can fail
+local record Module
+  decode: function(str: string): any, string
+  encode: function(value: any): string, string
+end
+
+--- Good: Method types show error possibility
+local record Database
+  prepare: function(self: Database, sql: string): Statement, string
+  exec: function(self: Database, sql: string): boolean, string
+end
+```
+
+## Doc Comments
+
+Use `---` comments with `@param` and `@return` tags:
+
+```teal
+--- Decode a JSON string into a Lua value.
+--- @param str string The JSON string to decode
+--- @return any The decoded Lua value
+--- @return string? Error message if decoding failed
+local function decode(str: string): any, string
+```
+
+## Summary
+
+| Situation | Pattern |
+|-----------|---------|
+| Simple operations | `value, string` (nil + error on failure) |
+| Boolean success/fail | `boolean, string` (false + error on failure) |
+| Complex results | Result record with `ok: boolean` and `error: string` |
+| Resource creation | `Handle, string` with `__close` metamethod |
+| Iteration | Return iterator from successful prepare; errors at prepare time |
+
+Consistency within a module matters more than which specific pattern you choose. Pick one and use it throughout.


### PR DESCRIPTION
## Summary

Add comprehensive documentation for error handling patterns and function signatures in the `lib/cosmic/` modules. This establishes consistent conventions for how library functions should report errors and structure their return values.

## Changes

- **New file: `lib/cosmic/CLAUDE.md`** - Guidelines document covering:
  - Primary error handling pattern: `value, string` returns (nil/false + error message on failure)
  - Result record pattern for complex operations with multiple error states
  - Anti-patterns to avoid: throwing exceptions, silent failures, mixing patterns
  - Type signature documentation standards
  - Doc comment conventions with `@param` and `@return` tags
  - Summary table of patterns for different situations

## Key Points

The guidelines establish that:
1. **Most functions should return `(value, error_string)`** - callers naturally check if the first return is nil/false
2. **Result records are for complex cases** - when operations return multiple related values (e.g., HTTP status + headers + body) or have multiple distinct error conditions
3. **Consistency within a module is critical** - pick one pattern and use it throughout rather than mixing approaches
4. **Library code should never throw exceptions** - errors should be returned as values so callers can handle them gracefully
5. **Errors should never be silently discarded** - always propagate error information to the caller

This document serves as a reference for maintaining consistent, predictable error handling across the cosmic library.

https://claude.ai/code/session_01S51mpLpnyqdRYsY1iqseWL