### PR TITLE
httpapi: add lightweight HTTP API framework

### DIFF
--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -1,5 +1,5 @@
 modules += cosmic
-cosmic_srcs := $(wildcard lib/cosmic/*.tl) $(wildcard lib/cosmic/quicksand/*.tl) $(wildcard lib/cosmic/quicksand/box/*.tl) $(wildcard lib/cosmic/quicksand/proxy/*.tl)
+cosmic_srcs := $(wildcard lib/cosmic/*.tl) $(wildcard lib/cosmic/quicksand/*.tl) $(wildcard lib/cosmic/quicksand/box/*.tl) $(wildcard lib/cosmic/quicksand/proxy/*.tl) $(wildcard lib/cosmic/httpapi/*.tl)
 cosmic_tests := $(filter %_test.tl,$(cosmic_srcs))
 cosmic_examples := $(filter %_example.tl,$(cosmic_srcs))
 cosmic_tl := $(filter-out $(cosmic_tests) $(cosmic_examples) lib/cosmic/main.tl,$(cosmic_srcs))

--- a/lib/cosmic/httpapi/init.tl
+++ b/lib/cosmic/httpapi/init.tl
@@ -1,0 +1,218 @@
+--- Lightweight HTTP API framework.
+--- Provides route registration, middleware chaining, and a poll-based server.
+---
+--- Example:
+---   local httpapi = require("cosmic.httpapi")
+---   local response = require("cosmic.httpapi.response")
+---   local app = httpapi.new()
+---   app:get("/", function(req) return response.json({ok = true}) end)
+---   app:listen("0.0.0.0", 8080)
+local net = require("cosmic.net")
+local poll = require("cosmic.poll")
+local request_mod = require("cosmic.httpapi.request")
+local response_mod = require("cosmic.httpapi.response")
+local router_mod = require("cosmic.httpapi.router")
+local middleware_mod = require("cosmic.httpapi.middleware")
+local types = require("cosmic.httpapi.types")
+
+local type Request = request_mod.Request
+local type Response = response_mod.Response
+local type Handler = types.Handler
+local type Middleware = types.Middleware
+local type Next = Handler
+
+--- Per-connection state for the poll-based server.
+local record Conn
+  sock: net.Socket
+  buf: string
+end
+
+--- HTTP application with routing and middleware.
+local record App
+  --- Register a GET route.
+  get: function(App, string, Handler)
+  --- Register a POST route.
+  post: function(App, string, Handler)
+  --- Register a PUT route.
+  put: function(App, string, Handler)
+  --- Register a DELETE route.
+  delete: function(App, string, Handler)
+  --- Register a PATCH route.
+  patch: function(App, string, Handler)
+  --- Register a route with explicit method.
+  route: function(App, string, string, Handler)
+  --- Add middleware to the stack.
+  use: function(App, Middleware)
+  --- Handle a raw HTTP request string (for testing).
+  --- @param raw string Raw HTTP request bytes
+  --- @return Response
+  handle: function(App, string): Response
+  --- Start the server on the given address and port.
+  --- @param host string Bind address
+  --- @param port number Port number
+  listen: function(App, string, number)
+end
+
+--- Build the 404 response for unmatched routes.
+local function not_found(): Response
+  return response_mod.json({error = "not found"}, 404)
+end
+
+--- Process a complete HTTP request buffer through the app pipeline.
+local function process(
+    app_router: router_mod.Router,
+    middlewares: {Middleware},
+    raw: string
+  ): Response
+  local req, err = request_mod.parse(raw)
+  if not req then
+    return response_mod.json({error = err or "bad request"}, 400)
+  end
+  local handler, params = app_router:match(req.method, req.path)
+  if not handler then
+    return not_found()
+  end
+  req.params = params
+  local final = middleware_mod.chain(middlewares, handler)
+  return final(req)
+end
+
+--- Check if buffer contains a complete HTTP request.
+--- Returns true if we have headers + full body (per Content-Length).
+local function request_complete(buf: string): boolean
+  local header_end = buf:find("\r\n\r\n", 1, true)
+  if not header_end then
+    return false
+  end
+  local cl = buf:lower():match("content%-length:%s*(%d+)")
+  if cl then
+    local expected = tonumber(cl) as integer
+    local body_start = header_end + 4
+    return #buf >= body_start + expected - 1
+  end
+  return true
+end
+
+--- Create a new HTTP application.
+--- @return App
+local function new(): App
+  local r = router_mod.new()
+  local middlewares: {Middleware} = {}
+  local app: App = {}
+
+  app.get = function(self: App, pattern: string, handler: Handler)
+    local _ = self
+    r:add("GET", pattern, handler)
+  end
+
+  app.post = function(self: App, pattern: string, handler: Handler)
+    local _ = self
+    r:add("POST", pattern, handler)
+  end
+
+  app.put = function(self: App, pattern: string, handler: Handler)
+    local _ = self
+    r:add("PUT", pattern, handler)
+  end
+
+  app.delete = function(self: App, pattern: string, handler: Handler)
+    local _ = self
+    r:add("DELETE", pattern, handler)
+  end
+
+  app.patch = function(self: App, pattern: string, handler: Handler)
+    local _ = self
+    r:add("PATCH", pattern, handler)
+  end
+
+  app.route = function(self: App, method: string, pattern: string, handler: Handler)
+    local _ = self
+    r:add(method, pattern, handler)
+  end
+
+  app.use = function(self: App, mw: Middleware)
+    local _ = self
+    table.insert(middlewares, mw)
+  end
+
+  app.handle = function(self: App, raw: string): Response
+    local _ = self
+    return process(r, middlewares, raw)
+  end
+
+  app.listen = function(self: App, host: string, port: number)
+    local _ = self
+    local ip = net.parseip(host)
+    local server, err = net.socket(net.AF_INET,
+      net.SOCK_STREAM | net.SOCK_NONBLOCK)
+    assert(server, "socket failed: " .. tostring(err))
+    local ok: boolean
+    ok, err = server:setsockopt(net.SOL_SOCKET, net.SO_REUSEADDR, true)
+    assert(ok, "setsockopt failed: " .. tostring(err))
+    ok, err = server:bind(ip, port as integer)
+    assert(ok, "bind failed: " .. tostring(err))
+    ok, err = server:listen(128)
+    assert(ok, "listen failed: " .. tostring(err))
+    local _, actual_port = server:getsockname()
+    io.write("listening on " .. host .. ":" .. tostring(actual_port) .. "\n")
+    local poller = poll.new()
+    poller:add(server.fd, poll.POLLIN)
+    local conns: {number: Conn} = {}
+    while true do
+      for fd, events in poller:wait(1000) do
+        if fd == server.fd then
+          if events.readable then
+            local client, _, _, accept_err = server:accept(
+              net.SOCK_NONBLOCK | net.SOCK_CLOEXEC)
+            if client then
+              poller:add(client.fd, poll.POLLIN)
+              conns[client.fd] = {sock = client, buf = ""}
+            else
+              io.stderr:write("accept: " .. tostring(accept_err) .. "\n")
+            end
+          end
+        else
+          local conn = conns[fd]
+          if not conn then
+            poller:remove(fd)
+          elseif events.readable then
+            local data, recv_err = conn.sock:recv(8192)
+            if not data or #data == 0 then
+              local _ = recv_err
+              conn.sock:close()
+              poller:remove(fd)
+              conns[fd] = nil
+            else
+              conn.buf = conn.buf .. data
+              if request_complete(conn.buf) then
+                local resp = process(r, middlewares, conn.buf)
+                local raw_resp = response_mod.serialize(resp)
+                conn.sock:send(raw_resp)
+                conn.sock:close()
+                poller:remove(fd)
+                conns[fd] = nil
+              end
+            end
+          elseif events.error or events.hangup then
+            conn.sock:close()
+            poller:remove(fd)
+            conns[fd] = nil
+          end
+        end
+      end
+    end
+  end
+
+  return app
+end
+
+return {
+  App = App,
+  Request = Request,
+  Response = Response,
+  Handler = Handler,
+  Middleware = Middleware,
+  Next = Next,
+  Conn = Conn,
+  new = new,
+}

--- a/lib/cosmic/httpapi/init_example.tl
+++ b/lib/cosmic/httpapi/init_example.tl
@@ -1,0 +1,94 @@
+#!/usr/bin/env cosmic
+--- Example: lightweight JSON API with routing and middleware.
+local httpapi = require("cosmic.httpapi")
+local response = require("cosmic.httpapi.response")
+local net = require("cosmic.net")
+local child = require("cosmic.child")
+
+--- Example_hello demonstrates basic route handling and middleware.
+--- Creates a server with JSON routes and a timing middleware,
+--- then verifies responses via a real HTTP connection.
+local function Example_hello()
+  local app = httpapi.new()
+
+  -- Middleware: add X-Powered-By header to every response
+  app:use(function(_req: httpapi.Request, nxt: httpapi.Next): httpapi.Response
+      local resp = nxt(_req)
+      resp.headers["X-Powered-By"] = "cosmic"
+      return resp
+    end)
+
+  -- Routes
+  app:get("/", function(_req: httpapi.Request): httpapi.Response
+      return response.json({message = "welcome to cosmic httpapi"})
+    end)
+
+  app:get("/users/{id}", function(req: httpapi.Request): httpapi.Response
+      return response.json({user_id = req.params["id"]})
+    end)
+
+  app:post("/echo", function(req: httpapi.Request): httpapi.Response
+      return response.text(req.body)
+    end)
+
+  -- Bind to ephemeral port
+  local server, err = net.socket()
+  assert(server ~= nil, "socket: " .. tostring(err))
+  server:setsockopt(net.SOL_SOCKET, net.SO_REUSEADDR, true)
+  server:bind(net.parseip("127.0.0.1"), 0)
+  server:listen()
+  local _, port = server:getsockname()
+
+  -- Fork a child to serve 3 requests
+  local pid = child.fork()
+  if pid == 0 then
+    for _ = 1, 3 do
+      local client = server:accept()
+      if client then
+        local data = client:recv(4096)
+        if data then
+          local resp = app:handle(data)
+          client:send(response.serialize(resp))
+        end
+        client:close()
+      end
+    end
+    server:close()
+    os.exit(0)
+  end
+  server:close()
+
+  -- Request 1: GET /
+  local c1 = net.socket()
+  assert(c1 ~= nil)
+  c1:connect(net.parseip("127.0.0.1"), port)
+  c1:send("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+  local r1 = c1:recv(4096)
+  c1:close()
+  assert(r1 and r1:find("welcome"), "expected welcome, got: " .. tostring(r1))
+  assert(r1:find("X%-Powered%-By: cosmic"), "expected powered-by header")
+
+  -- Request 2: GET /users/7
+  local c2 = net.socket()
+  assert(c2 ~= nil)
+  c2:connect(net.parseip("127.0.0.1"), port)
+  c2:send("GET /users/7 HTTP/1.1\r\nHost: localhost\r\n\r\n")
+  local r2 = c2:recv(4096)
+  c2:close()
+  assert(r2 and r2:find('"7"'), "expected user_id 7, got: " .. tostring(r2))
+
+  -- Request 3: POST /echo
+  local body = "hello cosmic"
+  local c3 = net.socket()
+  assert(c3 ~= nil)
+  c3:connect(net.parseip("127.0.0.1"), port)
+  c3:send("POST /echo HTTP/1.1\r\nHost: localhost\r\n"
+    .. "Content-Length: " .. tostring(#body) .. "\r\n\r\n" .. body)
+  local r3 = c3:recv(4096)
+  c3:close()
+  assert(r3 and r3:find("hello cosmic"),
+    "expected echo body, got: " .. tostring(r3))
+
+  child.wait(pid)
+end
+Example_hello()

--- a/lib/cosmic/httpapi/init_test.tl
+++ b/lib/cosmic/httpapi/init_test.tl
@@ -1,0 +1,138 @@
+#!/usr/bin/env cosmic
+local httpapi = require("cosmic.httpapi")
+local response = require("cosmic.httpapi.response")
+local net = require("cosmic.net")
+local child = require("cosmic.child")
+
+local function test_app_creation()
+  local app = httpapi.new()
+  assert(app ~= nil, "expected app")
+end
+test_app_creation()
+
+local function test_route_registration()
+  local app = httpapi.new()
+  app:get("/test", function(_req: httpapi.Request): httpapi.Response
+      return response.text("ok")
+    end)
+  app:post("/data", function(_req: httpapi.Request): httpapi.Response
+      return response.json({ok = true})
+    end)
+end
+test_route_registration()
+
+local function test_handle_request()
+  local app = httpapi.new()
+  app:get("/hello", function(_req: httpapi.Request): httpapi.Response
+      return response.text("world")
+    end)
+  local raw = "GET /hello HTTP/1.1\r\nHost: localhost\r\n\r\n"
+  local resp = app:handle(raw)
+  assert(resp ~= nil, "expected response")
+  assert(resp.status == 200, "expected 200, got " .. tostring(resp.status))
+  assert(resp.body == "world", "expected world, got " .. tostring(resp.body))
+end
+test_handle_request()
+
+local function test_handle_not_found()
+  local app = httpapi.new()
+  app:get("/exists", function(_req: httpapi.Request): httpapi.Response
+      return response.text("yes")
+    end)
+  local raw = "GET /missing HTTP/1.1\r\nHost: localhost\r\n\r\n"
+  local resp = app:handle(raw)
+  assert(resp ~= nil, "expected response")
+  assert(resp.status == 404, "expected 404, got " .. tostring(resp.status))
+end
+test_handle_not_found()
+
+local function test_handle_with_params()
+  local app = httpapi.new()
+  app:get("/users/{id}", function(req: httpapi.Request): httpapi.Response
+      return response.json({id = req.params["id"]})
+    end)
+  local raw = "GET /users/42 HTTP/1.1\r\nHost: localhost\r\n\r\n"
+  local resp = app:handle(raw)
+  assert(resp ~= nil, "expected response")
+  assert(resp.status == 200, "expected 200")
+  assert(resp.body:find('"42"') or resp.body:find('"id"'),
+    "expected id in body, got " .. tostring(resp.body))
+end
+test_handle_with_params()
+
+local function test_handle_with_middleware()
+  local app = httpapi.new()
+  app:use(function(_req: httpapi.Request, nxt: httpapi.Next): httpapi.Response
+      local resp = nxt(_req)
+      resp.headers["X-Powered-By"] = "cosmic"
+      return resp
+    end)
+  app:get("/", function(_req: httpapi.Request): httpapi.Response
+      return response.text("home")
+    end)
+  local raw = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
+  local resp = app:handle(raw)
+  assert(resp.status == 200, "expected 200")
+  assert(resp.body == "home", "expected home body")
+  assert(resp.headers["X-Powered-By"] == "cosmic",
+    "expected powered-by header")
+end
+test_handle_with_middleware()
+
+local function test_integration_server()
+  -- Start server in a child process, make a real HTTP request
+  local app = httpapi.new()
+  app:get("/ping", function(_req: httpapi.Request): httpapi.Response
+      return response.json({pong = true})
+    end)
+
+  -- Bind to ephemeral port to get the port number
+  local server_sock, err = net.socket()
+  assert(server_sock ~= nil, "socket failed: " .. tostring(err))
+  local ok = server_sock:setsockopt(net.SOL_SOCKET, net.SO_REUSEADDR, true)
+  assert(ok, "setsockopt failed")
+  ok, err = server_sock:bind(net.parseip("127.0.0.1"), 0)
+  assert(ok, "bind failed: " .. tostring(err))
+  local _, port = server_sock:getsockname()
+  assert(port > 0, "expected port")
+  ok, err = server_sock:listen()
+  assert(ok, "listen failed: " .. tostring(err))
+
+  -- Fork: child accepts one connection and handles it
+  local pid = child.fork()
+  if pid == 0 then
+    local client = server_sock:accept()
+    if client then
+      local data = client:recv(4096)
+      if data then
+        local resp = app:handle(data)
+        if resp then
+          local raw_resp = response.serialize(resp)
+          client:send(raw_resp)
+        end
+      end
+      client:close()
+    end
+    server_sock:close()
+    os.exit(0)
+  end
+
+  -- Parent: connect and send request
+  server_sock:close()
+  local client = net.socket()
+  assert(client ~= nil, "client socket failed")
+  ok = client:connect(net.parseip("127.0.0.1"), port)
+  assert(ok, "connect failed")
+  client:send("GET /ping HTTP/1.1\r\nHost: localhost\r\n\r\n")
+  local data = client:recv(4096)
+  client:close()
+
+  -- Wait for child
+  child.wait(pid)
+
+  -- Verify response
+  assert(data ~= nil, "expected response data")
+  assert(data:find("HTTP/1.1 200"), "expected 200 in response: " .. tostring(data))
+  assert(data:find("pong"), "expected pong in response body")
+end
+test_integration_server()

--- a/lib/cosmic/httpapi/middleware.tl
+++ b/lib/cosmic/httpapi/middleware.tl
@@ -1,0 +1,37 @@
+--- Middleware chaining for HTTP request/response pipeline.
+--- Composes a list of middleware functions with a final handler into
+--- a single handler. Middleware runs in list order (first added = outermost).
+local request_mod = require("cosmic.httpapi.request")
+local response_mod = require("cosmic.httpapi.response")
+local types = require("cosmic.httpapi.types")
+
+local type Handler = types.Handler
+local type Middleware = types.Middleware
+
+--- Compose middleware and a handler into a single handler.
+--- Middleware runs in order: first in the list wraps outermost.
+---
+--- Example:
+---   local h = chain({logging, auth}, my_handler)
+---   -- Executes: logging -> auth -> my_handler -> auth -> logging
+---
+--- @param middlewares {Middleware} List of middleware functions
+--- @param handler Handler Final request handler
+--- @return Handler Composed handler
+local function chain(middlewares: {Middleware}, handler: Handler): Handler
+  local h = handler
+  for i = #middlewares, 1, -1 do
+    local mw = middlewares[i]
+    local nxt = h
+    h = function(req: request_mod.Request): response_mod.Response
+      return mw(req, nxt)
+    end
+  end
+  return h
+end
+
+return {
+  Handler = Handler,
+  Middleware = Middleware,
+  chain = chain,
+}

--- a/lib/cosmic/httpapi/middleware_test.tl
+++ b/lib/cosmic/httpapi/middleware_test.tl
@@ -1,0 +1,110 @@
+#!/usr/bin/env cosmic
+local middleware = require("cosmic.httpapi.middleware")
+local response = require("cosmic.httpapi.response")
+local request_mod = require("cosmic.httpapi.request")
+local types = require("cosmic.httpapi.types")
+
+-- Track call order
+local call_log: {string} = {}
+
+local function make_handler(): types.Handler
+  return function(_req: request_mod.Request): response.Response
+    table.insert(call_log, "handler")
+    return response.text("ok")
+  end
+end
+
+local function test_chain_no_middleware()
+  call_log = {}
+  local handler = make_handler()
+  local chained = middleware.chain({}, handler)
+  local resp = chained(nil as request_mod.Request)
+  assert(resp.body == "ok", "expected ok body")
+  assert(#call_log == 1, "expected 1 call")
+  assert(call_log[1] == "handler", "expected handler call")
+end
+test_chain_no_middleware()
+
+local function test_single_middleware()
+  call_log = {}
+  local mw: types.Middleware =
+  function(req: request_mod.Request, nxt: types.Handler): response.Response
+    table.insert(call_log, "before")
+    local resp = nxt(req)
+    table.insert(call_log, "after")
+    resp.headers["X-MW"] = "applied"
+    return resp
+  end
+  local handler = make_handler()
+  local chained = middleware.chain({mw}, handler)
+  local resp = chained(nil as request_mod.Request)
+  assert(resp.headers["X-MW"] == "applied", "expected middleware header")
+  assert(#call_log == 3, "expected 3 calls, got " .. tostring(#call_log))
+  assert(call_log[1] == "before", "expected before first")
+  assert(call_log[2] == "handler", "expected handler second")
+  assert(call_log[3] == "after", "expected after third")
+end
+test_single_middleware()
+
+local function test_middleware_order()
+  call_log = {}
+  local mw1: types.Middleware =
+  function(req: request_mod.Request, nxt: types.Handler): response.Response
+    table.insert(call_log, "mw1-before")
+    local resp = nxt(req)
+    table.insert(call_log, "mw1-after")
+    return resp
+  end
+  local mw2: types.Middleware =
+  function(req: request_mod.Request, nxt: types.Handler): response.Response
+    table.insert(call_log, "mw2-before")
+    local resp = nxt(req)
+    table.insert(call_log, "mw2-after")
+    return resp
+  end
+  local handler = make_handler()
+  local chained = middleware.chain({mw1, mw2}, handler)
+  chained(nil as request_mod.Request)
+  assert(#call_log == 5, "expected 5 calls, got " .. tostring(#call_log))
+  assert(call_log[1] == "mw1-before", "first middleware runs first")
+  assert(call_log[2] == "mw2-before", "second middleware runs second")
+  assert(call_log[3] == "handler", "handler runs in the middle")
+  assert(call_log[4] == "mw2-after", "second middleware after")
+  assert(call_log[5] == "mw1-after", "first middleware after last")
+end
+test_middleware_order()
+
+local function test_middleware_short_circuit()
+  call_log = {}
+  local blocker: types.Middleware =
+  function(_req: request_mod.Request, _nxt: types.Handler): response.Response
+    table.insert(call_log, "blocked")
+    return response.json({error = "forbidden"}, 403)
+  end
+  local handler = make_handler()
+  local chained = middleware.chain({blocker}, handler)
+  local resp = chained(nil as request_mod.Request)
+  assert(resp.status == 403, "expected 403, got " .. tostring(resp.status))
+  assert(#call_log == 1, "expected only blocker call")
+  assert(call_log[1] == "blocked", "expected blocked")
+end
+test_middleware_short_circuit()
+
+local function test_middleware_modifies_request()
+  call_log = {}
+  local injector: types.Middleware =
+  function(req: request_mod.Request, nxt: types.Handler): response.Response
+    req.headers["x-injected"] = "yes"
+    return nxt(req)
+  end
+  local handler: types.Handler =
+  function(req: request_mod.Request): response.Response
+    assert(req.headers["x-injected"] == "yes", "expected injected header")
+    return response.text("ok")
+  end
+  local chained = middleware.chain({injector}, handler)
+  local req = request_mod.parse("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+  assert(req ~= nil, "parse failed")
+  chained(req)
+end
+test_middleware_modifies_request()

--- a/lib/cosmic/httpapi/request.tl
+++ b/lib/cosmic/httpapi/request.tl
@@ -1,0 +1,101 @@
+--- HTTP request parsing.
+--- Parses raw HTTP/1.1 request bytes into a typed Request record.
+local url = require("cosmic.url")
+
+--- Parsed HTTP request.
+local record Request
+  --- HTTP method (GET, POST, etc.).
+  method: string
+  --- URL path without query string.
+  path: string
+  --- Raw query string (without leading ?).
+  query: string
+  --- Parsed query parameters.
+  query_params: {string: string}
+  --- HTTP headers (lowercase keys).
+  headers: {string: string}
+  --- Request body (from Content-Length).
+  body: string
+  --- Path parameters populated by the router.
+  params: {string: string}
+  --- Full request target as received (path + query).
+  raw_path: string
+end
+
+--- Parse a raw HTTP/1.1 request string into a Request.
+--- Expects at minimum a complete request line and headers (terminated by \r\n\r\n).
+--- If Content-Length is present and body data follows the headers, it is captured.
+--- @param raw string Raw HTTP request bytes
+--- @return Request Parsed request, or nil on error
+--- @return string Error message on failure
+local function parse(raw: string): Request, string
+  if raw == "" then
+    return nil, "empty request"
+  end
+  -- Find end of headers
+  local header_end = raw:find("\r\n\r\n", 1, true)
+  if not header_end then
+    return nil, "incomplete request: no header terminator"
+  end
+  -- Parse request line
+  local line_end = raw:find("\r\n", 1, true)
+  if not line_end then
+    return nil, "no request line"
+  end
+  local request_line = raw:sub(1, line_end - 1)
+  local method, target, version = request_line:match("^(%S+)%s+(%S+)%s+(%S+)$")
+  if not method or not target or not version then
+    return nil, "invalid request line: " .. request_line
+  end
+  -- Parse path and query from target
+  local path: string
+  local query: string
+  local qpos = target:find("?", 1, true)
+  if qpos then
+    path = target:sub(1, qpos - 1)
+    query = target:sub(qpos + 1)
+  else
+    path = target
+    query = ""
+  end
+  -- Parse query params
+  local query_params: {string: string} = {}
+  if query ~= "" then
+    query_params = url.parse(query)
+  end
+  -- Parse headers
+  local headers: {string: string} = {}
+  local header_block = raw:sub(line_end + 2, header_end - 1)
+  for line in header_block:gmatch("([^\r\n]+)") do
+    local name, value = line:match("^([^:]+):%s*(.+)$")
+    if name then
+      headers[name:lower()] = value
+    end
+  end
+  -- Parse body if Content-Length present
+  local body = ""
+  local content_length_str = headers["content-length"]
+  if content_length_str then
+    local content_length = tonumber(content_length_str)
+    if content_length and content_length > 0 then
+      local body_start = header_end + 4
+      body = raw:sub(body_start, body_start + (content_length as integer) - 1)
+    end
+  end
+  local _ = version
+  return {
+    method = method,
+    path = path,
+    query = query,
+    query_params = query_params,
+    headers = headers,
+    body = body,
+    params = {},
+    raw_path = target,
+  }
+end
+
+return {
+  Request = Request,
+  parse = parse,
+}

--- a/lib/cosmic/httpapi/request_test.tl
+++ b/lib/cosmic/httpapi/request_test.tl
@@ -1,0 +1,95 @@
+#!/usr/bin/env cosmic
+local request = require("cosmic.httpapi.request")
+
+local function test_parse_get_request()
+  local raw = "GET /hello HTTP/1.1\r\nHost: localhost\r\n\r\n"
+  local req, err = request.parse(raw)
+  assert(req ~= nil, "parse failed: " .. tostring(err))
+  assert(req.method == "GET", "expected GET, got " .. tostring(req.method))
+  assert(req.path == "/hello", "expected /hello, got " .. tostring(req.path))
+  assert(req.headers["host"] == "localhost",
+    "expected host header, got " .. tostring(req.headers["host"]))
+end
+test_parse_get_request()
+
+local function test_parse_post_with_body()
+  local raw = "POST /data HTTP/1.1\r\n"
+  .. "Host: localhost\r\n"
+  .. "Content-Length: 13\r\n"
+  .. "\r\n"
+  .. '{"key":"val"}'
+  local req, err = request.parse(raw)
+  assert(req ~= nil, "parse failed: " .. tostring(err))
+  assert(req.method == "POST", "expected POST")
+  assert(req.path == "/data", "expected /data")
+  assert(req.body == '{"key":"val"}', "expected body, got " .. tostring(req.body))
+end
+test_parse_post_with_body()
+
+local function test_parse_query_string()
+  local raw = "GET /search?q=hello&page=2 HTTP/1.1\r\nHost: localhost\r\n\r\n"
+  local req, err = request.parse(raw)
+  assert(req ~= nil, "parse failed: " .. tostring(err))
+  assert(req.path == "/search", "expected /search, got " .. tostring(req.path))
+  assert(req.query == "q=hello&page=2",
+    "expected query string, got " .. tostring(req.query))
+  assert(req.query_params["q"] == "hello",
+    "expected q=hello, got " .. tostring(req.query_params["q"]))
+  assert(req.query_params["page"] == "2",
+    "expected page=2, got " .. tostring(req.query_params["page"]))
+end
+test_parse_query_string()
+
+local function test_parse_raw_path()
+  local raw = "GET /users/42?fields=name HTTP/1.1\r\nHost: localhost\r\n\r\n"
+  local req, err = request.parse(raw)
+  assert(req ~= nil, "parse failed: " .. tostring(err))
+  assert(req.raw_path == "/users/42?fields=name",
+    "expected raw_path, got " .. tostring(req.raw_path))
+end
+test_parse_raw_path()
+
+local function test_parse_multiple_headers()
+  local raw = "GET / HTTP/1.1\r\n"
+  .. "Host: localhost\r\n"
+  .. "Accept: application/json\r\n"
+  .. "Authorization: Bearer tok123\r\n"
+  .. "\r\n"
+  local req, err = request.parse(raw)
+  assert(req ~= nil, "parse failed: " .. tostring(err))
+  assert(req.headers["accept"] == "application/json", "expected accept header")
+  assert(req.headers["authorization"] == "Bearer tok123", "expected auth header")
+end
+test_parse_multiple_headers()
+
+local function test_parse_empty_path()
+  local raw = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
+  local req, err = request.parse(raw)
+  assert(req ~= nil, "parse failed: " .. tostring(err))
+  assert(req.path == "/", "expected /, got " .. tostring(req.path))
+  assert(req.query == nil or req.query == "", "expected no query")
+end
+test_parse_empty_path()
+
+local function test_parse_invalid_request_line()
+  local raw = "INVALID\r\nHost: localhost\r\n\r\n"
+  local req, err = request.parse(raw)
+  assert(req == nil, "expected parse to fail")
+  assert(err ~= nil, "expected error message")
+end
+test_parse_invalid_request_line()
+
+local function test_parse_empty_input()
+  local req, err = request.parse("")
+  assert(req == nil, "expected parse to fail on empty input")
+  assert(err ~= nil, "expected error message")
+end
+test_parse_empty_input()
+
+local function test_params_initialized_empty()
+  local raw = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
+  local req = request.parse(raw)
+  assert(req ~= nil, "parse failed")
+  assert(req.params ~= nil, "expected params table")
+end
+test_params_initialized_empty()

--- a/lib/cosmic/httpapi/response.tl
+++ b/lib/cosmic/httpapi/response.tl
@@ -1,0 +1,119 @@
+--- HTTP response building and serialization.
+--- Provides typed response records and helpers for common content types.
+local json = require("cosmic.json")
+
+--- HTTP response.
+local record Response
+  --- HTTP status code.
+  status: number
+  --- Response headers.
+  headers: {string: string}
+  --- Response body.
+  body: string
+end
+
+local status_text: {number: string} = {
+  [200] = "OK",
+  [201] = "Created",
+  [204] = "No Content",
+  [301] = "Moved Permanently",
+  [302] = "Found",
+  [304] = "Not Modified",
+  [400] = "Bad Request",
+  [401] = "Unauthorized",
+  [403] = "Forbidden",
+  [404] = "Not Found",
+  [405] = "Method Not Allowed",
+  [500] = "Internal Server Error",
+}
+
+--- Create a new response.
+--- @param status number HTTP status code
+--- @param body string Response body
+--- @param headers {string:string} Optional headers
+--- @return Response
+local function new(status: number, body: string, headers?: {string: string}): Response
+  return {
+    status = status,
+    body = body,
+    headers = headers or {},
+  }
+end
+
+--- Create a JSON response.
+--- @param data any Value to JSON-encode
+--- @param status number HTTP status code (default 200)
+--- @return Response
+local function json_response(data: any, status?: number): Response
+  local encoded = json.encode(data)
+  return {
+    status = status or 200,
+    body = encoded,
+    headers = {["Content-Type"] = "application/json"},
+  }
+end
+
+--- Create a plain text response.
+--- @param body string Text body
+--- @param status number HTTP status code (default 200)
+--- @return Response
+local function text(body: string, status?: number): Response
+  return {
+    status = status or 200,
+    body = body,
+    headers = {["Content-Type"] = "text/plain; charset=utf-8"},
+  }
+end
+
+--- Create an HTML response.
+--- @param body string HTML body
+--- @param status number HTTP status code (default 200)
+--- @return Response
+local function html(body: string, status?: number): Response
+  return {
+    status = status or 200,
+    body = body,
+    headers = {["Content-Type"] = "text/html; charset=utf-8"},
+  }
+end
+
+--- Create a redirect response.
+--- @param url string Redirect target URL
+--- @param status number HTTP status code (default 302)
+--- @return Response
+local function redirect(url: string, status?: number): Response
+  return {
+    status = status or 302,
+    body = "",
+    headers = {["Location"] = url},
+  }
+end
+
+--- Serialize a response to HTTP/1.1 wire format.
+--- @param resp Response The response to serialize
+--- @return string Raw HTTP response bytes
+local function serialize(resp: Response): string
+  local reason = status_text[resp.status] or "Unknown"
+  local parts: {string} = {}
+  table.insert(parts, "HTTP/1.1 " .. tostring(resp.status) .. " " .. reason .. "\r\n")
+  -- Set Content-Length if not already present
+  if not resp.headers["Content-Length"] then
+    table.insert(parts, "Content-Length: " .. tostring(#resp.body) .. "\r\n")
+  end
+  for k, v in pairs(resp.headers) do
+    table.insert(parts, k .. ": " .. v .. "\r\n")
+  end
+  table.insert(parts, "\r\n")
+  table.insert(parts, resp.body)
+  return table.concat(parts)
+end
+
+return {
+  Response = Response,
+  new = new,
+  json = json_response,
+  text = text,
+  html = html,
+  redirect = redirect,
+  serialize = serialize,
+}

--- a/lib/cosmic/httpapi/response_test.tl
+++ b/lib/cosmic/httpapi/response_test.tl
@@ -1,0 +1,95 @@
+#!/usr/bin/env cosmic
+local response = require("cosmic.httpapi.response")
+
+local function test_new_response()
+  local r = response.new(200, "hello")
+  assert(r.status == 200, "expected status 200, got " .. tostring(r.status))
+  assert(r.body == "hello", "expected body 'hello', got " .. tostring(r.body))
+  assert(r.headers ~= nil, "expected headers table")
+end
+test_new_response()
+
+local function test_new_with_headers()
+  local r = response.new(201, "created", {["X-Custom"] = "yes"})
+  assert(r.status == 201, "expected status 201")
+  assert(r.headers["X-Custom"] == "yes", "expected custom header")
+end
+test_new_with_headers()
+
+local function test_json_response()
+  local r = response.json({name = "alice"})
+  assert(r.status == 200, "expected status 200, got " .. tostring(r.status))
+  assert(r.headers["Content-Type"] == "application/json", "expected json content type")
+  assert(r.body:find('"name"'), "expected json body with name field")
+  assert(r.body:find('"alice"'), "expected json body with alice value")
+end
+test_json_response()
+
+local function test_json_custom_status()
+  local r = response.json({error = "not found"}, 404)
+  assert(r.status == 404, "expected status 404, got " .. tostring(r.status))
+end
+test_json_custom_status()
+
+local function test_text_response()
+  local r = response.text("hello world")
+  assert(r.status == 200, "expected status 200")
+  assert(r.body == "hello world", "expected text body")
+  assert(r.headers["Content-Type"] == "text/plain; charset=utf-8",
+    "expected text content type, got " .. tostring(r.headers["Content-Type"]))
+end
+test_text_response()
+
+local function test_text_custom_status()
+  local r = response.text("not found", 404)
+  assert(r.status == 404, "expected status 404")
+end
+test_text_custom_status()
+
+local function test_html_response()
+  local r = response.html("<h1>Hello</h1>")
+  assert(r.status == 200, "expected status 200")
+  assert(r.body == "<h1>Hello</h1>", "expected html body")
+  assert(r.headers["Content-Type"] == "text/html; charset=utf-8",
+    "expected html content type")
+end
+test_html_response()
+
+local function test_redirect_response()
+  local r = response.redirect("/new-location")
+  assert(r.status == 302, "expected status 302, got " .. tostring(r.status))
+  assert(r.headers["Location"] == "/new-location", "expected location header")
+  assert(r.body == "", "expected empty body")
+end
+test_redirect_response()
+
+local function test_redirect_permanent()
+  local r = response.redirect("/permanent", 301)
+  assert(r.status == 301, "expected status 301")
+end
+test_redirect_permanent()
+
+local function test_serialize_basic()
+  local r = response.new(200, "OK")
+  local raw = response.serialize(r)
+  assert(raw:find("HTTP/1.1 200"), "expected HTTP status line, got: " .. raw:sub(1, 40))
+  assert(raw:find("Content%-Length: 2"), "expected content-length header")
+  assert(raw:find("\r\n\r\nOK$"), "expected body after blank line")
+end
+test_serialize_basic()
+
+local function test_serialize_headers()
+  local r = response.new(404, "nope", {["X-Test"] = "val"})
+  local raw = response.serialize(r)
+  assert(raw:find("HTTP/1.1 404"), "expected 404 status")
+  assert(raw:find("X%-Test: val"), "expected custom header in output")
+end
+test_serialize_headers()
+
+local function test_serialize_empty_body()
+  local r = response.new(204, "")
+  local raw = response.serialize(r)
+  assert(raw:find("HTTP/1.1 204"), "expected 204 status")
+  assert(raw:find("Content%-Length: 0"), "expected zero content-length")
+end
+test_serialize_empty_body()

--- a/lib/cosmic/httpapi/router.tl
+++ b/lib/cosmic/httpapi/router.tl
@@ -1,0 +1,123 @@
+--- URL routing with path parameter capture.
+--- Matches request method and path against registered routes.
+--- Supports {param} placeholders in path patterns.
+local types = require("cosmic.httpapi.types")
+
+local type Handler = types.Handler
+
+--- A compiled path segment: either a literal string or a parameter name.
+local record Segment
+  --- Literal text to match (nil for param segments).
+  literal: string
+  --- Parameter name to capture (nil for literal segments).
+  param: string
+end
+
+--- A registered route.
+local record Route
+  method: string
+  pattern: string
+  segments: {Segment}
+  handler: Handler
+end
+
+--- Compile a path pattern into segments.
+--- Splits on "/" and identifies {param} placeholders.
+--- @param pattern string URL pattern like "/users/{id}/posts"
+--- @return {Segment} Compiled segments
+local function compile(pattern: string): {Segment}
+  local segments: {Segment} = {}
+  for part in pattern:gmatch("[^/]+") do
+    local param = part:match("^{(.+)}$")
+    if param then
+      table.insert(segments, {param = param})
+    else
+      table.insert(segments, {literal = part})
+    end
+  end
+  return segments
+end
+
+--- Match a path against compiled segments.
+--- @param segments {Segment} Compiled route segments
+--- @param path string Request path to match
+--- @return {string:string} Captured parameters, or nil if no match
+local function match_path(segments: {Segment}, path: string): {string: string}
+  -- Trailing slash means different path (except root)
+  if #path > 1 and path:sub(#path) == "/" then
+    return nil
+  end
+  local parts: {string} = {}
+  for part in path:gmatch("[^/]+") do
+    table.insert(parts, part)
+  end
+  if #parts ~= #segments then
+    return nil
+  end
+  local params: {string: string} = {}
+  for i = 1, #segments do
+    local seg = segments[i]
+    if seg.literal then
+      if parts[i] ~= seg.literal then
+        return nil
+      end
+    else
+      params[seg.param] = parts[i]
+    end
+  end
+  return params
+end
+
+--- Router that matches requests to handlers.
+local record Router
+  routes: {Route}
+  --- Register a route.
+  add: function(Router, string, string, Handler)
+  --- Find a matching handler for a method and path.
+  match: function(Router, string, string): Handler, {string: string}
+end
+
+--- Create a new router.
+--- @return Router
+local function new(): Router
+  local r: Router = {routes = {}}
+
+  r.add = function(self: Router, method: string, pattern: string, handler: Handler)
+    local segments = compile(pattern)
+    table.insert(self.routes, {
+        method = method,
+        pattern = pattern,
+        segments = segments,
+        handler = handler,
+      })
+  end
+
+  function r:match(method: string, path: string): Handler, {string: string}
+    -- Special case: root path "/" has zero segments
+    local is_root = path == "/"
+    for _, route in ipairs(self.routes) do
+      if route.method == method then
+        if is_root and route.pattern == "/" then
+          return route.handler, {}
+        end
+        local params = match_path(route.segments, path)
+        if params then
+          return route.handler, params
+        end
+      end
+    end
+    return nil, nil
+  end
+
+  return r
+end
+
+return {
+  Handler = Handler,
+  Route = Route,
+  Segment = Segment,
+  Router = Router,
+  compile = compile,
+  match_path = match_path,
+  new = new,
+}

--- a/lib/cosmic/httpapi/router_test.tl
+++ b/lib/cosmic/httpapi/router_test.tl
@@ -1,0 +1,113 @@
+#!/usr/bin/env cosmic
+local router = require("cosmic.httpapi.router")
+local response = require("cosmic.httpapi.response")
+local types = require("cosmic.httpapi.types")
+local request_mod = require("cosmic.httpapi.request")
+
+local function ok_handler(_req: request_mod.Request): response.Response
+  return response.text("ok")
+end
+
+local function user_handler(_req: request_mod.Request): response.Response
+  return response.text("user")
+end
+
+local function test_exact_match()
+  local r = router.new()
+  r:add("GET", "/hello", ok_handler)
+  local handler, params = r:match("GET", "/hello")
+  assert(handler ~= nil, "expected handler for GET /hello")
+  assert(params ~= nil, "expected params table")
+  assert(next(params) == nil, "expected empty params for exact match")
+end
+test_exact_match()
+
+local function test_no_match_returns_nil()
+  local r = router.new()
+  r:add("GET", "/hello", ok_handler)
+  local handler = r:match("GET", "/world")
+  assert(handler == nil, "expected nil for unmatched path")
+end
+test_no_match_returns_nil()
+
+local function test_method_mismatch()
+  local r = router.new()
+  r:add("GET", "/hello", ok_handler)
+  local handler = r:match("POST", "/hello")
+  assert(handler == nil, "expected nil for method mismatch")
+end
+test_method_mismatch()
+
+local function test_param_capture()
+  local r = router.new()
+  r:add("GET", "/users/{id}", user_handler)
+  local handler, params = r:match("GET", "/users/42")
+  assert(handler ~= nil, "expected handler for /users/42")
+  assert(params["id"] == "42", "expected id=42, got " .. tostring(params["id"]))
+end
+test_param_capture()
+
+local function test_multiple_params()
+  local r = router.new()
+  r:add("GET", "/users/{user_id}/posts/{post_id}", ok_handler)
+  local handler, params = r:match("GET", "/users/7/posts/99")
+  assert(handler ~= nil, "expected handler")
+  assert(params["user_id"] == "7",
+    "expected user_id=7, got " .. tostring(params["user_id"]))
+  assert(params["post_id"] == "99",
+    "expected post_id=99, got " .. tostring(params["post_id"]))
+end
+test_multiple_params()
+
+local function test_root_path()
+  local r = router.new()
+  r:add("GET", "/", ok_handler)
+  local handler = r:match("GET", "/")
+  assert(handler ~= nil, "expected handler for root path")
+end
+test_root_path()
+
+local function test_trailing_slash_no_match()
+  local r = router.new()
+  r:add("GET", "/hello", ok_handler)
+  local handler = r:match("GET", "/hello/")
+  assert(handler == nil, "expected no match for trailing slash")
+end
+test_trailing_slash_no_match()
+
+local function test_multiple_routes()
+  local r = router.new()
+  r:add("GET", "/a", ok_handler)
+  r:add("POST", "/b", user_handler)
+  local h1 = r:match("GET", "/a")
+  local h2 = r:match("POST", "/b")
+  local h3 = r:match("GET", "/b")
+  assert(h1 ~= nil, "expected handler for GET /a")
+  assert(h2 ~= nil, "expected handler for POST /b")
+  assert(h3 == nil, "expected nil for GET /b")
+end
+test_multiple_routes()
+
+local function test_param_with_dashes()
+  local r = router.new()
+  r:add("GET", "/items/{slug}", ok_handler)
+  local handler, params = r:match("GET", "/items/my-cool-item")
+  assert(handler ~= nil, "expected handler")
+  assert(params["slug"] == "my-cool-item",
+    "expected slug, got " .. tostring(params["slug"]))
+end
+test_param_with_dashes()
+
+local function test_same_path_different_methods()
+  local r = router.new()
+  r:add("GET", "/resource", ok_handler)
+  r:add("POST", "/resource", user_handler)
+  local h1 = r:match("GET", "/resource")
+  local h2 = r:match("POST", "/resource")
+  assert(h1 ~= nil, "expected GET handler")
+  assert(h2 ~= nil, "expected POST handler")
+  assert(h1 ~= h2, "expected different handlers")
+end
+test_same_path_different_methods()
+
+local _ = types

--- a/lib/cosmic/httpapi/types.tl
+++ b/lib/cosmic/httpapi/types.tl
@@ -1,0 +1,14 @@
+--- Shared type definitions for the httpapi framework.
+local request_mod = require("cosmic.httpapi.request")
+local response_mod = require("cosmic.httpapi.response")
+
+--- Request handler function.
+local type Handler = function(request_mod.Request): response_mod.Response
+
+  --- Middleware function that wraps a handler.
+  local type Middleware = function(request_mod.Request, Handler): response_mod.Response
+
+    return {
+      Handler = Handler,
+      Middleware = Middleware,
+    }


### PR DESCRIPTION
Starlette-inspired API framework in lib/cosmic/httpapi/ with:
- request parsing (HTTP/1.1 method, path, headers, body, query params)
- response building (json, text, html, redirect, serialization)
- URL routing with {param} path parameter capture
- middleware chaining (first-added = outermost, supports short-circuit)
- poll-based concurrent server loop via cosmic.poll
- shared type definitions (Handler, Middleware)

All modules are under 500 lines. Includes tests for each module
plus an integration test that forks a child server process and
makes real HTTP requests. Example demonstrates routes, middleware,
and POST echo.

https://claude.ai/code/session_01HPSUoAai4P2sMb9nEzzuKh