### PR TITLE
fix: formatter treats `as function(...)` type cast as block opener

### DIFF
--- a/lib/cosmic/benchmark.tl
+++ b/lib/cosmic/benchmark.tl
@@ -209,181 +209,181 @@ end
     local start = os_clock()
     for _ = 1, n do
       local run_ok, run_err: boolean, any = pcall(bench_fn as function())
-        if not run_ok then
-          -- Restore stdout/stderr before returning
-          if devnull then
-            io.stdout = old_stdout
-            io.stderr = old_stderr
-            io.output(old_stdout)
-            _G.print = old_print
-            devnull:close()
-          end
-          result.error = "runtime error: " .. tostring(run_err)
-          return result
+      if not run_ok then
+        -- Restore stdout/stderr before returning
+        if devnull then
+          io.stdout = old_stdout
+          io.stderr = old_stderr
+          io.output(old_stdout)
+          _G.print = old_print
+          devnull:close()
         end
-      end
-      elapsed = os_clock() - start
-
-      if elapsed < MIN_DURATION then
-        -- Estimate iterations needed to reach MIN_DURATION
-        if elapsed > 0 then
-          local estimate = math.ceil(n * MIN_DURATION / elapsed)
-          -- Don't grow too fast - cap at 10x
-          n = math.min(estimate, n * 10)
-        else
-          n = n * 10
-        end
+        result.error = "runtime error: " .. tostring(run_err)
+        return result
       end
     end
+    elapsed = os_clock() - start
 
-    -- Restore stdout/stderr
-    if devnull then
-      io.stdout = old_stdout
-      io.stderr = old_stderr
-      io.output(old_stdout)
-      _G.print = old_print
-      devnull:close()
+    if elapsed < MIN_DURATION then
+      -- Estimate iterations needed to reach MIN_DURATION
+      if elapsed > 0 then
+        local estimate = math.ceil(n * MIN_DURATION / elapsed)
+        -- Don't grow too fast - cap at 10x
+        n = math.min(estimate, n * 10)
+      else
+        n = n * 10
+      end
     end
-
-    -- Calculate results
-    result.iterations = n
-    result.total_ns = elapsed * 1e9
-    result.ns_per_op = result.total_ns / n
-
-    return result
   end
 
-  --- Run all benchmarks in a file, optionally filtered by pattern.
-  --- Parses and executes Benchmark_* functions, returning aggregated results.
-  --- @param file_path string Path to the Teal file containing benchmarks
-  --- @param filter string Optional Lua pattern to filter benchmark names (e.g., "concat" matches Benchmark_string_concat)
-  --- @return RunResult Result with exit code (0=pass, 1=fail, 2=skip), results, and errors
-  local function run(file_path: string, filter?: string): RunResult
-    local f, err = io.open(file_path, "r")
-    if not f then
-      return {
-        exit_code = 1,
-        results = {},
-        error = "cannot open file: " .. (err or "unknown"),
-      }
-    end
+  -- Restore stdout/stderr
+  if devnull then
+    io.stdout = old_stdout
+    io.stderr = old_stderr
+    io.output(old_stdout)
+    _G.print = old_print
+    devnull:close()
+  end
 
-    local source = f:read("*a")
-    f:close()
+  -- Calculate results
+  result.iterations = n
+  result.total_ns = elapsed * 1e9
+  result.ns_per_op = result.total_ns / n
 
-    local all_benchmarks = parse_benchmarks(source)
+  return result
+end
 
-    -- Filter benchmarks by pattern if provided
-    local benchmarks: {Benchmark} = {}
-    if filter then
-      for _, benchmark in ipairs(all_benchmarks) do
-        if benchmark.name:find(filter) then
-          table.insert(benchmarks, benchmark)
-        end
+--- Run all benchmarks in a file, optionally filtered by pattern.
+--- Parses and executes Benchmark_* functions, returning aggregated results.
+--- @param file_path string Path to the Teal file containing benchmarks
+--- @param filter string Optional Lua pattern to filter benchmark names (e.g., "concat" matches Benchmark_string_concat)
+--- @return RunResult Result with exit code (0=pass, 1=fail, 2=skip), results, and errors
+local function run(file_path: string, filter?: string): RunResult
+  local f, err = io.open(file_path, "r")
+  if not f then
+    return {
+      exit_code = 1,
+      results = {},
+      error = "cannot open file: " .. (err or "unknown"),
+    }
+  end
+
+  local source = f:read("*a")
+  f:close()
+
+  local all_benchmarks = parse_benchmarks(source)
+
+  -- Filter benchmarks by pattern if provided
+  local benchmarks: {Benchmark} = {}
+  if filter then
+    for _, benchmark in ipairs(all_benchmarks) do
+      if benchmark.name:find(filter) then
+        table.insert(benchmarks, benchmark)
       end
-    else
-      benchmarks = all_benchmarks
     end
+  else
+    benchmarks = all_benchmarks
+  end
 
-    if #benchmarks == 0 then
-      -- No benchmarks found (or none matched filter) - this is a skip (exit code 2)
-      if filter and #all_benchmarks > 0 then
-        return {
-          exit_code = 2,
-          results = {},
-          error = "no benchmarks matching '" .. filter .. "' (found " .. #all_benchmarks .. " total)",
-        }
-      end
+  if #benchmarks == 0 then
+    -- No benchmarks found (or none matched filter) - this is a skip (exit code 2)
+    if filter and #all_benchmarks > 0 then
       return {
         exit_code = 2,
         results = {},
-        error = nil,
+        error = "no benchmarks matching '" .. filter .. "' (found " .. #all_benchmarks .. " total)",
       }
     end
-
-    local results: {BenchmarkResult} = {}
-    local has_error = false
-
-    for _, benchmark in ipairs(benchmarks) do
-      local result = run_benchmark(benchmark, file_path)
-      table.insert(results, result)
-      if result.error then
-        has_error = true
-      end
-    end
-
     return {
-      exit_code = has_error and 1 or 0,
-      results = results,
+      exit_code = 2,
+      results = {},
       error = nil,
     }
   end
 
-  --- Format a number with appropriate units for readability.
-  --- @param ns number Nanoseconds
-  --- @return string Formatted time string
-  local function format_time(ns: number): string
-    if ns < 1000 then
-      return string.format("%.2f ns/op", ns)
-    elseif ns < 1000000 then
-      return string.format("%.2f µs/op", ns / 1000)
-    elseif ns < 1000000000 then
-      return string.format("%.2f ms/op", ns / 1000000)
-    else
-      return string.format("%.2f s/op", ns / 1000000000)
+  local results: {BenchmarkResult} = {}
+  local has_error = false
+
+  for _, benchmark in ipairs(benchmarks) do
+    local result = run_benchmark(benchmark, file_path)
+    table.insert(results, result)
+    if result.error then
+      has_error = true
     end
   end
 
-  --- Format results for human-readable output (Go-style).
-  --- Creates formatted benchmark output showing iterations and ns/op.
-  --- @param file_path string Path to the file that was benchmarked
-  --- @param run_result RunResult Results from running benchmarks
-  --- @return string Formatted output for display
-  local function format_results(file_path: string, run_result: RunResult): string
-    local lines: {string} = {}
+  return {
+    exit_code = has_error and 1 or 0,
+    results = results,
+    error = nil,
+  }
+end
 
-    if run_result.error then
-      table.insert(lines, file_path .. ": ERROR: " .. run_result.error)
-      return table.concat(lines, "\n")
-    end
+--- Format a number with appropriate units for readability.
+--- @param ns number Nanoseconds
+--- @return string Formatted time string
+local function format_time(ns: number): string
+  if ns < 1000 then
+    return string.format("%.2f ns/op", ns)
+  elseif ns < 1000000 then
+    return string.format("%.2f µs/op", ns / 1000)
+  elseif ns < 1000000000 then
+    return string.format("%.2f ms/op", ns / 1000000)
+  else
+    return string.format("%.2f s/op", ns / 1000000000)
+  end
+end
 
-    if run_result.exit_code == 2 then
-      table.insert(lines, file_path .. ": SKIP (no benchmarks)")
-      return table.concat(lines, "\n")
-    end
+--- Format results for human-readable output (Go-style).
+--- Creates formatted benchmark output showing iterations and ns/op.
+--- @param file_path string Path to the file that was benchmarked
+--- @param run_result RunResult Results from running benchmarks
+--- @return string Formatted output for display
+local function format_results(file_path: string, run_result: RunResult): string
+  local lines: {string} = {}
 
