### PR TITLE
build: stabilize timestamps with write-if-changed pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ $(o)/%: %
 # compile .tl files to .lua (extension changes)
 $(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files)
 	@mkdir -p $(@D)
-	@$(bootstrap_cosmic) --compile $< > $@
+	@$(bootstrap_cosmic) --compile $< > $@.tmp
+	@if cmp -s $@.tmp $@ 2>/dev/null; then rm $@.tmp; else mv $@.tmp $@; fi
 
 # tl files: modules declare _tl, derive compiled .lua outputs
 all_tl := $(call filter-only,$(foreach x,$(modules),$($(x)_tl)))
@@ -302,7 +303,8 @@ doc_index_script := lib/cosmic/docindex.tl
 
 $(doc_index): $(doc_index_srcs) $(doc_index_script) | $(bootstrap_cosmic)
 	@mkdir -p $(@D)
-	@$(bootstrap_cosmic) $(doc_index_script) $(doc_index_srcs) > $@
+	@$(bootstrap_cosmic) $(doc_index_script) $(doc_index_srcs) > $@.tmp
+	@if cmp -s $@.tmp $@ 2>/dev/null; then rm $@.tmp; else mv $@.tmp $@; fi
 
 .PHONY: doc-index
 ## Generate serialized documentation index

--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -17,7 +17,8 @@ cosmic_version_lua := $(o)/cosmic/version.lua
 
 $(cosmic_version_lua): .FORCE | $$(cosmos_staged)
 	@mkdir -p $(@D)
-	@echo "return { cosmic = \"$$(git describe --tags --always --dirty 2>/dev/null || echo unknown)\", cosmos = \"$$($(cosmos_lua_bin) -e "print(dofile('3p/cosmos/version.lua').version)")\" }" > $@
+	@echo "return { cosmic = \"$$(git describe --tags --always --dirty 2>/dev/null || echo unknown)\", cosmos = \"$$($(cosmos_lua_bin) -e "print(dofile('3p/cosmos/version.lua').version)")\" }" > $@.tmp
+	@if cmp -s $@.tmp $@ 2>/dev/null; then rm $@.tmp; else mv $@.tmp $@; fi
 
 .PHONY: .FORCE
 


### PR DESCRIPTION
## Problem

Every `make ci` invocation triggers a full rebuild of all ~600 check targets (137 format + 137 teal + tests + examples + lint), even when no source files changed.

The root cause is a dependency cascade:

```
.FORCE → version.lua (always rewrites)
  → cosmic_bin (always rebuilds)
    → ALL .format.got, .teal.got, .test.got (all rebuild)
```

`version.lua` uses `.FORCE` so it always regenerates. Even when content is identical (`git describe` output hasn't changed), the file gets a new timestamp, which makes `cosmic_bin` stale, which makes every check target stale.

This makes `make ci` take ~4 minutes on a 2-core machine even on a second run with zero changes.

## Fix

Apply the standard write-if-changed pattern (`> $@.tmp && cmp -s || mv`) to three build outputs:

1. **`.tl` → `.lua` compilation** — most `.lua` files don't change when an unrelated `.tl` file is edited. Prevents cascade through `cosmic_bin`.
2. **`version.lua`** — content only changes on new commits, not every build.
3. **`doc_index`** — content only changes when doc comments change.

## Effect

| scenario | before | after |
|---|---|---|
| second `make ci`, no changes | ~4 min (full rebuild) | ~0.1s |
| second `make ci`, one `.tl` edited | ~4 min (full rebuild) | ~4 min if cosmic_bin content changes, fast if only unrelated files |
| cold build | ~4 min | ~4 min (no change) |

## Context

Discovered while debugging timeout failures in the [working](https://github.com/whilp/working) repo's automated work loop. The check phase runs `make ci` inside an agent session with a 180s timeout. Cosmic's `make ci` always does a full rebuild, exceeding the timeout.