### PR TITLE
url: add encoding and decoding module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,16 @@ bootstrap: $(bootstrap_files)
 ## Build cosmic binary
 build: cosmic
 
+.PHONY: stage1
+## CI stage 1: build cosmic and refresh bootstrap with updated bundled types
+stage1: $(cosmic_bin)
+	@cp $(cosmic_bin) $(bootstrap_cosmic)
+	@echo "Bootstrap refreshed from $(cosmic_bin)"
+
+.PHONY: stage2
+## CI stage 2: type check and test with refreshed bootstrap (alias for ci)
+stage2: ci
+
 # Example testing - run Example_* functions in _example.tl files
 all_example_srcs := $(call filter-only,$(foreach m,$(modules),$($(m)_examples)))
 all_examples := $(patsubst %.tl,$(o)/%.tl.example.got,$(all_example_srcs))
@@ -280,10 +290,11 @@ doc-publish: $(all_docs) $(docs_publish) | $(bootstrap_cosmic)
 	@test -n "$(SOURCE_SHA)" || { echo "SOURCE_SHA required"; exit 1; }
 	@$(bootstrap_cosmic) -- $(docs_publish) $(SOURCE_SHA) $(o)/docs $(or $(DOCS_BRANCH),docs)
 
-ci_stages := teal test example build
+# CI stages: iterate with --keep-going to report all failures
+ci_stages := teal test example
 
 .PHONY: ci
