### PR TITLE
fs: add __close to Dir for automatic cleanup

### DIFF
--- a/lib/cosmic/fs.tl
+++ b/lib/cosmic/fs.tl
@@ -2,6 +2,15 @@
 --- Wraps cosmo.unix for file and directory operations: stat, mkdir, chmod, symlink, etc.
 local unix = require("cosmo.unix")
 
+-- Raw Dir type from cosmo.unix
+local record RawDir
+  read: function(self: RawDir): string
+  close: function(self: RawDir)
+  fd: function(self: RawDir): number
+  rewind: function(self: RawDir)
+  tell: function(self: RawDir): number
+end
+
 --- File or directory metadata.
 --- Use is_dir(), is_file(), etc. to check file type.
 local record Stat
@@ -28,6 +37,7 @@ local record Stat
 end
 
 --- Handle for reading directory entries.
+--- Supports automatic cleanup with `<close>` attribute.
 local record Dir
   --- Reads next directory entry. Returns nil when done.
   read: function(self: Dir): string
@@ -39,6 +49,48 @@ local record Dir
   rewind: function(self: Dir)
   --- Returns current position in directory stream.
   tell: function(self: Dir): number
+  --- Returns true if directory handle is closed.
+  closed: function(self: Dir): boolean
+end
+
+-- Wrap a raw cosmo Dir with __close support
+local function make_dir(raw: RawDir): Dir
+  local is_closed = false
+
+  local dir: Dir = {
+    read = function(_self: Dir): string
+      if is_closed then return nil end
+      return raw:read()
+    end,
+    close = function(_self: Dir)
+      if not is_closed then
+        raw:close()
+        is_closed = true
+      end
+    end,
+    fd = function(_self: Dir): number
+      if is_closed then return -1 end
+      return raw:fd()
+    end,
+    rewind = function(_self: Dir)
+      if not is_closed then raw:rewind() end
+    end,
+    tell = function(_self: Dir): number
+      if is_closed then return -1 end
+      return raw:tell()
+    end,
+    closed = function(_self: Dir): boolean
+      return is_closed
+    end,
+  }
+
+  local mt: metatable<Dir> = {
+    __close = function(self: Dir)
+      self:close()
+    end
+  }
+
+  return setmetatable(dir, mt)
 end
 
 -- Stat operations
@@ -190,27 +242,29 @@ end
 
 --- Open a directory for reading.
 --- Call dir:read() to iterate entries, dir:close() when done.
+--- Supports automatic cleanup with `<close>` attribute.
 --- @param path string Path to the directory
 --- @return Dir Directory handle, or nil on error
 --- @return string Error message if failed
 local function opendir(path: string): Dir, string
-  local dir = unix.opendir(path) as Dir
-  if not dir then
+  local raw = unix.opendir(path) as RawDir
+  if not raw then
     return nil, "opendir failed: " .. path
   end
-  return dir
+  return make_dir(raw)
 end
 
 --- Open a directory from a file descriptor.
+--- Supports automatic cleanup with `<close>` attribute.
 --- @param fd number File descriptor for an open directory
 --- @return Dir Directory handle, or nil on error
 --- @return string Error message if failed
 local function fdopendir(fd: number): Dir, string
-  local _, dir = unix.fdopendir(fd)
-  if not dir then
+  local _, raw = unix.fdopendir(fd)
+  if not raw then
     return nil, "fdopendir failed"
   end
-  return dir as Dir
+  return make_dir(raw as RawDir)
 end
 
 -- File operations

--- a/lib/cosmic/fs_test.tl
+++ b/lib/cosmic/fs_test.tl
@@ -415,3 +415,129 @@ local function test_is_type_functions()
   teardown(test_dir)
 end
 test_is_type_functions()
