### PR TITLE
ip: add cosmic.ip module for IP address utilities

### DIFF
--- a/lib/cosmic/ip.tl
+++ b/lib/cosmic/ip.tl
@@ -1,0 +1,76 @@
+--- IP address parsing, formatting, and classification utilities.
+local cosmo = require("cosmo")
+
+--- Parse an IP address string to its integer representation.
+--- Returns -1 for invalid or unsupported addresses (including IPv6).
+--- @param str string The IP address string (e.g., "192.168.1.1")
+--- @return integer The IP address as an integer, or -1 on error
+local function parse(str: string): integer
+  return cosmo.ParseIp(str)
+end
+
+--- Format an integer IP address as a string.
+--- @param ip integer The IP address as an integer
+--- @return string The formatted IP address string
+local function format(ip: integer): string
+  return cosmo.FormatIp(ip)
+end
+
+--- Categorize an IP address.
+--- Returns categories like "LOOPBACK", "PRIVATE", "ARIN", etc.
+--- @param ip integer The IP address as an integer
+--- @return string The category name
+local function categorize(ip: integer): string
+  return cosmo.CategorizeIp(ip)
+end
+
+--- Check if an IP address is a loopback address (127.x.x.x).
+--- @param ip integer The IP address as an integer
+--- @return boolean True if the address is a loopback address
+local function is_loopback(ip: integer): boolean
+  return cosmo.IsLoopbackIp(ip)
+end
+
+--- Check if an IP address is a private address.
+--- Private ranges: 10.x.x.x, 172.16-31.x.x, 192.168.x.x
+--- @param ip integer The IP address as an integer
+--- @return boolean True if the address is private
+local function is_private(ip: integer): boolean
+  return cosmo.IsPrivateIp(ip)
+end
+
+--- Check if an IP address is a public/routable address.
+--- @param ip integer The IP address as an integer
+--- @return boolean True if the address is public
+local function is_public(ip: integer): boolean
+  return cosmo.IsPublicIp(ip)
+end
+
+--- Resolve a hostname to an IP address.
+--- @param hostname string The hostname to resolve
+--- @return integer The IP address as an integer, or -1 on error
+local function resolve(hostname: string): integer
+  return cosmo.ResolveIp(hostname)
+end
+
+local record IpModule
+  parse: function(str: string): integer
+  format: function(ip: integer): string
+  categorize: function(ip: integer): string
+  is_loopback: function(ip: integer): boolean
+  is_private: function(ip: integer): boolean
+  is_public: function(ip: integer): boolean
+  resolve: function(hostname: string): integer
+end
+
+local M: IpModule = {
+  parse = parse,
+  format = format,
+  categorize = categorize,
+  is_loopback = is_loopback,
+  is_private = is_private,
+  is_public = is_public,
+  resolve = resolve,
+}
+
+return M

