### PR TITLE
codec: add validation to base64/base32 decoding

### DIFF
--- a/lib/cosmic/CLAUDE.md
+++ b/lib/cosmic/CLAUDE.md
@@ -170,6 +170,51 @@ Use `---` comments with `@param` and `@return` tags:
 local function decode(str: string): any, string
 ```
 
+### Infallible Functions
+
+Some functions cannot fail by design and return only a value (no error):
+
+```teal
+--- Good: Encoding always succeeds, no error needed
+local function encode_hex(data: string): string
+  return cosmo.EncodeHex(data)
+end
+
+--- Good: Compression always succeeds
+local function compress(data: string): string
+  return cosmo.Compress(data)
+end
+```
+
+Infallible functions include:
+- **Encoding**: `encode_hex`, `encode_base64`, `encode_base32`, `encode_lua` (input is always valid bytes)
+- **Compression**: `compress`, `deflate` (any byte sequence can be compressed)
+- **Escaping**: `escape_*` functions (always produce valid output)
+
+### Lenient Parsing Functions
+
+Some parsing functions are intentionally permissive, accepting malformed input
+rather than returning errors:
+
+```teal
+--- Lenient: Returns parsed URL, treating unrecognized input as path
+local function parse_url(url: string): Url
+  -- "not a url" -> {path = "not a url"}
+  -- Valid design choice for user input handling
+end
+
+--- Lenient: Decodes what it can, ignores invalid characters
+local function decode_base64(str: string): string
+  -- May produce garbage on invalid input
+  -- Use with trusted input or validate externally
+end
+```
+
+When wrapping lenient functions, document the behavior clearly:
+- Note that invalid input may produce garbage rather than errors
+- Recommend external validation for untrusted input
+- Consider adding a validating alternative (e.g., `try_decode_base64`)
+
 ## Summary
 
 | Situation | Pattern |
@@ -179,5 +224,7 @@ local function decode(str: string): any, string
 | Complex results | Result record with `ok: boolean` and `error: string` |
 | Resource creation | `Handle, string` with `__close` metamethod |
 | Iteration | Return iterator from successful prepare; errors at prepare time |
+| Infallible operations | Just `value` (no error return needed) |
+| Lenient parsing | Just `value` (document garbage-in/garbage-out behavior) |
 
 Consistency within a module matters more than which specific pattern you choose. Pick one and use it throughout.

--- a/lib/cosmic/codec.tl
+++ b/lib/cosmic/codec.tl
@@ -69,13 +69,26 @@ end
 --- Decode a base64 string to binary data.
 --- Accepts standard base64 encoding with or without padding.
 --- @param str string The base64 string to decode
---- @return string The decoded binary data
-local function decode_base64(str: string): string
+--- @return string The decoded binary data, or nil on error
+--- @return string? Error message if decoding failed
+local function decode_base64(str: string): string, string
+  -- Validate: base64 uses A-Z, a-z, 0-9, +, /, and = for padding
+  if str:match("[^A-Za-z0-9+/=]") then
+    return nil, "invalid base64 character"
+  end
+  -- Validate: = can only appear at the end, max 2
+  local content, padding = str:match("^([A-Za-z0-9+/]*)(%=*)$")
+  if not content then
+    return nil, "invalid base64: padding in middle"
+  end
+  if #padding > 2 then
+    return nil, "invalid base64 padding"
+  end
   return cosmo.DecodeBase64(str)
 end
 
 --- Encode binary data as base32.
---- Uses z-base-32 encoding (lowercase alphabet).
+--- Uses lowercase base32 alphabet (0-9a-v excluding i, l, o, u).
 --- @param data string The binary data to encode
 --- @return string The base32 encoded string
 local function encode_base32(data: string): string
@@ -83,10 +96,15 @@ local function encode_base32(data: string): string
 end
 
 --- Decode a base32 string to binary data.
---- Accepts z-base-32 encoding.
+--- Uses lowercase base32 alphabet (0-9a-v excluding i, l, o, u).
 --- @param str string The base32 string to decode
---- @return string The decoded binary data
-local function decode_base32(str: string): string
+--- @return string The decoded binary data, or nil on error
+--- @return string? Error message if decoding failed
+local function decode_base32(str: string): string, string
+  -- cosmo base32 alphabet: 0123456789abcdefghjkmnpqrstvwxyz (32 chars, no i,l,o,u)
+  if str:match("[^0-9a-hj-km-np-tv-z]") then
+    return nil, "invalid base32 character"
+  end
   return cosmo.DecodeBase32(str)
 end
 
@@ -116,9 +134,9 @@ local record CodecModule
   encode_lua: function(value: any, opts?: {string:any}): string
   decode_lua: function(code: string): any, string
   encode_base64: function(data: string): string
-  decode_base64: function(str: string): string
+  decode_base64: function(str: string): string, string
   encode_base32: function(data: string): string
-  decode_base32: function(str: string): string
+  decode_base32: function(str: string): string, string
   encode_latin1: function(str: string): string, string
   decode_latin1: function(data: string): string
 end

--- a/lib/cosmic/codec_test.tl
+++ b/lib/cosmic/codec_test.tl
@@ -184,27 +184,54 @@ end
 test_encode_base64_binary()
 
 local function test_decode_base64_basic()
-  local result = codec.decode_base64("aGVsbG8=")
-  assert(result == "hello", "expected 'hello', got '" .. result .. "'")
+  local result, err = codec.decode_base64("aGVsbG8=")
+  assert(err == nil, "unexpected error: " .. (err or ""))
+  assert(result == "hello", "expected 'hello', got '" .. (result or "nil") .. "'")
 end
 test_decode_base64_basic()
 
 local function test_decode_base64_no_padding()
-  local result = codec.decode_base64("aGVsbG8")
-  assert(result == "hello", "expected 'hello', got '" .. result .. "'")
+  local result, err = codec.decode_base64("aGVsbG8")
+  assert(err == nil, "unexpected error: " .. (err or ""))
+  assert(result == "hello", "expected 'hello', got '" .. (result or "nil") .. "'")
 end
 test_decode_base64_no_padding()
 
 local function test_decode_base64_empty()
-  local result = codec.decode_base64("")
+  local result, err = codec.decode_base64("")
+  assert(err == nil, "unexpected error: " .. (err or ""))
   assert(result == "", "expected empty string")
 end
 test_decode_base64_empty()
 
+local function test_decode_base64_invalid_char()
+  local result, err = codec.decode_base64("invalid!base64")
+  assert(result == nil, "expected nil for invalid base64")
+  assert(err ~= nil, "expected error message")
+  assert(err:match("invalid"), "error should mention invalid")
+end
+test_decode_base64_invalid_char()
+
+local function test_decode_base64_invalid_padding()
+  local result, err = codec.decode_base64("abc===")
+  assert(result == nil, "expected nil for invalid padding")
+  assert(err ~= nil, "expected error message")
+  assert(err:match("padding"), "error should mention padding")
+end
+test_decode_base64_invalid_padding()
+
+local function test_decode_base64_padding_in_middle()
+  local result, err = codec.decode_base64("ab=cd")
+  assert(result == nil, "expected nil for padding in middle")
+  assert(err ~= nil, "expected error message")
+end
+test_decode_base64_padding_in_middle()
+
 local function test_base64_roundtrip()
   local original = "Hello, World! \x00\xff\x10"
   local encoded = codec.encode_base64(original)
-  local decoded = codec.decode_base64(encoded)
+  local decoded, err = codec.decode_base64(encoded)
+  assert(err == nil, "roundtrip decode failed: " .. (err or ""))
   assert(decoded == original, "roundtrip mismatch")
 end
 test_base64_roundtrip()
@@ -224,21 +251,41 @@ end
 test_encode_base32_empty()
 
 local function test_decode_base32_basic()
-  local result = codec.decode_base32("d1jprv3f")
-  assert(result == "hello", "expected 'hello', got '" .. result .. "'")
+  local result, err = codec.decode_base32("d1jprv3f")
+  assert(err == nil, "unexpected error: " .. (err or ""))
+  assert(result == "hello", "expected 'hello', got '" .. (result or "nil") .. "'")
 end
 test_decode_base32_basic()
 
 local function test_decode_base32_empty()
-  local result = codec.decode_base32("")
+  local result, err = codec.decode_base32("")
+  assert(err == nil, "unexpected error: " .. (err or ""))
   assert(result == "", "expected empty string")
 end
 test_decode_base32_empty()
 
+local function test_decode_base32_invalid_char()
+  -- base32 alphabet excludes i, l, o, u
+  local result, err = codec.decode_base32("hello")  -- 'l' and 'o' are invalid
+  assert(result == nil, "expected nil for invalid base32")
+  assert(err ~= nil, "expected error message")
+  assert(err:match("invalid"), "error should mention invalid")
+end
+test_decode_base32_invalid_char()
+
+local function test_decode_base32_uppercase_invalid()
+  -- base32 is lowercase only
+  local result, err = codec.decode_base32("ABCDEFGH")
+  assert(result == nil, "expected nil for uppercase (base32 is lowercase)")
+  assert(err ~= nil, "expected error message")
+end
+test_decode_base32_uppercase_invalid()
+
 local function test_base32_roundtrip()
   local original = "Hello, World!"
   local encoded = codec.encode_base32(original)
-  local decoded = codec.decode_base32(encoded)
+  local decoded, err = codec.decode_base32(encoded)
+  assert(err == nil, "roundtrip decode failed: " .. (err or ""))
   assert(decoded == original, "roundtrip mismatch")
 end
 test_base32_roundtrip()


### PR DESCRIPTION
## Summary

- Add input validation to `decode_base64` and `decode_base32` so they return errors on invalid input instead of silently producing garbage
- Update `lib/cosmic/CLAUDE.md` with guidelines for infallible functions and lenient parsing functions
- Add comprehensive tests for invalid input handling

## Changes

**codec.tl:**
- `decode_base64` now validates:
  - Character set (A-Za-z0-9+/=)
  - Padding position (= only at end)
  - Padding length (max 2)
- `decode_base32` now validates:
  - Character set (lowercase 0-9a-hj-km-np-tv-z, no i/l/o/u)
- Both functions now return `string, string` (value + error) consistent with other decode functions

**CLAUDE.md:**
- Added section on "Infallible Functions" (encode_*, compress, escape_*)
- Added section on "Lenient Parsing Functions" with guidance
- Updated summary table with new categories

## Test plan
- [x] All existing codec tests pass
- [x] New tests for invalid base64 (bad chars, bad padding)
- [x] New tests for invalid base32 (bad chars, uppercase)
- [x] `make check` passes (97 type checks)
- [x] `make clean test` passes (49 tests)

Fixes #96