### PR TITLE
net: export Socket and Interface types on NetModule

### DIFF
--- a/lib/cosmic/net.tl
+++ b/lib/cosmic/net.tl
@@ -398,6 +398,10 @@ local function make_socket(fd: number): Socket
     end
 
     local record NetModule
+      -- Types
+      Socket: Socket
+      Interface: Interface
+
       -- Socket creation
       socket: function(family?: number, socktype?: number, protocol?: number): Socket, string
       socketpair: function(family?: number, socktype?: number, protocol?: number): Socket, Socket, string


### PR DESCRIPTION
Closes #230

Adds `Socket` and `Interface` as type fields on `NetModule`, following the pattern `ip.tl` uses for `Addr`. This lets consumers reference `net.Socket` and `net.Interface` directly instead of redeclaring the types.