### PR TITLE
ip: add lookup function with idiomatic error handling

### DIFF
--- a/lib/cosmic/ip.tl
+++ b/lib/cosmic/ip.tl
@@ -1,6 +1,72 @@
 --- IP address parsing, formatting, and classification utilities.
 local cosmo = require("cosmo")
 
+--- A typed IP address.
+--- Wraps the raw integer representation with convenience methods.
+local record Addr
+  _n: integer
+  --- Get the raw integer representation.
+  --- Use this when passing to net.Socket:connect() or other APIs that take integer IPs.
+  --- @return integer The IP address as an integer
+  int: function(Addr): integer
+  --- Format as a dotted-quad string (e.g., "192.168.1.1").
+  --- @return string The formatted IP address
+  format: function(Addr): string
+  --- Categorize the address (e.g., "LOOPBACK", "PRIVATE", "ARIN").
+  --- @return string The category name
+  categorize: function(Addr): string
+  --- Check if this is a loopback address (127.x.x.x).
+  --- @return boolean True if loopback
+  is_loopback: function(Addr): boolean
+  --- Check if this is a private address (10.x, 172.16-31.x, 192.168.x).
+  --- @return boolean True if private
+  is_private: function(Addr): boolean
+  --- Check if this is a public/routable address.
+  --- @return boolean True if public
+  is_public: function(Addr): boolean
+end
+
+local function make_addr(n: integer): Addr
+  local a: Addr = {_n = n}
+
+  function a:int(): integer
+    return self._n
+  end
+
+  function a:format(): string
+    return cosmo.FormatIp(self._n)
+  end
+
+  function a:categorize(): string
+    return cosmo.CategorizeIp(self._n)
+  end
+
+  function a:is_loopback(): boolean
+    return cosmo.IsLoopbackIp(self._n)
+  end
+
+  function a:is_private(): boolean
+    return cosmo.IsPrivateIp(self._n)
+  end
+
+  function a:is_public(): boolean
+    return cosmo.IsPublicIp(self._n)
+  end
+
+  return setmetatable(a, {
+    __tostring = function(self: Addr): string
+      return cosmo.FormatIp(self._n)
+    end,
+  }) as Addr
+end
+
+--- Wrap a raw integer as a typed Addr.
+--- @param n integer The IP address as an integer
+--- @return Addr The typed IP address
+local function addr(n: integer): Addr
+  return make_addr(n)
+end
+
 --- Parse an IP address string to its integer representation.
 --- Returns -1 for invalid or unsupported addresses (including IPv6).
 --- @param str string The IP address string (e.g., "192.168.1.1")
@@ -53,20 +119,22 @@ local function resolve(hostname: string): integer
   return cosmo.ResolveIp(hostname)
 end
 
---- Look up a hostname and return its IP address.
+--- Look up a hostname and return a typed Addr.
 --- Returns nil and an error message on failure.
 --- @param hostname string The hostname to look up
---- @return integer? The IP address as an integer, or nil on error
+--- @return Addr? The resolved IP address, or nil on error
 --- @return string? Error message on failure
-local function lookup(hostname: string): integer, string
+local function lookup(hostname: string): Addr, string
   local ip = cosmo.ResolveIp(hostname)
   if not ip or ip == -1 then
     return nil, "dns: lookup failed for " .. hostname
   end
-  return ip
+  return make_addr(ip)
 end
 
 local record IpModule
+  Addr: Addr
+  addr: function(n: integer): Addr
   parse: function(str: string): integer
   format: function(ip: integer): string
   categorize: function(ip: integer): string
@@ -74,10 +142,11 @@ local record IpModule
   is_private: function(ip: integer): boolean
   is_public: function(ip: integer): boolean
   resolve: function(hostname: string): integer
