### PR TITLE
Add time and clock utilities module

### DIFF
--- a/lib/cosmic/time.tl
+++ b/lib/cosmic/time.tl
@@ -1,0 +1,163 @@
+--- Time and clock utilities.
+--- Wraps cosmo.unix time functions for timestamps, sleeping, and time breakdown.
+local unix = require("cosmo.unix")
+
+--- DateTime represents a broken-down timestamp.
+--- Returned by gmtime() and localtime().
+local record DateTime
+  year: number        -- Full year (e.g., 2024)
+  month: number       -- Month (1-12)
+  day: number         -- Day of month (1-31)
+  hour: number        -- Hour (0-23)
+  min: number         -- Minute (0-59)
+  sec: number         -- Second (0-59)
+  gmtoff: number      -- Offset from UTC in seconds
+  wday: number        -- Day of week (1=Sunday, 7=Saturday)
+  yday: number        -- Day of year (1-366)
+  isdst: number       -- Daylight saving time flag (1=DST, 0=standard)
+  zone: string        -- Timezone name (e.g., "UTC", "PDT")
+end
+
+--- Clock identifiers for clock_gettime().
+local record Clock
+  REALTIME: number           -- Wall clock, subject to NTP adjustments
+  MONOTONIC: number          -- Monotonic clock, not affected by system time changes
+  BOOTTIME: number           -- Monotonic clock including suspend time
+  MONOTONIC_RAW: number      -- Raw monotonic clock, not adjusted for NTP
+  REALTIME_COARSE: number    -- Faster but less precise real time clock
+  MONOTONIC_COARSE: number   -- Faster but less precise monotonic clock
+  THREAD_CPUTIME_ID: number  -- CPU time for current thread
+  PROCESS_CPUTIME_ID: number -- CPU time for current process
+end
+
+--- Get current time from the specified clock.
+--- Returns seconds since epoch and nanoseconds.
+--- @param clock number? Clock identifier (default: CLOCK_REALTIME)
+--- @return number Seconds since epoch
+--- @return number Nanoseconds
+local function clock_gettime(clock?: number): number, number
+  return unix.clock_gettime(clock)
+end
+
+--- Get current wall clock time (real time).
+--- Returns seconds since epoch and nanoseconds.
+--- @return number Seconds since epoch
+--- @return number Nanoseconds
+local function now(): number, number
+  return unix.clock_gettime(unix.CLOCK_REALTIME)
+end
+
+--- Get monotonic time (not affected by system time changes).
+--- Returns seconds and nanoseconds from an unspecified epoch.
+--- @return number Seconds
+--- @return number Nanoseconds
+local function monotonic(): number, number
+  return unix.clock_gettime(unix.CLOCK_MONOTONIC)
+end
+
+--- Sleep for the specified duration.
+--- @param seconds number Seconds to sleep
+--- @param nanos number? Additional nanoseconds to sleep (default: 0)
+--- @return number Remaining seconds if interrupted
+--- @return number Remaining nanoseconds if interrupted
+local function sleep(seconds: number, nanos?: number): number, number
+  return unix.nanosleep(seconds, nanos or 0)
+end
+
+--- Sleep for the specified number of milliseconds.
+--- @param ms number Milliseconds to sleep
+--- @return number Remaining seconds if interrupted
+--- @return number Remaining nanoseconds if interrupted
+local function sleep_ms(ms: number): number, number
+  local seconds = math.floor(ms / 1000)
+  local remaining_ms = ms % 1000
+  local nanos = remaining_ms * 1000000
+  return unix.nanosleep(seconds, nanos)
+end
+
+--- Break down a UNIX timestamp into UTC (Zulu) time components.
+--- @param unixts number UNIX timestamp (seconds since epoch)
+--- @return DateTime Broken-down time in UTC
+local function gmtime(unixts: number): DateTime
+  local year, mon, mday, hour, min, sec, gmtoff, wday, yday, isdst, zone =
+    unix.gmtime(unixts)
+  return {
+    year = year,
+    month = mon,
+    day = mday,
+    hour = hour,
+    min = min,
+    sec = sec,
+    gmtoff = gmtoff,
+    wday = wday,
+    yday = yday,
+    isdst = isdst,
+    zone = zone,
+  }
+end
+
+--- Break down a UNIX timestamp into local time components.
+--- Respects the TZ environment variable.
+--- @param unixts number UNIX timestamp (seconds since epoch)
+--- @return DateTime Broken-down time in local timezone
+local function localtime(unixts: number): DateTime
+  local year, mon, mday, hour, min, sec, gmtoff, wday, yday, isdst, zone =
+    unix.localtime(unixts)
+  return {
+    year = year,
+    month = mon,
+    day = mday,
+    hour = hour,
+    min = min,
+    sec = sec,
+    gmtoff = gmtoff,
+    wday = wday,
+    yday = yday,
+    isdst = isdst,
+    zone = zone,
+  }
+end
+
+local record TimeModule
+  -- Clock constants
+  CLOCK_REALTIME: number
+  CLOCK_MONOTONIC: number
+  CLOCK_BOOTTIME: number
+  CLOCK_MONOTONIC_RAW: number
+  CLOCK_REALTIME_COARSE: number
+  CLOCK_MONOTONIC_COARSE: number
+  CLOCK_THREAD_CPUTIME_ID: number
+  CLOCK_PROCESS_CPUTIME_ID: number
+
+  -- Functions
+  clock_gettime: function(clock?: number): number, number
+  now: function(): number, number
+  monotonic: function(): number, number
+  sleep: function(seconds: number, nanos?: number): number, number
+  sleep_ms: function(ms: number): number, number
+  gmtime: function(unixts: number): DateTime
+  localtime: function(unixts: number): DateTime
+end
+
+local M: TimeModule = {
+  -- Clock constants
+  CLOCK_REALTIME = unix.CLOCK_REALTIME,
+  CLOCK_MONOTONIC = unix.CLOCK_MONOTONIC,
+  CLOCK_BOOTTIME = unix.CLOCK_BOOTTIME,
+  CLOCK_MONOTONIC_RAW = unix.CLOCK_MONOTONIC_RAW,
+  CLOCK_REALTIME_COARSE = unix.CLOCK_REALTIME_COARSE,
+  CLOCK_MONOTONIC_COARSE = unix.CLOCK_MONOTONIC_COARSE,
+  CLOCK_THREAD_CPUTIME_ID = unix.CLOCK_THREAD_CPUTIME_ID,
+  CLOCK_PROCESS_CPUTIME_ID = unix.CLOCK_PROCESS_CPUTIME_ID,
+
+  -- Functions
+  clock_gettime = clock_gettime,
+  now = now,
+  monotonic = monotonic,
+  sleep = sleep,
+  sleep_ms = sleep_ms,
+  gmtime = gmtime,
+  localtime = localtime,
+}
+
+return M

