### PR TITLE
cosmic: add uuid module

### DIFF
--- a/lib/cosmic/uuid.tl
+++ b/lib/cosmic/uuid.tl
@@ -1,0 +1,35 @@
+--- UUID generation utilities.
+--- Wraps cosmo UUID functions for generating unique identifiers.
+---
+--- Example usage:
+---   local uuid = require("cosmic.uuid")
+---   local id = uuid.v4()   -- random UUID
+---   local id = uuid.v7()   -- time-ordered UUID
+local cosmo = require("cosmo")
+
+--- Generate a random UUID (version 4).
+--- Returns a string in standard UUID format (e.g., "550e8400-e29b-41d4-a716-446655440000").
+--- @return string A random UUID string
+local function v4(): string
+  return cosmo.UuidV4()
+end
+
+--- Generate a time-ordered UUID (version 7).
+--- Returns a string in standard UUID format with embedded timestamp.
+--- UUIDv7 is useful for database primary keys since time-ordering provides better index locality.
+--- @return string A time-ordered UUID string
+local function v7(): string
+  return cosmo.UuidV7()
+end
+
+local record UuidModule
+  v4: function(): string
+  v7: function(): string
+end
+
+local M: UuidModule = {
+  v4 = v4,
+  v7 = v7,
+}
+
+return M

--- a/lib/cosmic/uuid_test.tl
+++ b/lib/cosmic/uuid_test.tl
@@ -1,0 +1,72 @@
+#!/usr/bin/env cosmic
+local uuid = require("cosmic.uuid")
+
+-- UUID format pattern: 8-4-4-4-12 hex digits
+local uuid_pattern = "^%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x$"
+
+-- v4 tests
+
+local function test_v4_returns_string()
+  local id = uuid.v4()
+  assert(type(id) == "string", "v4 should return a string, got " .. type(id))
+end
+test_v4_returns_string()
+
+local function test_v4_format()
+  local id = uuid.v4()
+  assert(id:match(uuid_pattern), "v4 should return valid UUID format, got " .. id)
+end
+test_v4_format()
+
+local function test_v4_version_digit()
+  local id = uuid.v4()
+  local version = id:sub(15, 15)
+  assert(version == "4", "v4 should have version digit 4, got " .. version .. " in " .. id)
+end
+test_v4_version_digit()
+
+local function test_v4_unique()
+  local id1 = uuid.v4()
+  local id2 = uuid.v4()
+  assert(id1 ~= id2, "v4 should generate unique UUIDs")
+end
+test_v4_unique()
+
+-- v7 tests
+
+local function test_v7_returns_string()
+  local id = uuid.v7()
+  assert(type(id) == "string", "v7 should return a string, got " .. type(id))
+end
+test_v7_returns_string()
+
+local function test_v7_format()
+  local id = uuid.v7()
+  assert(id:match(uuid_pattern), "v7 should return valid UUID format, got " .. id)
+end
+test_v7_format()
+
+local function test_v7_version_digit()
+  local id = uuid.v7()
+  local version = id:sub(15, 15)
+  assert(version == "7", "v7 should have version digit 7, got " .. version .. " in " .. id)
+end
+test_v7_version_digit()
+
+local function test_v7_unique()
+  local id1 = uuid.v7()
+  local id2 = uuid.v7()
+  assert(id1 ~= id2, "v7 should generate unique UUIDs")
+end
+test_v7_unique()
+
+local function test_v7_time_ordered()
+  local ids: {string} = {}
+  for _ = 1, 10 do
+    table.insert(ids, uuid.v7())
+  end
+  for i = 2, #ids do
+    assert(ids[i-1] < ids[i], "v7 UUIDs should be time-ordered, but " .. ids[i-1] .. " >= " .. ids[i])
+  end
+end
+test_v7_time_ordered()

--- a/lib/types/cosmo.d.tl
+++ b/lib/types/cosmo.d.tl
@@ -26,6 +26,10 @@ local record cosmo
   GetHostIsa: function(): string
   GetRandomBytes: function(count: number): string
 
+  -- uuid
+  UuidV4: function(): string
+  UuidV7: function(): string
+
   -- script detection
   is_main: function(): boolean
 


### PR DESCRIPTION
## Summary

- Add `cosmic.uuid` module wrapping cosmo UUID functions
- `uuid.v4()` - Generate random UUID (version 4)
- `uuid.v7()` - Generate time-ordered UUID (version 7, useful for DB primary keys)
- Add type definitions for `cosmo.UuidV4` and `cosmo.UuidV7`

## Test plan

- [x] `make clean test` passes (46/46 tests)
- [x] UUID format validation tests
- [x] Version digit tests (v4 has "4", v7 has "7")
- [x] Uniqueness tests
- [x] v7 time-ordering test

Closes #137