### PR TITLE
Add 'make check' target for type checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,10 @@ files: $(all_built_files)
 
 all_teals := $(patsubst %,%.teal.got,$(all_checkable_files))
 
+.PHONY: check
+## Run Teal type checking
+check: teal
+
 ## Run teal type checker on all files
 teal: $(o)/teal-summary.txt
 


### PR DESCRIPTION
Add a 'check' target that aliases to the 'teal' target, making 'make check' run Teal type checking as documented in CLAUDE.md.

https://claude.ai/code/session_01GCAyBbxH2jwyZFv3Up6Cg8