### PR TITLE
embed: preserve file modes in embed/extract roundtrip

### DIFF
--- a/lib/cosmic/embed.tl
+++ b/lib/cosmic/embed.tl
@@ -38,17 +38,28 @@ local record EmbedResult
   file_count: integer
 end
 
+--- Options for adding files to a ZIP archive.
+local record AddOptions
+  mode: number
+end
+
 --- Appender interface for modifying a ZIP archive in-place.
 local record ZipAppender
-  add: function(self: ZipAppender, name: string, content: string): boolean, string
+  add: function(self: ZipAppender, name: string, content: string, options?: AddOptions): boolean, string
   remove: function(self: ZipAppender, name: string): boolean, string
   close: function(self: ZipAppender)
+end
+
+--- Stat record for zip file metadata.
+local record ZipStat
+  mode: number
 end
 
 --- Reader interface for reading files from a ZIP archive.
 local record ZipReader
   list: function(self: ZipReader): {string}
   read: function(self: ZipReader, name: string): string | nil, string | nil
+  stat: function(self: ZipReader, name: string): ZipStat | nil
   close: function(self: ZipReader)
 end
 
@@ -57,6 +68,7 @@ local record FileToEmbed
   path: string
   content: string
   stored_name: string
+  mode: number
 end
 
 -- Unix interfaces used for directory walking.
@@ -109,10 +121,13 @@ local function collect_dir(dir: string): {FileToEmbed}, string
           end
           local content = f:read("*a")
           f:close()
+          -- Extract permission bits (lower 9 bits)
+          local file_mode = st:mode() & tonumber("777", 8)
           collected[#collected + 1] = {
             path = full_path,
             content = content,
             stored_name = stored_name,
+            mode = file_mode,
           }
         end
       end
@@ -168,10 +183,18 @@ local function run(paths: {string}, output?: string, exe_path?: string): EmbedRe
 
       local stored_name = p:gsub("^/+", "")
 
+      -- Get file mode
+      local st = unix.stat(p)
+      local file_mode = tonumber("644", 8) -- default
+      if st then
+        file_mode = st:mode() & tonumber("777", 8)
+      end
+
       files_to_embed[#files_to_embed + 1] = {
         path = p,
         content = content,
         stored_name = stored_name,
+        mode = file_mode,
       }
     end
   end
@@ -203,7 +226,7 @@ local function run(paths: {string}, output?: string, exe_path?: string): EmbedRe
   -- Remove existing entries that conflict, then add new ones
   for _, file_info in ipairs(files_to_embed) do
     appender:remove(file_info.stored_name)
-    local add_ok, add_err = appender:add(file_info.stored_name, file_info.content)
+    local add_ok, add_err = appender:add(file_info.stored_name, file_info.content, {mode = file_info.mode})
     if not add_ok then
       appender:close()
       os.remove(output)
@@ -261,7 +284,17 @@ local function extract(output_dir: string, exe_path?: string): EmbedResult
       local dir = pathlib.dirname(filepath)
       unix.makedirs(dir)
 
-      if not cosmo.Barf(filepath, content) then
+      -- Get file mode from zip, default to 644
+      local file_mode = tonumber("644", 8)
+      local st = reader:stat(name)
+      if st then
+        local mode = (st as ZipStat).mode & tonumber("777", 8)
+        if mode > 0 then
+          file_mode = mode
+        end
+      end
+
+      if not cosmo.Barf(filepath, content, file_mode) then
         reader:close()
         return {ok = false, message = "error: cannot write '" .. filepath .. "'", file_count = count}
       end

--- a/lib/cosmic/embed_test.tl
+++ b/lib/cosmic/embed_test.tl
@@ -14,7 +14,13 @@ local tmpdir = os.getenv("TEST_TMPDIR")
 local record Reader
   list: function(self: Reader): {string}
   read: function(self: Reader, name: string): string | nil, string | nil
+  stat: function(self: Reader, name: string): Stat | nil
   close: function(self: Reader)
+end
+
+-- Stat record for file metadata
+local record Stat
+  mode: number
 end
 
 local function write_temp(name: string, content: string): string
@@ -362,5 +368,99 @@ local function test_embed_overwrites_cleanly()
   new_reader:close()
 end
 test_embed_overwrites_cleanly()
