### PR TITLE
fuzzy: optimize levenshtein to use two-row algorithm and string.byte

### DIFF
--- a/lib/cosmic/fuzzy.tl
+++ b/lib/cosmic/fuzzy.tl
@@ -1,37 +1,50 @@
 --- Fuzzy string matching utilities.
 
 --- Compute Levenshtein distance between two strings.
+--- Uses a two-row algorithm with O(min(n,m)) memory and string.byte
+--- for fast character comparison.
 --- @param a string First string
 --- @param b string Second string
 --- @return integer Edit distance
 local function levenshtein(a: string, b: string): integer
-  if #a == 0 then return #b end
-  if #b == 0 then return #a end
+  local la = #a
+  local lb = #b
+  if la == 0 then return lb end
+  if lb == 0 then return la end
   if a == b then return 0 end
 
-  -- Create distance matrix
-  local matrix: {{integer}} = {}
-  for i = 0, #a do
-    matrix[i] = {}
-    matrix[i][0] = i
-  end
-  for j = 0, #b do
-    matrix[0][j] = j
+  -- swap so that b is always the shorter string (fewer columns)
+  if la < lb then
+    a, b = b, a
+    la, lb = lb, la
   end
 
-  -- Fill in the rest of the matrix
-  for i = 1, #a do
-    for j = 1, #b do
-      local cost = a:sub(i, i) == b:sub(j, j) and 0 or 1
-      matrix[i][j] = math.min(
-        matrix[i - 1][j] + 1, -- deletion
-        matrix[i][j - 1] + 1, -- insertion
-        matrix[i - 1][j - 1] + cost -- substitution
-      )
+  -- two-row algorithm: prev and curr, each of length lb+1
+  local prev: {integer} = {}
+  local curr: {integer} = {}
+  for j = 0, lb do
+    prev[j] = j
+  end
+
+  for i = 1, la do
+    curr[0] = i
+    local ai = a:byte(i)
+    for j = 1, lb do
+      local cost = ai == b:byte(j) and 0 or 1
+      local del = prev[j] + 1
+      local ins = curr[j - 1] + 1
+      local sub = prev[j - 1] + cost
+      -- inline min of three values
+      if del < ins then
+        curr[j] = del < sub and del or sub
+      else
+        curr[j] = ins < sub and ins or sub
+      end
     end
+    prev, curr = curr, prev
   end
 
-  return matrix[#a][#b]
+  return prev[lb]
 end
 
 --- Find similar strings from a list using Levenshtein distance.

--- a/lib/cosmic/fuzzy_test.tl
+++ b/lib/cosmic/fuzzy_test.tl
@@ -41,6 +41,49 @@ local function test_levenshtein_case_sensitive()
 end
 test_levenshtein_case_sensitive()
 
+local function test_levenshtein_symmetry()
+  -- distance(a,b) must equal distance(b,a) for all pairs
+  local pairs: {{string, string}} = {
+    {"kitten", "sitting"},
+    {"a", "abcdef"},
+    {"short", "a much longer string"},
+    {"xyz", ""},
+  }
+  for _, p in ipairs(pairs) do
+    local d1 = fuzzy.levenshtein(p[1], p[2])
+    local d2 = fuzzy.levenshtein(p[2], p[1])
+    assert(d1 == d2, "levenshtein should be symmetric: '" .. p[1] .. "' <-> '" .. p[2] .. "': " .. tostring(d1) .. " vs " .. tostring(d2))
+  end
+end
+test_levenshtein_symmetry()
+
+local function test_levenshtein_single_char()
+  assert(fuzzy.levenshtein("a", "b") == 1, "single char substitution")
+  assert(fuzzy.levenshtein("a", "a") == 0, "single char identical")
+  assert(fuzzy.levenshtein("a", "") == 1, "single char to empty")
+  assert(fuzzy.levenshtein("", "z") == 1, "empty to single char")
+end
+test_levenshtein_single_char()
+
+local function test_levenshtein_asymmetric_lengths()
+  -- when #a >> #b, the two-row optimization should swap to use less memory
+  assert(fuzzy.levenshtein("ab", "abcdefghij") == 8, "short vs long")
+  assert(fuzzy.levenshtein("abcdefghij", "ab") == 8, "long vs short")
+  assert(fuzzy.levenshtein("kitten", "sitting") == 3, "classic example")
+  assert(fuzzy.levenshtein("saturday", "sunday") == 3, "classic example 2")
+end
+test_levenshtein_asymmetric_lengths()
+
+local function test_levenshtein_longer_strings()
+  local a = string.rep("abc", 20) -- 60 chars
+  local b = string.rep("abc", 20) -- identical
+  assert(fuzzy.levenshtein(a, b) == 0, "long identical strings")
+  -- change one char in the middle
+  local c = a:sub(1, 30) .. "X" .. a:sub(32)
+  assert(fuzzy.levenshtein(a, c) == 1, "long strings with one substitution")
+end
+test_levenshtein_longer_strings()
+
 -- find_similar tests
 
 local function test_find_similar_exact_match()


### PR DESCRIPTION
## Summary

Optimize the Levenshtein distance implementation in `cosmic.fuzzy`:

- **Two-row algorithm**: replace the O(n×m) full matrix with a two-row (prev/curr) approach using O(min(n,m)) memory
- **string.byte**: use `string.byte(s, i)` instead of `string.sub(i, i)` for character comparison, avoiding per-character string allocation
- **Length swap**: swap a and b so the shorter string determines row width, minimizing both memory and inner-loop iterations
- **Inline min**: replace `math.min(a, b, c)` with inline comparisons to avoid function call overhead

## Tests added

- symmetry: distance(a,b) == distance(b,a) for various pairs
- single-char: edge cases with 1-character strings
- asymmetric lengths: short vs long strings (exercises the swap optimization)
- longer strings: 60-char strings with 0 and 1 edits

All existing tests continue to pass unchanged.

Fixes #382