### PR TITLE
time: add HTTP datetime parsing and formatting

### DIFF
--- a/lib/cosmic/time.tl
+++ b/lib/cosmic/time.tl
@@ -1,6 +1,7 @@
 --- Time and clock utilities.
 --- Wraps cosmo.unix time functions for timestamps, sleeping, and time breakdown.
 local unix = require("cosmo.unix")
+local cosmo = require("cosmo")
 
 --- DateTime represents a broken-down timestamp.
 --- Returned by gmtime() and localtime().
@@ -118,6 +119,21 @@ local function localtime(unixts: number): DateTime
   }
 end
 
+--- Format a UNIX timestamp as an HTTP date string (RFC 7231).
+--- @param timestamp number UNIX timestamp (seconds since epoch)
+--- @return string HTTP date string (e.g., "Sun, 01 Feb 2026 12:00:00 GMT")
+local function format_http(timestamp: number): string
+  return cosmo.FormatHttpDateTime(timestamp)
+end
+
+--- Parse an HTTP date string (RFC 7231) into a UNIX timestamp.
+--- Returns 0 for invalid input.
+--- @param str string HTTP date string
+--- @return number UNIX timestamp, or 0 if parsing failed
+local function parse_http(str: string): number
+  return cosmo.ParseHttpDateTime(str)
+end
+
 local record TimeModule
   -- Clock constants
   CLOCK_REALTIME: number
@@ -137,6 +153,8 @@ local record TimeModule
   sleep_ms: function(ms: number): number, number
   gmtime: function(unixts: number): DateTime
   localtime: function(unixts: number): DateTime
+  format_http: function(timestamp: number): string
+  parse_http: function(str: string): number
 end
 
 local M: TimeModule = {
@@ -158,6 +176,8 @@ local M: TimeModule = {
   sleep_ms = sleep_ms,
   gmtime = gmtime,
   localtime = localtime,
+  format_http = format_http,
+  parse_http = parse_http,
 }
 
 return M

--- a/lib/cosmic/time_test.tl
+++ b/lib/cosmic/time_test.tl
@@ -164,3 +164,55 @@ local function test_clock_realtime_is_zero()
   assert(time.CLOCK_REALTIME == 0, "CLOCK_REALTIME should be 0, got " .. tostring(time.CLOCK_REALTIME))
 end
 test_clock_realtime_is_zero()
+
+-- format_http tests
+
+local function test_format_http_epoch()
+  local http_date = time.format_http(0)
+  assert(http_date == "Thu, 01 Jan 1970 00:00:00 GMT", "expected epoch format, got " .. http_date)
+end
+test_format_http_epoch()
+
+local function test_format_http_known_date()
+  -- 2000-01-01 00:00:00 UTC = 946684800
+  local http_date = time.format_http(946684800)
+  assert(http_date == "Sat, 01 Jan 2000 00:00:00 GMT", "expected Y2K format, got " .. http_date)
+end
+test_format_http_known_date()
+
+local function test_format_http_format()
+  local secs, _ = time.now()
+  local http_date = time.format_http(secs)
+  -- Should match RFC 7231 format: "Day, DD Mon YYYY HH:MM:SS GMT"
+  assert(http_date:match("^%a%a%a, %d%d %a%a%a %d%d%d%d %d%d:%d%d:%d%d GMT$"),
+    "expected RFC 7231 format, got " .. http_date)
+end
+test_format_http_format()
+
+-- parse_http tests
+
+local function test_parse_http_epoch()
+  local ts = time.parse_http("Thu, 01 Jan 1970 00:00:00 GMT")
+  assert(ts == 0, "expected 0, got " .. tostring(ts))
+end
+test_parse_http_epoch()
+
+local function test_parse_http_known_date()
+  local ts = time.parse_http("Sat, 01 Jan 2000 00:00:00 GMT")
+  assert(ts == 946684800, "expected 946684800, got " .. tostring(ts))
+end
+test_parse_http_known_date()
+
+local function test_parse_http_invalid()
+  local ts = time.parse_http("invalid")
+  assert(ts == 0, "expected 0 for invalid input, got " .. tostring(ts))
+end
+test_parse_http_invalid()
+
+local function test_format_parse_roundtrip()
+  local original = 1705322245
+  local formatted = time.format_http(original)
+  local parsed = time.parse_http(formatted)
+  assert(parsed == original, "roundtrip failed: " .. tostring(original) .. " -> " .. formatted .. " -> " .. tostring(parsed))
+end
+test_format_parse_roundtrip()

--- a/lib/types/cosmo.d.tl
+++ b/lib/types/cosmo.d.tl
@@ -21,6 +21,10 @@ local record cosmo
   EscapeParam: function(str: string): string
   ParseParams: function(query: string): {{string, string}}
 
+  -- http datetime
+  FormatHttpDateTime: function(timestamp: number): string
+  ParseHttpDateTime: function(str: string): number
+
   -- system info
   GetHostOs: function(): string
   GetHostIsa: function(): string


### PR DESCRIPTION
## Summary

- Wraps `cosmo.FormatHttpDateTime` and `cosmo.ParseHttpDateTime` in `cosmic.time`
- Adds `format_http(timestamp)` to format UNIX timestamps as RFC 7231 HTTP dates
- Adds `parse_http(str)` to parse HTTP date strings back to UNIX timestamps
- Adds type declarations to `cosmo.d.tl`

## Test plan

- [x] `make test` passes (46/46 tests)
- [x] Tests cover epoch, known dates, format validation, invalid input, and roundtrip

Closes #140