### PR TITLE
cosmic: wrap remaining unix gaps (statfs, syslog, interfaces)

### DIFF
--- a/lib/cosmic/fs.tl
+++ b/lib/cosmic/fs.tl
@@ -11,6 +11,33 @@ local record RawDir
   tell: function(self: RawDir): number
 end
 
+--- Filesystem statistics.
+--- Returned by statfs() and fstatfs().
+local record Statfs
+  --- Returns filesystem type identifier.
+  type: function(self: Statfs): number
+  --- Returns optimal transfer block size.
+  bsize: function(self: Statfs): number
+  --- Returns total data blocks in filesystem.
+  blocks: function(self: Statfs): number
+  --- Returns free blocks in filesystem.
+  bfree: function(self: Statfs): number
+  --- Returns free blocks available to unprivileged user.
+  bavail: function(self: Statfs): number
+  --- Returns total file nodes in filesystem.
+  files: function(self: Statfs): number
+  --- Returns free file nodes in filesystem.
+  ffree: function(self: Statfs): number
+  --- Returns filesystem ID as two numbers.
+  fsid: function(self: Statfs): number, number
+  --- Returns maximum length of filenames.
+  namelen: function(self: Statfs): number
+  --- Returns fragment size.
+  frsize: function(self: Statfs): number
+  --- Returns mount flags.
+  flags: function(self: Statfs): number
+end
+
 --- File or directory metadata.
 --- Use is_dir(), is_file(), etc. to check file type.
 local record Stat
@@ -34,6 +61,10 @@ local record Stat
   blocks: function(self: Stat): number
   --- Returns number of hard links.
   nlink: function(self: Stat): number
+  --- Returns device ID containing the file.
+  dev: function(self: Stat): number
+  --- Returns device ID for special files (0 or -1 for non-devices).
+  rdev: function(self: Stat): number
 end
 
 --- Handle for reading directory entries.
@@ -472,6 +503,50 @@ local function tmpfd(): number, string
   return fd
 end
 
+-- Filesystem statistics
+
+--- Get filesystem statistics for a path.
+--- @param path string Path to any file on the filesystem
+--- @return Statfs Filesystem statistics, or nil on error
+--- @return string Error message if failed
+local function statfs(path: string): Statfs, string
+  local info = unix.statfs(path) as Statfs
+  if not info then
+    return nil, "statfs failed: " .. path
+  end
+  return info
+end
+
+--- Get filesystem statistics from a file descriptor.
+--- @param fd number File descriptor
+--- @return Statfs Filesystem statistics, or nil on error
+--- @return string Error message if failed
+local function fstatfs(fd: number): Statfs, string
+  local info = unix.fstatfs(fd) as Statfs
+  if not info then
+    return nil, "fstatfs failed"
+  end
+  return info
+end
+
+-- Device number utilities
+
+--- Extract major device number from a device ID.
+--- Use with stat():dev() or stat():rdev() to identify device types.
+--- @param dev number Device ID from stat
+--- @return number Major device number
+local function major(dev: number): number
+  return unix.major(dev)
+end
+
+--- Extract minor device number from a device ID.
+--- Use with stat():dev() or stat():rdev() to identify specific devices.
+--- @param dev number Device ID from stat
+--- @return number Minor device number
+local function minor(dev: number): number
+  return unix.minor(dev)
+end
+
 -- Access mode constants
 local F_OK <const> = unix.F_OK
 local R_OK <const> = unix.R_OK
@@ -570,6 +645,14 @@ local record FsModule
   mkstemp: function(template: string): number, string
   tmpfd: function(): number, string
 
+  -- Filesystem statistics
+  statfs: function(path: string): Statfs, string
+  fstatfs: function(fd: number): Statfs, string
+
+  -- Device number utilities
+  major: function(dev: number): number
+  minor: function(dev: number): number
+
   -- Access mode constants
   F_OK: number
   R_OK: number