-    -- Header (Go-style)
-    table.insert(lines, "pkg: " .. file_path)
-
-    for _, result in ipairs(run_result.results) do
-      if result.error then
-        table.insert(lines, result.name .. ": FAIL")
-        table.insert(lines, "  error: " .. result.error)
-      else
-        -- Go-style output: BenchmarkName    N    ns/op
-        local iter_str = tostring(result.iterations)
-        local time_str = format_time(result.ns_per_op)
-        -- Right-align iterations to ~10 chars for readability
-        local padding = string.rep(" ", math.max(1, 10 - #iter_str))
-        table.insert(lines, result.name .. padding .. iter_str .. "    " .. time_str)
-      end
-    end
-
-    table.insert(lines, "PASS")
-
+  if run_result.error then
+    table.insert(lines, file_path .. ": ERROR: " .. run_result.error)
     return table.concat(lines, "\n")
   end
 
-  local record BenchmarkModule
-    run: function(file_path: string, filter?: string): RunResult
-    parse_benchmarks: function(source: string): {Benchmark}
-    format_results: function(file_path: string, run_result: RunResult): string
+  if run_result.exit_code == 2 then
+    table.insert(lines, file_path .. ": SKIP (no benchmarks)")
+    return table.concat(lines, "\n")
   end
 
-  local M: BenchmarkModule = {
-    run = run,
-    parse_benchmarks = parse_benchmarks,
-    format_results = format_results,
-  }
+  -- Header (Go-style)
+  table.insert(lines, "pkg: " .. file_path)
 
-  return M
+  for _, result in ipairs(run_result.results) do
+    if result.error then
+      table.insert(lines, result.name .. ": FAIL")
+      table.insert(lines, "  error: " .. result.error)
+    else
+      -- Go-style output: BenchmarkName    N    ns/op
+      local iter_str = tostring(result.iterations)
+      local time_str = format_time(result.ns_per_op)
+      -- Right-align iterations to ~10 chars for readability
+      local padding = string.rep(" ", math.max(1, 10 - #iter_str))
+      table.insert(lines, result.name .. padding .. iter_str .. "    " .. time_str)
+    end
+  end
+
+  table.insert(lines, "PASS")
+
+  return table.concat(lines, "\n")
+end
+
+local record BenchmarkModule
+  run: function(file_path: string, filter?: string): RunResult
+  parse_benchmarks: function(source: string): {Benchmark}
+  format_results: function(file_path: string, run_result: RunResult): string
+end
+
+local M: BenchmarkModule = {
+  run = run,
+  parse_benchmarks = parse_benchmarks,
+  format_results = format_results,
+}
+
+return M

--- a/lib/cosmic/cosmic_test.tl
+++ b/lib/cosmic/cosmic_test.tl
@@ -55,6 +55,6 @@ local function test_cosmic_main_returns_when_not_main()
   end
   -- when required (not main), cosmic.main should return without calling fn
   cosmic.main(app as function({string}, any): number, string)
-    assert(not called, "expected app not to be called when not main")
-  end
-  test_cosmic_main_returns_when_not_main()
+  assert(not called, "expected app not to be called when not main")
+end
+test_cosmic_main_returns_when_not_main()

--- a/lib/cosmic/format.tl
+++ b/lib/cosmic/format.tl
@@ -270,20 +270,36 @@ end
 --- Determine if a `function` keyword on a line is a block-opening function
 --- definition (which needs indentation for its body) vs a function TYPE
 --- annotation (which does NOT open a block).
---- A function keyword is a type annotation when it appears after `:` in a
---- record field or parameter type position. We detect this by checking if
---- any prior token on the same line is `:` with no intervening block structure.
+--- A function keyword is a type annotation when it appears after `:` or `as`
+--- in a type position, or when it is nested inside parentheses that are part
+--- of a type annotation (e.g., return types like `(function | number)`).
 local function is_function_block_opener(line_items: {Item}, func_idx: integer): boolean
-  -- Scan backwards from func_idx to find context
+  -- Scan backwards from func_idx to find context.
+  -- Track paren depth so that `(` inside a balanced group (like a return type
+  -- annotation) is not mistaken for an expression-level opening paren.
+  local paren_depth = 0
   for i = func_idx - 1, 1, -1 do
     local item = line_items[i]
     if item.kind == "comment" then
       -- skip
-    elseif item.tk == ":" then
-      -- function appears after colon: it's a type annotation
+    elseif item.tk == ")" then
+      paren_depth = paren_depth + 1
+    elseif item.tk == "(" then
+      if paren_depth > 0 then
+        paren_depth = paren_depth - 1
+        -- Still inside a balanced group, keep scanning
+      else
+        -- function after ( at depth 0 is a value/expression, it's a block opener
+        return true
+      end
+    elseif paren_depth > 0 then
+      -- Inside balanced parens (type annotation); skip everything
+    elseif item.tk == ":" or item.tk == "as" then
+      -- function appears after colon (type annotation) or after "as" (type cast):
+      -- it's a type, not a block opener
       return false
-    elseif item.tk == "=" or item.tk == "(" or item.tk == "," then
-      -- function after = or ( or , is a value/expression, it's a block opener
+    elseif item.tk == "=" or item.tk == "," then
+      -- function after = or , is a value/expression, it's a block opener
       return true
     elseif item.kind == "keyword" and (item.tk == "local" or item.tk == "return") then
       return true
@@ -302,6 +318,67 @@ end
 local function compute_indent_change(line_items: {Item}): integer, integer
   local pre_change = 0
   local post_change = 0
+
+  -- Build a set of item indices that are inside a function-type annotation.
+  -- When `function` is determined to be a type (not a block opener), the
+  -- balanced `(...)` parameter list that follows it (and any return-type
+  -- `(...)` group) are purely type syntax — their parens and inner `function`
+  -- keywords must not affect indentation.
+  local type_ctx: {integer: boolean} = {}
+  for idx, item in ipairs(line_items) do
+    if item.kind == "keyword" and item.tk == "function" and not type_ctx[idx] then
+      if not is_function_block_opener(line_items, idx) then
+        -- Mark everything from here through the balanced param list and
+        -- optional return-type group as type context.
+        type_ctx[idx] = true
+        local depth = 0
+        local j = idx + 1
+        -- Skip the parameter list (...)
+        while j <= #line_items do
+          type_ctx[j] = true
+          if line_items[j].tk == "(" then
+            depth = depth + 1
+          elseif line_items[j].tk == ")" then
+            depth = depth - 1
+            if depth == 0 then
+              j = j + 1
+              break
+            end
+          end
+          j = j + 1
+        end
+        -- If followed by ":" there may be a return type; skip it too
+        if j <= #line_items and line_items[j].tk == ":" then
+          type_ctx[j] = true
+          j = j + 1
+          -- If the return type is wrapped in (...), skip that group
+          if j <= #line_items and line_items[j].tk == "(" then
+            depth = 0
+            while j <= #line_items do
+              type_ctx[j] = true
+              if line_items[j].tk == "(" then
+                depth = depth + 1
+              elseif line_items[j].tk == ")" then
+                depth = depth - 1
+                if depth == 0 then
+                  break
+                end
+              end
+              j = j + 1
+            end
+          else
+            -- Bare return types: skip comma-separated type tokens until we hit
+            -- something that can't be part of a type (newline boundary or a
+            -- keyword/identifier that starts a new statement).
+            -- In practice, on a single line the remaining tokens are just type
+            -- names, commas, and punctuation until end-of-line, but we don't
+            -- need to mark those — they contain no ( ) { } or block keywords
+            -- so they won't affect indent counts anyway.
+          end
+        end
+      end
+    end
+  end
 
   -- Find first non-comment item
   local first_code: Item = nil
@@ -327,6 +404,10 @@ local function compute_indent_change(line_items: {Item}): integer, integer
   for idx, item in ipairs(line_items) do
     if item.kind == "comment" then
       -- skip comments
+    elseif type_ctx[idx] then
+      -- Inside a function-type annotation; do not count for indentation.
+      -- Still track is_first_code so leading-closer logic works.
+      is_first_code = false
     else
       if is_block_opener(item) then
         post_change = post_change + 1

--- a/lib/cosmic/format_test.tl
+++ b/lib/cosmic/format_test.tl
@@ -370,4 +370,32 @@ assert_format(
   "long string concat inside function"
 )
 
+-- Bug: `as function(...)` type cast should not open a function block
+assert_format(
+  "local f = print as function(string)\nf(\"hello\")\n",
+  "local f = print as function(string)\nf(\"hello\")\n",
+  "as function cast no indent"
+)
+
+-- Bug variant: as function cast inside a function body
+assert_format(
+  "local function foo()\n  local f = print as function(string)\n  f(\"hello\")\nend\n\nfoo()\n",
+  "local function foo()\n  local f = print as function(string)\n  f(\"hello\")\nend\n\nfoo()\n",
+  "as function cast inside function body"
+)
+
+-- Bug variant: as function cast with multi-return type
+assert_format(
+  "local a = 1\nlocal b = 2\nlocal f = print as function(string): boolean, string\nlocal c = a + b\nprint(c)\n",
+  "local a = 1\nlocal b = 2\nlocal f = print as function(string): boolean, string\nlocal c = a + b\nprint(c)\n",
+  "as function cast with multi-return type"
+)
+
+-- Bug variant: as function cast with nested function types in signature
+assert_format(
+  "M.sa = unix.sa as function(number, function | number): (function | number, number)\nM.sp = unix.sp as function(number): number\nM.x = 1\n",
+  "M.sa = unix.sa as function(number, function | number): (function | number, number)\nM.sp = unix.sp as function(number): number\nM.x = 1\n",
+  "as function cast with nested function types"
+)
+
 print("All format tests passed!")

--- a/lib/cosmic/net.tl
+++ b/lib/cosmic/net.tl
@@ -161,458 +161,458 @@ local function make_socket(fd: number): Socket
   --- @return string Error message on failure
   function sock:bind_unix(path: string): boolean, string
     local ok = (unix.bind as function(number, string): boolean)(self.fd, path)
-      if not ok then
-        return false, "bind_unix failed"
-      end
-      return true
+    if not ok then
+      return false, "bind_unix failed"
     end
+    return true
+  end
 
-    --- Start listening for incoming connections.
-    --- @param backlog number Maximum pending connections (default 128)
-    --- @return boolean True on success
-    --- @return string Error message on failure
-    function sock:listen(backlog?: number): boolean, string
-      local ok = unix.listen(self.fd, backlog or 128)
-      if not ok then
-        return false, "listen failed"
-      end
-      return true
+  --- Start listening for incoming connections.
+  --- @param backlog number Maximum pending connections (default 128)
+  --- @return boolean True on success
+  --- @return string Error message on failure
+  function sock:listen(backlog?: number): boolean, string
+    local ok = unix.listen(self.fd, backlog or 128)
+    if not ok then
+      return false, "listen failed"
     end
+    return true
+  end
 
-    --- Accept an incoming connection.
-    --- @param flags number Optional flags (SOCK_CLOEXEC, SOCK_NONBLOCK)
-    --- @return Socket New client socket
-    --- @return number Client IP address
-    --- @return number Client port
-    --- @return string Error message on failure
-    function sock:accept(flags?: number): Socket, number, number, string
-      local clientfd, ip, port = unix.accept(self.fd, flags or 0)
-      if not clientfd then
-        return nil, nil, nil, "accept failed"
-      end
-      return make_socket(clientfd), ip, port
+  --- Accept an incoming connection.
+  --- @param flags number Optional flags (SOCK_CLOEXEC, SOCK_NONBLOCK)
+  --- @return Socket New client socket
+  --- @return number Client IP address
+  --- @return number Client port
+  --- @return string Error message on failure
+  function sock:accept(flags?: number): Socket, number, number, string
+    local clientfd, ip, port = unix.accept(self.fd, flags or 0)
+    if not clientfd then
+      return nil, nil, nil, "accept failed"
     end
+    return make_socket(clientfd), ip, port
+  end
 
-    --- Connect to a remote address.
-    --- @param ip number Remote IP address
-    --- @param port number Remote port
-    --- @return boolean True on success
-    --- @return string Error message on failure
-    function sock:connect(ip: number, port: number): boolean, string
-      local ok = unix.connect(self.fd, ip, port)
-      if not ok then
-        return false, "connect failed"
-      end
-      return true
+  --- Connect to a remote address.
+  --- @param ip number Remote IP address
+  --- @param port number Remote port
+  --- @return boolean True on success
+  --- @return string Error message on failure
+  function sock:connect(ip: number, port: number): boolean, string
+    local ok = unix.connect(self.fd, ip, port)
+    if not ok then
+      return false, "connect failed"
     end
+    return true
+  end
 
-    --- Connect to a Unix domain socket path.
-    --- @param path string Filesystem path of the socket to connect to
-    --- @return boolean True on success
-    --- @return string Error message on failure
-    function sock:connect_unix(path: string): boolean, string
-      local ok = (unix.connect as function(number, string): boolean)(self.fd, path)
-        if not ok then
-          return false, "connect_unix failed"
-        end
-        return true
-      end
-
-      --- Get a socket option value.
-      --- @param level number Option level (SOL_SOCKET, SOL_TCP, etc.)
-      --- @param optname number Option name (SO_REUSEADDR, TCP_NODELAY, etc.)
-      --- @return number|boolean Option value
-      --- @return string Error message on failure
-      function sock:getsockopt(level: number, optname: number): number | boolean, string
-        local val = unix.getsockopt(self.fd, level, optname)
-        if val == nil then
-          return nil, "getsockopt failed"
-        end
-        return val
-      end
-
-      --- Set a socket option value.
-      --- @param level number Option level (SOL_SOCKET, SOL_TCP, etc.)
-      --- @param optname number Option name (SO_REUSEADDR, TCP_NODELAY, etc.)
-      --- @param value number|boolean Option value
-      --- @return boolean True on success
-      --- @return string Error message on failure
-      function sock:setsockopt(level: number, optname: number, value: number | boolean): boolean, string
-        local ok = unix.setsockopt(self.fd, level, optname, value)
-        if not ok then
-          return false, "setsockopt failed"
-        end
-        return true
-      end
-
-      return setmetatable(sock, {
-          __close = function(self: Socket) self:close() end
-        }) as Socket
+  --- Connect to a Unix domain socket path.
+  --- @param path string Filesystem path of the socket to connect to
+  --- @return boolean True on success
+  --- @return string Error message on failure
+  function sock:connect_unix(path: string): boolean, string
+    local ok = (unix.connect as function(number, string): boolean)(self.fd, path)
+    if not ok then
+      return false, "connect_unix failed"
     end
+    return true
+  end
 
-    --- Create a new socket.
-    --- @param family number Address family (AF_INET, AF_UNIX). Default: AF_INET
-    --- @param socktype number Socket type (SOCK_STREAM, SOCK_DGRAM). Default: SOCK_STREAM
-    --- @param protocol number Protocol (IPPROTO_TCP, IPPROTO_UDP). Default: 0
-    --- @return Socket Socket handle
-    --- @return string Error message on failure
-    local function socket(family?: number, socktype?: number, protocol?: number): Socket, string
-      family = family or unix.AF_INET
-      socktype = socktype or unix.SOCK_STREAM
-      protocol = protocol or 0
-      local fd = unix.socket(family, socktype, protocol)
-      if not fd then
-        return nil, "socket creation failed"
-      end
-      return make_socket(fd)
+  --- Get a socket option value.
+  --- @param level number Option level (SOL_SOCKET, SOL_TCP, etc.)
+  --- @param optname number Option name (SO_REUSEADDR, TCP_NODELAY, etc.)
+  --- @return number|boolean Option value
+  --- @return string Error message on failure
+  function sock:getsockopt(level: number, optname: number): number | boolean, string
+    local val = unix.getsockopt(self.fd, level, optname)
+    if val == nil then
+      return nil, "getsockopt failed"
     end
+    return val
+  end
 
-    --- Create a pair of connected sockets.
-    --- @param family number Address family (AF_UNIX). Default: AF_UNIX
-    --- @param socktype number Socket type (SOCK_STREAM, SOCK_DGRAM). Default: SOCK_STREAM
-    --- @param protocol number Protocol. Default: 0
-    --- @return Socket First socket of the pair
-    --- @return Socket Second socket of the pair
-    --- @return string Error message on failure
-    local function socketpair(family?: number, socktype?: number, protocol?: number): Socket, Socket, string
-      family = family or unix.AF_UNIX
-      socktype = socktype or unix.SOCK_STREAM
-      protocol = protocol or 0
-      local fd1, fd2 = unix.socketpair(family, socktype, protocol)
-      if not fd1 then
-        return nil, nil, "socketpair creation failed"
-      end
-      return make_socket(fd1), make_socket(fd2)
+  --- Set a socket option value.
+  --- @param level number Option level (SOL_SOCKET, SOL_TCP, etc.)
+  --- @param optname number Option name (SO_REUSEADDR, TCP_NODELAY, etc.)
+  --- @param value number|boolean Option value
+  --- @return boolean True on success
+  --- @return string Error message on failure
+  function sock:setsockopt(level: number, optname: number, value: number | boolean): boolean, string
+    local ok = unix.setsockopt(self.fd, level, optname, value)
+    if not ok then
+      return false, "setsockopt failed"
     end
+    return true
+  end
 
-    --- Create a Unix domain socket, bind it to a path, and start listening.
-    --- @param path string Filesystem path for the socket
-    --- @param backlog number Maximum pending connections (default 128)
-    --- @return Socket Listening socket
-    --- @return string Error message on failure
-    local function listen_unix(path: string, backlog?: number): Socket, string
-      local sock, err = socket(unix.AF_UNIX, unix.SOCK_STREAM, 0)
-      if not sock then
-        return nil, err
-      end
-      local ok, bind_err = sock:bind_unix(path)
-      if not ok then
-        sock:close()
-        return nil, bind_err
-      end
-      local lok, listen_err = sock:listen(backlog)
-      if not lok then
-        sock:close()
-        return nil, listen_err
-      end
-      return sock
-    end
+  return setmetatable(sock, {
+      __close = function(self: Socket) self:close() end
+    }) as Socket
+end
 
-    --- Create a Unix domain socket and connect to a path.
-    --- @param path string Filesystem path of the socket to connect to
-    --- @return Socket Connected socket
-    --- @return string Error message on failure
-    local function connect_unix(path: string): Socket, string
-      local sock, err = socket(unix.AF_UNIX, unix.SOCK_STREAM, 0)
-      if not sock then
-        return nil, err
-      end
-      local ok, conn_err = sock:connect_unix(path)
-      if not ok then
-        sock:close()
-        return nil, conn_err
-      end
-      return sock
-    end
+--- Create a new socket.
+--- @param family number Address family (AF_INET, AF_UNIX). Default: AF_INET
+--- @param socktype number Socket type (SOCK_STREAM, SOCK_DGRAM). Default: SOCK_STREAM
+--- @param protocol number Protocol (IPPROTO_TCP, IPPROTO_UDP). Default: 0
+--- @return Socket Socket handle
+--- @return string Error message on failure
+local function socket(family?: number, socktype?: number, protocol?: number): Socket, string
+  family = family or unix.AF_INET
+  socktype = socktype or unix.SOCK_STREAM
+  protocol = protocol or 0
+  local fd = unix.socket(family, socktype, protocol)
+  if not fd then
+    return nil, "socket creation failed"
+  end
+  return make_socket(fd)
+end
 
-    --- Poll file descriptors for events.
-    --- The fds table maps file descriptor numbers to event masks (POLLIN, POLLOUT, etc.).
-    --- Returns a table with the same keys but containing revents for each fd.
-    --- @param fds {number:number} Map of fd to events to poll for
-    --- @param timeoutms number Timeout in milliseconds (-1 for infinite, 0 for non-blocking)
-    --- @return {number:number} Map of fd to revents
-    --- @return string Error message on failure
-    local function poll(fds: {number: number}, timeoutms?: number): {number: number}, string
-      local result = unix.poll(fds, timeoutms or -1)
-      if not result then
-        return nil, "poll failed"
-      end
-      return result
-    end
+--- Create a pair of connected sockets.
+--- @param family number Address family (AF_UNIX). Default: AF_UNIX
+--- @param socktype number Socket type (SOCK_STREAM, SOCK_DGRAM). Default: SOCK_STREAM
+--- @param protocol number Protocol. Default: 0
+--- @return Socket First socket of the pair
+--- @return Socket Second socket of the pair
+--- @return string Error message on failure
+local function socketpair(family?: number, socktype?: number, protocol?: number): Socket, Socket, string
+  family = family or unix.AF_UNIX
+  socktype = socktype or unix.SOCK_STREAM
+  protocol = protocol or 0
+  local fd1, fd2 = unix.socketpair(family, socktype, protocol)
+  if not fd1 then
+    return nil, nil, "socketpair creation failed"
+  end
+  return make_socket(fd1), make_socket(fd2)
+end
 
-    --- Get the local hostname.
-    --- @return string The hostname
-    --- @return string Error message on failure
-    local function gethostname(): string, string
-      local name = unix.gethostname()
-      if not name then
-        return nil, "gethostname failed"
-      end
-      return name
-    end
+--- Create a Unix domain socket, bind it to a path, and start listening.
+--- @param path string Filesystem path for the socket
+--- @param backlog number Maximum pending connections (default 128)
+--- @return Socket Listening socket
+--- @return string Error message on failure
+local function listen_unix(path: string, backlog?: number): Socket, string
+  local sock, err = socket(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+  if not sock then
+    return nil, err
+  end
+  local ok, bind_err = sock:bind_unix(path)
+  if not ok then
+    sock:close()
+    return nil, bind_err
+  end
+  local lok, listen_err = sock:listen(backlog)
+  if not lok then
+    sock:close()
+    return nil, listen_err
+  end
+  return sock
+end
 
-    --- Parse an IP address string to numeric form.
-    --- @param str string IP address in dotted notation (e.g., "127.0.0.1")
-    --- @return number Numeric IP address
-    --- @return string Error message on failure
-    local function parseip(str: string): number, string
-      local a, b, c, d = str:match("^(%d+)%.(%d+)%.(%d+)%.(%d+)$")
-      if not a then
-        return nil, "invalid IP address format"
-      end
-      local na, nb, nc, nd = tonumber(a), tonumber(b), tonumber(c), tonumber(d)
-      if na > 255 or nb > 255 or nc > 255 or nd > 255 then
-        return nil, "IP address octet out of range"
-      end
-      return (na << 24) | (nb << 16) | (nc << 8) | nd
-    end
+--- Create a Unix domain socket and connect to a path.
+--- @param path string Filesystem path of the socket to connect to
+--- @return Socket Connected socket
+--- @return string Error message on failure
+local function connect_unix(path: string): Socket, string
+  local sock, err = socket(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+  if not sock then
+    return nil, err
+  end
+  local ok, conn_err = sock:connect_unix(path)
+  if not ok then
+    sock:close()
+    return nil, conn_err
+  end
+  return sock
+end
 
-    --- Format a numeric IP address to string.
-    --- @param ip number Numeric IP address
-    --- @return string IP address in dotted notation
-    local function formatip(ip: number): string
-      return string.format("%d.%d.%d.%d",
-        (ip >> 24) & 0xff,
-        (ip >> 16) & 0xff,
-        (ip >> 8) & 0xff,
-        ip & 0xff)
-    end
+--- Poll file descriptors for events.
+--- The fds table maps file descriptor numbers to event masks (POLLIN, POLLOUT, etc.).
+--- Returns a table with the same keys but containing revents for each fd.
+--- @param fds {number:number} Map of fd to events to poll for
+--- @param timeoutms number Timeout in milliseconds (-1 for infinite, 0 for non-blocking)
+--- @return {number:number} Map of fd to revents
+--- @return string Error message on failure
+local function poll(fds: {number: number}, timeoutms?: number): {number: number}, string
+  local result = unix.poll(fds, timeoutms or -1)
+  if not result then
+    return nil, "poll failed"
+  end
+  return result
+end
 
-    --- Network interface information.
-    local record Interface
-      --- Interface name (e.g., "eth0", "lo").
-      name: string
-      --- IPv4 address as a number.
-      ip: number
-    end
+--- Get the local hostname.
+--- @return string The hostname
+--- @return string Error message on failure
+local function gethostname(): string, string
+  local name = unix.gethostname()
+  if not name then
+    return nil, "gethostname failed"
+  end
+  return name
+end
 
-    --- List network interfaces and their IPv4 addresses.
-    --- @return {Interface} List of interfaces
-    --- @return string Error message on failure
-    local function interfaces(): {Interface}, string
-      local raw = unix.siocgifconf()
-      if not raw then
-        return nil, "siocgifconf failed"
-      end
-      return raw as {Interface}
-    end
+--- Parse an IP address string to numeric form.
+--- @param str string IP address in dotted notation (e.g., "127.0.0.1")
+--- @return number Numeric IP address
+--- @return string Error message on failure
+local function parseip(str: string): number, string
+  local a, b, c, d = str:match("^(%d+)%.(%d+)%.(%d+)%.(%d+)$")
+  if not a then
+    return nil, "invalid IP address format"
+  end
+  local na, nb, nc, nd = tonumber(a), tonumber(b), tonumber(c), tonumber(d)
+  if na > 255 or nb > 255 or nc > 255 or nd > 255 then
+    return nil, "IP address octet out of range"
+  end
+  return (na << 24) | (nb << 16) | (nc << 8) | nd
+end
 
-    local record NetModule
-      -- Types
-      Socket: Socket
-      Interface: Interface
+--- Format a numeric IP address to string.
+--- @param ip number Numeric IP address
+--- @return string IP address in dotted notation
+local function formatip(ip: number): string
+  return string.format("%d.%d.%d.%d",
+    (ip >> 24) & 0xff,
+    (ip >> 16) & 0xff,
+    (ip >> 8) & 0xff,
+    ip & 0xff)
+end
 
-      -- Socket creation
-      socket: function(family?: number, socktype?: number, protocol?: number): Socket, string
-      socketpair: function(family?: number, socktype?: number, protocol?: number): Socket, Socket, string
+--- Network interface information.
+local record Interface
+  --- Interface name (e.g., "eth0", "lo").
+  name: string
+  --- IPv4 address as a number.
+  ip: number
+end
 
-      -- Unix domain socket helpers
-      listen_unix: function(path: string, backlog?: number): Socket, string
-      connect_unix: function(path: string): Socket, string
+--- List network interfaces and their IPv4 addresses.
+--- @return {Interface} List of interfaces
+--- @return string Error message on failure
+local function interfaces(): {Interface}, string
+  local raw = unix.siocgifconf()
+  if not raw then
+    return nil, "siocgifconf failed"
+  end
+  return raw as {Interface}
+end
 
-      -- Polling
-      poll: function(fds: {number: number}, timeoutms?: number): {number: number}, string
+local record NetModule
+  -- Types
+  Socket: Socket
+  Interface: Interface
 
-      -- Utility
-      gethostname: function(): string, string
-      parseip: function(str: string): number, string
-      formatip: function(ip: number): string
-      interfaces: function(): {Interface}, string
+  -- Socket creation
+  socket: function(family?: number, socktype?: number, protocol?: number): Socket, string
+  socketpair: function(family?: number, socktype?: number, protocol?: number): Socket, Socket, string
 
-      -- Address families
-      AF_INET: number
-      AF_UNIX: number
-      AF_UNSPEC: number
+  -- Unix domain socket helpers
+  listen_unix: function(path: string, backlog?: number): Socket, string
+  connect_unix: function(path: string): Socket, string
 
-      -- Socket types
-      SOCK_STREAM: number
-      SOCK_DGRAM: number
-      SOCK_RAW: number
-      SOCK_RDM: number
-      SOCK_SEQPACKET: number
-      SOCK_CLOEXEC: number
-      SOCK_NONBLOCK: number
+  -- Polling
+  poll: function(fds: {number: number}, timeoutms?: number): {number: number}, string
 
-      -- Protocols
-      IPPROTO_TCP: number
-      IPPROTO_UDP: number
-      IPPROTO_IP: number
-      IPPROTO_ICMP: number
-      IPPROTO_RAW: number
+  -- Utility
+  gethostname: function(): string, string
+  parseip: function(str: string): number, string
+  formatip: function(ip: number): string
+  interfaces: function(): {Interface}, string
 
-      -- Socket levels
-      SOL_SOCKET: number
-      SOL_TCP: number
-      SOL_UDP: number
-      SOL_IP: number
+  -- Address families
+  AF_INET: number
+  AF_UNIX: number
+  AF_UNSPEC: number
 
-      -- Socket options
-      SO_REUSEADDR: number
-      SO_REUSEPORT: number
-      SO_KEEPALIVE: number
-      SO_BROADCAST: number
-      SO_LINGER: number
-      SO_RCVBUF: number
-      SO_SNDBUF: number
-      SO_RCVTIMEO: number
-      SO_SNDTIMEO: number
-      SO_ERROR: number
-      SO_TYPE: number
-      SO_ACCEPTCONN: number
-      SO_DEBUG: number
-      SO_DONTROUTE: number
-      SO_RCVLOWAT: number
-      SO_SNDLOWAT: number
+  -- Socket types
+  SOCK_STREAM: number
+  SOCK_DGRAM: number
+  SOCK_RAW: number
+  SOCK_RDM: number
+  SOCK_SEQPACKET: number
+  SOCK_CLOEXEC: number
+  SOCK_NONBLOCK: number
 
-      -- TCP options
-      TCP_NODELAY: number
-      TCP_CORK: number
-      TCP_KEEPIDLE: number
-      TCP_KEEPINTVL: number
-      TCP_KEEPCNT: number
-      TCP_MAXSEG: number
-      TCP_SYNCNT: number
-      TCP_DEFER_ACCEPT: number
-      TCP_FASTOPEN: number
-      TCP_FASTOPEN_CONNECT: number
-      TCP_QUICKACK: number
-      TCP_NOTSENT_LOWAT: number
-      TCP_WINDOW_CLAMP: number
-      TCP_SAVE_SYN: number
-      TCP_SAVED_SYN: number
+  -- Protocols
+  IPPROTO_TCP: number
+  IPPROTO_UDP: number
+  IPPROTO_IP: number
+  IPPROTO_ICMP: number
+  IPPROTO_RAW: number
 
-      -- Shutdown modes
-      SHUT_RD: number
-      SHUT_WR: number
-      SHUT_RDWR: number
+  -- Socket levels
+  SOL_SOCKET: number
+  SOL_TCP: number
+  SOL_UDP: number
+  SOL_IP: number
 
-      -- Poll events
-      POLLIN: number
-      POLLOUT: number
-      POLLERR: number
-      POLLHUP: number
-      POLLNVAL: number
-      POLLPRI: number
-      POLLRDBAND: number
-      POLLRDHUP: number
-      POLLRDNORM: number
-      POLLWRBAND: number
-      POLLWRNORM: number
+  -- Socket options
+  SO_REUSEADDR: number
+  SO_REUSEPORT: number
+  SO_KEEPALIVE: number
+  SO_BROADCAST: number
+  SO_LINGER: number
+  SO_RCVBUF: number
+  SO_SNDBUF: number
+  SO_RCVTIMEO: number
+  SO_SNDTIMEO: number
+  SO_ERROR: number
+  SO_TYPE: number
+  SO_ACCEPTCONN: number
+  SO_DEBUG: number
+  SO_DONTROUTE: number
+  SO_RCVLOWAT: number
+  SO_SNDLOWAT: number
 
-      -- Message flags
-      MSG_PEEK: number
-      MSG_WAITALL: number
-      MSG_OOB: number
-      MSG_DONTROUTE: number
-      MSG_MORE: number
-      MSG_NOSIGNAL: number
-    end
+  -- TCP options
+  TCP_NODELAY: number
+  TCP_CORK: number
+  TCP_KEEPIDLE: number
+  TCP_KEEPINTVL: number
+  TCP_KEEPCNT: number
+  TCP_MAXSEG: number
+  TCP_SYNCNT: number
+  TCP_DEFER_ACCEPT: number
+  TCP_FASTOPEN: number
+  TCP_FASTOPEN_CONNECT: number
+  TCP_QUICKACK: number
+  TCP_NOTSENT_LOWAT: number
+  TCP_WINDOW_CLAMP: number
+  TCP_SAVE_SYN: number
+  TCP_SAVED_SYN: number
 
-    local M: NetModule = {
-      -- Socket creation
-      socket = socket,
-      socketpair = socketpair,
+  -- Shutdown modes
+  SHUT_RD: number
+  SHUT_WR: number
+  SHUT_RDWR: number
 
-      -- Unix domain socket helpers
-      listen_unix = listen_unix,
-      connect_unix = connect_unix,
+  -- Poll events
+  POLLIN: number
+  POLLOUT: number
+  POLLERR: number
+  POLLHUP: number
+  POLLNVAL: number
+  POLLPRI: number
+  POLLRDBAND: number
+  POLLRDHUP: number
+  POLLRDNORM: number
+  POLLWRBAND: number
+  POLLWRNORM: number
 
-      -- Polling
-      poll = poll,
+  -- Message flags
+  MSG_PEEK: number
+  MSG_WAITALL: number
+  MSG_OOB: number
+  MSG_DONTROUTE: number
+  MSG_MORE: number
+  MSG_NOSIGNAL: number
+end
 
-      -- Utility
-      gethostname = gethostname,
-      parseip = parseip,
-      formatip = formatip,
-      interfaces = interfaces,
+local M: NetModule = {
+  -- Socket creation
+  socket = socket,
+  socketpair = socketpair,
 
-      -- Address families
-      AF_INET = unix.AF_INET,
-      AF_UNIX = unix.AF_UNIX,
-      AF_UNSPEC = unix.AF_UNSPEC,
+  -- Unix domain socket helpers
+  listen_unix = listen_unix,
+  connect_unix = connect_unix,
 
-      -- Socket types
-      SOCK_STREAM = unix.SOCK_STREAM,
-      SOCK_DGRAM = unix.SOCK_DGRAM,
-      SOCK_RAW = unix.SOCK_RAW,
-      SOCK_RDM = unix.SOCK_RDM,
-      SOCK_SEQPACKET = unix.SOCK_SEQPACKET,
-      SOCK_CLOEXEC = unix.SOCK_CLOEXEC,
-      SOCK_NONBLOCK = unix.SOCK_NONBLOCK,
+  -- Polling
+  poll = poll,
 
-      -- Protocols
-      IPPROTO_TCP = unix.IPPROTO_TCP,
-      IPPROTO_UDP = unix.IPPROTO_UDP,
-      IPPROTO_IP = unix.IPPROTO_IP,
-      IPPROTO_ICMP = unix.IPPROTO_ICMP,
-      IPPROTO_RAW = unix.IPPROTO_RAW,
+  -- Utility
+  gethostname = gethostname,
+  parseip = parseip,
+  formatip = formatip,
+  interfaces = interfaces,
 
-      -- Socket levels
-      SOL_SOCKET = unix.SOL_SOCKET,
-      SOL_TCP = unix.SOL_TCP,
-      SOL_UDP = unix.SOL_UDP,
-      SOL_IP = unix.SOL_IP,
+  -- Address families
+  AF_INET = unix.AF_INET,
+  AF_UNIX = unix.AF_UNIX,
+  AF_UNSPEC = unix.AF_UNSPEC,
 
-      -- Socket options
-      SO_REUSEADDR = unix.SO_REUSEADDR,
-      SO_REUSEPORT = unix.SO_REUSEPORT,
-      SO_KEEPALIVE = unix.SO_KEEPALIVE,
-      SO_BROADCAST = unix.SO_BROADCAST,
-      SO_LINGER = unix.SO_LINGER,
-      SO_RCVBUF = unix.SO_RCVBUF,
-      SO_SNDBUF = unix.SO_SNDBUF,
-      SO_RCVTIMEO = unix.SO_RCVTIMEO,
-      SO_SNDTIMEO = unix.SO_SNDTIMEO,
-      SO_ERROR = unix.SO_ERROR,
-      SO_TYPE = unix.SO_TYPE,
-      SO_ACCEPTCONN = unix.SO_ACCEPTCONN,
-      SO_DEBUG = unix.SO_DEBUG,
-      SO_DONTROUTE = unix.SO_DONTROUTE,
-      SO_RCVLOWAT = unix.SO_RCVLOWAT,
-      SO_SNDLOWAT = unix.SO_SNDLOWAT,
+  -- Socket types
+  SOCK_STREAM = unix.SOCK_STREAM,
+  SOCK_DGRAM = unix.SOCK_DGRAM,
+  SOCK_RAW = unix.SOCK_RAW,
+  SOCK_RDM = unix.SOCK_RDM,
+  SOCK_SEQPACKET = unix.SOCK_SEQPACKET,
+  SOCK_CLOEXEC = unix.SOCK_CLOEXEC,
+  SOCK_NONBLOCK = unix.SOCK_NONBLOCK,
 
-      -- TCP options
-      TCP_NODELAY = unix.TCP_NODELAY,
-      TCP_CORK = unix.TCP_CORK,
-      TCP_KEEPIDLE = unix.TCP_KEEPIDLE,
-      TCP_KEEPINTVL = unix.TCP_KEEPINTVL,
-      TCP_KEEPCNT = unix.TCP_KEEPCNT,
-      TCP_MAXSEG = unix.TCP_MAXSEG,
-      TCP_SYNCNT = unix.TCP_SYNCNT,
-      TCP_DEFER_ACCEPT = unix.TCP_DEFER_ACCEPT,
-      TCP_FASTOPEN = unix.TCP_FASTOPEN,
-      TCP_FASTOPEN_CONNECT = unix.TCP_FASTOPEN_CONNECT,
-      TCP_QUICKACK = unix.TCP_QUICKACK,
-      TCP_NOTSENT_LOWAT = unix.TCP_NOTSENT_LOWAT,
-      TCP_WINDOW_CLAMP = unix.TCP_WINDOW_CLAMP,
-      TCP_SAVE_SYN = unix.TCP_SAVE_SYN,
-      TCP_SAVED_SYN = unix.TCP_SAVED_SYN,
+  -- Protocols
+  IPPROTO_TCP = unix.IPPROTO_TCP,
+  IPPROTO_UDP = unix.IPPROTO_UDP,
+  IPPROTO_IP = unix.IPPROTO_IP,
+  IPPROTO_ICMP = unix.IPPROTO_ICMP,
+  IPPROTO_RAW = unix.IPPROTO_RAW,
 
-      -- Shutdown modes
-      SHUT_RD = unix.SHUT_RD,
-      SHUT_WR = unix.SHUT_WR,
-      SHUT_RDWR = unix.SHUT_RDWR,
+  -- Socket levels
+  SOL_SOCKET = unix.SOL_SOCKET,
+  SOL_TCP = unix.SOL_TCP,
+  SOL_UDP = unix.SOL_UDP,
+  SOL_IP = unix.SOL_IP,
 
-      -- Poll events
-      POLLIN = unix.POLLIN,
-      POLLOUT = unix.POLLOUT,
-      POLLERR = unix.POLLERR,
-      POLLHUP = unix.POLLHUP,
-      POLLNVAL = unix.POLLNVAL,
-      POLLPRI = unix.POLLPRI,
-      POLLRDBAND = unix.POLLRDBAND,
-      POLLRDHUP = unix.POLLRDHUP,
-      POLLRDNORM = unix.POLLRDNORM,
-      POLLWRBAND = unix.POLLWRBAND,
-      POLLWRNORM = unix.POLLWRNORM,
+  -- Socket options
+  SO_REUSEADDR = unix.SO_REUSEADDR,
+  SO_REUSEPORT = unix.SO_REUSEPORT,
+  SO_KEEPALIVE = unix.SO_KEEPALIVE,
+  SO_BROADCAST = unix.SO_BROADCAST,
+  SO_LINGER = unix.SO_LINGER,
+  SO_RCVBUF = unix.SO_RCVBUF,
+  SO_SNDBUF = unix.SO_SNDBUF,
+  SO_RCVTIMEO = unix.SO_RCVTIMEO,
+  SO_SNDTIMEO = unix.SO_SNDTIMEO,
+  SO_ERROR = unix.SO_ERROR,
+  SO_TYPE = unix.SO_TYPE,
+  SO_ACCEPTCONN = unix.SO_ACCEPTCONN,
+  SO_DEBUG = unix.SO_DEBUG,
+  SO_DONTROUTE = unix.SO_DONTROUTE,
+  SO_RCVLOWAT = unix.SO_RCVLOWAT,
+  SO_SNDLOWAT = unix.SO_SNDLOWAT,
 
-      -- Message flags
-      MSG_PEEK = unix.MSG_PEEK,
-      MSG_WAITALL = unix.MSG_WAITALL,
-      MSG_OOB = unix.MSG_OOB,
-      MSG_DONTROUTE = unix.MSG_DONTROUTE,
-      MSG_MORE = unix.MSG_MORE,
-      MSG_NOSIGNAL = unix.MSG_NOSIGNAL,
-    }
+  -- TCP options
+  TCP_NODELAY = unix.TCP_NODELAY,
+  TCP_CORK = unix.TCP_CORK,
+  TCP_KEEPIDLE = unix.TCP_KEEPIDLE,
+  TCP_KEEPINTVL = unix.TCP_KEEPINTVL,
+  TCP_KEEPCNT = unix.TCP_KEEPCNT,
+  TCP_MAXSEG = unix.TCP_MAXSEG,
+  TCP_SYNCNT = unix.TCP_SYNCNT,
+  TCP_DEFER_ACCEPT = unix.TCP_DEFER_ACCEPT,
+  TCP_FASTOPEN = unix.TCP_FASTOPEN,
+  TCP_FASTOPEN_CONNECT = unix.TCP_FASTOPEN_CONNECT,
+  TCP_QUICKACK = unix.TCP_QUICKACK,
+  TCP_NOTSENT_LOWAT = unix.TCP_NOTSENT_LOWAT,
+  TCP_WINDOW_CLAMP = unix.TCP_WINDOW_CLAMP,
+  TCP_SAVE_SYN = unix.TCP_SAVE_SYN,
+  TCP_SAVED_SYN = unix.TCP_SAVED_SYN,
 
-    return M
+  -- Shutdown modes
+  SHUT_RD = unix.SHUT_RD,
+  SHUT_WR = unix.SHUT_WR,
+  SHUT_RDWR = unix.SHUT_RDWR,
+
+  -- Poll events
+  POLLIN = unix.POLLIN,
+  POLLOUT = unix.POLLOUT,
+  POLLERR = unix.POLLERR,
+  POLLHUP = unix.POLLHUP,
+  POLLNVAL = unix.POLLNVAL,
+  POLLPRI = unix.POLLPRI,
+  POLLRDBAND = unix.POLLRDBAND,
+  POLLRDHUP = unix.POLLRDHUP,
+  POLLRDNORM = unix.POLLRDNORM,
+  POLLWRBAND = unix.POLLWRBAND,
+  POLLWRNORM = unix.POLLWRNORM,
+
+  -- Message flags
+  MSG_PEEK = unix.MSG_PEEK,
+  MSG_WAITALL = unix.MSG_WAITALL,
+  MSG_OOB = unix.MSG_OOB,
+  MSG_DONTROUTE = unix.MSG_DONTROUTE,
+  MSG_MORE = unix.MSG_MORE,
+  MSG_NOSIGNAL = unix.MSG_NOSIGNAL,
+}
+
+return M

--- a/lib/cosmic/poll.tl
+++ b/lib/cosmic/poll.tl
@@ -72,142 +72,142 @@ local function get_fd(p: any): number
       return fd_val as number
     elseif type(fd_val) == "function" then
       return (fd_val as function(any): number)(p)
-      end
+    end
+  end
+  return nil
+end
+
+--- Make Events from raw revents bitmask.
+local function make_events(revents: number): Events
+  return {
+    readable = (revents & POLLIN) ~= 0,
+    writable = (revents & POLLOUT) ~= 0,
+    error = (revents & POLLERR) ~= 0,
+    hangup = (revents & POLLHUP) ~= 0,
+    invalid = (revents & POLLNVAL) ~= 0,
+    revents = revents,
+  }
+end
+
+--- Create a new poll set.
+--- @return Poller A new poll set
+--- Example:
+---   local p = poll.new()
+---   p:add(handle.stdout, poll.POLLIN)
+---   p:add(handle.stderr, poll.POLLIN)
+---   for fd, events in p:wait(30000) do
+---     if events.readable then
+---       -- read from fd
+---     end
+---   end
+local function new(): Poller
+  local fds: {number: number} = {}
+  local results: {number: number} = {}
+
+  local poller: Poller = {}
+
+  poller.add = function(self: Poller, p: any, events: number)
+    local fd = get_fd(p)
+    if fd then
+      fds[fd] = events
+    end
+  end
+
+  poller.remove = function(self: Poller, p: any)
+    local fd = get_fd(p)
+    if fd then
+      fds[fd] = nil
+      results[fd] = nil
+    end
+  end
+
+  poller.clear = function(self: Poller)
+    fds = {}
+    results = {}
+  end
+
+  poller.empty = function(self: Poller): boolean
+    return next(fds) == nil
+  end
+
+  poller.count = function(self: Poller): number
+    local n = 0
+    for _ in pairs(fds) do
+      n = n + 1
+    end
+    return n
+  end
+
+  poller.poll = function(self: Poller, timeoutms: number): number, string
+    results = unix.poll(fds, timeoutms or -1)
+    if not results then
+      return nil, "poll failed"
+    end
+    local ready = 0
+    for _ in pairs(results) do
+      ready = ready + 1
+    end
+    return ready
+  end
+
+  poller.events = function(self: Poller, fd: number): Events
+    local revents = results[fd]
+    if revents then
+      return make_events(revents)
     end
     return nil
   end
 
-  --- Make Events from raw revents bitmask.
-  local function make_events(revents: number): Events
-    return {
-      readable = (revents & POLLIN) ~= 0,
-      writable = (revents & POLLOUT) ~= 0,
-      error = (revents & POLLERR) ~= 0,
-      hangup = (revents & POLLHUP) ~= 0,
-      invalid = (revents & POLLNVAL) ~= 0,
-      revents = revents,
-    }
-  end
-
-  --- Create a new poll set.
-  --- @return Poller A new poll set
-  --- Example:
-  ---   local p = poll.new()
-  ---   p:add(handle.stdout, poll.POLLIN)
-  ---   p:add(handle.stderr, poll.POLLIN)
-  ---   for fd, events in p:wait(30000) do
-  ---     if events.readable then
-  ---       -- read from fd
-  ---     end
-  ---   end
-  local function new(): Poller
-    local fds: {number: number} = {}
-    local results: {number: number} = {}
-
-    local poller: Poller = {}
-
-    poller.add = function(self: Poller, p: any, events: number)
-      local fd = get_fd(p)
-      if fd then
-        fds[fd] = events
-      end
-    end
-
-    poller.remove = function(self: Poller, p: any)
-      local fd = get_fd(p)
-      if fd then
-        fds[fd] = nil
-        results[fd] = nil
-      end
-    end
-
-    poller.clear = function(self: Poller)
-      fds = {}
-      results = {}
-    end
-
-    poller.empty = function(self: Poller): boolean
-      return next(fds) == nil
-    end
-
-    poller.count = function(self: Poller): number
-      local n = 0
-      for _ in pairs(fds) do
-        n = n + 1
-      end
-      return n
-    end
-
-    poller.poll = function(self: Poller, timeoutms: number): number, string
-      results = unix.poll(fds, timeoutms or -1)
-      if not results then
-        return nil, "poll failed"
-      end
-      local ready = 0
-      for _ in pairs(results) do
-        ready = ready + 1
-      end
-      return ready
-    end
-
-    poller.events = function(self: Poller, fd: number): Events
-      local revents = results[fd]
-      if revents then
-        return make_events(revents)
-      end
-      return nil
-    end
-
-    poller.wait = function(self: Poller, timeoutms: number): function(): number, Events
-      local _, err = self:poll(timeoutms)
-      if err then
-        return function(): number, Events
-          return nil, nil
-        end
-      end
-      local iter_results = results
-      local k: number = nil
+  poller.wait = function(self: Poller, timeoutms: number): function(): number, Events
+    local _, err = self:poll(timeoutms)
+    if err then
       return function(): number, Events
-        local v: number
-        k, v = next(iter_results, k)
-        if k then
-          return k, make_events(v)
-        end
         return nil, nil
       end
     end
-
-    return poller
+    local iter_results = results
+    local k: number = nil
+    return function(): number, Events
+      local v: number
+      k, v = next(iter_results, k)
+      if k then
+        return k, make_events(v)
+      end
+      return nil, nil
+    end
   end
 
-  local record PollModule
-    new: function(): Poller
+  return poller
+end
 
-    --- Event mask for readable data.
-    POLLIN: number
-    --- Event mask for writable.
-    POLLOUT: number
-    --- Event mask for priority data (e.g., OOB on TCP).
-    POLLPRI: number
-    --- Event mask for error condition.
-    POLLERR: number
-    --- Event mask for hangup.
-    POLLHUP: number
-    --- Event mask for invalid fd.
-    POLLNVAL: number
-    --- Event mask for peer closed connection.
-    POLLRDHUP: number
-  end
+local record PollModule
+  new: function(): Poller
 
-  local M: PollModule = {
-    new = new,
-    POLLIN = POLLIN,
-    POLLOUT = POLLOUT,
-    POLLPRI = POLLPRI,
-    POLLERR = POLLERR,
-    POLLHUP = POLLHUP,
-    POLLNVAL = POLLNVAL,
-    POLLRDHUP = POLLRDHUP,
-  }
+  --- Event mask for readable data.
+  POLLIN: number
+  --- Event mask for writable.
+  POLLOUT: number
+  --- Event mask for priority data (e.g., OOB on TCP).
+  POLLPRI: number
+  --- Event mask for error condition.
+  POLLERR: number
+  --- Event mask for hangup.
+  POLLHUP: number
+  --- Event mask for invalid fd.
+  POLLNVAL: number
+  --- Event mask for peer closed connection.
+  POLLRDHUP: number
+end
 
-  return M
+local M: PollModule = {
+  new = new,
+  POLLIN = POLLIN,
+  POLLOUT = POLLOUT,
+  POLLPRI = POLLPRI,
+  POLLERR = POLLERR,
+  POLLHUP = POLLHUP,
+  POLLNVAL = POLLNVAL,
+  POLLRDHUP = POLLRDHUP,
+}
+
+return M

--- a/lib/cosmic/require.tl
+++ b/lib/cosmic/require.tl
@@ -197,26 +197,26 @@ end
 --- Call this early in startup to enable helpful error messages.
 local function install()
   _G.require = enhanced_require as function(string): any
-  end
+end
 
-  --- Restore original require.
-  --- Useful for testing or disabling enhanced errors.
-  local function uninstall()
-    _G.require = original_require
-  end
+--- Restore original require.
+--- Useful for testing or disabling enhanced errors.
+local function uninstall()
+  _G.require = original_require
+end
 
-  local record RequireModule
-    install: function()
-    uninstall: function()
-    module_exists: function(name: string): boolean
-    format_error: function(name: string): string
-  end
+local record RequireModule
+  install: function()
+  uninstall: function()
+  module_exists: function(name: string): boolean
+  format_error: function(name: string): string
+end
 
-  local M: RequireModule = {
-    install = install,
-    uninstall = uninstall,
-    module_exists = module_exists,
-    format_error = format_error,
-  }
+local M: RequireModule = {
+  install = install,
+  uninstall = uninstall,
+  module_exists = module_exists,
+  format_error = format_error,
+}
 
-  return M
+return M

--- a/lib/cosmic/signal.tl
+++ b/lib/cosmic/signal.tl
@@ -187,75 +187,75 @@ local M = {} as SignalModule
 
 -- Re-export functions that use Sigset directly from unix
 M.Sigset = unix.Sigset as function(...: number): Sigset
-  M.sigaction = unix.sigaction as function(sig: number, handler?: function | number, flags?: number, mask?: Sigset): (function | number, number, Sigset)
-      M.sigprocmask = unix.sigprocmask as function(how: number, set: Sigset): Sigset
-        M.sigsuspend = unix.sigsuspend as function(mask: Sigset): (boolean, Errno)
-          M.setitimer = unix.setitimer as function(which: number, intervalsec: number, intervalns: number, valuesec: number, valuens: number): (number, number, number, number)
+M.sigaction = unix.sigaction as function(sig: number, handler?: function | number, flags?: number, mask?: Sigset): (function | number, number, Sigset)
+M.sigprocmask = unix.sigprocmask as function(how: number, set: Sigset): Sigset
+M.sigsuspend = unix.sigsuspend as function(mask: Sigset): (boolean, Errno)
+M.setitimer = unix.setitimer as function(which: number, intervalsec: number, intervalns: number, valuesec: number, valuens: number): (number, number, number, number)
 
-            -- Delivery functions
-            M.kill = kill
-            M.killpg = killpg
-            M.raise = raise
+-- Delivery functions
+M.kill = kill
+M.killpg = killpg
+M.raise = raise
 
-            -- Utilities
-            M.strsignal = strsignal
+-- Utilities
+M.strsignal = strsignal
 
-            -- Signal constants
-            M.SIGABRT = unix.SIGABRT as number
-            M.SIGALRM = unix.SIGALRM as number
-            M.SIGBUS = unix.SIGBUS as number
-            M.SIGCHLD = unix.SIGCHLD as number
-            M.SIGCONT = unix.SIGCONT as number
-            M.SIGEMT = unix.SIGEMT as number
-            M.SIGFPE = unix.SIGFPE as number
-            M.SIGHUP = unix.SIGHUP as number
-            M.SIGILL = unix.SIGILL as number
-            M.SIGINFO = unix.SIGINFO as number
-            M.SIGINT = unix.SIGINT as number
-            M.SIGIO = unix.SIGIO as number
-            M.SIGKILL = unix.SIGKILL as number
-            M.SIGPIPE = unix.SIGPIPE as number
-            M.SIGPROF = unix.SIGPROF as number
-            M.SIGPWR = unix.SIGPWR as number
-            M.SIGQUIT = unix.SIGQUIT as number
-            M.SIGRTMAX = unix.SIGRTMAX as number
-            M.SIGRTMIN = unix.SIGRTMIN as number
-            M.SIGSEGV = unix.SIGSEGV as number
-            M.SIGSTKFLT = unix.SIGSTKFLT as number
-            M.SIGSTOP = unix.SIGSTOP as number
-            M.SIGSYS = unix.SIGSYS as number
-            M.SIGTERM = unix.SIGTERM as number
-            M.SIGTRAP = unix.SIGTRAP as number
-            M.SIGTSTP = unix.SIGTSTP as number
-            M.SIGTTIN = unix.SIGTTIN as number
-            M.SIGTTOU = unix.SIGTTOU as number
-            M.SIGURG = unix.SIGURG as number
-            M.SIGUSR1 = unix.SIGUSR1 as number
-            M.SIGUSR2 = unix.SIGUSR2 as number
-            M.SIGVTALRM = unix.SIGVTALRM as number
-            M.SIGWINCH = unix.SIGWINCH as number
-            M.SIGXCPU = unix.SIGXCPU as number
-            M.SIGXFSZ = unix.SIGXFSZ as number
+-- Signal constants
+M.SIGABRT = unix.SIGABRT as number
+M.SIGALRM = unix.SIGALRM as number
+M.SIGBUS = unix.SIGBUS as number
+M.SIGCHLD = unix.SIGCHLD as number
+M.SIGCONT = unix.SIGCONT as number
+M.SIGEMT = unix.SIGEMT as number
+M.SIGFPE = unix.SIGFPE as number
+M.SIGHUP = unix.SIGHUP as number
+M.SIGILL = unix.SIGILL as number
+M.SIGINFO = unix.SIGINFO as number
+M.SIGINT = unix.SIGINT as number
+M.SIGIO = unix.SIGIO as number
+M.SIGKILL = unix.SIGKILL as number
+M.SIGPIPE = unix.SIGPIPE as number
+M.SIGPROF = unix.SIGPROF as number
+M.SIGPWR = unix.SIGPWR as number
+M.SIGQUIT = unix.SIGQUIT as number
+M.SIGRTMAX = unix.SIGRTMAX as number
+M.SIGRTMIN = unix.SIGRTMIN as number
+M.SIGSEGV = unix.SIGSEGV as number
+M.SIGSTKFLT = unix.SIGSTKFLT as number
+M.SIGSTOP = unix.SIGSTOP as number
+M.SIGSYS = unix.SIGSYS as number
+M.SIGTERM = unix.SIGTERM as number
+M.SIGTRAP = unix.SIGTRAP as number
+M.SIGTSTP = unix.SIGTSTP as number
+M.SIGTTIN = unix.SIGTTIN as number
+M.SIGTTOU = unix.SIGTTOU as number
+M.SIGURG = unix.SIGURG as number
+M.SIGUSR1 = unix.SIGUSR1 as number
+M.SIGUSR2 = unix.SIGUSR2 as number
+M.SIGVTALRM = unix.SIGVTALRM as number
+M.SIGWINCH = unix.SIGWINCH as number
+M.SIGXCPU = unix.SIGXCPU as number
+M.SIGXFSZ = unix.SIGXFSZ as number
 
-            -- Signal mask operations
-            M.SIG_BLOCK = unix.SIG_BLOCK as number
-            M.SIG_UNBLOCK = unix.SIG_UNBLOCK as number
-            M.SIG_SETMASK = unix.SIG_SETMASK as number
+-- Signal mask operations
+M.SIG_BLOCK = unix.SIG_BLOCK as number
+M.SIG_UNBLOCK = unix.SIG_UNBLOCK as number
+M.SIG_SETMASK = unix.SIG_SETMASK as number
 
-            -- Default/ignore handlers
-            M.SIG_DFL = unix.SIG_DFL as number
-            M.SIG_IGN = unix.SIG_IGN as number
+-- Default/ignore handlers
+M.SIG_DFL = unix.SIG_DFL as number
+M.SIG_IGN = unix.SIG_IGN as number
 
-            -- sigaction flags
-            M.SA_NOCLDSTOP = unix.SA_NOCLDSTOP as number
-            M.SA_NOCLDWAIT = unix.SA_NOCLDWAIT as number
-            M.SA_NODEFER = unix.SA_NODEFER as number
-            M.SA_RESETHAND = unix.SA_RESETHAND as number
-            M.SA_RESTART = unix.SA_RESTART as number
+-- sigaction flags
+M.SA_NOCLDSTOP = unix.SA_NOCLDSTOP as number
+M.SA_NOCLDWAIT = unix.SA_NOCLDWAIT as number
+M.SA_NODEFER = unix.SA_NODEFER as number
+M.SA_RESETHAND = unix.SA_RESETHAND as number
+M.SA_RESTART = unix.SA_RESTART as number
 
-            -- Timer types
-            M.ITIMER_REAL = unix.ITIMER_REAL as number
-            M.ITIMER_VIRTUAL = unix.ITIMER_VIRTUAL as number
-            M.ITIMER_PROF = unix.ITIMER_PROF as number
+-- Timer types
+M.ITIMER_REAL = unix.ITIMER_REAL as number
+M.ITIMER_VIRTUAL = unix.ITIMER_VIRTUAL as number
+M.ITIMER_PROF = unix.ITIMER_PROF as number
 
-            return M
+return M


### PR DESCRIPTION
the backward scan in `is_function_block_opener` did not recognize `as` as a type-annotation context. when scanning backward from `function` in `print as function(string)`, it skipped past `as` and found `=`, incorrectly treating the function keyword as a block opener. this caused all subsequent lines to be indented and consumed the next `end` token.

adds `as` alongside `:` as a signal that the function keyword is in type position, not definition position.

three test cases cover:
- minimal repro (`local f = print as function(string)`)
- nested inside a function body (where it consumed the enclosing `end`)
- multi-return type cast (`as function(string): boolean, string`)

fixes #272