-## Run full CI pipeline (teal, test, example, build)
+## Run CI checks (teal, test, example) - run stage1 first to refresh bootstrap
 ci:
 	@rm -f $(o)/failed
 	@$(foreach s,$(ci_stages),\

--- a/lib/cosmic/teal.tl
+++ b/lib/cosmic/teal.tl
@@ -44,9 +44,9 @@ end
 --- @return {string} List of default include directory paths
 local function get_default_include_dirs(): {string}
   return {
+    "lib/types",             -- Local cosmic types (development, takes precedence)
     "/zip/.lua/types",       -- Bundled cosmic types (in binary)
     "/zip/.lua/teal-types",  -- Bundled third-party types (in binary)
-    "lib/types",             -- Local cosmic types (development)
   }
 end
 

--- a/lib/cosmic/url.tl
+++ b/lib/cosmic/url.tl
@@ -1,0 +1,42 @@
+--- URL encoding and decoding utilities.
+--- Wraps cosmo.EscapeParam for encoding; manual decode for percent-encoded strings.
+local cosmo = require("cosmo")
+
+--- Encode a string for use in URL query parameters.
+--- Spaces become %20, special characters become %XX.
+--- @param str string The string to encode
+--- @return string The percent-encoded string
+local function encode(str: string): string
+  return cosmo.EscapeParam(str)
+end
+
+--- Decode a percent-encoded string.
+--- Handles %XX sequences and + as space.
+--- @param str string The percent-encoded string
+--- @return string The decoded string, or nil on error
+--- @return string? Error message if decoding failed
+local function decode(str: string): string, string
+  -- Replace + with space first
+  local s = str:gsub("+", " ")
+  -- Decode valid %XX sequences
+  local result = s:gsub("%%(%x%x)", function(hex: string): string
+    return string.char(tonumber(hex, 16) as integer)
+  end)
+  -- Check for remaining % characters (invalid sequences that weren't decoded)
+  if result:match("%%") then
+    return nil, "invalid percent-encoding"
+  end
+  return result, nil
+end
+
+local record UrlModule
+  encode: function(str: string): string
+  decode: function(str: string): string, string
+end
+
+local M: UrlModule = {
+  encode = encode,
+  decode = decode,
+}
+
+return M

--- a/lib/cosmic/url_test.tl
+++ b/lib/cosmic/url_test.tl
@@ -1,0 +1,112 @@
+#!/usr/bin/env cosmic
+local url = require("cosmic.url")
+
+local function test_encode_spaces()
+  local result = url.encode("hello world")
+  assert(result == "hello%20world", "expected 'hello%20world', got '" .. result .. "'")
+end
+test_encode_spaces()
+
+local function test_encode_special_chars()
+  local result = url.encode("a,b&c=d")
+  assert(result:match("%%2C"), "expected comma to be encoded")
+  assert(result:match("%%26"), "expected ampersand to be encoded")
+  assert(result:match("%%3D"), "expected equals to be encoded")
+end
+test_encode_special_chars()
+
+local function test_encode_unreserved_chars()
+  -- Most unreserved characters should not be encoded: A-Z a-z 0-9 - _ .
+  -- Note: cosmo.EscapeParam encodes ~ as %7E (conservative but valid)
+  local result = url.encode("ABC-xyz_123.test")
+  assert(result == "ABC-xyz_123.test", "unreserved chars should pass through, got '" .. result .. "'")
+end
+test_encode_unreserved_chars()
+
+local function test_decode_percent_sequences()
+  local result = url.decode("hello%20world")
+  assert(result == "hello world", "expected 'hello world', got '" .. result .. "'")
+end
+test_decode_percent_sequences()
+
+local function test_decode_plus_as_space()
+  local result = url.decode("hello+world")
+  assert(result == "hello world", "expected 'hello world', got '" .. result .. "'")
+end
+test_decode_plus_as_space()
+
+local function test_decode_mixed()
+  local result = url.decode("a%2Cb%26c%3Dd")
+  assert(result == "a,b&c=d", "expected 'a,b&c=d', got '" .. result .. "'")
+end
+test_decode_mixed()
+
+local function test_roundtrip_basic()
+  local original = "hello world"
+  local encoded = url.encode(original)
+  local decoded = url.decode(encoded)
+  assert(decoded == original, "roundtrip failed: expected '" .. original .. "', got '" .. decoded .. "'")
+end
+test_roundtrip_basic()
+
+local function test_roundtrip_special()
+  local original = "name=value&foo=bar"
+  local encoded = url.encode(original)
+  local decoded = url.decode(encoded)
+  assert(decoded == original, "roundtrip failed: expected '" .. original .. "', got '" .. decoded .. "'")
+end
+test_roundtrip_special()
+
+local function test_roundtrip_unicode()
+  local original = "日本語テスト"
+  local encoded = url.encode(original)
+  local decoded = url.decode(encoded)
+  assert(decoded == original, "unicode roundtrip failed")
+end
+test_roundtrip_unicode()
+
+local function test_decode_invalid_trailing_percent()
+  local result, err = url.decode("test%")
+  assert(result == nil, "expected nil for trailing %")
+  assert(err ~= nil, "expected error message")
+  assert(err == "invalid percent-encoding", "expected 'invalid percent-encoding', got '" .. err .. "'")
+end
+test_decode_invalid_trailing_percent()
+
+local function test_decode_invalid_single_hex()
+  local result, err = url.decode("test%A")
+  assert(result == nil, "expected nil for single hex digit")
+  assert(err ~= nil, "expected error message")
+end
+test_decode_invalid_single_hex()
+
+local function test_decode_invalid_non_hex()
+  local result, err = url.decode("test%ZZ")
+  assert(result == nil, "expected nil for non-hex digits")
+  assert(err ~= nil, "expected error message")
+end
+test_decode_invalid_non_hex()
+
+local function test_decode_empty_string()
+  local result = url.decode("")
+  assert(result == "", "expected empty string")
+end
+test_decode_empty_string()
+
+local function test_encode_empty_string()
+  local result = url.encode("")
+  assert(result == "", "expected empty string")
+end
+test_encode_empty_string()
+
+local function test_decode_lowercase_hex()
+  local result = url.decode("%2f%3a")
+  assert(result == "/:", "expected '/:' for lowercase hex, got '" .. result .. "'")
+end
+test_decode_lowercase_hex()
+
+local function test_decode_uppercase_hex()
+  local result = url.decode("%2F%3A")
+  assert(result == "/:", "expected '/:' for uppercase hex, got '" .. result .. "'")
+end
+test_decode_uppercase_hex()

--- a/lib/types/cosmo.d.tl
+++ b/lib/types/cosmo.d.tl
@@ -17,6 +17,10 @@ local record cosmo
   DecodeJson: function(json: string): any, string
   EncodeLua: function(value: any, opts?: {string:any}): string
 
+  -- url encoding
+  EscapeParam: function(str: string): string
+  ParseParams: function(query: string): {string:string}
+
   -- system info
   GetHostOs: function(): string
   GetHostIsa: function(): string


### PR DESCRIPTION
## Summary

- Add `cosmic.url` module with `encode()` and `decode()` functions for URL percent-encoding
- Add two-stage CI build to handle bootstrap type updates

## Changes

- `lib/cosmic/url.tl` - URL encoding/decoding using `cosmo.EscapeParam`
- `lib/cosmic/url_test.tl` - comprehensive tests
- `lib/types/cosmo.d.tl` - add `EscapeParam` and `ParseParams` type declarations
- `lib/cosmic/teal.tl` - put local types first in include order
- `Makefile` - add `stage1`/`stage2` CI targets

## CI two-stage build

The CI now runs in two stages:
1. **stage1**: Build cosmic and refresh bootstrap with updated bundled types
2. **stage2**: Type check and test with the refreshed bootstrap

This ensures new type definitions work even when the downloaded bootstrap has older bundled types.

## Test plan

- [x] `make test` passes
- [x] URL encode/decode roundtrips work
- [x] Invalid percent-encoding returns errors

Closes #93