### PR TITLE
docs: suppress cosmo modules from interactive docs by default

### DIFF
--- a/lib/cosmic/binary_test.tl
+++ b/lib/cosmic/binary_test.tl
@@ -39,7 +39,7 @@ local function test_cosmic_help()
   assert(ok, "cosmic --help exited with error")
   assert((out as string):find("cosmic", 1, true), "expected output to contain 'cosmic'")
   assert((out as string):find("%-%-help", 1, false), "expected output to contain '--help'")
-  assert((out as string):find("Tip: Use cosmic", 1, true), "expected output to contain cosmic vs cosmo tip")
+  assert((out as string):find("Low%-level cosmo", 1, false), "expected output to contain note about cosmo bindings")
 end
 test_cosmic_help()
 

--- a/lib/cosmic/docs.tl
+++ b/lib/cosmic/docs.tl
@@ -129,9 +129,17 @@ local function first_paragraph(text: string): string
   return para
 end
 
+--- Check if a module name is a low-level cosmo module.
+--- @param name string Module name to check
+--- @return boolean True if this is a cosmo.* module
+local function is_cosmo_module(name: string): boolean
+  return name:match("^cosmo%.") ~= nil
+end
+
 --- List all available documentation topics.
+--- @param include_cosmo boolean Include low-level cosmo.* modules (default: false)
 --- @return {{string, string}} List of {name, description} pairs, sorted by name
-local function list_topics(): {{string, string}}
+local function list_topics(include_cosmo?: boolean): {{string, string}}
   local index, err = load_index()
   if not index then
     return {}
@@ -139,8 +147,11 @@ local function list_topics(): {{string, string}}
 
   local topics: {{string, string}} = {}
   for name, doc in pairs(index.modules) do
-    local desc = first_paragraph(doc.module_doc)
-    table.insert(topics, {name, desc})
+    -- Skip cosmo.* modules unless explicitly requested
+    if include_cosmo or not is_cosmo_module(name) then
+      local desc = first_paragraph(doc.module_doc)
+      table.insert(topics, {name, desc})
+    end
   end
 
   table.sort(topics, function(a: {string, string}, b: {string, string}): boolean
@@ -511,9 +522,11 @@ local function calc_score(
 end
 
 --- Search documentation for a query string.
+--- By default, excludes low-level cosmo.* modules from results.
 --- @param query string The search query
+--- @param include_cosmo boolean Include low-level cosmo.* modules (default: false)
 --- @return {SearchResult} List of search results, sorted by relevance
-local function search(query: string): {SearchResult}
+local function search(query: string, include_cosmo?: boolean): {SearchResult}
   local index, _ = load_index()
   if not index then
     return {}
@@ -524,6 +537,10 @@ local function search(query: string): {SearchResult}
 
   -- Search through all modules
   for mod_name, mod_doc in pairs(index.modules) do
+    -- Skip cosmo.* modules unless explicitly requested
+    if not include_cosmo and is_cosmo_module(mod_name) then
+      goto continue
+    end
     local simple_name = mod_name:match("([^%.]+)$") or mod_name
     local simple_lower = simple_name:lower()
 
@@ -623,6 +640,7 @@ local function search(query: string): {SearchResult}
         end
       end
     end
+    ::continue::
   end
 
   -- Sort by match score (highest first), then by module name for stability
@@ -644,8 +662,10 @@ local record ExampleEntry
 end
 
 --- List all examples across all modules.
+--- By default, excludes low-level cosmo.* modules.
+--- @param include_cosmo boolean Include low-level cosmo.* modules (default: false)
 --- @return {ExampleEntry} List of examples sorted by module then name
-local function list_all_examples(): {ExampleEntry}
+local function list_all_examples(include_cosmo?: boolean): {ExampleEntry}
   local index, _ = load_index()
   if not index then
     return {}
@@ -653,6 +673,10 @@ local function list_all_examples(): {ExampleEntry}
 
   local examples: {ExampleEntry} = {}
   for mod_name, mod_doc in pairs(index.modules) do
+    -- Skip cosmo.* modules unless explicitly requested
+    if not include_cosmo and is_cosmo_module(mod_name) then
+      goto continue
+    end
     if mod_doc.examples then
       for _, ex in ipairs(mod_doc.examples) do
         local display_name = ex.name:gsub("^Example_?", "")
@@ -663,6 +687,7 @@ local function list_all_examples(): {ExampleEntry}
         })
       end
     end
