### PR TITLE
fix version.lua race: add cosmos_staged order-only dep

### DIFF
--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -14,7 +14,7 @@ cosmic_built := $(o)/cosmic/.built
 
 cosmic_version_lua := $(o)/cosmic/version.lua
 
-$(cosmic_version_lua): .FORCE
+$(cosmic_version_lua): .FORCE | $$(cosmos_staged)
 	@mkdir -p $(@D)
 	@echo "return { cosmic = \"$$(git describe --tags --always --dirty 2>/dev/null || echo unknown)\", cosmos = \"$$($(cosmos_lua_bin) -e "print(dofile('3p/cosmos/version.lua').version)")\" }" > $@
 


### PR DESCRIPTION
fixes the release workflow failure from https://github.com/whilp/cosmic/actions/runs/22074890306

**root cause:** `cosmic_version_lua` uses `cosmos_lua_bin` to read the cosmos version, but has no dependency on `cosmos_staged`. with parallel builds (`-j`), cosmos may not be staged yet, producing an empty cosmos version string in `version.lua`. this causes `version_test.tl` to fail: `should have cosmos version in parens`.

**fix:** add an order-only dependency (`| $$(cosmos_staged)`) so the cosmos binary is available before version.lua generation.