### PR TITLE
Add codec module for hex and Lua serialization

### DIFF
--- a/lib/cosmic/codec.tl
+++ b/lib/cosmic/codec.tl
@@ -1,0 +1,75 @@
+--- Encoding and decoding utilities for various formats.
+--- Provides hex and Lua serialization codecs with consistent error handling.
+local cosmo = require("cosmo")
+
+--- Encode a string as hexadecimal.
+--- Each byte becomes two lowercase hex characters.
+--- @param data string The binary data to encode
+--- @return string The hexadecimal representation
+local function encode_hex(data: string): string
+  return cosmo.EncodeHex(data)
+end
+
+--- Decode a hexadecimal string to binary data.
+--- Accepts both uppercase and lowercase hex characters.
+--- @param hex string The hexadecimal string to decode
+--- @return string The decoded binary data, or nil on error
+--- @return string? Error message if decoding failed
+local function decode_hex(hex: string): string, string
+  -- Validate length is even
+  if #hex % 2 ~= 0 then
+    return nil, "hex string must have even length"
+  end
+  -- Validate characters are valid hex
+  if hex:match("[^0-9a-fA-F]") then
+    return nil, "invalid hex character"
+  end
+  -- Decode pairs of hex digits
+  local result = hex:gsub("(%x%x)", function(pair: string): string
+    return string.char(tonumber(pair, 16) as integer)
+  end)
+  return result, nil
+end
+
+--- Encode a Lua value as Lua source code.
+--- The output can be loaded with decode_lua to reconstruct the value.
+--- @param value any The Lua value to encode (table, string, number, boolean, or nil)
+--- @param opts {string:any}? Optional encoding options
+--- @return string The Lua source code representation
+local function encode_lua(value: any, opts?: {string:any}): string
+  return cosmo.EncodeLua(value, opts)
+end
+
+--- Decode Lua source code to a value.
+--- Only loads the code, does not execute arbitrary functions.
+--- WARNING: This executes Lua code. Only use with trusted input.
+--- @param code string The Lua source code to decode
+--- @return any The decoded Lua value, or nil on error
+--- @return string? Error message if decoding failed
+local function decode_lua(code: string): any, string
+  local chunk, err = load("return " .. code)
+  if not chunk then
+    return nil, err as string
+  end
+  local ok, result = pcall(chunk)
+  if not ok then
+    return nil, result as string
+  end
+  return result, nil
+end
+
+local record CodecModule
+  encode_hex: function(data: string): string
+  decode_hex: function(hex: string): string, string
+  encode_lua: function(value: any, opts?: {string:any}): string
+  decode_lua: function(code: string): any, string
+end
+
+local M: CodecModule = {
+  encode_hex = encode_hex,
+  decode_hex = decode_hex,
+  encode_lua = encode_lua,
+  decode_lua = decode_lua,
+}
+
+return M

