### PR TITLE
quicksand.box: rename from quicksand.jail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,7 +213,7 @@ all modules are under `lib/cosmic/` and imported as `cosmic.*`:
 | pledge | restrict system calls (OpenBSD, Linux) |
 | unveil | restrict filesystem visibility (OpenBSD) |
 | landlock | Linux >=5.13 self-restricting filesystem sandbox |
-| quicksand | Linux namespace + allowlist proxy jail primitives and declarative `Jail` builder |
+| quicksand | Linux namespace + allowlist proxy box primitives and declarative `Box` builder |
 | shm | shared memory with atomic ops and futexes |
 | signal | signal handling, timers, sigsets |
 | sqlite | SQLite with ergonomic query/exec/transaction API |

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ $(o)/%.tl.test.got: .UNVEIL = rx:$(o)/bootstrap r:lib r:3p rwcx:$(o) rwc:$(TMP) 
 quicksand_sandbox_tests := \
   $(o)/lib/cosmic/quicksand/netns_test.tl.test.got \
   $(o)/lib/cosmic/quicksand/proxy_test.tl.test.got \
-  $(o)/lib/cosmic/quicksand/jail/run_test.tl.test.got
+  $(o)/lib/cosmic/quicksand/box/run_test.tl.test.got
 $(quicksand_sandbox_tests): .PLEDGE =
 $(quicksand_sandbox_tests): .UNVEIL =
 

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -53,7 +53,7 @@ local sqlite = require("cosmic.sqlite")
 | `cosmic.pledge` | restrict system calls on OpenBSD and Linux |
 | `cosmic.unveil` | restrict filesystem visibility on OpenBSD |
 | `cosmic.landlock` | Linux >=5.13 self-restricting filesystem sandbox |
-| `cosmic.quicksand` | Linux namespace + allowlist proxy jail primitives and declarative `Jail` builder |
+| `cosmic.quicksand` | Linux namespace + allowlist proxy box primitives and declarative `Box` builder |
 
 ### Process
 
@@ -240,25 +240,25 @@ sock:close()
 
 ### Sandboxing
 
-`cosmic.quicksand.Jail` composes the Linux namespace primitives,
+`cosmic.quicksand.Box` composes the Linux namespace primitives,
 landlock, pledge, and an allowlist HTTP proxy into a single declarative
 policy + `run(argv)` call. Policy is a plain table, composable with
-`Jail.merge(base, over)`:
+`Box.merge(base, over)`:
 
 ```teal
 local quicksand = require("cosmic.quicksand")
 
-local jail = assert(quicksand.Jail.new({
+local box = assert(quicksand.Box.new({
   fs   = { ro = {"/usr", "/etc/ssl/certs"}, rw = {"/tmp"} },
   net  = { allow = { ["api.example.com:443"] = {} } },
   proc = { no_new_privs = true, uid = 1000 },
   env  = { keep = {"PATH", "HOME"}, set = { CI = "1" } },
   cwd  = "/tmp",
 }))
-os.exit(assert(jail:run({ "/usr/bin/bash", "-c", "make test" })))
+os.exit(assert(box:run({ "/usr/bin/bash", "-c", "make test" })))
 ```
 
-`Jail.new` validates shape and runs a capability preflight so
+`Box.new` validates shape and runs a capability preflight so
 misconfiguration surfaces before any syscall. `run` forks a supervisor
 that unshares `USER|NET|NS` (+`UTS` if `hostname` is set), writes
 uid/gid maps, brings up loopback, optionally starts the allowlist
@@ -273,7 +273,7 @@ For finer control the underlying primitives are still available:
 - `cosmic.landlock` / `cosmic.pledge` / `cosmic.unveil` for
   self-restriction in the current process
 - `cosmic.quicksand.netns` / `.proc` / `.proxy` for manually assembling
-  a jail
+  a box
 
 ## Documentation
 

--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -1,5 +1,5 @@
 modules += cosmic
