### PR TITLE
Add cosmic-debug binary to release

### DIFF
--- a/3p/cosmos/cook.mk
+++ b/3p/cosmos/cook.mk
@@ -2,4 +2,5 @@ modules += cosmos
 cosmos_version := 3p/cosmos/version.lua
 cosmos_tests := 3p/cosmos/cosmos_test.tl
 cosmos_lua_bin = $(cosmos_dir)/lua
+cosmos_lua_debug_bin = $(cosmos_dir)/lua-debug
 cosmos_zip_bin = $(cosmos_dir)/zip

--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -6,7 +6,8 @@ cosmic_tl := $(filter-out $(cosmic_tests) $(cosmic_examples) lib/cosmic/main.tl,
 cosmic_main := $(o)/lib/cosmic/main.lua
 cosmic_args := lib/cosmic/.args
 cosmic_bin := $(o)/bin/cosmic
-cosmic_files := $(cosmic_bin) $(cosmic_lua)
+cosmic_debug_bin := $(o)/bin/cosmic-debug
+cosmic_files := $(cosmic_bin) $(cosmic_debug_bin) $(cosmic_lua)
 cosmic_deps := cosmos tl teal-types
 
 cosmic_built := $(o)/cosmic/.built
@@ -26,6 +27,14 @@ $(cosmic_bin): $$(cosmic_lua) $(cosmic_main) $(cosmic_args) $$(tl_staged) $$(tea
 	@cd $(cosmic_built) && $(CURDIR)/$(cosmos_zip_bin) -qr $(CURDIR)/$@ .lua .docs
 	@$(cosmos_zip_bin) -qj $@ $(cosmic_main) $(cosmic_args)
 
+$(cosmic_debug_bin): $(cosmic_bin)
+	@$(cp) $(cosmos_lua_debug_bin) $@
+	@chmod +x $@
+	@cd $(cosmic_built) && $(CURDIR)/$(cosmos_zip_bin) -qr $(CURDIR)/$@ .lua .docs
+	@$(cosmos_zip_bin) -qj $@ $(cosmic_main) $(cosmic_args)
+
 cosmic: $(cosmic_bin)
 
-.PHONY: cosmic
+cosmic-debug: $(cosmic_debug_bin)
+
+.PHONY: cosmic cosmic-debug

--- a/lib/cosmic/cosmic_debug_test.tl
+++ b/lib/cosmic/cosmic_debug_test.tl
@@ -1,0 +1,36 @@
+#!/usr/bin/env cosmic
+--- Tests for cosmic-debug binary
+
+local spawn = require("cosmic.child")
+local path = require("cosmo.path")
+
+global TEST_BIN: string
+
+local function test_cosmic_debug_version()
+  local bin = path.join(TEST_BIN, "cosmic-debug")
+  local ok, got = spawn.spawn({ bin, "-v" }):read()
+  assert(ok, "cosmic-debug -v failed: " .. tostring(got))
+  local want = "Lua"
+  assert((got as string):find(want, 1, true), "expected '" .. want .. "' in output, got: " .. (got as string))
+end
+test_cosmic_debug_version()
+
+local function test_cosmic_debug_runs_lua()
+  local bin = path.join(TEST_BIN, "cosmic-debug")
+  local ok, got = spawn.spawn({ bin, "-e", "print('hello from debug')" }):read()
+  assert(ok, "cosmic-debug -e failed: " .. tostring(got))
+  local want = "hello from debug"
+  assert((got as string):find(want, 1, true), "expected '" .. want .. "' in output, got: " .. (got as string))
+end
+test_cosmic_debug_runs_lua()
+
+local function test_cosmic_debug_help()
+  local bin = path.join(TEST_BIN, "cosmic-debug")
+  local ok, got = spawn.spawn({ bin, "--help" }):read()
+  assert(ok, "cosmic-debug --help failed: " .. tostring(got))
+  local want = "cosmic"
+  assert((got as string):lower():find(want, 1, true), "expected '" .. want .. "' in help output, got: " .. (got as string))
+end
+test_cosmic_debug_help()
+
+print("cosmic_debug: all tests passed")


### PR DESCRIPTION
Adds cosmic-debug, a debug build of cosmic-lua using lua-debug from whilp/cosmopolitan.

## Changes

- **3p/cosmos/cook.mk**: expose `cosmos_lua_debug_bin` variable pointing to `lua-debug` in the cosmos release
- **lib/cosmic/cook.mk**: add `cosmic-debug` build target; include in `cosmic_files` so it's built with `make cosmic`
- **lib/cosmic/cosmic_debug_test.tl**: tests verifying the debug binary works correctly

## Usage

```bash
make cosmic-debug  # build just the debug binary
make cosmic        # builds both cosmic and cosmic-debug
```

The debug binary is identical to the regular cosmic binary except it uses the debug-enabled Lua interpreter (`lua-debug`) as its base, which includes debugging symbols and assertions.

## Testing

- [x] `make check` passes (107/107 teal checks)
- [x] `make test only=cosmic_debug` passes (3 tests)
- [x] Manual verification: `cosmic-debug -v`, `cosmic-debug -e 'print(1)'`, `cosmic-debug --help`

Note: There is a pre-existing failure in `lib/cosmic/fs_test.tl` unrelated to this PR.