### PR TITLE
update bootstrap to 2026-03-08-ac3a5d5 and use --include-dir for compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ $(o)/%: %
 # compile .tl files to .lua (extension changes)
 $(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files)
 	@mkdir -p $(@D)
-	@$(bootstrap_cosmic) --compile $< > $@.tmp
+	@$(bootstrap_cosmic) $(include_dir_flags) --compile $< > $@.tmp
 	@if cmp -s $@.tmp $@ 2>/dev/null; then rm $@.tmp; else mv $@.tmp $@; fi
 
 # tl files: modules declare _tl, derive compiled .lua outputs

--- a/cook.mk
+++ b/cook.mk
@@ -9,7 +9,7 @@ type_gen_outputs := $(patsubst %,lib/types/cosmo/%.d.tl,$(type_modules))
 modules += bootstrap
 bootstrap_cosmic := $(o)/bootstrap/cosmic
 bootstrap_files := $(bootstrap_cosmic)
-bootstrap_url := https://github.com/whilp/cosmic/releases/download/2026-02-07-a051c1d/cosmic-lua
+bootstrap_url := https://github.com/whilp/cosmic/releases/download/2026-03-08-ac3a5d5/cosmic-lua
 
 export PATH := $(o)/bootstrap:$(PATH)
 


### PR DESCRIPTION
- update bootstrap_url to latest release (2026-03-08-ac3a5d5) which includes `--include-dir` support
- pass `include_dir_flags` to bootstrap `--compile` rule so .tl compilation uses the same type resolution as `--check-types`

closes #389