### PR TITLE
child.spawn: support executing binaries from /zip/ via fexecve

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "7a95ae4b8784fb504450b8c65b2903daa64efa750683e9479ea617317280a7ef"}},
+  platforms = {["*"] = {sha = "c8074bf1e93ef7b97731811107fcee7545744f6fa7b6c520380a5d394f609601"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.02.10-ae1078722"
+  version = "2026.03.15-bbe7b3cf4"
 }

--- a/lib/cosmic/child.tl
+++ b/lib/cosmic/child.tl
@@ -4,7 +4,6 @@ local unix = require("cosmo.unix")
 local poll = require("cosmic.poll")
 
 --- Process resource usage statistics.
---- Contains CPU time, memory usage, I/O, and context switch counters.
 local record Rusage
   utime: function(self: Rusage): number, number
   stime: function(self: Rusage): number, number
@@ -43,9 +42,6 @@ local record Handle
 end
 
 --- Options for spawning a process.
---- env accepts either a list of "KEY=VALUE" strings ({string}) or a map
---- of name-to-value pairs ({string:string}). Maps are converted to list
---- format before passing to execve.
 local record Opts
   stdin: string | number
   stdout: number
@@ -92,37 +88,34 @@ end
 -- Low-level primitives --
 
 --- Creates a new process (fork).
---- Returns twice: parent gets child's pid (> 0), child gets 0.
 --- @return number The child process id in parent, 0 in child
 local function fork(): number
   return unix.fork()
 end
 
 --- Spawns a new process using posix_spawn (low-level).
---- More efficient than fork() + execve() on some systems.
 --- @param prog string Absolute path to the executable
 --- @param argv {string} Argument vector passed to the program
---- @param envp {string}? Environment variables (KEY=value format). Inherits if not specified
+--- @param envp {string}? Environment variables (KEY=value format)
 --- @return number The child process id on success
 local function posix_spawn(prog: string, argv: {string}, envp?: {string}): number
   return unix.spawn(prog, argv, envp)
 end
 
 --- Spawns a new process with PATH search (low-level).
---- Like posix_spawn() but searches for prog in $PATH directories.
 --- @param prog string The program name to execute
 --- @param argv {string} Argument vector passed to the program
---- @param envp {string}? Environment variables. Inherits if not specified
+--- @param envp {string}? Environment variables
 --- @return number The child process id on success
 local function posix_spawnp(prog: string, argv: {string}, envp?: {string}): number
   return unix.spawnp(prog, argv, envp)
 end
 
 --- Waits for child process to terminate.
---- @param pid number? Process id to wait for. -1 waits for any child (default)
---- @param options number? Wait options (e.g., WNOHANG for non-blocking)
+--- @param pid number? Process id to wait for (-1 for any child)
+--- @param options number? Wait options (e.g., WNOHANG)
 --- @return number The child process id that terminated
---- @return number Status code (use WIFEXITED, WEXITSTATUS, etc. to interpret)
+--- @return number Status code (use WIFEXITED, WEXITSTATUS to interpret)
 --- @return Rusage Resource usage statistics
 local function wait(pid?: number, options?: number): number, number, Rusage
   local wpid, status, rusage = unix.wait(pid, options)
@@ -139,46 +132,31 @@ end
 
 -- Status helpers --
 
---- Returns true if process exited normally (via exit() or return from main).
---- @param wstatus number Status code from wait()
---- @return boolean True if process exited cleanly
+--- Returns true if process exited normally.
 local function WIFEXITED(wstatus: number): boolean
   return unix.WIFEXITED(wstatus)
 end
 
---- Returns the exit code passed to exit().
---- Only valid if WIFEXITED(wstatus) is true.
---- @param wstatus number Status code from wait()
---- @return number The exit code
+--- Returns the exit code (valid if WIFEXITED is true).
 local function WEXITSTATUS(wstatus: number): number
   return unix.WEXITSTATUS(wstatus)
 end
 
 --- Returns true if process was terminated by a signal.
---- @param wstatus number Status code from wait()
---- @return boolean True if terminated by signal
 local function WIFSIGNALED(wstatus: number): boolean
   return unix.WIFSIGNALED(wstatus)
 end
 
---- Returns the signal number that terminated the process.
---- Only valid if WIFSIGNALED(wstatus) is true.
---- @param wstatus number Status code from wait()
---- @return number The signal number
+--- Returns the terminating signal number (valid if WIFSIGNALED is true).
 local function WTERMSIG(wstatus: number): number
   return unix.WTERMSIG(wstatus)
 end
 
 --- Normalize an env table to a list of "KEY=VALUE" strings.
---- Accepts either {string} (already a list) or {string:string} (map).
---- @param env {string} The environment table (list or map)
---- @return {string} A list of "KEY=VALUE" strings
 local function normalize_env(env: {string}): {string}
-  -- if the first element is a string, assume it's already a list
   if env[1] ~= nil then
     return env
   end
-  -- otherwise, treat as a map and convert to list
   local list: {string} = {}
   for k, v in pairs(env as {string: string}) do
     table.insert(list, k .. "=" .. v)
@@ -186,17 +164,43 @@ local function normalize_env(env: {string}): {string}
   return list
 end
 
+--- Checks if a path refers to a /zip/ virtual filesystem entry.
+local function is_zip_path(p: string): boolean
+  return p:sub(1, 5) == "/zip/"
+end
+
+--- Prepares an executable fd from a /zip/ path.
+--- Opens the path to get a zip fd suitable for fexecve.
+--- @param zip_path string Path starting with /zip/
+--- @return number The file descriptor ready for fexecve
+--- @return string Error message on failure
+local function prepare_zip_exec(zip_path: string): number, string
+  local fd = unix.open(zip_path, unix.O_RDONLY)
+  if not fd then
+    return nil, "failed to open zip path: " .. zip_path
+  end
+  return fd
+end
+
 -- High-level spawn API --
 
 --- Spawns a child process with I/O control.
+--- When argv[1] starts with /zip/, uses fexecve.
 --- @param argv {string} Command and arguments
---- @param opts Opts? Spawn options (stdin, stdout, stderr, env, cwd)
---- @return Handle Process handle with stdin, stdout, stderr pipes
---- @return string? Error message if spawn failed
+--- @param opts Opts? Spawn options
+--- @return Handle, string? Process handle or nil + error
 local function spawn(argv: {string}, opts?: Opts): Handle, string
   opts = opts or {}
 
-  if not (argv[1] as string):find("/") then
+  -- Handle /zip/ paths: open zip fd for fexecve
+  local exec_fd: number
+  if is_zip_path(argv[1]) then
+    local fd, err = prepare_zip_exec(argv[1])
+    if not fd then
+      return nil, err
+    end
+    exec_fd = fd
+  elseif not (argv[1] as string):find("/") then
     local cmd = unix.commandv(argv[1])
     if not cmd then
       return nil, "command not found: " .. argv[1]
@@ -274,8 +278,16 @@ local function spawn(argv: {string}, opts?: Opts): Handle, string
     end
 
     local env = opts.env and normalize_env(opts.env) or unix.environ()
-    unix.execve(argv[1], argv, env)
+    if exec_fd then
+      unix.fexecve(exec_fd, argv, env)
+    else
+      unix.execve(argv[1], argv, env)
+    end
     os.exit(127)
+  end
+
+  if exec_fd then
+    unix.close(exec_fd)
   end
 
   if pid == nil then
@@ -304,9 +316,7 @@ local function spawn(argv: {string}, opts?: Opts): Handle, string
     unix.close(stderr_w)
   end
 
-  -- Drain stdout and stderr concurrently using poll to avoid deadlock
-  -- when the child writes enough to fill a pipe buffer while the parent
-  -- is blocked reading the other pipe.
+  -- Drain stdout and stderr concurrently using poll to avoid deadlock.
   local function drain_pipes(out_pipe: Pipe, err_pipe: Pipe): string, string
     local out_chunks: {string} = {}
     local err_chunks: {string} = {}
@@ -408,6 +418,9 @@ local record ChildModule
   -- High-level spawn API
   spawn: function(argv: {string}, opts?: Opts): Handle, string
 
+  -- Zip binary helpers
+  prepare_zip_exec: function(zip_path: string): number, string
+
   -- Low-level primitives
   fork: function(): number
   posix_spawn: function(prog: string, argv: {string}, envp?: {string}): number
@@ -438,6 +451,9 @@ end
 local M: ChildModule = {
   -- High-level spawn API
   spawn = spawn,
+
+  -- Zip binary helpers
+  prepare_zip_exec = prepare_zip_exec,
 
   -- Low-level primitives
   fork = fork,

--- a/lib/cosmic/child_test.tl
+++ b/lib/cosmic/child_test.tl
@@ -317,3 +317,81 @@ local function test_read_no_deadlock_large_stderr()
   assert(out == "stdout ok\n", "expected 'stdout ok\\n', got '" .. tostring(out) .. "'")
 end
 test_read_no_deadlock_large_stderr()
+
+-- /zip/ binary execution via fexecve --
+
+local function test_prepare_zip_exec()
+  local prepare_zip_exec = child.prepare_zip_exec
+  assert(prepare_zip_exec, "prepare_zip_exec should be exported")
+
+  -- open a known /zip/ path (main.lua exists in every cosmic binary)
+  local fd, err = prepare_zip_exec("/zip/main.lua")
+  assert(fd, "should open zip fd: " .. tostring(err))
+  assert(fd > 0, "fd should be positive: " .. tostring(fd))
+  unix.close(fd)
+end
+test_prepare_zip_exec()
+
+local function test_prepare_zip_exec_nonexistent()
+  local fd, err = child.prepare_zip_exec("/zip/nonexistent_12345")
+  assert(fd == nil, "should fail for nonexistent zip path")
+  assert(err, "should have error message")
+  assert(err:find("zip", 1, true), "expected zip-related error: " .. err)
+end
+test_prepare_zip_exec_nonexistent()
+
+local function test_spawn_zip_nonexistent_path()
+  local handle, err = child.spawn({"/zip/nonexistent_binary_12345"})
+  assert(handle == nil, "handle should be nil for nonexistent /zip/ path")
+  assert(err, "should have error message")
+  assert(err:find("zip", 1, true) or err:find("not found", 1, true),
+    "expected zip-related error, got: " .. tostring(err))
+end
+test_spawn_zip_nonexistent_path()
+
+local function test_spawn_zip_non_executable()
+  -- /zip/main.lua exists but is not an ELF binary, so fexecve fails
+  local handle, err = child.spawn({"/zip/main.lua"})
+  assert(handle ~= nil, "spawn should succeed (fork works): " .. tostring(err))
+  local exit_code = handle:wait()
+  assert(exit_code == 127,
+    "expected exit 127 for non-executable, got " .. tostring(exit_code))
+end
+test_spawn_zip_non_executable()
+
+local function test_spawn_zip_embedded_binary()
+  -- embed /bin/echo into a copy of cosmic, then spawn it from /zip/
+  local fs = require("cosmic.fs")
+  local io_mod = require("cosmic.io")
+  local tmpdir = os.getenv("TEST_TMPDIR") as string
+
+  -- set up embed directory with .bin/echo
+  local bin_dir = fs.join(tmpdir, "embed", ".bin")
+  fs.makedirs(bin_dir)
+  local echo_data = io_mod.slurp("/bin/echo")
+  assert(echo_data, "should read /bin/echo")
+  io_mod.barf(fs.join(bin_dir, "echo"), echo_data)
+  fs.chmod(fs.join(bin_dir, "echo"), 493) -- 0755
+
+  -- create embedded cosmic binary
+  local out_bin = fs.join(tmpdir, "cosmic-with-echo")
+  local build = child.spawn(
+    {lua_bin, "--embed", fs.join(tmpdir, "embed"), "--output", out_bin})
+  assert(build, "embed spawn should succeed")
+  assert(build:wait() == 0, "embed should exit 0")
+
+  -- run the embedded binary: spawn /zip/.bin/echo via fexecve
+  local handle = child.spawn({out_bin, "-e", [[
+    local child = require("cosmic.child")
+    local h = child.spawn({"/zip/.bin/echo", "hello-from-zip"})
+    assert(h, "spawn /zip/.bin/echo failed")
+    local ok, out = h:read()
+    io.write(out)
+  ]]})
+  assert(handle, "should spawn embedded binary")
+  local ok, out = handle:read()
+  assert(ok, "embedded binary should succeed")
+  assert(out == "hello-from-zip\n",
+    "expected 'hello-from-zip\\n', got '" .. tostring(out) .. "'")
+end
+test_spawn_zip_embedded_binary()


### PR DESCRIPTION
closes #396

when `argv[1]` starts with `/zip/`, `child.spawn` now opens the zip fd and uses `fexecve` instead of `execve`. cosmopolitan's `fexecve` internally copies the zip fd contents to a memfd and executes from there — no temp files, no cleanup, transparent to callers.

## changes

**`lib/cosmic/child.tl`**
- `is_zip_path(p)` — checks if a path starts with `/zip/`
- `prepare_zip_exec(zip_path)` — opens a `/zip/` path, returns fd for fexecve
- `spawn()` — detects `/zip/` paths, opens zip fd before fork, uses `fexecve` in child
- exported `prepare_zip_exec` on `ChildModule` for direct use

**`lib/cosmic/child_test.tl`** — 5 new tests:
- `test_prepare_zip_exec` — opens known `/zip/main.lua`, gets valid fd
- `test_prepare_zip_exec_nonexistent` — returns nil + error for missing path
- `test_spawn_zip_nonexistent_path` — spawn returns nil + error
- `test_spawn_zip_non_executable` — spawn succeeds but child exits 127 (not ELF)
- `test_spawn_zip_embedded_binary` — end-to-end: embeds `/bin/echo` into cosmic, spawns `/zip/.bin/echo`, verifies output

**`3p/cosmos/version.lua`** — bumps to `2026.03.15-bbe7b3cf4` which includes the fexecve fix for non-APE ELF binaries from zip fds (whilp/cosmopolitan#93).

## cosmopolitan fix

discovered and fixed a bug in cosmopolitan's `fexecve`: `IsApeLoadable()` returns true for all ELF binaries (not just APE), so `ape_to_elf()` was called on native ELFs, failed, and caused `fexecve` to return `ENOEXEC`. fix landed in whilp/cosmopolitan@bbe7b3cf4.