### PR TITLE
io: add __close to Handle and Pipe for automatic cleanup

### DIFF
--- a/lib/cosmic/io.tl
+++ b/lib/cosmic/io.tl
@@ -4,18 +4,19 @@
 local cosmo = require("cosmo")
 
 local record UnixIO
-  open: function(path: string, flags: number, mode?: number): number, any
+  open: function(path: string, flags: number, mode?: number, dirfd?: number): number, any
   close: function(fd: number): boolean, any
-  read: function(fd: number, bufsiz?: number): string, any
-  write: function(fd: number, data: string): number, any
+  read: function(fd: number, bufsiz?: number, offset?: number): string, any
+  write: function(fd: number, data: string, offset?: number): number, any
   lseek: function(fd: number, offset: number, whence?: number): number, any
   truncate: function(path: string, length?: number): boolean, any
   ftruncate: function(fd: number, length?: number): boolean, any
-  dup: function(oldfd: number): number, any
+  dup: function(oldfd: number, newfd?: number, flags?: number, lowest?: number): number, any
   pipe: function(flags?: number): number, number | any
   fcntl: function(fd: number, cmd: number, arg?: number): number, any
   sync: function()
   fsync: function(fd: number): boolean, any
+  fdatasync: function(fd: number): boolean, any
 
   O_RDONLY: number
   O_WRONLY: number
@@ -26,6 +27,9 @@ local record UnixIO
   O_EXCL: number
   O_CLOEXEC: number
   O_NONBLOCK: number
+  O_DIRECT: number
+  O_DIRECTORY: number
+  O_NOFOLLOW: number
   SEEK_SET: number
   SEEK_CUR: number
   SEEK_END: number
@@ -37,7 +41,11 @@ local record UnixIO
   F_SETLK: number
   F_SETLKW: number
   F_GETLK: number
+  F_RDLCK: number
+  F_WRLCK: number
+  F_UNLCK: number
   FD_CLOEXEC: number
+  AT_FDCWD: number
 end
 
 local unix = require("cosmo.unix") as UnixIO
@@ -48,12 +56,13 @@ local record Handle
   close: function(self: Handle): boolean
   closed: function(self: Handle): boolean
   fd: function(self: Handle): number
-  read: function(self: Handle, size?: number): string, string
-  write: function(self: Handle, data: string): number, string
+  read: function(self: Handle, size?: number, offset?: number): string, string
+  write: function(self: Handle, data: string, offset?: number): number, string
   seek: function(self: Handle, offset: number, whence?: number): number, string
   truncate: function(self: Handle, length?: number): boolean, string
   sync: function(self: Handle): boolean, string
-  dup: function(self: Handle): Handle, string
+  datasync: function(self: Handle): boolean, string
+  dup: function(self: Handle, newfd?: number, flags?: number, lowest?: number): Handle, string
   fcntl: function(self: Handle, cmd: number, arg?: number): number, string
 end
 
@@ -83,11 +92,12 @@ make_handle = function(fd: number): Handle
   end
 
   --- Read up to size bytes. Returns empty string on EOF.
-  function handle:read(size?: number): string, string
+  --- If offset is provided, reads at that position (pread behavior).
+  function handle:read(size?: number, offset?: number): string, string
     if not handle_fd then
       return nil, "handle closed"
     end
-    local data, err = unix.read(handle_fd, size)
+    local data, err = unix.read(handle_fd, size, offset)
     if data == nil and err then
       return nil, tostring(err)
     end
@@ -95,11 +105,12 @@ make_handle = function(fd: number): Handle
   end
 
   --- Write data. Returns number of bytes written.
-  function handle:write(data: string): number, string
+  --- If offset is provided, writes at that position (pwrite behavior).
+  function handle:write(data: string, offset?: number): number, string
     if not handle_fd then
       return nil, "handle closed"
     end
-    local n, err = unix.write(handle_fd, data)
+    local n, err = unix.write(handle_fd, data, offset)
     if not n then
       return nil, tostring(err)
     end
@@ -130,7 +141,7 @@ make_handle = function(fd: number): Handle
     return true
   end
 
-  --- Flush to disk.
+  --- Flush data and metadata to disk.
   function handle:sync(): boolean, string
     if not handle_fd then
       return false, "handle closed"
@@ -142,16 +153,30 @@ make_handle = function(fd: number): Handle
     return true
   end
 
+  --- Flush data to disk (but not necessarily metadata).
+  function handle:datasync(): boolean, string
+    if not handle_fd then
+      return false, "handle closed"
+    end
+    local ok, err = unix.fdatasync(handle_fd)
+    if not ok then
+      return false, tostring(err)
+    end
+    return true
+  end
+
   --- Duplicate the handle.
-  function handle:dup(): Handle, string
+  --- If newfd is provided, duplicates to that specific fd (dup2 behavior).
+  --- flags can include O_CLOEXEC. lowest specifies minimum acceptable fd.
+  function handle:dup(newfd?: number, flags?: number, lowest?: number): Handle, string
     if not handle_fd then
       return nil, "handle closed"
     end
