### PR TITLE
child: handle wait() returning errno instead of status

### DIFF
--- a/lib/cosmic/child.tl
+++ b/lib/cosmic/child.tl
@@ -300,8 +300,14 @@ local function spawn(argv: {string}, opts?: Opts): Handle, string
     if self.stdout then self.stdout:close() end
     if self.stderr then self.stderr:close() end
     local _, status = unix.wait(self.pid)
+    if type(status) ~= "number" then
+      return nil, "wait failed: " .. tostring(status)
+    end
     if unix.WIFEXITED(status) then
       return unix.WEXITSTATUS(status)
+    end
+    if unix.WIFSIGNALED(status) then
+      return nil, "killed by signal " .. tostring(unix.WTERMSIG(status))
     end
     return nil, "process terminated abnormally"
   end


### PR DESCRIPTION
## Summary

When a child process is interrupted (e.g., via Ctrl+C), `unix.wait()` can return a `unix.Errno` instead of a number for the status. This caused a crash when `WIFEXITED` was called with the errno object:

```
/zip/.lua/cosmic/child.lua:303: bad argument #1 to 'WIFEXITED' (number expected, got unix.Errno)
```

## Changes

- Check if status is a number before calling `WIFEXITED()`
- Handle `WIFSIGNALED` to provide better error messages for signal-killed processes

## Test plan

- Spawn a command that prompts for input (e.g., `gh pr create` without auth)
- Press Ctrl+C to interrupt
- Previously: crash with "bad argument #1 to 'WIFEXITED'"
- Now: returns error gracefully