-cosmic_srcs := $(wildcard lib/cosmic/*.tl) $(wildcard lib/cosmic/quicksand/*.tl) $(wildcard lib/cosmic/quicksand/jail/*.tl)
+cosmic_srcs := $(wildcard lib/cosmic/*.tl) $(wildcard lib/cosmic/quicksand/*.tl) $(wildcard lib/cosmic/quicksand/box/*.tl)
 cosmic_tests := $(filter %_test.tl,$(cosmic_srcs))
 cosmic_examples := $(filter %_example.tl,$(cosmic_srcs))
 cosmic_tl := $(filter-out $(cosmic_tests) $(cosmic_examples) lib/cosmic/main.tl,$(cosmic_srcs))

--- a/lib/cosmic/landlock.tl
+++ b/lib/cosmic/landlock.tl
@@ -18,7 +18,7 @@
 ---     }
 ---
 --- Requires Linux >= 5.13. `available()` returns false on older kernels
---- and non-Linux hosts; gate jail setup on it. Pairs naturally with
+--- and non-Linux hosts; gate box setup on it. Pairs naturally with
 --- `cosmic.pledge` on Linux and is complementary to `cosmic.quicksand`
 --- network isolation.
 local clandlock = require("cosmo.sandbox.landlock")
@@ -80,7 +80,7 @@ local function abi(): integer, string
   return v
 end
 
---- True when abi() >= 1. Gate jail setup on this.
+--- True when abi() >= 1. Gate box setup on this.
 local function available(): boolean
   return clandlock.available()
 end

--- a/lib/cosmic/landlock_example.tl
+++ b/lib/cosmic/landlock_example.tl
@@ -5,7 +5,7 @@
 --- kernel support that varies by host.
 
 -- Example_available demonstrates the capability probe. Applications
--- should gate jail setup on available() so they degrade cleanly on
+-- should gate box setup on available() so they degrade cleanly on
 -- kernels older than 5.13 and on non-Linux hosts. This example prints
 -- a different line depending on whether landlock is supported, so no
 -- output check is attached.

--- a/lib/cosmic/quicksand/box/env.tl
+++ b/lib/cosmic/quicksand/box/env.tl
@@ -1,7 +1,7 @@
---- Pure env-policy helpers for cosmic.quicksand.Jail.
+--- Pure env-policy helpers for cosmic.quicksand.Box.
 ---
 --- Given an env policy (`keep` list, `set` map) and the parent
---- environment, return the env dict the jailed workload should see.
+--- environment, return the env dict the boxed workload should see.
 ---
 --- Semantics:
 ---   keep   list of variable names to inherit from the parent
@@ -51,12 +51,12 @@ local function render(env: {string: string}): {string}
   return out
 end
 
-local record JailEnvModule
+local record BoxEnvModule
   apply: function(opts: EnvOpts, parent: {string: string}): {string: string}
   render: function(env: {string: string}): {string}
 end
 
-local M: JailEnvModule = {
+local M: BoxEnvModule = {
   apply = apply,
   render = render,
 }

--- a/lib/cosmic/quicksand/box/env_test.tl
+++ b/lib/cosmic/quicksand/box/env_test.tl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cosmic
-local jenv = require("cosmic.quicksand.jail.env")
+local jenv = require("cosmic.quicksand.box.env")
 
 local function test_keep_filters_parent()
   local parent: {string: string} = {PATH = "/bin", HOME = "/h", SECRET = "s"}

--- a/lib/cosmic/quicksand/box/fs.tl
+++ b/lib/cosmic/quicksand/box/fs.tl
@@ -1,8 +1,8 @@
---- Pure translator: Jail `fs` policy → `cosmic.landlock.RestrictOpts`.
+--- Pure translator: Box `fs` policy → `cosmic.landlock.RestrictOpts`.
 ---
---- Keeps the fs → landlock mapping in one place so the Jail orchestrator
+--- Keeps the fs → landlock mapping in one place so the Box orchestrator
 --- stays clear of access-mask juggling. No syscalls; the result is fed
---- into `landlock.restrict{}` in the jailed child.
+--- into `landlock.restrict{}` in the boxed child.
 ---
 --- Policy shape (input):
 ---   fs = {
@@ -83,11 +83,11 @@ local function plan_landlock(fs: FsOpts): RestrictOpts
   }
 end
 
-local record JailFsModule
+local record BoxFsModule
   plan_landlock: function(fs: FsOpts): RestrictOpts
 end
 
-local M: JailFsModule = {
+local M: BoxFsModule = {
   plan_landlock = plan_landlock,
 }
 

--- a/lib/cosmic/quicksand/box/fs_test.tl
+++ b/lib/cosmic/quicksand/box/fs_test.tl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cosmic
-local jfs = require("cosmic.quicksand.jail.fs")
+local jfs = require("cosmic.quicksand.box.fs")
 local landlock = require("cosmic.landlock")
 
 local function find_rule(rules: {any}, path: string): {string: any}

--- a/lib/cosmic/quicksand/box/init.tl
+++ b/lib/cosmic/quicksand/box/init.tl
@@ -1,28 +1,28 @@
---- Declarative jail builder.
+--- Declarative box builder.
 ---
 --- Composes the quicksand primitives (netns, proxy, proc) plus
---- cosmic.landlock / cosmic.pledge into a single `jail:run(argv)` call
+--- cosmic.landlock / cosmic.pledge into a single `box:run(argv)` call
 --- that returns an exit code.
 ---
 --- Usage:
 ---
 ---     local quicksand = require("cosmic.quicksand")
----     local jail = quicksand.Jail.new{
+---     local box = quicksand.Box.new{
 ---       fs = { ro = { "/usr" }, rw = { "/tmp" } },
 ---       net = { allow = { ["api.example.com:443"] = {} } },
 ---       proc = { no_new_privs = true },
 ---       cwd = "/tmp",
 ---     }
----     os.exit(assert(jail:run({ "/usr/bin/bash", "-c", "make test" })))
+---     os.exit(assert(box:run({ "/usr/bin/bash", "-c", "make test" })))
 ---
---- Options are plain tables, composable with `Jail.merge(base, over)`.
---- Full schema in `JailOpts` below.
+--- Options are plain tables, composable with `Box.merge(base, over)`.
+--- Full schema in `BoxOpts` below.
 ---
 --- The capability probe is loaded lazily to avoid a require cycle with
---- cosmic.quicksand (which re-exports Jail from its umbrella). The
---- fork / exec orchestration lives in cosmic.quicksand.jail.run and is
+--- cosmic.quicksand (which re-exports Box from its umbrella). The
+--- fork / exec orchestration lives in cosmic.quicksand.box.run and is
 --- required on demand from `run()` so construction stays cheap.
-local jail_merge = require("cosmic.quicksand.jail.merge")
+local box_merge = require("cosmic.quicksand.box.merge")
 
 local record CapsModule
   capabilities: function(): {string: boolean}
@@ -70,10 +70,10 @@ local record EnvOpts
   set: {string: string}
 end
 
---- Full jail policy. Every field is optional; omitting a section skips
+--- Full box policy. Every field is optional; omitting a section skips
 --- that subsystem. Scalars default to nil (i.e. no policy); list fields
 --- default to empty.
-local record JailOpts
+local record BoxOpts
   hostname: string
   fs: FsOpts
   net: NetOpts
@@ -82,19 +82,19 @@ local record JailOpts
   cwd: string
 end
 
---- Jail instance. `run(argv)` returns an integer exit code on success
+--- Box instance. `run(argv)` returns an integer exit code on success
 --- or nil + error on failure. `close()` releases any parent-held
 --- resources; idempotent and safe to call after `run`.
-local record Jail
-  opts: JailOpts
+local record Box
+  opts: BoxOpts
   _closed: boolean
-  run: function(self: Jail, argv: {string}): integer, string
-  close: function(self: Jail): boolean
+  run: function(self: Box, argv: {string}): integer, string
+  close: function(self: Box): boolean
 end
 
 -- Validate structural shape only — we cannot test syscall-level
 -- feasibility here; that is the job of run()'s capability preflight.
-local function validate(opts: JailOpts): boolean, string
+local function validate(opts: BoxOpts): boolean, string
   if opts == nil then return true end
   if opts.cwd ~= nil and type(opts.cwd) ~= "string" then
     return false, "cwd must be a string"
@@ -133,7 +133,7 @@ end
 -- Check that every enabled feature can be honored by the host. Returns
 -- a specific error naming the first missing capability so callers can
 -- distinguish "not on Linux" from "landlock unavailable" etc.
-local function preflight(opts: JailOpts): boolean, string
+local function preflight(opts: BoxOpts): boolean, string
   local c = caps()
   if not c.linux then
     return false, "quicksand: Linux only"
@@ -164,35 +164,35 @@ local record RunModule
   run: function(opts: {string: any}, argv: {string}): integer, string
 end
 
-local function run(self: Jail, argv: {string}): integer, string
+local function run(self: Box, argv: {string}): integer, string
   if self._closed then
-    return nil, "quicksand: jail already closed"
+    return nil, "quicksand: box already closed"
   end
   if type(argv) ~= "table" or #argv == 0 then
     return nil, "quicksand: run(argv) requires a non-empty argv"
   end
   local ok, err = preflight(self.opts)
   if not ok then return nil, err end
-  local rm = require("cosmic.quicksand.jail.run") as RunModule
+  local rm = require("cosmic.quicksand.box.run") as RunModule
   return rm.run(self.opts as {string: any}, argv)
 end
 
-local function close(self: Jail): boolean
+local function close(self: Box): boolean
   if self._closed then return true end
   self._closed = true
   return true
 end
 
---- Build a Jail from an options table. Validates structural shape; a
+--- Build a Box from an options table. Validates structural shape; a
 --- bad `opts` returns nil + error without touching syscalls.
 ---
---- @param opts JailOpts? policy (all fields optional)
---- @return Jail? jail instance on success
+--- @param opts BoxOpts? policy (all fields optional)
+--- @return Box? box instance on success
 --- @return string? error message on failure
-local function new(opts?: JailOpts): Jail, string
+local function new(opts?: BoxOpts): Box, string
   local ok, err = validate(opts)
   if not ok then return nil, err end
-  local j: Jail = {
+  local j: Box = {
     opts = opts or {},
     _closed = false,
     run = run,
@@ -204,20 +204,20 @@ end
 --- Compose policy tables left-to-right. Scalars: later wins. Lists
 --- (fs.ro, fs.rw, fs.exec, fs.deny, env.keep): concat + dedupe. Maps
 --- (net.allow, env.set): per-key later wins. Returns a fresh table
---- suitable for `Jail.new`.
+--- suitable for `Box.new`.
 ---
---- @param ... JailOpts policy tables; nil entries are skipped
---- @return JailOpts merged policy
-local function merge(...: JailOpts): JailOpts
-  return jail_merge.merge(...) as JailOpts
+--- @param ... BoxOpts policy tables; nil entries are skipped
+--- @return BoxOpts merged policy
+local function merge(...: BoxOpts): BoxOpts
+  return box_merge.merge(...) as BoxOpts
 end
 
-local record JailModule
-  new: function(opts?: JailOpts): Jail, string
-  merge: function(...: JailOpts): JailOpts
+local record BoxModule
+  new: function(opts?: BoxOpts): Box, string
+  merge: function(...: BoxOpts): BoxOpts
 end
 
-local M: JailModule = {
+local M: BoxModule = {
   new = new,
   merge = merge,
 }

--- a/lib/cosmic/quicksand/box/init_example.tl
+++ b/lib/cosmic/quicksand/box/init_example.tl
@@ -1,33 +1,33 @@
---- Examples for cosmic.quicksand.Jail.
+--- Examples for cosmic.quicksand.Box.
 ---
 --- These illustrate the declarative API shape and the composition
 --- helper. run() itself is exercised from the integration test suite
 --- rather than here, because its behavior depends on kernel features
 --- that vary across CI hosts.
 
--- Example_new_and_close constructs a Jail from a policy table and tears
+-- Example_new_and_close constructs a Box from a policy table and tears
 -- it down. new() and close() are pure (no syscalls) and portable.
 local function Example_new_and_close()
-  local Jail = require("cosmic.quicksand.jail")
-  local jail = assert(Jail.new({
+  local Box = require("cosmic.quicksand.box")
+  local box = assert(Box.new({
         fs = {ro = {"/usr"}, rw = {"/tmp"}},
         net = {allow = {["api.example.com:443"] = {}}},
         proc = {no_new_privs = true},
         cwd = "/tmp",
       }))
-  jail:close()
+  box:close()
   io.write("ok\n")
   -- Output:
   -- ok
 end
 
 -- Example_merge shows the composition pattern: keep policies as plain
--- data, overlay them with Jail.merge, and feed the result into new().
+-- data, overlay them with Box.merge, and feed the result into new().
 local function Example_merge()
-  local Jail = require("cosmic.quicksand.jail")
+  local Box = require("cosmic.quicksand.box")
   local base = {fs = {ro = {"/usr", "/etc/ssl/certs"}}}
   local network = {net = {allow = {["api.example.com:443"] = {}}}}
-  local policy = Jail.merge(base, network, {cwd = "/work"})
+  local policy = Box.merge(base, network, {cwd = "/work"})
   io.write(tostring((policy as {string: any}).cwd) .. "\n")
   -- Output:
   -- /work
@@ -35,12 +35,12 @@ end
 
 -- Example_run_return_shape demonstrates that run() always comes back
 -- as a clean (integer|nil, string|nil) pair, whether the workload ran
--- to completion or the jail could not be assembled on this host. The
+-- to completion or the box could not be assembled on this host. The
 -- caller distinguishes "assembly failed" from "process exited" by
 -- checking whether code is nil.
 local function Example_run_return_shape()
-  local Jail = require("cosmic.quicksand.jail")
-  local j = assert(Jail.new())
+  local Box = require("cosmic.quicksand.box")
+  local j = assert(Box.new())
   local code, err = j:run({"/bin/true"})
   if code == nil then
     io.write("err " .. tostring((err or ""):sub(1, 10)) .. "\n")

--- a/lib/cosmic/quicksand/box/init_test.tl
+++ b/lib/cosmic/quicksand/box/init_test.tl
@@ -1,15 +1,15 @@
 #!/usr/bin/env cosmic
-local Jail = require("cosmic.quicksand.jail")
+local Box = require("cosmic.quicksand.box")
 local quicksand = require("cosmic.quicksand")
 
 local function test_module_exports()
-  assert(type(Jail.new) == "function")
-  assert(type(Jail.merge) == "function")
+  assert(type(Box.new) == "function")
+  assert(type(Box.merge) == "function")
 end
 test_module_exports()
 
 local function test_new_empty()
-  local j, err = Jail.new(nil)
+  local j, err = Box.new(nil)
   assert(j, "new(nil) should succeed: " .. tostring(err))
   assert(type(j.run) == "function")
   assert(type(j.close) == "function")
@@ -17,7 +17,7 @@ end
 test_new_empty()
 
 local function test_new_with_opts()
-  local j = assert(Jail.new({
+  local j = assert(Box.new({
         hostname = "work",
         fs = {ro = {"/usr"}, rw = {"/tmp"}},
         net = {allow = {["api.example.com:443"] = {}}},
@@ -32,7 +32,7 @@ test_new_with_opts()
 
 local function test_new_rejects_bad_types()
   -- Escape to raw tables so we can construct deliberately malformed opts.
-  local new_any = Jail.new as function(any): any, any
+  local new_any = Box.new as function(any): any, any
   local cases: {{string: any}} = {
     {opts = {cwd = 5}, want = "cwd"},
     {opts = {hostname = {}}, want = "hostname"},
@@ -51,7 +51,7 @@ end
 test_new_rejects_bad_types()
 
 local function test_run_requires_argv()
-  local j = assert(Jail.new())
+  local j = assert(Box.new())
   local run_any = j.run as function(any, any): any, any
   local code, err = run_any(j, nil)
   assert(code == nil)
@@ -66,7 +66,7 @@ test_run_requires_argv()
 local function test_run_on_non_linux_returns_specific_error()
   local c = quicksand.capabilities()
   if c.linux then return end
-  local j = assert(Jail.new())
+  local j = assert(Box.new())
   local code, err = j:run({"/bin/true"})
   assert(code == nil, "run should fail on non-linux")
   assert(err and (err as string):find("Linux only", 1, true),
@@ -82,7 +82,7 @@ local function test_run_on_linux_returns_clean_shape()
   -- (integer|nil, string|nil) pair rather than a raised error.
   local c = quicksand.capabilities()
   if not c.linux then return end
-  local j = assert(Jail.new())
+  local j = assert(Box.new())
   local code, err = j:run({"/bin/true"})
   if code == nil then
     assert(type(err) == "string", "nil code must come with string err")
@@ -93,7 +93,7 @@ end
 test_run_on_linux_returns_clean_shape()
 
 local function test_run_after_close_fails()
-  local j = assert(Jail.new())
+  local j = assert(Box.new())
   assert(j:close())
   local code, err = j:run({"/bin/true"})
   assert(code == nil)
@@ -102,7 +102,7 @@ end
 test_run_after_close_fails()
 
 local function test_close_idempotent()
-  local j = assert(Jail.new())
+  local j = assert(Box.new())
   assert(j:close())
   assert(j:close(), "second close should be a no-op")
 end
@@ -111,7 +111,7 @@ test_close_idempotent()
 local function test_merge_reexported()
   local a = {fs = {ro = {"/usr"}}}
   local b = {fs = {ro = {"/etc"}, rw = {"/tmp"}}}
-  local out = Jail.merge(a, b)
+  local out = Box.merge(a, b)
   local fs = (out as {string: any}).fs as {string: any}
   local ro = fs.ro as {string}
   assert(#ro == 2 and ro[1] == "/usr" and ro[2] == "/etc")

--- a/lib/cosmic/quicksand/box/merge.tl
+++ b/lib/cosmic/quicksand/box/merge.tl
@@ -1,4 +1,4 @@
---- Pure table-merge helpers for cosmic.quicksand.Jail.
+--- Pure table-merge helpers for cosmic.quicksand.Box.
 ---
 --- Keeps policy composition as plain data: mixins, overlays, and
 --- per-environment overrides all go through `merge(...)` and yield a
@@ -121,11 +121,11 @@ local function merge(...: {string: any}): {string: any}
   return acc
 end
 
-local record JailMergeModule
+local record BoxMergeModule
   merge: function(...: {string: any}): {string: any}
 end
 
-local M: JailMergeModule = {
+local M: BoxMergeModule = {
   merge = merge,
 }
 

--- a/lib/cosmic/quicksand/box/merge_test.tl
+++ b/lib/cosmic/quicksand/box/merge_test.tl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cosmic
-local m = require("cosmic.quicksand.jail.merge")
+local m = require("cosmic.quicksand.box.merge")
 
 local function test_scalar_later_wins()
   local out = m.merge({hostname = "a", cwd = "/x"}, {hostname = "b"})

--- a/lib/cosmic/quicksand/box/run.tl
+++ b/lib/cosmic/quicksand/box/run.tl
@@ -1,6 +1,6 @@
---- Fork / unshare / exec orchestration for cosmic.quicksand.Jail:run.
+--- Fork / unshare / exec orchestration for cosmic.quicksand.Box:run.
 ---
---- Pulled in lazily by jail/init.tl so that hosts using only new() /
+--- Pulled in lazily by box/init.tl so that hosts using only new() /
 --- merge() / close() don't load the entire sandbox plumbing on require.
 ---
 --- Flow:
@@ -27,8 +27,8 @@ local qproc = require("cosmic.quicksand.proc")
 local proxy = require("cosmic.quicksand.proxy")
 local landlock = require("cosmic.landlock")
 local pledge = require("cosmic.pledge")
-local jail_fs = require("cosmic.quicksand.jail.fs")
-local jail_env = require("cosmic.quicksand.jail.env")
+local box_fs = require("cosmic.quicksand.box.fs")
+local box_env = require("cosmic.quicksand.box.env")
 local cenv = require("cosmic.env")
 local cio = require("cosmic.io")
 
@@ -37,8 +37,8 @@ local u = unix as {string: any}
 -- Cast the typed-record helpers to `any`-accepting shapes so we can
 -- thread raw {string: any} opt tables through without duplicating every
 -- record definition here.
-local plan_landlock = jail_fs.plan_landlock as function(any): any
-local env_apply = jail_env.apply as function(any, {string: string}): {string: string}
+local plan_landlock = box_fs.plan_landlock as function(any): any
+local env_apply = box_env.apply as function(any, {string: string}): {string: string}
 local ll_restrict = landlock.restrict as function(any): boolean, string
 local proxy_start = proxy.start as function(any): {string: any}, string
 
@@ -57,7 +57,7 @@ local function compute_env(opts: {string: any}): {string}
   if not env_opts then
     return cenv.list()
   end
-  return jail_env.render(env_apply(env_opts, cenv.all()))
+  return box_env.render(env_apply(env_opts, cenv.all()))
 end
 
 local function inject_proxy_env(env_list: {string}, port: integer): {string}
@@ -210,7 +210,7 @@ local function supervisor(
   os.exit(code)
 end
 
---- Fork+orchestrate a Jail policy around argv. Returns an integer exit
+--- Fork+orchestrate a Box policy around argv. Returns an integer exit
 --- code on success, or nil + string when setup itself failed before the
 --- fork (e.g. couldn't open the parent netns fd).
 local function run(opts: {string: any}, argv: {string}): integer, string
@@ -250,11 +250,11 @@ local function run(opts: {string: any}, argv: {string}): integer, string
   return nil, "quicksand: unexpected wait status " .. tostring(status)
 end
 
-local record JailRunModule
+local record BoxRunModule
   run: function(opts: {string: any}, argv: {string}): integer, string
 end
 
-local M: JailRunModule = {
+local M: BoxRunModule = {
   run = run,
 }
 

--- a/lib/cosmic/quicksand/box/run_test.tl
+++ b/lib/cosmic/quicksand/box/run_test.tl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cosmic
---- Integration test for cosmic.quicksand.Jail:run.
+--- Integration test for cosmic.quicksand.Box:run.
 ---
---- jail:run unshares CLONE_NEWUSER, which is irreversible for the
+--- box:run unshares CLONE_NEWUSER, which is irreversible for the
 --- calling thread — and can be blocked entirely by an outer seccomp /
 --- pledge filter. Run the workload in a fresh cosmic subprocess so
 --- failures don't poison the rest of the test harness, and follow the
@@ -19,10 +19,10 @@ local function test_run_true_in_subprocess()
   local c = quicksand.capabilities()
   if not (c.linux and c.user_ns and c.net_ns) then return end
 
-  local script = path.join(tmpdir, "jail_run_true.lua")
+  local script = path.join(tmpdir, "box_run_true.lua")
   cosmo.Barf(script, [[
 local qs = require("cosmic.quicksand")
-local j, nerr = qs.Jail.new({})
+local j, nerr = qs.Box.new({})
 if not j then io.stderr:write("new: " .. tostring(nerr) .. "\n"); os.exit(1) end
 local code, rerr = j:run({"/bin/true"})
 if code == nil then

--- a/lib/cosmic/quicksand/init.tl
+++ b/lib/cosmic/quicksand/init.tl
@@ -1,6 +1,6 @@
 --- Network + filesystem process isolation primitives.
 ---
---- cosmic.quicksand is the umbrella for Linux-specific jail assembly:
+--- cosmic.quicksand is the umbrella for Linux-specific box assembly:
 --- network-namespace setup (cosmic.quicksand.netns), an allowlist
 --- HTTP/CONNECT proxy (cosmic.quicksand.proxy), and after-fork process
 --- primitives (cosmic.quicksand.proc). Pair it with the top-level
@@ -9,14 +9,14 @@
 ---
 --- This module (the umbrella) exposes a capability probe so callers
 --- can fail fast with a specific reason instead of bailing partway
---- through setup on ENOSYS. It also re-exports the declarative Jail
---- builder (cosmic.quicksand.jail) that composes the primitives into a
+--- through setup on ENOSYS. It also re-exports the declarative Box
+--- builder (cosmic.quicksand.box) that composes the primitives into a
 --- single run() call.
 ---
 --- Linux-only at runtime. Non-Linux hosts see `capabilities().linux ==
 --- false` and all submodule calls return ENOSYS-shaped errors.
 local sandbox = require("cosmo.sandbox")
-local jail = require("cosmic.quicksand.jail")
+local box = require("cosmic.quicksand.box")
 
 --- Fine-grained feature availability on the current host.
 --- Every field is a boolean. Higher-level helpers use these to fail
@@ -39,7 +39,7 @@ end
 local record QuicksandModule
   capabilities: function(): Capabilities
   is_supported: function(): boolean
-  Jail: any -- re-export of cosmic.quicksand.jail
+  Box: any -- re-export of cosmic.quicksand.box
 end
 
 local cached: Capabilities = nil
@@ -68,7 +68,7 @@ local function capabilities(): Capabilities
   return cached
 end
 
---- True when the namespace-based jail primitives can do real work
+--- True when the namespace-based box primitives can do real work
 --- (Linux host with net + mount namespaces). Kept for backwards
 --- compatibility with cosmo.sandbox.is_supported(); prefer
 --- capabilities() for fine-grained checks.
@@ -80,7 +80,7 @@ end
 local M: QuicksandModule = {
   capabilities = capabilities,
   is_supported = is_supported,
-  Jail = jail,
+  Box = box,
 }
 
 return M

--- a/lib/cosmic/quicksand/init_test.tl
+++ b/lib/cosmic/quicksand/init_test.tl
@@ -45,10 +45,10 @@ local function test_is_supported_matches_capabilities()
 end
 test_is_supported_matches_capabilities()
 
-local function test_jail_reexported()
-  local J = quicksand.Jail as {string: any}
-  assert(J, "Jail should be re-exported from cosmic.quicksand")
+local function test_box_reexported()
+  local J = quicksand.Box as {string: any}
+  assert(J, "Box should be re-exported from cosmic.quicksand")
   assert(type(J.new) == "function")
   assert(type(J.merge) == "function")
 end
-test_jail_reexported()
+test_box_reexported()

--- a/lib/cosmic/quicksand/proc.tl
+++ b/lib/cosmic/quicksand/proc.tl
@@ -1,10 +1,10 @@
---- Process-setup primitives for jail assembly.
+--- Process-setup primitives for box assembly.
 ---
 --- Typed wrappers over cosmo.sandbox.proc for the "after fork, before
---- exec" work of a jailed child plus the PID-1 supervisor loop used
+--- exec" work of a boxed child plus the PID-1 supervisor loop used
 --- by netns + proxy sidecar topologies. Linux-only.
 ---
---- no_new_privs, drop_privs: call before execve in the jailed child.
+--- no_new_privs, drop_privs: call before execve in the boxed child.
 --- barrier: synchronize parent/child across unshare + /proc/<pid>/ns/
 ---   observation windows.
 --- become_init: run a PID-1 loop that forwards signals, reaps zombies,

--- a/lib/types/cosmo/sandbox/fs.d.tl
+++ b/lib/types/cosmo/sandbox/fs.d.tl
@@ -1,12 +1,12 @@
 -- type declarations for cosmo.sandbox.fs
 --
 -- Raw cosmo.sandbox.fs surface — filesystem primitives for building a
--- mount-based jail root. These wrap Linux mount(2) / pivot_root(2) /
+-- mount-based box root. These wrap Linux mount(2) / pivot_root(2) /
 -- umount2(2) with opinionated defaults. Intended to be called from a
 -- child that has already CLONE_NEWNS'd its mount namespace.
 --
 -- cosmic does not yet ship a public wrapper over these; they surface
--- through cosmic.quicksand.Jail as implementation details.
+-- through cosmic.quicksand.Box as implementation details.
 
 local record fs
   --- Directory mode 0755.


### PR DESCRIPTION
## Summary

- Rename `cosmic.quicksand.jail` → `cosmic.quicksand.box` and the `Jail` record → `Box`. The child sits inside a safe box, not a jail.
- Moves `lib/cosmic/quicksand/jail/` → `lib/cosmic/quicksand/box/` and updates every identifier, `require` path, docstring, and build glob that referenced the old name.

## Test plan

- [x] `bin/make ci` (format + teal + test + example + lint) passes