### PR TITLE
poll: add ergonomic typed interface for polling

### DIFF
--- a/lib/cosmic/poll.tl
+++ b/lib/cosmic/poll.tl
@@ -1,0 +1,213 @@
+--- Typed interface for polling file descriptors.
+--- Provides an ergonomic wrapper around unix.poll().
+local unix = require("cosmo.unix")
+
+--- Poll event flags.
+--- Use these to specify which events to monitor.
+local POLLIN: number = unix.POLLIN
+local POLLOUT: number = unix.POLLOUT
+local POLLPRI: number = unix.POLLPRI
+local POLLERR: number = unix.POLLERR
+local POLLHUP: number = unix.POLLHUP
+local POLLNVAL: number = unix.POLLNVAL
+local POLLRDHUP: number = unix.POLLRDHUP
+
+--- Resolved events from a poll operation.
+local record Events
+  --- True if readable data is available.
+  readable: boolean
+  --- True if writing is possible.
+  writable: boolean
+  --- True if an error occurred.
+  error: boolean
+  --- True if the peer closed the connection.
+  hangup: boolean
+  --- True if the fd is invalid.
+  invalid: boolean
+  --- Raw revents bitmask from poll.
+  revents: number
+end
+
+--- Poll set for monitoring multiple file descriptors.
+local record Poller
+  --- Add a file descriptor or handle to the set.
+  --- Accepts raw fd numbers, or objects with .fd field or :fd() method.
+  --- @param p any File descriptor number, io.Handle, child.Pipe, or net.Socket
+  --- @param events number Event mask (POLLIN, POLLOUT, etc.)
+  add: function(Poller, any, number)
+  --- Remove a file descriptor or handle from the set.
+  --- @param p any The fd or handle to remove
+  remove: function(Poller, any)
+  --- Clear all file descriptors from the set.
+  clear: function(Poller)
+  --- Poll for events with optional timeout.
+  --- Returns an iterator over (fd, events) pairs for ready descriptors.
+  --- @param timeoutms number Timeout in ms (-1 for infinite, 0 for non-blocking)
+  --- @return function Iterator yielding (fd: number, events: Events)
+  wait: function(Poller, number): function(): number, Events
+  --- Poll and return count of ready descriptors.
+  --- @param timeoutms number Timeout in ms (-1 for infinite, 0 for non-blocking)
+  --- @return number Count of ready descriptors
+  --- @return string Error message on failure
+  poll: function(Poller, number): number, string
+  --- Get events for a specific fd after poll().
+  --- @param fd number The file descriptor
+  --- @return Events The events for this fd, or nil if not ready
+  events: function(Poller, number): Events
+  --- Returns true if the poller has no registered fds.
+  empty: function(Poller): boolean
+  --- Returns the number of registered fds.
+  count: function(Poller): number
+end
+
+--- Extract a file descriptor number from a pollable object.
+--- Supports: raw fd numbers, objects with .fd field, objects with :fd() method.
+local function get_fd(p: any): number
+  if type(p) == "number" then
+    return p as number
+  elseif type(p) == "table" then
+    local t = p as {any:any}
+    local fd_val = t.fd
+    if type(fd_val) == "number" then
+      return fd_val as number
+    elseif type(fd_val) == "function" then
+      return (fd_val as function(any): number)(p)
+    end
+  end
+  return nil
+end
+
+--- Make Events from raw revents bitmask.
+local function make_events(revents: number): Events
+  return {
+    readable = (revents & POLLIN) ~= 0,
+    writable = (revents & POLLOUT) ~= 0,
+    error = (revents & POLLERR) ~= 0,
+    hangup = (revents & POLLHUP) ~= 0,
+    invalid = (revents & POLLNVAL) ~= 0,
+    revents = revents,
+  }
+end
+
+--- Create a new poll set.
+--- @return Poller A new poll set
+--- Example:
+---   local p = poll.new()
+---   p:add(handle.stdout, poll.POLLIN)
+---   p:add(handle.stderr, poll.POLLIN)
+---   for fd, events in p:wait(30000) do
+---     if events.readable then
+---       -- read from fd
+---     end
+---   end
+local function new(): Poller
+  local fds: {number:number} = {}
+  local results: {number:number} = {}
+
+  local poller: Poller = {}
+
+  poller.add = function(self: Poller, p: any, events: number)
+    local fd = get_fd(p)
+    if fd then
+      fds[fd] = events
+    end
+  end
+
+  poller.remove = function(self: Poller, p: any)
+    local fd = get_fd(p)
+    if fd then
+      fds[fd] = nil
+      results[fd] = nil
+    end
+  end
+
+  poller.clear = function(self: Poller)
+    fds = {}
+    results = {}
+  end
+
+  poller.empty = function(self: Poller): boolean
+    return next(fds) == nil
+  end
+
+  poller.count = function(self: Poller): number
+    local n = 0
+    for _ in pairs(fds) do
+      n = n + 1
+    end
+    return n
+  end
+
+  poller.poll = function(self: Poller, timeoutms: number): number, string
+    results = unix.poll(fds, timeoutms or -1)
+    if not results then
+      return nil, "poll failed"
+    end
+    local ready = 0
+    for _ in pairs(results) do
+      ready = ready + 1
+    end
+    return ready
+  end
+
+  poller.events = function(self: Poller, fd: number): Events
+    local revents = results[fd]
+    if revents then
+      return make_events(revents)
+    end
+    return nil
+  end
+
+  poller.wait = function(self: Poller, timeoutms: number): function(): number, Events
+    local _, err = self:poll(timeoutms)
+    if err then
+      return function(): number, Events
+        return nil, nil
+      end
+    end
+    local iter_results = results
+    local k: number = nil
+    return function(): number, Events
+      local v: number
+      k, v = next(iter_results, k)
+      if k then
+        return k, make_events(v)
+      end
+      return nil, nil
+    end
+  end
+
+  return poller
+end
+
+local record PollModule
+  new: function(): Poller
+
+  --- Event mask for readable data.
+  POLLIN: number
+  --- Event mask for writable.
+  POLLOUT: number
+  --- Event mask for priority data (e.g., OOB on TCP).
+  POLLPRI: number
+  --- Event mask for error condition.
+  POLLERR: number
+  --- Event mask for hangup.
+  POLLHUP: number
+  --- Event mask for invalid fd.
+  POLLNVAL: number
+  --- Event mask for peer closed connection.
+  POLLRDHUP: number
+end
+
+local M: PollModule = {
+  new = new,
+  POLLIN = POLLIN,
+  POLLOUT = POLLOUT,
+  POLLPRI = POLLPRI,
+  POLLERR = POLLERR,
+  POLLHUP = POLLHUP,
+  POLLNVAL = POLLNVAL,
+  POLLRDHUP = POLLRDHUP,
+}
+
+return M

