### PR TITLE
re: add cosmic.re module wrapping cosmo.re

### DIFF
--- a/lib/cosmic/re.tl
+++ b/lib/cosmic/re.tl
@@ -1,0 +1,100 @@
+--- Regular expression matching using POSIX extended regex syntax.
+--- Wraps cosmo.re for pattern compilation and searching.
+---
+--- For best performance, compile patterns once and reuse them.
+--- The search() convenience function compiles on each call (O(2^n) complexity).
+local re = require("cosmo.re")
+
+--- A compiled regular expression pattern.
+--- Use compile() to create, then call :search() for O(n) matching.
+local record Regex
+  --- Search for pattern match in text.
+  --- Returns the matched substring, or nil if no match.
+  --- @param text string The text to search
+  --- @param flags number? Optional flags: NOTBOL, NOTEOL
+  --- @return string? The matched substring, or nil if no match
+  search: function(self: Regex, text: string, flags?: number): string
+end
+
+--- Compile a regular expression pattern.
+--- Compiled patterns can be reused for efficient O(n) matching.
+--- Uses POSIX extended syntax by default.
+--- @param pattern string The regex pattern to compile
+--- @param flags number? Optional flags: BASIC, ICASE, NEWLINE, NOSUB
+--- @return Regex? The compiled regex, or nil on error
+--- @return string? Error message if compilation failed
+local function compile(pattern: string, flags?: number): Regex, string
+  local result, err = re.compile(pattern, flags)
+  if not result then
+    -- err is an Errno userdata with __tostring metamethod
+    return nil, tostring(err)
+  end
+  return result as Regex
+end
+
+--- Search for pattern match in text (convenience function).
+--- Compiles pattern on each call - use compile() for repeated searches.
+--- Uses POSIX extended syntax by default.
+--- @param pattern string The regex pattern to search for
+--- @param text string The text to search in
+--- @param flags number? Optional compile flags: BASIC, ICASE, NEWLINE, NOSUB
+--- @return string? The matched substring, or nil if no match
+--- @return string? Error message if pattern compilation failed
+local function search(pattern: string, text: string, flags?: number): string, string
+  local regex, err = compile(pattern, flags)
+  if not regex then
+    return nil, err
+  end
+  -- Note: regex:search returns nil for no match, not an error condition
+  -- Search flags (NOTBOL/NOTEOL) are not passed here; use compile() + :search() for those
+  local result = regex:search(text)
+  return result
+end
+
+--- Check if pattern matches anywhere in text.
+--- Convenience function that returns boolean instead of matched text.
+--- @param pattern string The regex pattern to match
+--- @param text string The text to search in
+--- @param flags number? Optional compile flags: BASIC, ICASE, NEWLINE, NOSUB
+--- @return boolean True if pattern matches, false otherwise
+--- @return string? Error message if pattern compilation failed
+local function match(pattern: string, text: string, flags?: number): boolean, string
+  local result, err = search(pattern, text, flags)
+  if err then
+    return false, err
+  end
+  return result ~= nil
+end
+
+local record ReModule
+  -- Functions
+  compile: function(pattern: string, flags?: number): Regex, string
+  search: function(pattern: string, text: string, flags?: number): string, string
+  match: function(pattern: string, text: string, flags?: number): boolean, string
+
+  -- Compile flags
+  BASIC: number    -- Use basic (obsolete) regex syntax instead of extended
+  ICASE: number    -- Case-insensitive matching
+  NEWLINE: number  -- Treat newline as special (affects ^ and $)
+  NOSUB: number    -- Report only success/failure, not match position
+
+  -- Search flags
+  NOTBOL: number   -- First character is not at beginning of line
+  NOTEOL: number   -- Last character is not at end of line
+end
+
+local M: ReModule = {
+  compile = compile,
+  search = search,
+  match = match,
+
+  -- Expose flags from cosmo.re
+  BASIC = re.BASIC,
+  ICASE = re.ICASE,
+  NEWLINE = re.NEWLINE,
+  NOSUB = re.NOSUB,
+  NOTBOL = re.NOTBOL,
+  NOTEOL = re.NOTEOL,
+}
+
+return M