@@ -620,6 +703,14 @@ local M: FsModule = {
   mkdtemp = mkdtemp,
   mkstemp = mkstemp,
   tmpfd = tmpfd,
+
+  -- Filesystem statistics
+  statfs = statfs,
+  fstatfs = fstatfs,
+
+  -- Device number utilities
+  major = major,
+  minor = minor,
 
   -- Access mode constants
   F_OK = F_OK,

--- a/lib/cosmic/fs_test.tl
+++ b/lib/cosmic/fs_test.tl
@@ -541,3 +541,84 @@ local function test_dir_fd()
   teardown(test_dir)
 end
 test_dir_fd()
+
+-- Filesystem statistics tests
+
+local function test_statfs()
+  local info, err = fs.statfs("/")
+  assert(info, "statfs should succeed: " .. (err or ""))
+
+  -- Check that we can call all the methods
+  assert(info:type() ~= nil, "type() should return a value")
+  assert(info:bsize() > 0, "bsize() should be positive")
+  assert(info:blocks() > 0, "blocks() should be positive")
+  assert(info:bfree() >= 0, "bfree() should be non-negative")
+  assert(info:bavail() >= 0, "bavail() should be non-negative")
+  assert(info:files() >= 0, "files() should be non-negative")
+  assert(info:ffree() >= 0, "ffree() should be non-negative")
+  local fsid1, fsid2 = info:fsid()
+  assert(fsid1 ~= nil, "fsid() should return first value")
+  assert(fsid2 ~= nil, "fsid() should return second value")
+  assert(info:namelen() > 0, "namelen() should be positive")
+  assert(info:frsize() > 0, "frsize() should be positive")
+  assert(info:flags() ~= nil, "flags() should return a value")
+end
+test_statfs()
+
+local function test_statfs_nonexistent()
+  local info, err = fs.statfs("/nonexistent/path/that/does/not/exist")
+  assert(info == nil, "statfs should fail for nonexistent path")
+  assert(err, "should return error message")
+end
+test_statfs_nonexistent()
+
+local function test_fstatfs()
+  local fd = unix.open("/", unix.O_RDONLY | unix.O_DIRECTORY)
+  assert(fd, "open should succeed")
+
+  local info, err = fs.fstatfs(fd)
+  assert(info, "fstatfs should succeed: " .. (err or ""))
+
+  assert(info:bsize() > 0, "bsize() should be positive")
+  assert(info:blocks() > 0, "blocks() should be positive")
+
+  unix.close(fd)
+end
+test_fstatfs()
+
+-- Device number utilities tests
+
+local function test_major_minor()
+  -- Test with /dev/null which should have rdev set
+  local st = fs.stat("/dev/null")
+  if st then
+    local rdev = st:rdev()
+    local maj = fs.major(rdev)
+    local min = fs.minor(rdev)
+    -- /dev/null is typically major 1, minor 3
+    assert(maj ~= nil, "major() should return a value")
+    assert(min ~= nil, "minor() should return a value")
+    assert(maj >= 0, "major should be non-negative")
+    assert(min >= 0, "minor should be non-negative")
+  end
+end
+test_major_minor()
+
+local function test_major_minor_regular_file()
+  local test_dir = setup()
+  local filepath = path.join(test_dir, "file.txt")
+  touch(filepath)
+
+  local st = fs.stat(filepath)
+  assert(st, "stat should succeed")
+
+  -- Regular files have a dev (the filesystem device)
+  local dev = st:dev()
+  local maj = fs.major(dev)
+  local min = fs.minor(dev)
+  assert(maj ~= nil, "major() should return a value for dev")
+  assert(min ~= nil, "minor() should return a value for dev")
+
+  teardown(test_dir)
+end
+test_major_minor_regular_file()

--- a/lib/cosmic/net.tl
+++ b/lib/cosmic/net.tl
@@ -313,6 +313,25 @@ local function formatip(ip: number): string
     ip & 0xff)
 end
 
+--- Network interface information.
+local record Interface
+  --- Interface name (e.g., "eth0", "lo").
+  name: string
+  --- IPv4 address as a number.
+  ip: number
+end
+
+--- List network interfaces and their IPv4 addresses.
+--- @return {Interface} List of interfaces
+--- @return string Error message on failure
+local function interfaces(): {Interface}, string
+  local raw = unix.siocgifconf()
+  if not raw then
+    return nil, "siocgifconf failed"
+  end
+  return raw as {Interface}
+end
+
 local record NetModule
   -- Socket creation
   socket: function(family?: number, socktype?: number, protocol?: number): Socket, string
