### PR TITLE
bump ah to 2026-02-15-c23c9f6

### DIFF
--- a/3p/ah/version.lua
+++ b/3p/ah/version.lua
@@ -1,6 +1,6 @@
 return {
   format = "binary",
-  platforms = {["*"] = {sha = "32ea226682a500c1c8da44b5635e7a3370f9467ac3f404a2c0146abad4164d63"}},
+  platforms = {["*"] = {sha = "4c5908db097256d20c06d81ace64dfc9521a66c673fc2a28d1cede38933eaad0"}},
   url = "https://github.com/whilp/ah/releases/download/{version}/ah",
-  version = "2026-02-14-2fa4047"
+  version = "2026-02-15-c23c9f6"
 }


### PR DESCRIPTION
fixes failing work workflow ([run #22043124507](https://github.com/whilp/cosmic/actions/runs/22043124507)).

the old ah version (`2026-02-14-2fa4047`) didn't support `--skill`, `--must-produce`, `--sandbox`, or `--unveil` flags used by `work.mk`. the binary printed usage help and exited 1 on every invocation.

bumps to `2026-02-15-c23c9f6` which adds support for all of these flags.