### PR TITLE
user, sandbox, signal: add error message returns

### DIFF
--- a/lib/cosmic/sandbox.tl
+++ b/lib/cosmic/sandbox.tl
@@ -2,6 +2,14 @@
 --- Wraps cosmo.unix for pledge and unveil operations to restrict system calls and filesystem access.
 local unix = require("cosmo.unix")
 
+local record Errno
+  errno: function(self: Errno): number
+  winerr: function(self: Errno): number
+  name: function(self: Errno): string
+  call: function(self: Errno): string
+  doc: function(self: Errno): string
+end
+
 --- Restricts system calls available to the process.
 --- Pledging causes most system calls to become unavailable. Using pledge is irreversible.
 --- On Linux disabled calls return EPERM; OpenBSD kills the process.
@@ -23,8 +31,20 @@ local unix = require("cosmo.unix")
 --- @param execpromises string|nil Promises for child processes after exec (nil = unrestricted)
 --- @param mode number|nil Optional mode flags
 --- @return boolean True on success
-local function pledge(promises?: string, execpromises?: string, mode?: number): boolean
-  return unix.pledge(promises, execpromises, mode)
+--- @return string? Error message on failure
+local function pledge(promises?: string, execpromises?: string, mode?: number): boolean, string
+  local ok, err = unix.pledge(promises, execpromises, mode) as (boolean, any)
+  if not ok then
+    if err then
+      local errno = err as Errno
+      if errno.doc then
+        return false, errno:doc()
+      end
+      return false, tostring(err)
+    end
+    return false, "pledge failed"
+  end
+  return true
 end
 
 --- Restricts filesystem visibility to specified paths.
@@ -41,13 +61,25 @@ end
 --- @param path string|nil Path to unveil (nil to commit policy)
 --- @param permissions string|nil Permission string like "r", "rw", "rwxc" (nil to commit)
 --- @return boolean True on success
-local function unveil(path: string, permissions: string): boolean
-  return unix.unveil(path, permissions)
+--- @return string? Error message on failure
+local function unveil(path: string, permissions: string): boolean, string
+  local ok, err = unix.unveil(path, permissions) as (boolean, any)
+  if not ok then
+    if err then
+      local errno = err as Errno
+      if errno.doc then
+        return false, errno:doc()
+      end
+      return false, tostring(err)
+    end
+    return false, "unveil failed"
+  end
+  return true
 end
 
 local record SandboxModule
