### PR TITLE
url: add ParseUrl and ParseHost parsing functions

### DIFF
--- a/lib/cosmic/url.tl
+++ b/lib/cosmic/url.tl
@@ -42,16 +42,99 @@ local function parse(query: string): {string:string}
   return result
 end
 
+--- Parsed URL components.
+local record Url
+  scheme: string
+  user: string
+  pass: string
+  host: string
+  port: integer
+  path: string
+  query: string
+  fragment: string
+end
+
 local record UrlModule
+  Url: Url
+
   encode: function(str: string): string
   decode: function(str: string): string, string
   parse: function(query: string): {string:string}
+  parse_url: function(url: string): Url
+  parse_host: function(hostport: string): string, integer
+end
+
+--- Parse a URL into its components.
+--- @param url string The URL to parse
+--- @return Url The parsed URL components
+local function parse_url(url: string): Url
+  local parsed = cosmo.ParseUrl(url)
+
+  -- Convert port from string to integer if present
+  local port: integer = nil
+  if parsed.port and parsed.port ~= "" then
+    port = tonumber(parsed.port) as integer
+  end
+
+  -- Reconstruct query string from params
+  local query: string = nil
+  if parsed.params and #parsed.params > 0 then
+    local parts: {string} = {}
+    for _, pair in ipairs(parsed.params) do
+      table.insert(parts, pair[1] .. "=" .. pair[2])
+    end
+    query = table.concat(parts, "&")
+  end
+
+  return {
+    scheme = parsed.scheme,
+    user = parsed.user,
+    pass = parsed.pass,
+    host = parsed.host,
+    port = port,
+    path = parsed.path,
+    query = query,
+    fragment = parsed.fragment,
+  }
+end
+
+--- Parse a host:port string into its components.
+--- @param hostport string The host:port string (e.g., "example.com:8080")
+--- @return string The host
+--- @return integer? The port, or nil if not specified
+local function parse_host(hostport: string): string, integer
+  if not hostport or hostport == "" then
+    return nil, nil
+  end
+
+  -- Handle IPv6 addresses in brackets: [::1]:8080
+  local ipv6_host, ipv6_port = hostport:match("^%[([^%]]+)%]:(%d+)$")
+  if ipv6_host then
+    return ipv6_host, tonumber(ipv6_port) as integer
+  end
+
+  -- Handle IPv6 without port: [::1]
+  local ipv6_only = hostport:match("^%[([^%]]+)%]$")
+  if ipv6_only then
+    return ipv6_only, nil
+  end
+
+  -- Handle regular host:port
+  local host, port_str = hostport:match("^(.+):(%d+)$")
+  if host and port_str then
+    return host, tonumber(port_str) as integer
+  end
+
+  -- No port specified
+  return hostport, nil
 end
 
 local M: UrlModule = {
   encode = encode,
   decode = decode,
   parse = parse,
+  parse_url = parse_url,
+  parse_host = parse_host,
 }
 
 return M

--- a/lib/cosmic/url_test.tl
+++ b/lib/cosmic/url_test.tl
@@ -154,3 +154,99 @@ local function test_parse_plus_as_space()
   assert(result.msg == "hello world", "expected 'hello world', got '" .. tostring(result.msg) .. "'")
 end
 test_parse_plus_as_space()
