### PR TITLE
build: run CI stages in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,7 @@ ci:
 		echo "::group::$$s"; \
 		if [ -f $(o)/$$s-summary.txt ]; then \
 			cat $(o)/$$s-summary.txt; \
-			if grep -q "failed" $(o)/$$s-summary.txt; then \
+			if grep -qE "[1-9][0-9]* failed" $(o)/$$s-summary.txt; then \
 				echo $$s >> $(o)/failed; \
 			fi; \
 		else \


### PR DESCRIPTION
Run CI stages (format, teal, test, example, lint) in parallel via a single Make invocation instead of sequential submake calls. With `-j`, independent stages like format, teal, and lint overlap with test.

Summary output with `::group::` markers is preserved by reporting after all stages complete.