### PR TITLE
quicksand.box: use unix.sethostname(2)

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "35a93bdbd721d5aff769bbafb905e86b3e6294b9e4e02478009b6da0e1fded1a"}},
+  platforms = {["*"] = {sha = "98a915c93a454991f2162e0ec9382d782cea8441c1d809e86ef51e348ee7d515"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.04.18-4cf0a1277"
+  version = "2026.04.19-97f550ca9"
 }

--- a/lib/cosmic/quicksand/box/run.tl
+++ b/lib/cosmic/quicksand/box/run.tl
@@ -9,8 +9,8 @@
 ---      upstream_ns_fd so the proxy can dial out from the outer ns.
 ---   2. parent fork()s the supervisor and wait()s for it.
 ---   3. supervisor unshares USER | NET | NS (+ UTS if hostname), writes
----      uid_map / gid_map, brings up lo, optionally writes
----      /proc/sys/kernel/hostname.
+---      uid_map / gid_map, brings up lo, optionally calls
+---      sethostname(2).
 ---   4. supervisor starts the allowlist proxy sidecar if net.allow is
 ---      set, and prepends HTTP(S)_PROXY into the workload env when
 ---      net.proxy_env is not explicitly false.
@@ -30,7 +30,6 @@ local pledge = require("cosmic.pledge")
 local box_fs = require("cosmic.quicksand.box.fs")
 local box_env = require("cosmic.quicksand.box.env")
 local cenv = require("cosmic.env")
-local cio = require("cosmic.io")
 
 local u = unix as {string: any}
 
@@ -149,10 +148,10 @@ local function supervisor(
   end
 
   if opts and opts.hostname then
-    local ok4, err4 = cio.barf("/proc/sys/kernel/hostname",
+    local ok4, err4 = (u.sethostname as function(string): boolean, any)(
       opts.hostname as string)
     if not ok4 then
-      io.stderr:write("quicksand: hostname: " .. tostring(err4) .. "\n")
+      io.stderr:write("quicksand: sethostname: " .. tostring(err4) .. "\n")
       os.exit(126)
     end
   end

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -1789,6 +1789,10 @@ local record unix
   poll: function(fds: {number: number}, timeoutms?: number): {number: number}
   --- Returns hostname of system.
   gethostname: function(): string
+  --- Sets hostname of system. Requires `CAP_SYS_ADMIN` in the current
+  --- UTS namespace; typical callers are sandbox builders that first
+  --- `unshare(CLONE_NEWUTS)`. Returns `(nil, Errno)` on failure.
+  sethostname: function(name: string): boolean, Errno
   --- Begins listening for incoming connections on a socket.
   listen: function(fd: number, backlog?: number): boolean
   --- Accepts new client socket descriptor for a listening tcp socket.


### PR DESCRIPTION
## Summary

- Bump cosmopolitan dep to `2026.04.19-97f550ca9` (picks up [whilp/cosmopolitan#119](https://github.com/whilp/cosmopolitan/pull/119) which exposes `cosmo.unix.sethostname`).
- Swap the `/proc/sys/kernel/hostname` write in `cosmic.quicksand.box` supervisor for the POSIX syscall. Surfaces `EPERM` rather than `EACCES` when `CAP_SYS_ADMIN` is missing in the current UTS namespace, and keeps the code path reachable on non-Linux hosts (the syscall itself returns `ENOSYS` there).
- Drop the now-unused `cosmic.io` import from `box/run.tl` and add the `sethostname` binding to the `cosmo.unix` type stub.

## Test plan

- [x] `bin/make ci` (format + teal + test + example + lint) passes locally
- [ ] CI green on PR