### PR TITLE
Add ISO 8601 timestamp support and timegm function

### DIFF
--- a/lib/cosmic/time.tl
+++ b/lib/cosmic/time.tl
@@ -134,6 +134,77 @@ local function parse_http(str: string): number
   return cosmo.ParseHttpDateTime(str)
 end
 
+--- Return true if year is a leap year.
+local function is_leap_year(year: number): boolean
+  return year % 4 == 0 and (year % 100 ~= 0 or year % 400 == 0)
+end
+
+--- Days in each month for a non-leap year.
+local MONTH_DAYS: {integer} = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
+
+--- Convert UTC broken-down time to UNIX epoch seconds.
+--- @param year number Full year (e.g., 2025)
+--- @param month number Month (1-12)
+--- @param day number Day of month (1-31)
+--- @param hour number Hour (0-23)
+--- @param min number Minute (0-59)
+--- @param sec number Second (0-59)
+--- @return number UNIX epoch seconds
+local function timegm(year: number, month: number, day: number,
+    hour: number, min: number, sec: number): number
+  local days: number = 0
+  -- count days for complete years since 1970
+  for y = 1970, year - 1 do
+    days = days + (is_leap_year(y) and 366 or 365)
+  end
+  -- count days for complete months in the target year
+  for m = 1, month - 1 do
+    days = days + MONTH_DAYS[m as integer]
+    if m == 2 and is_leap_year(year) then
+      days = days + 1
+    end
+  end
+  days = days + day - 1
+  return days * 86400 + hour * 3600 + min * 60 + sec
+end
+
+--- Format a UNIX timestamp as an ISO 8601 string in UTC.
+--- @param timestamp number UNIX timestamp (seconds since epoch)
+--- @return string ISO 8601 string (e.g., "2025-01-01T00:00:00Z")
+local function format_iso8601(timestamp: number): string
+  local dt = gmtime(timestamp)
+  return string.format("%.4d-%.2d-%.2dT%.2d:%.2d:%.2dZ",
+    dt.year as integer, dt.month as integer, dt.day as integer,
+    dt.hour as integer, dt.min as integer, dt.sec as integer)
+end
+
+--- Parse an ISO 8601 timestamp string into a UNIX epoch seconds value.
+--- Accepts "Z" suffix, "+HH:MM"/"-HH:MM" offsets, or no suffix (treated as UTC).
+--- Returns 0 for invalid input.
+--- @param str string ISO 8601 string (e.g., "2025-01-01T00:00:00Z")
+--- @return number UNIX timestamp, or 0 if parsing failed
+local function parse_iso8601(str: string): number
+  local y, mo, d, h, mi, s, tz = str:match(
+    "^(%d%d%d%d)-(%d%d)-(%d%d)T(%d%d):(%d%d):(%d%d)(.*)")
+  if not y then return 0 end
+  local epoch = timegm(
+    tonumber(y) as number, tonumber(mo) as number, tonumber(d) as number,
+    tonumber(h) as number, tonumber(mi) as number, tonumber(s) as number)
+  -- parse timezone offset
+  if tz == "Z" or tz == "z" or tz == "" then
+    return epoch
+  end
+  local sign, oh, om = tz:match("^([%+%-])(%d%d):(%d%d)$")
+  if not sign then return 0 end
+  local offset = (tonumber(oh) as number) * 3600 + (tonumber(om) as number) * 60
+  if sign == "+" then
+    epoch = epoch - offset
+  else
+    epoch = epoch + offset
+  end
+  return epoch
+end
+
 local record TimeModule
   -- Clock constants
   CLOCK_REALTIME: number
@@ -155,6 +226,9 @@ local record TimeModule
   localtime: function(unixts: number): DateTime
   format_http: function(timestamp: number): string
   parse_http: function(str: string): number
