### PR TITLE
docs: explain cosmic vs cosmo distinction

### DIFF
--- a/lib/cosmic/binary_test.tl
+++ b/lib/cosmic/binary_test.tl
@@ -39,6 +39,7 @@ local function test_cosmic_help()
   assert(ok, "cosmic --help exited with error")
   assert((out as string):find("cosmic", 1, true), "expected output to contain 'cosmic'")
   assert((out as string):find("%-%-help", 1, false), "expected output to contain '--help'")
+  assert((out as string):find("Tip: Use cosmic", 1, true), "expected output to contain cosmic vs cosmo tip")
 end
 test_cosmic_help()
 

--- a/lib/cosmic/docs.tl
+++ b/lib/cosmic/docs.tl
@@ -68,6 +68,11 @@ end
 
 local INDEX_PATH = "/zip/.docs/index.lua"
 
+-- Map low-level cosmo modules to their high-level cosmic equivalents
+local COSMIC_EQUIVALENTS: {string: string} = {
+  ["cosmo.lsqlite3"] = "cosmic.sqlite",
+}
+
 -- Cached index
 local cached_index: DocIndex = nil
 
@@ -317,6 +322,13 @@ local function render_module(name: string, doc: ModuleDoc): string
 
   if doc.module_doc then
     table.insert(lines, doc.module_doc)
+    table.insert(lines, "")
+  end
+
+  -- Show tip if this cosmo module has a cosmic equivalent
+  local equivalent = COSMIC_EQUIVALENTS[name]
+  if equivalent then
+    table.insert(lines, "**Tip:** For a high-level API, see `" .. equivalent .. "`.")
     table.insert(lines, "")
   end
 

--- a/lib/cosmic/docs_test.tl
+++ b/lib/cosmic/docs_test.tl
@@ -181,6 +181,20 @@ local function test_run_method()
 end
 test_run_method()
 
+-- Test cosmo module shows tip about cosmic equivalent
+local function test_cosmic_equivalent_tip()
+  local result = docs.run("cosmo.lsqlite3")
+  assert(result, "run should return a result")
+  if result.ok then
+    assert(result.output:find("cosmic.sqlite", 1, true),
+           "cosmo.lsqlite3 docs should mention cosmic.sqlite equivalent")
+    assert(result.output:find("Tip:", 1, true),
+           "cosmo.lsqlite3 docs should show tip")
+  end
+  print("test_cosmic_equivalent_tip: PASS")
+end
+test_cosmic_equivalent_tip()
+
 -- Test search finds bind methods
 local function test_search_bind_methods()
   local results = docs.search("bind")

--- a/lib/cosmic/main.tl
+++ b/lib/cosmic/main.tl
@@ -400,6 +400,8 @@ local function generate_help(): string
         end
 
         table.insert(lines, "")
+        table.insert(lines, "  Tip: Use cosmic.* for high-level APIs. Use cosmo.* for low-level bindings.")
+        table.insert(lines, "")
       end
     end
   end


### PR DESCRIPTION
## Summary
- Add tip to `--help` output after module listing explaining cosmic.* vs cosmo.*
- Add cross-reference in `--docs cosmo.lsqlite3` pointing to `cosmic.sqlite`
- Add tests for both features

Closes #86

## Test plan
- [x] `make teal` passes
- [x] `make test` passes
- [x] `cosmic --help` shows tip
- [x] `cosmic --docs cosmo.lsqlite3` shows tip about cosmic.sqlite