### PR TITLE
pin release workflow actions to full commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: make teal test build
         shell: bash -x {0}
         run: bin/make -j teal test build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cosmic-lua
           path: |
@@ -37,9 +37,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts/
 


### PR DESCRIPTION
fixes failing release workflow: https://github.com/whilp/cosmic/actions/runs/22074786428

the repo requires all actions to be pinned to full-length commit SHAs. release.yml was using short `@v4` tags, causing the workflow to fail at job setup:

```
The actions actions/checkout@v4 and actions/upload-artifact@v4 are not allowed
in whilp/cosmic because all actions must be pinned to a full-length commit SHA.
```

pins all three actions to the same SHAs used in pr.yml and docs.yml:
- `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5`
- `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02`
- `actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093`