### PR TITLE
format: indent continuation lines inside open parens

### DIFF
--- a/lib/cosmic/format.tl
+++ b/lib/cosmic/format.tl
@@ -317,7 +317,7 @@ local function compute_indent_change(line_items: {Item}): integer, integer
     if is_block_closer(first_code) or is_half_closer(first_code) then
       pre_change = pre_change - 1
     end
-    if first_code.tk == "}" then
+    if first_code.tk == "}" or first_code.tk == ")" then
       pre_change = pre_change - 1
     end
   end
@@ -330,7 +330,7 @@ local function compute_indent_change(line_items: {Item}): integer, integer
     else
       if is_block_opener(item) then
         post_change = post_change + 1
-      elseif item.tk == "{" then
+      elseif item.tk == "{" or item.tk == "(" then
         post_change = post_change + 1
       elseif item.kind == "keyword" and item.tk == "function" then
         -- Only count as block opener if it's a function definition, not a type
@@ -344,7 +344,7 @@ local function compute_indent_change(line_items: {Item}): integer, integer
         if is_block_closer(item) or is_half_closer(item) then
           post_change = post_change - 1
         end
-        if item.tk == "}" then
+        if item.tk == "}" or item.tk == ")" then
           post_change = post_change - 1
         end
       end

--- a/lib/cosmic/format_test.tl
+++ b/lib/cosmic/format_test.tl
@@ -252,4 +252,32 @@ assert_format(
   "test.tl"
 )
 
+-- Bug 6: multi-line function call args should get continuation indent
+assert_format(
+  "local function foo()\n  assert(result == 0,\n    \"message\" ..\n    \"more\")\nend\n",
+  "local function foo()\n  assert(result == 0,\n    \"message\" ..\n    \"more\")\nend\n",
+  "multi-line call continuation indent"
+)
+
+-- Bug 6 variant: closing paren on own line dedents
+assert_format(
+  "foo(\n  x,\n  y\n)\n",
+  "foo(\n  x,\n  y\n)\n",
+  "multi-line call close paren dedents"
+)
+
+-- Bug 6 variant: single-line call unchanged
+assert_format(
+  "foo(x, y)\n",
+  "foo(x, y)\n",
+  "single-line call no indent change"
+)
+
+-- Bug 6 variant: nested multi-line calls
+assert_format(
+  "foo(\n  bar(\n    x\n  )\n)\n",
+  "foo(\n  bar(\n    x\n  )\n)\n",
+  "nested multi-line calls"
+)
+
 print("All format tests passed!")


### PR DESCRIPTION
The formatter tracked `{`/`}` for indentation but ignored `(`/`)`. Multi-line function call arguments lost their continuation indent:

```lua
-- before (wrong: continuation at same indent as assert)
assert(result.exit_code == 0,
"expected make -n files to succeed")

-- after (correct: indented inside parens)
assert(result.exit_code == 0,
  "expected make -n files to succeed")
```

Noticed via #235 where `makefile_test.tl` got its assert continuation lines flattened.

## Changes

- `lib/cosmic/format.tl`: treat `(` and `)` like `{` and `}` in `compute_indent_change` (3 lines changed)
- `lib/cosmic/format_test.tl`: 4 new test cases (multi-line call, closing paren on own line, single-line call, nested calls)

## Impact

~86 source files will get reformatted when `--format` is next applied, gaining correct paren-continuation indent.