### PR TITLE
link TODOs to GitHub issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ all_tested := $(patsubst %,$(o)/%.test.got,$(all_tests))
 ## Run all tests (incremental)
 test: $(o)/test-summary.txt
 
-# TODO: use `cosmic --report $^` after next release
+# TODO(#241): use `cosmic --report $^` after next release
 $(o)/test-summary.txt: $(all_tested) | $(build_reporter)
 	@$(reporter) --dir $(o) $^ | tee $@
 
@@ -125,7 +125,7 @@ export LUA_PATH := $(subst $(space),;,$(foreach d,$(lua_path_dirs),$(CURDIR)/$(d
 export NO_COLOR := 1
 
 # Test rule: execute test directly via shebang, capture exit code, stdout, stderr
-# TODO: use `cosmic --test $(basename $@) $<` after next release
+# TODO(#241): use `cosmic --test $(basename $@) $<` after next release
 $(o)/%.tl.test.got: .PLEDGE = stdio rpath wpath cpath proc exec
 $(o)/%.tl.test.got: .UNVEIL = rx:$(o)/bootstrap r:lib r:3p rwc:$(o) rwc:$(TMP) rx:/usr rx:/proc r:/etc r:/dev/null
 $(o)/%.tl.test.got: $(o)/%.lua $(test_files) $(o)/bin/cosmic | $(bootstrap_files)

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -1948,7 +1948,7 @@ local record unix
   --- limits the process, with respect to the activities of the user id
   --- as a whole.
   --- - `RLIMIT_NOFILE` limits the number of open file descriptors and it
-  --- should work on all platforms except Windows (TODO).
+  --- should work on all platforms except Windows (TODO(#242)).
   --- If a limit isn't supported by the host platform, it'll be set to
   --- 127. On most platforms these limits are enforced by the kernel and
   --- as such are inherited by subprocesses.


### PR DESCRIPTION
## Summary

Find all TODOs in project-owned code, create tracking issues, and annotate each TODO with its issue number.

## Changes

- `Makefile`: annotate 2 TODOs about `cosmic --report` and `cosmic --test` CLI migration with `TODO(#241)`
- `lib/types/cosmo/unix.d.tl`: annotate TODO about RLIMIT_NOFILE Windows support with `TODO(#242)`

## Issues created

- #241: Makefile: switch to cosmic --report and cosmic --test CLI commands
- #242: unix.d.tl: clarify RLIMIT_NOFILE Windows support status

## Scope

Only project-owned files were considered. Third-party code in `o/staged/`, `o/cosmic/.built/`, and `3p/` was excluded.