--- a/lib/cosmic/time_test.tl
+++ b/lib/cosmic/time_test.tl
@@ -1,0 +1,166 @@
+#!/usr/bin/env cosmic
+local time = require("cosmic.time")
+
+-- clock_gettime tests
+
+local function test_clock_gettime_default()
+  local secs, nanos = time.clock_gettime()
+  assert(secs ~= nil, "expected seconds to be non-nil")
+  assert(nanos ~= nil, "expected nanoseconds to be non-nil")
+  assert(secs > 0, "expected positive seconds")
+  assert(nanos >= 0, "expected non-negative nanoseconds")
+  assert(nanos < 1000000000, "expected nanoseconds < 1 billion")
+end
+test_clock_gettime_default()
+
+local function test_clock_gettime_realtime()
+  local secs, nanos = time.clock_gettime(time.CLOCK_REALTIME)
+  assert(secs ~= nil, "expected seconds to be non-nil")
+  assert(secs > 1700000000, "expected timestamp after 2023")
+end
+test_clock_gettime_realtime()
+
+local function test_clock_gettime_monotonic()
+  local secs1, _ = time.clock_gettime(time.CLOCK_MONOTONIC)
+  local secs2, _ = time.clock_gettime(time.CLOCK_MONOTONIC)
+  assert(secs2 >= secs1, "monotonic clock should not go backwards")
+end
+test_clock_gettime_monotonic()
+
+-- now() tests
+
+local function test_now()
+  local secs, nanos = time.now()
+  assert(secs ~= nil, "expected seconds to be non-nil")
+  assert(nanos ~= nil, "expected nanoseconds to be non-nil")
+  assert(secs > 1700000000, "expected timestamp after 2023")
+end
+test_now()
+
+-- monotonic() tests
+
+local function test_monotonic()
+  local secs1, nanos1 = time.monotonic()
+  local secs2, nanos2 = time.monotonic()
+  local t1 = secs1 + nanos1 / 1000000000
+  local t2 = secs2 + nanos2 / 1000000000
+  assert(t2 >= t1, "monotonic clock should not go backwards")
+end
+test_monotonic()
+
+-- sleep tests
+
+local function test_sleep()
+  local before_secs, before_nanos = time.monotonic()
+  time.sleep(0, 1000000) -- sleep 1ms
+  local after_secs, after_nanos = time.monotonic()
+  local before = before_secs + before_nanos / 1000000000
+  local after = after_secs + after_nanos / 1000000000
+  assert(after > before, "time should have passed after sleep")
+end
+test_sleep()
+
+local function test_sleep_zero()
+  -- sleep(0) should return immediately
+  local secs, nanos = time.sleep(0)
+  assert(secs ~= nil, "expected seconds to be non-nil")
+end
+test_sleep_zero()
+
+-- sleep_ms tests
+
+local function test_sleep_ms()
+  local before_secs, before_nanos = time.monotonic()
+  time.sleep_ms(1) -- sleep 1ms
+  local after_secs, after_nanos = time.monotonic()
+  local before = before_secs + before_nanos / 1000000000
+  local after = after_secs + after_nanos / 1000000000
+  assert(after > before, "time should have passed after sleep_ms")
+end
+test_sleep_ms()
+
+local function test_sleep_ms_conversion()
+  -- Test that 1500ms = 1.5 seconds is handled correctly
+  -- We don't actually sleep that long, just verify the function exists
+  local before_secs, _ = time.monotonic()
+  time.sleep_ms(0)
+  local after_secs, _ = time.monotonic()
+  assert(after_secs >= before_secs, "monotonic time should not go backwards")
+end
+test_sleep_ms_conversion()
+
+-- gmtime tests
+
+local function test_gmtime_epoch()
+  local dt = time.gmtime(0)
+  assert(dt.year == 1970, "expected year 1970, got " .. tostring(dt.year))
+  assert(dt.month == 1, "expected month 1, got " .. tostring(dt.month))
+  assert(dt.day == 1, "expected day 1, got " .. tostring(dt.day))
+  assert(dt.hour == 0, "expected hour 0, got " .. tostring(dt.hour))
+  assert(dt.min == 0, "expected min 0, got " .. tostring(dt.min))
+  assert(dt.sec == 0, "expected sec 0, got " .. tostring(dt.sec))
+end
+test_gmtime_epoch()
+
+local function test_gmtime_known_date()
+  -- 2000-01-01 00:00:00 UTC = 946684800
+  local dt = time.gmtime(946684800)
+  assert(dt.year == 2000, "expected year 2000, got " .. tostring(dt.year))
+  assert(dt.month == 1, "expected month 1, got " .. tostring(dt.month))
+  assert(dt.day == 1, "expected day 1, got " .. tostring(dt.day))
+  assert(dt.hour == 0, "expected hour 0, got " .. tostring(dt.hour))
+  assert(dt.min == 0, "expected min 0, got " .. tostring(dt.min))
+  assert(dt.sec == 0, "expected sec 0, got " .. tostring(dt.sec))
+end
+test_gmtime_known_date()
+
+local function test_gmtime_fields()
+  local dt = time.gmtime(1705322245)
+  assert(dt.gmtoff == 0, "expected gmtoff 0 for UTC, got " .. tostring(dt.gmtoff))
+  assert(dt.zone == "UTC" or dt.zone == "GMT", "expected UTC or GMT timezone, got " .. tostring(dt.zone))
+  assert(dt.wday >= 1 and dt.wday <= 7, "expected wday 1-7, got " .. tostring(dt.wday))
+  assert(dt.yday >= 1 and dt.yday <= 366, "expected yday 1-366, got " .. tostring(dt.yday))
+end
+test_gmtime_fields()
+
+-- localtime tests
+
+local function test_localtime_returns_datetime()
+  local secs, _ = time.now()
+  local dt = time.localtime(secs)
+  assert(dt.year ~= nil, "expected year to be non-nil")
+  assert(dt.month >= 1 and dt.month <= 12, "expected month 1-12, got " .. tostring(dt.month))
+  assert(dt.day >= 1 and dt.day <= 31, "expected day 1-31, got " .. tostring(dt.day))
+  assert(dt.hour >= 0 and dt.hour <= 23, "expected hour 0-23, got " .. tostring(dt.hour))
+  assert(dt.min >= 0 and dt.min <= 59, "expected min 0-59, got " .. tostring(dt.min))
+  assert(dt.sec >= 0 and dt.sec <= 60, "expected sec 0-60, got " .. tostring(dt.sec))
+end
+test_localtime_returns_datetime()
+
+local function test_localtime_zone()
+  local secs, _ = time.now()
+  local dt = time.localtime(secs)
+  assert(dt.zone ~= nil, "expected zone to be non-nil")
+  assert(type(dt.zone) == "string", "expected zone to be a string")
+end
+test_localtime_zone()
+
+-- Clock constants tests
+
+local function test_clock_constants_exist()
+  assert(time.CLOCK_REALTIME ~= nil, "CLOCK_REALTIME should exist")
+  assert(time.CLOCK_MONOTONIC ~= nil, "CLOCK_MONOTONIC should exist")
+  assert(time.CLOCK_BOOTTIME ~= nil, "CLOCK_BOOTTIME should exist")
+  assert(time.CLOCK_MONOTONIC_RAW ~= nil, "CLOCK_MONOTONIC_RAW should exist")
+  assert(time.CLOCK_REALTIME_COARSE ~= nil, "CLOCK_REALTIME_COARSE should exist")
+  assert(time.CLOCK_MONOTONIC_COARSE ~= nil, "CLOCK_MONOTONIC_COARSE should exist")
+  assert(time.CLOCK_THREAD_CPUTIME_ID ~= nil, "CLOCK_THREAD_CPUTIME_ID should exist")
+  assert(time.CLOCK_PROCESS_CPUTIME_ID ~= nil, "CLOCK_PROCESS_CPUTIME_ID should exist")
+end
+test_clock_constants_exist()
+
+local function test_clock_realtime_is_zero()
+  -- Per the docs, CLOCK_REALTIME is always 0
+  assert(time.CLOCK_REALTIME == 0, "CLOCK_REALTIME should be 0, got " .. tostring(time.CLOCK_REALTIME))
+end
+test_clock_realtime_is_zero()


