### PR TITLE
envd: add ${VAR} variable expansion in dotenv values

### DIFF
--- a/lib/cosmic/envd.tl
+++ b/lib/cosmic/envd.tl
@@ -20,6 +20,14 @@
 --- starting with # are ignored. Values are taken as-is after the first =
 --- (no trimming, no quote stripping).
 ---
+--- Variable expansion is supported in values using ${VAR} syntax:
+---   ${VAR}            expands to the value of VAR
+---   ${VAR:-default}   expands to default if VAR is unset or empty
+---   ${VAR-default}    expands to default if VAR is unset
+--- Variables defined earlier in the same file or in earlier files (lexical
+--- order) are available for expansion, as are existing environment variables.
+--- Undefined variables with no default expand to empty string.
+---
 --- Set COSMIC_DEBUG=1 to see which vars are loaded and which are skipped.
 local fs = require("cosmic.fs")
 local cio = require("cosmic.io")
@@ -33,19 +41,66 @@ local record LoadResult
   source: string
 end
 
+--- Expand ${VAR}, ${VAR:-default}, and ${VAR-default} references in a
+--- string. Looks up variables in ctx first, then falls back to the
+--- process environment. Undefined variables with no default expand to
+--- empty string.
+--- @param value string The string to expand
+--- @param ctx {string: string} Context of previously defined variables
+--- @return string The expanded string
+local function expand(value: string, ctx: {string: string}): string
+  return (value:gsub("%${([^}]+)}", function(expr: string): string
+        -- ${VAR:-default} — use default if unset or empty
+        local name, default = expr:match("^([A-Za-z_][A-Za-z0-9_]*):%-(.*)")
+        if name then
+          local v = ctx[name] or env.get(name)
+          if v and v ~= "" then
+            return v
+          end
+          return default
+        end
+        -- ${VAR-default} — use default if unset (empty is ok)
+        name, default = expr:match("^([A-Za-z_][A-Za-z0-9_]*)%-(.*)")
+        if name then
+          local v = ctx[name] or env.get(name)
+          if v ~= nil then
+            return v
+          end
+          return default
+        end
+        -- ${VAR} — plain expansion
+        name = expr:match("^([A-Za-z_][A-Za-z0-9_]*)$")
+        if name then
+          return ctx[name] or env.get(name) or ""
+        end
+        -- malformed expression — leave as-is
+        return "${" .. expr .. "}"
+      end))
+end
+
 --- Parse a single dotenv-format string. Returns a map of KEY=VALUE pairs.
 --- Lines starting with # are comments. Blank lines are skipped.
 --- Keys must match [A-Za-z_][A-Za-z0-9_]*.
+--- Values undergo ${VAR} expansion using ctx as the lookup context.
 --- @param content string The dotenv content to parse
+--- @param ctx? {string: string} Context for variable expansion (default: {})
 --- @return {string: string} Parsed key-value pairs
-local function parse(content: string): {string: string}
+local function parse(content: string, ctx: {string: string}): {string: string}
   local vars: {string: string} = {}
+  local lookup: {string: string} = {}
+  if ctx then
+    for k, v in pairs(ctx) do
+      lookup[k] = v
+    end
+  end
   for line in content:gmatch("[^\n]+") do
     -- skip comments and blank lines
     if not line:match("^%s*#") and not line:match("^%s*$") then
       local key, value = line:match("^([A-Za-z_][A-Za-z0-9_]*)=(.*)")
       if key then
-        vars[key] = value
+        local expanded = expand(value, lookup)
+        vars[key] = expanded
+        lookup[key] = expanded
       end
     end
   end
@@ -91,7 +146,7 @@ local function load_dir(dir: string): LoadResult
     local path = fs.join(dir, name)
     local content = cio.slurp(path)
     if content then
-      local vars = parse(content)
+      local vars = parse(content, merged)
       for key, value in pairs(vars) do
         merged[key] = value
         sources[key] = name
@@ -140,13 +195,15 @@ end
 local record EnvdModule
   load: function(): LoadResult
   load_dir: function(dir: string): LoadResult
-  parse: function(content: string): {string: string}
+  parse: function(content: string, ctx?: {string: string}): {string: string}
+  expand: function(value: string, ctx: {string: string}): string
 end
 
 local M: EnvdModule = {
   load = load,
   load_dir = load_dir,
   parse = parse,
+  expand = expand,
 }
 
 return M

