### PR TITLE
Fix security bugs from repo review: command injection, zip-slip, glob injection, unverified bootstrap binaries

### DIFF
--- a/bin/make
+++ b/bin/make
@@ -5,6 +5,25 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MAKE_BIN="${SCRIPT_DIR}/cosmo-make"
 RELEASE_URL="https://github.com/whilp/cosmopolitan/releases/download/2026.01.04-bc03f9aa8/make"
+# SHA-256 of the landlock-make binary. This binary is executed with full
+# control over the build, so verify its integrity before running it. Update
+# this when bumping RELEASE_URL.
+MAKE_SHA256="c7c8e7f09a1ed51d875bd6b3b1048e9faeb9d76cb3c7eedf01e153cced4a9373"
+
+verify_sha256() {
+    # Usage: verify_sha256 <file> <expected-hex>. Returns non-zero on mismatch.
+    file="$1"
+    expected="$2"
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual="$(sha256sum "${file}" | cut -d' ' -f1)"
+    elif command -v shasum >/dev/null 2>&1; then
+        actual="$(shasum -a 256 "${file}" | cut -d' ' -f1)"
+    else
+        echo "no sha256 tool available to verify ${file}" >&2
+        return 1
+    fi
+    [ "${actual}" = "${expected}" ]
+}
 
 # Download make if it doesn't exist. Retry on transient CDN errors
 # (e.g. 504 Gateway Timeout) that occasionally hit unauthenticated GitHub
@@ -22,6 +41,11 @@ if [ ! -f "${MAKE_BIN}" ]; then
         echo "Retrying landlock-make download (attempt ${attempt})..." >&2
         sleep $((attempt * 5))
     done
+    if ! verify_sha256 "${MAKE_BIN}" "${MAKE_SHA256}"; then
+        echo "landlock-make checksum verification failed; refusing to run" >&2
+        rm -f "${MAKE_BIN}"
+        exit 1
+    fi
     chmod +x "${MAKE_BIN}"
 fi
 

--- a/cook.mk
+++ b/cook.mk
@@ -10,11 +10,15 @@ modules += bootstrap
 bootstrap_cosmic := $(o)/bootstrap/cosmic
 bootstrap_files := $(bootstrap_cosmic)
 bootstrap_url := https://github.com/whilp/cosmic/releases/download/2026-03-08-ac3a5d5/cosmic-lua
+# SHA-256 of the bootstrap cosmic binary. It compiles the entire project, so
+# verify it before executing. Update this when bumping bootstrap_url.
+bootstrap_sha256 := 4aee99daab172af2c662354e519170fa5c5793e5820e8a2bcd02f23f1d99e531
 
 export PATH := $(o)/bootstrap:$(PATH)
 
 $(bootstrap_cosmic):
 	@mkdir -p $(@D)
 	curl -fsSL -o $@ $(bootstrap_url)
+	@echo "$(bootstrap_sha256)  $@" | sha256sum -c - || { rm -f $@; echo "bootstrap cosmic checksum verification failed" >&2; exit 1; }
 	chmod +x $@
 	@ln -sf cosmic $(@D)/lua

--- a/lib/cosmic/embed.tl
+++ b/lib/cosmic/embed.tl
@@ -287,6 +287,13 @@ local function extract(output_dir: string, exe_path?: string): EmbedResult
   local count = 0
 
   for _, name in ipairs(entries) do
+    -- Guard against zip-slip: an archive entry with an absolute path or a
+    -- ".." component could otherwise be written outside output_dir.
+    if name:sub(1, 1) == "/" or name:match("^%.%./") or name:match("/%.%./")
+    or name:match("/%.%.$") or name == ".." then
+      reader:close()
+      return {ok = false, message = "error: unsafe path in archive: " .. name, file_count = count}
+    end
     -- Skip directory entries (trailing /)
     if name:sub(-1) == "/" then
       fs.makedirs(fs.join(output_dir, name))

--- a/lib/cosmic/embed_advanced_test.tl
+++ b/lib/cosmic/embed_advanced_test.tl
@@ -6,6 +6,7 @@ local unix = require("cosmo.unix")
 local spawn = require("cosmic.child")
 local cosmo = require("cosmo")
 local zip = require("cosmo.zip")
