### PR TITLE
sqlite: add parameterized exec

### DIFF
--- a/lib/cosmic/sqlite.tl
+++ b/lib/cosmic/sqlite.tl
@@ -48,7 +48,7 @@ end
 local record Database
   prepare: function(self: Database, sql: string): Statement, string
   query: function(self: Database, sql: string, ...: any): function(): {string:any}
-  exec: function(self: Database, sql: string): boolean, string
+  exec: function(self: Database, sql: string, ...: any): boolean, string
   last_insert_rowid: function(self: Database): number
   changes: function(self: Database): number
   close: function(self: Database)
@@ -190,12 +190,32 @@ local function make_database(raw_db: RawDatabase): Database
     end
   end
 
-  function db:exec(sql: string): boolean, string
-    local rc = raw_db:exec(sql)
-    if rc ~= sqlite3.OK then
-      return false, raw_db:errmsg()
+  function db:exec(sql: string, ...: any): boolean, string
+    local args = {...}
+    if #args == 0 then
+      -- no params: use raw exec (faster for DDL)
+      local rc = raw_db:exec(sql)
+      if rc ~= sqlite3.OK then
+        return false, raw_db:errmsg()
+      end
+      return true
     end
-    return true
+
+    -- has params: prepare/bind/exec
+    local stmt, err = self:prepare(sql)
+    if not stmt then
+      return false, err or "prepare failed"
+    end
+
+    local ok, bind_err = stmt:bind(table.unpack(args))
+    if not ok then
+      stmt:close()
+      return false, bind_err or "bind failed"
+    end
+
+    local exec_ok, exec_err = stmt:exec()
+    stmt:close()
+    return exec_ok, exec_err
   end
 
   function db:last_insert_rowid(): number

--- a/lib/cosmic/sqlite_example.tl
+++ b/lib/cosmic/sqlite_example.tl
@@ -57,4 +57,24 @@ local function Example_query_params()
   -- 5
 end
 
+-- Example_exec_params demonstrates exec with parameter binding
+local function Example_exec_params()
+  local sqlite = require("cosmic.sqlite")
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE cities (id INTEGER PRIMARY KEY, name TEXT, pop INTEGER)")
+
+  db:exec("INSERT INTO cities (name, pop) VALUES (?, ?)", "Tokyo", 13960000)
+  db:exec("INSERT INTO cities (name, pop) VALUES (?, ?)", "Delhi", 16787941)
+  db:exec("INSERT INTO cities (name, pop) VALUES (?, ?)", "Shanghai", 24870895)
+
+  for row in db:query("SELECT * FROM cities ORDER BY pop DESC") do
+    print(row.name, row.pop)
+  end
+  db:close()
+  -- Output:
+  -- Shanghai	24870895
+  -- Delhi	16787941
+  -- Tokyo	13960000
+end
+
 return {}

--- a/lib/cosmic/sqlite_test.tl
+++ b/lib/cosmic/sqlite_test.tl
@@ -71,6 +71,50 @@ local function test_changes()
 end
 test_changes()
 
+local function test_exec_with_params()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+
+  local ok, err = db:exec("INSERT INTO t (name) VALUES (?)", "Alice")
+  assert(ok, "exec with param should succeed: " .. tostring(err))
+  assert(db:last_insert_rowid() == 1, "should have inserted row")
+
+  ok, err = db:exec("UPDATE t SET name = ? WHERE id = ?", "Bob", 1)
+  assert(ok, "exec update should succeed: " .. tostring(err))
+
+  ok, err = db:exec("DELETE FROM t WHERE name = ?", "Bob")
+  assert(ok, "exec delete should succeed: " .. tostring(err))
+  assert(db:changes() == 1, "should have deleted 1 row")
+  db:close()
+end
+test_exec_with_params()
+
+local function test_exec_multiple_params()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (a TEXT, b INTEGER, c REAL)")
+
+  local ok, err = db:exec("INSERT INTO t (a, b, c) VALUES (?, ?, ?)", "hello", 42, 3.14)
+  assert(ok, "exec with multiple params should succeed: " .. tostring(err))
+
+  for row in db:query("SELECT * FROM t") do
+    assert(row.a == "hello", "a should be 'hello'")
+    assert(row.b == 42, "b should be 42")
+    assert(math.abs((row.c as number) - 3.14) < 0.001, "c should be ~3.14")
+  end
+  db:close()
+end
+test_exec_multiple_params()
+
+local function test_exec_no_params()
+  local db = sqlite.open(":memory:")
+  local ok, err = db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+  assert(ok, "exec without params should succeed: " .. tostring(err))
+  ok, err = db:exec("INSERT INTO t DEFAULT VALUES")
+  assert(ok, "exec without params should succeed: " .. tostring(err))
+  db:close()
+end
+test_exec_no_params()
+
 -- Prepared statements
 
 local function test_prepare_bind_exec()


### PR DESCRIPTION
## Summary
- Extend `db:exec()` to accept optional bind parameters
- No params: uses raw exec (fast path for DDL)
- With params: uses prepare/bind/exec pattern
- Backwards compatible with existing code

## Test plan
- [x] `test_exec_with_params` - INSERT/UPDATE/DELETE with parameters
- [x] `test_exec_multiple_params` - multiple bind values  
- [x] `test_exec_no_params` - existing behavior unchanged
- [x] `Example_exec_params` - demonstrates city population inserts

Closes #95