### PR TITLE
fix: correct environ() type and simplify spawn env handling

### DIFF
--- a/lib/cosmic/binary_test.tl
+++ b/lib/cosmic/binary_test.tl
@@ -11,10 +11,9 @@ local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
 -- this ensures we test the bundled libraries, not the repo
 local function clean_env(): {string}
   local env: {string} = {}
-  for key, val in pairs(unix.environ() as {string: string}) do
-    local line = key .. "=" .. val
-    if not line:match("^LUA_PATH=") and not line:match("^LUA_CPATH=") then
-      env[#env + 1] = line
+  for _, entry in ipairs(unix.environ()) do
+    if not entry:match("^LUA_PATH=") and not entry:match("^LUA_CPATH=") then
+      env[#env + 1] = entry
     end
   end
   return env

--- a/lib/cosmic/child.tl
+++ b/lib/cosmic/child.tl
@@ -251,24 +251,11 @@ local function spawn(argv: {string}, opts?: Opts): Handle, string
       end
     end
 
-    if opts.env then
-      if (argv[1] as string):find("/") then
-        unix.execve(argv[1], argv, opts.env)
-      else
-        unix.execvpe(argv[1], argv, opts.env)
-      end
+    local env = opts.env or unix.environ()
+    if (argv[1] as string):find("/") then
+      unix.execve(argv[1], argv, env)
     else
-      -- no explicit env: inherit the parent's environment.
-      -- environ() returns {string} ("KEY=VALUE" entries); copy to a
-      -- plain table to avoid any issues with the original's identity.
-      local src = unix.environ() as {string}
-      local env: {string} = {}
-      for i = 1, #src do env[i] = src[i] end
-      if (argv[1] as string):find("/") then
-        unix.execve(argv[1], argv, env)
-      else
-        unix.execvpe(argv[1], argv, env)
-      end
+      unix.execvpe(argv[1], argv, env)
     end
     os.exit(127)
   end

--- a/lib/cosmic/env.tl
+++ b/lib/cosmic/env.tl
@@ -2,7 +2,7 @@
 --- Provides get, set, unset, clear, and all functions for environment variables.
 --- For the common case of reading a single variable, use env.get() — it wraps
 --- os.getenv() internally and is the simplest approach. Use env.all() to get
---- all variables as a plain {string:string} table (unlike raw unix.environ()).
+--- all variables as a {string:string} map parsed from unix.environ().
 local unix = require("cosmo.unix")
 
 --- Get the value of an environment variable.
@@ -55,7 +55,15 @@ end
 --- Returns a table mapping variable names to their values.
 --- @return {string:string} A table of all environment variables
 local function all(): {string: string}
-  return unix.environ() as {string: string}
+  local entries = unix.environ()
+  local result: {string: string} = {}
+  for _, entry in ipairs(entries) do
+    local eq = entry:find("=", 1, true)
+    if eq then
+      result[entry:sub(1, eq - 1)] = entry:sub(eq + 1)
+    end
+  end
+  return result
 end
 
 local record EnvModule

--- a/lib/cosmic/env_test.tl
+++ b/lib/cosmic/env_test.tl
@@ -75,10 +75,11 @@ test_all()
 
 local function test_all_includes_set_variable()
   env.set("COSMIC_TEST_ALL_CHECK", "check_value")
-  -- Note: unix.environ() may not reflect recent setenv changes
-  -- This tests that all() returns a valid table structure
   local vars = env.all()
   assert(type(vars) == "table", "all() should return a table")
+  -- all() should parse KEY=VALUE entries into a proper map
+  assert(vars["COSMIC_TEST_ALL_CHECK"] == "check_value",
+    "expected 'check_value', got '" .. tostring(vars["COSMIC_TEST_ALL_CHECK"]) .. "'")
   env.unset("COSMIC_TEST_ALL_CHECK")
 end
 test_all_includes_set_variable()

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -806,8 +806,9 @@ local record unix
   --- function never returns.
   exit: function(exitcode?: number)
   --- Returns raw environment variables.
-  --- This allocates and constructs the C/C++ `environ` variable as a Lua
-  --- table consisting of string keys and string values.
+  --- Returns an integer-indexed array of "KEY=VALUE" strings, one per
+  --- environment variable.  The result can be passed directly to
+  --- execve(), execvpe(), spawn(), or child.spawn()'s env option.
   --- This data structure preserves casing. On Windows NT, by convention,
   --- environment variable keys are treated in a case-insensitive way. It
   --- is the responsibility of the caller to consider this.
@@ -818,7 +819,7 @@ local record unix
   --- there's some irregular uses of environment variables such as how the
   --- command prompt inserts multiple environment variables with empty
   --- string as keys, for its internal bookkeeping.
-  environ: function(): {string: string | nil}
+  environ: function(): {string}
   --- Sets environment variable.
   --- This wraps the C `setenv()` function to allow Lua scripts to set
   --- environment variables.


### PR DESCRIPTION
fixes #263

`unix.environ()` returns `{string}` (integer-indexed `KEY=VALUE` entries), not `{string: string | nil}` as the type definition claimed. this type mismatch was the root cause of the spawn env confusion that necessitated the workaround in whilp/working#7 — callers had to cast with `as {string}` and code that iterated the result as a map produced mangled `1=KEY=VALUE` garbage.

## changes

- **unix.d.tl**: fix `environ()` return type from `{string: string | nil}` to `{string}`
- **child.tl**: simplify spawn env handling — `opts.env or unix.environ()` replaces the duplicated branch + manual copy
- **binary_test.tl**: fix `clean_env()` to iterate `environ()` as an array with `ipairs` instead of `pairs` with key/val reassembly
- **env.tl**: `all()` now actually parses `KEY=VALUE` strings into a proper `{string:string}` map instead of casting the raw array
- **env_test.tl**: verify `all()` returns correct key-value pairs

## validation

- `make teal`: 112 passed
- `make format`: 112 passed
- `make test only=child`: passed
- `make test only=env`: passed
- `make test only=binary`: passed