--- a/lib/cosmic/ip_test.tl
+++ b/lib/cosmic/ip_test.tl
@@ -1,0 +1,157 @@
+#!/usr/bin/env cosmic
+local ip = require("cosmic.ip")
+
+-- parse tests
+
+local function test_parse_ipv4_basic()
+  local result = ip.parse("192.168.1.1")
+  assert(result == 3232235777, "expected 3232235777, got " .. tostring(result))
+end
+test_parse_ipv4_basic()
+
+local function test_parse_localhost()
+  local result = ip.parse("127.0.0.1")
+  assert(result == 2130706433, "expected 2130706433, got " .. tostring(result))
+end
+test_parse_localhost()
+
+local function test_parse_invalid_returns_negative()
+  local result = ip.parse("invalid")
+  assert(result == -1, "expected -1 for invalid IP, got " .. tostring(result))
+end
+test_parse_invalid_returns_negative()
+
+local function test_parse_out_of_range()
+  local result = ip.parse("256.1.1.1")
+  assert(result == -1, "expected -1 for out-of-range IP, got " .. tostring(result))
+end
+test_parse_out_of_range()
+
+-- format tests
+
+local function test_format_basic()
+  local result = ip.format(3232235777)
+  assert(result == "192.168.1.1", "expected '192.168.1.1', got '" .. result .. "'")
+end
+test_format_basic()
+
+local function test_format_localhost()
+  local result = ip.format(2130706433)
+  assert(result == "127.0.0.1", "expected '127.0.0.1', got '" .. result .. "'")
+end
+test_format_localhost()
+
+local function test_format_roundtrip()
+  local original = "10.0.0.1"
+  local parsed = ip.parse(original)
+  local formatted = ip.format(parsed)
+  assert(formatted == original, "expected roundtrip to preserve '" .. original .. "', got '" .. formatted .. "'")
+end
+test_format_roundtrip()
+
+-- categorize tests
+
+local function test_categorize_loopback()
+  local result = ip.categorize(ip.parse("127.0.0.1"))
+  assert(result == "LOOPBACK", "expected 'LOOPBACK', got '" .. result .. "'")
+end
+test_categorize_loopback()
+
+local function test_categorize_private_192()
+  local result = ip.categorize(ip.parse("192.168.1.1"))
+  assert(result == "PRIVATE", "expected 'PRIVATE', got '" .. result .. "'")
+end
+test_categorize_private_192()
+
+local function test_categorize_private_10()
+  local result = ip.categorize(ip.parse("10.0.0.1"))
+  assert(result == "PRIVATE", "expected 'PRIVATE', got '" .. result .. "'")
+end
+test_categorize_private_10()
+
+local function test_categorize_public()
+  local result = ip.categorize(ip.parse("8.8.8.8"))
+  -- Public IPs return RIR name like "ARIN"
+  assert(result ~= "LOOPBACK" and result ~= "PRIVATE", "expected public category, got '" .. result .. "'")
+end
+test_categorize_public()
+
+-- is_loopback tests
+
+local function test_is_loopback_true()
+  local result = ip.is_loopback(ip.parse("127.0.0.1"))
+  assert(result == true, "expected true for loopback")
+end
+test_is_loopback_true()
+
+local function test_is_loopback_127_255()
+  local result = ip.is_loopback(ip.parse("127.255.255.255"))
+  assert(result == true, "expected true for 127.255.255.255")
+end
+test_is_loopback_127_255()
+
+local function test_is_loopback_false()
+  local result = ip.is_loopback(ip.parse("192.168.1.1"))
+  assert(result == false, "expected false for non-loopback")
+end
+test_is_loopback_false()
+
+-- is_private tests
+
+local function test_is_private_192_168()
+  local result = ip.is_private(ip.parse("192.168.1.1"))
+  assert(result == true, "expected true for 192.168.x.x")
+end
+test_is_private_192_168()
+
+local function test_is_private_10()
+  local result = ip.is_private(ip.parse("10.0.0.1"))
+  assert(result == true, "expected true for 10.x.x.x")
+end
+test_is_private_10()
+
+local function test_is_private_172_16()
+  local result = ip.is_private(ip.parse("172.16.0.1"))
+  assert(result == true, "expected true for 172.16.x.x")
+end
+test_is_private_172_16()
+
+local function test_is_private_false()
+  local result = ip.is_private(ip.parse("8.8.8.8"))
+  assert(result == false, "expected false for public IP")
+end
+test_is_private_false()
+
+-- is_public tests
+
+local function test_is_public_true()
+  local result = ip.is_public(ip.parse("8.8.8.8"))
+  assert(result == true, "expected true for public IP")
+end
+test_is_public_true()
+
+local function test_is_public_cloudflare()
+  local result = ip.is_public(ip.parse("1.1.1.1"))
+  assert(result == true, "expected true for Cloudflare DNS")
+end
+test_is_public_cloudflare()
+
+local function test_is_public_false_private()
+  local result = ip.is_public(ip.parse("192.168.1.1"))
+  assert(result == false, "expected false for private IP")
+end
+test_is_public_false_private()
+
+local function test_is_public_false_loopback()
+  local result = ip.is_public(ip.parse("127.0.0.1"))
+  assert(result == false, "expected false for loopback")
+end
+test_is_public_false_loopback()
+
+-- resolve tests
+
+local function test_resolve_localhost()
+  local result = ip.resolve("localhost")
+  assert(result == 2130706433, "expected 127.0.0.1 for localhost, got " .. tostring(result))
+end
+test_resolve_localhost()

--- a/lib/types/cosmo.d.tl
+++ b/lib/types/cosmo.d.tl
@@ -56,6 +56,15 @@ local record cosmo
   FormatHttpDateTime: function(timestamp: number): string
   ParseHttpDateTime: function(str: string): number
 
+  -- ip address utilities
+  ParseIp: function(str: string): integer
+  FormatIp: function(ip: integer): string
+  CategorizeIp: function(ip: integer): string
+  IsLoopbackIp: function(ip: integer): boolean
+  IsPrivateIp: function(ip: integer): boolean
+  IsPublicIp: function(ip: integer): boolean
+  ResolveIp: function(hostname: string): integer
+
   -- system info
   GetHostOs: function(): string
   GetHostIsa: function(): string


### PR DESCRIPTION
## Summary

- Add `cosmic.ip` module wrapping cosmo's IP address functions
- Add type declarations for IP functions in cosmo.d.tl
- Add comprehensive tests for all IP functions

## Functions

| Function | Purpose |
|----------|---------|
| `parse(str)` | Parse IP address string to integer |
| `format(ip)` | Format integer as IP address string |
| `categorize(ip)` | Classify IP (LOOPBACK, PRIVATE, ARIN, etc.) |
| `is_loopback(ip)` | Check if loopback address (127.x.x.x) |
| `is_private(ip)` | Check if private (10.x, 172.16-31.x, 192.168.x) |
| `is_public(ip)` | Check if public/routable |
| `resolve(hostname)` | Resolve hostname to IP address |

## Test plan

- [x] Parse/format roundtrip tested
- [x] Invalid IP handling tested
- [x] All classification functions tested with known addresses
- [x] `make test` passes (48 tests)

Closes #139