### PR TITLE
Add unix domain socket proxy support to cosmic.fetch

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format="zip",
-  platforms={["*"]={sha="9afe513ee832910afc54a24b260008ab0730992ae4fd7a3f7172d789c4818f1d"}},
+  platforms={["*"]={sha="7a95ae4b8784fb504450b8c65b2903daa64efa750683e9479ea617317280a7ef"}},
   strip_components=0,
   url="https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version="2026.02.08-c6243a911"
+  version="2026.02.10-ae1078722"
 }

--- a/lib/cosmic/fetch.tl
+++ b/lib/cosmic/fetch.tl
@@ -15,6 +15,7 @@ end
 
 local record Opts
   headers: {string:string}
+  proxy: string
   maxresponse: number
   max_attempts: number
   max_delay: number
@@ -181,6 +182,27 @@ local function stream(url: string, opts?: Opts): StreamResult
   }
 end
 
+--- Build a unix domain socket proxy URL from a socket path.
+--- @param path string Absolute path to the unix domain socket
+--- @return string proxy URL in unix:// format
+--- @return string? Error message if path is invalid
+local function unix_proxy(path: string): string, string
+  if not path or path == "" then
+    return nil, "empty socket path"
+  end
+  if path:sub(1, 1) ~= "/" then
+    return nil, "socket path must be absolute"
+  end
+  if path:match("/%.%./") or path:match("/%.%.$") or path:match("/%./") or path:match("/%.$") then
+    return nil, "socket path must not contain . or .. segments"
+  end
+  -- unix(7) sockaddr_un sun_path is typically 108 bytes
+  if #path >= 108 then
+    return nil, "socket path too long"
+  end
+  return "unix://" .. path
+end
+
 -- Example_get demonstrates a simple HTTP GET request
 local function Example_get()
   local fetch = require("cosmic.fetch")
@@ -206,6 +228,7 @@ end
 local record fetch
   Fetch: function(url: string, opts?: Opts): Result
   stream: function(url: string, opts?: Opts): StreamResult
+  unix_proxy: function(path: string): string, string
   Opts: Opts
   Result: Result
   Reader: Reader
@@ -215,6 +238,7 @@ end
 local M: fetch = {
   Fetch = Fetch,
   stream = stream,
+  unix_proxy = unix_proxy,
 }
 
 return M

--- a/lib/cosmic/fetch_test.tl
+++ b/lib/cosmic/fetch_test.tl
@@ -203,3 +203,82 @@ local function test_stream_http_error_status_returns_reader()
   result.reader:close()
 end
 test_stream_http_error_status_returns_reader()