+    ::continue::
   end
 
   table.sort(examples, function(a: ExampleEntry, b: ExampleEntry): boolean
@@ -993,10 +1018,10 @@ end
 local record DocsModule
   run: function(query?: string): DocsResult
   has_docs: function(): boolean
-  list_topics: function(): {{string, string}}
+  list_topics: function(include_cosmo?: boolean): {{string, string}}
   load_index: function(): DocIndex, string
   render_module: function(name: string, doc: ModuleDoc): string
-  search: function(query: string): {SearchResult}
+  search: function(query: string, include_cosmo?: boolean): {SearchResult}
   render_search_results: function(results: {SearchResult}, query: string): string
   show_module_examples: function(module_name: string): DocsResult
 end

--- a/lib/cosmic/docs_test.tl
+++ b/lib/cosmic/docs_test.tl
@@ -265,5 +265,86 @@ local function test_module_path_boost()
 end
 test_module_path_boost()
 
+-- Test that list_topics excludes cosmo.* modules by default
+local function test_list_topics_excludes_cosmo()
+  local topics = docs.list_topics()
+  local found_cosmo = false
+  for _, topic in ipairs(topics) do
+    if topic[1]:match("^cosmo%.") then
+      found_cosmo = true
+      break
+    end
+  end
+  assert(not found_cosmo, "list_topics should exclude cosmo.* modules by default")
+  print("test_list_topics_excludes_cosmo: PASS")
+end
+test_list_topics_excludes_cosmo()
+
+-- Test that list_topics(true) includes cosmo.* modules
+local function test_list_topics_includes_cosmo_when_requested()
+  local topics = docs.list_topics(true)
+  local found_cosmo = false
+  local found_cosmic = false
+  for _, topic in ipairs(topics) do
+    if topic[1]:match("^cosmo%.") then
+      found_cosmo = true
+    end
+    if topic[1]:match("^cosmic%.") then
+      found_cosmic = true
+    end
+  end
+  if docs.has_docs() then
+    assert(found_cosmo, "list_topics(true) should include cosmo.* modules")
+    assert(found_cosmic, "list_topics(true) should include cosmic.* modules")
+  end
+  print("test_list_topics_includes_cosmo_when_requested: PASS")
+end
+test_list_topics_includes_cosmo_when_requested()
+
+-- Test that search excludes cosmo.* results by default
+local function test_search_excludes_cosmo()
+  -- Search for something that exists in cosmo modules (like "unix")
+  local results = docs.search("unix")
+  local found_cosmo = false
+  for _, result in ipairs(results) do
+    if result.module_name:match("^cosmo%.") then
+      found_cosmo = true
+      break
+    end
+  end
+  assert(not found_cosmo, "search should exclude cosmo.* modules by default")
+  print("test_search_excludes_cosmo: PASS")
+end
+test_search_excludes_cosmo()
+
+-- Test that search(query, true) includes cosmo.* results
+local function test_search_includes_cosmo_when_requested()
+  local results = docs.search("unix", true)
+  local found_cosmo = false
+  for _, result in ipairs(results) do
+    if result.module_name:match("^cosmo%.") then
+      found_cosmo = true
+      break
+    end
+  end
+  if docs.has_docs() then
+    assert(found_cosmo, "search(query, true) should include cosmo.* modules")
+  end
+  print("test_search_includes_cosmo_when_requested: PASS")
+end
+test_search_includes_cosmo_when_requested()
+
+-- Test that explicit cosmo module lookup still works
+local function test_explicit_cosmo_access()
+  local result = docs.run("cosmo.unix")
+  assert(result, "run should return a result")
+  if docs.has_docs() then
+    assert(result.ok, "explicit cosmo.unix lookup should succeed")
+    assert(result.output:match("unix"), "output should contain unix content")
+  end
+  print("test_explicit_cosmo_access: PASS")
+end
+test_explicit_cosmo_access()
+
 print("")
 print("All docs tests passed!")

--- a/lib/cosmic/main.tl
+++ b/lib/cosmic/main.tl
@@ -355,41 +355,28 @@ local function generate_help(): string
   table.insert(lines, "  -W                          turn warnings into errors")
   table.insert(lines, "")
 
-  -- Try to show module table
+  -- Try to show module table (only cosmic.* modules, not cosmo.* bindings)
   local docs = require("cosmic.docs")
   if docs.has_docs() then
-    local topics = docs.list_topics()
+    local topics = docs.list_topics()  -- excludes cosmo.* by default
     if #topics > 0 then
-      -- Separate cosmic and cosmo modules
       local cosmic_modules: {string} = {}
-      local cosmo_modules: {string} = {}
 
       for _, topic in ipairs(topics) do
         local name: string = topic[1] as string
         if name:match("^cosmic%.") then
           local short_name = name:gsub("^cosmic%.", "")
           table.insert(cosmic_modules, short_name)
-        elseif name:match("^cosmo%.") then
-          local short_name = name:gsub("^cosmo%.", "")
-          table.insert(cosmo_modules, short_name)
         end
       end
 
-      if #cosmic_modules > 0 or #cosmo_modules > 0 then
+      if #cosmic_modules > 0 then
         table.insert(lines, "Available modules:")
-
-        if #cosmic_modules > 0 then
-          table.sort(cosmic_modules)
-          table.insert(lines, "  cosmic:  " .. table.concat(cosmic_modules, ", "))
-        end
-
-        if #cosmo_modules > 0 then
-          table.sort(cosmo_modules)
-          table.insert(lines, "  cosmo:   " .. table.concat(cosmo_modules, ", "))
-        end
-
+        table.sort(cosmic_modules)
+        table.insert(lines, "  cosmic:  " .. table.concat(cosmic_modules, ", "))
         table.insert(lines, "")
-        table.insert(lines, "  Tip: Use cosmic.* for high-level APIs. Use cosmo.* for low-level bindings.")
+        table.insert(lines, "  Low-level cosmo.* bindings are available but hidden by default.")
+        table.insert(lines, "  Use --docs cosmo.<module> to access them directly.")
         table.insert(lines, "")
       end
     end


### PR DESCRIPTION
## Summary

- Hide low-level `cosmo.*` modules from `--docs` output and `--help` listings by default
- Users can still access cosmo modules explicitly (e.g., `--docs cosmo.unix`)
- Keeps focus on ergonomic `cosmic.*` wrappers while maintaining access to underlying bindings

## Changes

- `list_topics()` excludes `cosmo.*` by default (accepts optional `include_cosmo` param)
- `search()` excludes `cosmo.*` by default (accepts optional `include_cosmo` param)
- `list_all_examples()` excludes `cosmo.*` by default
- `--help` shows only `cosmic.*` modules with note about accessing `cosmo.*` bindings

## Test plan

- [x] `make check` passes
- [x] `make test` passes
- [x] Verify `--docs` listing excludes `cosmo.*` modules
- [x] Verify `--docs cosmo.unix` still works for explicit access
- [x] Verify `--help` shows only `cosmic.*` modules with note

Fixes #178