### PR TITLE
codec: add base32, base64, latin1 encoding functions

### DIFF
--- a/lib/cosmic/codec.tl
+++ b/lib/cosmic/codec.tl
@@ -58,11 +58,69 @@ local function decode_lua(code: string): any, string
   return result, nil
 end
 
+--- Encode binary data as base64.
+--- Uses standard base64 encoding (RFC 4648).
+--- @param data string The binary data to encode
+--- @return string The base64 encoded string
+local function encode_base64(data: string): string
+  return cosmo.EncodeBase64(data)
+end
+
+--- Decode a base64 string to binary data.
+--- Accepts standard base64 encoding with or without padding.
+--- @param str string The base64 string to decode
+--- @return string The decoded binary data
+local function decode_base64(str: string): string
+  return cosmo.DecodeBase64(str)
+end
+
+--- Encode binary data as base32.
+--- Uses z-base-32 encoding (lowercase alphabet).
+--- @param data string The binary data to encode
+--- @return string The base32 encoded string
+local function encode_base32(data: string): string
+  return cosmo.EncodeBase32(data)
+end
+
+--- Decode a base32 string to binary data.
+--- Accepts z-base-32 encoding.
+--- @param str string The base32 string to decode
+--- @return string The decoded binary data
+local function decode_base32(str: string): string
+  return cosmo.DecodeBase32(str)
+end
+
+--- Encode a UTF-8 string as Latin-1 (ISO-8859-1).
+--- Characters outside the Latin-1 range will cause an error.
+--- @param str string The UTF-8 string to encode
+--- @return string The Latin-1 encoded bytes, or nil on error
+--- @return string? Error message if encoding failed
+local function encode_latin1(str: string): string, string
+  local ok, result = pcall(cosmo.EncodeLatin1, str)
+  if not ok then
+    return nil, "cannot encode to Latin-1: character out of range"
+  end
+  return result
+end
+
+--- Decode Latin-1 (ISO-8859-1) bytes to a UTF-8 string.
+--- @param data string The Latin-1 bytes to decode
+--- @return string The UTF-8 string
+local function decode_latin1(data: string): string
+  return cosmo.DecodeLatin1(data)
+end
+
 local record CodecModule
   encode_hex: function(data: string): string
   decode_hex: function(hex: string): string, string
   encode_lua: function(value: any, opts?: {string:any}): string
   decode_lua: function(code: string): any, string
