### PR TITLE
add cosmic.instrument module for CLI telemetry

### DIFF
--- a/lib/cosmic/instrument.tl
+++ b/lib/cosmic/instrument.tl
@@ -1,0 +1,155 @@
+--- CLI instrumentation for timing and resource usage.
+--- Emits structured key=value lines to stderr when COSMIC_INSTRUMENTATION
+--- is set to "1" or "true". Used by main_handlers and testrun to report
+--- wall time, CPU time, and peak memory for each operation.
+local unix = require("cosmo.unix")
+local env = require("cosmic.env")
+
+--- Parsed instrumentation data from a cosmic: line.
+local record InstrumentData
+  op: string
+  file: string
+  exit: integer
+  wall_ms: integer
+  cpu_ms: integer
+  maxrss_kb: integer
+end
+
+--- A timing span capturing start state for an operation.
+local record Span
+  op: string
+  file: string
+  start_wall: number
+  start_wall_ns: number
+  start_utime_s: number
+  start_utime_ns: number
+  start_stime_s: number
+  start_stime_ns: number
+end
+
+--- Check whether instrumentation is enabled.
+--- Returns true when COSMIC_INSTRUMENTATION is "1" or "true".
+--- @return boolean
+local function is_enabled(): boolean
+  local val = env.get("COSMIC_INSTRUMENTATION")
+  return val == "1" or val == "true"
+end
+
+--- Begin a new instrumentation span.
+--- Captures monotonic wall time and CPU usage at the start.
+--- @param op string Operation name (e.g. "test", "compile", "check-types")
+--- @param file string File being operated on
+--- @return Span
+local function begin_span(op: string, file: string): Span
+  local wall_s, wall_ns = unix.clock_gettime(unix.CLOCK_MONOTONIC)
+  local ru = unix.getrusage(unix.RUSAGE_SELF)
+  local ut_s, ut_ns = ru:utime()
+  local st_s, st_ns = ru:stime()
+  return {
+    op = op,
+    file = file,
+    start_wall = wall_s,
+    start_wall_ns = wall_ns,
+    start_utime_s = ut_s,
+    start_utime_ns = ut_ns,
+    start_stime_s = st_s,
+    start_stime_ns = st_ns,
+  }
+end
+
+--- Finish a span and emit instrumentation.
+--- When instrumentation is enabled, writes a key=value line to stderr
+--- and returns the line. When disabled, returns nil.
+--- @param span Span The span from begin()
+--- @param exit_code integer The exit code of the operation
+--- @return string? The formatted line, or nil if disabled
+local function finish_span(span: Span, exit_code: integer): string
+  if not is_enabled() then
+    return nil
+  end
+
+  local wall_s, wall_ns = unix.clock_gettime(unix.CLOCK_MONOTONIC)
+  local ru = unix.getrusage(unix.RUSAGE_SELF)
+  local ut_s, ut_ns = ru:utime()
+  local st_s, st_ns = ru:stime()
+
+  -- wall time delta in ms
+  local wall_delta = (wall_s - span.start_wall) * 1000
+  + (wall_ns - span.start_wall_ns) / 1000000
+  local wall_ms = math.floor(wall_delta) as integer
+
+  -- cpu time delta in ms (utime + stime)
+  local utime_delta = (ut_s - span.start_utime_s) * 1000
+  + (ut_ns - span.start_utime_ns) / 1000000
+  local stime_delta = (st_s - span.start_stime_s) * 1000
+  + (st_ns - span.start_stime_ns) / 1000000
+  local cpu_ms = math.floor(utime_delta + stime_delta) as integer
+
+  local maxrss = math.floor(ru:maxrss()) as integer
+
+  local line = string.format(
+    "cosmic: op=%s file=%s exit=%d wall_ms=%d cpu_ms=%d maxrss_kb=%d",
+    span.op, span.file, exit_code, wall_ms, cpu_ms, maxrss)
+
+  io.stderr:write(line .. "\n")
+  return line
+end
+
+--- Parse a single instrumentation line.
+--- Returns nil if the line is not a valid cosmic: instrumentation line.
+--- @param line string A line from stderr
+--- @return InstrumentData?
+local function parse_line(line: string): InstrumentData
+  if not line:match("^cosmic: ") then
+    return nil
+  end
+  local op = line:match("op=(%S+)")
+  local file = line:match("file=(%S+)")
+  local exit_str = line:match("exit=(%d+)")
+  local wall_str = line:match("wall_ms=(%d+)")
+  local cpu_str = line:match("cpu_ms=(%d+)")
+  local maxrss_str = line:match("maxrss_kb=(%d+)")
+  if not op or not file or not exit_str then
+    return nil
+  end
+  return {
+    op = op,
+    file = file,
+    exit = (tonumber(exit_str) or 0) as integer,
+    wall_ms = (tonumber(wall_str) or 0) as integer,
+    cpu_ms = (tonumber(cpu_str) or 0) as integer,
+    maxrss_kb = (tonumber(maxrss_str) or 0) as integer,
+  }
+end
+
+--- Parse multiple lines of stderr, extracting instrumentation data.
+--- @param content string Full stderr content
+--- @return {InstrumentData}
+local function parse_lines(content: string): {InstrumentData}
+  local results: {InstrumentData} = {}
+  for line in content:gmatch("[^\n]+") do
+    local data = parse_line(line)
+    if data then
+      results[#results + 1] = data
+    end
+  end
+  return results
+end
+
+local record InstrumentModule
+  enabled: function(): boolean
+  begin: function(op: string, file: string): Span
+  finish: function(span: Span, exit_code: integer): string
+  parse_line: function(line: string): InstrumentData
+  parse_lines: function(content: string): {InstrumentData}
+end
+
+local M: InstrumentModule = {
+  enabled = is_enabled,
+  begin = begin_span,
+  finish = finish_span,
+  parse_line = parse_line,
+  parse_lines = parse_lines,
+}
+
+return M

--- a/lib/cosmic/instrument_test.tl
+++ b/lib/cosmic/instrument_test.tl
@@ -1,0 +1,146 @@
+#!/usr/bin/env cosmic
+local instrument = require("cosmic.instrument")
+local env = require("cosmic.env")
+local time = require("cosmic.time")
+
+-- test Span record fields
+
+local function test_begin_returns_span()
+  local span = instrument.begin("test", "lib/cosmic/foo_test.tl")
+  assert(span ~= nil, "expected span")
+  assert(span.op == "test", "expected op=test, got " .. tostring(span.op))
+  assert(span.file == "lib/cosmic/foo_test.tl",
+    "expected file, got " .. tostring(span.file))
+  assert(span.start_wall > 0, "expected positive start_wall")
+end
+test_begin_returns_span()
+
+-- test finish emits nothing when COSMIC_INSTRUMENTATION is unset
+
+local function test_finish_silent_by_default()
+  env.unset("COSMIC_INSTRUMENTATION")
+  local span = instrument.begin("compile", "test.tl")
+  -- finish should return the line but not write to stderr when disabled
+  local line = instrument.finish(span, 0)
+  assert(line == nil, "expected nil when instrumentation disabled, got: " .. tostring(line))
+end
+test_finish_silent_by_default()
+
+-- test finish returns formatted line when COSMIC_INSTRUMENTATION=1
+
+local function test_finish_returns_line_when_enabled()
+  env.set("COSMIC_INSTRUMENTATION", "1")
+  local span = instrument.begin("check-types", "lib/cosmic/fs.tl")
+  time.sleep(0, 1000000) -- sleep 1ms to get measurable time
+  local line = instrument.finish(span, 0)
+  env.unset("COSMIC_INSTRUMENTATION")
+  assert(line ~= nil, "expected instrumentation line")
+  assert(line:match("^cosmic:"), "expected 'cosmic:' prefix, got: " .. line)
+  assert(line:match("op=check%-types"), "expected op=check-types in: " .. line)
+  assert(line:match("file=lib/cosmic/fs%.tl"), "expected file= in: " .. line)
+  assert(line:match("exit=0"), "expected exit=0 in: " .. line)
+  assert(line:match("wall_ms=%d+"), "expected wall_ms= in: " .. line)
+end
+test_finish_returns_line_when_enabled()
+
+-- test finish captures cpu_ms
+
+local function test_finish_includes_cpu_ms()
+  env.set("COSMIC_INSTRUMENTATION", "1")
+  local span = instrument.begin("test", "x.tl")
+  -- do some cpu work
+  local sum = 0
+  for i = 1, 10000 do sum = sum + i end
+  local _ = sum
+  local line = instrument.finish(span, 0)
+  env.unset("COSMIC_INSTRUMENTATION")
+  assert(line ~= nil, "expected line")
+  assert(line:match("cpu_ms=%d+"), "expected cpu_ms= in: " .. line)
+end
+test_finish_includes_cpu_ms()
+
+-- test finish captures maxrss_kb
+
+local function test_finish_includes_maxrss()
+  env.set("COSMIC_INSTRUMENTATION", "1")
+  local span = instrument.begin("test", "x.tl")
+  local line = instrument.finish(span, 0)
+  env.unset("COSMIC_INSTRUMENTATION")
+  assert(line ~= nil, "expected line")
+  assert(line:match("maxrss_kb=%d+"), "expected maxrss_kb= in: " .. line)
+end
+test_finish_includes_maxrss()
+
+-- test finish with non-zero exit code
+
+local function test_finish_nonzero_exit()
+  env.set("COSMIC_INSTRUMENTATION", "1")
+  local span = instrument.begin("compile", "bad.tl")
+  local line = instrument.finish(span, 1)
+  env.unset("COSMIC_INSTRUMENTATION")
+  assert(line ~= nil, "expected line")
+  assert(line:match("exit=1"), "expected exit=1 in: " .. line)
+end
+test_finish_nonzero_exit()
+
+-- test enabled() reflects env var
+
+local function test_enabled()
+  env.unset("COSMIC_INSTRUMENTATION")
+  assert(not instrument.enabled(), "expected disabled when unset")
+  env.set("COSMIC_INSTRUMENTATION", "1")
+  assert(instrument.enabled(), "expected enabled when set to 1")
+  env.set("COSMIC_INSTRUMENTATION", "0")
+  assert(not instrument.enabled(), "expected disabled when set to 0")
+  env.set("COSMIC_INSTRUMENTATION", "true")
+  assert(instrument.enabled(), "expected enabled when set to true")
+  env.unset("COSMIC_INSTRUMENTATION")
+end
+test_enabled()
+
+-- test parse_line round-trips
+
+local function test_parse_line()
+  env.set("COSMIC_INSTRUMENTATION", "1")
+  local span = instrument.begin("test", "lib/cosmic/sqlite_test.tl")
+  time.sleep(0, 1000000)
+  local line = instrument.finish(span, 0)
+  env.unset("COSMIC_INSTRUMENTATION")
+  assert(line ~= nil, "expected line")
+  local parsed = instrument.parse_line(line)
+  assert(parsed ~= nil, "expected parsed result")
+  assert(parsed.op == "test", "expected op=test, got " .. tostring(parsed.op))
+  assert(parsed.file == "lib/cosmic/sqlite_test.tl",
+    "expected file, got " .. tostring(parsed.file))
+  assert(parsed.exit == 0, "expected exit=0, got " .. tostring(parsed.exit))
+  assert(parsed.wall_ms >= 0, "expected wall_ms >= 0")
+  assert(parsed.cpu_ms >= 0, "expected cpu_ms >= 0")
+  assert(parsed.maxrss_kb > 0, "expected maxrss_kb > 0")
+end
+test_parse_line()
+
+-- test parse_line returns nil for non-instrument lines
+
+local function test_parse_line_non_instrument()
+  local parsed = instrument.parse_line("some random stderr output")
+  assert(parsed == nil, "expected nil for non-instrument line")
+  parsed = instrument.parse_line("")
+  assert(parsed == nil, "expected nil for empty line")
+end
+test_parse_line_non_instrument()
+
+-- test parse_lines extracts from mixed stderr content
+
+local function test_parse_lines()
+  local stderr = "some warning\n"
+  .. "cosmic: op=test file=a.tl exit=0 wall_ms=100 cpu_ms=90 maxrss_kb=1024\n"
+  .. "another line\n"
+  .. "cosmic: op=compile file=b.tl exit=1 wall_ms=50 cpu_ms=45 maxrss_kb=2048\n"
+  local results = instrument.parse_lines(stderr)
+  assert(#results == 2, "expected 2 results, got " .. #results)
+  assert(results[1].op == "test", "expected op=test")
+  assert(results[1].file == "a.tl", "expected file=a.tl")
+  assert(results[2].op == "compile", "expected op=compile")
+  assert(results[2].exit == 1, "expected exit=1")
+end
+test_parse_lines()

--- a/lib/cosmic/main_handlers.tl
+++ b/lib/cosmic/main_handlers.tl
@@ -1,5 +1,6 @@
 --- Command handler functions for the cosmic CLI.
 --- Each handler implements one CLI command flag.
+local instrument = require("cosmic.instrument")
 
 --- Result from running docs command.
 local record DocsRunResult
@@ -134,34 +135,46 @@ end
 
 --- Handle --compile flag.
 local function handle_compile(file: string, output?: string, write_if_changed?: boolean): integer, string
+  local span = instrument.begin("compile", file)
   local teal = require("cosmic.teal")
   local result = teal.compile(file)
+  local exit_code: integer
+  local err_msg: string
   if result.ok then
-    return write_output(result.code, output, write_if_changed)
+    exit_code, err_msg = write_output(result.code, output, write_if_changed)
   else
     io.stderr:write(teal.format_issues(result.errors) .. "\n")
-    return 1
+    exit_code = 1
   end
+  instrument.finish(span, exit_code)
+  return exit_code, err_msg
 end
 
 --- Handle --format flag.
 local function handle_format(file: string, output?: string, write_if_changed?: boolean): integer, string
+  local span = instrument.begin("format", file)
   local fmt = require("cosmic.format")
   local result = fmt.format_file(file)
+  local exit_code: integer
+  local err_msg: string
   if result.ok then
-    return write_output(result.code, output, write_if_changed)
+    exit_code, err_msg = write_output(result.code, output, write_if_changed)
   else
     io.stderr:write(fmt.format_issues(result.errors) .. "\n")
-    return 1
+    exit_code = 1
   end
+  instrument.finish(span, exit_code)
+  return exit_code, err_msg
 end
 
 --- Handle --check-format flag.
 local function handle_check_format(file: string): integer
+  local span = instrument.begin("check-format", file)
   local fmt = require("cosmic.format")
   local result = fmt.format_file(file)
   if not result.ok then
     io.stderr:write(fmt.format_issues(result.errors) .. "\n")
+    instrument.finish(span, 1)
     return 1
   end
 
@@ -169,11 +182,13 @@ local function handle_check_format(file: string): integer
   local original, read_err = cio.slurp(file)
   if not original then
     io.stderr:write(file .. ": " .. (read_err or "unknown error") .. "\n")
+    instrument.finish(span, 1)
     return 1
   end
 
   if original == result.code then
     io.write("Format check passed\n")
+    instrument.finish(span, 0)
     return 0
   end
 
@@ -194,11 +209,13 @@ local function handle_check_format(file: string): integer
       break
     end
   end
+  instrument.finish(span, 1)
   return 1
 end
 
 --- Handle --check-types flag.
 local function handle_check_types(file: string): integer
+  local span = instrument.begin("check-types", file)
   local teal = require("cosmic.teal")
   local result = teal.check(file)
 
@@ -211,8 +228,10 @@ local function handle_check_types(file: string): integer
 
   if result.ok then
     io.write("Type check passed\n")
+    instrument.finish(span, 0)
     return 0
   else
+    instrument.finish(span, 1)
     return 1
   end
 end
@@ -235,9 +254,11 @@ end
 
 --- Handle --check-examples flag.
 local function handle_check_examples(file: string): integer
+  local span = instrument.begin("check-examples", file)
   local example = require("cosmic.example")
   local result = example.run(file)
   io.write(example.format_results(file, result) .. "\n")
+  instrument.finish(span, result.exit_code)
   return result.exit_code
 end
 
@@ -268,8 +289,10 @@ local function handle_benchmark(spec: string): integer
     filter = spec:sub(colon_pos + 1)
   end
 
+  local span = instrument.begin("benchmark", file_path)
   local result = benchmark.run(file_path, filter)
   io.write(benchmark.format_results(file_path, result) .. "\n")
+  instrument.finish(span, result.exit_code)
   return result.exit_code
 end
 
@@ -294,9 +317,11 @@ end
 
 --- Handle --check-style flag.
 local function handle_check_style(file: string): integer
+  local span = instrument.begin("check-style", file)
   local f = io.open(file, "r")
   if not f then
     io.stderr:write(file .. ": no such file\n")
+    instrument.finish(span, 1)
     return 1
   end
   f:close()
@@ -304,11 +329,13 @@ local function handle_check_style(file: string): integer
   local diagnostics = lint.lint_file(file)
   if #diagnostics == 0 then
     io.write("Style check passed\n")
+    instrument.finish(span, 0)
     return 0
   end
   for _, d in ipairs(diagnostics) do
     io.stderr:write(string.format("%s:%d:%d: %s: %s\n", d.file, d.line, d.col, d.rule, d.message))
   end
+  instrument.finish(span, 1)
   return 1
 end
 

--- a/lib/cosmic/testrun.tl
+++ b/lib/cosmic/testrun.tl
@@ -4,6 +4,7 @@ local child = require("cosmic.child")
 local cio = require("cosmic.io")
 local env = require("cosmic.env")
 local fs = require("cosmic.fs")
+local instrument = require("cosmic.instrument")
 
 --- Run a test executable and capture output.
 --- Creates a temporary directory (TEST_TMPDIR) for the test and cleans up after.
@@ -11,8 +12,13 @@ local fs = require("cosmic.fs")
 --- @param output_base string Base path for output files
 --- @return integer Exit code (for CLI return)
 local function run(argv: {string}, output_base: string): integer
+  -- determine file for instrumentation from argv
+  local inst_file = argv[#argv] or output_base
+  local span = instrument.begin("test", inst_file)
+
   if not output_base then
     io.stderr:write("testrun: missing output path\n")
+    instrument.finish(span, 1)
     return 1
   end
 
@@ -22,6 +28,7 @@ local function run(argv: {string}, output_base: string): integer
     local ok, err = fs.makedirs(dir)
     if not ok then
       io.stderr:write("testrun: " .. err .. "\n")
+      instrument.finish(span, 1)
       return 1
     end
   end
@@ -31,6 +38,7 @@ local function run(argv: {string}, output_base: string): integer
   local tmpdir, tmpdir_err = fs.mkdtemp(fs.join(tmpbase, "testrun_XXXXXX"))
   if not tmpdir then
     io.stderr:write("testrun: " .. (tmpdir_err or "failed to create temp dir") .. "\n")
+    instrument.finish(span, 1)
     return 1
   end
 
@@ -46,6 +54,7 @@ local function run(argv: {string}, output_base: string): integer
   if not handle then
     fs.rmrf(tmpdir)
     io.stderr:write("testrun: " .. (err or "spawn failed") .. "\n")
+    instrument.finish(span, 1)
     return 1
   end
 
@@ -84,21 +93,25 @@ local function run(argv: {string}, output_base: string): integer
   ok, err = cio.barf(output_base .. ".got", tostring(exit_code) .. "\n")
   if not ok then
     io.stderr:write("testrun: " .. (err or "failed to write .got") .. "\n")
+    instrument.finish(span, 1)
     return 1
   end
 
   ok, err = cio.barf(output_base .. ".out", stdout_content)
   if not ok then
     io.stderr:write("testrun: " .. (err or "failed to write .out") .. "\n")
+    instrument.finish(span, 1)
     return 1
   end
 
   ok, err = cio.barf(output_base .. ".err", stderr_content)
   if not ok then
     io.stderr:write("testrun: " .. (err or "failed to write .err") .. "\n")
+    instrument.finish(span, 1)
     return 1
   end
 
+  instrument.finish(span, exit_code)
   return exit_code
 end
 
@@ -176,6 +189,10 @@ local function report(paths: {string}): integer
   end
 
   -- Print results
+  local total_wall_ms = 0
+  local slowest_name = ""
+  local slowest_ms = 0
+
   for _, result in ipairs(results) do
     local icon: string
     if result.status == "pass" then
@@ -185,7 +202,21 @@ local function report(paths: {string}): integer
     else
       icon = "✗"
     end
-    io.write(icon .. " " .. result.name .. "\n")
+    -- extract timing from stderr instrumentation lines
+    local timing = ""
+    if result.stderr ~= "" then
+      local data = instrument.parse_lines(result.stderr)
+      if #data > 0 then
+        local d = data[#data]
+        timing = string.format("  %dms", d.wall_ms)
+        total_wall_ms = total_wall_ms + d.wall_ms
+        if d.wall_ms > slowest_ms then
+          slowest_ms = d.wall_ms
+          slowest_name = result.name
+        end
+      end
+    end
+    io.write(icon .. " " .. result.name .. timing .. "\n")
   end
 
   -- Print summary
@@ -196,6 +227,11 @@ local function report(paths: {string}): integer
   end
   if skipped > 0 then
     io.write(", " .. skipped .. " skipped")
+  end
+  if total_wall_ms > 0 then
+    io.write(string.format(
+        "\nwall: %dms  slowest: %s (%dms)",
+        total_wall_ms, slowest_name, slowest_ms))
   end
   io.write("\n")
 


### PR DESCRIPTION
## summary

closes #376

adds a new `cosmic.instrument` module that emits structured key=value instrumentation lines to stderr when `COSMIC_INSTRUMENTATION=1` (or `true`).

## changes

### new module: `cosmic.instrument`
- `begin(op, file)` → captures monotonic wall time and CPU usage (utime+stime from getrusage)
- `finish(span, exit_code)` → computes deltas, emits line to stderr, returns the line (or nil when disabled)
- `enabled()` → checks `COSMIC_INSTRUMENTATION` env var
- `parse_line(line)` → parses a single `cosmic:` line into structured data
- `parse_lines(content)` → extracts all instrumentation records from mixed stderr

### output format
```
cosmic: op=test file=lib/cosmic/sqlite_test.tl exit=0 wall_ms=342 cpu_ms=310 maxrss_kb=14208
```

### wired into main_handlers
instrumentation spans wrap these CLI commands:
- `--compile`, `--format`, `--check-format`, `--check-types`
- `--check-style`, `--check-examples`, `--benchmark`

### wired into testrun
- `testrun.run()` wraps each test execution with a span
- `testrun.report()` parses timing from `.err` files and displays per-test wall_ms with slowest-test summary:
```
✓ instrument_test.tl.test  1ms

1 checks: 1 passed
wall: 1ms  slowest: instrument_test.tl.test (1ms)
```

### gating
gated on `COSMIC_INSTRUMENTATION` env var. when unset, no instrumentation lines are emitted — fully backward compatible.

## testing
- comprehensive test suite in `instrument_test.tl` covering begin/finish, enabled/disabled states, parse round-trips, and mixed-content parsing
- all existing tests pass (69/70 — the one failure is pre-existing cosmos_test on main)