-  pledge: function(promises?: string, execpromises?: string, mode?: number): boolean
-  unveil: function(path: string, permissions: string): boolean
+  pledge: function(promises?: string, execpromises?: string, mode?: number): boolean, string
+  unveil: function(path: string, permissions: string): boolean, string
 end
 
 local M: SandboxModule = {

--- a/lib/cosmic/signal.tl
+++ b/lib/cosmic/signal.tl
@@ -2,28 +2,65 @@
 --- Wraps cosmo.unix signal functions for process signaling, handlers, and timers.
 local unix = require("cosmo.unix")
 
+local record Errno
+  errno: function(self: Errno): number
+  winerr: function(self: Errno): number
+  name: function(self: Errno): string
+  call: function(self: Errno): string
+  doc: function(self: Errno): string
+end
+
 --- Send a signal to a process.
 --- @param pid number The process ID (>0 for specific process, 0 for process group, -1 for all)
 --- @param sig number The signal to send
 --- @return boolean True on success
-local function kill(pid: number, sig: number): boolean
-  return unix.kill(pid, sig)
+--- @return string? Error message on failure
+local function kill(pid: number, sig: number): boolean, string
+  local ok, err = unix.kill(pid, sig) as (boolean, any)
+  if not ok then
+    if err then
+      local errno = err as Errno
+      if errno.doc then
+        return false, errno:doc()
+      end
+      return false, tostring(err)
+    end
+    return false, "kill failed"
+  end
+  return true
 end
 
 --- Send a signal to a process group.
 --- @param pgrp number The process group ID
 --- @param sig number The signal to send
 --- @return boolean True on success
-local function killpg(pgrp: number, sig: number): boolean
-  return unix.killpg(pgrp, sig)
+--- @return string? Error message on failure
+local function killpg(pgrp: number, sig: number): boolean, string
+  local ok, err = unix.killpg(pgrp, sig) as (boolean, any)
+  if not ok then
+    if err then
+      local errno = err as Errno
+      if errno.doc then
+        return false, errno:doc()
+      end
+      return false, tostring(err)
+    end
+    return false, "killpg failed"
+  end
+  return true
 end
 
 --- Send a signal to the current process.
 --- Equivalent to kill(getpid(), sig).
 --- @param sig number The signal to send
---- @return number 0 on success
-local function raise(sig: number): number
-  return unix.raise(sig)
+--- @return boolean True on success
+--- @return string? Error message on failure
+local function raise(sig: number): boolean, string
+  local result = unix.raise(sig) as number
+  if result ~= 0 then
+    return false, "raise failed"
+  end
+  return true
 end
 
 --- Get the name of a signal.

--- a/lib/cosmic/signal_test.tl
+++ b/lib/cosmic/signal_test.tl
@@ -76,8 +76,8 @@ local function test_sigaction_ignore()
   local old_handler, old_flags, old_mask = signal.sigaction(signal.SIGUSR1, signal.SIG_IGN)
 
   -- Raise SIGUSR1 - should not terminate since it's ignored
-  local ret = signal.raise(signal.SIGUSR1)
-  assert(ret == 0, "raise should return 0")
+  local ok, err = signal.raise(signal.SIGUSR1)
+  assert(ok, "raise should succeed: " .. (err or ""))
 
   -- Restore old handler
   signal.sigaction(signal.SIGUSR1, old_handler, old_flags, old_mask)

--- a/lib/cosmic/user.tl
+++ b/lib/cosmic/user.tl
@@ -2,6 +2,14 @@
 --- Wraps cosmo.unix for user/group ID queries and modifications.
 local unix = require("cosmo.unix")
 
+local record Errno
+  errno: function(self: Errno): number
+  winerr: function(self: Errno): number
+  name: function(self: Errno): string
+  call: function(self: Errno): string
+  doc: function(self: Errno): string
+end
+
 --- Get the real user ID of the calling process.
 --- @return number The real user ID
 local function getuid(): number
@@ -41,24 +49,60 @@ end
 --- Set the user ID of the calling process.
 --- Returns ENOSYS on Windows NT if uid isn't getuid().
 --- @param uid number The user ID to set
---- @return boolean True on success, nil on failure
-local function setuid(uid: number): boolean
-  return unix.setuid(uid)
+--- @return boolean True on success
+--- @return string? Error message on failure
+local function setuid(uid: number): boolean, string
+  local ok, err = unix.setuid(uid) as (boolean, any)
+  if not ok then
+    if err then
+      local errno = err as Errno
+      if errno.doc then
+        return false, errno:doc()
+      end
+      return false, tostring(err)
+    end
+    return false, "setuid failed"
+  end
+  return true
 end
 
 --- Set the group ID of the calling process.
 --- Returns ENOSYS on Windows NT if gid isn't getgid().
 --- @param gid number The group ID to set
---- @return boolean True on success, nil on failure
-local function setgid(gid: number): boolean
-  return unix.setgid(gid)
+--- @return boolean True on success
+--- @return string? Error message on failure
+local function setgid(gid: number): boolean, string
+  local ok, err = unix.setgid(gid) as (boolean, any)
+  if not ok then
+    if err then
+      local errno = err as Errno
+      if errno.doc then
+        return false, errno:doc()
+      end
+      return false, tostring(err)
+    end
+    return false, "setgid failed"
+  end
+  return true
 end
 
 --- Set the filesystem user ID.
 --- @param uid number The filesystem user ID to set
---- @return boolean True on success, nil on failure
-local function setfsuid(uid: number): boolean
-  return unix.setfsuid(uid)
+--- @return boolean True on success
+--- @return string? Error message on failure
+local function setfsuid(uid: number): boolean, string
+  local ok, err = unix.setfsuid(uid) as (boolean, any)
+  if not ok then
+    if err then
+      local errno = err as Errno
+      if errno.doc then
+        return false, errno:doc()
+      end
+      return false, tostring(err)
+    end
+    return false, "setfsuid failed"
+  end
+  return true
 end
 
 --- Set real, effective, and saved user IDs.
@@ -66,9 +110,21 @@ end
 --- @param real number The real user ID to set (-1 to leave unchanged)
 --- @param effective number The effective user ID to set (-1 to leave unchanged)
 --- @param saved number The saved user ID to set (-1 to leave unchanged)
---- @return boolean True on success, nil on failure
-local function setresuid(real: number, effective: number, saved: number): boolean
-  return unix.setresuid(real, effective, saved)
+--- @return boolean True on success
+--- @return string? Error message on failure
+local function setresuid(real: number, effective: number, saved: number): boolean, string
+  local ok, err = unix.setresuid(real, effective, saved) as (boolean, any)
+  if not ok then
+    if err then
+      local errno = err as Errno
+      if errno.doc then
+        return false, errno:doc()
+      end
+      return false, tostring(err)
+    end
+    return false, "setresuid failed"
+  end
+  return true
 end
 
 --- Set real, effective, and saved group IDs.
@@ -76,9 +132,21 @@ end
 --- @param real number The real group ID to set (-1 to leave unchanged)
 --- @param effective number The effective group ID to set (-1 to leave unchanged)
 --- @param saved number The saved group ID to set (-1 to leave unchanged)
---- @return boolean True on success, nil on failure
-local function setresgid(real: number, effective: number, saved: number): boolean
-  return unix.setresgid(real, effective, saved)
+--- @return boolean True on success
+--- @return string? Error message on failure
+local function setresgid(real: number, effective: number, saved: number): boolean, string
+  local ok, err = unix.setresgid(real, effective, saved) as (boolean, any)
+  if not ok then
+    if err then
+      local errno = err as Errno
+      if errno.doc then
+        return false, errno:doc()
+      end
+      return false, tostring(err)
+    end
+    return false, "setresgid failed"
+  end
+  return true
 end
 
 --- Set the file mode creation mask.
@@ -94,9 +162,21 @@ end
 --- Changes the root directory of the calling process to the specified path.
 --- This call requires appropriate privileges (typically root).
 --- @param path string The new root directory path
---- @return boolean True on success, nil on failure
-local function chroot(path: string): boolean
-  return unix.chroot(path)
+--- @return boolean True on success
+--- @return string? Error message on failure
+local function chroot(path: string): boolean, string
+  local ok, err = unix.chroot(path) as (boolean, any)
+  if not ok then
+    if err then
+      local errno = err as Errno
+      if errno.doc then
+        return false, errno:doc()
+      end
+      return false, tostring(err)
+    end
+    return false, "chroot failed"
+  end
+  return true
 end
 
 local record UserModule
@@ -105,13 +185,13 @@ local record UserModule
   geteuid: function(): number
   getegid: function(): number
   getlogin: function(): string
-  setuid: function(uid: number): boolean
-  setgid: function(gid: number): boolean
-  setfsuid: function(uid: number): boolean
-  setresuid: function(real: number, effective: number, saved: number): boolean
-  setresgid: function(real: number, effective: number, saved: number): boolean
+  setuid: function(uid: number): boolean, string
+  setgid: function(gid: number): boolean, string
+  setfsuid: function(uid: number): boolean, string
+  setresuid: function(real: number, effective: number, saved: number): boolean, string
+  setresgid: function(real: number, effective: number, saved: number): boolean, string
   umask: function(newmask: number): number
-  chroot: function(path: string): boolean
+  chroot: function(path: string): boolean, string
 end
 
 local M: UserModule = {


### PR DESCRIPTION
## Summary

- Fix error return consistency in `cosmic.user`, `cosmic.sandbox`, and `cosmic.signal`
- All affected functions now return `(boolean, string?)` with error messages on failure
- Updated `signal.raise` to return boolean instead of number for consistency

## Test plan

- [x] `make test` passes (all 48 tests)
- [x] Manual verification that error messages are returned correctly

Fixes #127