--- a/lib/cosmic/re_test.tl
+++ b/lib/cosmic/re_test.tl
@@ -1,0 +1,233 @@
+#!/usr/bin/env cosmic
+local re = require("cosmic.re")
+
+-- compile tests
+
+local function test_compile_simple()
+  local regex, err = re.compile("hello")
+  assert(regex ~= nil, "expected compiled regex, got error: " .. tostring(err))
+  assert(err == nil, "expected no error")
+end
+test_compile_simple()
+
+local function test_compile_with_groups()
+  local regex, err = re.compile("(foo|bar)")
+  assert(regex ~= nil, "expected compiled regex with groups")
+  assert(err == nil, "expected no error")
+end
+test_compile_with_groups()
+
+local function test_compile_invalid_pattern()
+  local regex, err = re.compile("[invalid")
+  assert(regex == nil, "expected nil for invalid pattern")
+  assert(err ~= nil, "expected error message for invalid pattern")
+  assert(type(err) == "string", "error should be a string")
+end
+test_compile_invalid_pattern()
+
+local function test_compile_invalid_unbalanced_parens()
+  local regex, err = re.compile("(unbalanced")
+  assert(regex == nil, "expected nil for unbalanced parens")
+  assert(err ~= nil, "expected error message")
+end
+test_compile_invalid_unbalanced_parens()
+
+-- search with compiled regex tests
+
+local function test_regex_search_match()
+  local regex = re.compile("world")
+  assert(regex, "compile failed")
+  local result = regex:search("hello world")
+  assert(result == "world", "expected 'world', got '" .. tostring(result) .. "'")
+end
+test_regex_search_match()
+
+local function test_regex_search_no_match()
+  local regex = re.compile("xyz")
+  assert(regex, "compile failed")
+  local result = regex:search("hello world")
+  assert(result == nil, "expected nil for no match")
+end
+test_regex_search_no_match()
+
+local function test_regex_search_beginning()
+  local regex = re.compile("^hello")
+  assert(regex, "compile failed")
+  local result = regex:search("hello world")
+  assert(result == "hello", "expected 'hello', got '" .. tostring(result) .. "'")
+end
+test_regex_search_beginning()
+
+local function test_regex_search_end()
+  local regex = re.compile("world$")
+  assert(regex, "compile failed")
+  local result = regex:search("hello world")
+  assert(result == "world", "expected 'world', got '" .. tostring(result) .. "'")
+end
+test_regex_search_end()
+
+local function test_regex_search_character_class()
+  local regex = re.compile("[0-9]+")
+  assert(regex, "compile failed")
+  local result = regex:search("abc123def")
+  assert(result == "123", "expected '123', got '" .. tostring(result) .. "'")
+end
+test_regex_search_character_class()
+
+local function test_regex_search_alternation()
+  local regex = re.compile("cat|dog")
+  assert(regex, "compile failed")
+  local result = regex:search("I have a dog")
+  assert(result == "dog", "expected 'dog', got '" .. tostring(result) .. "'")
+end
+test_regex_search_alternation()
+
+-- search convenience function tests
+
+local function test_search_simple()
+  local result, err = re.search("world", "hello world")
+  assert(err == nil, "expected no error, got: " .. tostring(err))
+  assert(result == "world", "expected 'world', got '" .. tostring(result) .. "'")
+end
+test_search_simple()
+
+local function test_search_no_match()
+  local result, err = re.search("xyz", "hello world")
+  assert(err == nil, "expected no error")
+  assert(result == nil, "expected nil for no match")
+end
+test_search_no_match()
+
+local function test_search_invalid_pattern()
+  local result, err = re.search("[invalid", "hello world")
+  assert(result == nil, "expected nil for invalid pattern")
+  assert(err ~= nil, "expected error message")
+end
+test_search_invalid_pattern()
+
+local function test_search_regex_metacharacters()
+  local result = re.search("h.llo", "hello")
+  assert(result == "hello", "expected 'hello', got '" .. tostring(result) .. "'")
+end
+test_search_regex_metacharacters()
+
+local function test_search_quantifiers()
+  local result = re.search("he+llo", "heeeello world")
+  assert(result == "heeeello", "expected 'heeeello', got '" .. tostring(result) .. "'")
+end
+test_search_quantifiers()
+
+local function test_search_optional()
+  local result = re.search("colou?r", "color")
+  assert(result == "color", "expected 'color', got '" .. tostring(result) .. "'")
+
+  result = re.search("colou?r", "colour")
+  assert(result == "colour", "expected 'colour', got '" .. tostring(result) .. "'")
+end
+test_search_optional()
+
+-- match convenience function tests
+
+local function test_match_true()
+  local result, err = re.match("world", "hello world")
+  assert(err == nil, "expected no error")
+  assert(result == true, "expected true for matching pattern")
+end
+test_match_true()
+
+local function test_match_false()
+  local result, err = re.match("xyz", "hello world")
+  assert(err == nil, "expected no error")
+  assert(result == false, "expected false for non-matching pattern")
+end
+test_match_false()
+
+local function test_match_invalid_pattern()
+  local result, err = re.match("[invalid", "hello world")
+  assert(result == false, "expected false for invalid pattern")
+  assert(err ~= nil, "expected error message")
+end
+test_match_invalid_pattern()
+
+-- flag tests
+
+local function test_icase_flag()
+  -- Without ICASE, should not match
+  local result = re.search("HELLO", "hello world")
+  assert(result == nil, "expected nil without ICASE flag")
+
+  -- With ICASE, should match
+  result = re.search("HELLO", "hello world", re.ICASE)
+  assert(result == "hello", "expected 'hello' with ICASE flag, got '" .. tostring(result) .. "'")
+end
+test_icase_flag()
+
+local function test_compile_icase_flag()
+  local regex, err = re.compile("WORLD", re.ICASE)
+  assert(regex ~= nil, "expected compiled regex: " .. tostring(err))
+  local result = regex:search("hello world")
+  assert(result == "world", "expected 'world' with ICASE flag")
+end
+test_compile_icase_flag()
+
+-- flag constants existence tests
+
+local function test_flags_exist()
+  assert(re.BASIC ~= nil, "BASIC flag should exist")
+  assert(re.ICASE ~= nil, "ICASE flag should exist")
+  assert(re.NEWLINE ~= nil, "NEWLINE flag should exist")
+  assert(re.NOSUB ~= nil, "NOSUB flag should exist")
+  assert(re.NOTBOL ~= nil, "NOTBOL flag should exist")
+  assert(re.NOTEOL ~= nil, "NOTEOL flag should exist")
+end
+test_flags_exist()
+
+-- edge case tests
+
+local function test_empty_pattern()
+  local result = re.search("", "hello")
+  -- Empty pattern matches empty string at start
+  assert(result == "", "expected empty string match, got '" .. tostring(result) .. "'")
+end
+test_empty_pattern()
+
+local function test_empty_text()
+  local result = re.search("hello", "")
+  assert(result == nil, "expected nil for empty text")
+end
+test_empty_text()
+
+local function test_full_match()
+  local result = re.search("^hello world$", "hello world")
+  assert(result == "hello world", "expected full match")
+end
+test_full_match()
+
+local function test_special_characters()
+  -- Dot matches any character
+  local result = re.search("a.c", "abc")
+  assert(result == "abc", "expected 'abc', got '" .. tostring(result) .. "'")
+end
+test_special_characters()
+
+local function test_escaped_special_characters()
+  -- Escaped dot matches literal dot
+  local result = re.search("a\\.c", "a.c")
+  assert(result == "a.c", "expected 'a.c', got '" .. tostring(result) .. "'")
+end
+test_escaped_special_characters()
+
+local function test_reuse_compiled_regex()
+  local regex = re.compile("[a-z]+")
+  assert(regex, "compile failed")
+
+  local r1 = regex:search("123abc456")
+  assert(r1 == "abc", "first search failed")
+
+  local r2 = regex:search("xyz789")
+  assert(r2 == "xyz", "second search failed")
+
+  local r3 = regex:search("12345")
+  assert(r3 == nil, "expected nil for no match")
+end
+test_reuse_compiled_regex()

