### PR TITLE
Fix is_main() stack frame to correctly detect main script

### DIFF
--- a/lib/cosmic/proc.tl
+++ b/lib/cosmic/proc.tl
@@ -269,9 +269,9 @@ end
 --- Returns false if the script is being loaded as a module via require().
 --- Use this to guard code that should only run when executed directly.
 --- @return boolean True if running as main script
-local function is_main(): boolean
-  return cosmo.is_main()
-end
+-- Assigned directly to avoid adding a stack frame, since cosmo.is_main()
+-- inspects the call stack to determine if the caller is the main script.
+local is_main: function(): boolean = cosmo.is_main
 
 local record ProcModule
   -- Identity

--- a/lib/cosmic/proc_test.tl
+++ b/lib/cosmic/proc_test.tl
@@ -125,6 +125,25 @@ end
 end
 test_is_main_true_when_run_directly()
 
+local function test_proc_is_main_true_when_run_directly()
+  local script_path = path.join(TEST_TMPDIR, "proc_is_main_direct.lua")
+  cosmo.Barf(script_path, [[
+local proc = require("cosmic.proc")
+if proc.is_main() then
+  os.exit(0)
+else
+  os.exit(1)
+end
+]])
+
+  local pid = child.posix_spawnp(lua_bin, {lua_bin, script_path})
+  local _, status = child.wait(pid)
+  assert(child.WIFEXITED(status), "expected normal exit")
+  local exit_code = child.WEXITSTATUS(status)
+  assert(exit_code == 0, "expected proc.is_main to return true when script is run directly, got exit code " .. tostring(exit_code))
+end
+test_proc_is_main_true_when_run_directly()
+
 local function test_is_main_false_when_required()
   local mod_path = path.join(TEST_TMPDIR, "is_main_module.lua")
   cosmo.Barf(mod_path, [[


### PR DESCRIPTION
## Summary
Fixed the `is_main()` function in `cosmic.proc` to correctly detect when a script is being run as the main script rather than loaded as a module. The issue was that wrapping `cosmo.is_main()` in a function added an extra stack frame, causing the stack inspection logic to fail.

## Changes
- **lib/cosmic/proc.tl**: Changed `is_main()` from a wrapper function to a direct assignment of `cosmo.is_main`. This eliminates the extra stack frame that was interfering with `cosmo.is_main()`'s call stack inspection logic.
- **lib/cosmic/proc_test.tl**: Added `test_proc_is_main_true_when_run_directly()` test to verify that `proc.is_main()` correctly returns `true` when the script is executed directly (not loaded via `require()`).

## Implementation Details
The `cosmo.is_main()` function works by inspecting the call stack to determine if the caller is the main script. By wrapping it in a function, an additional stack frame was introduced, causing the inspection to look at the wrong level. Assigning the function directly avoids this issue while maintaining the same public API.

https://claude.ai/code/session_01WaR9QaJ5SSsvniiKoBnvHG