--- a/lib/cosmic/codec_test.tl
+++ b/lib/cosmic/codec_test.tl
@@ -1,0 +1,164 @@
+#!/usr/bin/env cosmic
+local codec = require("cosmic.codec")
+
+-- Hex encoding tests
+
+local function test_encode_hex_basic()
+  local result = codec.encode_hex("hello")
+  assert(result == "68656c6c6f", "expected '68656c6c6f', got '" .. result .. "'")
+end
+test_encode_hex_basic()
+
+local function test_encode_hex_empty()
+  local result = codec.encode_hex("")
+  assert(result == "", "expected empty string")
+end
+test_encode_hex_empty()
+
+local function test_encode_hex_binary()
+  local result = codec.encode_hex("\x00\xff\x10")
+  assert(result == "00ff10", "expected '00ff10', got '" .. result .. "'")
+end
+test_encode_hex_binary()
+
+-- Hex decoding tests
+
+local function test_decode_hex_basic()
+  local result, err = codec.decode_hex("68656c6c6f")
+  assert(err == nil, "unexpected error: " .. (err or ""))
+  assert(result == "hello", "expected 'hello', got '" .. (result or "nil") .. "'")
+end
+test_decode_hex_basic()
+
+local function test_decode_hex_uppercase()
+  local result, err = codec.decode_hex("48454C4C4F")
+  assert(err == nil, "unexpected error: " .. (err or ""))
+  assert(result == "HELLO", "expected 'HELLO', got '" .. (result or "nil") .. "'")
+end
+test_decode_hex_uppercase()
+
+local function test_decode_hex_empty()
+  local result, err = codec.decode_hex("")
+  assert(err == nil, "unexpected error: " .. (err or ""))
+  assert(result == "", "expected empty string")
+end
+test_decode_hex_empty()
+
+local function test_decode_hex_odd_length()
+  local result, err = codec.decode_hex("abc")
+  assert(result == nil, "expected nil for odd length")
+  assert(err ~= nil, "expected error message")
+  assert(err:match("even length"), "error should mention even length")
+end
+test_decode_hex_odd_length()
+
+local function test_decode_hex_invalid_char()
+  local result, err = codec.decode_hex("ghij")
+  assert(result == nil, "expected nil for invalid hex")
+  assert(err ~= nil, "expected error message")
+  assert(err:match("invalid"), "error should mention invalid")
+end
+test_decode_hex_invalid_char()
+
+local function test_hex_roundtrip()
+  local original = "Hello, World! \x00\xff"
+  local encoded = codec.encode_hex(original)
+  local decoded, err = codec.decode_hex(encoded)
+  assert(err == nil, "roundtrip decode failed: " .. (err or ""))
+  assert(decoded == original, "roundtrip mismatch")
+end
+test_hex_roundtrip()
+
+-- Lua encoding tests
+
+local function test_encode_lua_string()
+  local result = codec.encode_lua("hello")
+  assert(result == '"hello"', "expected '\"hello\"', got '" .. result .. "'")
+end
+test_encode_lua_string()
+
+local function test_encode_lua_number()
+  local result = codec.encode_lua(42)
+  assert(result == "42", "expected '42', got '" .. result .. "'")
+end
+test_encode_lua_number()
+
+local function test_encode_lua_boolean()
+  assert(codec.encode_lua(true) == "true", "expected 'true'")
+  assert(codec.encode_lua(false) == "false", "expected 'false'")
+end
+test_encode_lua_boolean()
+
+local function test_encode_lua_table()
+  local result = codec.encode_lua({a = 1})
+  assert(result:match("a") and result:match("1"), "expected table with a=1")
+end
+test_encode_lua_table()
+
+local function test_encode_lua_nil()
+  local result = codec.encode_lua(nil)
+  assert(result == "nil", "expected 'nil', got '" .. result .. "'")
+end
+test_encode_lua_nil()
+
+-- Lua decoding tests
+
+local function test_decode_lua_string()
+  local result, err = codec.decode_lua('"hello"')
+  assert(err == nil, "unexpected error: " .. (err or ""))
+  assert(result == "hello", "expected 'hello'")
+end
+test_decode_lua_string()
+
+local function test_decode_lua_number()
+  local result, err = codec.decode_lua("42")
+  assert(err == nil, "unexpected error: " .. (err or ""))
+  assert(result == 42, "expected 42")
+end
+test_decode_lua_number()
+
+local function test_decode_lua_boolean()
+  local t, err1 = codec.decode_lua("true")
+  assert(err1 == nil and t == true, "expected true")
+  local f, err2 = codec.decode_lua("false")
+  assert(err2 == nil and f == false, "expected false")
+end
+test_decode_lua_boolean()
+
+local function test_decode_lua_table()
+  local result, err = codec.decode_lua('{a = 1, b = "hello"}')
+  assert(err == nil, "unexpected error: " .. (err or ""))
+  local t = result as {string:any}
+  assert(t.a == 1, "expected a=1")
+  assert(t.b == "hello", "expected b='hello'")
+end
+test_decode_lua_table()
+
+local function test_decode_lua_nil()
+  local result, err = codec.decode_lua("nil")
+  assert(err == nil, "unexpected error: " .. (err or ""))
+  assert(result == nil, "expected nil")
+end
+test_decode_lua_nil()
+
+local function test_decode_lua_invalid()
+  local result, err = codec.decode_lua("invalid syntax {{{{")
+  assert(result == nil, "expected nil for invalid syntax")
+  assert(err ~= nil, "expected error message")
+end
+test_decode_lua_invalid()
+
+local function test_lua_roundtrip()
+  local original = {name = "test", count = 42, flag = true, nested = {x = 1, y = 2}}
+  local encoded = codec.encode_lua(original)
+  local decoded, err = codec.decode_lua(encoded)
+  assert(err == nil, "roundtrip decode failed: " .. (err or ""))
+  local t = decoded as {string:any}
+  assert(t.name == original.name, "name mismatch")
+  assert(t.count == original.count, "count mismatch")
+  assert(t.flag == original.flag, "flag mismatch")
+  local nested = t.nested as {string:number}
+  assert(nested.x == original.nested.x, "nested.x mismatch")
+  assert(nested.y == original.nested.y, "nested.y mismatch")
+end
+test_lua_roundtrip()


### PR DESCRIPTION
## Summary
Introduces a new `cosmic.codec` module that provides encoding and decoding utilities for hexadecimal and Lua serialization formats. This module offers a consistent interface for converting between binary data and text representations.

## Key Changes
- **New `lib/cosmic/codec.tl` module** with four main functions:
  - `encode_hex(data)` - Converts binary data to lowercase hexadecimal strings
  - `decode_hex(hex)` - Converts hexadecimal strings back to binary data with validation
  - `encode_lua(value, opts)` - Serializes Lua values to source code representation
  - `decode_lua(code)` - Deserializes Lua source code back to values

- **Comprehensive test suite** (`lib/cosmic/codec_test.tl`) covering:
  - Hex encoding/decoding with edge cases (empty strings, binary data, uppercase/lowercase)
  - Input validation (odd-length hex strings, invalid characters)
  - Lua serialization for all basic types (strings, numbers, booleans, tables, nil)
  - Roundtrip testing to ensure encode/decode consistency
  - Error handling and edge cases

## Implementation Details
- **Hex decoding** includes validation for even length and valid hex characters before decoding
- **Lua decoding** uses `load()` with `pcall()` for safe execution with proper error handling
- All functions follow a consistent error-handling pattern: returning `(value, nil)` on success or `(nil, error_message)` on failure
- Module is written in Teal with full type annotations for type safety
- Leverages the `cosmo` library for hex encoding and Lua encoding operations

https://claude.ai/code/session_012Jfe3U9dD6SV8uLgHbRgY3

#101 