### PR TITLE
Add Teal-typed getopt wrapper for command-line parsing

### DIFF
--- a/lib/cosmic/getopt.tl
+++ b/lib/cosmic/getopt.tl
@@ -19,8 +19,9 @@ end
 --- after parsing is complete.
 local record Parser
   --- Get the next option from the parser.
-  --- Returns the option character (for short options) or long option name,
-  --- along with its argument if the option takes one.
+  --- Returns the short option character when a short alias is defined,
+  --- or the long option name when no short alias exists.
+  --- This means both `-h` and `--help` return `"h"` if `short = "h"` is set.
   --- Returns nil when no more options remain.
   --- If the option is unknown, returns "?" as the option name and the
   --- unknown option string as the argument.
@@ -61,12 +62,13 @@ end
 ---     while true do
 ---       local opt, optarg = parser:next()
 ---       if not opt then break end
----       if opt == "h" or opt == "help" then
+---       -- Both -h and --help return "h" since short alias is defined
+---       if opt == "h" then
 ---         print("Usage: ...")
 ---         os.exit(0)
----       elseif opt == "v" or opt == "verbose" then
+---       elseif opt == "v" then
 ---         verbose = true
----       elseif opt == "o" or opt == "output" then
+---       elseif opt == "o" then
 ---         output = optarg
 ---       end
 ---     end

--- a/lib/cosmic/getopt_test.tl
+++ b/lib/cosmic/getopt_test.tl
@@ -47,7 +47,8 @@ local function test_combined_short_options()
 end
 test_combined_short_options()
 
-local function test_long_options()
+local function test_long_options_with_short_alias()
+  -- When long options have short aliases, cosmo.getopt returns the short form
   local parser = getopt.new({"--help", "--verbose"}, "hv", {
     {name = "help", has_arg = "none", short = "h"},
     {name = "verbose", has_arg = "none", short = "v"},
@@ -59,27 +60,29 @@ local function test_long_options()
     table.insert(opts, opt)
   end
   assert(#opts == 2, "expected 2 long options")
-  assert(opts[1] == "help", "expected 'help', got '" .. opts[1] .. "'")
-  assert(opts[2] == "verbose", "expected 'verbose', got '" .. opts[2] .. "'")
+  assert(opts[1] == "h", "expected 'h', got '" .. opts[1] .. "'")
+  assert(opts[2] == "v", "expected 'v', got '" .. opts[2] .. "'")
 end
-test_long_options()
+test_long_options_with_short_alias()
 
 local function test_long_option_with_equals_arg()
+  -- Returns short alias 'o' since one is defined
   local parser = getopt.new({"--output=file.txt"}, "o:", {
     {name = "output", has_arg = "required", short = "o"},
   })
   local opt, optarg = parser:next()
-  assert(opt == "output", "expected 'output', got '" .. tostring(opt) .. "'")
+  assert(opt == "o", "expected 'o', got '" .. tostring(opt) .. "'")
   assert(optarg == "file.txt", "expected 'file.txt', got '" .. tostring(optarg) .. "'")
 end
 test_long_option_with_equals_arg()
 
 local function test_long_option_with_separate_arg()
+  -- Returns short alias 'o' since one is defined
   local parser = getopt.new({"--output", "file.txt"}, "o:", {
     {name = "output", has_arg = "required", short = "o"},
   })
   local opt, optarg = parser:next()
-  assert(opt == "output", "expected 'output'")
+  assert(opt == "o", "expected 'o'")
   assert(optarg == "file.txt", "expected 'file.txt', got '" .. tostring(optarg) .. "'")
 end
 test_long_option_with_separate_arg()
@@ -143,6 +146,7 @@ end
 test_repeated_options()
 
 local function test_mixed_short_and_long()
+  -- All options return short form since short aliases are defined
   local parser = getopt.new({"-v", "--output", "out.txt", "-h"}, "vho:", {
     {name = "verbose", has_arg = "none", short = "v"},
     {name = "output", has_arg = "required", short = "o"},
@@ -156,7 +160,7 @@ local function test_mixed_short_and_long()
   end
   assert(#results == 3, "expected 3 options")
   assert(results[1][1] == "v", "expected 'v' first")
-  assert(results[2][1] == "output", "expected 'output' second")
+  assert(results[2][1] == "o", "expected 'o' second")
   assert(results[2][2] == "out.txt", "expected 'out.txt' as output arg")
   assert(results[3][1] == "h", "expected 'h' third")
 end


### PR DESCRIPTION
## Summary
Add a new `cosmic.getopt` module that provides a Teal-typed wrapper around the underlying `cosmo.getopt` library. This enables type-safe command-line argument parsing with support for short options, long options, and optional/required arguments.

## Changes
- **lib/cosmic/getopt.tl**: New module providing typed interfaces for command-line option parsing
  - `LongOpt` record type for defining long options with name, argument behavior, and optional short alias
  - `Parser` record type with methods for iterating through options (`next()`), retrieving remaining arguments (`remaining()`), and accessing unknown options (`unknown()`)
  - `new()` function to create a parser from argument list, short option string, and optional long options table
  - Comprehensive documentation with usage examples

- **lib/cosmic/getopt_test.tl**: Comprehensive test suite covering:
  - Short options without arguments
  - Short options with required and attached arguments
  - Combined short options (e.g., `-hv`)
  - Long options with and without arguments
  - Long options with `--option=value` syntax
  - Remaining positional arguments after option parsing
  - Double-dash (`--`) to stop option parsing
  - Unknown option detection
  - Repeated options
  - Mixed short and long options
  - Edge cases (empty args, only positional args, long options without short aliases)

## Implementation Details
- The module wraps `cosmo.getopt` while converting the typed `LongOpt` records to the table format expected by the underlying library
- All three parser methods (`next()`, `remaining()`, `unknown()`) are properly delegated to the wrapped parser
- The implementation maintains full compatibility with the underlying `cosmo.getopt` behavior while providing Teal type safety

https://claude.ai/code/session_015dVV6gKrrQibnc2KQPP3dg
fixes https://github.com/whilp/cosmic/issues/125