### PR TITLE
proc: remove signal-sending functions

### DIFF
--- a/lib/cosmic/proc.tl
+++ b/lib/cosmic/proc.tl
@@ -1,5 +1,5 @@
 --- Current process management.
---- Identity, session/group control, exec, signals, and resource usage.
+--- Identity, session/group control, exec, and resource usage.
 local unix = require("cosmo.unix")
 local cosmo = require("cosmo")
 
@@ -102,32 +102,6 @@ end
 --- @return boolean True on success
 local function daemon(nochdir?: boolean, noclose?: boolean): boolean
   return unix.daemon(nochdir, noclose)
-end
-
--- Signals --
-
---- Sends signal to process(es).
---- @param pid number Process id to signal. Negative values target process groups
---- @param sig number Signal number (e.g., SIGTERM, SIGKILL)
---- @return boolean True on success
-local function kill(pid: number, sig: number): boolean
-  return unix.kill(pid, sig)
-end
-
---- Sends signal to process group.
---- @param pgrp number Process group id. If 0, sends to calling process's group
---- @param sig number Signal number
---- @return boolean True on success
-local function killpg(pgrp: number, sig: number): boolean
-  return unix.killpg(pgrp, sig)
-end
-
---- Sends signal to current process.
---- Equivalent to kill(getpid(), sig).
---- @param sig number Signal number to raise
---- @return number 0 on success
-local function raise(sig: number): number
-  return unix.raise(sig)
 end
 
 -- Termination --
@@ -313,11 +287,6 @@ local record ProcModule
   setsid: function(): number
   daemon: function(nochdir?: boolean, noclose?: boolean): boolean
 
-  -- Signals
-  kill: function(pid: number, sig: number): boolean
-  killpg: function(pgrp: number, sig: number): boolean
-  raise: function(sig: number): number
-
   -- Termination
   exit: function(exitcode?: number)
 
@@ -352,20 +321,6 @@ local record ProcModule
   RUSAGE_THREAD: number
   RUSAGE_BOTH: number
 
-  -- Signal constants
-  SIGTERM: number
-  SIGKILL: number
-  SIGINT: number
-  SIGQUIT: number
-  SIGHUP: number
-  SIGCHLD: number
-  SIGSTOP: number
-  SIGCONT: number
-  SIGUSR1: number
-  SIGUSR2: number
-  SIGPIPE: number
-  SIGALRM: number
-
   -- Resource limit constants
   RLIMIT_AS: number
   RLIMIT_CPU: number
@@ -393,11 +348,6 @@ local M: ProcModule = {
   setpgid = setpgid,
   setsid = setsid,
   daemon = daemon,
-
-  -- Signals
-  kill = kill,
-  killpg = killpg,
-  raise = raise,
 
   -- Termination
   exit = exit,
@@ -432,20 +382,6 @@ local M: ProcModule = {
   RUSAGE_CHILDREN = unix.RUSAGE_CHILDREN,
   RUSAGE_THREAD = unix.RUSAGE_THREAD,
   RUSAGE_BOTH = unix.RUSAGE_BOTH,
-
-  -- Signal constants
-  SIGTERM = unix.SIGTERM,
-  SIGKILL = unix.SIGKILL,
-  SIGINT = unix.SIGINT,
-  SIGQUIT = unix.SIGQUIT,
-  SIGHUP = unix.SIGHUP,
-  SIGCHLD = unix.SIGCHLD,
-  SIGSTOP = unix.SIGSTOP,
-  SIGCONT = unix.SIGCONT,
-  SIGUSR1 = unix.SIGUSR1,
-  SIGUSR2 = unix.SIGUSR2,
-  SIGPIPE = unix.SIGPIPE,
-  SIGALRM = unix.SIGALRM,
 
   -- Resource limit constants
   RLIMIT_AS = unix.RLIMIT_AS,

--- a/lib/cosmic/proc_test.tl
+++ b/lib/cosmic/proc_test.tl
@@ -151,35 +151,7 @@ end
 end
 test_is_main_false_when_required()
 
--- kill / raise tests --
-
-local function test_kill_sends_signal()
-  local pid = child.fork()
-  if pid == 0 then
-    while true do end
-  else
-    local killed = proc.kill(pid, proc.SIGKILL)
-    assert(killed, "expected kill to succeed")
-    child.wait(pid)
-  end
-end
-test_kill_sends_signal()
-
 -- Constants tests --
-
-local function test_signal_constants_defined()
-  assert(type(proc.SIGTERM) == "number", "SIGTERM should be a number")
-  assert(type(proc.SIGKILL) == "number", "SIGKILL should be a number")
-  assert(type(proc.SIGINT) == "number", "SIGINT should be a number")
-  assert(type(proc.SIGQUIT) == "number", "SIGQUIT should be a number")
-  assert(type(proc.SIGHUP) == "number", "SIGHUP should be a number")
-  assert(type(proc.SIGCHLD) == "number", "SIGCHLD should be a number")
-  assert(type(proc.SIGUSR1) == "number", "SIGUSR1 should be a number")
-  assert(type(proc.SIGUSR2) == "number", "SIGUSR2 should be a number")
-  assert(type(proc.SIGPIPE) == "number", "SIGPIPE should be a number")
-  assert(type(proc.SIGALRM) == "number", "SIGALRM should be a number")
-end
-test_signal_constants_defined()
 
 local function test_rusage_constants_defined()
   assert(type(proc.RUSAGE_SELF) == "number", "RUSAGE_SELF should be a number")


### PR DESCRIPTION
## Summary
- Remove `kill`, `killpg`, `raise` functions from `cosmic.proc` (they duplicate `cosmic.signal`)
- Remove signal constants (`SIGTERM`, `SIGKILL`, etc.) from `cosmic.proc`
- Keep `child.kill` in `cosmic.child` since it operates in the child process management context

## Test plan
- [x] All tests pass (`make test`)
- [x] Type checking passes (`make check`)

Fixes #129