+local embed = require("cosmic.embed")
 
 local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
@@ -21,6 +22,12 @@ end
 -- Stat record for file metadata
 local record Stat
   mode: number
+end
+
+-- Writer interface for crafting test archives
+local record Writer
+  add: function(self: Writer, name: string, content: string): boolean, string
+  close: function(self: Writer)
 end
 
 local function write_temp(name: string, content: string): string
@@ -282,5 +289,34 @@ io.write("OK:" .. #result)
   assert(stdout and (stdout as string):match("^OK:"), "process should print OK, got: " .. tostring(stdout))
 end
 test_embed_does_not_corrupt_running_process()
+
+-- Test --extract rejects archive entries that escape the output directory
+-- (zip-slip). A crafted archive with a "../" entry must not write outside
+-- the target directory.
+local function test_extract_rejects_path_traversal()
+  -- cosmic's own zip writer refuses ".." names, so simulate an archive
+  -- produced by another tool: write a same-length placeholder name and
+  -- byte-patch it to a traversal name (no offsets change, so the zip stays
+  -- valid). "XX/escaped.txt" -> "../escaped.txt".
+  local safe = path.join(tmpdir, "patched.zip")
+  local w = zip.open(safe, "w") as Writer
+  assert(w, "should open zip for writing")
+  w:add("XX/escaped.txt", "pwned")
+  w:close()
+  local raw = cosmo.Slurp(safe)
+  local patched = (raw as string):gsub("XX/escaped%.txt", "../escaped.txt")
+  local malicious = path.join(tmpdir, "malicious.zip")
+  cosmo.Barf(malicious, patched)
+
+  local outdir = path.join(tmpdir, "extract-target")
+  local result = embed.extract(outdir, malicious)
+  assert(not result.ok, "extract should reject path traversal entry")
+  assert(result.message:match("unsafe path"), "expected unsafe path error, got: " .. result.message)
+
+  -- The escaping file must not have been written next to the target dir.
+  local escaped = path.join(tmpdir, "escaped.txt")
+  assert(not path.isfile(escaped), "traversal file should not be written outside target")
+end
+test_extract_rejects_path_traversal()
 
 print("All embed tests passed!")

--- a/lib/cosmic/fs_path_test.tl
+++ b/lib/cosmic/fs_path_test.tl
@@ -125,6 +125,15 @@ local function test_collect_with_glob()
 end
 test_collect_with_glob()
 
+local function test_collect_glob_escapes_brackets()
+  -- A glob's [ ] must be literal, not a Lua class: "*[1].lua" matches nothing.
+  local walk_dir = setup_walk()
+  local found = fs.collect(walk_dir, "*[1].lua")
+  assert(#found == 0, "expected brackets treated literally, got " .. #found)
+  teardown(walk_dir)
+end
+test_collect_glob_escapes_brackets()
+
 local function test_collect_with_lua_pattern()
   local walk_dir = setup_walk()
   local found = fs.collect(walk_dir, "%.txt$")

--- a/lib/cosmic/fs_walk.tl
+++ b/lib/cosmic/fs_walk.tl
@@ -47,8 +47,11 @@ end
 --- @param glob string The glob pattern
 --- @return string The equivalent Lua pattern
 local function glob_to_pattern(glob: string): string
+  -- Escape every Lua pattern magic character, including [ ] and + - which are
+  -- meaningful inside Lua character classes. Otherwise a glob like "*[a-z]*"
+  -- would smuggle a Lua character class through and match the wrong files.
   local pattern = glob
-  :gsub("([%.%^%$%(%)%%])", "%%%1") -- escape special chars (except * ? [ ])
+  :gsub("([%.%^%$%(%)%[%]%+%-%%])", "%%%1") -- escape special chars (except * ?)
   :gsub("%*", ".*") -- * -> .*
   :gsub("%?", ".") -- ? -> .
   return "^" .. pattern .. "$"

--- a/lib/cosmic/make.tl
+++ b/lib/cosmic/make.tl
@@ -202,9 +202,14 @@ local function run(dir?: string, target?: string): boolean, string
     return true, "stdout"
   end
 
-  -- pipe to make
+  -- pipe to make. The target name is interpolated into a shell command, so
+  -- reject anything that isn't a plain make target to avoid shell injection
+  -- (e.g. a target of `; rm -rf ~` would otherwise run arbitrary commands).
   local cmd = "make -f -"
   if target then
+    if not target:match("^[%w._/-]+$") then
+      return false, "invalid make target: " .. target
+    end
     cmd = cmd .. " " .. target
   end
   local p = io.popen(cmd, "w")

--- a/lib/cosmic/make_test.tl
+++ b/lib/cosmic/make_test.tl
@@ -180,6 +180,18 @@ local function test_generate_custom_config()
 end
 test_generate_custom_config()
 
+-- Test run rejects shell metacharacters in the target name. The target is
+-- interpolated into a shell command, so a value like "; rm -rf ~" must be
+-- refused rather than executed.
+local function test_run_rejects_unsafe_target()
+  local test_dir = setup()
+  local ok, err = make.run(test_dir, "all; touch /tmp/pwned")
+  assert(not ok, "run should reject unsafe target")
+  assert(err:match("invalid make target"), "expected invalid target error, got: " .. tostring(err))
+  teardown(test_dir)
+end
+test_run_rejects_unsafe_target()
+
 -- Test generate includes cosmic.mk
 local function test_generate_includes_cosmic_mk()
   local project = {


### PR DESCRIPTION
This PR fixes the highest-confidence security and correctness issues found in a review of the repository. Each library-level fix ships with a regression test, and the full `bin/make ci` suite (format + type-check + test + example + lint) passes.

## Fixes

### 1. Command injection in `cosmic --make <dir> <target>` (high)
`make.tl` interpolated the user-supplied `target` unquoted into `io.popen("make -f - " .. target)`. A target like `all; rm -rf ~` would execute arbitrary shell commands. The target is now validated against `^[%w._/-]+$` and rejected otherwise.

### 2. Zip-slip in `cosmic --extract` (high)
`embed.extract` joined archive entry names onto the output directory with `fs.join`, which does not normalize `..` and lets a later absolute component reset the path. A crafted archive could write files outside the target directory. Extraction now rejects entries with absolute paths or `..` components. (cosmic's own zip *writer* already refuses such names, so the realistic vector is an archive produced by another tool — the test byte-patches a same-length placeholder name to simulate that.)

### 3. Glob → Lua pattern injection in `fs_walk` (high)
`glob_to_pattern` escaped most magic characters but left `[` `]` `+` `-` unescaped, so a glob like `*[a-z]*` smuggled a Lua character class through and matched unintended files. These characters are now escaped.

### 4. Unverified bootstrap binaries (high, supply chain)
`bin/make` (landlock-make) and `cook.mk` (bootstrap cosmic) downloaded executables over the network and ran them with no integrity check. Both now verify a pinned SHA-256 before execution and refuse to run on mismatch.

## Tests added
- `fs_path_test.tl`: glob with `[ ]` is treated literally
- `embed_advanced_test.tl`: `--extract` rejects a path-traversal entry and does not write outside the target
- `make_test.tl`: `make.run` rejects a target containing shell metacharacters

## Notes on other review findings (not changed here)
- The `3p/teal-types/version.lua` URL that looks suspicious (`{version}` + hex suffix) is correct — it resolves to a valid 40-char commit SHA and fetches fine.
- `compress.inflate` decodes a 4-byte size prefix that can read as negative for sizes ≥ 2 GiB; worth a follow-up bounds check but not exploitable for memory safety here.
- `fetch` TLS verification, IPv6 in `net`, and partial-write loops in `io`/`child` are potential follow-ups but were left out to keep this PR focused on verified, high-confidence bugs.

https://claude.ai/code/session_019wiKgUaxBdeAbeDTMnpK87

---
_Generated by [Claude Code](https://claude.ai/code/session_019wiKgUaxBdeAbeDTMnpK87)_