### PR TITLE
Security and functional audit: sandbox, I/O, crypto/data, and build-infra fixes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,15 +5,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 env:
   SOURCE_SHA: ${{ github.sha }}
 
 jobs:
   docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,6 @@ jobs:
           tag="$(date -u +%Y-%m-%d)-${GITHUB_SHA::7}"
           (cd release && sha256sum cosmic-lua cosmic-lua-debug > SHA256SUMS && cat SHA256SUMS)
           gh release create "$tag" \
-            ${PRERELEASE_FLAG} \
+            ${PRERELEASE_FLAG:+"$PRERELEASE_FLAG"} \
             --title "$tag" \
             release/cosmic-lua release/cosmic-lua-debug release/SHA256SUMS

--- a/bin/make
+++ b/bin/make
@@ -29,24 +29,27 @@ verify_sha256() {
 # (e.g. 504 Gateway Timeout) that occasionally hit unauthenticated GitHub
 # release downloads.
 if [ ! -f "${MAKE_BIN}" ]; then
+    MAKE_BIN_TMP="${MAKE_BIN}.tmp.$$"
     echo "Downloading landlock-make..." >&2
     attempt=0
     until curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
-        -o "${MAKE_BIN}" "${RELEASE_URL}"; do
+        -o "${MAKE_BIN_TMP}" "${RELEASE_URL}"; do
         attempt=$((attempt + 1))
         if [ "${attempt}" -ge 3 ]; then
             echo "Failed to download landlock-make after ${attempt} attempts" >&2
+            rm -f "${MAKE_BIN_TMP}"
             exit 1
         fi
         echo "Retrying landlock-make download (attempt ${attempt})..." >&2
         sleep $((attempt * 5))
     done
-    if ! verify_sha256 "${MAKE_BIN}" "${MAKE_SHA256}"; then
+    if ! verify_sha256 "${MAKE_BIN_TMP}" "${MAKE_SHA256}"; then
         echo "landlock-make checksum verification failed; refusing to run" >&2
-        rm -f "${MAKE_BIN}"
+        rm -f "${MAKE_BIN_TMP}"
         exit 1
     fi
-    chmod +x "${MAKE_BIN}"
+    chmod +x "${MAKE_BIN_TMP}"
+    mv -f "${MAKE_BIN_TMP}" "${MAKE_BIN}"
 fi
 
 # Execute make with all arguments

--- a/lib/build/build-fetch.tl
+++ b/lib/build/build-fetch.tl
@@ -61,6 +61,22 @@ local function verify_sha256(content: string, expected: string): boolean, string
   return nil, string.format("sha256 mismatch: expected %s, got %s", expected, actual)
 end
 
+--- Validate an archive filename extracted from a URL.
+--- Rejects empty names, "." and "..", and names with characters outside
+--- the safe set [A-Za-z0-9._-].
+local function validate_archive_name(name: string): boolean, string
+  if not name or name == "" then
+    return nil, "archive name must not be empty"
+  end
+  if name == "." or name == ".." then
+    return nil, "archive name must not be '.' or '..': " .. name
+  end
+  if not name:match("^[%w._%-]+$") then
+    return nil, "archive name contains unsafe characters: " .. name
+  end
+  return true
+end
+
 local function main(version_file: string, platform: string, output: string): boolean, string
   if not version_file or not platform or not output then
     return nil, "usage: fetch.lua <version_file> <platform> <output>"
@@ -109,6 +125,10 @@ local function main(version_file: string, platform: string, output: string): boo
     archive_name = "binary"
   else
     archive_name = url:match("([^/]+)$")
+    local name_ok, name_err = validate_archive_name(archive_name)
+    if not name_ok then
+      return nil, "unsafe archive name from URL: " .. (name_err or "unknown")
+    end
   end
   local version_sha = spec.version .. "-" .. plat.sha
   local archive_dir = fs.join(fetch_o, module_name, version_sha)
@@ -146,4 +166,5 @@ end
 
 return {
   build_url = build_url,
+  validate_archive_name = validate_archive_name,
 }

--- a/lib/build/build-fetch_test.tl
+++ b/lib/build/build-fetch_test.tl
@@ -1,0 +1,66 @@
+#!/usr/bin/env cosmic
+
+local fetch = require("build.build-fetch")
+
+-- validate_archive_name tests
+
+local function test_validate_archive_name_ok_zip()
+  local ok, err = fetch.validate_archive_name("cosmos.zip")
+  assert(ok, "expected ok for cosmos.zip, got: " .. tostring(err))
+end
+test_validate_archive_name_ok_zip()
+
+local function test_validate_archive_name_ok_targz()
+  local ok, err = fetch.validate_archive_name("v0.24.8.tar.gz")
+  assert(ok, "expected ok for v0.24.8.tar.gz, got: " .. tostring(err))
+end
+test_validate_archive_name_ok_targz()
+
+local function test_validate_archive_name_ok_hex()
+  local ok, err = fetch.validate_archive_name(
+    "0137f934c9946cfe4134a0217ac5cacf9dd49332.tar.gz"
+  )
+  assert(ok, "expected ok for hex-prefixed archive name, got: " .. tostring(err))
+end
+test_validate_archive_name_ok_hex()
+
+local function test_validate_archive_name_ok_hyphen()
+  local ok, err = fetch.validate_archive_name("my-archive-1.0.tar.gz")
+  assert(ok, "expected ok for archive with hyphens, got: " .. tostring(err))
+end
+test_validate_archive_name_ok_hyphen()
+
+local function test_validate_archive_name_empty()
+  local ok, err = fetch.validate_archive_name("")
+  assert(not ok, "expected failure for empty name")
+  assert(err ~= nil, "expected error message for empty name")
+end
+test_validate_archive_name_empty()
+
+local function test_validate_archive_name_dot()
+  local ok, err = fetch.validate_archive_name(".")
+  assert(not ok, "expected failure for '.'")
+  assert(err ~= nil, "expected error message for '.'")
+end
+test_validate_archive_name_dot()
+
+local function test_validate_archive_name_dotdot()
+  local ok, err = fetch.validate_archive_name("..")
+  assert(not ok, "expected failure for '..'")
+  assert(err ~= nil, "expected error message for '..'")
+end
+test_validate_archive_name_dotdot()
+
+local function test_validate_archive_name_slash()
+  local ok, err = fetch.validate_archive_name("foo/bar.tar.gz")
+  assert(not ok, "expected failure for name containing '/'")
+  assert(err ~= nil, "expected error message for slash in name")
+end
+test_validate_archive_name_slash()
+
+local function test_validate_archive_name_space()
+  local ok, err = fetch.validate_archive_name("my archive.tar.gz")
+  assert(not ok, "expected failure for name containing space")
+  assert(err ~= nil, "expected error message for space in name")
+end
+test_validate_archive_name_space()

--- a/lib/build/build-stage.tl
+++ b/lib/build/build-stage.tl
@@ -160,8 +160,50 @@ local type ExtractFn = function(string, string, number): boolean, string
     return ok, err
   end
 
+  --- Validate a relative path component for use within the stage directory.
+  --- Rejects empty paths, absolute paths (leading /), and paths containing
+  --- `..` components. Returns an error string on failure, nil on success.
+  local function validate_stage_path(p: string): string
+    if not p or p == "" then
+      return "path must not be empty"
+    end
+    if p:sub(1, 1) == "/" then
+      return "path must not be absolute: " .. p
+    end
+    for component in (p .. "/"):gmatch("([^/]*)/") do
+      if component == ".." then
+        return "path must not contain '..': " .. p
+      end
+    end
+    return nil
+  end
+
+  --- Validate a symlink target: must be relative and contain no `..` components.
+  local function validate_link_target(target: string): string
+    if not target or target == "" then
+      return "symlink target must not be empty"
+    end
+    if target:sub(1, 1) == "/" then
+      return "symlink target must not be absolute: " .. target
+    end
+    for component in (target .. "/"):gmatch("([^/]*)/") do
+      if component == ".." then
+        return "symlink target must not contain '..': " .. target
+      end
+    end
+    return nil
+  end
+
   local function apply_install(stage_dir: string, install: {string: string}): boolean, string
     for src, dst in pairs(install) do
+      local src_err = validate_stage_path(src)
+      if src_err then
+        return nil, "install src invalid: " .. src_err
+      end
+      local dst_err = validate_stage_path(dst)
+      if dst_err then
+        return nil, "install dst invalid: " .. dst_err
+      end
       local src_path = fs.join(stage_dir, src)
       local dst_path = fs.join(stage_dir, dst)
       fs.makedirs(fs.dirname(dst_path))
@@ -175,6 +217,10 @@ local type ExtractFn = function(string, string, number): boolean, string
 
   local function apply_remove(stage_dir: string, remove: {string}): boolean, string
     for _, file in ipairs(remove) do
+      local file_err = validate_stage_path(file)
+      if file_err then
+        return nil, "remove path invalid: " .. file_err
+      end
       local file_path = fs.join(stage_dir, file)
       fs.rmrf(file_path)
     end
@@ -183,6 +229,14 @@ local type ExtractFn = function(string, string, number): boolean, string
 
   local function apply_links(stage_dir: string, links: {string: string}): boolean, string
     for link, target in pairs(links) do
+      local link_err = validate_stage_path(link)
+      if link_err then
+        return nil, "link path invalid: " .. link_err
+      end
+      local target_err = validate_link_target(target)
+      if target_err then
+        return nil, "link target invalid: " .. target_err
+      end
       local link_path = fs.join(stage_dir, link)
       fs.makedirs(fs.dirname(link_path))
       fs.rmrf(link_path)
@@ -317,3 +371,8 @@ local type ExtractFn = function(string, string, number): boolean, string
       os.exit(1)
     end
   end
+
+  return {
+    validate_stage_path = validate_stage_path,
+    validate_link_target = validate_link_target,
+  }

--- a/lib/build/build-stage_test.tl
+++ b/lib/build/build-stage_test.tl
@@ -1,0 +1,87 @@
+#!/usr/bin/env cosmic
+
+local stage = require("build.build-stage")
+
+-- validate_stage_path tests
+
+local function test_validate_stage_path_ok_simple()
+  local err = stage.validate_stage_path("foo")
+  assert(err == nil, "expected nil for simple path, got: " .. tostring(err))
+end
+test_validate_stage_path_ok_simple()
+
+local function test_validate_stage_path_ok_nested()
+  local err = stage.validate_stage_path("foo/bar/baz")
+  assert(err == nil, "expected nil for nested path, got: " .. tostring(err))
+end
+test_validate_stage_path_ok_nested()
+
+local function test_validate_stage_path_empty()
+  local err = stage.validate_stage_path("")
+  assert(err ~= nil, "expected error for empty path")
+  assert(err:match("empty"), "expected 'empty' in error, got: " .. tostring(err))
+end
+test_validate_stage_path_empty()
+
+local function test_validate_stage_path_absolute()
+  local err = stage.validate_stage_path("/etc/passwd")
+  assert(err ~= nil, "expected error for absolute path")
+  assert(err:match("absolute"), "expected 'absolute' in error, got: " .. tostring(err))
+end
+test_validate_stage_path_absolute()
+
+local function test_validate_stage_path_dotdot()
+  local err = stage.validate_stage_path("../etc/passwd")
+  assert(err ~= nil, "expected error for .. path")
+  assert(err:match("%.%."), "expected '..' in error, got: " .. tostring(err))
+end
+test_validate_stage_path_dotdot()
+
+local function test_validate_stage_path_dotdot_middle()
+  local err = stage.validate_stage_path("foo/../etc/passwd")
+  assert(err ~= nil, "expected error for .. in middle of path")
+  assert(err:match("%.%."), "expected '..' in error, got: " .. tostring(err))
+end
+test_validate_stage_path_dotdot_middle()
+
+local function test_validate_stage_path_dotdot_dst()
+  -- this specifically tests the .. in dst scenario from the spec
+  local err = stage.validate_stage_path("../outside")
+  assert(err ~= nil, "expected error for ../outside dst")
+end
+test_validate_stage_path_dotdot_dst()
+
+-- validate_link_target tests
+
+local function test_validate_link_target_ok()
+  local err = stage.validate_link_target("lib/libfoo.so")
+  assert(err == nil, "expected nil for valid relative target, got: " .. tostring(err))
+end
+test_validate_link_target_ok()
+
+local function test_validate_link_target_empty()
+  local err = stage.validate_link_target("")
+  assert(err ~= nil, "expected error for empty target")
+  assert(err:match("empty"), "expected 'empty' in error, got: " .. tostring(err))
+end
+test_validate_link_target_empty()
+
+local function test_validate_link_target_absolute()
+  local err = stage.validate_link_target("/usr/lib/libfoo.so")
+  assert(err ~= nil, "expected error for absolute target")
+  assert(err:match("absolute"), "expected 'absolute' in error, got: " .. tostring(err))
+end
+test_validate_link_target_absolute()
+
+local function test_validate_link_target_dotdot()
+  local err = stage.validate_link_target("../x")
+  assert(err ~= nil, "expected error for ../x target")
+  assert(err:match("%.%."), "expected '..' in error, got: " .. tostring(err))
+end
+test_validate_link_target_dotdot()
+
+local function test_validate_link_target_dotdot_nested()
+  local err = stage.validate_link_target("foo/../../escape")
+  assert(err ~= nil, "expected error for escaping target via ..")
+end
+test_validate_link_target_dotdot_nested()

--- a/lib/build/lint.tl
+++ b/lib/build/lint.tl
@@ -77,9 +77,33 @@ local function check_assert_order(file: string, lines: {string}): {Diagnostic}
       i = i + 1
       while i <= #lines and depth > 0 do
         local l = lines[i]
-        -- Count function keywords that open a new scope
+        -- Count keywords that open a new block scope
         for _ in l:gmatch("%f[%w_]function%f[^%w_]") do
           depth = depth + 1
+        end
+        for _ in l:gmatch("%f[%w_]if%f[^%w_]") do
+          depth = depth + 1
+        end
+        for _ in l:gmatch("%f[%w_]for%f[^%w_]") do
+          depth = depth + 1
+        end
+        for _ in l:gmatch("%f[%w_]while%f[^%w_]") do
+          depth = depth + 1
+        end
+        for _ in l:gmatch("%f[%w_]repeat%f[^%w_]") do
+          depth = depth + 1
+        end
+        -- Count standalone `do` (not the `do` terminating a for/while header,
+        -- which is already counted above via for/while). A `do` is standalone
+        -- when the same line contains no `for` or `while` keyword.
+        if l:match("%f[%w_]do%f[^%w_]") and
+        not l:match("%f[%w_]for%f[^%w_]") and
+        not l:match("%f[%w_]while%f[^%w_]") then
+          depth = depth + 1
+        end
+        -- `until` closes a repeat block without an `end`
+        for _ in l:gmatch("%f[%w_]until%f[^%w_]") do
+          depth = depth - 1
         end
         -- Count end keywords
         for _ in l:gmatch("%f[%w_]end%f[^%w_]") do

--- a/lib/build/lint_test.tl
+++ b/lib/build/lint_test.tl
@@ -164,3 +164,84 @@ local function test_count_lines_directory()
   assert(n == 0, "expected 0 for directory path, got: " .. tostring(n))
 end
 test_count_lines_directory()
+
+local function test_check_assert_order_do_block()
+  -- A function body with a standalone do...end block must not confuse the closer detection.
+  -- Previously, the `end` for the `do` block decremented depth below 1, causing
+  -- the function body to appear to close early.
+  local lines = {
+    "local function foo()",
+    "  do",
+    "    local x = 1",
+    "  end",
+    "  return 2",
+    "end",
+    "foo()",
+  }
+  local diags = lint.check_assert_order("test.tl", lines)
+  assert(#diags == 0, "expected no diagnostic for function with do...end block, got: " .. tostring(#diags))
+end
+test_check_assert_order_do_block()
+
+local function test_check_assert_order_for_loop()
+  -- A function body with a for loop must not confuse the closer detection.
+  local lines = {
+    "local function foo()",
+    "  for i = 1, 10 do",
+    "    local x = i",
+    "  end",
+    "  return 1",
+    "end",
+    "foo()",
+  }
+  local diags = lint.check_assert_order("test.tl", lines)
+  assert(#diags == 0, "expected no diagnostic for function with for loop, got: " .. tostring(#diags))
+end
+test_check_assert_order_for_loop()
+
+local function test_check_assert_order_if_block()
+  -- A function body with an if...end block must not confuse the closer detection.
+  local lines = {
+    "local function foo()",
+    "  if true then",
+    "    return 1",
+    "  end",
+    "  return 2",
+    "end",
+    "foo()",
+  }
+  local diags = lint.check_assert_order("test.tl", lines)
+  assert(#diags == 0, "expected no diagnostic for function with if block, got: " .. tostring(#diags))
+end
+test_check_assert_order_if_block()
+
+local function test_check_assert_order_repeat_until()
+  -- A function body with a repeat...until must not confuse the closer detection.
+  local lines = {
+    "local function foo()",
+    "  local x = 0",
+    "  repeat",
+    "    x = x + 1",
+    "  until x >= 3",
+    "  return x",
+    "end",
+    "foo()",
+  }
+  local diags = lint.check_assert_order("test.tl", lines)
+  assert(#diags == 0, "expected no diagnostic for function with repeat...until, got: " .. tostring(#diags))
+end
+test_check_assert_order_repeat_until()
+
+local function test_check_assert_order_one_line_if()
+  -- One-line if/end must net to zero depth change.
+  local lines = {
+    "local function foo()",
+    "  if true then return 1 end",
+    "  return 2",
+    "end",
+    "foo()",
+  }
+  local diags = lint.check_assert_order("test.tl", lines)
+  assert(#diags == 0, "expected no diagnostic for function with one-line if, got: " .. tostring(#diags))
+end
+test_check_assert_order_one_line_if()

--- a/lib/cosmic/child.tl
+++ b/lib/cosmic/child.tl
@@ -234,40 +234,52 @@ local function spawn(argv: {string}, opts?: Opts): Handle, string
     -- stdin (fd 0)
     if stdin_is_fd then
       if opts.stdin ~= 0 then
-        unix.close(0)
-        unix.dup(opts.stdin as number)
+        unix.dup(opts.stdin as number, 0)
       end
     else
-      unix.close(0)
-      unix.close(stdin_w)
-      unix.dup(stdin_r)
-      unix.close(stdin_r)
+      -- Close the write end first, then dup2 the read end onto fd 0.
+      -- If stdin_r already IS fd 0, dup2 is a no-op (same fd), so skip
+      -- the close to avoid closing the fd we are about to use.
+      if stdin_r ~= 0 then
+        unix.close(stdin_w)
+        unix.dup(stdin_r, 0)
+        unix.close(stdin_r)
+      else
+        -- stdin_r == 0: dup2(0, 0) is fine, just close the write end
+        unix.close(stdin_w)
+      end
     end
 
     -- stdout (fd 1)
     if stdout_is_fd then
       if opts.stdout ~= 1 then
-        unix.close(1)
-        unix.dup(opts.stdout as number)
+        unix.dup(opts.stdout as number, 1)
       end
     else
-      unix.close(1)
-      unix.close(stdout_r)
-      unix.dup(stdout_w)
-      unix.close(stdout_w)
+      if stdout_w ~= 1 then
+        unix.close(stdout_r)
+        unix.dup(stdout_w, 1)
+        unix.close(stdout_w)
+      else
+        -- stdout_w == 1: dup2(1, 1) is fine, just close the read end
+        unix.close(stdout_r)
+      end
     end
 
     -- stderr (fd 2)
     if stderr_is_fd then
       if opts.stderr ~= 2 then
-        unix.close(2)
-        unix.dup(opts.stderr as number)
+        unix.dup(opts.stderr as number, 2)
       end
     else
-      unix.close(2)
-      unix.close(stderr_r)
-      unix.dup(stderr_w)
-      unix.close(stderr_w)
+      if stderr_w ~= 2 then
+        unix.close(stderr_r)
+        unix.dup(stderr_w, 2)
+        unix.close(stderr_w)
+      else
+        -- stderr_w == 2: dup2(2, 2) is fine, just close the read end
+        unix.close(stderr_r)
+      end
     end
 
     -- change working directory if specified

--- a/lib/cosmic/child_test.tl
+++ b/lib/cosmic/child_test.tl
@@ -395,3 +395,41 @@ local function test_spawn_zip_embedded_binary()
     "expected 'hello-from-zip\\n', got '" .. tostring(out) .. "'")
 end
 test_spawn_zip_embedded_binary()
+
+-- FIX 4: fd redirection correctness using dup2-style unix.dup(src, dst).
+-- Verify that stdout and stderr are independently redirected so that output
+-- written to each stream appears on the correct pipe.
+local function test_spawn_stdout_stderr_separate()
+  -- Child writes distinct text to stdout and stderr.
+  local handle = child.spawn({lua_bin, "-e", [[
+    io.stdout:write("to-stdout\n")
+    io.stdout:flush()
+    io.stderr:write("to-stderr\n")
+    io.stderr:flush()
+  ]]})
+  assert(handle ~= nil, "handle should not be nil")
+  local ok, out, code = handle:read()
+  assert(ok, "command should succeed, exit=" .. tostring(code))
+  assert(out == "to-stdout\n",
+    "expected 'to-stdout\\n' on stdout, got '" .. tostring(out) .. "'")
+end
+test_spawn_stdout_stderr_separate()
+
+-- FIX 4: when stdin pipe fd happens to already be fd 0 in child, we must not
+-- double-close it.  A pathological but valid scenario where spawning many
+-- children leaves fd slots at low numbers.  The existing simple redirection
+-- test covers the common case; this test exercises correct behavior when a
+-- pipe end lands on the target fd.
+local function test_spawn_many_captures_correct()
+  -- Spawn several children in quick succession to exercise fd reuse.
+  for i = 1, 5 do
+    local handle = child.spawn({lua_bin, "-e",
+        "io.write('iter" .. tostring(i) .. "\\n')"})
+    assert(handle ~= nil, "handle should not be nil on iteration " .. i)
+    local ok, out = handle:read()
+    assert(ok, "iteration " .. i .. " should succeed")
+    assert(out == "iter" .. tostring(i) .. "\n",
+      "expected 'iter" .. i .. "\\n', got '" .. tostring(out) .. "'")
+  end
+end
+test_spawn_many_captures_correct()

--- a/lib/cosmic/codec.tl
+++ b/lib/cosmic/codec.tl
@@ -98,7 +98,7 @@ local function encode_base32(data: string): string
 end
 
 --- Decode a base32 string to binary data.
---- Uses lowercase base32 alphabet (0-9a-v excluding i, l, o, u).
+--- Uses lowercase base32 alphabet (0-9a-z excluding i, l, o, u).
 --- @param str string The base32 string to decode
 --- @return string The decoded binary data, or nil on error
 --- @return string? Error message if decoding failed

--- a/lib/cosmic/doc.tl
+++ b/lib/cosmic/doc.tl
@@ -348,7 +348,7 @@ local function serialize_index(index: DocIndex): string
 end
 
 local function load_index(source: string): DocIndex, string
-  local chunk, err = load("return " .. source)
+  local chunk, err = load("return " .. source, "=docindex", "t", {})
   if not chunk then return nil, "failed to parse index: " .. (err or "unknown") end
   local ok, result = pcall(chunk)
   if not ok then return nil, "failed to load index: " .. tostring(result) end

--- a/lib/cosmic/docs.tl
+++ b/lib/cosmic/docs.tl
@@ -28,7 +28,7 @@ local function load_index(): DocIndex, string
     return nil, "no documentation index embedded"
   end
 
-  local chunk, err = load("return " .. source)
+  local chunk, err = load("return " .. source, "=docindex", "t", {})
   if not chunk then
     return nil, "failed to parse index: " .. (err or "unknown")
   end

--- a/lib/cosmic/embed.tl
+++ b/lib/cosmic/embed.tl
@@ -106,13 +106,18 @@ local function collect_dir(dir: string): {FileToEmbed}, string
 
     for _, entry in ipairs(entries) do
       local full_path = fs.join(base_dir, entry)
-      local st = fs.stat(full_path)
+      -- Use lstat (follow_symlinks=false) so symlinked dirs appear as S_ISLNK,
+      -- not S_ISDIR.  This prevents infinite recursion through symlink cycles
+      -- and stops symlinks to paths outside the embed dir from being followed.
+      local st = fs.stat(full_path, false)
       if st then
         if fs.is_dir(st:mode()) then
+          -- Only recurse into real directories, never symlinked ones.
           local rel = rel_prefix == "" and entry or (rel_prefix .. "/" .. entry)
           local walk_err = do_walk(full_path, rel)
           if walk_err then return walk_err end
-        else
+        elseif unix.S_ISREG(st:mode()) then
+          -- Only embed regular files; skip symlinks (S_ISLNK) entirely.
           local stored_name = rel_prefix == "" and entry or (rel_prefix .. "/" .. entry)
           local content, read_err = cio.slurp(full_path)
           if not content then
@@ -127,6 +132,7 @@ local function collect_dir(dir: string): {FileToEmbed}, string
             mode = file_mode,
           }
         end
+        -- S_ISLNK entries are silently skipped (no recurse, no embed)
       end
     end
     return nil

--- a/lib/cosmic/embed_advanced_test.tl
+++ b/lib/cosmic/embed_advanced_test.tl
@@ -319,4 +319,52 @@ local function test_extract_rejects_path_traversal()
 end
 test_extract_rejects_path_traversal()
 
+-- FIX 2: collect_dir must not recurse into symlinked directories.
+-- A symlink loop inside the embed dir must terminate without error.
+local function test_embed_symlink_loop_terminates()
+  local appdir = path.join(tmpdir, "symlinkloop")
+  unix.makedirs(path.join(appdir, "sub"))
+  cosmo.Barf(path.join(appdir, "sub", "real.txt"), "data")
+  -- Create a cycle: sub/loop -> ..  (points back to appdir)
+  unix.symlink("..", path.join(appdir, "sub", "loop"))
+
+  -- embed.collect_dir is called internally; run via the module directly
+  local result = embed.run({appdir}, path.join(tmpdir, "cosmic-symlinkloop"), cosmic)
+  assert(result.ok, "embed of dir with symlink loop should succeed: " .. (result.message or ""))
+  -- Only real.txt should be embedded, not any path through the loop
+  local data = cosmo.Slurp(path.join(tmpdir, "cosmic-symlinkloop"))
+  local reader = zip.from(data) as Reader
+  local files = reader:list()
+  for _, f in ipairs(files) do
+    assert(not f:match("loop"), "embedded zip should not contain loop path: " .. f)
+  end
+  reader:close()
+end
+test_embed_symlink_loop_terminates()
+
+-- FIX 2: a symlink to a file *outside* the embed dir must NOT be embedded.
+local function test_embed_symlink_to_outside_file_skipped()
+  -- Create a file outside the embed dir
+  local outside = path.join(tmpdir, "outside_secret.txt")
+  cosmo.Barf(outside, "secret-content")
+
+  local appdir = path.join(tmpdir, "symlinkoutside")
+  unix.makedirs(appdir)
+  cosmo.Barf(path.join(appdir, "main.lua"), 'print("hi")\n')
+  -- Symlink inside the embed dir pointing outside
+  unix.symlink(outside, path.join(appdir, "leaked.txt"))
+
+  local result = embed.run({appdir}, path.join(tmpdir, "cosmic-symlinkoutside"), cosmic)
+  assert(result.ok, "embed should succeed even with outside symlink: " .. (result.message or ""))
+  -- "leaked.txt" (the symlink) must not appear in the zip
+  local data = cosmo.Slurp(path.join(tmpdir, "cosmic-symlinkoutside"))
+  local reader = zip.from(data) as Reader
+  local files = reader:list()
+  for _, f in ipairs(files) do
+    assert(not f:match("leaked"), "symlink to outside file should not be embedded: " .. f)
+  end
+  reader:close()
+end
+test_embed_symlink_to_outside_file_skipped()
+
 print("All embed tests passed!")

--- a/lib/cosmic/envd.tl
+++ b/lib/cosmic/envd.tl
@@ -93,7 +93,7 @@ local function parse(content: string, ctx: {string: string}): {string: string}
       lookup[k] = v
     end
   end
-  for line in content:gmatch("[^\n]+") do
+  for line in content:gmatch("[^\r\n]+") do
     -- skip comments and blank lines
     if not line:match("^%s*#") and not line:match("^%s*$") then
       local key, value = line:match("^([A-Za-z_][A-Za-z0-9_]*)=(.*)")
@@ -118,7 +118,8 @@ end
 --- @return LoadResult Result with count of variables set and source path
 local function load_dir(dir: string): LoadResult
   local result: LoadResult = {count = 0, source = dir}
-  local debug = env.get("COSMIC_DEBUG") ~= nil
+  local cosmic_debug_val = env.get("COSMIC_DEBUG")
+  local debug = cosmic_debug_val ~= nil and cosmic_debug_val ~= ""
 
   local dh, dh_err = fs.opendir(dir)
   if not dh then

--- a/lib/cosmic/envd_test.tl
+++ b/lib/cosmic/envd_test.tl
@@ -319,3 +319,54 @@ local function test_expand_function_directly()
   assert(result == "hello bar world", "expected 'hello bar world', got '" .. result .. "'")
 end
 test_expand_function_directly()
+
+-- FIX 3a: parse must strip trailing \r from CRLF dotenv files.
+local function test_parse_crlf_no_trailing_cr()
+  -- Simulate a CRLF dotenv file (e.g. produced on Windows or by some editors).
+  local crlf_content = "COSMIC_ENVD_CRLF_A=hello\r\nCOSMIC_ENVD_CRLF_B=world\r\n"
+  local vars = envd.parse(crlf_content)
+  assert(vars["COSMIC_ENVD_CRLF_A"] == "hello",
+    "CRLF: expected 'hello' (len 5), got len=" .. tostring(#tostring(vars["COSMIC_ENVD_CRLF_A"] or "")))
+  assert(vars["COSMIC_ENVD_CRLF_B"] == "world",
+    "CRLF: expected 'world' (len 5), got len=" .. tostring(#tostring(vars["COSMIC_ENVD_CRLF_B"] or "")))
+end
+test_parse_crlf_no_trailing_cr()
+
+-- FIX 3a: load_dir must also strip trailing \r when reading from a real CRLF file.
+local function test_load_dir_crlf_file()
+  local dir = make_envd("crlf_dir")
+  -- Write a CRLF-encoded dotenv file using raw bytes
+  local crlf_content = "COSMIC_ENVD_CRLF_C=crvalue\r\n"
+  cio.barf(fs.join(dir, "vars"), crlf_content)
+
+  env.unset("COSMIC_ENVD_CRLF_C")
+  local result = envd.load_dir(dir)
+  assert(result.count == 1, "expected 1 var from CRLF file, got " .. tostring(result.count))
+  local val = env.get("COSMIC_ENVD_CRLF_C")
+  assert(val == "crvalue",
+    "CRLF file: expected 'crvalue', got '" .. tostring(val) .. "'")
+  env.unset("COSMIC_ENVD_CRLF_C")
+end
+test_load_dir_crlf_file()
+
+-- FIX 3b: COSMIC_DEBUG='' (empty string) must NOT enable debug mode.
+-- Only a non-empty COSMIC_DEBUG value should enable debug output.
+local function test_cosmic_debug_empty_not_enabled()
+  -- When COSMIC_DEBUG is set to empty string, load_dir should NOT print debug.
+  -- We can't easily capture stderr, but we can verify that setting COSMIC_DEBUG=""
+  -- does NOT cause any side-effects that only happen in debug mode.
+  -- The observable behavior: with COSMIC_DEBUG="" the function should still work
+  -- normally (count==1), and the result should be the same as with no debug.
+  local dir = make_envd("debug_empty")
+  cio.barf(fs.join(dir, "vars"), "COSMIC_ENVD_DEBUG_TEST=value\n")
+  env.unset("COSMIC_ENVD_DEBUG_TEST")
+
+  -- Set COSMIC_DEBUG to empty string
+  env.set("COSMIC_DEBUG", "")
+  local result = envd.load_dir(dir)
+  env.unset("COSMIC_DEBUG")
+
+  assert(result.count == 1, "expected 1 with empty COSMIC_DEBUG, got " .. tostring(result.count))
+  env.unset("COSMIC_ENVD_DEBUG_TEST")
+end
+test_cosmic_debug_empty_not_enabled()

--- a/lib/cosmic/fs_walk.tl
+++ b/lib/cosmic/fs_walk.tl
@@ -15,6 +15,7 @@ end
 
 --- Walk a directory tree, calling visitor for each entry.
 --- Recursively traverses all subdirectories.
+--- Does NOT recurse into symlinked directories to prevent symlink cycles.
 --- @param dir string The directory to walk
 --- @param visitor function Visitor callback Function called for each file and directory
 --- @param ctx T Optional context passed to visitor function
@@ -29,7 +30,9 @@ local function walk < T > (dir: string, visitor: function(string, string, WalkSt
     if not entry then break end
     if entry ~= "." and entry ~= ".." then
       local full_path = cosmo_path.join(dir, entry)
-      local st = unix.stat(full_path) as WalkStat
+      -- Use AT_SYMLINK_NOFOLLOW so symlinked dirs are seen as S_ISLNK, not S_ISDIR.
+      -- This prevents infinite recursion through symlink cycles.
+      local st = unix.stat(full_path, unix.AT_SYMLINK_NOFOLLOW) as WalkStat
       if st then
         visitor(full_path, entry, st, ctx)
         if unix.S_ISDIR(st:mode()) then
@@ -99,12 +102,14 @@ local function collect_all(dir: string): {string: FileInfo}
       if entry ~= "." and entry ~= ".." then
         local full_path = cosmo_path.join(base_dir, entry)
         local rel_path = rel_base == "" and entry or cosmo_path.join(rel_base, entry)
-        local st = unix.stat(full_path) as WalkStat
+        -- Use AT_SYMLINK_NOFOLLOW to detect symlinked dirs as S_ISLNK, not S_ISDIR.
+        -- This prevents infinite recursion through symlink cycles.
+        local st = unix.stat(full_path, unix.AT_SYMLINK_NOFOLLOW) as WalkStat
 
         if st then
           if unix.S_ISDIR(st:mode()) then
             do_walk(full_path, rel_path)
-          elseif unix.S_ISREG(st:mode()) or unix.S_ISLNK(st:mode()) then
+          elseif unix.S_ISREG(st:mode()) then
             local mode = st:mode() & 0x1ff
             files[rel_path] = {mode = mode}
           end
@@ -154,7 +159,9 @@ local function files(dir: string, pattern?: string): function(): string
         table.remove(stack)
       elseif entry ~= "." and entry ~= ".." then
         local full_path = cosmo_path.join(current_dir, entry)
-        local st = unix.stat(full_path) as WalkStat
+        -- Use AT_SYMLINK_NOFOLLOW to detect symlinked dirs as S_ISLNK, not S_ISDIR.
+        -- This prevents infinite recursion through symlink cycles.
+        local st = unix.stat(full_path, unix.AT_SYMLINK_NOFOLLOW) as WalkStat
         if st then
           if unix.S_ISDIR(st:mode()) then
             -- Push subdirectory onto stack

--- a/lib/cosmic/fs_walk_test.tl
+++ b/lib/cosmic/fs_walk_test.tl
@@ -1,0 +1,116 @@
+#!/usr/bin/env cosmic
+--- Tests for fs_walk module (symlink cycle safety)
+local fs_walk = require("cosmic.fs_walk")
+local fs = require("cosmic.fs")
+local unix = require("cosmo.unix")
+
+local tmpdir = os.getenv("TEST_TMPDIR") as string
+
+-- Helper: create a directory under tmpdir
+local function mksubdir(name: string): string
+  local p = fs.join(tmpdir, name)
+  fs.makedirs(p)
+  return p
+end
+
+-- Helper: write a file
+local function write_file(path: string, content: string)
+  local f = io.open(path, "w")
+  assert(f, "cannot open " .. path)
+  f:write(content)
+  f:close()
+end
+
+-- FIX 1a: walk() must not recurse into symlinked directories
+-- A symlink loop (e.g. dir/loop -> ..) must terminate and not stack-overflow.
+local function test_walk_symlink_cycle_terminates()
+  local base = mksubdir("walk_cycle")
+  local subdir = fs.join(base, "sub")
+  fs.makedirs(subdir)
+  write_file(fs.join(subdir, "real.txt"), "hello")
+  -- Create a symlink cycle: sub/loop -> ..  (points back to base)
+  unix.symlink("..", fs.join(subdir, "loop"))
+
+  local count = 0
+  local max_depth_seen = 0
+  -- walk the base directory; collect all entries to detect infinite loop
+  -- (the test harness has a timeout; if we don't hang this is fine)
+  local results: {string} = {}
+  fs_walk.walk(base, function(full_path: string, _entry: string, _st: any, ctx: {string})
+      ctx[#ctx + 1] = full_path
+    end, results)
+
+  -- Must NOT contain any path that descends deeper than base/sub/
+  -- (i.e. no base/sub/loop/sub/loop/... paths)
+  for _, p in ipairs(results) do
+    -- Count path separators relative to base to detect runaway depth
+    local rel = p:sub(#base + 2)
+    local depth = 0
+    for _ in rel:gmatch("/") do depth = depth + 1 end
+    if depth > max_depth_seen then max_depth_seen = depth end
+  end
+  -- A real.txt at base/sub/real.txt has depth 1. Symlink entries at base/sub
+  -- should not be recursed, so max depth should be 1.
+  assert(max_depth_seen <= 1,
+    "walk recursed into symlink cycle: max depth " .. tostring(max_depth_seen))
+end
+test_walk_symlink_cycle_terminates()
+
+-- FIX 1b: collect_all() must not recurse into symlinked directories
+local function test_collect_all_symlink_cycle_terminates()
+  local base = mksubdir("collect_all_cycle")
+  local subdir = fs.join(base, "sub")
+  fs.makedirs(subdir)
+  write_file(fs.join(subdir, "real.txt"), "data")
+  unix.symlink("..", fs.join(subdir, "loop"))
+
+  local files = fs_walk.collect_all(base)
+  -- Should contain sub/real.txt but NOT any path with loop/ in it
+  for rel_path in pairs(files) do
+    assert(not rel_path:match("loop"),
+      "collect_all should not recurse into symlink loop, found: " .. rel_path)
+  end
+  assert(files["sub/real.txt"] ~= nil, "real.txt should be found")
+end
+test_collect_all_symlink_cycle_terminates()
+
+-- FIX 1c: files() iterator must not recurse into symlinked directories
+local function test_files_symlink_cycle_terminates()
+  local base = mksubdir("files_cycle")
+  local subdir = fs.join(base, "sub")
+  fs.makedirs(subdir)
+  write_file(fs.join(subdir, "real.lua"), "-- lua")
+  unix.symlink("..", fs.join(subdir, "loop"))
+
+  local collected: {string} = {}
+  for p in fs_walk.files(base, "*.lua") do
+    collected[#collected + 1] = p
+    -- Safety: abort if we find more than a small number
+    assert(#collected <= 10,
+      "files() appears to iterate infinitely (>10 results from 1 real file)")
+  end
+  assert(#collected == 1, "expected 1 lua file, got " .. tostring(#collected))
+  assert(collected[1]:match("real%.lua$"), "expected real.lua, got " .. tostring(collected[1]))
+end
+test_files_symlink_cycle_terminates()
+
+-- FIX 1d: symlinked regular files should still be visited (not skipped)
+-- Only symlinked *directories* are not recursed into.
+local function test_walk_symlink_file_visited()
+  local base = mksubdir("walk_symlink_file")
+  write_file(fs.join(base, "real.txt"), "content")
+  -- Symlink to a file in same dir
+  unix.symlink("real.txt", fs.join(base, "alias.txt"))
+
+  local found: {string: boolean} = {}
+  fs_walk.walk(base, function(full_path: string, entry: string, _st: any, ctx: {string: boolean})
+      ctx[entry] = true
+    end, found)
+  -- Both the real file and the symlink to a file should be visited
+  -- (walk visits entries without distinguishing symlinked files from real ones,
+  -- since we only skip recursion into symlinked dirs)
+  assert(found["real.txt"], "real.txt should be visited")
+  -- alias.txt: walk calls lstat, sees S_ISLNK (not S_ISDIR), visits it
+  assert(found["alias.txt"], "symlinked file should be visited")
+end
+test_walk_symlink_file_visited()

--- a/lib/cosmic/fuzzy.tl
+++ b/lib/cosmic/fuzzy.tl
@@ -59,10 +59,13 @@ local function find_similar(query: string, candidates: {string}, max_distance?: 
 
   local query_lower = query:lower()
   for _, candidate in ipairs(candidates) do
-    if not seen[candidate] then
-      local dist = levenshtein(query_lower, candidate:lower())
+    -- Key seen on the lowercased form so that "Foo" and "foo" are treated as
+    -- the same candidate (matching is already case-insensitive).
+    local candidate_lower = candidate:lower()
+    if not seen[candidate_lower] then
+      local dist = levenshtein(query_lower, candidate_lower)
       if dist <= max_distance then
-        seen[candidate] = true
+        seen[candidate_lower] = true
         table.insert(results, {candidate, dist})
       end
     end

--- a/lib/cosmic/fuzzy_test.tl
+++ b/lib/cosmic/fuzzy_test.tl
@@ -151,4 +151,13 @@ local function test_find_similar_default_max_distance()
 end
 test_find_similar_default_max_distance()
 
+-- FIX 5: dedup must be case-insensitive — {"Foo","foo"} should produce 1 result.
+local function test_find_similar_dedup_case_insensitive()
+  local candidates = {"Foo", "foo"}
+  local results = fuzzy.find_similar("foo", candidates, 0)
+  assert(#results == 1,
+    "case-insensitive dedup: expected 1 result for {Foo, foo}, got " .. #results)
+end
+test_find_similar_dedup_case_insensitive()
+
 print("All fuzzy tests passed")

--- a/lib/cosmic/hash.tl
+++ b/lib/cosmic/hash.tl
@@ -16,7 +16,7 @@ local rand = require("cosmic.rand")
 --- Options for password hashing with Argon2.
 --- All fields are optional and have sensible defaults.
 local record HashOptions
-  --- Memory cost in kibibytes (default: 4096, i.e. 4 MiB)
+  --- Memory cost in kibibytes (default: 19456, i.e. 19 MiB per OWASP minimum)
   m_cost: number
   --- Time cost / iterations (default: 3)
   t_cost: number
@@ -62,7 +62,8 @@ local function password(pwd: string, options?: HashOptions): string, string
   local salt = rand.bytes(16)
 
   -- Build config from options
-  local config: argon2.Config = {}
+  -- Default m_cost to 19456 KiB (19 MiB) per OWASP minimum recommendation.
+  local config: argon2.Config = {m_cost = 19456}
   if options then
     if options.m_cost then config.m_cost = options.m_cost end
     if options.t_cost then config.t_cost = options.t_cost end
@@ -86,12 +87,24 @@ local function password(pwd: string, options?: HashOptions): string, string
 end
 
 --- Verify a password against an Argon2 encoded hash.
+--- Returns true on match, false (no error) on clean mismatch, or
+--- false plus an error string when the hash is malformed or the binding
+--- reports an error (e.g. "Decoding failed").
 --- @param encoded string The encoded hash string (from password)
 --- @param pwd string The password to verify
---- @return boolean True if the password matches
-local function verify_password(encoded: string, pwd: string): boolean
-  local ok = argon2.verify(encoded, pwd)
-  return ok == true
+--- @return boolean True if the password matches, false otherwise
+--- @return string? Error message if the hash is malformed or another error occurred
+local function verify_password(encoded: string, pwd: string): boolean, string
+  local ok, err = (argon2.verify as function(string, string): boolean, any)(encoded, pwd)
+  if ok == true then
+    return true
+  end
+  if ok == false then
+    -- Clean mismatch: wrong password, no error.
+    return false
+  end
+  -- ok is nil: the binding reported an error (e.g. malformed hash).
+  return false, tostring(err or "argon2 verify failed")
 end
 
 local record HashModule
@@ -100,7 +113,7 @@ local record HashModule
   sha256: function(data: string): string
   sha256_hex: function(data: string): string
   password: function(pwd: string, options?: HashOptions): string, string
-  verify_password: function(encoded: string, pwd: string): boolean
+  verify_password: function(encoded: string, pwd: string): boolean, string
 end
 
 local M: HashModule = {

--- a/lib/cosmic/hash_test.tl
+++ b/lib/cosmic/hash_test.tl
@@ -120,3 +120,27 @@ local function test_password_invalid_variant()
   assert(err and err:match("invalid variant"), "error should mention invalid variant")
 end
 test_password_invalid_variant()
+
+-- FIX 1: verify_password should return false+error on malformed hash
+local function test_verify_password_malformed_hash()
+  local ok, err = hash.verify_password("not-a-hash", "password")
+  assert(ok == false, "verify_password should return false for malformed hash, got: " .. tostring(ok))
+  assert(err ~= nil, "verify_password should return error message for malformed hash")
+end
+test_verify_password_malformed_hash()
+
+local function test_verify_password_returns_two_values_on_mismatch()
+  local encoded = hash.password("correct")
+  local ok, err = hash.verify_password(encoded, "wrong")
+  assert(ok == false, "verify_password should return false for wrong password")
+  assert(err == nil, "verify_password should NOT return error for clean mismatch (wrong password)")
+end
+test_verify_password_returns_two_values_on_mismatch()
+
+-- FIX 2: default m_cost should be 19456 (OWASP minimum 19 MiB)
+local function test_password_default_mcost_is_19456()
+  local encoded, err = hash.password("password", {t_cost = 1})
+  assert(encoded, "password with default m_cost should succeed: " .. tostring(err))
+  assert(encoded:match("m=19456"), "default m_cost should be 19456, encoded string: " .. encoded)
+end
+test_password_default_mcost_is_19456()

--- a/lib/cosmic/html_test.tl
+++ b/lib/cosmic/html_test.tl
@@ -34,3 +34,13 @@ local function test_escape_empty_string()
   assert(result == "", "expected empty string")
 end
 test_escape_empty_string()
+
+-- FIX 7: single quotes must be escaped (important in HTML attribute contexts).
+local function test_escape_single_quote()
+  local result = html.escape("'")
+  assert(result ~= "'", "single quote must be escaped, got bare '")
+  -- Accept either &#39; or &apos;
+  assert(result == "&#39;" or result == "&apos;",
+    "single quote should become &#39; or &apos;, got: " .. result)
+end
+test_escape_single_quote()

--- a/lib/cosmic/io.tl
+++ b/lib/cosmic/io.tl
@@ -53,7 +53,7 @@ local unix = require("cosmo.unix") as UnixIO
 --- File handle for I/O operations.
 --- Supports Lua 5.4's to-be-closed via __close metamethod.
 local record Handle
-  close: function(self: Handle): boolean
+  close: function(self: Handle): boolean, string
   closed: function(self: Handle): boolean
   fd: function(self: Handle): number
   read: function(self: Handle, size?: number, offset?: number): string, string
@@ -73,10 +73,15 @@ make_handle = function(fd: number): Handle
   local handle: Handle = {}
 
   --- Close the handle. Idempotent.
-  function handle:close(): boolean
+  --- Returns false + error message if unix.close() fails; true on success.
+  --- A second call on an already-closed handle always returns true.
+  function handle:close(): boolean, string
     if handle_fd then
-      unix.close(handle_fd)
+      local ok, err = unix.close(handle_fd)
       handle_fd = nil
+      if not ok then
+        return false, tostring(err)
+      end
     end
     return true
   end

--- a/lib/cosmic/io_test.tl
+++ b/lib/cosmic/io_test.tl
@@ -357,3 +357,28 @@ local function test_datasync()
   os.remove(filepath)
 end
 test_datasync()
+
+-- FIX 5: handle:close() must propagate unix.close() failure instead of
+-- always returning true.  The error path is hard to trigger directly, so we
+-- verify: (a) successful close returns true, (b) idempotent second close
+-- returns true, and (c) the return type is boolean (not always true when
+-- unix.close would fail on a bad fd).
+local function test_close_returns_boolean_and_is_idempotent()
+  local filepath = path.join(TEST_TMPDIR, "io_test_close_bool.txt")
+
+  local f = assert(io_m.open(filepath, io_m.O_WRONLY | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
+  assert(f:write("x"))
+
+  -- First close should succeed and return true
+  local ok, err = f:close()
+  assert(ok == true, "first close should return true, got: " .. tostring(ok) .. " err=" .. tostring(err))
+  assert(err == nil, "first close should have no error, got: " .. tostring(err))
+
+  -- Second close (already closed) should return true (idempotent)
+  ok, err = f:close()
+  assert(ok == true, "second close (idempotent) should return true, got: " .. tostring(ok))
+  assert(err == nil, "second close should have no error, got: " .. tostring(err))
+
+  os.remove(filepath)
+end
+test_close_returns_boolean_and_is_idempotent()

--- a/lib/cosmic/quicksand/box/init.tl
+++ b/lib/cosmic/quicksand/box/init.tl
@@ -80,6 +80,7 @@ local record BoxOpts
   proc: ProcOpts
   env: EnvOpts
   cwd: string
+  pid_ns: boolean -- set false to opt out of CLONE_NEWPID isolation
 end
 
 --- Box instance. `run(argv)` returns an integer exit code on success
@@ -150,6 +151,9 @@ local function preflight(opts: BoxOpts): boolean, string
     end
     local fs = opts.fs
     local has_fs = fs and (fs.ro or fs.rw or fs.exec)
+    if fs and fs.deny and not has_fs then
+      return false, "quicksand: fs.deny requires at least one of fs.ro, fs.rw, or fs.exec (deny is informational; landlock is allowlist-based)"
+    end
     if has_fs and not c.landlock then
       return false, "quicksand: landlock unavailable (fs policy requested)"
     end

--- a/lib/cosmic/quicksand/box/init_test.tl
+++ b/lib/cosmic/quicksand/box/init_test.tl
@@ -118,3 +118,30 @@ local function test_merge_reexported()
   assert((fs.rw as {string})[1] == "/tmp")
 end
 test_merge_reexported()
+
+-- FIX 3: a deny-only fs policy (no ro/rw/exec) must be rejected at
+-- preflight so landlock is never silently skipped.
+local function test_deny_only_requires_allowlist()
+  local c = quicksand.capabilities()
+  if not c.linux then return end
+
+  local j = assert(Box.new({fs = {deny = {"/proc"}}}))
+  local code, err = j:run({"/bin/true"})
+  assert(code == nil, "deny-only policy should fail preflight, got code: " .. tostring(code))
+  assert(err and (err as string):find("deny", 1, true),
+    "error should mention 'deny', got: " .. tostring(err))
+end
+test_deny_only_requires_allowlist()
+
+-- FIX 3: a policy with both deny and an allowlist should still pass preflight.
+local function test_deny_with_allowlist_passes_preflight()
+  local c = quicksand.capabilities()
+  if not c.linux then return end
+
+  -- new() + run() on a non-linux-capable environment skips gracefully.
+  -- On Linux, preflight should NOT reject a policy that has deny + ro.
+  local j, jerr = Box.new({fs = {ro = {"/usr"}, deny = {"/proc"}}})
+  assert(j, "deny + ro should be accepted: " .. tostring(jerr))
+  -- We don't actually run the box here; structural validity is enough.
+end
+test_deny_with_allowlist_passes_preflight()

--- a/lib/cosmic/quicksand/box/run.tl
+++ b/lib/cosmic/quicksand/box/run.tl
@@ -41,12 +41,28 @@ local env_apply = box_env.apply as function(any, {string: string}): {string: str
 local ll_restrict = landlock.restrict as function(any): boolean, string
 local proxy_start = proxy.start as function(any): {string: any}, string
 
+local record CapsModule
+  capabilities: function(): {string: boolean}
+end
+
 local function clone_flags(opts: {string: any}): integer
   local flags = (u.CLONE_NEWUSER as integer)
   | (u.CLONE_NEWNET as integer)
   | (u.CLONE_NEWNS as integer)
   if opts and opts.hostname then
     flags = flags | (u.CLONE_NEWUTS as integer)
+  end
+  -- Include CLONE_NEWPID by default for PID namespace isolation, unless
+  -- the caller has opted out with pid_ns = false, or the kernel lacks
+  -- the capability. After unshare(CLONE_NEWPID) the supervisor stays in
+  -- the old PID ns; the first forked child (proxy or workload) becomes
+  -- PID 1 of the new namespace.
+  if opts == nil or opts.pid_ns ~= false then
+    local qs = require("cosmic.quicksand") as CapsModule
+    local c = qs.capabilities()
+    if (c as {string: boolean}).pid_ns then
+      flags = flags | (u.CLONE_NEWPID as integer)
+    end
   end
   return flags
 end
@@ -92,7 +108,7 @@ local function workload_setup(opts: {string: any}): string
     if not ok then return "landlock: " .. tostring(err) end
   end
   local pr = opts and opts.proc as {string: any}
-  if pr and pr.no_new_privs then
+  if pr and (pr.no_new_privs or pr.uid ~= nil) then
     local ok, err = qproc.no_new_privs()
     if not ok then return "no_new_privs: " .. tostring(err) end
   end
@@ -185,7 +201,7 @@ local function supervisor(
   end
 
   local env_list = compute_env(opts)
-  if proxy_port and (net == nil or net.proxy_env ~= false) then
+  if proxy_port and net.proxy_env ~= false then
     env_list = inject_proxy_env(env_list, proxy_port)
   end
 

--- a/lib/cosmic/quicksand/box/run_test.tl
+++ b/lib/cosmic/quicksand/box/run_test.tl
@@ -49,3 +49,88 @@ io.write("skipped: exit=" .. tostring(code) .. "\n"); os.exit(0)
     "expected ok or skipped, got: " .. s)
 end
 test_run_true_in_subprocess()
+
+-- FIX 1: proc.uid without no_new_privs must still set NoNewPrivs.
+-- The workload reads /proc/self/status and greps for NoNewPrivs:1.
+local function test_uid_drop_sets_no_new_privs_subprocess()
+  local c = quicksand.capabilities()
+  if not (c.linux and c.user_ns and c.net_ns) then return end
+
+  local script = path.join(tmpdir, "box_nnp_uid.lua")
+  cosmo.Barf(script, [[
+local qs = require("cosmic.quicksand")
+local j, nerr = qs.Box.new({ proc = { uid = 65534 } })
+if not j then io.stderr:write("new: " .. tostring(nerr) .. "\n"); os.exit(1) end
+local code, rerr = j:run({"/bin/sh", "-c",
+  "grep 'NoNewPrivs:' /proc/self/status | grep -q 1 && echo ok || echo fail"})
+if code == nil then
+  io.stderr:write("run nil: " .. tostring(rerr) .. "\n"); os.exit(1)
+end
+if code ~= 0 then
+  -- unshare failed under outer sandbox; treat as skip
+  io.write("skipped: exit=" .. tostring(code) .. "\n"); os.exit(0)
+end
+]])
+
+  local ok, out = spawn.spawn({cosmic, script}):read()
+  if not ok then return end
+  local s = out as string
+  assert(s:find("ok") or s:find("skipped"),
+    "expected ok or skipped (NoNewPrivs should be 1), got: " .. s)
+end
+test_uid_drop_sets_no_new_privs_subprocess()
+
+-- FIX 2: PID namespace isolation — workload should get a low PID (<= 2).
+local function test_pid_namespace_workload_has_low_pid_subprocess()
+  local c = quicksand.capabilities()
+  if not (c.linux and c.user_ns and c.net_ns and c.pid_ns) then return end
+
+  local script = path.join(tmpdir, "box_pidns.lua")
+  cosmo.Barf(script, [[
+local qs = require("cosmic.quicksand")
+local j, nerr = qs.Box.new({})
+if not j then io.stderr:write("new: " .. tostring(nerr) .. "\n"); os.exit(1) end
+local code, rerr = j:run({"/bin/sh", "-c", "test $$ -le 2 && echo ok || echo fail:$$"})
+if code == nil then
+  io.stderr:write("run nil: " .. tostring(rerr) .. "\n"); os.exit(1)
+end
+if code ~= 0 then
+  io.write("skipped: exit=" .. tostring(code) .. "\n"); os.exit(0)
+end
+]])
+
+  local ok, out = spawn.spawn({cosmic, script}):read()
+  if not ok then return end
+  local s = out as string
+  assert(s:find("ok") or s:find("skipped"),
+    "expected ok or skipped (PID should be <= 2), got: " .. s)
+end
+test_pid_namespace_workload_has_low_pid_subprocess()
+
+-- FIX 2: Opt-out of PID namespace via pid_ns = false still runs.
+local function test_pid_namespace_opt_out_subprocess()
+  local c = quicksand.capabilities()
+  if not (c.linux and c.user_ns and c.net_ns) then return end
+
+  local script = path.join(tmpdir, "box_nopidns.lua")
+  cosmo.Barf(script, [[
+local qs = require("cosmic.quicksand")
+local j, nerr = qs.Box.new({ pid_ns = false })
+if not j then io.stderr:write("new: " .. tostring(nerr) .. "\n"); os.exit(1) end
+local code, rerr = j:run({"/bin/true"})
+if code == nil then
+  io.stderr:write("run nil: " .. tostring(rerr) .. "\n"); os.exit(1)
+end
+if code ~= 0 then
+  io.write("skipped: exit=" .. tostring(code) .. "\n"); os.exit(0)
+end
+io.write("ok\n")
+]])
+
+  local ok, out = spawn.spawn({cosmic, script}):read()
+  if not ok then return end
+  local s = out as string
+  assert(s:find("ok") or s:find("skipped"),
+    "expected ok or skipped, got: " .. s)
+end
+test_pid_namespace_opt_out_subprocess()

--- a/lib/cosmic/sqlite.tl
+++ b/lib/cosmic/sqlite.tl
@@ -377,15 +377,26 @@ local type RowIter = function(): {string: any}
 
     --- Return the first row matching a query, or nil if no rows match.
     --- Convenience method for single-row lookups.
+    --- The underlying prepared statement is always finalized before returning,
+    --- even when only the first row is consumed, preventing statement leaks.
     function db:query_one(sql: string, ...: any): {string: any}, string
       local iter, err = self:query(sql, ...)
       if not iter then
         return nil, err
       end
+      -- Capture the first row, then drain the iterator so the statement is
+      -- finalized deterministically (returning early from a for-loop leaves
+      -- the iterator open and the prepared statement unfinalized until GC).
+      local first: {string: any} = nil
       for row in iter do
-        return row
+        first = row
+        break
       end
-      return nil
+      -- Drain remaining rows so the wrapping closure calls stmt:close().
+      if first ~= nil then
+        while iter() ~= nil do end
+      end
+      return first
     end
 
     --- Execute fn within a transaction. Calls BEGIN before fn, COMMIT after

--- a/lib/cosmic/sqlite_test.tl
+++ b/lib/cosmic/sqlite_test.tl
@@ -409,3 +409,25 @@ local function test_query_one_invalid_sql()
   db:close()
 end
 test_query_one_invalid_sql()
+
+-- FIX 3: query_one must finalize the prepared statement so db:close() succeeds
+-- and subsequent queries work (statement leak regression test).
+local function test_query_one_close_after_hit()
+  local db, err = sqlite.open(":memory:")
+  assert(db, "should open db: " .. tostring(err))
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+  db:exec("INSERT INTO t (name) VALUES ('alice')")
+
+  -- query_one that returns a row — previously leaked the iterator/statement
+  local row = db:query_one("SELECT * FROM t WHERE name = ?", "alice")
+  assert(row ~= nil, "query_one should return a row")
+  assert(row.name == "alice", "row.name should be 'alice'")
+
+  -- A subsequent query must still work (leaked stmt could lock the table)
+  local row2 = db:query_one("SELECT * FROM t WHERE name = ?", "alice")
+  assert(row2 ~= nil, "second query_one should still work after first")
+
+  -- db:close() must succeed without error (lsqlite3 fails if stmts unfinalized)
+  db:close()
+end
+test_query_one_close_after_hit()

--- a/lib/cosmic/tty.tl
+++ b/lib/cosmic/tty.tl
@@ -220,11 +220,19 @@ local function getpass(prompt: string): string, string
   if not original then
     return nil, err
   end
-  -- Read one line; restore terminal before each return path
-  local line = io.stdin:read("l")
-  -- Write newline to stderr since echo is off
+  -- Read one line inside pcall so we always restore the terminal, even if
+  -- io.stdin:read raises an error (e.g. EINTR or a Lua I/O error).
+  local read_ok, line_or_err = pcall(function(): string
+      return io.stdin:read("l")
+    end)
+  -- Write newline to stderr since echo is off (regardless of outcome)
   io.stderr:write("\n")
   restore(0, original)
+  if not read_ok then
+    -- pcall caught an error: line_or_err is the error message
+    return nil, tostring(line_or_err)
+  end
+  local line = line_or_err as string
   if line == nil then
     return nil, "EOF"
   end

--- a/lib/cosmic/url.tl
+++ b/lib/cosmic/url.tl
@@ -38,6 +38,7 @@ end
 
 --- Parse a query string into key-value pairs.
 --- Handles URL-encoded keys and values.
+--- Duplicate keys: last value wins.
 --- @param query string The query string (without leading ?)
 --- @return {string:string} Table of key-value pairs
 local function parse(query: string): {string: string}
@@ -91,12 +92,21 @@ local function parse_url(url: string): Url
     port = tonumber(parsed.port) as integer
   end
 
-  -- Reconstruct query string from params
+  -- Reconstruct query string from params, re-encoding each decoded key and
+  -- value so that characters like & and = inside values are not confused with
+  -- query-string delimiters (e.g. ?a=x%26y must not become a=x&y).
   local query: string = nil
   if parsed.params and #parsed.params > 0 then
     local parts: {string} = {}
     for _, pair in ipairs(parsed.params) do
-      table.insert(parts, pair[1] .. "=" .. pair[2])
+      local k = cosmo.EscapeParam(pair[1])
+      local v = pair[2] as string
+      if v ~= nil then
+        table.insert(parts, k .. "=" .. cosmo.EscapeParam(v))
+      else
+        -- Flag-style param with no value (e.g. ?flag) — emit key only.
+        table.insert(parts, k)
+      end
     end
     query = table.concat(parts, "&")
   end

--- a/lib/cosmic/url_test.tl
+++ b/lib/cosmic/url_test.tl
@@ -362,3 +362,30 @@ local function test_escape_ip_ipv6()
   assert(result:match("::1") or result:match("%%3A"), "expected ipv6 to be handled, got '" .. result .. "'")
 end
 test_escape_ip_ipv6()
+
+-- FIX 4: parse_url must preserve percent-encoding in the query field.
+-- ?a=x%26y has ONE param (key=a, value=x&y); the reconstructed query must
+-- not turn %26 into a literal & (which would look like two params).
+
+local function test_parse_url_query_preserves_encoding()
+  local result = url.parse_url("http://x.com/?a=x%26y")
+  assert(result.query ~= nil, "query should not be nil")
+  -- The query must not be decoded to "a=x&y" (that reads as two params).
+  assert(result.query ~= "a=x&y",
+    "query must not decode %26 to &, got: " .. tostring(result.query))
+  -- Parsing the reconstructed query must yield exactly one param with value "x&y".
+  local params = url.parse(result.query)
+  assert(params.a == "x&y",
+    "parsed param 'a' must equal 'x&y', got: " .. tostring(params.a))
+end
+test_parse_url_query_preserves_encoding()
+
+local function test_parse_url_query_flag_param()
+  -- ?flag has a key with no value; reconstructing must not emit a bare "=".
+  local result = url.parse_url("http://x.com/?flag")
+  assert(result.query ~= nil, "query should not be nil for flag param")
+  -- The query string must contain "flag" and must not end in bare "=".
+  assert(result.query:match("flag"), "query should contain 'flag'")
+  assert(not result.query:match("flag=$"), "query must not end with 'flag='")
+end
+test_parse_url_query_flag_param()


### PR DESCRIPTION
Follow-up to #411: a four-area security/functional audit of the repo, with all confirmed findings fixed test-first (red-green TDD). Full CI is green: 178 format, 178 teal, 85 tests (up from 82), 16 examples, 239 lint.

## quicksand sandbox (3ed4571)
- **`no_new_privs` now applied whenever a uid drop is requested** (previously only with an explicit opt-in flag), and before `drop_privs`/landlock — closes a setuid re-elevation window.
- **PID namespace isolation by default**: `CLONE_NEWPID` added to the unshare flags, gated on the detected `pid_ns` capability, opt-out via `BoxOpts.pid_ns = false`. Boxed workloads can no longer see/signal host pids. (When a proxy sidecar is in use it becomes PID 1 of the inner ns — fail-closed: proxy death kills the box.)
- **Deny-only fs policies now fail closed**: `fs = { deny = ... }` without ro/rw/exec previously passed preflight but applied no landlock at all; it now errors at preflight.
- Removed a dead `net == nil` arm in the proxy-env injection condition.

## I/O & process (09a38f5)
- **Symlink-cycle safety**: `fs_walk` (walk/collect_all/files) and `embed.collect_dir` no longer follow symlinks when recursing — a `ln -s . loop` previously caused infinite recursion, and embed silently included content from outside the embed tree. Embed now skips symlinks; symlinked files are still *visited* (not recursed) by walk.
- `child.tl` fd redirection rewritten from racy `close(n); dup(fd)` to atomic dup2-style `unix.dup(src, dst)`, with same-fd edge cases handled.
- `envd`: CRLF dotenv files no longer leave a trailing `\r` on values; `COSMIC_DEBUG=` (empty) no longer enables debug output.
- `io.handle:close()` propagates `unix.close()` failures instead of always returning true.
- `tty` password read restores termios even if the stdin read raises.

## crypto/data (b9d7ffe)
- **`hash.verify_password` now returns `boolean, string`**: argon2 distinguishes a clean mismatch (`false, nil`) from a corrupt/malformed hash (`nil, "Decoding failed"`); previously both collapsed to `false`, hiding storage corruption.
- Argon2 default `m_cost` raised 4096 → 19456 KiB (OWASP minimum).
- `sqlite.query_one` finalizes its prepared statement deterministically instead of leaking it until GC (could previously interfere with `db:close()`).
- **`url.parse_url` query reconstruction was lossy**: `?a=x%26y` round-tripped to `a=x&y` (two params). Keys/values are now re-encoded via `EscapeParam`; valueless flags don't emit a bare `=`; last-wins duplicate-key behavior documented.
- `fuzzy.find_similar` dedup is now case-insensitive to match its matching semantics.
- `codec` base32 doc comment corrected; regression test added pinning `html.escape`'s single-quote escaping (already correct in the C layer).

## build infrastructure (22964e3)
- **Version-spec path containment**: `install`, `remove`, and `links` entries in dep specs are validated (no absolute paths, no `..` components) before being joined onto the stage dir; symlink targets restricted to relative within-stage paths. Previously a spec could rename/delete/symlink outside the stage directory.
- `build-fetch` validates the archive filename derived from the URL (`[A-Za-z0-9._-]+` only, no `.`/`..`).
- `bin/make` bootstrap download is now atomic: download to a temp file, verify SHA-256, then `mv` into place.
- Workflows: `pr.yml` gets top-level `permissions: contents: read`; `docs.yml`'s `contents: write` scoped to the publishing job; `release.yml`'s `${PRERELEASE_FLAG}` expansion made word-splitting-safe.
- `lint.tl` `check_assert_order` depth counter now accounts for `if`/`for`/`while`/`do`/`repeat..until` blocks (previously only `function`/`end`, corrupting body-boundary detection).
- Doc-index `load()` in `docs.tl`/`doc.tl` sandboxed (`"t"` mode, empty environment).

## Reviewed but deliberately not changed
- **Proxy allowlist matching and TLS verification** live in the `cosmo.sandbox.proxy` / `cosmo.Fetch` C layer (the cosmos binary), outside this repo. Worth a C-side audit: IP-literal bypass, `*.suffix` wildcard anchoring, Host-vs-CONNECT-target validation, and whether TLS verification is on by default (and exposing a `verify_tls` opt in `fetch.Opts`).
- `tar --no-absolute-names` during staging: GNU-only flag (portability risk); both GNU and BSD tar strip absolute paths by default, and the Lua-side containment checks above cover the spec-injection vector.
- `sqlite.transaction` re-entrancy and `fetch.lines()` unbounded line buffering: noted as design follow-ups, not bugs in current documented usage.

https://claude.ai/code/session_015HySqtvzggrDGawqwJX7B1

---
_Generated by [Claude Code](https://claude.ai/code/session_015HySqtvzggrDGawqwJX7B1)_