### PR TITLE
work: capture stderr in run() and add --repo to gh pr create

### DIFF
--- a/lib/work/work.tl
+++ b/lib/work/work.tl
@@ -18,11 +18,12 @@ local json = require("cosmic.json")
 
 -- --- helpers ---
 
-local function run(argv: {string}): boolean, string
+local function run(argv: {string}): boolean, string, string
   local h, err = child.spawn(argv)
-  if not h then return false, err end
+  if not h then return false, err, "" end
+  local stderr_out = h.stderr:read()
   local ok, out = h:read()
-  return ok as boolean, out
+  return ok as boolean, out, stderr_out
 end
 
 local function require_env(name: string): string
@@ -192,6 +193,7 @@ commands = {
       return url:match("/issues/(%d+)")
     end
 
+    local repo = require_env("WORK_REPO")
     local issue_file = require_env("WORK_ISSUE")
     local actions_file = require_env("WORK_ACTIONS")
 
@@ -229,9 +231,9 @@ commands = {
 
       if action_type == "comment_issue" then
         local body = (act.body or "") as string
-        local ok, out = run({"gh", "issue", "comment", issue_url, "--body", body})
+        local ok, out, errmsg = run({"gh", "issue", "comment", issue_url, "--body", body})
         if not ok then
-          io.stderr:write("  failed: " .. (out or "") .. "\n")
+          io.stderr:write("  failed: " .. (errmsg or out or "") .. "\n")
           all_ok = false
         end
 
@@ -248,9 +250,9 @@ commands = {
           end
         end
 
-        local ok, out = run({"gh", "pr", "create", "--head", branch, "--title", title, "--body", body})
+        local ok, out, errmsg = run({"gh", "pr", "create", "--repo", repo, "--head", branch, "--title", title, "--body", body})
         if not ok then
-          io.stderr:write("  failed: " .. (out or "") .. "\n")
+          io.stderr:write("  failed: " .. (errmsg or out or "") .. "\n")
           all_ok = false
         end
       else


### PR DESCRIPTION
## Problem

The work loop's act phase was failing to create PRs silently. The `run()` helper in `lib/work/work.tl` only captured stdout from child processes, but `gh pr create` outputs errors to stderr. This resulted in CI logs showing `failed: ` with no error message, making debugging impossible.

The create_pr action failed on all 3 convergence attempts in run [22044482078](https://github.com/whilp/cosmic/actions/runs/22044482078), despite the branch being pushed successfully and the check phase passing.

## Changes

- `run()` now reads child stderr and returns it as a third value
- act command logs stderr (not just stdout) on failure for both `comment_issue` and `create_pr`
- added `--repo` flag to `gh pr create` for explicit repo targeting (defensive fix)
- act command now reads `WORK_REPO` env var

## Analysis

The root cause of the `gh pr create` failure is still unknown — the error message was swallowed. This change ensures the next failure will be visible in CI logs. The `--repo` flag may also fix the issue if it was caused by `gh` failing to infer the repository from the local git context.

Ref: #230