### PR TITLE
Add cosmic.io module for file descriptor I/O operations

### DIFF
--- a/lib/cosmic/io.tl
+++ b/lib/cosmic/io.tl
@@ -1,0 +1,374 @@
+--- File descriptor I/O operations.
+--- Wraps low-level file descriptor operations from cosmo.unix.
+local raw_unix = require("cosmo.unix")
+local cosmo = require("cosmo")
+
+--- Result from a pipe operation.
+local record PipeResult
+  reader: number
+  writer: number
+end
+
+-- Internal record with proper error return signatures for cosmo.unix functions
+-- The actual cosmo.unix returns Errno objects on failure, but the .d.tl types
+-- don't reflect this. We cast to our own type with correct signatures.
+local record UnixIO
+  open: function(path: string, flags: number, mode?: number, dirfd?: number): number, any
+  close: function(fd: number): boolean, any
+  read: function(fd: number, bufsiz?: number, offset?: number): string, any
+  write: function(fd: number, data: string, offset?: number): number, any
+  lseek: function(fd: number, offset: number, whence?: number): number, any
+  truncate: function(path: string, length?: number): boolean, any
+  ftruncate: function(fd: number, length?: number): boolean, any
+  dup: function(oldfd: number, newfd?: number, flags?: number, lowest?: number): number, any
+  pipe: function(flags?: number): number, number | any
+  fcntl: function(fd: number, cmd: number, ...: any): any
+  sync: function()
+  fsync: function(fd: number): boolean, any
+  fdatasync: function(fd: number): boolean, any
+
+  -- Constants
+  O_RDONLY: number
+  O_WRONLY: number
+  O_RDWR: number
+  O_CREAT: number
+  O_TRUNC: number
+  O_APPEND: number
+  O_EXCL: number
+  O_CLOEXEC: number
+  O_NONBLOCK: number
+  O_DIRECT: number
+  O_DIRECTORY: number
+  O_NOFOLLOW: number
+  SEEK_SET: number
+  SEEK_CUR: number
+  SEEK_END: number
+  F_GETFD: number
+  F_SETFD: number
+  F_GETFL: number
+  F_SETFL: number
+  F_SETLK: number
+  F_SETLKW: number
+  F_RDLCK: number
+  F_WRLCK: number
+  F_UNLCK: number
+  FD_CLOEXEC: number
+  AT_FDCWD: number
+end
+
+local unix = raw_unix as UnixIO
+
+--- Opens a file and returns a file descriptor.
+--- @param path string The path to the file
+--- @param flags number Bitwise OR of O_* flags (e.g., O_RDONLY, O_WRONLY | O_CREAT)
+--- @param mode number Optional file mode for creation (e.g., 0644)
+--- @param dirfd number Optional directory file descriptor for relative paths
+--- @return number File descriptor on success
+--- @return string Error message on failure
+local function open(path: string, flags: number, mode?: number, dirfd?: number): number, string
+  local fd, err = unix.open(path, flags, mode, dirfd)
+  if not fd then
+    return nil, tostring(err)
+  end
+  return fd
+end
+
+--- Closes a file descriptor.
+--- @param fd number The file descriptor to close
+--- @return boolean True on success
+--- @return string Error message on failure
+local function close(fd: number): boolean, string
+  local ok, err = unix.close(fd)
+  if not ok then
+    return false, tostring(err)
+  end
+  return true
+end
+
+--- Reads from a file descriptor.
+--- Returns empty string on end of file.
+--- @param fd number The file descriptor to read from
+--- @param size number Optional maximum bytes to read (default: BUFSIZ)
+--- @param offset number Optional offset for pread behavior
+--- @return string Data read on success
+--- @return string Error message on failure
+local function read(fd: number, size?: number, offset?: number): string, string
+  local data, err = unix.read(fd, size, offset)
+  if data == nil and err then
+    return nil, tostring(err)
+  end
+  return data or ""
+end
+
+--- Writes to a file descriptor.
+--- @param fd number The file descriptor to write to
+--- @param data string The data to write
+--- @param offset number Optional offset for pwrite behavior
+--- @return number Number of bytes written on success
+--- @return string Error message on failure
+local function write(fd: number, data: string, offset?: number): number, string
+  local n, err = unix.write(fd, data, offset)
+  if not n then
+    return nil, tostring(err)
+  end
+  return n
+end
+
+--- Seeks to a position in a file.
+--- @param fd number The file descriptor
+--- @param offset number The offset to seek to
+--- @param whence number Optional seek mode: SEEK_SET (default), SEEK_CUR, or SEEK_END
+--- @return number New position from start of file
+--- @return string Error message on failure
+local function lseek(fd: number, offset: number, whence?: number): number, string
+  local pos, err = unix.lseek(fd, offset, whence)
+  if not pos then
+    return nil, tostring(err)
+  end
+  return pos
+end
+
+--- Truncates a file to a specified length.
+--- @param path string The path to the file
+--- @param length number Optional new length (default: 0)
+--- @return boolean True on success
+--- @return string Error message on failure
+local function truncate(path: string, length?: number): boolean, string
+  local ok, err = unix.truncate(path, length)
+  if not ok then
+    return false, tostring(err)
+  end
+  return true
+end
+
+--- Truncates an open file to a specified length.
+--- @param fd number The file descriptor
+--- @param length number Optional new length (default: 0)
+--- @return boolean True on success
+--- @return string Error message on failure
+local function ftruncate(fd: number, length?: number): boolean, string
+  local ok, err = unix.ftruncate(fd, length)
+  if not ok then
+    return false, tostring(err)
+  end
+  return true
+end
+
+--- Duplicates a file descriptor.
+--- @param oldfd number The file descriptor to duplicate
+--- @param newfd number Optional specific fd number to use
+--- @param flags number Optional flags (e.g., O_CLOEXEC)
+--- @param lowest number Optional lowest acceptable fd number
+--- @return number New file descriptor on success
+--- @return string Error message on failure
+local function dup(oldfd: number, newfd?: number, flags?: number, lowest?: number): number, string
+  local fd, err = unix.dup(oldfd, newfd, flags, lowest)
+  if not fd then
+    return nil, tostring(err)
+  end
+  return fd
+end
+
+--- Creates a pipe for inter-process communication.
+--- @param flags number Optional flags (O_CLOEXEC, O_NONBLOCK, O_DIRECT)
+--- @return PipeResult Table with reader and writer file descriptors
+--- @return string Error message on failure
+local function pipe(flags?: number): PipeResult, string
+  local reader, writer = unix.pipe(flags)
+  if not reader then
+    return nil, tostring(writer)
+  end
+  return { reader = reader, writer = writer as number }
+end
+
+--- Performs file control operations.
+--- @param fd number The file descriptor
+--- @param cmd number The command (F_GETFD, F_SETFD, F_GETFL, F_SETFL, etc.)
+--- @param ... any Command-specific arguments
+--- @return any Command-specific return value
+local function fcntl(fd: number, cmd: number, ...: any): any
+  return unix.fcntl(fd, cmd, ...)
+end
+
+--- Flushes all file system buffers to disk.
+local function sync()
+  unix.sync()
+end
+
+--- Flushes file data and metadata to disk.
+--- @param fd number The file descriptor
+--- @return boolean True on success
+--- @return string Error message on failure
+local function fsync(fd: number): boolean, string
+  local ok, err = unix.fsync(fd)
+  if not ok then
+    return false, tostring(err)
+  end
+  return true
+end
+
+--- Flushes file data to disk (but not necessarily metadata).
+--- @param fd number The file descriptor
+--- @return boolean True on success
+--- @return string Error message on failure
+local function fdatasync(fd: number): boolean, string
+  local ok, err = unix.fdatasync(fd)
+  if not ok then
+    return false, tostring(err)
+  end
+  return true
+end
+
+--- Reads entire file contents.
+--- @param path string The path to the file
+--- @return string File contents on success
+--- @return string Error message on failure (nil contents)
+local function slurp(path: string): string, string
+  local data = cosmo.Slurp(path)
+  if not data then
+    return nil, "failed to read file: " .. path
+  end
+  return data
+end
+
+--- Writes data to a file, creating or overwriting it.
+--- @param path string The path to the file
+--- @param data string The data to write
+--- @param mode number Optional file mode (e.g., 0644)
+--- @return boolean True on success
+--- @return string Error message on failure
+local function barf(path: string, data: string, mode?: number): boolean, string
+  local ok = cosmo.Barf(path, data, mode)
+  if not ok then
+    return false, "failed to write file: " .. path
+  end
+  return true
+end
+
+local record IoModule
+  -- High-level file operations
+  slurp: function(path: string): string, string
+  barf: function(path: string, data: string, mode?: number): boolean, string
+
+  -- Core operations
+  open: function(path: string, flags: number, mode?: number, dirfd?: number): number, string
+  close: function(fd: number): boolean, string
+  read: function(fd: number, size?: number, offset?: number): string, string
+  write: function(fd: number, data: string, offset?: number): number, string
+
+  -- Positioning
+  lseek: function(fd: number, offset: number, whence?: number): number, string
+  truncate: function(path: string, length?: number): boolean, string
+  ftruncate: function(fd: number, length?: number): boolean, string
+
+  -- Duplication
+  dup: function(oldfd: number, newfd?: number, flags?: number, lowest?: number): number, string
+  pipe: function(flags?: number): PipeResult, string
+
+  -- Control
+  fcntl: function(fd: number, cmd: number, ...: any): any
+
+  -- Sync
+  sync: function()
+  fsync: function(fd: number): boolean, string
+  fdatasync: function(fd: number): boolean, string
+
+  -- Open flags
+  O_RDONLY: number
+  O_WRONLY: number
+  O_RDWR: number
+  O_CREAT: number
+  O_TRUNC: number
+  O_APPEND: number
+  O_EXCL: number
+  O_CLOEXEC: number
+  O_NONBLOCK: number
+  O_DIRECT: number
+  O_DIRECTORY: number
+  O_NOFOLLOW: number
+
+  -- Seek positions
+  SEEK_SET: number
+  SEEK_CUR: number
+  SEEK_END: number
+
+  -- fcntl commands
+  F_GETFD: number
+  F_SETFD: number
+  F_GETFL: number
+  F_SETFL: number
+  F_SETLK: number
+  F_SETLKW: number
+  F_RDLCK: number
+  F_WRLCK: number
+  F_UNLCK: number
+  FD_CLOEXEC: number
+
+  -- Special directory fd
+  AT_FDCWD: number
+end
+
+local M: IoModule = {
+  -- High-level file operations
+  slurp = slurp,
+  barf = barf,
+
+  -- Core operations
+  open = open,
+  close = close,
+  read = read,
+  write = write,
+
+  -- Positioning
+  lseek = lseek,
+  truncate = truncate,
+  ftruncate = ftruncate,
+
+  -- Duplication
+  dup = dup,
+  pipe = pipe,
+
+  -- Control
+  fcntl = fcntl,
+
+  -- Sync
+  sync = sync,
+  fsync = fsync,
+  fdatasync = fdatasync,
+
+  -- Open flags
+  O_RDONLY = unix.O_RDONLY,
+  O_WRONLY = unix.O_WRONLY,
+  O_RDWR = unix.O_RDWR,
+  O_CREAT = unix.O_CREAT,
+  O_TRUNC = unix.O_TRUNC,
+  O_APPEND = unix.O_APPEND,
+  O_EXCL = unix.O_EXCL,
+  O_CLOEXEC = unix.O_CLOEXEC,
+  O_NONBLOCK = unix.O_NONBLOCK,
+  O_DIRECT = unix.O_DIRECT,
+  O_DIRECTORY = unix.O_DIRECTORY,
+  O_NOFOLLOW = unix.O_NOFOLLOW,
+
+  -- Seek positions
+  SEEK_SET = unix.SEEK_SET,
+  SEEK_CUR = unix.SEEK_CUR,
+  SEEK_END = unix.SEEK_END,
+
+  -- fcntl commands
+  F_GETFD = unix.F_GETFD,
+  F_SETFD = unix.F_SETFD,
+  F_GETFL = unix.F_GETFL,
+  F_SETFL = unix.F_SETFL,
+  F_SETLK = unix.F_SETLK,
+  F_SETLKW = unix.F_SETLKW,
+  F_RDLCK = unix.F_RDLCK,
+  F_WRLCK = unix.F_WRLCK,
+  F_UNLCK = unix.F_UNLCK,
+  FD_CLOEXEC = unix.FD_CLOEXEC,
+
+  -- Special directory fd
+  AT_FDCWD = unix.AT_FDCWD,
+}
+
+return M