+  format_iso8601: function(timestamp: number): string
+  parse_iso8601: function(str: string): number
+  timegm: function(year: number, month: number, day: number, hour: number, min: number, sec: number): number
 end
 
 local M: TimeModule = {
@@ -178,6 +252,9 @@ local M: TimeModule = {
   localtime = localtime,
   format_http = format_http,
   parse_http = parse_http,
+  format_iso8601 = format_iso8601,
+  parse_iso8601 = parse_iso8601,
+  timegm = timegm,
 }
 
 return M

--- a/lib/cosmic/time_test.tl
+++ b/lib/cosmic/time_test.tl
@@ -216,3 +216,127 @@ local function test_format_parse_roundtrip()
   assert(parsed == original, "roundtrip failed: " .. tostring(original) .. " -> " .. formatted .. " -> " .. tostring(parsed))
 end
 test_format_parse_roundtrip()
+
+-- timegm tests
+
+local function test_timegm_epoch()
+  local ts = time.timegm(1970, 1, 1, 0, 0, 0)
+  assert(ts == 0, "expected 0, got " .. tostring(ts))
+end
+test_timegm_epoch()
+
+local function test_timegm_y2k()
+  -- 2000-01-01 00:00:00 UTC = 946684800
+  local ts = time.timegm(2000, 1, 1, 0, 0, 0)
+  assert(ts == 946684800, "expected 946684800, got " .. tostring(ts))
+end
+test_timegm_y2k()
+
+local function test_timegm_known_timestamp()
+  -- 2025-01-01 00:00:00 UTC = 1735689600
+  local ts = time.timegm(2025, 1, 1, 0, 0, 0)
+  assert(ts == 1735689600, "expected 1735689600, got " .. tostring(ts))
+end
+test_timegm_known_timestamp()
+
+local function test_timegm_roundtrip()
+  local original = 1705322245
+  local dt = time.gmtime(original)
+  local back = time.timegm(dt.year, dt.month, dt.day, dt.hour, dt.min, dt.sec)
+  assert(back == original, "roundtrip failed: " .. tostring(original) .. " -> " .. tostring(back))
+end
+test_timegm_roundtrip()
+
+local function test_timegm_leap_year()
+  -- 2024-03-01 00:00:00 UTC (2024 is a leap year)
+  -- 2024-02-29 00:00:00 UTC should be valid
+  local feb29 = time.timegm(2024, 2, 29, 0, 0, 0)
+  local mar01 = time.timegm(2024, 3, 1, 0, 0, 0)
+  assert(mar01 - feb29 == 86400, "expected 1 day between Feb 29 and Mar 1 in leap year")
+end
+test_timegm_leap_year()
+
+-- format_iso8601 tests
+
+local function test_format_iso8601_epoch()
+  local s = time.format_iso8601(0)
+  assert(s == "1970-01-01T00:00:00Z", "expected epoch, got " .. s)
+end
+test_format_iso8601_epoch()
+
+local function test_format_iso8601_y2k()
+  local s = time.format_iso8601(946684800)
+  assert(s == "2000-01-01T00:00:00Z", "expected Y2K, got " .. s)
+end
+test_format_iso8601_y2k()
+
+local function test_format_iso8601_known()
+  -- 2025-01-02T10:00:00Z (same timestamp used in working PR tests)
+  local s = time.format_iso8601(1735812000)
+  assert(s == "2025-01-02T10:00:00Z", "expected 2025-01-02T10:00:00Z, got " .. s)
+end
+test_format_iso8601_known()
+
+local function test_format_iso8601_format()
+  local secs, _ = time.now()
+  local s = time.format_iso8601(secs)
+  assert(s:match("^%d%d%d%d%-%d%d%-%d%dT%d%d:%d%d:%d%dZ$"),
+    "expected ISO 8601 format, got " .. s)
+end
+test_format_iso8601_format()
+
+-- parse_iso8601 tests
+
+local function test_parse_iso8601_z_suffix()
+  local ts = time.parse_iso8601("2025-01-01T00:00:00Z")
+  assert(ts == 1735689600, "expected 1735689600, got " .. tostring(ts))
+end
+test_parse_iso8601_z_suffix()
+
+local function test_parse_iso8601_no_suffix()
+  local ts = time.parse_iso8601("2025-01-01T00:00:00")
+  assert(ts == 1735689600, "expected 1735689600 (treat as UTC), got " .. tostring(ts))
+end
+test_parse_iso8601_no_suffix()
+
+local function test_parse_iso8601_positive_offset()
+  -- 2025-01-01T05:30:00+05:30 = 2025-01-01T00:00:00Z
+  local ts = time.parse_iso8601("2025-01-01T05:30:00+05:30")
+  assert(ts == 1735689600, "expected 1735689600, got " .. tostring(ts))
+end
+test_parse_iso8601_positive_offset()
+
+local function test_parse_iso8601_negative_offset()
+  -- 2024-12-31T19:00:00-05:00 = 2025-01-01T00:00:00Z
+  local ts = time.parse_iso8601("2024-12-31T19:00:00-05:00")
+  assert(ts == 1735689600, "expected 1735689600, got " .. tostring(ts))
+end
+test_parse_iso8601_negative_offset()
+
+local function test_parse_iso8601_invalid()
+  local ts = time.parse_iso8601("not-a-date")
+  assert(ts == 0, "expected 0 for invalid input, got " .. tostring(ts))
+end
+test_parse_iso8601_invalid()
+
+local function test_parse_iso8601_invalid_offset()
+  local ts = time.parse_iso8601("2025-01-01T00:00:00+garbage")
+  assert(ts == 0, "expected 0 for invalid offset, got " .. tostring(ts))
+end
+test_parse_iso8601_invalid_offset()
+
+local function test_iso8601_roundtrip()
+  local original = 1705322245
+  local formatted = time.format_iso8601(original)
+  local parsed = time.parse_iso8601(formatted)
+  assert(parsed == original,
+    "roundtrip failed: " .. tostring(original) .. " -> " .. formatted .. " -> " .. tostring(parsed))
+end
+test_iso8601_roundtrip()
+
+local function test_iso8601_epoch_roundtrip()
+  local formatted = time.format_iso8601(0)
+  local parsed = time.parse_iso8601(formatted)
+  assert(parsed == 0, "epoch roundtrip failed: " .. formatted .. " -> " .. tostring(parsed))
+end
+test_iso8601_epoch_roundtrip()


### PR DESCRIPTION
## Summary
This PR adds comprehensive ISO 8601 timestamp parsing and formatting capabilities to the time module, along with a `timegm` function for converting broken-down UTC time to UNIX epoch seconds.

## Key Changes
- **Added `timegm()` function**: Converts UTC broken-down time (year, month, day, hour, minute, second) to UNIX epoch seconds. Includes proper leap year handling.
- **Added `format_iso8601()` function**: Formats UNIX timestamps as ISO 8601 strings in UTC (e.g., "2025-01-01T00:00:00Z").
- **Added `parse_iso8601()` function**: Parses ISO 8601 timestamp strings with support for:
  - "Z" suffix for UTC
  - "+HH:MM" and "-HH:MM" timezone offsets
  - No suffix (treated as UTC)
  - Returns 0 for invalid input
- **Added helper utilities**:
  - `is_leap_year()`: Determines if a year is a leap year
  - `MONTH_DAYS`: Constant array for days in each month (non-leap year)

## Implementation Details
- The `timegm()` function correctly handles leap years when calculating total days
- The `parse_iso8601()` function properly converts timezone offsets to UTC by subtracting positive offsets and adding negative offsets
- Comprehensive test coverage added including:
  - Epoch and Y2K timestamp tests
  - Known timestamp validation
  - Roundtrip conversion tests (timestamp → formatted → parsed)
  - Leap year handling
  - Timezone offset parsing (positive, negative, and Z suffix)
  - Invalid input handling

https://claude.ai/code/session_018UA4daf5qZE4qkT3f2proN