### PR TITLE
testrun: add --test and --report CLI options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ all_tested := $(patsubst %,$(o)/%.test.got,$(all_tests))
 ## Run all tests (incremental)
 test: $(o)/test-summary.txt
 
+# TODO: use `cosmic --report $^` after next release
 $(o)/test-summary.txt: $(all_tested) | $(build_reporter)
 	@$(reporter) --dir $(o) $^ | tee $@
 
@@ -123,6 +124,7 @@ export LUA_PATH := $(subst $(space),;,$(foreach d,$(lua_path_dirs),$(CURDIR)/$(d
 export NO_COLOR := 1
 
 # Test rule: execute test directly via shebang, capture exit code, stdout, stderr
+# TODO: use `cosmic --test $(basename $@) $<` after next release
 $(o)/%.tl.test.got: .PLEDGE = stdio rpath wpath cpath proc exec
 $(o)/%.tl.test.got: .UNVEIL = rx:$(o)/bootstrap r:lib r:3p rwc:$(o) rwc:$(TMP) rx:/usr rx:/proc r:/etc r:/dev/null
 $(o)/%.tl.test.got: $(o)/%.lua $(test_files) $(o)/bin/cosmic | $(bootstrap_files)

--- a/lib/cosmic/example.tl
+++ b/lib/cosmic/example.tl
@@ -145,7 +145,7 @@ local function parse_examples(source: string): {Example}
         output_pos = line_end + 1
         -- Collect subsequent comment lines
         while true do
-          local line_start, _, prefix, content = body:find("^(%s*%-%-%s?)([^\n]*)", output_pos)
+          local line_start, _, prefix, content = body:find("^([ \t]*%-%-[ \t]?)([^\n]*)", output_pos)
           if line_start == output_pos and prefix then
             table.insert(lines, content)
             output_pos = output_pos + #prefix + #content

--- a/lib/cosmic/example_test.tl
+++ b/lib/cosmic/example_test.tl
@@ -181,6 +181,26 @@ end
 end
 test_multiline_output()
 
+-- Test blank lines in output
+local function test_blank_line_in_output()
+  local input = write_temp("blank.tl", [[
+local function Example_blank()
+  print("before")
+  print("")
+  print("after")
+  -- Output:
+  -- before
+  --
+  -- after
+end
+]])
+  local result = example.run(input)
+  assert(result.exit_code == 0, "should pass with blank line: " .. (result.results[1].error or ""))
+  assert(result.results[1].passed, "blank line example should pass")
+  assert(result.results[1].expected:find("\n\n"), "expected should contain blank line")
+end
+test_blank_line_in_output()
+
 -- Test trailing newline normalization
 local function test_trailing_newline()
   local input = write_temp("newline.tl", [[

--- a/lib/cosmic/main.tl
+++ b/lib/cosmic/main.tl
@@ -30,6 +30,9 @@ local record Opts
   benchmark: string        -- Input file for --benchmark (run benchmarks)
   docs: string             -- Module/symbol/query for --docs
   welcome: boolean         -- Show welcome message
+  test_argv: {string}      -- Command for --test
+  test_output: string      -- Output base for --test
+  report_paths: {string}   -- Paths for --report
   error: string            -- Parse error message
 end
 
@@ -54,6 +57,9 @@ local function parse_args(): Opts
     benchmark = nil,
     docs = nil,
     welcome = false,
+    test_argv = nil,
+    test_output = nil,
+    report_paths = nil,
     error = nil,
   }
 
@@ -70,6 +76,8 @@ local function parse_args(): Opts
     { name = "benchmark", has_arg = "required" },
     { name = "docs", has_arg = "required" },
     { name = "welcome", has_arg = "none" },
+    { name = "test", has_arg = "required" },
+    { name = "report", has_arg = "none" },
   }
 
   -- Parse shortopts to build set of options that require arguments
@@ -96,7 +104,13 @@ local function parse_args(): Opts
   end
 
   -- Options that consume all remaining arguments (no script after them)
-  local long_greedy: {string:boolean} = {}
+  local long_greedy: {string:boolean} = {
+    ["report"] = true,
+    ["test"] = true,
+  }
+
+  -- Options that take required arg + one additional positional arg
+  local long_extra_arg: {string:boolean} = {}
 
   -- Find first non-option argument (script name) to know where to stop parsing
   local script_idx: integer = nil
@@ -114,6 +128,9 @@ local function parse_args(): Opts
         -- Greedy option: consumes all remaining args, no script
         script_idx = nil
         break
+      elseif long_extra_arg[opt_name] then
+        -- Takes required arg + one extra positional arg
+        i = i + 3
       elseif not opt_name:find("=") and long_needs_arg[opt_name] then
         -- Takes next arg
         i = i + 2
@@ -213,6 +230,13 @@ local function parse_args(): Opts
       return opts
     elseif opt == "welcome" then
       opts.welcome = true
+    elseif opt == "test" then
+      opts.test_output = optarg
+      opts.test_argv = parser:remaining()
+      return opts
+    elseif opt == "report" then
+      opts.report_paths = parser:remaining()
+      return opts
     end
   end
 
@@ -347,6 +371,8 @@ local function generate_help(): string
   table.insert(lines, "  --extract <dir>               extract zip contents to directory")
   table.insert(lines, "  --benchmark <file.tl[:pat]>   run Benchmark_* functions, report timing")
   table.insert(lines, "  --docs <query>                show documentation for module or symbol")
+  table.insert(lines, "  --test <output> <cmd>...      run command, write .got/.out/.err")
+  table.insert(lines, "  --report <paths>...           report on test results")
   table.insert(lines, "  --welcome                     show welcome message")
   table.insert(lines, "  --help                        show this help message")
   table.insert(lines, "")
@@ -566,6 +592,18 @@ local function main(): integer, string
       io.stderr:write(result.output .. "\n")
       return 1
     end
+  end
+
+  -- Handle --test
+  if opts.test_argv then
+    local testrun = require("cosmic.testrun")
+    return testrun.run(opts.test_argv, opts.test_output)
+  end
+
+  -- Handle --report
+  if opts.report_paths then
+    local testrun = require("cosmic.testrun")
+    return testrun.report(opts.report_paths)
   end
 
   -- Handle -W warnings: convert warnings to errors

--- a/lib/cosmic/testrun.tl
+++ b/lib/cosmic/testrun.tl
@@ -1,0 +1,276 @@
+--- Test runner for cosmic executables.
+--- Provides functions to run test executables and report on results.
+local child = require("cosmic.child")
+local cio = require("cosmic.io")
+local env = require("cosmic.env")
+local fs = require("cosmic.fs")
+
+--- Run a test executable and capture output.
+--- Creates a temporary directory (TEST_TMPDIR) for the test and cleans up after.
+--- @param argv {string} Command and arguments
+--- @param output_base string Base path for output files
+--- @return integer Exit code (for CLI return)
+local function run(argv: {string}, output_base: string): integer
+  if not output_base then
+    io.stderr:write("testrun: missing output path\n")
+    return 1
+  end
+
+  -- Create parent directories if needed
+  local dir = fs.dirname(output_base)
+  if dir ~= "." and dir ~= "/" then
+    local ok, err = fs.makedirs(dir)
+    if not ok then
+      io.stderr:write("testrun: " .. err .. "\n")
+      return 1
+    end
+  end
+
+  -- Create temp directory for the test
+  local tmpbase = env.get("TMP") or "/tmp"
+  local tmpdir, tmpdir_err = fs.mkdtemp(fs.join(tmpbase, "testrun_XXXXXX"))
+  if not tmpdir then
+    io.stderr:write("testrun: " .. (tmpdir_err or "failed to create temp dir") .. "\n")
+    return 1
+  end
+
+  -- Build environment with TEST_TMPDIR
+  local child_env: {string} = {}
+  for key, val in pairs(env.all()) do
+    child_env[#child_env + 1] = key .. "=" .. val
+  end
+  child_env[#child_env + 1] = "TEST_TMPDIR=" .. tmpdir
+
+  -- Spawn the process
+  local handle, err = child.spawn(argv, {env = child_env})
+  if not handle then
+    fs.rmrf(tmpdir)
+    io.stderr:write("testrun: " .. (err or "spawn failed") .. "\n")
+    return 1
+  end
+
+  -- Close stdin, read stdout and stderr
+  if handle.stdin then
+    handle.stdin:close()
+  end
+
+  local stdout_content = ""
+  local stderr_content = ""
+
+  if handle.stdout then
+    stdout_content = handle.stdout:read() or ""
+    handle.stdout:close()
+  end
+
+  if handle.stderr then
+    stderr_content = handle.stderr:read() or ""
+    handle.stderr:close()
+  end
+
+  -- Wait for exit
+  local _, status = child.wait(handle.pid)
+  local exit_code: integer = 1
+  if child.WIFEXITED(status) then
+    exit_code = child.WEXITSTATUS(status) as integer
+  elseif child.WIFSIGNALED(status) then
+    exit_code = (128 + child.WTERMSIG(status)) as integer
+  end
+
+  -- Clean up temp directory
+  fs.rmrf(tmpdir)
+
+  -- Write output files
+  local ok: boolean
+  ok, err = cio.barf(output_base .. ".got", tostring(exit_code) .. "\n")
+  if not ok then
+    io.stderr:write("testrun: " .. (err or "failed to write .got") .. "\n")
+    return 1
+  end
+
+  ok, err = cio.barf(output_base .. ".out", stdout_content)
+  if not ok then
+    io.stderr:write("testrun: " .. (err or "failed to write .out") .. "\n")
+    return 1
+  end
+
+  ok, err = cio.barf(output_base .. ".err", stderr_content)
+  if not ok then
+    io.stderr:write("testrun: " .. (err or "failed to write .err") .. "\n")
+    return 1
+  end
+
+  return exit_code
+end
+
+--- Test result for a single test.
+local record TestResult
+  name: string
+  exit_code: integer
+  stdout: string
+  stderr: string
+  status: string  -- "pass", "fail", "skip"
+end
+
+--- Normalize a path to a .got file base path.
+--- @param path string A .got file path or base path
+--- @return string The base path (without .got extension)
+local function normalize_path(path: string): string
+  if path:match("%.got$") then
+    return path:sub(1, -5)  -- Remove .got
+  end
+  return path
+end
+
+--- Report on test results from .got files.
+--- @param paths {string} Paths to .got files or base paths
+--- @return integer Exit code (0 if all pass, 1 if any fail)
+local function report(paths: {string}): integer
+  local results: {TestResult} = {}
+  local passed = 0
+  local failed = 0
+  local skipped = 0
+
+  for _, path in ipairs(paths) do
+    local base = normalize_path(path)
+    local name = fs.basename(base)
+
+    -- Read exit code from .got file
+    local got_content, err = cio.slurp(base .. ".got")
+    if not got_content then
+      io.stderr:write("testrun: cannot read " .. base .. ".got: " .. (err or "unknown error") .. "\n")
+      failed = failed + 1
+      table.insert(results, {
+        name = name,
+        exit_code = -1 as integer,
+        stdout = "",
+        stderr = "cannot read .got file",
+        status = "fail",
+      } as TestResult)
+    else
+      local exit_code = (tonumber(got_content:match("^(%d+)")) or -1) as integer
+
+      -- Read stdout and stderr
+      local stdout_content = cio.slurp(base .. ".out") or ""
+      local stderr_content = cio.slurp(base .. ".err") or ""
+
+      local status: string
+      if exit_code == 0 then
+        status = "pass"
+        passed = passed + 1
+      elseif exit_code == 2 then
+        status = "skip"
+        skipped = skipped + 1
+      else
+        status = "fail"
+        failed = failed + 1
+      end
+
+      table.insert(results, {
+        name = name,
+        exit_code = exit_code,
+        stdout = stdout_content,
+        stderr = stderr_content,
+        status = status,
+      } as TestResult)
+    end
+  end
+
+  -- Print results
+  for _, result in ipairs(results) do
+    local icon: string
+    if result.status == "pass" then
+      icon = "✓"
+    elseif result.status == "skip" then
+      icon = "→"
+    else
+      icon = "✗"
+    end
+    io.write(icon .. " " .. result.name .. "\n")
+  end
+
+  -- Print summary
+  local total = passed + failed + skipped
+  io.write("\n" .. total .. " checks: " .. passed .. " passed")
+  if failed > 0 then
+    io.write(", " .. failed .. " failed")
+  end
+  if skipped > 0 then
+    io.write(", " .. skipped .. " skipped")
+  end
+  io.write("\n")
+
+  -- Print failure details
+  if failed > 0 then
+    io.write("\nFailures:\n")
+    for _, result in ipairs(results) do
+      if result.status == "fail" then
+        io.write("\n" .. result.name .. " (exit " .. result.exit_code .. "):\n")
+        if result.stderr ~= "" then
+          io.write("  stderr:\n")
+          for line in result.stderr:gmatch("[^\n]+") do
+            io.write("    " .. line .. "\n")
+          end
+        end
+        if result.stdout ~= "" then
+          io.write("  stdout:\n")
+          for line in result.stdout:gmatch("[^\n]+") do
+            io.write("    " .. line .. "\n")
+          end
+        end
+      end
+    end
+  end
+
+  return failed > 0 and 1 or 0
+end
+
+--- Example showing a minimal Makefile-based test harness.
+--- Demonstrates pattern rules for running tests and collecting results.
+---
+--- ```makefile
+--- # Pattern rule: for each test_*.lua, run it and capture output
+--- o/test/%.got: test_%.lua $(COSMIC)
+--- 	$(COSMIC) --test $@ $< $<
+---
+--- # Collect all test targets
+--- tests := $(patsubst test_%.lua,o/test/%.got,$(wildcard test_*.lua))
+---
+--- # Run all tests and report
+--- test: $(tests)
+--- 	$(COSMIC) --report $(tests)
+--- ```
+local function Example_makefile()
+  local testrun = require("cosmic.testrun")
+  local fs = require("cosmic.fs")
+  local tmpdir = fs.mkdtemp("/tmp/testrun_example_XXXXXX")
+  if not tmpdir then return end
+
+  -- Run /bin/true and capture output
+  local exit_code = testrun.run({"/bin/true"}, fs.join(tmpdir, "test1"))
+  print("exit_code:", exit_code)
+
+  -- Report on the result
+  testrun.report({fs.join(tmpdir, "test1")})
+
+  fs.rmrf(tmpdir)
+  -- Output:
+  -- exit_code:	0
+  -- ✓ test1
+  --
+  -- 1 checks: 1 passed
+end
+
+-- Suppress unused warning
+local _ = Example_makefile
+
+local record TestrunModule
+  run: function(argv: {string}, output_base: string): integer
+  report: function(paths: {string}): integer
+end
+
+local M: TestrunModule = {
+  run = run,
+  report = report,
+}
+
+return M

--- a/lib/cosmic/testrun_test.tl
+++ b/lib/cosmic/testrun_test.tl
@@ -1,0 +1,207 @@
+#!/usr/bin/env cosmic
+local path = require("cosmo.path")
+local testrun = require("cosmic.testrun")
+local cio = require("cosmic.io")
+local fs = require("cosmic.fs")
+
+local TEST_BIN = os.getenv("TEST_BIN")
+local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
+local cosmic_bin = path.join(TEST_BIN, "cosmic")
+
+-- Test running cosmic with a script
+local function test_run_cosmic_script()
+  local script = path.join(TEST_TMPDIR, "test_script.lua")
+  local output_base = path.join(TEST_TMPDIR, "result_script")
+
+  cio.barf(script, [[print("hello from script")]])
+
+  local exit_code = testrun.run({cosmic_bin, script}, output_base)
+  assert(exit_code == 0, "expected exit code 0, got " .. exit_code)
+
+  local out = cio.slurp(output_base .. ".out")
+  assert(out == "hello from script\n", "expected script output, got '" .. (out or "nil") .. "'")
+end
+test_run_cosmic_script()
+
+-- Test run with nested output directory
+local function test_run_creates_parent_dirs()
+  local output_base = path.join(TEST_TMPDIR, "nested", "dir", "result")
+
+  local exit_code = testrun.run({"/bin/true"}, output_base)
+  assert(exit_code == 0, "expected exit code 0, got " .. exit_code)
+
+  -- Check files exist
+  local got = cio.slurp(output_base .. ".got")
+  assert(got == "0\n", "expected .got to contain '0\\n', got '" .. (got or "nil") .. "'")
+
+  local out = cio.slurp(output_base .. ".out")
+  assert(out ~= nil, "expected .out file to exist")
+
+  local err = cio.slurp(output_base .. ".err")
+  assert(err ~= nil, "expected .err file to exist")
+
+  -- Cleanup
+  fs.rmrf(path.join(TEST_TMPDIR, "nested"))
+end
+test_run_creates_parent_dirs()
+
+-- Test run with executable that writes to stdout/stderr
+local function test_run_captures_output()
+  local script = path.join(TEST_TMPDIR, "test_output.sh")
+  local output_base = path.join(TEST_TMPDIR, "result_output")
+
+  cio.barf(script, [[#!/bin/sh
+echo "stdout line"
+echo "stderr line" >&2
+exit 0
+]], tonumber("755", 8))
+
+  local exit_code = testrun.run({script}, output_base)
+  assert(exit_code == 0, "expected exit code 0, got " .. exit_code)
+
+  local got = cio.slurp(output_base .. ".got")
+  assert(got == "0\n", "expected .got to contain '0\\n', got '" .. (got or "nil") .. "'")
+
+  local out = cio.slurp(output_base .. ".out")
+  assert(out == "stdout line\n", "expected .out to contain 'stdout line\\n', got '" .. (out or "nil") .. "'")
+
+  local err = cio.slurp(output_base .. ".err")
+  assert(err == "stderr line\n", "expected .err to contain 'stderr line\\n', got '" .. (err or "nil") .. "'")
+end
+test_run_captures_output()
+
+-- Test that TEST_TMPDIR is set and is a directory
+local function test_run_sets_test_tmpdir()
+  local script = path.join(TEST_TMPDIR, "test_tmpdir.sh")
+  local output_base = path.join(TEST_TMPDIR, "result_tmpdir")
+
+  -- Script checks TEST_TMPDIR exists and is a directory
+  cio.barf(script, [[#!/bin/sh
+if [ -z "$TEST_TMPDIR" ]; then
+  echo "TEST_TMPDIR not set" >&2
+  exit 1
+fi
+if [ ! -d "$TEST_TMPDIR" ]; then
+  echo "TEST_TMPDIR is not a directory: $TEST_TMPDIR" >&2
+  exit 1
+fi
+# Create a file to prove we can write to it
+echo "test" > "$TEST_TMPDIR/test_file"
+if [ ! -f "$TEST_TMPDIR/test_file" ]; then
+  echo "Failed to create file in TEST_TMPDIR" >&2
+  exit 1
+fi
+echo "TEST_TMPDIR works"
+exit 0
+]], tonumber("755", 8))
+
+  local exit_code = testrun.run({script}, output_base)
+  assert(exit_code == 0, "expected exit code 0, got " .. exit_code)
+
+  local out = cio.slurp(output_base .. ".out")
+  assert(out == "TEST_TMPDIR works\n", "expected success message, got '" .. (out or "nil") .. "'")
+end
+test_run_sets_test_tmpdir()
+
+-- Test run with nonexistent executable
+local function test_run_nonexistent()
+  local output_base = path.join(TEST_TMPDIR, "result_nonexistent")
+
+  local exit_code = testrun.run({"/nonexistent/path/to/exe"}, output_base)
+  -- Child process exits 127 when execve fails (command not found)
+  assert(exit_code == 127, "expected exit code 127 for nonexistent executable, got " .. exit_code)
+
+  -- Check that the .got file was written with the exit code
+  local got = cio.slurp(output_base .. ".got")
+  assert(got == "127\n", "expected .got to contain '127\\n', got '" .. (got or "nil") .. "'")
+end
+test_run_nonexistent()
+
+-- Test report with passing test
+local function test_report_pass()
+  local base = path.join(TEST_TMPDIR, "report_pass")
+
+  cio.barf(base .. ".got", "0\n")
+  cio.barf(base .. ".out", "")
+  cio.barf(base .. ".err", "")
+
+  -- Capture stdout by redirecting (would need to capture, skip for now)
+  local exit_code = testrun.report({base})
+  assert(exit_code == 0, "expected exit code 0 for passing test, got " .. exit_code)
+end
+test_report_pass()
+
+-- Test report with failing test
+local function test_report_fail()
+  local base = path.join(TEST_TMPDIR, "report_fail")
+
+  cio.barf(base .. ".got", "1\n")
+  cio.barf(base .. ".out", "stdout output\n")
+  cio.barf(base .. ".err", "error output\n")
+
+  local exit_code = testrun.report({base})
+  assert(exit_code == 1, "expected exit code 1 for failing test, got " .. exit_code)
+end
+test_report_fail()
+
+-- Test report with skipped test
+local function test_report_skip()
+  local base = path.join(TEST_TMPDIR, "report_skip")
+
+  cio.barf(base .. ".got", "2\n")
+  cio.barf(base .. ".out", "")
+  cio.barf(base .. ".err", "")
+
+  local exit_code = testrun.report({base})
+  assert(exit_code == 0, "expected exit code 0 for skipped test, got " .. exit_code)
+end
+test_report_skip()
+
+-- Test report with multiple tests
+local function test_report_multiple()
+  local base1 = path.join(TEST_TMPDIR, "report_multi_1")
+  local base2 = path.join(TEST_TMPDIR, "report_multi_2")
+  local base3 = path.join(TEST_TMPDIR, "report_multi_3")
+
+  cio.barf(base1 .. ".got", "0\n")
+  cio.barf(base1 .. ".out", "")
+  cio.barf(base1 .. ".err", "")
+
+  cio.barf(base2 .. ".got", "1\n")
+  cio.barf(base2 .. ".out", "failed\n")
+  cio.barf(base2 .. ".err", "error\n")
+
+  cio.barf(base3 .. ".got", "2\n")
+  cio.barf(base3 .. ".out", "")
+  cio.barf(base3 .. ".err", "")
+
+  local exit_code = testrun.report({base1, base2, base3})
+  assert(exit_code == 1, "expected exit code 1 when any test fails, got " .. exit_code)
+end
+test_report_multiple()
+
+-- Test report with .got extension
+local function test_report_with_got_extension()
+  local base = path.join(TEST_TMPDIR, "report_ext")
+
+  cio.barf(base .. ".got", "0\n")
+  cio.barf(base .. ".out", "")
+  cio.barf(base .. ".err", "")
+
+  -- Pass path with .got extension
+  local exit_code = testrun.report({base .. ".got"})
+  assert(exit_code == 0, "expected exit code 0 when passing .got path, got " .. exit_code)
+end
+test_report_with_got_extension()
+
+-- Test report with missing .got file
+local function test_report_missing_got()
+  local base = path.join(TEST_TMPDIR, "report_missing")
+
+  -- Don't create any files
+  local exit_code = testrun.report({base})
+  assert(exit_code == 1, "expected exit code 1 for missing .got file, got " .. exit_code)
+end
+test_report_missing_got()
+
+print("testrun tests passed")


### PR DESCRIPTION
## Summary

- Add `--test <output> <cmd>...` to run a command and capture results to .got/.out/.err files
- Add `--report <paths>...` to aggregate and display test results with pass/fail/skip icons
- Creates isolated TEST_TMPDIR for each test run (cleaned up after)
- Exit codes: 0=pass, 2=skip, other=fail
- Fix example.tl pattern to handle blank lines in Output comments (`%s` → `[ \t]`)
- Add TODOs in Makefile to use this after next release

## Test plan

- [x] Unit tests pass (`make test only=testrun,example`)
- [x] Full test suite passes
- [x] Manual verification:
  ```bash
  cosmic --test /tmp/result /bin/echo hello
  cat /tmp/result.got  # 0
  cat /tmp/result.out  # hello
  cosmic --report /tmp/result.got
  ```