--- a/lib/cosmic/io_test.tl
+++ b/lib/cosmic/io_test.tl
@@ -1,0 +1,313 @@
+#!/usr/bin/env cosmic
+local io_m = require("cosmic.io")
+local path = require("cosmo.path")
+
+global TEST_TMPDIR: string
+
+local function test_open_read_write_close()
+  local filepath = path.join(TEST_TMPDIR, "io_test_basic.txt")
+  local content = "hello, cosmic.io!"
+
+  -- Open for writing (create)
+  local fd, err = io_m.open(filepath, io_m.O_WRONLY | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8))
+  assert(fd, "open for write failed: " .. (err or ""))
+
+  -- Write
+  local n, werr = io_m.write(fd, content)
+  assert(n == #content, "write failed: " .. (werr or "") .. " wrote " .. tostring(n) .. " expected " .. #content)
+
+  -- Close
+  local ok, cerr = io_m.close(fd)
+  assert(ok, "close failed: " .. (cerr or ""))
+
+  -- Open for reading
+  fd, err = io_m.open(filepath, io_m.O_RDONLY)
+  assert(fd, "open for read failed: " .. (err or ""))
+
+  -- Read
+  local data, rerr = io_m.read(fd, 1024)
+  assert(data == content, "read failed: " .. (rerr or "") .. " got '" .. tostring(data) .. "'")
+
+  -- Close
+  ok, cerr = io_m.close(fd)
+  assert(ok, "close failed: " .. (cerr or ""))
+
+  -- Cleanup
+  os.remove(filepath)
+end
+test_open_read_write_close()
+
+local function test_lseek()
+  local filepath = path.join(TEST_TMPDIR, "io_test_lseek.txt")
+  local content = "0123456789"
+
+  -- Create file with content
+  local fd = assert(io_m.open(filepath, io_m.O_WRONLY | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
+  assert(io_m.write(fd, content))
+  assert(io_m.close(fd))
+
+  -- Open for reading and test seek
+  fd = assert(io_m.open(filepath, io_m.O_RDONLY))
+
+  -- Seek to position 5
+  local pos, err = io_m.lseek(fd, 5, io_m.SEEK_SET)
+  assert(pos == 5, "lseek SEEK_SET failed: " .. (err or "") .. " pos=" .. tostring(pos))
+
+  -- Read from position 5
+  local data = assert(io_m.read(fd, 5))
+  assert(data == "56789", "expected '56789' got '" .. data .. "'")
+
+  -- Seek back 3 from current
+  pos = assert(io_m.lseek(fd, -3, io_m.SEEK_CUR))
+  assert(pos == 7, "lseek SEEK_CUR failed, pos=" .. tostring(pos))
+
+  -- Seek to end
+  pos = assert(io_m.lseek(fd, 0, io_m.SEEK_END))
+  assert(pos == 10, "lseek SEEK_END failed, pos=" .. tostring(pos))
+
+  assert(io_m.close(fd))
+  os.remove(filepath)
+end
+test_lseek()
+
+local function test_ftruncate()
+  local filepath = path.join(TEST_TMPDIR, "io_test_ftrunc.txt")
+  local content = "0123456789"
+
+  -- Create file with content
+  local fd = assert(io_m.open(filepath, io_m.O_RDWR | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
+  assert(io_m.write(fd, content))
+
+  -- Truncate to 5 bytes
+  local ok, err = io_m.ftruncate(fd, 5)
+  assert(ok, "ftruncate failed: " .. (err or ""))
+
+  -- Seek to start and read
+  assert(io_m.lseek(fd, 0, io_m.SEEK_SET))
+  local data = assert(io_m.read(fd, 100))
+  assert(data == "01234", "expected '01234' got '" .. data .. "'")
+
+  assert(io_m.close(fd))
+  os.remove(filepath)
+end
+test_ftruncate()
+
+local function test_truncate()
+  local filepath = path.join(TEST_TMPDIR, "io_test_trunc.txt")
+  local content = "0123456789"
+
+  -- Create file with content
+  local fd = assert(io_m.open(filepath, io_m.O_WRONLY | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
+  assert(io_m.write(fd, content))
+  assert(io_m.close(fd))
+
+  -- Truncate using path
+  local ok, err = io_m.truncate(filepath, 3)
+  assert(ok, "truncate failed: " .. (err or ""))
+
+  -- Verify
+  fd = assert(io_m.open(filepath, io_m.O_RDONLY))
+  local data = assert(io_m.read(fd, 100))
+  assert(data == "012", "expected '012' got '" .. data .. "'")
+  assert(io_m.close(fd))
+
+  os.remove(filepath)
+end
+test_truncate()
+
+local function test_dup()
+  local filepath = path.join(TEST_TMPDIR, "io_test_dup.txt")
+  local content = "dup test"
+
+  -- Create and write file
+  local fd = assert(io_m.open(filepath, io_m.O_RDWR | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
+  assert(io_m.write(fd, content))
+
+  -- Duplicate the fd
+  local fd2, err = io_m.dup(fd)
+  assert(fd2, "dup failed: " .. (err or ""))
+  assert(fd2 ~= fd, "dup should return different fd")
+
+  -- Seek to start on duplicated fd and read
+  assert(io_m.lseek(fd2, 0, io_m.SEEK_SET))
+  local data = assert(io_m.read(fd2, 100))
+  assert(data == content, "read from dup'd fd failed: got '" .. data .. "'")
+
+  assert(io_m.close(fd))
+  assert(io_m.close(fd2))
+  os.remove(filepath)
+end
+test_dup()
+
+local function test_pipe()
+  local result, err = io_m.pipe()
+  assert(result, "pipe failed: " .. (err or ""))
+  assert(result.reader, "pipe missing reader")
+  assert(result.writer, "pipe missing writer")
+  assert(result.reader ~= result.writer, "reader and writer should be different fds")
+
+  -- Write to pipe
+  local msg = "pipe test message"
+  local n = assert(io_m.write(result.writer, msg))
+  assert(n == #msg, "write to pipe failed")
+
+  -- Read from pipe
+  local data = assert(io_m.read(result.reader, #msg))
+  assert(data == msg, "read from pipe failed: got '" .. data .. "'")
+
+  assert(io_m.close(result.reader))
+  assert(io_m.close(result.writer))
+end
+test_pipe()
+
+local function test_fsync_fdatasync()
+  local filepath = path.join(TEST_TMPDIR, "io_test_sync.txt")
+
+  local fd = assert(io_m.open(filepath, io_m.O_WRONLY | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
+  assert(io_m.write(fd, "sync test"))
+
+  -- Test fsync
+  local ok, err = io_m.fsync(fd)
+  assert(ok, "fsync failed: " .. (err or ""))
+
+  -- Test fdatasync
+  ok, err = io_m.fdatasync(fd)
+  assert(ok, "fdatasync failed: " .. (err or ""))
+
+  assert(io_m.close(fd))
+  os.remove(filepath)
+end
+test_fsync_fdatasync()
+
+local function test_constants()
+  -- Verify constants are exported
+  assert(io_m.O_RDONLY ~= nil, "O_RDONLY not exported")
+  assert(io_m.O_WRONLY ~= nil, "O_WRONLY not exported")
+  assert(io_m.O_RDWR ~= nil, "O_RDWR not exported")
+  assert(io_m.O_CREAT ~= nil, "O_CREAT not exported")
+  assert(io_m.O_TRUNC ~= nil, "O_TRUNC not exported")
+  assert(io_m.O_APPEND ~= nil, "O_APPEND not exported")
+  assert(io_m.O_EXCL ~= nil, "O_EXCL not exported")
+  assert(io_m.O_CLOEXEC ~= nil, "O_CLOEXEC not exported")
+
+  assert(io_m.SEEK_SET ~= nil, "SEEK_SET not exported")
+  assert(io_m.SEEK_CUR ~= nil, "SEEK_CUR not exported")
+  assert(io_m.SEEK_END ~= nil, "SEEK_END not exported")
+
+  assert(io_m.F_GETFD ~= nil, "F_GETFD not exported")
+  assert(io_m.F_SETFD ~= nil, "F_SETFD not exported")
+  assert(io_m.F_GETFL ~= nil, "F_GETFL not exported")
+  assert(io_m.F_SETFL ~= nil, "F_SETFL not exported")
+  assert(io_m.FD_CLOEXEC ~= nil, "FD_CLOEXEC not exported")
+
+  assert(io_m.AT_FDCWD ~= nil, "AT_FDCWD not exported")
+end
+test_constants()
+
+local function test_fcntl_getfl_setfl()
+  local filepath = path.join(TEST_TMPDIR, "io_test_fcntl.txt")
+
+  local fd = assert(io_m.open(filepath, io_m.O_RDWR | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
+
+  -- Get flags
+  local flags = io_m.fcntl(fd, io_m.F_GETFL)
+  assert(flags ~= nil, "fcntl F_GETFL failed")
+
+  assert(io_m.close(fd))
+  os.remove(filepath)
+end
+test_fcntl_getfl_setfl()
+
+local function test_open_nonexistent_fails()
+  local fd, err = io_m.open("/nonexistent/path/to/file.txt", io_m.O_RDONLY)
+  assert(fd == nil, "opening nonexistent file should fail")
+  assert(err ~= nil, "should have error message")
+end
+test_open_nonexistent_fails()
+
+local function test_append_mode()
+  local filepath = path.join(TEST_TMPDIR, "io_test_append.txt")
+
+  -- Create file with initial content
+  local fd = assert(io_m.open(filepath, io_m.O_WRONLY | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
+  assert(io_m.write(fd, "hello"))
+  assert(io_m.close(fd))
+
+  -- Open in append mode
+  fd = assert(io_m.open(filepath, io_m.O_WRONLY | io_m.O_APPEND))
+  assert(io_m.write(fd, " world"))
+  assert(io_m.close(fd))
+
+  -- Verify content
+  fd = assert(io_m.open(filepath, io_m.O_RDONLY))
+  local data = assert(io_m.read(fd, 100))
+  assert(data == "hello world", "append mode failed: got '" .. data .. "'")
+  assert(io_m.close(fd))
+
+  os.remove(filepath)
+end
+test_append_mode()
+
+local function test_slurp()
+  local filepath = path.join(TEST_TMPDIR, "io_test_slurp.txt")
+  local content = "hello from slurp test\nwith multiple lines"
+
+  -- Write file using barf
+  local ok, err = io_m.barf(filepath, content)
+  assert(ok, "barf failed: " .. (err or ""))
+
+  -- Read file using slurp
+  local data: string
+  data, err = io_m.slurp(filepath)
+  assert(data == content, "slurp failed: " .. (err or "") .. " got '" .. tostring(data) .. "'")
+
+  os.remove(filepath)
+end
+test_slurp()
+
+local function test_barf_with_mode()
+  local filepath = path.join(TEST_TMPDIR, "io_test_barf_mode.txt")
+  local content = "file with specific mode"
+
+  local ok, err = io_m.barf(filepath, content, tonumber("600", 8))
+  assert(ok, "barf with mode failed: " .. (err or ""))
+
+  local data = assert(io_m.slurp(filepath))
+  assert(data == content, "content mismatch after barf with mode")
+
+  os.remove(filepath)
+end
+test_barf_with_mode()
+
+local function test_slurp_nonexistent()
+  local data, err = io_m.slurp("/nonexistent/file/path.txt")
+  assert(data == nil, "slurp of nonexistent file should return nil")
+  assert(err ~= nil, "slurp of nonexistent file should return error")
+end
+test_slurp_nonexistent()
+
+local function test_read_write_with_offset()
+  local filepath = path.join(TEST_TMPDIR, "io_test_pread.txt")
+
+  -- Create file with content
+  local fd = assert(io_m.open(filepath, io_m.O_RDWR | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
+  assert(io_m.write(fd, "0123456789"))
+
+  -- Read at offset (pread behavior)
+  local data, err = io_m.read(fd, 3, 5)
+  assert(data == "567", "read with offset failed: " .. (err or "") .. " got '" .. tostring(data) .. "'")
+
+  -- Write at offset (pwrite behavior)
+  local n: number
+  n, err = io_m.write(fd, "ABC", 2)
+  assert(n == 3, "write with offset failed: " .. (err or ""))
+
+  -- Verify
+  assert(io_m.lseek(fd, 0, io_m.SEEK_SET))
+  data = assert(io_m.read(fd, 100))
+  assert(data == "01ABC56789", "write with offset result: got '" .. data .. "'")
+
+  assert(io_m.close(fd))
+  os.remove(filepath)
+end
+test_read_write_with_offset()


### PR DESCRIPTION
## Summary
Introduces a new `cosmic.io` module that provides a high-level, type-safe wrapper around low-level file descriptor operations from `cosmo.unix`. This module simplifies file I/O operations while maintaining full access to POSIX semantics.

## Key Changes
- **New module**: `lib/cosmic/io.tl` - Comprehensive file descriptor I/O wrapper with:
  - Core operations: `open`, `close`, `read`, `write`
  - Positioning: `lseek`, `truncate`, `ftruncate`
  - Duplication: `dup`, `pipe`
  - Control: `fcntl`
  - Synchronization: `sync`, `fsync`, `fdatasync`
  - High-level helpers: `slurp`, `barf`
  
- **Comprehensive test suite**: `lib/cosmic/io_test.tl` with 15+ test cases covering:
  - Basic read/write operations
  - Seeking and truncation
  - File descriptor duplication and pipes
  - Synchronization operations
  - Error handling
  - Append mode and offset-based I/O
  - High-level file operations

## Implementation Details
- All functions return consistent error signatures: `(result, error_string)` instead of raw `Errno` objects
- Exports all relevant POSIX constants (O_* flags, SEEK_* modes, F_* commands)
- Includes a `PipeResult` record type for structured pipe return values
- Uses type casting to bridge the gap between `cosmo.unix` return types and proper error handling
- Comprehensive JSDoc-style documentation for all public functions

https://claude.ai/code/session_01LKegCUQSX9FfeLNAGhbCaK
toward #101 