+
+-- unix_proxy helper tests
+
+local function test_unix_proxy_valid_path()
+  local url, err = fetch.unix_proxy("/tmp/proxy.sock")
+  assert(url == "unix:///tmp/proxy.sock", "expected unix:///tmp/proxy.sock, got: " .. tostring(url))
+  assert(err == nil, "expected no error, got: " .. tostring(err))
+end
+test_unix_proxy_valid_path()
+
+local function test_unix_proxy_empty_path()
+  local url, err = fetch.unix_proxy("")
+  assert(url == nil, "expected nil for empty path")
+  assert(err == "empty socket path", "expected 'empty socket path', got: " .. tostring(err))
+end
+test_unix_proxy_empty_path()
+
+local function test_unix_proxy_relative_path()
+  local url, err = fetch.unix_proxy("relative/path.sock")
+  assert(url == nil, "expected nil for relative path")
+  assert(err == "socket path must be absolute", "expected absolute path error, got: " .. tostring(err))
+end
+test_unix_proxy_relative_path()
+
+local function test_unix_proxy_dotdot_segment()
+  local url, err = fetch.unix_proxy("/tmp/../etc/proxy.sock")
+  assert(url == nil, "expected nil for path with .. segment")
+  assert(err == "socket path must not contain . or .. segments", "expected segment error, got: " .. tostring(err))
+end
+test_unix_proxy_dotdot_segment()
+
+local function test_unix_proxy_dot_segment()
+  local url, err = fetch.unix_proxy("/tmp/./proxy.sock")
+  assert(url == nil, "expected nil for path with . segment")
+  assert(err == "socket path must not contain . or .. segments", "expected segment error, got: " .. tostring(err))
+end
+test_unix_proxy_dot_segment()
+
+local function test_unix_proxy_too_long_path()
+  local long_path = "/" .. string.rep("a", 108)
+  local url, err = fetch.unix_proxy(long_path)
+  assert(url == nil, "expected nil for too-long path")
+  assert(err == "socket path too long", "expected too-long error, got: " .. tostring(err))
+end
+test_unix_proxy_too_long_path()
+
+local function test_unix_proxy_trailing_dotdot()
+  local url, err = fetch.unix_proxy("/tmp/..")
+  assert(url == nil, "expected nil for path ending with ..")
+  assert(err == "socket path must not contain . or .. segments", "expected segment error, got: " .. tostring(err))
+end
+test_unix_proxy_trailing_dotdot()
+
+local function test_unix_proxy_trailing_dot()
+  local url, err = fetch.unix_proxy("/tmp/.")
+  assert(url == nil, "expected nil for path ending with .")
+  assert(err == "socket path must not contain . or .. segments", "expected segment error, got: " .. tostring(err))
+end
+test_unix_proxy_trailing_dot()
+
+-- proxy option passthrough test
+local function test_fetch_with_proxy_nonexistent_socket()
+  -- Verify that the proxy option is passed through to cosmo.Fetch
+  -- by using a socket path that doesn't exist (should produce a connection error)
+  local result = fetch.Fetch("http://example.com", {proxy = "unix:///tmp/nonexistent-cosmic-test.sock"})
+  assert(result ~= nil, "result should not be nil")
+  assert(result.ok == false, "result.ok should be false for nonexistent socket")
+  assert(result.error ~= nil, "result.error should describe the failure")
+end
+test_fetch_with_proxy_nonexistent_socket()
+
+local function test_stream_with_proxy_nonexistent_socket()
+  if not has_fetch_stream then return end
+  local result = fetch.stream("http://example.com", {proxy = "unix:///tmp/nonexistent-cosmic-test.sock"})
+  assert(result ~= nil, "result should not be nil")
+  assert(result.ok == false, "result.ok should be false for nonexistent socket")
+  assert(result.error ~= nil, "result.error should describe the failure")
+end
+test_stream_with_proxy_nonexistent_socket()


### PR DESCRIPTION
## Summary
This PR adds support for Unix domain socket proxies to the cosmic.fetch module, enabling HTTP requests to be routed through Unix sockets. It includes a new `unix_proxy()` helper function for safely constructing proxy URLs and updates the Opts record to support the proxy parameter.

## Key Changes
- **Added `unix_proxy()` helper function** that validates socket paths and constructs `unix://` format proxy URLs with comprehensive validation:
  - Rejects empty paths
  - Requires absolute paths (starting with `/`)
  - Prevents path traversal attacks (blocks `.` and `..` segments)
  - Enforces Unix socket path length limits (< 108 bytes per sockaddr_un)

- **Extended Opts record** with a new `proxy: string` field to support proxy configuration in both `Fetch()` and `stream()` functions

- **Updated module exports** to include the new `unix_proxy` function in the public API

- **Added comprehensive test coverage** including:
  - Valid path handling
  - Empty path rejection
  - Relative path rejection
  - Path traversal attack prevention (both `..` and `.` segments)
  - Path length validation
  - Integration tests verifying proxy option passthrough to cosmo.Fetch

- **Updated cosmopolitan dependency** from version 2026.02.08-c6243a911 to 2026.02.10-ae1078722

## Implementation Details
The `unix_proxy()` function performs strict validation to prevent security issues and compatibility problems with Unix socket implementations. The validation checks are ordered from most common failures to least common for efficiency. The function returns both a URL string and an optional error message following Lua conventions.

https://claude.ai/code/session_01738UATmrqrpr6KyrDhazMo