@@ -325,6 +344,7 @@ local record NetModule
   gethostname: function(): string, string
   parseip: function(str: string): number, string
   formatip: function(ip: number): string
+  interfaces: function(): {Interface}, string
 
   -- Address families
   AF_INET: number
@@ -427,6 +447,7 @@ local M: NetModule = {
   gethostname = gethostname,
   parseip = parseip,
   formatip = formatip,
+  interfaces = interfaces,
 
   -- Address families
   AF_INET = unix.AF_INET,

--- a/lib/cosmic/net_test.tl
+++ b/lib/cosmic/net_test.tl
@@ -370,4 +370,36 @@ local function test_accept_socket_has_close_metamethod()
 end
 test_accept_socket_has_close_metamethod()
 
+local function test_interfaces()
+  local ifaces, err = net.interfaces()
+  assert(ifaces ~= nil, "interfaces() failed: " .. tostring(err))
+  assert(type(ifaces) == "table", "expected table, got " .. type(ifaces))
+
+  -- Should have at least the loopback interface
+  local has_loopback = false
+  for _, iface in ipairs(ifaces) do
+    assert(iface.name ~= nil, "interface should have name")
+    assert(iface.ip ~= nil, "interface should have ip")
+    if iface.name == "lo" then
+      has_loopback = true
+      -- Loopback should be 127.0.0.1 (0x7f000001)
+      assert(iface.ip == 0x7f000001, "loopback should have 127.0.0.1, got " .. net.formatip(iface.ip))
+    end
+  end
+  assert(has_loopback, "should have loopback interface")
+end
+test_interfaces()
+
+local function test_interfaces_formatip()
+  -- Test that we can format interface IPs
+  local ifaces = net.interfaces()
+  if ifaces then
+    for _, iface in ipairs(ifaces) do
+      local ip_str = net.formatip(iface.ip)
+      assert(ip_str:match("^%d+%.%d+%.%d+%.%d+$"), "expected dotted IP format, got " .. ip_str)
+    end
+  end
+end
+test_interfaces_formatip()
+
 print("All net tests passed")

--- a/lib/cosmic/syslog.tl
+++ b/lib/cosmic/syslog.tl
@@ -1,0 +1,125 @@
+--- System logging.
+--- Wraps unix.syslog() for writing to the system log.
+local unix = require("cosmo.unix")
+
+-- Priority levels
+
+--- Emergency: system is unusable.
+local LOG_EMERG <const> = unix.LOG_EMERG
+--- Alert: action must be taken immediately.
+local LOG_ALERT <const> = unix.LOG_ALERT
+--- Critical: critical conditions.
+local LOG_CRIT <const> = unix.LOG_CRIT
+--- Error: error conditions.
+local LOG_ERR <const> = unix.LOG_ERR
+--- Warning: warning conditions.
+local LOG_WARNING <const> = unix.LOG_WARNING
+--- Notice: normal but significant condition.
+local LOG_NOTICE <const> = unix.LOG_NOTICE
+--- Informational: informational messages.
+local LOG_INFO <const> = unix.LOG_INFO
+--- Debug: debug-level messages.
+local LOG_DEBUG <const> = unix.LOG_DEBUG
+
+--- Write a message to the system log.
+--- @param priority number Log priority (LOG_EMERG through LOG_DEBUG)
+--- @param message string The message to log
+local function write(priority: number, message: string)
+  unix.syslog(priority, message)
+end
+
+--- Write an emergency message to the system log.
+--- @param message string The message to log
+local function emerg(message: string)
+  unix.syslog(LOG_EMERG, message)
+end
+
+--- Write an alert message to the system log.
+--- @param message string The message to log
+local function alert(message: string)
+  unix.syslog(LOG_ALERT, message)
+end
+
+--- Write a critical message to the system log.
+--- @param message string The message to log
+local function crit(message: string)
+  unix.syslog(LOG_CRIT, message)
+end
+
+--- Write an error message to the system log.
+--- @param message string The message to log
+local function err(message: string)
+  unix.syslog(LOG_ERR, message)
+end
+
+--- Write a warning message to the system log.
+--- @param message string The message to log
+local function warning(message: string)
+  unix.syslog(LOG_WARNING, message)
+end
+
+--- Write a notice message to the system log.
+--- @param message string The message to log
+local function notice(message: string)
+  unix.syslog(LOG_NOTICE, message)
+end
+
+--- Write an info message to the system log.
+--- @param message string The message to log
+local function info(message: string)
+  unix.syslog(LOG_INFO, message)
+end
+
+--- Write a debug message to the system log.
+--- @param message string The message to log
+local function debug(message: string)
+  unix.syslog(LOG_DEBUG, message)
+end
+
+local record SyslogModule
+  -- Writing
+  write: function(priority: number, message: string)
+  emerg: function(message: string)
+  alert: function(message: string)
+  crit: function(message: string)
+  err: function(message: string)
+  warning: function(message: string)
+  notice: function(message: string)
+  info: function(message: string)
+  debug: function(message: string)
+
+  -- Priority constants
+  LOG_EMERG: number
+  LOG_ALERT: number
+  LOG_CRIT: number
+  LOG_ERR: number
+  LOG_WARNING: number
+  LOG_NOTICE: number
+  LOG_INFO: number
+  LOG_DEBUG: number
+end
+
+local M: SyslogModule = {
+  -- Writing
+  write = write,
+  emerg = emerg,
+  alert = alert,
+  crit = crit,
+  err = err,
+  warning = warning,
+  notice = notice,
+  info = info,
+  debug = debug,
+
+  -- Priority constants
+  LOG_EMERG = LOG_EMERG,
+  LOG_ALERT = LOG_ALERT,
+  LOG_CRIT = LOG_CRIT,
+  LOG_ERR = LOG_ERR,
+  LOG_WARNING = LOG_WARNING,
+  LOG_NOTICE = LOG_NOTICE,
+  LOG_INFO = LOG_INFO,
+  LOG_DEBUG = LOG_DEBUG,
+}
+
+return M

--- a/lib/cosmic/syslog_test.tl
+++ b/lib/cosmic/syslog_test.tl
@@ -1,0 +1,47 @@
+#!/usr/bin/env cosmic
+local syslog = require("cosmic.syslog")
+
+-- Test that priority constants are defined
+local function test_constants()
+  assert(syslog.LOG_EMERG ~= nil, "LOG_EMERG should be defined")
+  assert(syslog.LOG_ALERT ~= nil, "LOG_ALERT should be defined")
+  assert(syslog.LOG_CRIT ~= nil, "LOG_CRIT should be defined")
+  assert(syslog.LOG_ERR ~= nil, "LOG_ERR should be defined")
+  assert(syslog.LOG_WARNING ~= nil, "LOG_WARNING should be defined")
+  assert(syslog.LOG_NOTICE ~= nil, "LOG_NOTICE should be defined")
+  assert(syslog.LOG_INFO ~= nil, "LOG_INFO should be defined")
+  assert(syslog.LOG_DEBUG ~= nil, "LOG_DEBUG should be defined")
+
+  -- Check that priorities have expected ordering (lower = more severe)
+  assert(syslog.LOG_EMERG < syslog.LOG_DEBUG, "LOG_EMERG should be lower than LOG_DEBUG")
+  assert(syslog.LOG_ERR < syslog.LOG_WARNING, "LOG_ERR should be lower than LOG_WARNING")
+  assert(syslog.LOG_WARNING < syslog.LOG_INFO, "LOG_WARNING should be lower than LOG_INFO")
+end
+test_constants()
+
+-- Test that functions exist and are callable
+-- Note: actual syslog delivery may fail in containerized environments
+-- where /dev/log doesn't exist, but the functions should not error
+local function test_write_functions_exist()
+  assert(type(syslog.write) == "function", "write should be a function")
+  assert(type(syslog.emerg) == "function", "emerg should be a function")
+  assert(type(syslog.alert) == "function", "alert should be a function")
+  assert(type(syslog.crit) == "function", "crit should be a function")
+  assert(type(syslog.err) == "function", "err should be a function")
+  assert(type(syslog.warning) == "function", "warning should be a function")
+  assert(type(syslog.notice) == "function", "notice should be a function")
+  assert(type(syslog.info) == "function", "info should be a function")
+  assert(type(syslog.debug) == "function", "debug should be a function")
+end
+test_write_functions_exist()
+
+-- Test calling the functions (they may print errors if syslog unavailable)
+local function test_write_calls()
+  -- These may fail silently if syslog is unavailable, but should not throw
+  syslog.write(syslog.LOG_INFO, "cosmic.syslog test: write()")
+  syslog.info("cosmic.syslog test: info()")
+  syslog.debug("cosmic.syslog test: debug()")
+end
+test_write_calls()
+
+print("All syslog tests passed")

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -286,6 +286,32 @@ local record Stat
   flags: function(self: Stat): any
 end
 
+--- Filesystem statistics returned by statfs() and fstatfs().
+local record Statfs
+  --- Returns filesystem type identifier.
+  type: function(self: Statfs): number
+  --- Returns optimal transfer block size.
+  bsize: function(self: Statfs): number
+  --- Returns total data blocks in filesystem.
+  blocks: function(self: Statfs): number
+  --- Returns free blocks in filesystem.
+  bfree: function(self: Statfs): number
+  --- Returns free blocks available to unprivileged user.
+  bavail: function(self: Statfs): number
+  --- Returns total file nodes in filesystem.
+  files: function(self: Statfs): number
+  --- Returns free file nodes in filesystem.
+  ffree: function(self: Statfs): number
+  --- Returns filesystem ID as two numbers.
+  fsid: function(self: Statfs): number, number
+  --- Returns maximum length of filenames.
+  namelen: function(self: Statfs): number
+  --- Returns fragment size.
+  frsize: function(self: Statfs): number
+  --- Returns mount flags.
+  flags: function(self: Statfs): number
+end
+
 local record Sigset
   --- Adds signal to bitset.
   add: function(self: Sigset, sig: number)
@@ -2113,6 +2139,18 @@ local record unix
   --- Log(kLogInfo, 'hello.txt is %d bytes in size' % {st:size()})
   --- unix.close(fd)
   fstat: function(fd: number): Stat
+  --- Gets filesystem statistics for a path.
+  --- Returns information about the filesystem containing the specified file.
+  statfs: function(path: string): Statfs
+  --- Gets filesystem statistics from a file descriptor.
+  --- Returns information about the filesystem containing the open file.
+  fstatfs: function(fd: number): Statfs
+  --- Extracts major device number from a device ID.
+  --- Use with stat():dev() or stat():rdev() to identify device types.
+  major: function(dev: number): number
+  --- Extracts minor device number from a device ID.
+  --- Use with stat():dev() or stat():rdev() to identify specific devices.
+  minor: function(dev: number): number
   --- Opens directory for listing its contents.
   --- For example, to print a simple directory listing:
   --- Write('<ul>\r\n')


### PR DESCRIPTION
## Summary

- Add `statfs()`/`fstatfs()` to `cosmic.fs` for filesystem statistics (block size, free space, etc.)
- Add `major()`/`minor()` to `cosmic.fs` for extracting device numbers
- Add `dev()`/`rdev()` methods to the `Stat` record
- Add `interfaces()` to `cosmic.net` for listing network adapters via `siocgifconf`
- Add new `cosmic.syslog` module for system logging with priority levels (LOG_EMERG through LOG_DEBUG)
- Add type definitions for `Statfs`, `statfs`, `fstatfs`, `major`, `minor` in `unix.d.tl`

## Test plan

- [x] `make check` passes (type checking)
- [x] `make test` passes (all 50 tests)
- [x] New tests added for statfs, fstatfs, major, minor
- [x] New tests added for interfaces()
- [x] New tests added for syslog module

Closes #143