### PR DESCRIPTION
## Summary
Add a new `cosmic.time` module that provides a high-level Teal interface to UNIX time functions, including clock operations, sleeping, and timestamp breakdown utilities.

## Changes
- **New module**: `lib/cosmic/time.tl` - Wraps `cosmo.unix` time functions with:
  - `DateTime` record type for broken-down timestamp components (year, month, day, hour, min, sec, timezone info, etc.)
  - Clock identifier constants (`CLOCK_REALTIME`, `CLOCK_MONOTONIC`, `CLOCK_BOOTTIME`, etc.)
  - `clock_gettime(clock?)` - Get time from specified clock with nanosecond precision
  - `now()` - Convenience function for wall clock time
  - `monotonic()` - Convenience function for monotonic clock (unaffected by system time changes)
  - `sleep(seconds, nanos?)` - Sleep with nanosecond precision
  - `sleep_ms(ms)` - Sleep with millisecond convenience
  - `gmtime(unixts)` - Break down UNIX timestamp to UTC components
  - `localtime(unixts)` - Break down UNIX timestamp to local time components

- **Comprehensive test suite**: `lib/cosmic/time_test.tl` with 16 test functions covering:
  - Clock operations (default, realtime, monotonic)
  - Sleep functionality (nanosecond and millisecond variants)
  - Timestamp breakdown (epoch, known dates, field validation)
  - Clock constants availability
  - Monotonic clock monotonicity guarantees

## Implementation Details
- Provides type-safe Teal wrappers around raw `cosmo.unix` functions
- Returns `DateTime` records instead of multiple return values for better ergonomics
- Includes proper documentation with parameter and return type annotations
- All clock constants are re-exported from the underlying `cosmo.unix` module

https://claude.ai/code/session_01WeQ7s6jpCYEcyVpbKKE93c
toward #101 