+
+-- Dir __close tests
+
+local function test_dir_has_close_metamethod()
+  local test_dir = setup()
+
+  local dir = fs.opendir(test_dir)
+  assert(dir, "opendir should succeed")
+
+  -- Verify __close metamethod exists
+  local mt = getmetatable(dir)
+  assert(mt, "dir should have a metatable")
+  assert(mt.__close, "dir metatable should have __close")
+
+  -- Call __close directly to verify it works
+  mt.__close(dir)
+  assert(dir:closed(), "dir should be closed after __close")
+
+  teardown(test_dir)
+end
+test_dir_has_close_metamethod()
+
+local function test_dir_closed_method()
+  local test_dir = setup()
+
+  local dir = fs.opendir(test_dir)
+  assert(dir, "opendir should succeed")
+
+  assert(not dir:closed(), "dir should not be closed initially")
+  dir:close()
+  assert(dir:closed(), "dir should be closed after close()")
+
+  teardown(test_dir)
+end
+test_dir_closed_method()
+
+local function test_dir_close_idempotent()
+  local test_dir = setup()
+
+  local dir = fs.opendir(test_dir)
+  assert(dir, "opendir should succeed")
+
+  dir:close()
+  assert(dir:closed(), "dir should be closed")
+
+  -- Should not error when closing again
+  dir:close()
+  dir:close()
+  assert(dir:closed(), "dir should still be closed")
+
+  teardown(test_dir)
+end
+test_dir_close_idempotent()
+
+local function test_dir_methods_after_close()
+  local test_dir = setup()
+  touch(path.join(test_dir, "file.txt"))
+
+  local dir = fs.opendir(test_dir)
+  assert(dir, "opendir should succeed")
+  dir:close()
+
+  -- read() returns nil when closed
+  local entry = dir:read()
+  assert(entry == nil, "read should return nil after close")
+
+  -- fd() returns -1 when closed
+  local fd = dir:fd()
+  assert(fd == -1, "fd should return -1 after close")
+
+  -- tell() returns -1 when closed
+  local pos = dir:tell()
+  assert(pos == -1, "tell should return -1 after close")
+
+  -- rewind() should be a no-op when closed (no error)
+  dir:rewind()
+
+  teardown(test_dir)
+end
+test_dir_methods_after_close()
+
+local function test_dir_rewind_and_tell()
+  local test_dir = setup()
+  touch(path.join(test_dir, "file1.txt"))
+  touch(path.join(test_dir, "file2.txt"))
+
+  local dir = fs.opendir(test_dir)
+  assert(dir, "opendir should succeed")
+
+  -- Read some entries
+  local count = 0
+  while dir:read() do
+    count = count + 1
+  end
+  assert(count >= 2, "should read at least 2 entries")
+
+  -- Tell should return a position
+  local pos_end = dir:tell()
+  assert(pos_end >= 0, "tell should return valid position")
+
+  -- Rewind and count again
+  dir:rewind()
+  local count2 = 0
+  while dir:read() do
+    count2 = count2 + 1
+  end
+  assert(count2 == count, "should read same number of entries after rewind")
+
+  dir:close()
+  teardown(test_dir)
+end
+test_dir_rewind_and_tell()
+
+local function test_dir_fd()
+  local test_dir = setup()
+
+  local dir = fs.opendir(test_dir)
+  assert(dir, "opendir should succeed")
+
+  local fd = dir:fd()
+  assert(fd >= 0, "fd should be a valid file descriptor")
+
+  dir:close()
+  teardown(test_dir)
+end
+test_dir_fd()


### PR DESCRIPTION
## Summary

- Wrap the raw cosmo `Dir` type with a cosmic `Dir` that supports `__close` for automatic resource cleanup with Lua 5.4's `<close>` attribute
- Track closed state for idempotent cleanup
- Add `closed()` method to check directory state
- Methods return safe values after close (nil, -1, no-op)

## Test plan

- [x] Type check passes (`make check`)
- [x] All 49 tests pass (`make clean test`)
- [x] New tests verify `__close` metamethod, `closed()` method, idempotent close, and safe behavior after close

Closes #160