-    local newfd, err = unix.dup(handle_fd)
-    if not newfd then
+    local dupfd, err = unix.dup(handle_fd, newfd, flags, lowest)
+    if not dupfd then
       return nil, tostring(err)
     end
-    return make_handle(newfd)
+    return make_handle(dupfd)
   end
 
   --- File control operations. cmd: F_GETFD, F_SETFD, F_GETFL, F_SETFL, F_SETLK, etc.
@@ -202,8 +227,9 @@ local function make_pipe(reader: Handle, writer: Handle): Pipe
 end
 
 --- Open a file. flags: O_RDONLY, O_WRONLY, O_RDWR, combined with O_CREAT, O_TRUNC, etc.
-local function open(path: string, flags: number, mode?: number): Handle, string
-  local fd, err = unix.open(path, flags, mode)
+--- If dirfd is provided, path is relative to that directory (openat behavior).
+local function open(path: string, flags: number, mode?: number, dirfd?: number): Handle, string
+  local fd, err = unix.open(path, flags, mode, dirfd)
   if not fd then
     return nil, tostring(err)
   end
@@ -254,7 +280,7 @@ end
 local record IoModule
   slurp: function(path: string): string, string
   barf: function(path: string, data: string, mode?: number): boolean, string
-  open: function(path: string, flags: number, mode?: number): Handle, string
+  open: function(path: string, flags: number, mode?: number, dirfd?: number): Handle, string
   pipe: function(flags?: number): Pipe, string
   truncate: function(path: string, length?: number): boolean, string
   sync: function()
@@ -268,6 +294,9 @@ local record IoModule
   O_EXCL: number
   O_CLOEXEC: number
   O_NONBLOCK: number
+  O_DIRECT: number
+  O_DIRECTORY: number
+  O_NOFOLLOW: number
 
   SEEK_SET: number
   SEEK_CUR: number
@@ -281,7 +310,12 @@ local record IoModule
   F_SETLK: number
   F_SETLKW: number
   F_GETLK: number
+  F_RDLCK: number
+  F_WRLCK: number
+  F_UNLCK: number
   FD_CLOEXEC: number
