### PR TITLE
Add system information utilities module (cosmic.sys)

### DIFF
--- a/lib/cosmic/sys.tl
+++ b/lib/cosmic/sys.tl
@@ -1,0 +1,38 @@
+--- System information utilities.
+--- Wraps cosmo system functions for OS and architecture queries.
+local cosmo = require("cosmo")
+
+--- Get the operating system name.
+--- Returns lowercase strings: "linux", "macos", "windows", "freebsd", "openbsd", "netbsd".
+--- @return string The operating system name
+local function host_os(): string
+  return cosmo.GetHostOs():lower()
+end
+
+--- Get the CPU architecture (instruction set architecture).
+--- Returns lowercase strings: "x86_64", "aarch64".
+--- @return string The CPU architecture
+local function host_isa(): string
+  return cosmo.GetHostIsa():lower()
+end
+
+--- Get the platform identifier combining OS and architecture.
+--- Returns a string in the format "os-arch" (e.g., "linux-x86_64", "macos-aarch64").
+--- @return string The platform identifier
+local function platform(): string
+  return host_os() .. "-" .. host_isa()
+end
+
+local record SysModule
+  host_os: function(): string
+  host_isa: function(): string
+  platform: function(): string
+end
+
+local M: SysModule = {
+  host_os = host_os,
+  host_isa = host_isa,
+  platform = platform,
+}
+
+return M

--- a/lib/cosmic/sys_test.tl
+++ b/lib/cosmic/sys_test.tl
@@ -1,0 +1,77 @@
+#!/usr/bin/env cosmic
+local sys = require("cosmic.sys")
+
+-- host_os tests
+
+local function test_host_os_returns_string()
+  local os_name = sys.host_os()
+  assert(type(os_name) == "string", "host_os should return a string, got " .. type(os_name))
+  assert(#os_name > 0, "host_os should return a non-empty string")
+end
+test_host_os_returns_string()
+
+local function test_host_os_is_lowercase()
+  local os_name = sys.host_os()
+  assert(os_name == os_name:lower(), "host_os should return lowercase, got " .. os_name)
+end
+test_host_os_is_lowercase()
+
+local function test_host_os_is_known_value()
+  local os_name = sys.host_os()
+  local is_known = os_name == "linux" or os_name == "macos" or os_name == "windows"
+    or os_name == "freebsd" or os_name == "openbsd" or os_name == "netbsd"
+  assert(is_known, "host_os should return a known OS, got " .. os_name)
+end
+test_host_os_is_known_value()
+
+-- host_isa tests
+
+local function test_host_isa_returns_string()
+  local isa = sys.host_isa()
+  assert(type(isa) == "string", "host_isa should return a string, got " .. type(isa))
+  assert(#isa > 0, "host_isa should return a non-empty string")
+end
+test_host_isa_returns_string()
+
+local function test_host_isa_is_lowercase()
+  local isa = sys.host_isa()
+  assert(isa == isa:lower(), "host_isa should return lowercase, got " .. isa)
+end
+test_host_isa_is_lowercase()
+
+local function test_host_isa_is_known_value()
+  local isa = sys.host_isa()
+  local is_known = isa == "x86_64" or isa == "aarch64"
+  assert(is_known, "host_isa should return a known ISA, got " .. isa)
+end
+test_host_isa_is_known_value()
+
+-- platform tests
+
+local function test_platform_returns_string()
+  local plat = sys.platform()
+  assert(type(plat) == "string", "platform should return a string, got " .. type(plat))
+  assert(#plat > 0, "platform should return a non-empty string")
+end
+test_platform_returns_string()
+
+local function test_platform_contains_hyphen()
+  local plat = sys.platform()
+  assert(plat:find("-"), "platform should contain a hyphen separator, got " .. plat)
+end
+test_platform_contains_hyphen()
+
+local function test_platform_matches_os_and_isa()
+  local os_name = sys.host_os()
+  local isa = sys.host_isa()
+  local expected = os_name .. "-" .. isa
+  local plat = sys.platform()
+  assert(plat == expected, "platform should be " .. expected .. ", got " .. plat)
+end
+test_platform_matches_os_and_isa()
+
+local function test_platform_is_lowercase()
+  local plat = sys.platform()
+  assert(plat == plat:lower(), "platform should be lowercase, got " .. plat)
+end
+test_platform_is_lowercase()


### PR DESCRIPTION
## Summary
Add a new `cosmic.sys` module that provides utilities for querying system information such as the operating system, CPU architecture, and platform identifier. This module wraps the underlying cosmo system functions and normalizes their output to lowercase strings.

## Changes
- **New module**: `lib/cosmic/sys.tl` - System information utilities with three main functions:
  - `host_os()`: Returns the operating system name (linux, macos, windows, freebsd, openbsd, netbsd)
  - `host_isa()`: Returns the CPU architecture (x86_64, aarch64)
  - `platform()`: Returns a combined platform identifier in "os-arch" format (e.g., "linux-x86_64")

- **New test file**: `lib/cosmic/sys_test.tl` - Comprehensive test suite covering:
  - Return type validation (all functions return strings)
  - Output format validation (lowercase, non-empty)
  - Known value validation (OS and ISA are from expected sets)
  - Platform format validation (contains hyphen separator, matches os-isa combination)

## Implementation Details
- All functions normalize output to lowercase for consistency
- The module uses Teal's type annotations for type safety
- Platform identifier is constructed by combining `host_os()` and `host_isa()` with a hyphen separator
- Tests are executable as a Cosmic script and validate both individual functions and their interactions

https://claude.ai/code/session_01VVHgfMbEV5CbkVNnie4qyy