--- a/lib/cosmic/poll_test.tl
+++ b/lib/cosmic/poll_test.tl
@@ -1,0 +1,247 @@
+#!/usr/bin/env cosmic
+local poll = require("cosmic.poll")
+local cio = require("cosmic.io")
+local net = require("cosmic.net")
+local child = require("cosmic.child")
+
+local function test_poll_constants()
+  assert(poll.POLLIN ~= nil, "POLLIN not defined")
+  assert(poll.POLLOUT ~= nil, "POLLOUT not defined")
+  assert(poll.POLLERR ~= nil, "POLLERR not defined")
+  assert(poll.POLLHUP ~= nil, "POLLHUP not defined")
+  assert(poll.POLLNVAL ~= nil, "POLLNVAL not defined")
+  assert(poll.POLLPRI ~= nil, "POLLPRI not defined")
+  assert(poll.POLLRDHUP ~= nil, "POLLRDHUP not defined")
+end
+test_poll_constants()
+
+local function test_poller_new()
+  local p = poll.new()
+  assert(p ~= nil, "new() returned nil")
+  assert(p.empty ~= nil, "empty method missing")
+  assert(p.add ~= nil, "add method missing")
+  assert(p.remove ~= nil, "remove method missing")
+  assert(p.wait ~= nil, "wait method missing")
+  assert(p:empty(), "new poller should be empty")
+  assert(p:count() == 0, "new poller count should be 0")
+end
+test_poller_new()
+
+local function test_poller_add_remove_raw_fd()
+  local p = poll.new()
+  -- Add a raw fd number
+  p:add(1, poll.POLLOUT)  -- stdout
+  assert(not p:empty(), "poller should not be empty after add")
+  assert(p:count() == 1, "count should be 1")
+
+  p:add(2, poll.POLLOUT)  -- stderr
+  assert(p:count() == 2, "count should be 2")
+
+  p:remove(1)
+  assert(p:count() == 1, "count should be 1 after remove")
+
+  p:clear()
+  assert(p:empty(), "poller should be empty after clear")
+end
+test_poller_add_remove_raw_fd()
+
+local function test_poll_pipe_readable()
+  local pipe, err = cio.pipe()
+  assert(pipe ~= nil, "pipe creation failed: " .. tostring(err))
+
+  -- Write to the pipe so it becomes readable
+  local n = pipe.writer:write("hello")
+  assert(n == 5, "expected 5 bytes written")
+
+  local p = poll.new()
+  -- Add the reader using its fd() method
+  p:add(pipe.reader, poll.POLLIN)
+  assert(p:count() == 1, "count should be 1")
+
+  -- Poll with short timeout - should return immediately since data is available
+  local count = 0
+  for fd, events in p:wait(100) do
+    assert(fd == pipe.reader:fd(), "expected reader fd")
+    assert(events.readable, "expected readable event")
+    assert(not events.error, "unexpected error event")
+    count = count + 1
+  end
+  assert(count == 1, "expected 1 ready fd, got " .. count)
+
+  pipe:close()
+end
+test_poll_pipe_readable()
+
+local function test_poll_pipe_writable()
+  local pipe, err = cio.pipe()
+  assert(pipe ~= nil, "pipe creation failed: " .. tostring(err))
+
+  local p = poll.new()
+  -- Check if writer is writable (should be, since buffer is empty)
+  p:add(pipe.writer, poll.POLLOUT)
+
+  local count = 0
+  for fd, events in p:wait(100) do
+    assert(fd == pipe.writer:fd(), "expected writer fd")
+    assert(events.writable, "expected writable event")
+    count = count + 1
+  end
+  assert(count == 1, "expected 1 ready fd")
+
+  pipe:close()
+end
+test_poll_pipe_writable()
+
+local function test_poll_multiple_fds()
+  local pipe1, err1 = cio.pipe()
+  assert(pipe1 ~= nil, "pipe1 creation failed: " .. tostring(err1))
+
+  local pipe2, err2 = cio.pipe()
+  assert(pipe2 ~= nil, "pipe2 creation failed: " .. tostring(err2))
+
+  -- Write to both pipes
+  pipe1.writer:write("hello")
+  pipe2.writer:write("world")
+
+  local p = poll.new()
+  p:add(pipe1.reader, poll.POLLIN)
+  p:add(pipe2.reader, poll.POLLIN)
+  assert(p:count() == 2, "count should be 2")
+
+  local ready_fds: {number:boolean} = {}
+  for fd, events in p:wait(100) do
+    assert(events.readable, "expected readable")
+    ready_fds[fd] = true
+  end
+
+  assert(ready_fds[pipe1.reader:fd()], "pipe1 reader should be ready")
+  assert(ready_fds[pipe2.reader:fd()], "pipe2 reader should be ready")
+
+  pipe1:close()
+  pipe2:close()
+end
+test_poll_multiple_fds()
+
+local function test_poll_timeout()
+  local pipe, err = cio.pipe()
+  assert(pipe ~= nil, "pipe creation failed: " .. tostring(err))
+
+  local p = poll.new()
+  -- Poll for read on empty pipe - should timeout
+  p:add(pipe.reader, poll.POLLIN)
+
+  local count = 0
+  for _, _ in p:wait(10) do  -- 10ms timeout
+    count = count + 1
+  end
+  assert(count == 0, "expected no ready fds on timeout")
+
+  pipe:close()
+end
+test_poll_timeout()
+
+local function test_poll_with_socket()
+  local sock1, sock2, err = net.socketpair()
+  assert(sock1 ~= nil and sock2 ~= nil, "socketpair failed: " .. tostring(err))
+
+  -- Send data on sock1
+  sock1:send("hello")
+
+  local p = poll.new()
+  -- Socket has fd field directly
+  p:add(sock2, poll.POLLIN)
+
+  local count = 0
+  for fd, events in p:wait(100) do
+    assert(fd == sock2.fd, "expected sock2 fd")
+    assert(events.readable, "expected readable")
+    count = count + 1
+  end
+  assert(count == 1, "expected 1 ready socket")
+
+  sock1:close()
+  sock2:close()
+end
+test_poll_with_socket()
+
+local function test_poll_with_child_pipes()
+  local handle, err = child.spawn({"echo", "hello"})
+  assert(handle ~= nil, "spawn failed: " .. tostring(err))
+
+  local p = poll.new()
+  -- child.Pipe has .fd field
+  p:add(handle.stdout, poll.POLLIN)
+
+  local count = 0
+  for fd, events in p:wait(1000) do
+    assert(fd == handle.stdout.fd, "expected stdout fd")
+    assert(events.readable or events.hangup, "expected readable or hangup")
+    count = count + 1
+  end
+  assert(count >= 1, "expected at least 1 event from child stdout")
+
+  handle:wait()
+end
+test_poll_with_child_pipes()
+
+local function test_poll_events_method()
+  local pipe, err = cio.pipe()
+  assert(pipe ~= nil, "pipe creation failed: " .. tostring(err))
+
+  pipe.writer:write("test")
+
+  local p = poll.new()
+  p:add(pipe.reader, poll.POLLIN)
+
+  local ready, poll_err = p:poll(100)
+  assert(ready ~= nil, "poll failed: " .. tostring(poll_err))
+  assert(ready == 1, "expected 1 ready fd")
+
+  local events = p:events(pipe.reader:fd())
+  assert(events ~= nil, "events should not be nil for ready fd")
+  assert(events.readable, "expected readable")
+  assert(events.revents ~= nil, "revents should be set")
+
+  local no_events = p:events(999)
+  assert(no_events == nil, "events should be nil for non-ready fd")
+
+  pipe:close()
+end
+test_poll_events_method()
+
+local function test_poll_nonblocking()
+  local pipe, err = cio.pipe()
+  assert(pipe ~= nil, "pipe creation failed: " .. tostring(err))
+
+  local p = poll.new()
+  p:add(pipe.reader, poll.POLLIN)
+
+  -- Non-blocking poll (timeout = 0)
+  local ready, _ = p:poll(0)
+  assert(ready == 0, "expected 0 ready fds for non-blocking poll on empty pipe")
+
+  pipe:close()
+end
+test_poll_nonblocking()
+
+local function test_poll_hangup()
+  local pipe, err = cio.pipe()
+  assert(pipe ~= nil, "pipe creation failed: " .. tostring(err))
+
+  -- Close the writer to trigger hangup on reader
+  pipe.writer:close()
+
+  local p = poll.new()
+  p:add(pipe.reader, poll.POLLIN)
+
+  for fd, events in p:wait(100) do
+    assert(fd == pipe.reader:fd(), "expected reader fd")
+    -- When writer closes, reader gets POLLHUP
+    assert(events.hangup or events.readable, "expected hangup or readable on closed pipe")
+  end
+
+  pipe.reader:close()
+end
+test_poll_hangup()
+
+print("all poll tests passed")


### PR DESCRIPTION
## Summary
- Adds `cosmic.poll` module providing a typed wrapper around `unix.poll()`
- Supports io.Handle, child.Pipe, net.Socket, or raw fd numbers
- Iterator-based `wait()` for clean for-loop usage
- Events record with readable/writable/error/hangup boolean flags

Example usage:
```lua
local poll = require("cosmic.poll")
local p = poll.new()
p:add(handle.stdout, poll.POLLIN)
p:add(handle.stderr, poll.POLLIN)

for fd, events in p:wait(30000) do
  if events.readable then
    -- read from fd
  end
end
```

Closes #177

## Test plan
- [x] Type checking passes (`make check`)
- [x] All tests pass (`make clean test`)
- [x] Tests cover constants, add/remove, pipe read/write, multiple fds, timeout, socket, child pipes, hangup