### PR TITLE
crypto: add symmetric encryption module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,7 @@ all modules are under `lib/cosmic/` and imported as `cosmic.*`:
 | child | child process spawning with I/O control |
 | codec | hex encoding/decoding, Lua serialization |
 | compress | zlib compression/decompression |
+| crypto | symmetric encryption: encrypt, decrypt, password-based variants |
 | doc | extract docs from Teal source files |
 | docs | query embedded documentation index |
 | embed | create custom executables with embedded files |

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -48,6 +48,7 @@ local sqlite = require("cosmic.sqlite")
 
 | module | description |
 |--------|-------------|
+| `cosmic.crypto` | symmetric authenticated encryption |
 | `cosmic.hash` | SHA-256 and Argon2 password hashing |
 | `cosmic.rand` | cryptographic random bytes |
 | `cosmic.pledge` | restrict system calls on OpenBSD and Linux |

--- a/lib/cosmic/crypto.tl
+++ b/lib/cosmic/crypto.tl
@@ -1,0 +1,188 @@
+--- Symmetric encryption utilities.
+--- Implements authenticated encryption using HMAC-SHA256 + SHA256-CTR stream cipher.
+--- This is a best-effort construction using available cosmo primitives.
+---
+--- Security notes:
+--- - SHA256-CTR is a PRF-based stream cipher. ChaCha20-Poly1305 or AES-GCM
+---   would be preferable but are not available in cosmo.
+--- - Password key derivation uses HKDF-SHA256 for clean raw-byte output.
+---
+--- Example usage:
+---   local crypto = require("cosmic.crypto")
+---   local key = require("cosmic.rand").bytes(32)
+---   local ct, err = crypto.encrypt("hello", key)
+---   local pt, err = crypto.decrypt(ct, key)
+---   local ct, err = crypto.encrypt_with_password("hello", "my password")
+---   local pt, err = crypto.decrypt_with_password(ct, "my password")
+local cosmo = require("cosmo")
+local rand = require("cosmic.rand")
+
+-- HMAC-SHA256 block size and output size
+local BLOCK = 64
+local HASH_LEN = 32
+local KEY_LEN = 32
+local NONCE_LEN = 16
+
+-- Compute HMAC-SHA256(key, msg).
+-- key and msg are raw byte strings.
+local function hmac_sha256(key: string, msg: string): string
+  -- Normalize key to block size
+  local k = key
+  if #k > BLOCK then
+    k = cosmo.Sha256(k)
+  end
+  -- Pad key to block size
+  local ipad_parts: {string} = {}
+  local opad_parts: {string} = {}
+  for i = 1, BLOCK do
+    local b = (i <= #k) and string.byte(k, i) or 0
+    ipad_parts[i] = string.char(b ~ 0x36)
+    opad_parts[i] = string.char(b ~ 0x5c)
+  end
+  local ipad = table.concat(ipad_parts)
+  local opad = table.concat(opad_parts)
+  local inner = cosmo.Sha256(ipad .. msg)
+  return cosmo.Sha256(opad .. inner)
+end
+
+-- SHA256-CTR stream cipher: XOR data with keystream derived from enc_key + nonce.
+-- enc_key: 32-byte encryption key
+-- nonce: 16-byte nonce
+-- data: plaintext or ciphertext
+local function sha256_ctr(enc_key: string, nonce: string, data: string): string
+  local out: {string} = {}
+  local pos = 1
+  local counter = 0
+  while pos <= #data do
+    local block = cosmo.Sha256(enc_key .. nonce .. string.pack(">I8", counter))
+    counter = counter + 1
+    local chunk_parts: {string} = {}
+    local block_len = #block
+    local i = 1
+    while pos <= #data and i <= block_len do
+      local db = string.byte(data, pos)
+      local kb = string.byte(block, i)
+      chunk_parts[i] = string.char(db ~ kb)
+      pos = pos + 1
+      i = i + 1
+    end
+    out[#out + 1] = table.concat(chunk_parts)
+  end
+  return table.concat(out)
+end
+
+-- Compare two strings in constant time to prevent timing attacks.
+local function ct_equal(a: string, b: string): boolean
+  if #a ~= #b then
+    return false
+  end
+  local diff = 0
+  for i = 1, #a do
+    diff = diff | (a:byte(i) ~ b:byte(i))
+  end
+  return diff == 0
+end
+
+-- Derive enc_key and mac_key from a 32-byte root key.
+local function derive_keys(key: string): string, string
+  local enc_key = hmac_sha256(key, "enc")
+  local mac_key = hmac_sha256(key, "mac")
+  return enc_key, mac_key
+end
+
+-- Derive a 32-byte key from a password and a 16-byte salt using HKDF-SHA256.
+local function derive_key_from_password(password: string, salt: string): string
+  -- HKDF-extract: PRK = HMAC-SHA256(salt, password)
+  local prk = hmac_sha256(salt, password)
+  -- HKDF-expand: one block is enough for 32 bytes
+  local key = hmac_sha256(prk, "cosmic.crypto v1\x01")
+  return key
+end
+
+--- Encrypt plaintext with a 32-byte key.
+--- Uses SHA256-CTR + HMAC-SHA256 (Encrypt-then-MAC).
+--- Wire format: nonce(16) || tag(32) || ciphertext.
+--- @param plaintext string the data to encrypt
+--- @param key string a 32-byte encryption key
+--- @return string? the encrypted data, or nil on error
+--- @return string? error message if encryption failed
+local function encrypt(plaintext: string, key: string): string, string
+  if #key ~= KEY_LEN then
+    return nil, "key must be exactly 32 bytes, got " .. #key
+  end
+  local nonce = rand.bytes(NONCE_LEN)
+  local enc_key, mac_key = derive_keys(key)
+  local ciphertext = sha256_ctr(enc_key, nonce, plaintext)
+  local tag = hmac_sha256(mac_key, nonce .. ciphertext)
+  return nonce .. tag .. ciphertext
+end
+
+--- Decrypt data encrypted with encrypt().
+--- @param data string the encrypted data (nonce || tag || ciphertext)
+--- @param key string a 32-byte encryption key
+--- @return string? the decrypted plaintext, or nil on error
+--- @return string? error message if decryption or authentication failed
+local function decrypt(data: string, key: string): string, string
+  if #key ~= KEY_LEN then
+    return nil, "key must be exactly 32 bytes, got " .. #key
+  end
+  if #data < NONCE_LEN + HASH_LEN then
+    return nil, "ciphertext too short"
+  end
+  local nonce = data:sub(1, NONCE_LEN)
+  local tag = data:sub(NONCE_LEN + 1, NONCE_LEN + HASH_LEN)
+  local ciphertext = data:sub(NONCE_LEN + HASH_LEN + 1)
+  local enc_key, mac_key = derive_keys(key)
+  local expected_tag = hmac_sha256(mac_key, nonce .. ciphertext)
+  if not ct_equal(tag, expected_tag) then
+    return nil, "authentication failed"
+  end
+  return sha256_ctr(enc_key, nonce, ciphertext)
+end
+
+--- Encrypt plaintext with a password using HKDF-SHA256 key derivation.
+--- Wire format: pwsalt(16) || nonce(16) || tag(32) || ciphertext.
+--- @param plaintext string the data to encrypt
+--- @param password string the password for key derivation
+--- @return string? the encrypted data, or nil on error
+--- @return string? error message if encryption failed
+local function encrypt_with_password(plaintext: string, password: string): string, string
+  local pwsalt = rand.bytes(NONCE_LEN)
+  local key = derive_key_from_password(password, pwsalt)
+  local inner, err = encrypt(plaintext, key)
+  if not inner then
+    return nil, err
+  end
+  return pwsalt .. inner
+end
+
+--- Decrypt data encrypted with encrypt_with_password().
+--- @param data string the encrypted data (pwsalt || nonce || tag || ciphertext)
+--- @param password string the password for key derivation
+--- @return string? the decrypted plaintext, or nil on error
+--- @return string? error message if decryption or authentication failed
+local function decrypt_with_password(data: string, password: string): string, string
+  if #data < NONCE_LEN + NONCE_LEN + HASH_LEN then
+    return nil, "ciphertext too short"
+  end
+  local pwsalt = data:sub(1, NONCE_LEN)
+  local inner = data:sub(NONCE_LEN + 1)
+  local key = derive_key_from_password(password, pwsalt)
+  return decrypt(inner, key)
+end
+
+local record CryptoModule
+  encrypt: function(plaintext: string, key: string): string, string
+  decrypt: function(data: string, key: string): string, string
+  encrypt_with_password: function(plaintext: string, password: string): string, string
+  decrypt_with_password: function(data: string, password: string): string, string
+end
+
+local M: CryptoModule = {
+  encrypt = encrypt,
+  decrypt = decrypt,
+  encrypt_with_password = encrypt_with_password,
+  decrypt_with_password = decrypt_with_password,
+}
+
+return M

--- a/lib/cosmic/crypto_test.tl
+++ b/lib/cosmic/crypto_test.tl
@@ -1,0 +1,179 @@
+#!/usr/bin/env cosmic
+local crypto = require("cosmic.crypto")
+local rand = require("cosmic.rand")
+
+-- Helper: make a fresh 32-byte key
+local function make_key(): string
+  return rand.bytes(32)
+end
+
+-- Round-trip encrypt/decrypt with a 32-byte key
+local function test_encrypt_decrypt_round_trip()
+  local key = make_key()
+  local plain = "hello, world"
+  local ct, err = crypto.encrypt(plain, key)
+  assert(ct, "encrypt failed: " .. tostring(err))
+  local pt, err2 = crypto.decrypt(ct, key)
+  assert(pt, "decrypt failed: " .. tostring(err2))
+  assert(pt == plain, "round-trip mismatch: got " .. tostring(pt))
+end
+test_encrypt_decrypt_round_trip()
+
+-- Encrypt twice: nonce randomness means different ciphertext
+local function test_encrypt_returns_different_ciphertext_each_call()
+  local key = make_key()
+  local plain = "same plaintext"
+  local ct1, err1 = crypto.encrypt(plain, key)
+  local ct2, err2 = crypto.encrypt(plain, key)
+  assert(ct1, "first encrypt failed: " .. tostring(err1))
+  assert(ct2, "second encrypt failed: " .. tostring(err2))
+  assert(ct1 ~= ct2, "two encryptions of same plaintext should differ")
+end
+test_encrypt_returns_different_ciphertext_each_call()
+
+-- Wrong key: decrypt must fail
+local function test_decrypt_wrong_key_fails()
+  local key1 = make_key()
+  local key2 = make_key()
+  local ct, err = crypto.encrypt("secret", key1)
+  assert(ct, "encrypt failed: " .. tostring(err))
+  local pt, err2 = crypto.decrypt(ct, key2)
+  assert(pt == nil, "decrypt with wrong key should return nil")
+  assert(err2 ~= nil, "decrypt with wrong key should return error")
+end
+test_decrypt_wrong_key_fails()
+
+-- Tampered ciphertext: authentication must fail
+local function test_decrypt_tampered_ciphertext_fails()
+  local key = make_key()
+  local ct, err = crypto.encrypt("original", key)
+  assert(ct, "encrypt failed: " .. tostring(err))
+  -- Flip the last byte
+  local tampered = ct:sub(1, -2) .. string.char(string.byte(ct, -1) ~ 0x01)
+  local pt, err2 = crypto.decrypt(tampered, key)
+  assert(pt == nil, "decrypt of tampered ciphertext should return nil")
+  assert(err2 ~= nil, "decrypt of tampered ciphertext should return error")
+end
+test_decrypt_tampered_ciphertext_fails()
+
+-- Tampered tag: authentication must fail
+local function test_decrypt_tampered_tag_fails()
+  local key = make_key()
+  local ct, err = crypto.encrypt("sensitive", key)
+  assert(ct, "encrypt failed: " .. tostring(err))
+  -- Flip a byte in the tag region (bytes 17-48)
+  local tampered = ct:sub(1, 19) .. string.char(ct:byte(20) ~ 0xff) .. ct:sub(21)
+  local pt, err2 = crypto.decrypt(tampered, key)
+  assert(pt == nil, "decrypt of tampered tag should return nil")
+  assert(err2 and err2:find("authentication"),
+    "error should mention authentication, got: " .. tostring(err2))
+end
+test_decrypt_tampered_tag_fails()
+
+-- Too-short ciphertext: must fail validation
+local function test_decrypt_too_short_fails()
+  local key = make_key()
+  local pt, err = crypto.decrypt("short", key)
+  assert(pt == nil, "decrypt of too-short data should return nil")
+  assert(err ~= nil, "decrypt of too-short data should return error")
+end
+test_decrypt_too_short_fails()
+
+-- Key must be exactly 32 bytes
+local function test_encrypt_requires_32_byte_key()
+  local pt1, err1 = crypto.encrypt("data", "tooshort")
+  assert(pt1 == nil, "encrypt with short key should return nil")
+  assert(err1 ~= nil, "encrypt with short key should return error")
+
+  local pt2, err2 = crypto.encrypt("data", string.rep("x", 33))
+  assert(pt2 == nil, "encrypt with long key should return nil")
+  assert(err2 ~= nil, "encrypt with long key should return error")
+end
+test_encrypt_requires_32_byte_key()
+
+-- Empty plaintext is valid
+local function test_encrypt_empty_plaintext()
+  local key = make_key()
+  local ct, err = crypto.encrypt("", key)
+  assert(ct, "encrypt of empty string failed: " .. tostring(err))
+  -- nonce(16) + tag(32) + 0 bytes = 48
+  assert(#ct == 48, "empty ciphertext should be 48 bytes, got " .. #ct)
+  local pt, err2 = crypto.decrypt(ct, key)
+  assert(pt, "decrypt of empty string failed: " .. tostring(err2))
+  assert(pt == "", "round-trip of empty string should yield empty string")
+end
+test_encrypt_empty_plaintext()
+
+-- Large plaintext spans multiple keystream blocks
+local function test_encrypt_large_plaintext()
+  local key = make_key()
+  local plain = string.rep("A", 1000)
+  local ct, err = crypto.encrypt(plain, key)
+  assert(ct, "encrypt of large plaintext failed: " .. tostring(err))
+  local pt, err2 = crypto.decrypt(ct, key)
+  assert(pt, "decrypt of large plaintext failed: " .. tostring(err2))
+  assert(pt == plain, "round-trip of large plaintext mismatch")
+end
+test_encrypt_large_plaintext()
+
+-- Ciphertext has expected overhead
+local function test_encrypt_ciphertext_length()
+  local key = make_key()
+  local plain = "test"
+  local ct, err = crypto.encrypt(plain, key)
+  assert(ct, "encrypt should succeed: " .. tostring(err))
+  -- nonce(16) + tag(32) + plaintext(4) = 52
+  assert(#ct == 52, "ciphertext length should be 52, got " .. #ct)
+end
+test_encrypt_ciphertext_length()
+
+-- Password-based round-trip
+local function test_encrypt_with_password_round_trip()
+  local plain = "password-protected secret"
+  local ct, err = crypto.encrypt_with_password(plain, "my password")
+  assert(ct, "encrypt_with_password failed: " .. tostring(err))
+  local pt, err2 = crypto.decrypt_with_password(ct, "my password")
+  assert(pt, "decrypt_with_password failed: " .. tostring(err2))
+  assert(pt == plain, "password round-trip mismatch: got " .. tostring(pt))
+end
+test_encrypt_with_password_round_trip()
+
+-- Wrong password: must fail
+local function test_decrypt_with_password_wrong_password_fails()
+  local ct, err = crypto.encrypt_with_password("data", "correct")
+  assert(ct, "encrypt_with_password failed: " .. tostring(err))
+  local pt, err2 = crypto.decrypt_with_password(ct, "wrong")
+  assert(pt == nil, "decrypt_with_password with wrong password should return nil")
+  assert(err2 ~= nil, "decrypt_with_password with wrong password should return error")
+end
+test_decrypt_with_password_wrong_password_fails()
+
+-- Tampered password ciphertext: must fail
+local function test_decrypt_with_password_tampered_fails()
+  local ct, err = crypto.encrypt_with_password("data", "password")
+  assert(ct, "encrypt_with_password failed: " .. tostring(err))
+  local tampered = ct:sub(1, -2) .. string.char(string.byte(ct, -1) ~ 0x01)
+  local pt, err2 = crypto.decrypt_with_password(tampered, "password")
+  assert(pt == nil, "decrypt_with_password of tampered data should return nil")
+  assert(err2 ~= nil, "decrypt_with_password of tampered data should return error")
+end
+test_decrypt_with_password_tampered_fails()
+
+-- Password encrypt produces different ciphertext each call (different salt)
+local function test_encrypt_with_password_different_each_call()
+  local ct1, err1 = crypto.encrypt_with_password("same", "password")
+  local ct2, err2 = crypto.encrypt_with_password("same", "password")
+  assert(ct1, "first encrypt_with_password failed: " .. tostring(err1))
+  assert(ct2, "second encrypt_with_password failed: " .. tostring(err2))
+  assert(ct1 ~= ct2, "two password encryptions should differ")
+end
+test_encrypt_with_password_different_each_call()
+
+-- Password decrypt too-short blob
+local function test_decrypt_with_password_truncated_fails()
+  local pt, err = crypto.decrypt_with_password("short", "password")
+  assert(pt == nil, "decrypt_with_password of truncated data should return nil")
+  assert(err and err:find("too short"),
+    "error should mention too short, got: " .. tostring(err))
+end
+test_decrypt_with_password_truncated_fails()


### PR DESCRIPTION
Closes #193

Consolidates #326, #329, and #372 into a single implementation.

## API

```lua
local crypto = require("cosmic.crypto")
local key = require("cosmic.rand").bytes(32)

-- Key-based encryption
local ct, err = crypto.encrypt(plaintext, key)
local pt, err = crypto.decrypt(ct, key)

-- Password-based encryption (HKDF-SHA256 key derivation)
local ct, err = crypto.encrypt_with_password(plaintext, password)
local pt, err = crypto.decrypt_with_password(ct, password)
```

## Construction (Encrypt-then-MAC)

- **Sub-key derivation**: `HMAC(key, "enc")` / `HMAC(key, "mac")` — proper HMAC-SHA256 (RFC 2104)
- **Stream cipher**: SHA256-CTR with 8-byte BE counter (`string.pack`)
- **Authentication**: HMAC-SHA256 over `nonce || ciphertext`
- **MAC comparison**: constant-time (bitwise OR accumulator)
- **Password KDF**: HKDF-SHA256 (extract + expand) with 16-byte random salt

## Wire formats

- Key-based: `nonce(16) || tag(32) || ciphertext`
- Password-based: `pwsalt(16) || nonce(16) || tag(32) || ciphertext`

## What was consolidated

Best parts from each PR:
- **#372**: cleanest code (182 lines), proper HMAC, HKDF, `string.pack` counter, strict 32-byte key
- **#329**: constant-time MAC comparison, `cosmo.d.tl` type additions (`GetCryptoHash`, `Curve25519`)
- **#326**: AGENTS.md and docs/stdlib.md documentation updates

## Changes

- `lib/cosmic/crypto.tl` — 189-line module
- `lib/cosmic/crypto_test.tl` — 14 tests (roundtrip, nonce randomness, wrong key, tampered tag, tampered ciphertext, too-short, key length validation, empty/large plaintext, password variants)
- `AGENTS.md` — add crypto to module table
- `docs/stdlib.md` — add crypto to security section
- `lib/types/cosmo.d.tl` — add `GetCryptoHash` and `Curve25519` declarations

Supersedes #326, #329, #372.