### PR TITLE
skip welcome message when --help, --version, or --welcome is passed

### DIFF
--- a/lib/cosmic/main.tl
+++ b/lib/cosmic/main.tl
@@ -296,7 +296,11 @@ local function main(): integer, string
     opts.extract = extract_env
   end
 
-  -- Show welcome on first invocation
+  if opts.version then return handlers.handle_version() end
+  if opts.help then io.write(help.generate() .. "\n"); return 0 end
+  if opts.welcome then io.write(handlers.generate_welcome()); return 0 end
+
+  -- Show welcome on first invocation (skip when --help/--version/--welcome handled above)
   if not os.getenv("COSMIC_NO_WELCOME") then
     local welcome = require("cosmic.welcome")
     if not welcome.was_shown() then
@@ -307,10 +311,6 @@ local function main(): integer, string
       end
     end
   end
-
-  if opts.version then return handlers.handle_version() end
-  if opts.help then io.write(help.generate() .. "\n"); return 0 end
-  if opts.welcome then io.write(handlers.generate_welcome()); return 0 end
   if opts.compile then return handlers.handle_compile(opts.compile, opts.output, opts.write_if_changed) end
   if opts.format then return handlers.handle_format(opts.format, opts.output, opts.write_if_changed) end
   if opts.check_format then return handlers.handle_check_format(opts.check_format) end

--- a/lib/cosmic/welcome_test.tl
+++ b/lib/cosmic/welcome_test.tl
@@ -121,17 +121,15 @@ local function test_welcome_with_e_flag()
 end
 test_welcome_with_e_flag()
 
--- Test welcome appears on first run with -v flag
-local function test_welcome_with_v_flag()
+-- Test welcome does NOT appear with -v flag (early-return skips welcome)
+local function test_welcome_skipped_with_v_flag()
   local ok, out = run_with_pty({"-v"})
   assert(ok, "cosmic -v should succeed: " .. out)
-  assert(out:find("Welcome to cosmic%-lua!"), "welcome should appear with -v: " .. out)
-  -- Version output goes to stdout; PTY may not capture it before exit.
-  -- Accept either the full version line or just the welcome banner.
-  assert(out:find("Lua 5%.4") or out:find("cosmic%-lua"), "should show version or cosmic-lua: " .. out)
-  print("test_welcome_with_v_flag: PASS")
+  assert(not out:find("Welcome to cosmic%-lua!"), "welcome should NOT appear with -v: " .. out)
+  assert(out:find("Lua 5%.4") or out:find("cosmic%-lua"), "should show version: " .. out)
+  print("test_welcome_skipped_with_v_flag: PASS")
 end
-test_welcome_with_v_flag()
+test_welcome_skipped_with_v_flag()
 
 -- Test welcome does NOT appear on second run (marker embedded)
 local function test_welcome_not_shown_twice()
@@ -140,8 +138,8 @@ local function test_welcome_not_shown_twice()
   local copy_ok = spawn.spawn({"cp", cosmic, fresh_cosmic}):wait()
   assert(copy_ok, "failed to copy cosmic binary")
 
-  -- First run - should show welcome
-  local cmd1 = fresh_cosmic .. " -v"
+  -- First run - should show welcome (use -e to avoid early-return)
+  local cmd1 = fresh_cosmic .. " -e 'print(1)'"
   local ok1, out1 = spawn.spawn({"script", "-qc", cmd1, "/dev/null"}):read()
   local s1 = out1 as string
   assert(ok1, "first run should succeed: " .. s1)
@@ -152,7 +150,6 @@ local function test_welcome_not_shown_twice()
   local s2 = out2 as string
   assert(ok2, "second run should succeed: " .. s2)
   assert(not s2:find("Welcome to cosmic%-lua!"), "second run should NOT show welcome: " .. s2)
-  assert(s2:find("Lua 5.4"), "second run should still show version: " .. s2)
 
   print("test_welcome_not_shown_twice: PASS")
 end
@@ -165,13 +162,12 @@ local function test_no_welcome_env_suppresses()
   local copy_ok = spawn.spawn({"cp", cosmic, fresh_cosmic}):wait()
   assert(copy_ok, "failed to copy cosmic binary")
 
-  -- Run with COSMIC_NO_WELCOME set
-  local cmd = "COSMIC_NO_WELCOME=1 " .. fresh_cosmic .. " -v"
+  -- Run with COSMIC_NO_WELCOME set (use -e to avoid early-return)
+  local cmd = "COSMIC_NO_WELCOME=1 " .. fresh_cosmic .. " -e 'print(1)'"
   local ok, out = spawn.spawn({"script", "-qc", cmd, "/dev/null"}):read()
   local s = out as string
   assert(ok, "should succeed: " .. s)
   assert(not s:find("Welcome to cosmic%-lua!"), "welcome should be suppressed: " .. s)
-  assert(s:find("Lua 5.4"), "should still show version: " .. s)
 
   print("test_no_welcome_env_suppresses: PASS")
 end


### PR DESCRIPTION
move the --version/--help/--welcome early-return checks before the welcome block in main(). on first invocation with a tty, the welcome message no longer prints alongside explicit informational flags.

## changes

**lib/cosmic/main.tl**: moved early-return checks for `opts.version`, `opts.help`, `opts.welcome` above the welcome message block so these flags return immediately without triggering the first-run welcome banner.

**lib/cosmic/welcome_test.tl**: updated tests to match:
- `test_welcome_with_v_flag` → renamed to `test_welcome_skipped_with_v_flag`, asserts welcome does NOT appear with `-v`
- PTY-based tests use `-e 'print(1)'` instead of `-v` where welcome is expected (since `-v` now early-returns before welcome)