+
+  AT_FDCWD: number
 end
 
 local M: IoModule = {
@@ -301,6 +335,9 @@ local M: IoModule = {
   O_EXCL = unix.O_EXCL,
   O_CLOEXEC = unix.O_CLOEXEC,
   O_NONBLOCK = unix.O_NONBLOCK,
+  O_DIRECT = unix.O_DIRECT,
+  O_DIRECTORY = unix.O_DIRECTORY,
+  O_NOFOLLOW = unix.O_NOFOLLOW,
 
   SEEK_SET = unix.SEEK_SET,
   SEEK_CUR = unix.SEEK_CUR,
@@ -314,7 +351,12 @@ local M: IoModule = {
   F_SETLK = unix.F_SETLK,
   F_SETLKW = unix.F_SETLKW,
   F_GETLK = unix.F_GETLK,
+  F_RDLCK = unix.F_RDLCK,
+  F_WRLCK = unix.F_WRLCK,
+  F_UNLCK = unix.F_UNLCK,
   FD_CLOEXEC = unix.FD_CLOEXEC,
+
+  AT_FDCWD = unix.AT_FDCWD,
 }
 
 return M

--- a/lib/cosmic/io_test.tl
+++ b/lib/cosmic/io_test.tl
@@ -155,6 +155,9 @@ local function test_constants()
   assert(io_m.O_APPEND ~= nil, "O_APPEND not exported")
   assert(io_m.O_EXCL ~= nil, "O_EXCL not exported")
   assert(io_m.O_CLOEXEC ~= nil, "O_CLOEXEC not exported")
+  assert(io_m.O_DIRECT ~= nil, "O_DIRECT not exported")
+  assert(io_m.O_DIRECTORY ~= nil, "O_DIRECTORY not exported")
+  assert(io_m.O_NOFOLLOW ~= nil, "O_NOFOLLOW not exported")
 
   assert(io_m.SEEK_SET ~= nil, "SEEK_SET not exported")
   assert(io_m.SEEK_CUR ~= nil, "SEEK_CUR not exported")
@@ -164,7 +167,12 @@ local function test_constants()
   assert(io_m.F_SETFD ~= nil, "F_SETFD not exported")
   assert(io_m.F_GETFL ~= nil, "F_GETFL not exported")
   assert(io_m.F_SETFL ~= nil, "F_SETFL not exported")
+  assert(io_m.F_RDLCK ~= nil, "F_RDLCK not exported")
+  assert(io_m.F_WRLCK ~= nil, "F_WRLCK not exported")
+  assert(io_m.F_UNLCK ~= nil, "F_UNLCK not exported")
   assert(io_m.FD_CLOEXEC ~= nil, "FD_CLOEXEC not exported")
+
+  assert(io_m.AT_FDCWD ~= nil, "AT_FDCWD not exported")
 end
 test_constants()
 
@@ -296,3 +304,56 @@ local function test_pipe_close_metamethod_exists()
   assert(p:closed(), "pipe should be closed after __close")
 end
 test_pipe_close_metamethod_exists()
+
+local function test_read_write_with_offset()
+  local filepath = path.join(TEST_TMPDIR, "io_test_pread.txt")
+
+  local f = assert(io_m.open(filepath, io_m.O_RDWR | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
+  assert(f:write("0123456789"))
+
+  -- Read at offset (pread behavior)
+  local data, err = f:read(3, 5)
+  assert(data == "567", "read with offset failed: " .. (err or "") .. " got '" .. tostring(data) .. "'")
+
+  -- Write at offset (pwrite behavior)
+  local n: number
+  n, err = f:write("ABC", 2)
+  assert(n == 3, "write with offset failed: " .. (err or ""))
+
+  -- Verify
+  assert(f:seek(0, io_m.SEEK_SET))
+  data = assert(f:read(100))
+  assert(data == "01ABC56789", "write with offset result: got '" .. data .. "'")
+
+  assert(f:close())
+  os.remove(filepath)
+end
+test_read_write_with_offset()
+
+local function test_barf_with_mode()
+  local filepath = path.join(TEST_TMPDIR, "io_test_barf_mode.txt")
+  local content = "file with specific mode"
+
+  local ok, err = io_m.barf(filepath, content, tonumber("600", 8))
+  assert(ok, "barf with mode failed: " .. (err or ""))
+
+  local data = assert(io_m.slurp(filepath))
+  assert(data == content, "content mismatch after barf with mode")
+
+  os.remove(filepath)
+end
+test_barf_with_mode()
+
+local function test_datasync()
+  local filepath = path.join(TEST_TMPDIR, "io_test_datasync.txt")
+
+  local f = assert(io_m.open(filepath, io_m.O_WRONLY | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
+  assert(f:write("datasync test"))
+
+  local ok, err = f:datasync()
+  assert(ok, "datasync failed: " .. (err or ""))
+
+  assert(f:close())
+  os.remove(filepath)
+end
+test_datasync()


### PR DESCRIPTION
## Summary

Wrap file descriptors in Handle objects that support Lua 5.4's to-be-closed via `__close` metamethod.

**Module functions:**
- `open(path, flags, mode?, dirfd?)` → Handle
- `pipe(flags?)` → Pipe
- `slurp(path)` → string
- `barf(path, data, mode?)` → boolean
- `truncate(path, length?)` → boolean
- `sync()`

**Handle methods:**
- `close()`, `closed()` - close and check state
- `fd()` - get underlying file descriptor
- `read(size?, offset?)`, `write(data, offset?)` - I/O (offset for pread/pwrite)
- `seek(offset, whence?)` - positioning
- `truncate(length?)`, `sync()`, `datasync()` - file operations
- `dup(newfd?, flags?, lowest?)` - duplicate handle (supports dup2/dup3)
- `fcntl(cmd, arg?)` - file control

**Pipe:** has `reader`/`writer` Handle fields plus `close()`/`closed()`.

Closes #161

## Breaking changes

This PR changes the `cosmic.io` API from raw file descriptors to Handle objects:

| Before | After |
|--------|-------|
| `io.open()` returns `number` (fd) | `io.open()` returns `Handle` |
| `io.pipe()` returns `{reader: number, writer: number}` | `io.pipe()` returns `Pipe` with `Handle` fields |
| `io.close(fd)` | `handle:close()` |
| `io.read(fd, size?, offset?)` | `handle:read(size?, offset?)` |
| `io.write(fd, data, offset?)` | `handle:write(data, offset?)` |
| `io.lseek(fd, offset, whence?)` | `handle:seek(offset, whence?)` |
| `io.ftruncate(fd, length?)` | `handle:truncate(length?)` |
| `io.fsync(fd)` | `handle:sync()` |
| `io.fdatasync(fd)` | `handle:datasync()` |
| `io.dup(oldfd, newfd?, flags?, lowest?)` | `handle:dup(newfd?, flags?, lowest?)` |
| `io.fcntl(fd, cmd, arg?)` | `handle:fcntl(cmd, arg?)` |

**Migration example:**

```lua
-- Before
local fd = io.open(path, io.O_RDONLY)
local data = io.read(fd, 1024)
io.close(fd)

-- After
local handle = io.open(path, io.O_RDONLY)
local data = handle:read(1024)
handle:close()

-- Or with to-be-closed (Lua 5.4)
local handle <close> = io.open(path, io.O_RDONLY)
local data = handle:read(1024)
-- handle automatically closed when it goes out of scope
```

## Test plan

- [x] `make check` - type checking passes
- [x] `make test` - all tests pass