### PR TITLE
codec: fix missing return value in encode_latin1

### DIFF
--- a/lib/cosmic/codec.tl
+++ b/lib/cosmic/codec.tl
@@ -100,7 +100,7 @@ local function encode_latin1(str: string): string, string
   if not ok then
     return nil, "cannot encode to Latin-1: character out of range"
   end
-  return result
+  return result, nil
 end
 
 --- Decode Latin-1 (ISO-8859-1) bytes to a UTF-8 string.


### PR DESCRIPTION
## Summary

- Fix `encode_latin1()` to return explicit nil as second value on success, matching the declared return type `string, string`

## Test plan

- [x] `make test only=codec` passes
- [x] Type checking passes with `cosmic --check-types`

Fixes #163