--- a/lib/types/cosmo/re.d.tl
+++ b/lib/types/cosmo/re.d.tl
@@ -33,6 +33,7 @@ local record Regex
 end
 
 local record re
+  -- Error codes
   NOMATCH: number
   BADPAT: number
   ECOLLATE: number
@@ -41,6 +42,16 @@ local record re
   ESUBREG: number
   EBRACK: number
   EPAREN: number
+
+  -- Compile flags
+  BASIC: number    -- Use basic (obsolete) regex syntax instead of extended
+  ICASE: number    -- Case-insensitive matching
+  NEWLINE: number  -- Treat newline as special (affects ^ and $)
+  NOSUB: number    -- Report only success/failure, not match position
+
+  -- Search flags
+  NOTBOL: number   -- First character is not at beginning of line
+  NOTEOL: number   -- Last character is not at end of line
 
   --- Searches for regular expression match in text.
   --- This is a shorthand notation roughly equivalent to:
@@ -65,7 +76,8 @@ local record re
   --- If regex is an untrusted user value, then `unix.setrlimit` should be
   --- used to impose cpu and memory quotas for security.
   --- This uses POSIX extended syntax by default.
-  compile: function(regex: string, flags?: number): Regex
+  --- Returns nil and an Errno on failure.
+  compile: function(regex: string, flags?: number): Regex, Errno
 end
 
 return re


### PR DESCRIPTION
Adds cosmic.re module providing POSIX extended regex support:
- compile(pattern, flags) - compile pattern for efficient reuse
- search(pattern, text, flags) - convenience search (compiles each time)
- match(pattern, text, flags) - boolean match check

Also updates lib/types/cosmo/re.d.tl with missing compile/search flags
(BASIC, ICASE, NEWLINE, NOSUB, NOTBOL, NOTEOL) and correct return type
for compile() to include Errno on failure.

Toward #101

https://claude.ai/code/session_013o55omqNWjpS5Fr11E46oX