--- a/lib/cosmic/envd_example.tl
+++ b/lib/cosmic/envd_example.tl
@@ -80,4 +80,27 @@ print("MY_SECRET_TOKEN is " .. (env.get("MY_SECRET_TOKEN") and "set" or "unset")
   -- MY_SECRET_TOKEN is set
 end
 
+-- Example_variable_expansion shows ${VAR} expansion in dotenv values.
+-- Variables defined earlier in the same file or from an external context
+-- are available for expansion. Supports ${VAR:-default} and ${VAR-default}.
+local function Example_variable_expansion()
+  local envd = require("cosmic.envd")
+
+  -- basic expansion: later values can reference earlier ones
+  local vars = envd.parse("HOST=localhost\nPORT=8080\nURL=http://${HOST}:${PORT}\n")
+  print("URL=" .. vars["URL"])
+
+  -- ${VAR:-default} uses fallback when unset or empty
+  vars = envd.parse("TIMEOUT=${MISSING:-30}\n")
+  print("TIMEOUT=" .. vars["TIMEOUT"])
+
+  -- ${VAR-default} uses fallback only when unset (empty is kept)
+  vars = envd.parse("EMPTY=\nKEEP=${EMPTY-fallback}\n")
+  print("KEEP=" .. vars["KEEP"])
+  -- Output:
+  -- URL=http://localhost:8080
+  -- TIMEOUT=30
+  -- KEEP=
+end
+
 return {}

--- a/lib/cosmic/envd_test.tl
+++ b/lib/cosmic/envd_test.tl
@@ -202,3 +202,120 @@ local function test_underscore_prefix_key()
   env.unset("_COSMIC_ENVD_TEST_UNDER")
 end
 test_underscore_prefix_key()
+
+-- variable expansion tests
+
+local function test_expand_plain_var()
+  local vars = envd.parse("BASE=/opt\nPATH_VAR=${BASE}/bin\n")
+  assert(vars["BASE"] == "/opt", "expected '/opt', got '" .. tostring(vars["BASE"]) .. "'")
+  assert(vars["PATH_VAR"] == "/opt/bin", "expected '/opt/bin', got '" .. tostring(vars["PATH_VAR"]) .. "'")
+end
+test_expand_plain_var()
+
+local function test_expand_undefined_var()
+  env.unset("COSMIC_ENVD_TEST_UNDEF")
+  local vars = envd.parse("VAL=${COSMIC_ENVD_TEST_UNDEF}rest\n")
+  assert(vars["VAL"] == "rest", "undefined should expand to empty, got '" .. tostring(vars["VAL"]) .. "'")
+end
+test_expand_undefined_var()
+
+local function test_expand_from_env()
+  env.set("COSMIC_ENVD_TEST_FROMENV", "envval")
+  local vars = envd.parse("VAL=${COSMIC_ENVD_TEST_FROMENV}\n")
+  assert(vars["VAL"] == "envval", "expected 'envval', got '" .. tostring(vars["VAL"]) .. "'")
+  env.unset("COSMIC_ENVD_TEST_FROMENV")
+end
+test_expand_from_env()
+
+local function test_expand_default_unset()
+  env.unset("COSMIC_ENVD_TEST_NOSUCH")
+  local vars = envd.parse("VAL=${COSMIC_ENVD_TEST_NOSUCH:-fallback}\n")
+  assert(vars["VAL"] == "fallback", "expected 'fallback', got '" .. tostring(vars["VAL"]) .. "'")
+end
+test_expand_default_unset()
+
+local function test_expand_default_empty()
+  local vars = envd.parse("EMPTY=\nVAL=${EMPTY:-fallback}\n")
+  assert(vars["VAL"] == "fallback", ":-default should trigger on empty, got '" .. tostring(vars["VAL"]) .. "'")
+end
+test_expand_default_empty()
+
+local function test_expand_default_set()
+  local vars = envd.parse("BASE=real\nVAL=${BASE:-fallback}\n")
+  assert(vars["VAL"] == "real", ":-default should not trigger when set, got '" .. tostring(vars["VAL"]) .. "'")
+end
+test_expand_default_set()
+
+local function test_expand_dash_default_unset()
+  env.unset("COSMIC_ENVD_TEST_NOSUCH2")
+  local vars = envd.parse("VAL=${COSMIC_ENVD_TEST_NOSUCH2-fallback}\n")
+  assert(vars["VAL"] == "fallback", "expected 'fallback', got '" .. tostring(vars["VAL"]) .. "'")
+end
+test_expand_dash_default_unset()
+
+local function test_expand_dash_default_empty()
+  local vars = envd.parse("EMPTY=\nVAL=${EMPTY-fallback}\n")
+  assert(vars["VAL"] == "", "-default should NOT trigger on empty, got '" .. tostring(vars["VAL"]) .. "'")
+end
+test_expand_dash_default_empty()
+
+local function test_expand_multiple_refs()
+  local vars = envd.parse("HOST=localhost\nPORT=8080\nURL=http://${HOST}:${PORT}/api\n")
+  assert(vars["URL"] == "http://localhost:8080/api",
+    "expected 'http://localhost:8080/api', got '" .. tostring(vars["URL"]) .. "'")
+end
+test_expand_multiple_refs()
+
+local function test_expand_with_ctx()
+  local ctx: {string: string} = {PRIOR = "fromctx"}
+  local vars = envd.parse("VAL=${PRIOR}/more\n", ctx)
+  assert(vars["VAL"] == "fromctx/more", "expected 'fromctx/more', got '" .. tostring(vars["VAL"]) .. "'")
+end
+test_expand_with_ctx()
+
+local function test_expand_across_files()
+  local dir = make_envd("expand_across")
+  cio.barf(fs.join(dir, "01-base"), "COSMIC_ENVD_TEST_BASE=/opt\n")
+  cio.barf(fs.join(dir, "02-derived"), "COSMIC_ENVD_TEST_DERIVED=${COSMIC_ENVD_TEST_BASE}/bin\n")
+
+  env.unset("COSMIC_ENVD_TEST_BASE")
+  env.unset("COSMIC_ENVD_TEST_DERIVED")
+
+  local result = envd.load_dir(dir)
+  assert(result.count == 2, "expected 2, got " .. tostring(result.count))
+  assert(env.get("COSMIC_ENVD_TEST_BASE") == "/opt")
+  assert(env.get("COSMIC_ENVD_TEST_DERIVED") == "/opt/bin",
+    "expected '/opt/bin', got '" .. tostring(env.get("COSMIC_ENVD_TEST_DERIVED")) .. "'")
+
+  env.unset("COSMIC_ENVD_TEST_BASE")
+  env.unset("COSMIC_ENVD_TEST_DERIVED")
+end
+test_expand_across_files()
+
+local function test_expand_no_expansion_without_braces()
+  local vars = envd.parse("BASE=val\nVAL=$BASE/rest\n")
+  assert(vars["VAL"] == "$BASE/rest",
+    "$VAR without braces should not expand, got '" .. tostring(vars["VAL"]) .. "'")
+end
+test_expand_no_expansion_without_braces()
+
+local function test_expand_malformed_expr()
+  local vars = envd.parse("VAL=${123BAD}\n")
+  assert(vars["VAL"] == "${123BAD}",
+    "malformed should be left as-is, got '" .. tostring(vars["VAL"]) .. "'")
+end
+test_expand_malformed_expr()
+
+local function test_expand_nested_default()
+  local vars = envd.parse("VAL=${NOSUCH:-a=b}\n")
+  assert(vars["VAL"] == "a=b",
+    "default can contain =, got '" .. tostring(vars["VAL"]) .. "'")
+end
+test_expand_nested_default()
+
+local function test_expand_function_directly()
+  local ctx: {string: string} = {FOO = "bar"}
+  local result = envd.expand("hello ${FOO} world", ctx)
+  assert(result == "hello bar world", "expected 'hello bar world', got '" .. result .. "'")
+end
+test_expand_function_directly()


### PR DESCRIPTION
adds `${VAR}` variable expansion to `cosmic.envd` dotenv parsing, following the dotenv standard.

## supported syntax

- `${VAR}` — expands to the value of VAR (empty string if undefined)
- `${VAR:-default}` — expands to default if VAR is unset or empty
- `${VAR-default}` — expands to default if VAR is unset (empty is kept)

## lookup order

1. variables defined earlier in the same file
2. variables from earlier files (lexical order) via the `ctx` parameter
3. process environment variables (`env.get`)

## changes

- **`lib/cosmic/envd.tl`** — new `expand()` function, updated `parse()` to accept optional context and expand values, updated `load_dir()` to pass accumulated context across files, exported `expand` on module record, updated module docs
- **`lib/cosmic/envd_test.tl`** — 15 new tests: plain expansion, undefined vars, env fallback, `:-default` (unset/empty/set), `-default` (unset/empty), multiple refs, context passing, cross-file expansion, bare `$VAR` non-expansion, malformed expressions, default with `=`, direct `expand()` call
- **`lib/cosmic/envd_example.tl`** — new `Example_variable_expansion` demonstrating all three forms

## validation

```
✓ PASS   format   lib/cosmic/envd.tl
✓ PASS   format   lib/cosmic/envd_example.tl
✓ PASS   format   lib/cosmic/envd_test.tl
✓ PASS   teal     lib/cosmic/envd.tl
✓ PASS   teal     lib/cosmic/envd_example.tl
✓ PASS   teal     lib/cosmic/envd_test.tl
✓ PASS   test     lib/cosmic/envd_test.tl
✓ PASS   example  lib/cosmic/envd_example.tl
```