+
+-- parse_url tests
+
+local function test_parse_url_full()
+  local result = url.parse_url("https://user:pass@example.com:8080/path?foo=1&bar=2#frag")
+  assert(result.scheme == "https", "expected 'https', got '" .. tostring(result.scheme) .. "'")
+  assert(result.user == "user", "expected 'user', got '" .. tostring(result.user) .. "'")
+  assert(result.pass == "pass", "expected 'pass', got '" .. tostring(result.pass) .. "'")
+  assert(result.host == "example.com", "expected 'example.com', got '" .. tostring(result.host) .. "'")
+  assert(result.port == 8080, "expected 8080, got " .. tostring(result.port))
+  assert(result.path == "/path", "expected '/path', got '" .. tostring(result.path) .. "'")
+  assert(result.query == "foo=1&bar=2", "expected 'foo=1&bar=2', got '" .. tostring(result.query) .. "'")
+  assert(result.fragment == "frag", "expected 'frag', got '" .. tostring(result.fragment) .. "'")
+end
+test_parse_url_full()
+
+local function test_parse_url_minimal()
+  local result = url.parse_url("http://example.com")
+  assert(result.scheme == "http", "expected 'http', got '" .. tostring(result.scheme) .. "'")
+  assert(result.host == "example.com", "expected 'example.com', got '" .. tostring(result.host) .. "'")
+  assert(result.port == nil, "expected nil port, got " .. tostring(result.port))
+  assert(result.path == "" or result.path == nil, "expected empty path, got '" .. tostring(result.path) .. "'")
+  assert(result.query == nil, "expected nil query, got '" .. tostring(result.query) .. "'")
+end
+test_parse_url_minimal()
+
+local function test_parse_url_with_path_only()
+  local result = url.parse_url("http://example.com/api/v1/users")
+  assert(result.scheme == "http", "expected 'http'")
+  assert(result.host == "example.com", "expected 'example.com'")
+  assert(result.path == "/api/v1/users", "expected '/api/v1/users', got '" .. tostring(result.path) .. "'")
+end
+test_parse_url_with_path_only()
+
+local function test_parse_url_with_query_only()
+  local result = url.parse_url("http://example.com?search=test")
+  assert(result.query == "search=test", "expected 'search=test', got '" .. tostring(result.query) .. "'")
+end
+test_parse_url_with_query_only()
+
+local function test_parse_url_with_fragment_only()
+  local result = url.parse_url("http://example.com#section")
+  assert(result.fragment == "section", "expected 'section', got '" .. tostring(result.fragment) .. "'")
+end
+test_parse_url_with_fragment_only()
+
+-- parse_host tests
+
+local function test_parse_host_with_port()
+  local host, port = url.parse_host("example.com:8080")
+  assert(host == "example.com", "expected 'example.com', got '" .. tostring(host) .. "'")
+  assert(port == 8080, "expected 8080, got " .. tostring(port))
+end
+test_parse_host_with_port()
+
+local function test_parse_host_without_port()
+  local host, port = url.parse_host("example.com")
+  assert(host == "example.com", "expected 'example.com', got '" .. tostring(host) .. "'")
+  assert(port == nil, "expected nil port, got " .. tostring(port))
+end
+test_parse_host_without_port()
+
+local function test_parse_host_localhost()
+  local host, port = url.parse_host("localhost:3000")
+  assert(host == "localhost", "expected 'localhost', got '" .. tostring(host) .. "'")
+  assert(port == 3000, "expected 3000, got " .. tostring(port))
+end
+test_parse_host_localhost()
+
+local function test_parse_host_ipv4()
+  local host, port = url.parse_host("192.168.1.1:80")
+  assert(host == "192.168.1.1", "expected '192.168.1.1', got '" .. tostring(host) .. "'")
+  assert(port == 80, "expected 80, got " .. tostring(port))
+end
+test_parse_host_ipv4()
+
+local function test_parse_host_ipv6_with_port()
+  local host, port = url.parse_host("[::1]:8080")
+  assert(host == "::1", "expected '::1', got '" .. tostring(host) .. "'")
+  assert(port == 8080, "expected 8080, got " .. tostring(port))
+end
+test_parse_host_ipv6_with_port()
+
+local function test_parse_host_ipv6_without_port()
+  local host, port = url.parse_host("[::1]")
+  assert(host == "::1", "expected '::1', got '" .. tostring(host) .. "'")
+  assert(port == nil, "expected nil port, got " .. tostring(port))
+end
+test_parse_host_ipv6_without_port()
+
+local function test_parse_host_empty()
+  local host, port = url.parse_host("")
+  assert(host == nil, "expected nil host for empty string")
+  assert(port == nil, "expected nil port for empty string")
+end
+test_parse_host_empty()

--- a/lib/types/cosmo.d.tl
+++ b/lib/types/cosmo.d.tl
@@ -21,6 +21,20 @@ local record cosmo
   EscapeParam: function(str: string): string
   ParseParams: function(query: string): {{string, string}}
 
+  -- url parsing
+  record ParsedUrl
+    scheme: string
+    user: string
+    pass: string
+    host: string
+    port: string
+    path: string
+    fragment: string
+    params: {{string, string}}
+  end
+  ParseUrl: function(url: string): ParsedUrl
+  ParseHost: function(hostport: string): string
+
   -- http datetime
   FormatHttpDateTime: function(timestamp: number): string
   ParseHttpDateTime: function(str: string): number


### PR DESCRIPTION
## Summary

- Add `parse_url(url)` function to parse full URLs into components (scheme, user, pass, host, port, path, query, fragment)
- Add `parse_host(hostport)` function to parse host:port strings with IPv6 support
- Add type declarations for `cosmo.ParseUrl` and `cosmo.ParseHost`

## Test plan

- [x] Type check passes (`make teal`)
- [x] All tests pass (`make test`)
- [x] New tests cover full URLs, minimal URLs, various components, IPv4/IPv6 hosts

Closes #138