+
+-- Test that file modes are preserved in the zip archive
+local function test_embed_preserves_file_modes()
+  local appdir = path.join(tmpdir, "modeapp")
+  unix.makedirs(appdir)
+
+  -- Create files with different modes
+  local script = path.join(appdir, "run.sh")
+  local config = path.join(appdir, "config.txt")
+  local secret = path.join(appdir, "secret.key")
+
+  cosmo.Barf(script, "#!/bin/sh\necho hello\n")
+  cosmo.Barf(config, "setting=value\n")
+  cosmo.Barf(secret, "private-key-data\n")
+
+  -- Set specific modes
+  unix.chmod(script, tonumber("755", 8))
+  unix.chmod(config, tonumber("644", 8))
+  unix.chmod(secret, tonumber("600", 8))
+
+  local output = path.join(tmpdir, "cosmic-modes")
+  local ok, out = spawn.spawn({cosmic, "--embed", appdir, "--output", output}):read()
+  assert(ok, "embed should succeed: " .. (out or ""))
+
+  -- Check modes in the zip archive
+  local data = cosmo.Slurp(output)
+  local reader_maybe = zip.from(data)
+  assert(reader_maybe, "failed to open zip from data")
+  local reader = reader_maybe as Reader
+
+  local script_stat = reader:stat("run.sh")
+  local config_stat = reader:stat("config.txt")
+  local secret_stat = reader:stat("secret.key")
+
+  assert(script_stat, "run.sh should exist in zip")
+  assert(config_stat, "config.txt should exist in zip")
+  assert(secret_stat, "secret.key should exist in zip")
+
+  -- Check permission bits (mask with 0777 to get just permission bits)
+  local script_mode = (script_stat as Stat).mode & tonumber("777", 8)
+  local config_mode = (config_stat as Stat).mode & tonumber("777", 8)
+  local secret_mode = (secret_stat as Stat).mode & tonumber("777", 8)
+
+  assert(script_mode == tonumber("755", 8),
+    "run.sh should have mode 755, got " .. string.format("%o", script_mode))
+  assert(config_mode == tonumber("644", 8),
+    "config.txt should have mode 644, got " .. string.format("%o", config_mode))
+  assert(secret_mode == tonumber("600", 8),
+    "secret.key should have mode 600, got " .. string.format("%o", secret_mode))
+
+  reader:close()
+end
+test_embed_preserves_file_modes()
+
+-- Test that file modes are restored on extract
+local function test_extract_preserves_file_modes()
+  -- First embed files with specific modes
+  local appdir = path.join(tmpdir, "extract-modeapp")
+  unix.makedirs(appdir)
+
+  local script = path.join(appdir, "run.sh")
+  local secret = path.join(appdir, "secret.key")
+
+  cosmo.Barf(script, "#!/bin/sh\necho hello\n")
+  cosmo.Barf(secret, "private-key-data\n")
+
+  unix.chmod(script, tonumber("755", 8))
+  unix.chmod(secret, tonumber("600", 8))
+
+  local embedded = path.join(tmpdir, "cosmic-extract-modes")
+  local ok, out = spawn.spawn({cosmic, "--embed", appdir, "--output", embedded}):read()
+  assert(ok, "embed should succeed: " .. (out or ""))
+
+  -- Extract to a new directory
+  local extractdir = path.join(tmpdir, "extracted-modes")
+  ok, out = spawn.spawn({embedded, "--extract", extractdir}):read()
+  assert(ok, "extract should succeed: " .. (out or ""))
+
+  -- Check modes of extracted files
+  local script_stat = unix.stat(path.join(extractdir, "run.sh"))
+  local secret_stat = unix.stat(path.join(extractdir, "secret.key"))
+
+  assert(script_stat, "run.sh should exist after extract")
+  assert(secret_stat, "secret.key should exist after extract")
+
+  local script_mode = script_stat:mode() & tonumber("777", 8)
+  local secret_mode = secret_stat:mode() & tonumber("777", 8)
+
+  assert(script_mode == tonumber("755", 8),
+    "run.sh should have mode 755 after extract, got " .. string.format("%o", script_mode))
+  assert(secret_mode == tonumber("600", 8),
+    "secret.key should have mode 600 after extract, got " .. string.format("%o", secret_mode))
+end
+test_extract_preserves_file_modes()
 
 print("All embed tests passed!")


### PR DESCRIPTION
Preserves Unix file permissions when embedding files into cosmic executables and extracting them back out.

**Changes:**
- Capture file mode (permission bits) when collecting files to embed
- Pass mode to `appender:add()` when writing to zip
- Read mode from `reader:stat()` when extracting and pass to `cosmo.Barf()`

**Tests:**
- `test_embed_preserves_file_modes`: verifies 755/644/600 modes are stored in zip
- `test_extract_preserves_file_modes`: verifies modes are restored on extract

**Usage:**
```bash
# Scripts stay executable, secrets stay private
chmod 755 myapp/run.sh
chmod 600 myapp/secret.key
cosmic --embed myapp/ --output myapp
cosmic --extract restored/
ls -l restored/  # modes preserved
```