### PR TITLE
fix: child.spawn accepts map-format env from env.all()

### DIFF
--- a/lib/cosmic/child.tl
+++ b/lib/cosmic/child.tl
@@ -42,6 +42,9 @@ local record Handle
 end
 
 --- Options for spawning a process.
+--- env accepts either a list of "KEY=VALUE" strings ({string}) or a map
+--- of name-to-value pairs ({string:string}). Maps are converted to list
+--- format before passing to execve.
 local record Opts
   stdin: string | number
   stdout: number
@@ -165,6 +168,23 @@ local function WTERMSIG(wstatus: number): number
   return unix.WTERMSIG(wstatus)
 end
 
+--- Normalize an env table to a list of "KEY=VALUE" strings.
+--- Accepts either {string} (already a list) or {string:string} (map).
+--- @param env {string} The environment table (list or map)
+--- @return {string} A list of "KEY=VALUE" strings
+local function normalize_env(env: {string}): {string}
+  -- if the first element is a string, assume it's already a list
+  if env[1] ~= nil then
+    return env
+  end
+  -- otherwise, treat as a map and convert to list
+  local list: {string} = {}
+  for k, v in pairs(env as {string: string}) do
+    table.insert(list, k .. "=" .. v)
+  end
+  return list
+end
+
 -- High-level spawn API --
 
 --- Spawns a child process with I/O control.
@@ -251,7 +271,7 @@ local function spawn(argv: {string}, opts?: Opts): Handle, string
       end
     end
 
-    local env = opts.env or unix.environ()
+    local env = opts.env and normalize_env(opts.env) or unix.environ()
     if (argv[1] as string):find("/") then
       unix.execve(argv[1], argv, env)
     else

--- a/lib/cosmic/child_test.tl
+++ b/lib/cosmic/child_test.tl
@@ -212,6 +212,38 @@ local function test_spawn_inherits_env()
 end
 test_spawn_inherits_env()
 
+local function test_spawn_with_env_map()
+  -- child.spawn should accept {string:string} map from env.all()
+  local env = require("cosmic.env")
+  local sentinel = "cosmic_test_map_" .. tostring(unix.getpid())
+  unix.setenv("COSMIC_TEST_MAP", sentinel)
+  local vars = env.all()
+  local handle = child.spawn({lua_bin, "-e", [[
+    io.write(os.getenv("COSMIC_TEST_MAP") or "")
+  ]]}, {env = vars as {string}})
+  assert(handle ~= nil, "handle should not be nil")
+  local ok, out, code = handle:read()
+  assert(ok, "child should exit 0, got code " .. tostring(code))
+  assert(out == sentinel, "expected '" .. sentinel .. "', got '" .. tostring(out) .. "'")
+end
+test_spawn_with_env_map()
+
+local function test_spawn_with_env_list()
+  -- child.spawn should still accept {string} list format
+  local env_mod = require("cosmic.env")
+  local sentinel = "cosmic_test_list_" .. tostring(unix.getpid())
+  unix.setenv("COSMIC_TEST_LIST", sentinel)
+  local vars = env_mod.list()
+  local handle = child.spawn({lua_bin, "-e", [[
+    io.write(os.getenv("COSMIC_TEST_LIST") or "")
+  ]]}, {env = vars})
+  assert(handle ~= nil, "handle should not be nil")
+  local ok, out, code = handle:read()
+  assert(ok, "child should exit 0, got code " .. tostring(code))
+  assert(out == sentinel, "expected '" .. sentinel .. "', got '" .. tostring(out) .. "'")
+end
+test_spawn_with_env_list()
+
 -- Constants tests --
 
 local function test_signal_constants_defined()

--- a/lib/cosmic/env.tl
+++ b/lib/cosmic/env.tl
@@ -66,12 +66,26 @@ local function all(): {string: string}
   return result
 end
 
+--- Get all environment variables as a list.
+--- Returns a list of "KEY=VALUE" strings suitable for passing to
+--- child.spawn or execve.
+--- @return {string} A list of "KEY=VALUE" strings
+local function list(): {string}
+  local entries = unix.environ()
+  local result: {string} = {}
+  for _, entry in ipairs(entries) do
+    table.insert(result, entry)
+  end
+  return result
+end
+
 local record EnvModule
   get: function(name: string): string
   set: function(name: string, value: string, overwrite?: boolean): boolean, string
   unset: function(name: string): boolean, string
   clear: function(): boolean, string
   all: function(): {string: string}
+  list: function(): {string}
 end
 
 local M: EnvModule = {
@@ -80,6 +94,7 @@ local M: EnvModule = {
   unset = unset,
   clear = clear,
   all = all,
+  list = list,
 }
 
 return M

--- a/lib/cosmic/env_test.tl
+++ b/lib/cosmic/env_test.tl
@@ -84,6 +84,33 @@ local function test_all_includes_set_variable()
 end
 test_all_includes_set_variable()
 
+local function test_list()
+  local entries = env.list()
+  assert(type(entries) == "table", "list() should return a table")
+  assert(#entries > 0, "list() should return non-empty list")
+  -- verify entries are "KEY=VALUE" strings
+  for _, entry in ipairs(entries) do
+    assert(type(entry) == "string", "list entry should be a string")
+    assert(entry:find("=", 1, true), "list entry should contain '=': " .. entry)
+  end
+end
+test_list()
+
+local function test_list_includes_set_variable()
+  env.set("COSMIC_TEST_LIST_CHECK", "list_value")
+  local entries = env.list()
+  local found = false
+  for _, entry in ipairs(entries) do
+    if entry == "COSMIC_TEST_LIST_CHECK=list_value" then
+      found = true
+      break
+    end
+  end
+  assert(found, "list() should include COSMIC_TEST_LIST_CHECK=list_value")
+  env.unset("COSMIC_TEST_LIST_CHECK")
+end
+test_list_includes_set_variable()
+
 local function test_set_empty_value()
   local ok = env.set("COSMIC_TEST_EMPTY", "")
   assert(ok, "set with empty value should succeed")


### PR DESCRIPTION
## summary

fixes #279.

`env.all()` returns `{string: string}` (map) but `child.spawn` passes `opts.env` directly to `execve`/`execvpe`, which expect `{string}` (list of `KEY=VALUE` entries). passing `env.all()` to spawn produced garbage or an empty environment.

## changes

- **lib/cosmic/child.tl**: add `normalize_env()` helper that detects map-format env tables (no integer key `[1]`) and converts them to `KEY=VALUE` list format. list-format env passes through unchanged. updated `Opts` doc comment to document both accepted formats.
- **lib/cosmic/env.tl**: add `env.list()` returning `{string}` list format directly, for callers wanting the execve-native format without conversion.
- **lib/cosmic/child_test.tl**: add `test_spawn_with_env_map` (passes `env.all()` map to spawn) and `test_spawn_with_env_list` (passes `env.list()` to spawn).
- **lib/cosmic/env_test.tl**: add `test_list` and `test_list_includes_set_variable` for the new `env.list()` function.

## validation

- all 55 tests pass
- all 112 type checks pass
- all 112 format checks pass