### PR TITLE
format: merge .. continuation after long string close

### DIFF
--- a/lib/cosmic/format.tl
+++ b/lib/cosmic/format.tl
@@ -460,9 +460,10 @@ local function format(input: string, filename: string): FormatResult
     end
   end
 
-  -- Merge pass: absorb lines that start with closing punctuation after a long
-  -- string back into the previous line. This handles both ]]) on one source
-  -- line and the already-split case where ]] and ) are on separate lines.
+  -- Merge pass: absorb lines that start with closing punctuation or
+  -- continuation operators after a long string back into the previous line.
+  -- This handles ]]) on one source line, already-split ]] / ) across lines,
+  -- and ]] .. concat continuations.
   local merged: {Line} = {}
   for _, line in ipairs(lines) do
     local prev = merged[#merged]
@@ -473,7 +474,7 @@ local function format(input: string, filename: string): FormatResult
       and last_prev.kind == "string"
       and last_prev.tk:sub(1, 1) == "[" and last_prev.tk:sub(-1) == "]"
       and (first_cur.tk == ")" or first_cur.tk == "]" or first_cur.tk == "}"
-        or first_cur.tk == ",") then
+        or first_cur.tk == "," or first_cur.tk == "..") then
         -- Merge all items from this line into the previous line
         for _, item in ipairs(line.items) do
           prev.items[#prev.items + 1] = item

--- a/lib/cosmic/format_test.tl
+++ b/lib/cosmic/format_test.tl
@@ -349,4 +349,25 @@ assert_format(
   "long string assignment followed by new statement stays separate"
 )
 
+-- Bug 7 variant: long string followed by .. concatenation stays on same line
+assert_format(
+  "local s = [[\nhello\n]] .. body .. [[\nworld\n]]\n",
+  "local s = [[\nhello\n]] .. body .. [[\nworld\n]]\n",
+  "long string concat stays on same line"
+)
+
+-- Bug 7 variant: already-split long string .. concat gets rejoined
+assert_format(
+  "local s = [[\nhello\n]]\n\n  .. body .. [[\nworld\n]]\n",
+  "local s = [[\nhello\n]] .. body .. [[\nworld\n]]\n",
+  "already-split long string concat gets rejoined"
+)
+
+-- Bug 7 variant: long string concat inside function
+assert_format(
+  "local function run()\n  local s = [[\nfirst\n]] .. body .. [[\nsecond\n]]\n  return s\nend\n",
+  "local function run()\n  local s = [[\nfirst\n]] .. body .. [[\nsecond\n]]\n  return s\nend\n",
+  "long string concat inside function"
+)
+
 print("All format tests passed!")


### PR DESCRIPTION
Add `..` (concatenation) to the long string merge pass so `]] .. expr` stays on the same line.

## Problem

The formatter splits `]] .. body .. [[` across lines:

```lua
-- before (wrong)
local script = [[
return function()
]]

  .. benchmark.body .. [[
end
]]
```

## Fix

Add `..` to the merge pass that absorbs tokens after a long string close. Handles both the unsplit case and already-split input from previous formatting.

```lua
-- after (correct)
local script = [[
return function()
]] .. benchmark.body .. [[
end
]]
```

## Validation

- `make check`: 108/108 pass
- 3 new test cases for `]] ..` concatenation

Follows #237.