+  encode_base64: function(data: string): string
+  decode_base64: function(str: string): string
+  encode_base32: function(data: string): string
+  decode_base32: function(str: string): string
+  encode_latin1: function(str: string): string, string
+  decode_latin1: function(data: string): string
 end
 
 local M: CodecModule = {
@@ -70,6 +128,12 @@ local M: CodecModule = {
   decode_hex = decode_hex,
   encode_lua = encode_lua,
   decode_lua = decode_lua,
+  encode_base64 = encode_base64,
+  decode_base64 = decode_base64,
+  encode_base32 = encode_base32,
+  decode_base32 = decode_base32,
+  encode_latin1 = encode_latin1,
+  decode_latin1 = decode_latin1,
 }
 
 return M

--- a/lib/cosmic/codec_test.tl
+++ b/lib/cosmic/codec_test.tl
@@ -162,3 +162,121 @@ local function test_lua_roundtrip()
   assert(nested.y == original.nested.y, "nested.y mismatch")
 end
 test_lua_roundtrip()
+
+-- Base64 encoding tests
+
+local function test_encode_base64_basic()
+  local result = codec.encode_base64("hello")
+  assert(result == "aGVsbG8=", "expected 'aGVsbG8=', got '" .. result .. "'")
+end
+test_encode_base64_basic()
+
+local function test_encode_base64_empty()
+  local result = codec.encode_base64("")
+  assert(result == "", "expected empty string")
+end
+test_encode_base64_empty()
+
+local function test_encode_base64_binary()
+  local result = codec.encode_base64("\x00\xff")
+  assert(result == "AP8=", "expected 'AP8=', got '" .. result .. "'")
+end
+test_encode_base64_binary()
+
+local function test_decode_base64_basic()
+  local result = codec.decode_base64("aGVsbG8=")
+  assert(result == "hello", "expected 'hello', got '" .. result .. "'")
+end
+test_decode_base64_basic()
+
+local function test_decode_base64_no_padding()
+  local result = codec.decode_base64("aGVsbG8")
+  assert(result == "hello", "expected 'hello', got '" .. result .. "'")
+end
+test_decode_base64_no_padding()
+
+local function test_decode_base64_empty()
+  local result = codec.decode_base64("")
+  assert(result == "", "expected empty string")
+end
+test_decode_base64_empty()
+
+local function test_base64_roundtrip()
+  local original = "Hello, World! \x00\xff\x10"
+  local encoded = codec.encode_base64(original)
+  local decoded = codec.decode_base64(encoded)
+  assert(decoded == original, "roundtrip mismatch")
+end
+test_base64_roundtrip()
+
+-- Base32 encoding tests (z-base-32)
+
+local function test_encode_base32_basic()
+  local result = codec.encode_base32("hello")
+  assert(result == "d1jprv3f", "expected 'd1jprv3f', got '" .. result .. "'")
+end
+test_encode_base32_basic()
+
+local function test_encode_base32_empty()
+  local result = codec.encode_base32("")
+  assert(result == "", "expected empty string")
+end
+test_encode_base32_empty()
+
+local function test_decode_base32_basic()
+  local result = codec.decode_base32("d1jprv3f")
+  assert(result == "hello", "expected 'hello', got '" .. result .. "'")
+end
+test_decode_base32_basic()
+
+local function test_decode_base32_empty()
+  local result = codec.decode_base32("")
+  assert(result == "", "expected empty string")
+end
+test_decode_base32_empty()
+
+local function test_base32_roundtrip()
+  local original = "Hello, World!"
+  local encoded = codec.encode_base32(original)
+  local decoded = codec.decode_base32(encoded)
+  assert(decoded == original, "roundtrip mismatch")
+end
+test_base32_roundtrip()
+
+-- Latin-1 encoding tests
+
+local function test_encode_latin1_ascii()
+  local result, err = codec.encode_latin1("hello")
+  assert(err == nil, "unexpected error: " .. (err or ""))
+  assert(result == "hello", "expected 'hello', got '" .. (result or "nil") .. "'")
+end
+test_encode_latin1_ascii()
+
+local function test_encode_latin1_accented()
+  local result, err = codec.encode_latin1("café")
+  assert(err == nil, "unexpected error: " .. (err or ""))
+  assert(#result == 4, "expected 4 bytes, got " .. #result)
+end
+test_encode_latin1_accented()
+
+local function test_encode_latin1_out_of_range()
+  local result, err = codec.encode_latin1("日本語")
+  assert(result == nil, "expected nil for out-of-range characters")
+  assert(err ~= nil, "expected error message")
+end
+test_encode_latin1_out_of_range()
+
+local function test_decode_latin1_basic()
+  local result = codec.decode_latin1("hello")
+  assert(result == "hello", "expected 'hello', got '" .. result .. "'")
+end
+test_decode_latin1_basic()
+
+local function test_latin1_roundtrip()
+  local original = "café résumé naïve"
+  local encoded, err = codec.encode_latin1(original)
+  assert(err == nil, "encode failed: " .. (err or ""))
+  local decoded = codec.decode_latin1(encoded)
+  assert(decoded == original, "roundtrip mismatch: got '" .. decoded .. "'")
+end
+test_latin1_roundtrip()

--- a/lib/types/cosmo.d.tl
+++ b/lib/types/cosmo.d.tl
@@ -16,6 +16,12 @@ local record cosmo
   EncodeJson: function(value: any): string, string
   DecodeJson: function(json: string): any, string
   EncodeLua: function(value: any, opts?: {string:any}): string
+  EncodeBase64: function(data: string): string
+  DecodeBase64: function(str: string): string
+  EncodeBase32: function(data: string): string
+  DecodeBase32: function(str: string): string
+  EncodeLatin1: function(str: string): string
+  DecodeLatin1: function(data: string): string
 
   -- url encoding
   EscapeParam: function(str: string): string


### PR DESCRIPTION
## Summary

- Add `encode_base64` / `decode_base64` for standard base64 encoding (RFC 4648)
- Add `encode_base32` / `decode_base32` for z-base-32 encoding
- Add `encode_latin1` / `decode_latin1` for Latin-1 (ISO-8859-1) with error handling

## Test plan

- [x] `make teal` passes
- [x] `make clean test` passes
- [x] Tests cover encoding, decoding, roundtrips, edge cases (empty strings, binary data)
- [x] Latin-1 encoding returns error for out-of-range characters

Closes #134