### PR TITLE
work: treat pr-already-exists as success in act

### DIFF
--- a/lib/work/work.tl
+++ b/lib/work/work.tl
@@ -252,8 +252,13 @@ commands = {
 
         local ok, out, errmsg = run({"gh", "pr", "create", "--repo", repo, "--head", branch, "--title", title, "--body", body})
         if not ok then
-          io.stderr:write("  failed: " .. (errmsg or out or "") .. "\n")
-          all_ok = false
+          local combined = (out or "") .. (errmsg or "")
+          if combined:find("already exists") then
+            io.stderr:write("  pr already exists, treating as success\n")
+          else
+            io.stderr:write("  failed: " .. (errmsg or out or "") .. "\n")
+            all_ok = false
+          end
         end
       else
         io.stderr:write("  skipped unknown action: " .. action_type .. "\n")


### PR DESCRIPTION
## Problem

The work loop re-executes do/push/check/act after a successful pass verdict and PR creation. In LOOP=2, `gh pr create` fails because the PR already exists from LOOP=1. This sets `all_ok = false`, so `success = false`, and the issue gets labeled `failed` instead of `done`.

## Fix

In the `create_pr` action handler, check stdout+stderr for "already exists" and treat it as success rather than failure. Defense-in-depth for any re-run scenario.

Port of https://github.com/whilp/ah/pull/283 (the check.md skill fix is in the ah binary and takes effect when ah is updated).