-  lookup: function(hostname: string): integer, string
+  lookup: function(hostname: string): Addr, string
 end
 
 local M: IpModule = {
+  addr = addr,
   parse = parse,
   format = format,
   categorize = categorize,

--- a/lib/cosmic/ip_test.tl
+++ b/lib/cosmic/ip_test.tl
@@ -159,16 +159,77 @@ test_resolve_localhost()
 -- lookup tests
 
 local function test_lookup_localhost()
-  local result, err = ip.lookup("localhost")
-  assert(result == 2130706433, "expected 127.0.0.1 for localhost, got " .. tostring(result))
+  local a, err = ip.lookup("localhost")
+  assert(a, "expected Addr for localhost, got nil: " .. tostring(err))
   assert(err == nil, "expected nil error, got " .. tostring(err))
+  assert(a:int() == 2130706433, "expected 127.0.0.1, got " .. tostring(a:int()))
 end
 test_lookup_localhost()
 
 local function test_lookup_invalid_returns_nil()
-  local result, err = ip.lookup("this.host.does.not.exist.invalid")
-  assert(result == nil, "expected nil for invalid hostname, got " .. tostring(result))
+  local a, err = ip.lookup("this.host.does.not.exist.invalid")
+  assert(a == nil, "expected nil for invalid hostname")
   assert(err ~= nil, "expected error message for invalid hostname")
   assert(err:find("lookup failed"), "expected 'lookup failed' in error: " .. tostring(err))
 end
 test_lookup_invalid_returns_nil()
+
+-- addr tests
+
+local function test_addr_int()
+  local a = ip.addr(2130706433)
+  assert(a:int() == 2130706433, "expected 2130706433, got " .. tostring(a:int()))
+end
+test_addr_int()
+
+local function test_addr_format()
+  local a = ip.addr(ip.parse("192.168.1.1"))
+  assert(a:format() == "192.168.1.1", "expected '192.168.1.1', got '" .. a:format() .. "'")
+end
+test_addr_format()
+
+local function test_addr_tostring()
+  local a = ip.addr(ip.parse("10.0.0.1"))
+  assert(tostring(a) == "10.0.0.1", "expected '10.0.0.1', got '" .. tostring(a) .. "'")
+end
+test_addr_tostring()
+
+local function test_addr_categorize()
+  local a = ip.addr(ip.parse("127.0.0.1"))
+  assert(a:categorize() == "LOOPBACK", "expected 'LOOPBACK', got '" .. a:categorize() .. "'")
+end
+test_addr_categorize()
+
+local function test_addr_is_loopback()
+  local a = ip.addr(ip.parse("127.0.0.1"))
+  assert(a:is_loopback() == true, "expected true for loopback")
+  local b = ip.addr(ip.parse("8.8.8.8"))
+  assert(b:is_loopback() == false, "expected false for non-loopback")
+end
+test_addr_is_loopback()
+
+local function test_addr_is_private()
+  local a = ip.addr(ip.parse("192.168.1.1"))
+  assert(a:is_private() == true, "expected true for private")
+  local b = ip.addr(ip.parse("8.8.8.8"))
+  assert(b:is_private() == false, "expected false for public")
+end
+test_addr_is_private()
+
+local function test_addr_is_public()
+  local a = ip.addr(ip.parse("8.8.8.8"))
+  assert(a:is_public() == true, "expected true for public")
+  local b = ip.addr(ip.parse("10.0.0.1"))
+  assert(b:is_public() == false, "expected false for private")
+end
+test_addr_is_public()
+
+local function test_lookup_returns_addr_with_methods()
+  local a, err = ip.lookup("localhost")
+  assert(a, "lookup failed: " .. tostring(err))
+  assert(a:format() == "127.0.0.1", "expected '127.0.0.1', got '" .. a:format() .. "'")
+  assert(a:is_loopback() == true, "expected loopback")
+  assert(a:is_public() == false, "expected not public")
+  assert(tostring(a) == "127.0.0.1", "expected tostring '127.0.0.1'")
+end
+test_lookup_returns_addr_with_methods()


### PR DESCRIPTION
Add ip.lookup() as an alternative to ip.resolve() that follows the Lua
convention of returning (nil, error_message) on failure instead of -1.
This makes DNS resolution errors easier to handle in proxy and networking
code that follows the standard (value, error) pattern.

The existing resolve() function is preserved for backward compatibility.

https://claude.ai/code/session_01BqvsMMzFxFoUkyYUn2Gh4w