### PR TITLE
Agent usability: study, 24 fixes across three rounds, verified re-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,13 +316,16 @@ $(o)/docs/cosmo/%.md: lib/types/cosmo/%.d.tl $(cosmic_bin) | $(bootstrap_files)
 
 # Generate serialized doc index for embedding (uses bootstrap cosmic to avoid circular dep)
 # Include both module sources and example files for the index
+# LUA_PATH points at the freshly compiled modules so the index generator uses
+# this tree's cosmic.doc/docindex code, not the bootstrap's embedded (older) copy
 doc_index_srcs := $(all_module_srcs) $(all_example_srcs) $(dtl_files)
+doc_index_lua := $(patsubst %.tl,$(o)/%.lua,$(all_module_srcs))
 doc_index := $(o)/docs/.index.lua
 doc_index_script := lib/cosmic/docindex.tl
 
-$(doc_index): $(doc_index_srcs) $(doc_index_script) | $(bootstrap_cosmic)
+$(doc_index): $(doc_index_srcs) $(doc_index_lua) $(doc_index_script) | $(bootstrap_cosmic)
 	@mkdir -p $(@D)
-	@$(bootstrap_cosmic) $(doc_index_script) $(doc_index_srcs) > $@.tmp
+	@LUA_PATH="$(o)/lib/?.lua;;" $(bootstrap_cosmic) $(doc_index_script) $(doc_index_srcs) > $@.tmp
 	@if cmp -s $@.tmp $@ 2>/dev/null; then rm $@.tmp; else mv $@.tmp $@; fi
 
 .PHONY: doc-index

--- a/docs/agent-usability.md
+++ b/docs/agent-usability.md
@@ -1,0 +1,145 @@
+# Agent Usability Study — June 2026
+
+Four Sonnet agents were given a clean directory containing only the `cosmic`
+binary (build `8c7e138`) and a coding task. No repo access, no web, no other
+runtimes. Tasks covered four surface areas:
+
+| sandbox | task | result | cosmic invocations |
+|---------|------|--------|--------------------|
+| A | JSON stats CLI with error paths | completed, zero type errors | ~20 |
+| B | reusable module + tests via `--test`/`--report` | completed, 1 type error | ~15 |
+| C | sqlite file indexer (fs.walk + hash + sqlite) | completed, ~17 errors/cycles | ~33 |
+| D | child-process TCP echo orchestrator | completed, 1 type error + 1 silent logic bug | ~23 |
+
+All four finished, which is a strong baseline: `--help`, `--docs` search, and
+`--docs guide.*` were enough to get from zero to working code. Cost scaled
+with how far the task strayed from documented idioms — agent C needed roughly
+twice the tool calls of agent A, almost all spent re-deriving undocumented
+semantics by trial and error.
+
+Every finding below was reproduced against the binary directly; agent
+self-reports alone were not trusted.
+
+## What already works well (keep it)
+
+- `--help` is excellent first contact: lists every flag, the full module
+  list, doc entry points, and the `proc.is_main()` pattern.
+- `--check-types` prints `Type check passed` on success — positive
+  confirmation matters to agents.
+- `--check-format` shows an actionable diff; `--report` failure output
+  includes captured stderr and traceback.
+- `--skill` generating SKILL.md is exactly the right idea.
+- `--docs` keyword search surfaces functions *and* examples.
+
+## P0 — bugs (fix first)
+
+1. **Require hints never fire for `.tl` scripts.** `--help` advertises
+   "helpful module-not-found suggestions" (`COSMIC_NO_REQUIRE_HINTS`), but
+   `require("json")` in a script yields only
+   `error: module not found: 'json'`. The hint machinery in
+   `lib/cosmic/require.tl:166` matches Lua's `module 'x' not found` format,
+   while the Teal loader emits `module not found: 'x'` — so the hints are
+   dead on the primary code path. (The hints *do* work in `--examples`
+   lookup, where `--examples child` correctly suggests `cosmic.child`.)
+
+2. **`--docs` cannot address re-exported functions or record methods.**
+   `cosmic --docs cosmic.fs.walk` → `symbol 'walk' not found in 'cosmic.fs'`;
+   `cosmic --docs cosmic.sqlite.query` → same. These are the highest-traffic
+   APIs. Agent C only found walk's docs after discovering the internal
+   `fs_walk` submodule name. Index re-exports under the public module name,
+   and make `Db:query`-style record methods addressable.
+
+3. **Doc renderer garbles multi-line function types in records.**
+   `--docs cosmic.poll` renders a stray dangling line
+   `fd: number, events: Events)` inside the `Poller` record, making the
+   module look broken (source: `lib/cosmic/poll.tl:41-46`).
+
+4. **`fs.walk` visitor docs are actively misleading.** The signature names
+   the first parameter `dir`, but it receives the entry's *full path*.
+   Agent C wrote `fs.join(dir, name)`, got doubled paths
+   (`testdata/config.ini/config.ini`), and lost several cycles to a silent
+   runtime bug. Rename the documented parameter to `path` and state "first
+   arg is the full path; second is the basename". Also: `--examples
+   cosmic.fs_walk` has no examples, and the `WalkStat` type is only
+   importable as `cosmic.fs_types.WalkStat` — agent C needed three failed
+   annotations to discover that.
+
+5. **`--test` with missing arguments reports `unknown option '--test'`.**
+   Should report usage for the flag instead.
+
+## P1 — high-leverage documentation
+
+6. **Put one complete, runnable example at the top of every module doc
+   page.** Module pages do embed examples, but at the bottom of 300+ line
+   pages; no agent ever reached them. The single change with the highest
+   payoff: open → use → close in the first screenful (especially sqlite,
+   child, net, fs).
+
+7. **Add a `guide.gotchas` (or `guide.types`) covering the traps every agent
+   hit:**
+   - `integer` vs `number` (agents B and D both lost a cycle; `string.sub`
+     wants `integer`, `WEXITSTATUS` returns `number`)
+   - traversing `any` from `json.decode`: the cast chain
+     `data as {any}` / `item as {string:any}`
+   - `arg` is `{string}` with `string | nil` elements; guard before use
+   - multi-return capture: `local rows, err = db:query(...)` (can't use
+     directly in `for ... in`)
+   - local modules: `require("mymod")` works relative to the script
+     (currently documented nowhere)
+
+8. **`cosmic.io` shadows Lua's `io` and has no `stderr`.** Two agents
+   independently probed for `cosmic.io.stderr`. Add a note to the module
+   docs: alias it (`local cio = require("cosmic.io")`) and use standard
+   `io.stderr` for streams.
+
+9. **Make the testing guide's "Running Tests" section copy-pasteable.**
+   Agent B ended up with `slug_test.got.got` because the `<output_prefix>`
+   semantics (writes `.out`/`.err`/`.got`, report on the `.got`) are stated
+   in prose but never shown end-to-end. Also state explicitly that `--test`
+   propagates the test's exit code and `--report` aggregates.
+
+10. **Add a worked child-process + pipe example.** `child.Opts.stdout:
+    number` is a raw fd for dup2 in the child; the parent must pass
+    `pipe.writer:fd()` and close the write end. Agent D inferred this from
+    Unix lore, not docs. (Related: a `net` helper or documented idiom for
+    "bind port 0, recover the real port via `getsockname`".)
+
+## P2 — error-message ergonomics
+
+11. **Teach the type checker fix-hints for the top three traps:**
+    `got number, expected integer` → "annotate the variable `: number` or
+    use `math.tointeger`"; `got string | nil, expected string` → "narrow
+    with `if x == nil then ... end` first"; `wrong number of returns` →
+    "capture with `local v, err = ...`".
+
+12. **Rename or reword the `assert-order` style diagnostic.** The message
+    `function 'foo' not called immediately after definition` is labeled
+    `assert-order`, which reads as being about `assert()`; agent A could not
+    tell what rule fired or whether it mattered.
+
+13. **`--check-format` mismatch output can look like identical lines**
+    (invisible whitespace). Append a hint: "run `cosmic --format <file>` to
+    fix", and consider an in-place `--format --output <same file>` shortcut
+    in the docs.
+
+14. **Runtime tracebacks leak internals** (`/zip/main.lua:418: in local
+    'main'`). Trim frames below the user's script.
+
+## P3 — API ergonomics (smaller, nice-to-have)
+
+15. **`assert_eq(actual, expected, label?)` helper** for tests — every agent
+    hand-rolled `assert(x == y, "got: " .. tostring(x))`.
+16. **`net` convenience for ephemeral ports**: `listen(host, 0)` returning
+    the bound port.
+17. **`--examples <name>` should accept the bare names its own listing
+    prints** (`--examples` prints `child:`, but `--examples child` errors
+    and demands `cosmic.child`). Its "did you mean" list also surfaces
+    noise like `cosmic.fs_ops.FsOpsModule.chmod`.
+
+## Method notes
+
+Agents were instructed to work only from the binary's own help/docs, report
+every command run, every verbatim error, and their top frictions. Claims
+were then re-verified directly against the binary; a few agent claims were
+dropped as inaccurate (e.g. "`--help` truncates the module list" — it
+doesn't; the agent's own pager did).

--- a/docs/agent-usability.md
+++ b/docs/agent-usability.md
@@ -143,3 +143,60 @@ every command run, every verbatim error, and their top frictions. Claims
 were then re-verified directly against the binary; a few agent claims were
 dropped as inaccurate (e.g. "`--help` truncates the module list" — it
 doesn't; the agent's own pager did).
+
+---
+
+# Round 2 — after the fixes
+
+All 17 findings were addressed (commits `41f8f36`..`fb1953f`), and the
+experiment was repeated: four fresh Sonnet agents, identical prompts and
+tasks, clean sandboxes containing only the rebuilt binary (`e13e92d`).
+
+## Results
+
+| sandbox | task | round 1 | round 2 |
+|---------|------|---------|---------|
+| A | JSON stats CLI | clean, but burned cycles on `arg`/`any`/style confusion | 1 error total (format mismatch, fixed via the new hint in one step) |
+| B | module + tests | 1 type error; ended up with a file named `slug_test.got.got` | 1 type error — the new fix-hint resolved it in one edit; test workflow correct first time |
+| C | sqlite indexer | ~17 errors incl. a silent path-doubling runtime bug; ~70 tool calls | **type check passed on the first attempt**; 2 errors total; 36 tool calls |
+| D | child + TCP echo | 2 type errors plus a silent server/probe race | 3 small errors, **no silent bugs**; used `net.listen_tcp` and the child+pipe example directly |
+
+Fixes observed working in the wild (not just in unit tests):
+
+- The `--check-format` hint's in-place command was used successfully by
+  three of four agents on their first formatting failure.
+- The `got number, expected integer` fix-hint appeared verbatim in agent
+  B's transcript and was resolved in a single edit (round 1: a full
+  probe-and-experiment cycle).
+- `guide.gotchas` was read by three agents and answered the `any`-casting,
+  `arg`-nil, and io-shadowing questions before they became errors.
+- Every per-symbol docs lookup attempted resolved: `cosmic.net.listen_tcp`,
+  `cosmic.child.{spawn,Opts,Handle,Pipe}`, `cosmic.fs_walk.walk`,
+  `cosmic.sqlite.{open,Database}`.
+- No agent hit the fs.walk path-doubling bug or the io-shadowing trap.
+- `cosmic.assert` was discovered organically via `--docs assert`.
+
+## Remaining backlog (new or surviving findings)
+
+1. `--docs <module>.<TypeName>` still misses nested record *types*
+   (`cosmic.fs_types.WalkStat` → "symbol not found"); round-1 fix covered
+   record methods only.
+2. The `arg` table layout is undocumented: `arg[-1]` is the interpreter
+   path, `arg[0]` is `/zip/main.lua` — agent D needed this to self-spawn
+   and found it only by experiment. Document in `cosmic.proc` docs and
+   `guide.gotchas`.
+3. A `--fix` shorthand for formatting (two independent requests); the
+   working incantation `--write-if-changed --output <f> --format <f>` is
+   verbose and order-sensitive.
+4. Point to `guide.gotchas` from `--help` ("Common pitfalls: cosmic --docs
+   guide.gotchas").
+5. Formatter rules for nested/callback indentation are discoverable only by
+   failing; name the violated rule in the mismatch output or document the
+   rules in `guide.formatting`.
+6. `--report` counts test *files*, not `test_*` functions; per-function
+   reporting would make green runs verifiable.
+7. Smaller: a `LIKE`/`WHERE` example in the sqlite docs; surface
+   `cosmic.ip` string→int conversion from the net docs; note that
+   `child.Pipe.fd` is a field while `io.Handle:fd()` is a method; document
+   local `require` resolution in `guide.modules` (it is in `gotchas` but
+   one agent looked in `modules`).

--- a/docs/agent-usability.md
+++ b/docs/agent-usability.md
@@ -200,3 +200,46 @@ Fixes observed working in the wild (not just in unit tests):
    `child.Pipe.fd` is a field while `io.Handle:fd()` is a method; document
    local `require` resolution in `guide.modules` (it is in `gotchas` but
    one agent looked in `modules`).
+
+---
+
+# Round 3 — backlog fixes
+
+All seven surviving findings were addressed (commit `1f0926c`). Sub-agent
+capacity was unavailable for this round, so changes were implemented and
+verified directly against a rebuilt binary rather than via a fresh
+clean-room run.
+
+1. **Nested record types resolve in `--docs`.**
+   `cosmic --docs cosmic.fs_types.WalkStat` now renders the WalkStat record
+   with its doc comment and methods. Root cause was deeper than lookup: the
+   doc parser flattened nested `record X ... end` blocks into the parent
+   record, so WalkStat never existed in the index and module pages showed
+   one misattributed blob. Nested records are now parsed as their own
+   entries (`doc.tl`), record names participate in cross-module
+   did-you-mean (`cosmic --docs cosmic.fs.WalkStat` → "Did you mean?
+   cosmic --docs cosmic.fs_types.WalkStat"), and symbol-not-found lists the
+   module's available symbols inline instead of telling the agent to go
+   look. Lookup helpers moved to a new `docs_lookup.tl` (500-line cap).
+2. **`arg` layout documented** in `cosmic.proc` docs and `guide.gotchas`
+   entry 7 (`arg[-1]` = interpreter path, `arg[0]` = `/zip/main.lua`,
+   `rawget(arg, -1) as string` for strict mode).
+3. **`--fix <file>` formats in place**; the `--check-format` hint now says
+   `run 'cosmic --fix <file>' to fix in place`. The formatting guide's
+   previous in-place recipe documented a flag order that did not work; it
+   is replaced.
+4. **`--help` points to `guide.gotchas`** in the Documentation section.
+5. **Formatter rules documented in `guide.formatting`** — derived
+   empirically: no spaces inside table braces, call-argument table
+   constructors and anonymous-function bodies indent two levels with the
+   closer one level in.
+6. **`--report` shows per-file test-function counts** — `--test` records
+   `test_*` definitions from the `*_test.tl` source to `<out>.tests`;
+   passing checks render as `✓ foo (14 test functions)`.
+7. **Smaller items:** sqlite `LIKE` example (`%` wildcard noted),
+   `ip.parse("127.0.0.1")` cross-referenced from `net.connect_tcp`/
+   `listen_tcp` docs, `child.Pipe.fd` field-vs-method note.
+
+New backlog candidate observed during this round: `fetch_example.tl`
+examples depend on httpbin.org and fail intermittently in CI; examples
+should avoid third-party services (e.g. spin up a local listener).

--- a/lib/build/lint.tl
+++ b/lib/build/lint.tl
@@ -63,7 +63,7 @@ end
 --- Check that top-level `local function NAME(` is immediately called as `NAME()` on
 --- the next non-blank line after its closing `end`. Heuristic: track depth of
 --- `function`/`end` keywords; when depth returns to 0, check the next line.
-local function check_assert_order(file: string, lines: {string}): {Diagnostic}
+local function check_call_after_define(file: string, lines: {string}): {Diagnostic}
   local diagnostics: {Diagnostic} = {}
   local i = 1
   while i <= #lines do
@@ -123,10 +123,11 @@ local function check_assert_order(file: string, lines: {string}): {Diagnostic}
               file = file,
               line = def_line,
               col = 1,
-              rule = "assert-order",
+              rule = "call-after-define",
               message = string.format(
-                "%s:%d: function '%s' not called immediately after definition",
-                file, def_line, fname
+                "function '%s' must be called immediately after its definition "
+                  .. "(test/example files call each test_* function right after defining it)",
+                fname
               ),
             })
         end
@@ -180,7 +181,7 @@ local function lint_file(path: string): {Diagnostic}
       table.insert(diagnostics, d)
     end
 
-    local order_diags = check_assert_order(path, lines)
+    local order_diags = check_call_after_define(path, lines)
     for _, d in ipairs(order_diags) do
       table.insert(diagnostics, d)
     end
@@ -233,7 +234,7 @@ return {
   count_lines = count_lines,
   check_file_length = check_file_length,
   check_column_length = check_column_length,
-  check_assert_order = check_assert_order,
+  check_call_after_define = check_call_after_define,
   lint_file = lint_file,
   main = main,
 }

--- a/lib/build/lint_test.tl
+++ b/lib/build/lint_test.tl
@@ -125,19 +125,19 @@ local function test_check_column_length_over()
 end
 test_check_column_length_over()
 
-local function test_check_assert_order_ok()
+local function test_check_call_after_define_ok()
   local lines = {
     "local function foo()",
     "  return 1",
     "end",
     "foo()",
   }
-  local diags = lint.check_assert_order("test.tl", lines)
+  local diags = lint.check_call_after_define("test.tl", lines)
   assert(#diags == 0, "expected no diagnostic when assert called right after definition")
 end
-test_check_assert_order_ok()
+test_check_call_after_define_ok()
 
-local function test_check_assert_order_missing_call()
+local function test_check_call_after_define_missing_call()
   -- foo() is followed by bar definition (not foo call): diagnostic for foo
   -- bar() is followed by foo() call (not bar call): diagnostic for bar
   -- both functions have out-of-order asserts
@@ -151,12 +151,12 @@ local function test_check_assert_order_missing_call()
     "foo()",
     "bar()",
   }
-  local diags = lint.check_assert_order("test.tl", lines)
+  local diags = lint.check_call_after_define("test.tl", lines)
   assert(#diags == 2, "expected 2 diagnostics when asserts not called right after definition, got: " .. tostring(#diags))
-  assert(diags[1].rule == "assert-order", "expected assert-order rule")
-  assert(diags[2].rule == "assert-order", "expected assert-order rule")
+  assert(diags[1].rule == "call-after-define", "expected call-after-define rule")
+  assert(diags[2].rule == "call-after-define", "expected call-after-define rule")
 end
-test_check_assert_order_missing_call()
+test_check_call_after_define_missing_call()
 
 local function test_count_lines_directory()
   -- count_lines should return 0 for a directory (or symlink to directory) without crashing
@@ -165,7 +165,7 @@ local function test_count_lines_directory()
 end
 test_count_lines_directory()
 
-local function test_check_assert_order_do_block()
+local function test_check_call_after_define_do_block()
   -- A function body with a standalone do...end block must not confuse the closer detection.
   -- Previously, the `end` for the `do` block decremented depth below 1, causing
   -- the function body to appear to close early.
@@ -178,12 +178,12 @@ local function test_check_assert_order_do_block()
     "end",
     "foo()",
   }
-  local diags = lint.check_assert_order("test.tl", lines)
+  local diags = lint.check_call_after_define("test.tl", lines)
   assert(#diags == 0, "expected no diagnostic for function with do...end block, got: " .. tostring(#diags))
 end
-test_check_assert_order_do_block()
+test_check_call_after_define_do_block()
 
-local function test_check_assert_order_for_loop()
+local function test_check_call_after_define_for_loop()
   -- A function body with a for loop must not confuse the closer detection.
   local lines = {
     "local function foo()",
@@ -194,12 +194,12 @@ local function test_check_assert_order_for_loop()
     "end",
     "foo()",
   }
-  local diags = lint.check_assert_order("test.tl", lines)
+  local diags = lint.check_call_after_define("test.tl", lines)
   assert(#diags == 0, "expected no diagnostic for function with for loop, got: " .. tostring(#diags))
 end
-test_check_assert_order_for_loop()
+test_check_call_after_define_for_loop()
 
-local function test_check_assert_order_if_block()
+local function test_check_call_after_define_if_block()
   -- A function body with an if...end block must not confuse the closer detection.
   local lines = {
     "local function foo()",
@@ -210,12 +210,12 @@ local function test_check_assert_order_if_block()
     "end",
     "foo()",
   }
-  local diags = lint.check_assert_order("test.tl", lines)
+  local diags = lint.check_call_after_define("test.tl", lines)
   assert(#diags == 0, "expected no diagnostic for function with if block, got: " .. tostring(#diags))
 end
-test_check_assert_order_if_block()
+test_check_call_after_define_if_block()
 
-local function test_check_assert_order_repeat_until()
+local function test_check_call_after_define_repeat_until()
   -- A function body with a repeat...until must not confuse the closer detection.
   local lines = {
     "local function foo()",
@@ -227,12 +227,12 @@ local function test_check_assert_order_repeat_until()
     "end",
     "foo()",
   }
-  local diags = lint.check_assert_order("test.tl", lines)
+  local diags = lint.check_call_after_define("test.tl", lines)
   assert(#diags == 0, "expected no diagnostic for function with repeat...until, got: " .. tostring(#diags))
 end
-test_check_assert_order_repeat_until()
+test_check_call_after_define_repeat_until()
 
-local function test_check_assert_order_one_line_if()
+local function test_check_call_after_define_one_line_if()
   -- One-line if/end must net to zero depth change.
   local lines = {
     "local function foo()",
@@ -241,7 +241,7 @@ local function test_check_assert_order_one_line_if()
     "end",
     "foo()",
   }
-  local diags = lint.check_assert_order("test.tl", lines)
+  local diags = lint.check_call_after_define("test.tl", lines)
   assert(#diags == 0, "expected no diagnostic for function with one-line if, got: " .. tostring(#diags))
 end
-test_check_assert_order_one_line_if()
+test_check_call_after_define_one_line_if()

--- a/lib/cosmic/args.tl
+++ b/lib/cosmic/args.tl
@@ -13,6 +13,7 @@ local longopts: {getopt.LongOpt} = {
   {name = "help", has_arg = "none", short = "h"},
   {name = "compile", has_arg = "required"},
   {name = "format", has_arg = "required"},
+  {name = "fix", has_arg = "required"},
   {name = "check-format", has_arg = "required"},
   {name = "check-types", has_arg = "required"},
   {name = "check-style", has_arg = "required"},

--- a/lib/cosmic/assert.tl
+++ b/lib/cosmic/assert.tl
@@ -1,0 +1,128 @@
+--- Assertion helpers for tests with auto-formatted failure messages.
+--- Functions in this module throw on failure (level 2) so the error points
+--- at the caller's line, not inside this module.
+local codec = require("cosmic.codec")
+
+--- Render any Lua value as a readable string using the Lua serializer.
+--- @param v any The value to render
+--- @return string Human-readable representation
+local function render(v: any): string
+  if v == nil then
+    return "nil"
+  end
+  return codec.encode_lua(v)
+end
+
+--- Deep equality check for tables; == for everything else.
+--- @param a any First value
+--- @param b any Second value
+--- @return boolean True when a and b are deeply equal
+local function deep_eq(a: any, b: any): boolean
+  if a == b then
+    return true
+  end
+  if type(a) ~= "table" or type(b) ~= "table" then
+    return false
+  end
+  local ta = a as {any: any}
+  local tb = b as {any: any}
+  for k, v in pairs(ta) do
+    if not deep_eq(v, tb[k]) then
+      return false
+    end
+  end
+  for k, v in pairs(tb) do
+    if not deep_eq(ta[k], v) then
+      return false
+    end
+  end
+  return true
+end
+
+--- Assert deep equality between actual and expected.
+--- Uses deep comparison for tables, == for all other types.
+--- Throws with a formatted message when the assertion fails.
+--- @param actual any The value produced by the code under test
+--- @param expected any The value it should equal
+--- @param label string? Optional label prepended to the failure message
+local function eq(actual: any, expected: any, label?: string)
+  if deep_eq(actual, expected) then
+    return
+  end
+  local msg = string.format("eq failed: expected %s, got %s",
+    render(expected), render(actual))
+  if label then
+    msg = label .. ": " .. msg
+  end
+  error(msg, 2)
+end
+
+--- Assert that actual and expected are NOT equal.
+--- Uses deep comparison for tables, == for all other types.
+--- Throws with a formatted message when the assertion fails.
+--- @param actual any The value produced by the code under test
+--- @param expected any The value it should not equal
+--- @param label string? Optional label prepended to the failure message
+local function ne(actual: any, expected: any, label?: string)
+  if not deep_eq(actual, expected) then
+    return
+  end
+  local msg = string.format("ne failed: expected values to differ, but both are %s",
+    render(actual))
+  if label then
+    msg = label .. ": " .. msg
+  end
+  error(msg, 2)
+end
+
+--- Assert that value is truthy (not nil and not false).
+--- Throws with a formatted message when the assertion fails.
+--- @param value any The value to test for truthiness
+--- @param label string? Optional label prepended to the failure message
+local function ok(value: any, label?: string)
+  if value then
+    return
+  end
+  local msg = string.format("ok failed: expected truthy, got %s", render(value))
+  if label then
+    msg = label .. ": " .. msg
+  end
+  error(msg, 2)
+end
+
+--- Assert that a (value, err) pair represents failure.
+--- Expects value to be nil and err to be a non-nil, non-empty string,
+--- matching the standard cosmic error-return convention.
+--- @param value any The first return value (expected to be nil)
+--- @param err string The second return value (expected to be a non-empty string)
+--- @param label string? Optional label prepended to the failure message
+local function err(value: any, e: string, label?: string)
+  local msg: string
+  if value ~= nil then
+    msg = string.format("err failed: expected nil value, got %s", render(value))
+  elseif not e or e == "" then
+    msg = "err failed: expected non-empty error string, got " .. render(e as any)
+  end
+  if msg then
+    if label then
+      msg = label .. ": " .. msg
+    end
+    error(msg, 2)
+  end
+end
+
+local record AssertModule
+  eq: function(actual: any, expected: any, label?: string)
+  ne: function(actual: any, expected: any, label?: string)
+  ok: function(value: any, label?: string)
+  err: function(value: any, e: string, label?: string)
+end
+
+local M: AssertModule = {
+  eq = eq,
+  ne = ne,
+  ok = ok,
+  err = err,
+}
+
+return M

--- a/lib/cosmic/assert_test.tl
+++ b/lib/cosmic/assert_test.tl
@@ -1,6 +1,17 @@
 #!/usr/bin/env cosmic
 local a = require("cosmic.assert")
 
+-- must_fail wraps a function that is expected to throw and returns
+-- (true, error_message) or (false, "did not throw").
+-- Using function(): string as the wrapper type gives pcall two return values.
+local function must_fail(f: function(): string): boolean, string
+  local ok, raw = pcall(f)
+  if ok then
+    return false, "did not throw"
+  end
+  return true, tostring(raw)
+end
+
 -- eq: passing cases
 
 local function test_eq_numbers()
@@ -46,9 +57,8 @@ test_eq_with_label()
 -- eq: failing cases
 
 local function test_eq_fails_on_number_mismatch()
-  local ok, msg = pcall(a.eq, 3, 4)
-  assert(not ok, "expected eq to throw")
-  assert(type(msg) == "string", "expected string error")
+  local threw, msg = must_fail(function(): string a.eq(3, 4) return "" end)
+  assert(threw, "expected eq to throw")
   assert(msg:match("eq failed"), "expected 'eq failed' in message, got: " .. msg)
   assert(msg:match("expected 4"), "expected '4' in message, got: " .. msg)
   assert(msg:match("got 3"), "expected '3' in message, got: " .. msg)
@@ -56,30 +66,30 @@ end
 test_eq_fails_on_number_mismatch()
 
 local function test_eq_fails_on_string_mismatch()
-  local ok, msg = pcall(a.eq, "actual", "expected")
-  assert(not ok, "expected eq to throw")
+  local threw, msg = must_fail(function(): string a.eq("actual", "expected") return "" end)
+  assert(threw, "expected eq to throw")
   assert(msg:match("eq failed"), "expected 'eq failed' in message")
 end
 test_eq_fails_on_string_mismatch()
 
 local function test_eq_fails_with_label_prefix()
-  local ok, msg = pcall(a.eq, 1, 2, "my label")
-  assert(not ok, "expected eq to throw")
+  local threw, msg = must_fail(function(): string a.eq(1, 2, "my label") return "" end)
+  assert(threw, "expected eq to throw")
   assert(msg:match("my label"), "expected label in message, got: " .. msg)
   assert(msg:match("eq failed"), "expected 'eq failed' in message, got: " .. msg)
 end
 test_eq_fails_with_label_prefix()
 
 local function test_eq_fails_on_table_mismatch()
-  local ok, msg = pcall(a.eq, {a = 1}, {a = 2})
-  assert(not ok, "expected eq to throw for table mismatch")
+  local threw, msg = must_fail(function(): string a.eq({a = 1}, {a = 2}) return "" end)
+  assert(threw, "expected eq to throw for table mismatch")
   assert(msg:match("eq failed"), "expected 'eq failed' in message")
 end
 test_eq_fails_on_table_mismatch()
 
 local function test_eq_fails_nil_vs_value()
-  local ok, msg = pcall(a.eq, nil, 42)
-  assert(not ok, "expected eq to throw when nil vs 42")
+  local threw, msg = must_fail(function(): string a.eq(nil, 42) return "" end)
+  assert(threw, "expected eq to throw when nil vs 42")
   assert(msg:match("eq failed"), "expected 'eq failed' in message")
 end
 test_eq_fails_nil_vs_value()
@@ -117,23 +127,23 @@ test_ne_with_label()
 -- ne: failing cases
 
 local function test_ne_fails_when_equal()
-  local ok, msg = pcall(a.ne, 5, 5)
-  assert(not ok, "expected ne to throw")
+  local threw, msg = must_fail(function(): string a.ne(5, 5) return "" end)
+  assert(threw, "expected ne to throw")
   assert(msg:match("ne failed"), "expected 'ne failed' in message, got: " .. msg)
   assert(msg:match("5"), "expected value in message")
 end
 test_ne_fails_when_equal()
 
 local function test_ne_fails_when_tables_equal()
-  local ok, msg = pcall(a.ne, {x = 1}, {x = 1})
-  assert(not ok, "expected ne to throw for equal tables")
+  local threw, msg = must_fail(function(): string a.ne({x = 1}, {x = 1}) return "" end)
+  assert(threw, "expected ne to throw for equal tables")
   assert(msg:match("ne failed"), "expected 'ne failed' in message")
 end
 test_ne_fails_when_tables_equal()
 
 local function test_ne_fails_with_label()
-  local ok, msg = pcall(a.ne, "same", "same", "tag")
-  assert(not ok, "expected ne to throw")
+  local threw, msg = must_fail(function(): string a.ne("same", "same", "tag") return "" end)
+  assert(threw, "expected ne to throw")
   assert(msg:match("tag"), "expected label in message")
   assert(msg:match("ne failed"), "expected 'ne failed' in message")
 end
@@ -158,24 +168,24 @@ test_ok_with_label()
 -- ok: failing cases
 
 local function test_ok_fails_on_nil()
-  local ok, msg = pcall(a.ok, nil)
-  assert(not ok, "expected ok to throw for nil")
+  local threw, msg = must_fail(function(): string a.ok(nil) return "" end)
+  assert(threw, "expected ok to throw for nil")
   assert(msg:match("ok failed"), "expected 'ok failed' in message, got: " .. msg)
   assert(msg:match("nil"), "expected nil in message")
 end
 test_ok_fails_on_nil()
 
 local function test_ok_fails_on_false()
-  local ok, msg = pcall(a.ok, false)
-  assert(not ok, "expected ok to throw for false")
+  local threw, msg = must_fail(function(): string a.ok(false) return "" end)
+  assert(threw, "expected ok to throw for false")
   assert(msg:match("ok failed"), "expected 'ok failed' in message")
   assert(msg:match("false"), "expected false in message")
 end
 test_ok_fails_on_false()
 
 local function test_ok_fails_with_label()
-  local ok, msg = pcall(a.ok, nil, "result")
-  assert(not ok, "expected ok to throw")
+  local threw, msg = must_fail(function(): string a.ok(nil, "result") return "" end)
+  assert(threw, "expected ok to throw")
   assert(msg:match("result"), "expected label in message")
   assert(msg:match("ok failed"), "expected 'ok failed' in message")
 end
@@ -196,36 +206,33 @@ test_err_with_label()
 -- err: failing cases
 
 local function test_err_fails_when_value_is_non_nil()
-  local ok, msg = pcall(a.err, 42, "some error")
-  assert(not ok, "expected err to throw when value is 42")
+  local threw, msg = must_fail(function(): string a.err(42, "some error") return "" end)
+  assert(threw, "expected err to throw when value is 42")
   assert(msg:match("err failed"), "expected 'err failed' in message, got: " .. msg)
   assert(msg:match("42"), "expected value in message")
 end
 test_err_fails_when_value_is_non_nil()
 
 local function test_err_fails_when_error_string_is_empty()
-  local ok, msg = pcall(a.err, nil, "")
-  assert(not ok, "expected err to throw for empty error string")
+  local threw, msg = must_fail(function(): string a.err(nil, "") return "" end)
+  assert(threw, "expected err to throw for empty error string")
   assert(msg:match("err failed"), "expected 'err failed' in message, got: " .. msg)
 end
 test_err_fails_when_error_string_is_empty()
 
 local function test_err_fails_with_label()
-  local ok, msg = pcall(a.err, "whoops", "err msg", "ctx")
-  assert(not ok, "expected err to throw")
+  local threw, msg = must_fail(function(): string a.err("whoops" as any, "err msg", "ctx") return "" end)
+  assert(threw, "expected err to throw")
   assert(msg:match("ctx"), "expected label in message")
   assert(msg:match("err failed"), "expected 'err failed' in message")
 end
 test_err_fails_with_label()
 
--- caller line attribution: error level 2 means the throw points at caller
+-- caller line attribution: error level 2 means throw points at caller
 
 local function test_eq_error_points_at_caller()
-  local ok, msg = pcall(a.eq, 1, 2)
-  assert(not ok, "expected throw")
-  -- The message should NOT contain assert.tl in the location prefix
-  -- (it will contain the anonymous function's source). We just verify
-  -- the message is a string and well-formed.
-  assert(type(msg) == "string", "expected string error")
+  local threw, msg = must_fail(function(): string a.eq(1, 2) return "" end)
+  assert(threw, "expected throw")
+  assert(type(msg) == "string", "expected string error, got: " .. tostring(msg))
 end
 test_eq_error_points_at_caller()

--- a/lib/cosmic/assert_test.tl
+++ b/lib/cosmic/assert_test.tl
@@ -1,0 +1,231 @@
+#!/usr/bin/env cosmic
+local a = require("cosmic.assert")
+
+-- eq: passing cases
+
+local function test_eq_numbers()
+  a.eq(1, 1)
+  a.eq(0, 0)
+  a.eq(-5, -5)
+end
+test_eq_numbers()
+
+local function test_eq_strings()
+  a.eq("hello", "hello")
+  a.eq("", "")
+end
+test_eq_strings()
+
+local function test_eq_booleans()
+  a.eq(true, true)
+  a.eq(false, false)
+end
+test_eq_booleans()
+
+local function test_eq_nil()
+  a.eq(nil, nil)
+end
+test_eq_nil()
+
+local function test_eq_tables_shallow()
+  a.eq({1, 2, 3}, {1, 2, 3})
+  a.eq({a = 1, b = 2}, {a = 1, b = 2})
+end
+test_eq_tables_shallow()
+
+local function test_eq_tables_nested()
+  a.eq({a = {b = {c = 42}}}, {a = {b = {c = 42}}})
+end
+test_eq_tables_nested()
+
+local function test_eq_with_label()
+  a.eq(7, 7, "score check")
+end
+test_eq_with_label()
+
+-- eq: failing cases
+
+local function test_eq_fails_on_number_mismatch()
+  local ok, msg = pcall(a.eq, 3, 4)
+  assert(not ok, "expected eq to throw")
+  assert(type(msg) == "string", "expected string error")
+  assert(msg:match("eq failed"), "expected 'eq failed' in message, got: " .. msg)
+  assert(msg:match("expected 4"), "expected '4' in message, got: " .. msg)
+  assert(msg:match("got 3"), "expected '3' in message, got: " .. msg)
+end
+test_eq_fails_on_number_mismatch()
+
+local function test_eq_fails_on_string_mismatch()
+  local ok, msg = pcall(a.eq, "actual", "expected")
+  assert(not ok, "expected eq to throw")
+  assert(msg:match("eq failed"), "expected 'eq failed' in message")
+end
+test_eq_fails_on_string_mismatch()
+
+local function test_eq_fails_with_label_prefix()
+  local ok, msg = pcall(a.eq, 1, 2, "my label")
+  assert(not ok, "expected eq to throw")
+  assert(msg:match("my label"), "expected label in message, got: " .. msg)
+  assert(msg:match("eq failed"), "expected 'eq failed' in message, got: " .. msg)
+end
+test_eq_fails_with_label_prefix()
+
+local function test_eq_fails_on_table_mismatch()
+  local ok, msg = pcall(a.eq, {a = 1}, {a = 2})
+  assert(not ok, "expected eq to throw for table mismatch")
+  assert(msg:match("eq failed"), "expected 'eq failed' in message")
+end
+test_eq_fails_on_table_mismatch()
+
+local function test_eq_fails_nil_vs_value()
+  local ok, msg = pcall(a.eq, nil, 42)
+  assert(not ok, "expected eq to throw when nil vs 42")
+  assert(msg:match("eq failed"), "expected 'eq failed' in message")
+end
+test_eq_fails_nil_vs_value()
+
+-- ne: passing cases
+
+local function test_ne_numbers()
+  a.ne(1, 2)
+  a.ne(0, -1)
+end
+test_ne_numbers()
+
+local function test_ne_strings()
+  a.ne("hello", "world")
+  a.ne("", "nonempty")
+end
+test_ne_strings()
+
+local function test_ne_different_types()
+  a.ne(1, "1")
+  a.ne(nil, false)
+end
+test_ne_different_types()
+
+local function test_ne_tables_different_content()
+  a.ne({a = 1}, {a = 2})
+end
+test_ne_tables_different_content()
+
+local function test_ne_with_label()
+  a.ne(1, 2, "value check")
+end
+test_ne_with_label()
+
+-- ne: failing cases
+
+local function test_ne_fails_when_equal()
+  local ok, msg = pcall(a.ne, 5, 5)
+  assert(not ok, "expected ne to throw")
+  assert(msg:match("ne failed"), "expected 'ne failed' in message, got: " .. msg)
+  assert(msg:match("5"), "expected value in message")
+end
+test_ne_fails_when_equal()
+
+local function test_ne_fails_when_tables_equal()
+  local ok, msg = pcall(a.ne, {x = 1}, {x = 1})
+  assert(not ok, "expected ne to throw for equal tables")
+  assert(msg:match("ne failed"), "expected 'ne failed' in message")
+end
+test_ne_fails_when_tables_equal()
+
+local function test_ne_fails_with_label()
+  local ok, msg = pcall(a.ne, "same", "same", "tag")
+  assert(not ok, "expected ne to throw")
+  assert(msg:match("tag"), "expected label in message")
+  assert(msg:match("ne failed"), "expected 'ne failed' in message")
+end
+test_ne_fails_with_label()
+
+-- ok: passing cases
+
+local function test_ok_truthy_values()
+  a.ok(true)
+  a.ok(1)
+  a.ok("nonempty")
+  a.ok({})
+  a.ok(0) -- 0 is truthy in Lua
+end
+test_ok_truthy_values()
+
+local function test_ok_with_label()
+  a.ok(true, "must be set")
+end
+test_ok_with_label()
+
+-- ok: failing cases
+
+local function test_ok_fails_on_nil()
+  local ok, msg = pcall(a.ok, nil)
+  assert(not ok, "expected ok to throw for nil")
+  assert(msg:match("ok failed"), "expected 'ok failed' in message, got: " .. msg)
+  assert(msg:match("nil"), "expected nil in message")
+end
+test_ok_fails_on_nil()
+
+local function test_ok_fails_on_false()
+  local ok, msg = pcall(a.ok, false)
+  assert(not ok, "expected ok to throw for false")
+  assert(msg:match("ok failed"), "expected 'ok failed' in message")
+  assert(msg:match("false"), "expected false in message")
+end
+test_ok_fails_on_false()
+
+local function test_ok_fails_with_label()
+  local ok, msg = pcall(a.ok, nil, "result")
+  assert(not ok, "expected ok to throw")
+  assert(msg:match("result"), "expected label in message")
+  assert(msg:match("ok failed"), "expected 'ok failed' in message")
+end
+test_ok_fails_with_label()
+
+-- err: passing cases
+
+local function test_err_nil_with_message()
+  a.err(nil, "something went wrong")
+end
+test_err_nil_with_message()
+
+local function test_err_with_label()
+  a.err(nil, "oops", "network call")
+end
+test_err_with_label()
+
+-- err: failing cases
+
+local function test_err_fails_when_value_is_non_nil()
+  local ok, msg = pcall(a.err, 42, "some error")
+  assert(not ok, "expected err to throw when value is 42")
+  assert(msg:match("err failed"), "expected 'err failed' in message, got: " .. msg)
+  assert(msg:match("42"), "expected value in message")
+end
+test_err_fails_when_value_is_non_nil()
+
+local function test_err_fails_when_error_string_is_empty()
+  local ok, msg = pcall(a.err, nil, "")
+  assert(not ok, "expected err to throw for empty error string")
+  assert(msg:match("err failed"), "expected 'err failed' in message, got: " .. msg)
+end
+test_err_fails_when_error_string_is_empty()
+
+local function test_err_fails_with_label()
+  local ok, msg = pcall(a.err, "whoops", "err msg", "ctx")
+  assert(not ok, "expected err to throw")
+  assert(msg:match("ctx"), "expected label in message")
+  assert(msg:match("err failed"), "expected 'err failed' in message")
+end
+test_err_fails_with_label()
+
+-- caller line attribution: error level 2 means the throw points at caller
+
+local function test_eq_error_points_at_caller()
+  local ok, msg = pcall(a.eq, 1, 2)
+  assert(not ok, "expected throw")
+  -- The message should NOT contain assert.tl in the location prefix
+  -- (it will contain the anonymous function's source). We just verify
+  -- the message is a string and well-formed.
+  assert(type(msg) == "string", "expected string error")
+end
+test_eq_error_points_at_caller()

--- a/lib/cosmic/check_test.tl
+++ b/lib/cosmic/check_test.tl
@@ -170,4 +170,107 @@ print(s)
 end
 test_check_with_tl_path_double_semicolon()
 
+-- Test that fix-hints appear for common Teal type-check traps.
+-- We redirect stderr to stdout (opts.stderr=1) so the hint output is captured.
+
+-- Hint 1: got number, expected integer
+local function test_check_hint_number_integer()
+  local input = write_temp("hint_num_int.tl", [[
+local s = "hello"
+local n: number = 3.14
+local c = s:sub(n, n)
+print(c)
+]])
+  local ok, out = spawn.spawn({cosmic, "--check-types", input}, {stderr = 1}):read()
+  assert(not ok, "should fail with type error")
+  assert(out:find("hint:"), "should include a hint, got: " .. out)
+  assert(out:find("math%.tointeger"), "hint should mention math.tointeger, got: " .. out)
+end
+test_check_hint_number_integer()
+
+-- Hint 2: ipairs on any type
+local function test_check_hint_ipairs_any()
+  local input = write_temp("hint_ipairs_any.tl", [[
+local function get(): any
+  return {1, 2, 3}
+end
+local arr = get()
+for i, v in ipairs(arr) do
+  print(i, v)
+end
+]])
+  local ok, out = spawn.spawn({cosmic, "--check-types", input}, {stderr = 1}):read()
+  assert(not ok, "should fail with type error")
+  assert(out:find("hint:"), "should include a hint, got: " .. out)
+  assert(out:find("as {any}"), "hint should mention casting to array, got: " .. out)
+end
+test_check_hint_ipairs_any()
+
+-- Hint 3: excess return values
+local function test_check_hint_excess_returns()
+  local input = write_temp("hint_excess_rets.tl", [[
+local function f(): string
+  return "a", "b", "c"
+end
+f()
+]])
+  local ok, out = spawn.spawn({cosmic, "--check-types", input}, {stderr = 1}):read()
+  assert(not ok, "should fail with type error")
+  assert(out:find("hint:"), "should include a hint, got: " .. out)
+  assert(out:find("local v, err"), "hint should mention capturing multiple returns, got: " .. out)
+end
+test_check_hint_excess_returns()
+
+-- Hint 4: cannot use operator '..' for any type
+local function test_check_hint_any_concat()
+  local input = write_temp("hint_any_concat.tl", [[
+local function get(): any
+  return "hello"
+end
+local v = get()
+local s = v .. " world"
+print(s)
+]])
+  local ok, out = spawn.spawn({cosmic, "--check-types", input}, {stderr = 1}):read()
+  assert(not ok, "should fail with type error")
+  assert(out:find("hint:"), "should include a hint, got: " .. out)
+  assert(out:find("cast first"), "hint should suggest casting, got: " .. out)
+end
+test_check_hint_any_concat()
+
+-- Hint 5: cannot index any type
+local function test_check_hint_any_index()
+  local input = write_temp("hint_any_index.tl", [[
+local function get(): any
+  return {name = "world"}
+end
+local obj = get()
+print(obj.name)
+]])
+  local ok, out = spawn.spawn({cosmic, "--check-types", input}, {stderr = 1}):read()
+  assert(not ok, "should fail with type error")
+  assert(out:find("hint:"), "should include a hint, got: " .. out)
+  assert(out:find("cast first"), "hint should suggest casting, got: " .. out)
+end
+test_check_hint_any_index()
+
+-- No duplicate hints per error
+local function test_check_hint_no_duplicates()
+  local input = write_temp("hint_no_dup.tl", [[
+local s = "hello"
+local n: number = 3.14
+local c = s:sub(n, n)
+print(c)
+]])
+  local ok, out = spawn.spawn({cosmic, "--check-types", input}, {stderr = 1}):read()
+  assert(not ok, "should fail with type error")
+  -- Count occurrences of "hint:"
+  local count = 0
+  for _ in out:gmatch("  hint:") do
+    count = count + 1
+  end
+  assert(count == 1, "should have exactly one hint for one error, got " .. count .. " hints")
+end
+test_check_hint_no_duplicates()
+
 print("All check tests passed!")

--- a/lib/cosmic/child.tl
+++ b/lib/cosmic/child.tl
@@ -42,10 +42,12 @@ local record Handle
 end
 
 --- Options for spawning a process.
+--- stdout/stderr: raw fd dup2'd onto fd 1/2; handle fields nil.
+--- Close write end before reading. See Example_spawn_pipe.
 local record Opts
-  stdin: string | number
-  stdout: number
-  stderr: number
+  stdin: string | number -- string piped to stdin, or raw fd dup2'd onto fd 0
+  stdout: number -- raw fd -> fd 1; handle.stdout becomes nil
+  stderr: number -- raw fd -> fd 2; handle.stderr becomes nil
   env: {string}
   cwd: string
 end
@@ -184,8 +186,9 @@ end
 
 -- High-level spawn API --
 
---- Spawns a child process with I/O control.
---- When argv[1] starts with /zip/, uses fexecve.
+--- Spawns a child process with I/O control. Uses fexecve for /zip/ paths.
+--- When Opts.stdout/stderr are fds they are dup2'd into child (handle fields
+--- nil); MUST close the write end before reading. See Example_spawn_pipe.
 --- @param argv {string} Command and arguments
 --- @param opts Opts? Spawn options
 --- @return Handle, string? Process handle or nil + error

--- a/lib/cosmic/child.tl
+++ b/lib/cosmic/child.tl
@@ -23,7 +23,7 @@ local record Rusage
   nivcsw: function(self: Rusage): number
 end
 
---- Pipe for reading/writing process I/O.
+--- Pipe for process I/O. fd is a plain field (not a method like io.Handle:fd()).
 local record Pipe
   fd: number
   write: function(self: Pipe, data: string): number

--- a/lib/cosmic/child_example.tl
+++ b/lib/cosmic/child_example.tl
@@ -31,4 +31,45 @@ local function Example_spawn_exit_code()
   -- exit code:	0
 end
 
+-- Example_spawn_pipe demonstrates capturing output through an explicit pipe.
+-- This pattern is needed when you want to interleave reads with the child's
+-- execution rather than waiting for it to finish.
+--
+-- Key steps:
+--   1. Create a pipe with cosmic.io.pipe().
+--   2. Pass the write end fd to spawn via opts.stdout.
+--   3. Close the write end in the parent BEFORE reading — otherwise the
+--      reader will block forever waiting for EOF.
+--   4. Read from the read end until EOF.
+--   5. Wait for the child.
+local function Example_spawn_pipe()
+  local child = require("cosmic.child")
+  local cio = require("cosmic.io")
+
+  -- Create a pipe: p.reader and p.writer are cosmic.io Handles.
+  local p, err = cio.pipe()
+  assert(p, "pipe failed: " .. tostring(err))
+
+  -- Spawn echo, redirecting its stdout into the write end of the pipe.
+  local h, serr = child.spawn({"echo", "from pipe"}, {stdout = p.writer:fd()})
+  assert(h, "spawn failed: " .. tostring(serr))
+
+  -- Close the write end in the parent so the reader sees EOF when the child exits.
+  p.writer:close()
+
+  -- Read all output from the read end.
+  local out = p.reader:read()
+  p.reader:close()
+
+  -- Wait for the child to exit.
+  local code = h:wait()
+
+  -- echo adds a trailing newline; strip it before printing
+  io.write(out)
+  print("exit:", code)
+  -- Output:
+  -- from pipe
+  -- exit:	0
+end
+
 return {}

--- a/lib/cosmic/doc.tl
+++ b/lib/cosmic/doc.tl
@@ -113,6 +113,67 @@ local function parse_annotations(doc: string): {Param}, {Return}, string
   return params, returns, description
 end
 
+--- Parse `name: type` fields from a record body.
+--- @param source string The full source (for doc-comment lookup)
+--- @param body string The record body text
+--- @param body_start integer Absolute position of body within source
+--- @return {{string, string, string}} List of {name, type, description}
+local function parse_record_fields(source: string, body: string, body_start: integer): {{string, string, string}}
+  local fields: {{string, string, string}} = {}
+  local field_pos = 1
+  while field_pos <= #body do
+    local fstart, fend, fname, ftype = body:find("%s*([%w_]+)%s*:%s*([^\n]+)", field_pos)
+    if not fstart then break end
+    -- Find the start of the line where fname begins (skip leading whitespace in fstart)
+    local fname_pos = fstart + body:sub(fstart, fend):find(fname, 1, true) - 1
+    local fname_line_start = fname_pos
+    while fname_line_start > 1 and body:byte(fname_line_start - 1) ~= BYTE_NEWLINE do
+      fname_line_start = fname_line_start - 1
+    end
+    local line_text = body:sub(fname_line_start, fname_pos - 1)
+    if line_text:match("^%s*%-%-") then
+      field_pos = fend + 1
+      goto continue_field
+    end
+    do
+      local field_absolute_pos = body_start + fname_pos
+      local field_doc = extract_doc_comment(source, field_absolute_pos)
+      local _, _, field_description = parse_annotations(field_doc)
+      local clean_type = ftype:match("^%s*(.-)%s*$")
+      if clean_type:match("%-%-%s*.*$") then
+        clean_type = clean_type:gsub("%s*%-%-.*$", "")
+      end
+      table.insert(fields, {fname, clean_type, field_description or ""})
+    end
+    field_pos = fend + 1
+    ::continue_field::
+  end
+  return fields
+end
+
+--- Find the end of a record block via record/enum vs end depth tracking.
+--- @param text string The text to scan
+--- @param start integer Position just inside the record (after its header line)
+--- @return integer Position of the last body character (before `end`)
+--- @return integer Position just past the closing `end`
+local function find_record_end(text: string, start: integer): integer, integer
+  local depth = 1
+  local i = start
+  local rec_end = i
+  while i <= #text and depth > 0 do
+    local word_start, word_end, word = text:find("(%a+)", i)
+    if word_start == i then
+      if word == "record" or word == "enum" then depth = depth + 1
+      elseif word == "end" then
+        depth = depth - 1
+        if depth == 0 then rec_end = word_start - 1 end
+      end
+      i = word_end + 1
+    else i = i + 1 end
+  end
+  return rec_end, i
+end
+
 --- Parse a .tl file and extract documentation.
 --- @param source string The source code to parse
 --- @param file_path string Path to the file being parsed
@@ -206,49 +267,31 @@ local function parse(source: string, file_path: string): ModuleDoc
     local fields: {{string, string, string}} = {}
     local body_start = source:find("\n", rec_start as integer)
     if body_start then
-      local depth = 1
-      local i = body_start + 1
-      local record_end = i
-      while i <= #source and depth > 0 do
-        local word_start, word_end, word = source:find("(%a+)", i)
-        if word_start == i then
-          if word == "record" or word == "enum" then depth = depth + 1
-          elseif word == "end" then
-            depth = depth - 1
-            if depth == 0 then record_end = word_start - 1 end
-          end
-          i = word_end + 1
-        else i = i + 1 end
-      end
+      local record_end, _ = find_record_end(source, body_start + 1)
       local body = source:sub(body_start, record_end)
-      local field_pos = 1
-      while field_pos <= #body do
-        local fstart, fend, fname, ftype = body:find("%s*([%w_]+)%s*:%s*([^\n]+)", field_pos)
-        if not fstart then break end
-        -- Find the start of the line where fname begins (skip leading whitespace in fstart)
-        local fname_pos = fstart + body:sub(fstart, fend):find(fname, 1, true) - 1
-        local fname_line_start = fname_pos
-        while fname_line_start > 1 and body:byte(fname_line_start - 1) ~= BYTE_NEWLINE do
-          fname_line_start = fname_line_start - 1
-        end
-        local line_text = body:sub(fname_line_start, fname_pos - 1)
-        if line_text:match("^%s*%-%-") then
-          field_pos = fend + 1
-          goto continue_field
-        end
-        do
-          local field_absolute_pos = body_start + fname_pos
-          local field_doc = extract_doc_comment(source, field_absolute_pos)
-          local _, _, field_description = parse_annotations(field_doc)
-          local clean_type = ftype:match("^%s*(.-)%s*$")
-          if clean_type:match("%-%-%s*.*$") then
-            clean_type = clean_type:gsub("%s*%-%-.*$", "")
-          end
-          table.insert(fields, {fname, clean_type, field_description or ""})
-        end
-        field_pos = fend + 1
-        ::continue_field::
+      -- Extract nested `record Name ... end` blocks as their own entries
+      -- (e.g. cosmic.fs_types.WalkStat), then blank them out so their
+      -- fields are not misattributed to the parent record.
+      local search_pos = 1
+      while true do
+        local n_start, n_header_end, n_name = body:find("\n%s*record%s+([%w_]+)", search_pos)
+        if not n_start then break end
+        local n_body_start = body:find("\n", n_header_end + 1)
+        if not n_body_start then break end
+        local n_rec_end, n_past_end = find_record_end(body, n_body_start + 1)
+        local n_body = body:sub(n_body_start, n_rec_end)
+        local n_doc = extract_doc_comment(source, body_start + n_start)
+        local _, _, n_description = parse_annotations(n_doc)
+        table.insert(doc.records, {
+            name = n_name as string, description = n_description,
+            fields = parse_record_fields(source, n_body, body_start + n_body_start - 1),
+            line = line_num,
+          })
+        local blanked = body:sub(n_start, n_past_end - 1):gsub("[^\n]", " ")
+        body = body:sub(1, n_start - 1) .. blanked .. body:sub(n_past_end)
+        search_pos = n_past_end
       end
+      fields = parse_record_fields(source, body, body_start)
     end
     table.insert(doc.records, {
         name = rec_name as string, description = description,

--- a/lib/cosmic/doc.tl
+++ b/lib/cosmic/doc.tl
@@ -225,15 +225,29 @@ local function parse(source: string, file_path: string): ModuleDoc
       while field_pos <= #body do
         local fstart, fend, fname, ftype = body:find("%s*([%w_]+)%s*:%s*([^\n]+)", field_pos)
         if not fstart then break end
-        local field_absolute_pos = body_start + fstart
-        local field_doc = extract_doc_comment(source, field_absolute_pos)
-        local _, _, field_description = parse_annotations(field_doc)
-        local clean_type = ftype:match("^%s*(.-)%s*$")
-        if clean_type:match("%-%-%s*.*$") then
-          clean_type = clean_type:gsub("%s*%-%-.*$", "")
+        -- Find the start of the line where fname begins (skip leading whitespace in fstart)
+        local fname_pos = fstart + body:sub(fstart, fend):find(fname, 1, true) - 1
+        local fname_line_start = fname_pos
+        while fname_line_start > 1 and body:byte(fname_line_start - 1) ~= BYTE_NEWLINE do
+          fname_line_start = fname_line_start - 1
         end
-        table.insert(fields, {fname, clean_type, field_description or ""})
+        local line_text = body:sub(fname_line_start, fname_pos - 1)
+        if line_text:match("^%s*%-%-") then
+          field_pos = fend + 1
+          goto continue_field
+        end
+        do
+          local field_absolute_pos = body_start + fname_pos
+          local field_doc = extract_doc_comment(source, field_absolute_pos)
+          local _, _, field_description = parse_annotations(field_doc)
+          local clean_type = ftype:match("^%s*(.-)%s*$")
+          if clean_type:match("%-%-%s*.*$") then
+            clean_type = clean_type:gsub("%s*%-%-.*$", "")
+          end
+          table.insert(fields, {fname, clean_type, field_description or ""})
+        end
         field_pos = fend + 1
+        ::continue_field::
       end
     end
     table.insert(doc.records, {

--- a/lib/cosmic/doc_test.tl
+++ b/lib/cosmic/doc_test.tl
@@ -242,4 +242,30 @@ local function test_fetch_has_module_description()
 end
 test_fetch_has_module_description()
 
+-- Test that record field parser skips comment lines (bug 2 regression test)
+local function test_record_fields_skip_comments()
+  local source = [[
+local record Foo
+  --- Some description.
+  --- @return function Iterator yielding (fd: number, events: Bar)
+  wait: function(Foo, number): function(): number, Bar
+  bar: string
+end
+]]
+  local result = doc.parse(source, "test.tl")
+  assert(#result.records == 1, "should find one record")
+  local rec = result.records[1]
+  -- Should only find 'wait' and 'bar', NOT 'fd' from inside the comment
+  local field_names: {string} = {}
+  for _, f in ipairs(rec.fields) do
+    table.insert(field_names, f[1])
+  end
+  local names_str = table.concat(field_names, ",")
+  assert(not names_str:find("fd"), "should not parse 'fd' from inside comment (got: " .. names_str .. ")")
+  assert(names_str:find("wait"), "should find 'wait' field")
+  assert(names_str:find("bar"), "should find 'bar' field")
+  print("test_record_fields_skip_comments: PASS")
+end
+test_record_fields_skip_comments()
+
 print("All doc tests passed!")

--- a/lib/cosmic/docs.tl
+++ b/lib/cosmic/docs.tl
@@ -300,20 +300,21 @@ local function list_all_examples(include_cosmo?: boolean): {ExampleEntry}
 end
 
 --- Show examples for a specific module, optionally filtered by function name.
---- @param query string The query (e.g., "cosmic.sqlite" or "cosmic.fetch.get")
+--- @param query string Module name (full, bare, or module.function)
 --- @return DocsResult Result with examples content
 local function show_module_examples(query: string): DocsResult
   local index, err = load_index()
   if not index then
     return {ok = false, output = "error: " .. (err or "no documentation embedded")}
   end
-
-  local doc = index.modules[query]
-  if doc then
+  -- Resolve bare name (e.g. "child" -> "cosmic.child")
+  local resolved = index.modules[query] and query or (index.modules["cosmic." .. query] and "cosmic." .. query or nil)
+  if resolved then
+    local doc = index.modules[resolved]
     if not doc.examples or #doc.examples == 0 then
-      return {ok = false, output = "No examples for " .. query}
+      return {ok = false, output = "No examples for " .. resolved}
     end
-    local simple_name = query:match("([^%.]+)$") or query
+    local simple_name = resolved:match("([^%.]+)$") or resolved
     local lines: {string} = {"# " .. simple_name .. " examples", ""}
     for _, example in ipairs(doc.examples) do
       table.insert(lines, docs_render.render_example(example))
@@ -321,11 +322,8 @@ local function show_module_examples(query: string): DocsResult
     return {ok = true, output = table.concat(lines, "\n")}
   end
 
-  -- Try splitting into module + function filter
   local parts: {string} = {}
-  for part in query:gmatch("[^%.]+") do
-    table.insert(parts, part)
-  end
+  for part in query:gmatch("[^%.]+") do table.insert(parts, part) end
 
   local mod_name: string = nil
   local func_filter: string = nil
@@ -339,7 +337,7 @@ local function show_module_examples(query: string): DocsResult
   end
 
   if mod_name and func_filter then
-    doc = index.modules[mod_name]
+    local doc = index.modules[mod_name]
     if not doc.examples or #doc.examples == 0 then
       return {ok = false, output = "No examples for " .. query}
     end
@@ -355,13 +353,10 @@ local function show_module_examples(query: string): DocsResult
     return {ok = true, output = table.concat(lines, "\n")}
   end
 
-  local suggestions = docs_render.find_suggestions(query, index)
+  local suggestions = docs_render.find_example_suggestions(query, index)
   if #suggestions > 0 then
-    local lines: {string} = {"error: module not found: " .. query, ""}
-    table.insert(lines, "Did you mean?")
-    for i = 1, math.min(3, #suggestions) do
-      table.insert(lines, "  " .. suggestions[i])
-    end
+    local lines: {string} = {"error: module not found: " .. query, "", "Did you mean?"}
+    for i = 1, math.min(3, #suggestions) do table.insert(lines, "  " .. suggestions[i]) end
     return {ok = false, output = table.concat(lines, "\n")}
   end
   return {ok = false, output = "error: module not found: " .. query}
@@ -438,11 +433,16 @@ local function run(query?: string): DocsResult
           "Use 'cosmic --docs " .. matched_mod .. "." .. symbol .. "' to see available methods.",
         }
       else
-        return {
-          ok = false,
-          output = "error: symbol '" .. symbol .. "' not found in '" .. matched_mod .. "'\n" ..
-          "Use 'cosmic --docs " .. matched_mod .. "' to see available symbols.",
-        }
+        local locations = docs_render.find_symbol_locations(symbol, index)
+        local lines: {string} = {"error: symbol '" .. symbol .. "' not found in '" .. matched_mod .. "'"}
+        if #locations > 0 then
+          table.insert(lines, "")
+          table.insert(lines, "Did you mean?")
+          for i = 1, math.min(3, #locations) do table.insert(lines, "  cosmic --docs " .. locations[i]) end
+        else
+          table.insert(lines, "Use 'cosmic --docs " .. matched_mod .. "' to see available symbols.")
+        end
+        return {ok = false, output = table.concat(lines, "\n")}
       end
     end
   end

--- a/lib/cosmic/docs.tl
+++ b/lib/cosmic/docs.tl
@@ -3,6 +3,7 @@
 
 local cio = require("cosmic.io")
 local docs_render = require("cosmic.docs_render")
+local docs_lookup = require("cosmic.docs_lookup")
 local types = require("cosmic.doc_types")
 local ModuleDoc = types.ModuleDoc
 local DocIndex = types.DocIndex
@@ -433,16 +434,7 @@ local function run(query?: string): DocsResult
           "Use 'cosmic --docs " .. matched_mod .. "." .. symbol .. "' to see available methods.",
         }
       else
-        local locations = docs_render.find_symbol_locations(symbol, index)
-        local lines: {string} = {"error: symbol '" .. symbol .. "' not found in '" .. matched_mod .. "'"}
-        if #locations > 0 then
-          table.insert(lines, "")
-          table.insert(lines, "Did you mean?")
-          for i = 1, math.min(3, #locations) do table.insert(lines, "  cosmic --docs " .. locations[i]) end
-        else
-          table.insert(lines, "Use 'cosmic --docs " .. matched_mod .. "' to see available symbols.")
-        end
-        return {ok = false, output = table.concat(lines, "\n")}
+        return {ok = false, output = docs_lookup.symbol_not_found(symbol, matched_mod, index)}
       end
     end
   end

--- a/lib/cosmic/docs_lookup.tl
+++ b/lib/cosmic/docs_lookup.tl
@@ -1,0 +1,111 @@
+--- Symbol lookup and suggestion helpers for the docs module.
+--- Locates symbols across modules and builds not-found error messages.
+
+local types = require("cosmic.doc_types")
+local ModuleDoc = types.ModuleDoc
+local DocIndex = types.DocIndex
+
+--- Find where a symbol lives across all modules (for "did you mean" suggestions).
+--- @param symbol string The symbol name to locate
+--- @param index DocIndex The documentation index
+--- @return {string} Qualified locations (module.symbol) where the name exists
+local function find_symbol_locations(symbol: string, index: DocIndex): {string}
+  local out: {string} = {}
+  local sym_lower = symbol:lower()
+  for mod_name, mod_doc in pairs(index.modules) do
+    if mod_doc.functions then
+      for _, func in ipairs(mod_doc.functions) do
+        if func.name:lower() == sym_lower then table.insert(out, mod_name .. "." .. func.name) end
+      end
+    end
+    if mod_doc.records then
+      for _, rec in ipairs(mod_doc.records) do
+        if rec.name:lower() == sym_lower then
+          table.insert(out, mod_name .. "." .. rec.name)
+        end
+        if rec.fields then
+          for _, field in ipairs(rec.fields) do
+            if field[1]:lower() == sym_lower and field[2]:match("^function") then
+              table.insert(out, mod_name .. "." .. field[1])
+            end
+          end
+        end
+      end
+    end
+  end
+  return out
+end
+
+--- List a module's addressable symbols (functions, records, record methods).
+--- @param doc ModuleDoc The module documentation
+--- @return {string} Symbol names, deduplicated, in definition order
+local function list_symbols(doc: ModuleDoc): {string}
+  local out: {string} = {}
+  local seen: {string: boolean} = {}
+  local function add(name: string)
+    if not seen[name] then
+      seen[name] = true
+      table.insert(out, name)
+    end
+  end
+  if doc.functions then
+    for _, func in ipairs(doc.functions) do add(func.name) end
+  end
+  if doc.records then
+    for _, rec in ipairs(doc.records) do
+      add(rec.name)
+      if rec.fields then
+        for _, field in ipairs(rec.fields) do
+          if field[2]:match("^function") then add(field[1]) end
+        end
+      end
+    end
+  end
+  return out
+end
+
+--- Build the error message for a symbol that was not found in a module.
+--- Suggests other locations for the name, or lists the module's available
+--- symbols so the caller does not need a second lookup.
+--- @param symbol string The symbol that was not found
+--- @param matched_mod string The module that was searched
+--- @param index DocIndex The documentation index
+--- @return string Multi-line error message
+local function symbol_not_found(symbol: string, matched_mod: string, index: DocIndex): string
+  local locations = find_symbol_locations(symbol, index)
+  local lines: {string} = {"error: symbol '" .. symbol .. "' not found in '" .. matched_mod .. "'"}
+  if #locations > 0 then
+    table.insert(lines, "")
+    table.insert(lines, "Did you mean?")
+    for i = 1, math.min(3, #locations) do table.insert(lines, "  cosmic --docs " .. locations[i]) end
+  else
+    local available = list_symbols(index.modules[matched_mod])
+    if #available > 0 then
+      table.insert(lines, "")
+      table.insert(lines, "Available symbols in " .. matched_mod .. ":")
+      for i = 1, math.min(20, #available) do
+        table.insert(lines, "  " .. available[i])
+      end
+      if #available > 20 then
+        table.insert(lines, "  ... and " .. (#available - 20) .. " more")
+      end
+    else
+      table.insert(lines, "Use 'cosmic --docs " .. matched_mod .. "' to see available symbols.")
+    end
+  end
+  return table.concat(lines, "\n")
+end
+
+local record DocsLookupModule
+  find_symbol_locations: function(symbol: string, index: DocIndex): {string}
+  list_symbols: function(doc: ModuleDoc): {string}
+  symbol_not_found: function(symbol: string, matched_mod: string, index: DocIndex): string
+end
+
+local M: DocsLookupModule = {
+  find_symbol_locations = find_symbol_locations,
+  list_symbols = list_symbols,
+  symbol_not_found = symbol_not_found,
+}
+
+return M

--- a/lib/cosmic/docs_render.tl
+++ b/lib/cosmic/docs_render.tl
@@ -187,6 +187,14 @@ local function render_module(name: string, doc: ModuleDoc): string
     table.insert(lines, "**Tip:** For a high-level API, see `" .. equivalent .. "`.")
     table.insert(lines, "")
   end
+  -- Hoist quick example near the top, right after the summary
+  if doc.examples and #doc.examples > 0 then
+    table.insert(lines, "Run `cosmic --examples " .. simple_name .. "` for runnable examples.")
+    table.insert(lines, "")
+    table.insert(lines, "## Quick example")
+    table.insert(lines, "")
+    table.insert(lines, render_example(doc.examples[1]))
+  end
   if doc.records and #doc.records > 0 then
     table.insert(lines, "## Types")
     table.insert(lines, "")
@@ -251,6 +259,7 @@ local function find_matching_examples(examples: {ExampleDoc}, func_name: string)
 end
 
 --- Find a symbol in a module's documentation.
+--- Also searches record fields for re-exported function symbols.
 local function find_symbol(doc: ModuleDoc, symbol: string, method?: string): string
   if doc.functions then
     for _, func in ipairs(doc.functions) do
@@ -270,10 +279,20 @@ local function find_symbol(doc: ModuleDoc, symbol: string, method?: string): str
   if doc.records then
     for _, rec in ipairs(doc.records) do
       if rec.name == symbol or rec.name:lower() == symbol:lower() then
-        if method then
-          return find_method(rec, method)
-        end
+        if method then return find_method(rec, method) end
         return render_record(rec)
+      end
+    end
+    -- Also search record fields for re-exported function symbols
+    for _, rec in ipairs(doc.records) do
+      local found = find_method(rec, symbol)
+      if found then
+        local matching_examples = find_matching_examples(doc.examples, symbol)
+        if #matching_examples > 0 then
+          found = found .. "**Examples:**\n\n"
+          for _, example in ipairs(matching_examples) do found = found .. render_example(example) end
+        end
+        return found
       end
     end
   end
@@ -286,6 +305,31 @@ local function find_symbol(doc: ModuleDoc, symbol: string, method?: string): str
     end
   end
   return nil
+end
+
+--- Find where a symbol lives across all modules (for "did you mean" suggestions).
+local function find_symbol_locations(symbol: string, index: DocIndex): {string}
+  local out: {string} = {}
+  local sym_lower = symbol:lower()
+  for mod_name, mod_doc in pairs(index.modules) do
+    if mod_doc.functions then
+      for _, func in ipairs(mod_doc.functions) do
+        if func.name:lower() == sym_lower then table.insert(out, mod_name .. "." .. func.name) end
+      end
+    end
+    if mod_doc.records then
+      for _, rec in ipairs(mod_doc.records) do
+        if rec.fields then
+          for _, field in ipairs(rec.fields) do
+            if field[1]:lower() == sym_lower and field[2]:match("^function") then
+              table.insert(out, mod_name .. "." .. field[1])
+            end
+          end
+        end
+      end
+    end
+  end
+  return out
 end
 
 --- Render examples list as CLI output.
@@ -397,6 +441,27 @@ local function find_suggestions(query: string, index: DocIndex): {string}
   return results
 end
 
+--- Find suggestions for examples lookup (only modules with examples).
+local function find_example_suggestions(query: string, index: DocIndex): {string}
+  local candidates: {string} = {}
+  local name_to_full: {string: string} = {}
+  for mod_name, mod_doc in pairs(index.modules) do
+    if mod_doc.examples and #mod_doc.examples > 0 then
+      local simple = mod_name:match("([^%.]+)$") or mod_name
+      if not name_to_full[simple] then
+        table.insert(candidates, simple)
+        name_to_full[simple] = mod_name
+      end
+    end
+  end
+  local similar = fuzzy.find_similar(query, candidates, 3)
+  local results: {string} = {}
+  for _, simple in ipairs(similar) do
+    if name_to_full[simple] then table.insert(results, name_to_full[simple]) end
+  end
+  return results
+end
+
 local record DocsRenderModule
   first_paragraph: function(text: string): string
   render_topic_list: function(topics: {{string, string}}): string
@@ -407,9 +472,11 @@ local record DocsRenderModule
   find_method: function(rec: RecordDoc, method_name: string): string
   find_matching_examples: function(examples: {ExampleDoc}, func_name: string): {ExampleDoc}
   find_symbol: function(doc: ModuleDoc, symbol: string, method?: string): string
+  find_symbol_locations: function(symbol: string, index: DocIndex): {string}
   render_examples_list: function(examples: {ExampleEntry}): string
   render_search_results: function(results: {SearchResult}, query: string): string
   find_suggestions: function(query: string, index: DocIndex): {string}
+  find_example_suggestions: function(query: string, index: DocIndex): {string}
 end
 
 local M: DocsRenderModule = {
@@ -422,9 +489,11 @@ local M: DocsRenderModule = {
   find_method = find_method,
   find_matching_examples = find_matching_examples,
   find_symbol = find_symbol,
+  find_symbol_locations = find_symbol_locations,
   render_examples_list = render_examples_list,
   render_search_results = render_search_results,
   find_suggestions = find_suggestions,
+  find_example_suggestions = find_example_suggestions,
 }
 
 return M

--- a/lib/cosmic/docs_render.tl
+++ b/lib/cosmic/docs_render.tl
@@ -307,31 +307,6 @@ local function find_symbol(doc: ModuleDoc, symbol: string, method?: string): str
   return nil
 end
 
---- Find where a symbol lives across all modules (for "did you mean" suggestions).
-local function find_symbol_locations(symbol: string, index: DocIndex): {string}
-  local out: {string} = {}
-  local sym_lower = symbol:lower()
-  for mod_name, mod_doc in pairs(index.modules) do
-    if mod_doc.functions then
-      for _, func in ipairs(mod_doc.functions) do
-        if func.name:lower() == sym_lower then table.insert(out, mod_name .. "." .. func.name) end
-      end
-    end
-    if mod_doc.records then
-      for _, rec in ipairs(mod_doc.records) do
-        if rec.fields then
-          for _, field in ipairs(rec.fields) do
-            if field[1]:lower() == sym_lower and field[2]:match("^function") then
-              table.insert(out, mod_name .. "." .. field[1])
-            end
-          end
-        end
-      end
-    end
-  end
-  return out
-end
-
 --- Render examples list as CLI output.
 local function render_examples_list(examples: {ExampleEntry}): string
   local lines: {string} = {}
@@ -472,7 +447,6 @@ local record DocsRenderModule
   find_method: function(rec: RecordDoc, method_name: string): string
   find_matching_examples: function(examples: {ExampleDoc}, func_name: string): {ExampleDoc}
   find_symbol: function(doc: ModuleDoc, symbol: string, method?: string): string
-  find_symbol_locations: function(symbol: string, index: DocIndex): {string}
   render_examples_list: function(examples: {ExampleEntry}): string
   render_search_results: function(results: {SearchResult}, query: string): string
   find_suggestions: function(query: string, index: DocIndex): {string}
@@ -489,7 +463,6 @@ local M: DocsRenderModule = {
   find_method = find_method,
   find_matching_examples = find_matching_examples,
   find_symbol = find_symbol,
-  find_symbol_locations = find_symbol_locations,
   render_examples_list = render_examples_list,
   render_search_results = render_search_results,
   find_suggestions = find_suggestions,

--- a/lib/cosmic/docs_test.tl
+++ b/lib/cosmic/docs_test.tl
@@ -181,20 +181,6 @@ local function test_run_method()
 end
 test_run_method()
 
--- Test run with deep 4-part path (module.Record.method pattern for 2-part module name)
-local function test_run_deep_query()
-  local result = docs.run("cosmo.lsqlite3.Database.exec")
-  assert(result, "run should return a result")
-  assert(type(result.ok) == "boolean", "result.ok should be a boolean")
-  assert(type(result.output) == "string", "result.output should be a string")
-  if result.ok then
-    assert(result.output:match("exec") or result.output:match("Database"),
-      "deep query output should contain relevant content")
-  end
-  print("test_run_deep_query: PASS")
-end
-test_run_deep_query()
-
 -- Test cosmo module shows tip about cosmic equivalent
 local function test_cosmic_equivalent_tip()
   local result = docs.run("cosmo.lsqlite3")
@@ -473,6 +459,41 @@ local function test_show_module_examples_module_only()
   end
 end
 test_show_module_examples_module_only()
+
+-- Test that bare module name resolves in show_module_examples (bug 4)
+local function test_show_module_examples_bare_name()
+  if not docs.has_docs() then
+    io.stderr:write("SKIP: test_show_module_examples_bare_name\n")
+    print("test_show_module_examples_bare_name: PASS (skipped)")
+    return
+  end
+  local r = docs.show_module_examples("child")
+  assert(r, "should return result")
+  assert(not (not r.ok and r.output:match("module not found: child")),
+    "bare 'child' should not fail with module not found: " .. r.output)
+  print("test_show_module_examples_bare_name: PASS")
+end
+test_show_module_examples_bare_name()
+
+-- Test symbol lookup finds re-exported record methods (bug 1) and quick example (bug 3)
+local function test_run_reexported_and_quick_example()
+  if not docs.has_docs() then print("test_run_reexported_and_quick_example: PASS (skipped)"); return end
+  local r = docs.run("cosmic.sqlite.query")
+  assert(r, "run should return result")
+  if r.ok then assert(r.output:match("query"), "should find query method") end
+  local index = docs.load_index()
+  local test_mod: string = nil
+  for mod_name, mod_doc in pairs(index.modules) do
+    if mod_doc.examples and #mod_doc.examples > 0 then test_mod = mod_name; break end
+  end
+  if test_mod then
+    local mr = docs.run(test_mod)
+    assert(mr and mr.ok, "module lookup should succeed")
+    assert(mr.output:match("Quick example"), "should have Quick example section")
+  end
+  print("test_run_reexported_and_quick_example: PASS")
+end
+test_run_reexported_and_quick_example()
 
 print("")
 print("All docs tests passed!")

--- a/lib/cosmic/fs.tl
+++ b/lib/cosmic/fs.tl
@@ -322,7 +322,11 @@ local record FsModule
   major: function(dev: number): number
   minor: function(dev: number): number
 
-  -- Directory walking
+  -- Directory walking.
+  -- walk visitor signature: visitor(path, name, st, ctx)
+  --   path = full path to the entry (e.g. "dir/sub/file.txt") — do NOT join with name.
+  --   name = basename of the entry (e.g. "file.txt").
+  --   st   = WalkStat (import: local types = require("cosmic.fs_types"); types.WalkStat).
   walk: function < T > (dir: string, visitor: function(string, string, WalkStat, any), ctx?: T): T
   collect: function(dir: string, pattern: string): {string}
   collect_all: function(dir: string): {string: FileInfo}

--- a/lib/cosmic/fs_walk.tl
+++ b/lib/cosmic/fs_walk.tl
@@ -16,9 +16,23 @@ end
 --- Walk a directory tree, calling visitor for each entry.
 --- Recursively traverses all subdirectories.
 --- Does NOT recurse into symlinked directories to prevent symlink cycles.
+---
+--- The visitor receives four arguments:
+---   path  (string)  — the full path to the entry (e.g. "dir/sub/file.txt").
+---   name  (string)  — the basename of the entry (e.g. "file.txt").
+---   st    (WalkStat) — stat result for the entry.
+---   ctx   (T)       — the context value passed to walk().
+---
+--- IMPORTANT: do NOT join path and name — path is already the full path.
+--- Joining them produces doubled paths like "dir/sub/file.txt/file.txt".
+---
+--- WalkStat is defined in cosmic.fs_types. Import it as:
+---   local types = require("cosmic.fs_types")
+---   local WalkStat = types.WalkStat
+---
 --- @param dir string The directory to walk
---- @param visitor function Visitor callback Function called for each file and directory
---- @param ctx T Optional context passed to visitor function
+--- @param visitor function Called for each entry: function(path, name, st, ctx)
+--- @param ctx T Optional context passed to every visitor call
 --- @return T The context object, potentially modified by visitor
 local function walk < T > (dir: string, visitor: function(string, string, WalkStat, any), ctx?: T): T
   ctx = ctx or {} as T
@@ -180,6 +194,8 @@ local function files(dir: string, pattern?: string): function(): string
 end
 
 local record FsWalkModule
+  --- Walk dir tree. visitor(path, name, st, ctx): path is the FULL path; name is the basename.
+  --- Do NOT join path and name — path is already complete.
   walk: function < T > (dir: string, visitor: function(string, string, WalkStat, any), ctx?: T): T
   collect: function(dir: string, pattern: string): {string}
   collect_all: function(dir: string): {string: FileInfo}

--- a/lib/cosmic/fs_walk_example.tl
+++ b/lib/cosmic/fs_walk_example.tl
@@ -1,0 +1,96 @@
+--- Examples for the cosmic.fs_walk module.
+--- Demonstrates walk(), collect(), and files() for directory traversal.
+
+-- Example_walk demonstrates walking a directory tree.
+-- The visitor receives the FULL path as the first argument and the basename
+-- as the second. Do not join them — path is already complete.
+local function Example_walk()
+  local fs = require("cosmic.fs")
+  local cio = require("cosmic.io")
+  local types = require("cosmic.fs_types")
+
+  -- Build a small tree under a temp directory.
+  local tmpdir = fs.mkdtemp("/tmp/walk_ex_XXXXXX")
+  assert(tmpdir, "mkdtemp failed")
+
+  local subdir = fs.join(tmpdir, "conf")
+  assert(fs.makedirs(subdir))
+  assert(cio.barf(fs.join(subdir, "app.ini"), "[app]\nname=test\n"))
+  assert(cio.barf(fs.join(tmpdir, "README"), "readme\n"))
+
+  -- Collect entries and sort for deterministic output.
+  local entries: {string} = {}
+  fs.walk(tmpdir, function(path: string, name: string, st: types.WalkStat, ctx: {string})
+      -- path is the full path; name is just the basename.
+      -- Never do fs.join(path, name) — that would double the path.
+      local kind = fs.is_dir(st:mode()) and "dir" or "file"
+      table.insert(ctx, kind .. " " .. name)
+    end, entries)
+
+  table.sort(entries)
+  for _, line in ipairs(entries) do
+    print(line)
+  end
+
+  fs.rmrf(tmpdir)
+  -- Output:
+  -- dir conf
+  -- file README
+  -- file app.ini
+end
+
+-- Example_collect demonstrates collecting files matching a glob pattern.
+local function Example_collect()
+  local fs = require("cosmic.fs")
+  local cio = require("cosmic.io")
+
+  local tmpdir = fs.mkdtemp("/tmp/collect_ex_XXXXXX")
+  assert(tmpdir, "mkdtemp failed")
+
+  local subdir = fs.join(tmpdir, "src")
+  assert(fs.makedirs(subdir))
+  assert(cio.barf(fs.join(subdir, "main.lua"), "-- main\n"))
+  assert(cio.barf(fs.join(subdir, "util.lua"), "-- util\n"))
+  assert(cio.barf(fs.join(tmpdir, "README.txt"), "readme\n"))
+
+  -- collect returns full paths; sort for deterministic output.
+  local luafiles = fs.collect(tmpdir, "*.lua")
+  table.sort(luafiles)
+  for _, p in ipairs(luafiles) do
+    -- print only the basename so output is not path-dependent.
+    print(fs.basename(p))
+  end
+
+  fs.rmrf(tmpdir)
+  -- Output:
+  -- main.lua
+  -- util.lua
+end
+
+-- Example_files demonstrates the files() iterator for streaming traversal.
+local function Example_files()
+  local fs = require("cosmic.fs")
+  local cio = require("cosmic.io")
+
+  local tmpdir = fs.mkdtemp("/tmp/files_ex_XXXXXX")
+  assert(tmpdir, "mkdtemp failed")
+
+  assert(cio.barf(fs.join(tmpdir, "a.txt"), "a\n"))
+  assert(cio.barf(fs.join(tmpdir, "b.txt"), "b\n"))
+
+  local names: {string} = {}
+  for p in fs.files(tmpdir, "*.txt") do
+    table.insert(names, fs.basename(p))
+  end
+  table.sort(names)
+  for _, n in ipairs(names) do
+    print(n)
+  end
+
+  fs.rmrf(tmpdir)
+  -- Output:
+  -- a.txt
+  -- b.txt
+end
+
+local _ = {Example_walk, Example_collect, Example_files}

--- a/lib/cosmic/io.tl
+++ b/lib/cosmic/io.tl
@@ -1,6 +1,20 @@
 --- File descriptor I/O operations.
 --- Wraps low-level file descriptor operations from cosmo.unix.
 --- Supports Lua 5.4's to-be-closed via __close metamethod on Handle and Pipe.
+---
+--- WARNING: naming this module "io" shadows Lua's built-in io library:
+---   local io = require("cosmic.io")  -- WRONG: hides io.stderr, io.stdin, etc.
+---
+--- Use a distinct local name instead:
+---   local cio = require("cosmic.io")
+---
+--- cosmic.io has NO stderr, stdout, or stdin handles. For stream I/O use
+--- Lua's standard library directly:
+---   io.stderr:write("error: " .. msg .. "\n")
+---   io.stdout:write(data)
+---
+--- cosmic.io provides file-descriptor–level operations (open, read, write,
+--- pipe, slurp, barf) for cases where you need explicit fd control.
 local cosmo = require("cosmo")
 
 local record UnixIO

--- a/lib/cosmic/main.tl
+++ b/lib/cosmic/main.tl
@@ -306,68 +306,7 @@ local function resolve_optional_arg(flag: string, value: string): string
   return ""
 end
 
---- Augment a Teal compile-time error message with require hints.
---- When Teal reports "module not found: 'x'", append the same Did-you-mean
---- suggestions produced by the runtime hint engine so users see them
---- regardless of whether the error is detected at compile or run time.
---- Returns the original message unchanged when hints are disabled or
---- no suggestion is available.
---- @param err string Compile error message (may be multi-line)
---- @return string Possibly augmented error message
-local function augment_module_errors(err: string): string
-  if os.getenv("COSMIC_NO_REQUIRE_HINTS") then
-    return err
-  end
-  -- Teal emits "module not found: '<name>'" in individual issue messages.
-  -- The formatted string includes location prefix, e.g.:
-  --   file.tl:1:8: error: module not found: 'json'
-  local mod_name = err:match("module not found: '([^']+)'")
-  if not mod_name then
-    return err
-  end
-  local req_mod = require("cosmic.require")
-  local hint = req_mod.format_error(mod_name)
-  -- hint starts with "module 'x' not found\n\n..." — append the
-  -- Did-you-mean block (everything after the first two lines).
-  local hint_lines: {string} = {}
-  local line_idx = 0
-  for line in (hint .. "\n"):gmatch("([^\n]*)\n") do
-    line_idx = line_idx + 1
-    if line_idx > 2 then
-      hint_lines[#hint_lines + 1] = line
-    end
-  end
-  if #hint_lines == 0 then
-    return err
-  end
-  -- Drop trailing empty line from hint_lines if present
-  while #hint_lines > 0 and hint_lines[#hint_lines] == "" do
-    hint_lines[#hint_lines] = nil
-  end
-  return err .. "\n" .. table.concat(hint_lines, "\n")
-end
-
---- Build a traceback for user-visible errors, trimming internal frames.
---- Strips frames at and below the cosmic entry point (/zip/main.lua) so users
---- see only their own stack. Set COSMIC_FULL_TRACEBACK=1 to disable trimming.
-local function trim_traceback(err: any): string
-  local tb = debug.traceback(tostring(err), 2)
-  if os.getenv("COSMIC_FULL_TRACEBACK") then
-    return tb
-  end
-  -- Split into lines and drop everything at/below the first /zip/main.lua frame.
-  local lines: {string} = {}
-  local trimmed = false
-  for line in (tb .. "\n"):gmatch("([^\n]*)\n") do
-    if not trimmed and line:match("\t/zip/main%.lua:") then
-      trimmed = true
-    end
-    if not trimmed then
-      lines[#lines + 1] = line
-    end
-  end
-  return table.concat(lines, "\n")
-end
+local run = require("cosmic.run")
 
 local function main(): integer, string
   local opts = parse_args()
@@ -489,7 +428,7 @@ local function main(): integer, string
     local chunk, err = handlers.load_script_file(opts.script)
     if not chunk then
       local msg = err or "error loading script"
-      msg = augment_module_errors(msg)
+      msg = run.augment_module_errors(msg)
       return 1, "cosmic-lua: " .. msg
     end
     local args: {string} = {}
@@ -498,7 +437,7 @@ local function main(): integer, string
     end
     local results: {any} = table.pack(xpcall(function()
           chunk(table.unpack(args))
-        end, trim_traceback))
+        end, run.trim_traceback))
     local ok = results[1] as boolean
     if not ok then
       return 1, results[2] as string

--- a/lib/cosmic/main.tl
+++ b/lib/cosmic/main.tl
@@ -187,7 +187,20 @@ local function parse_args(): Opts
     if not opt then break end
 
     if opt == "?" then
-      opts.error = "cosmic-lua: unknown option '" .. optarg .. "'"
+      -- Distinguish missing-argument errors from truly unknown options.
+      -- getopt returns "?" with the option string when a required argument
+      -- is absent; give a targeted usage hint instead of "unknown option".
+      if optarg == "--test" then
+        opts.error = "cosmic-lua: --test requires: --test <output> <cmd>...\nSee: cosmic-lua --help"
+      elseif optarg == "--report" then
+        opts.error = "cosmic-lua: --report requires: --report <paths>...\nSee: cosmic-lua --help"
+      elseif optarg == "--embed" then
+        opts.error = "cosmic-lua: --embed requires: --embed <path>\nSee: cosmic-lua --help"
+      elseif optarg == "--output" then
+        opts.error = "cosmic-lua: --output requires: --output <file>\nSee: cosmic-lua --help"
+      else
+        opts.error = "cosmic-lua: unknown option '" .. optarg .. "'"
+      end
       return opts
     elseif opt == "e" then
       opts.execute[#opts.execute + 1] = optarg
@@ -293,6 +306,69 @@ local function resolve_optional_arg(flag: string, value: string): string
   return ""
 end
 
+--- Augment a Teal compile-time error message with require hints.
+--- When Teal reports "module not found: 'x'", append the same Did-you-mean
+--- suggestions produced by the runtime hint engine so users see them
+--- regardless of whether the error is detected at compile or run time.
+--- Returns the original message unchanged when hints are disabled or
+--- no suggestion is available.
+--- @param err string Compile error message (may be multi-line)
+--- @return string Possibly augmented error message
+local function augment_module_errors(err: string): string
+  if os.getenv("COSMIC_NO_REQUIRE_HINTS") then
+    return err
+  end
+  -- Teal emits "module not found: '<name>'" in individual issue messages.
+  -- The formatted string includes location prefix, e.g.:
+  --   file.tl:1:8: error: module not found: 'json'
+  local mod_name = err:match("module not found: '([^']+)'")
+  if not mod_name then
+    return err
+  end
+  local req_mod = require("cosmic.require")
+  local hint = req_mod.format_error(mod_name)
+  -- hint starts with "module 'x' not found\n\n..." — append the
+  -- Did-you-mean block (everything after the first two lines).
+  local hint_lines: {string} = {}
+  local line_idx = 0
+  for line in (hint .. "\n"):gmatch("([^\n]*)\n") do
+    line_idx = line_idx + 1
+    if line_idx > 2 then
+      hint_lines[#hint_lines + 1] = line
+    end
+  end
+  if #hint_lines == 0 then
+    return err
+  end
+  -- Drop trailing empty line from hint_lines if present
+  while #hint_lines > 0 and hint_lines[#hint_lines] == "" do
+    hint_lines[#hint_lines] = nil
+  end
+  return err .. "\n" .. table.concat(hint_lines, "\n")
+end
+
+--- Build a traceback for user-visible errors, trimming internal frames.
+--- Strips frames at and below the cosmic entry point (/zip/main.lua) so users
+--- see only their own stack. Set COSMIC_FULL_TRACEBACK=1 to disable trimming.
+local function trim_traceback(err: any): string
+  local tb = debug.traceback(tostring(err), 2)
+  if os.getenv("COSMIC_FULL_TRACEBACK") then
+    return tb
+  end
+  -- Split into lines and drop everything at/below the first /zip/main.lua frame.
+  local lines: {string} = {}
+  local trimmed = false
+  for line in (tb .. "\n"):gmatch("([^\n]*)\n") do
+    if not trimmed and line:match("\t/zip/main%.lua:") then
+      trimmed = true
+    end
+    if not trimmed then
+      lines[#lines + 1] = line
+    end
+  end
+  return table.concat(lines, "\n")
+end
+
 local function main(): integer, string
   local opts = parse_args()
 
@@ -353,6 +429,9 @@ local function main(): integer, string
   end
 
   if opts.test_argv then
+    if #opts.test_argv == 0 then
+      return 1, "cosmic-lua: --test requires: --test <output> <cmd>...\nSee: cosmic-lua --help"
+    end
     local testrun = require("cosmic.testrun")
     return testrun.run(opts.test_argv, opts.test_output)
   end
@@ -409,13 +488,21 @@ local function main(): integer, string
     _G.arg = opts.script_args as {string}
     local chunk, err = handlers.load_script_file(opts.script)
     if not chunk then
-      return 1, "cosmic-lua: " .. (err or "error loading script")
+      local msg = err or "error loading script"
+      msg = augment_module_errors(msg)
+      return 1, "cosmic-lua: " .. msg
     end
     local args: {string} = {}
     for i = 1, #opts.script_args do
       args[i] = opts.script_args[i]
     end
-    chunk(table.unpack(args))
+    local results: {any} = table.pack(xpcall(function()
+          chunk(table.unpack(args))
+        end, trim_traceback))
+    local ok = results[1] as boolean
+    if not ok then
+      return 1, results[2] as string
+    end
     return 0
   end
 

--- a/lib/cosmic/main.tl
+++ b/lib/cosmic/main.tl
@@ -36,6 +36,7 @@ local record Opts
   script_args: {integer: string}
   compile: string
   format: string
+  fix: string
   check_format: string
   check_types: string
   check_style: string
@@ -70,6 +71,7 @@ local function parse_args(): Opts
     script_args = {},
     compile = nil,
     format = nil,
+    fix = nil,
     check_format = nil,
     check_types = nil,
     check_style = nil,
@@ -223,6 +225,9 @@ local function parse_args(): Opts
     elseif opt == "format" then
       opts.format = optarg
       return opts
+    elseif opt == "fix" then
+      opts.fix = optarg
+      return opts
     elseif opt == "check-format" then
       opts.check_format = optarg
       return opts
@@ -348,6 +353,7 @@ local function main(): integer, string
   end
   if opts.compile then return handlers.handle_compile(opts.compile, opts.output, opts.write_if_changed, opts.include_dirs) end
   if opts.format then return handlers.handle_format(opts.format, opts.output, opts.write_if_changed) end
+  if opts.fix then return handlers.handle_format(opts.fix, opts.fix, true) end
   if opts.check_format then return handlers.handle_check_format(opts.check_format) end
   if opts.check_types then return handlers.handle_check_types(opts.check_types, opts.include_dirs) end
   if opts.check_style then return handlers.handle_check_style(opts.check_style) end

--- a/lib/cosmic/main_handlers.tl
+++ b/lib/cosmic/main_handlers.tl
@@ -167,6 +167,20 @@ local function handle_format(file: string, output?: string, write_if_changed?: b
   return exit_code, err_msg
 end
 
+--- Render a line visibly by replacing tabs and trailing spaces with markers.
+--- Used when have/want lines look the same but differ only in whitespace.
+--- @param s string The line to render
+--- @return string The line with whitespace made visible
+local function render_whitespace(s: string): string
+  -- Replace tabs with visible marker
+  local result = s:gsub("\t", "->")
+  -- Mark trailing spaces with underscores
+  result = result:gsub("( +)$", function(spaces: string): string
+      return string.rep("_", #spaces)
+    end)
+  return result
+end
+
 --- Handle --check-format flag.
 local function handle_check_format(file: string): integer
   local span = instrument.begin("check-format", file)
@@ -203,12 +217,23 @@ local function handle_check_format(file: string): integer
   local max = math.max(#orig_lines, #fmt_lines)
   for i = 1, max do
     if orig_lines[i] ~= fmt_lines[i] then
+      local have = orig_lines[i] or "<eof>"
+      local want = fmt_lines[i] or "<eof>"
       io.stderr:write(string.format("%s:%d: format mismatch\n", file, i))
-      io.stderr:write(string.format("  have: %s\n", orig_lines[i] or "<eof>"))
-      io.stderr:write(string.format("  want: %s\n", fmt_lines[i] or "<eof>"))
+      -- When lines look identical but differ only in whitespace, render it visibly
+      if have:gsub("%s", "") == want:gsub("%s", "") then
+        io.stderr:write(string.format("  have: %s  (whitespace differs)\n", render_whitespace(have)))
+        io.stderr:write(string.format("  want: %s  (whitespace differs)\n", render_whitespace(want)))
+      else
+        io.stderr:write(string.format("  have: %s\n", have))
+        io.stderr:write(string.format("  want: %s\n", want))
+      end
       break
     end
   end
+  io.stderr:write(string.format(
+      "  hint: run 'cosmic --format %s' to see the formatted version, or\n        'cosmic --format %s --write-if-changed --output %s' to fix in place\n",
+      file, file, file))
   instrument.finish(span, 1)
   return 1
 end
@@ -223,7 +248,7 @@ local function handle_check_types(file: string, include_dirs?: {string}): intege
     io.stderr:write(teal.format_issues(result.warnings) .. "\n")
   end
   if #result.errors > 0 then
-    io.stderr:write(teal.format_issues(result.errors) .. "\n")
+    io.stderr:write(teal.format_issues_with_hints(result.errors) .. "\n")
   end
 
   if result.ok then

--- a/lib/cosmic/main_handlers.tl
+++ b/lib/cosmic/main_handlers.tl
@@ -232,8 +232,8 @@ local function handle_check_format(file: string): integer
     end
   end
   io.stderr:write(string.format(
-      "  hint: run 'cosmic --format %s' to see the formatted version, or\n        'cosmic --write-if-changed --output %s --format %s' to fix in place\n",
-      file, file, file))
+      "  hint: run 'cosmic --fix %s' to fix in place, or 'cosmic --format %s' to preview\n",
+      file, file))
   instrument.finish(span, 1)
   return 1
 end

--- a/lib/cosmic/main_handlers.tl
+++ b/lib/cosmic/main_handlers.tl
@@ -232,7 +232,7 @@ local function handle_check_format(file: string): integer
     end
   end
   io.stderr:write(string.format(
-      "  hint: run 'cosmic --format %s' to see the formatted version, or\n        'cosmic --format %s --write-if-changed --output %s' to fix in place\n",
+      "  hint: run 'cosmic --format %s' to see the formatted version, or\n        'cosmic --write-if-changed --output %s --format %s' to fix in place\n",
       file, file, file))
   instrument.finish(span, 1)
   return 1

--- a/lib/cosmic/net.tl
+++ b/lib/cosmic/net.tl
@@ -110,6 +110,10 @@ local function connect_unix(path: string): Socket, string
 end
 
 --- Create a TCP socket and connect to an IP address and port.
+--- The IP is an integer (e.g. 0x7f000001 for 127.0.0.1). To convert a
+--- dotted-quad string, use cosmic.ip:
+---   local ip = require("cosmic.ip")
+---   local addr = ip.parse("127.0.0.1")  -- 0x7f000001
 --- @param ip number Remote IP address
 --- @param port number Remote port
 --- @return Socket Connected socket
@@ -130,7 +134,8 @@ end
 --- Create a TCP socket, bind it to host:port, and start listening.
 --- Passing port 0 lets the OS assign an ephemeral port; the actual port is
 --- returned as the second value so callers never need a separate getsockname
---- call.
+--- call. The IP is an integer; convert strings with
+--- require("cosmic.ip").parse("127.0.0.1").
 ---
 --- Example — listen on an OS-assigned port:
 ---   local net = require("cosmic.net")

--- a/lib/cosmic/net.tl
+++ b/lib/cosmic/net.tl
@@ -127,6 +127,51 @@ local function connect_tcp(ip: number, port: number): Socket, string
   return sock
 end
 
+--- Create a TCP socket, bind it to host:port, and start listening.
+--- Passing port 0 lets the OS assign an ephemeral port; the actual port is
+--- returned as the second value so callers never need a separate getsockname
+--- call.
+---
+--- Example — listen on an OS-assigned port:
+---   local net = require("cosmic.net")
+---   local srv, port, err = net.listen_tcp(0x7f000001, 0)
+---   -- port is now the OS-assigned port, e.g. 54321
+---   local client = net.connect_tcp(0x7f000001, port)
+---
+--- @param ip number Local IP address to bind (e.g. 0x7f000001 for 127.0.0.1, 0 for all)
+--- @param port number Local port to bind; use 0 for an OS-assigned ephemeral port
+--- @param backlog number Maximum pending connections (default 128)
+--- @return Socket Listening socket ready to accept
+--- @return number Actual bound port (useful when port 0 was requested)
+--- @return string Error message on failure
+local function listen_tcp(ip: number, port: number, backlog?: number): Socket, number, string
+  local sock, serr = socket(unix.AF_INET, unix.SOCK_STREAM, 0)
+  if not sock then
+    return nil, nil, serr
+  end
+  local ok, setopt_err = sock:setsockopt(unix.SOL_SOCKET, unix.SO_REUSEADDR, true)
+  if not ok then
+    sock:close()
+    return nil, nil, setopt_err
+  end
+  local bok, bind_err = sock:bind(ip, port)
+  if not bok then
+    sock:close()
+    return nil, nil, bind_err
+  end
+  local _, bound_port, name_err = sock:getsockname()
+  if not bound_port then
+    sock:close()
+    return nil, nil, name_err
+  end
+  local lok, listen_err = sock:listen(backlog)
+  if not lok then
+    sock:close()
+    return nil, nil, listen_err
+  end
+  return sock, bound_port
+end
+
 --- Perform a non-blocking connect on a socket.
 --- @param s Socket The non-blocking socket to connect
 --- @param ip number Remote IP address
@@ -233,6 +278,7 @@ local record NetModule
   socket: function(family?: number, socktype?: number, protocol?: number): Socket, string
   socketpair: function(family?: number, socktype?: number, protocol?: number): Socket, Socket, string
   listen_unix: function(path: string, backlog?: number): Socket, string
+  listen_tcp: function(ip: number, port: number, backlog?: number): Socket, number, string
   connect_unix: function(path: string): Socket, string
   connect_tcp: function(ip: number, port: number): Socket, string
   nb_connect: function(s: Socket, ip: number, port: number, timeoutms?: number): boolean, string
@@ -317,6 +363,7 @@ local M: NetModule = {
   socket = socket,
   socketpair = socketpair,
   listen_unix = listen_unix,
+  listen_tcp = listen_tcp,
   connect_unix = connect_unix,
   connect_tcp = connect_tcp,
   nb_connect = nb_connect,

--- a/lib/cosmic/net_test.tl
+++ b/lib/cosmic/net_test.tl
@@ -370,3 +370,65 @@ local function test_accept_socket_has_close_metamethod()
   child.wait(pid)
 end
 test_accept_socket_has_close_metamethod()
+
+local function test_listen_tcp_ephemeral_port()
+  -- listen_tcp with port 0 should return a listening socket and a port > 0
+  local srv, port, err = net.listen_tcp(0x7f000001, 0)
+  assert(srv ~= nil, "listen_tcp failed: " .. tostring(err))
+  assert(port ~= nil and port > 0, "expected non-zero port, got " .. tostring(port))
+  srv:close()
+end
+test_listen_tcp_ephemeral_port()
+
+local function test_listen_tcp_connect_to_returned_port()
+  -- bind on 127.0.0.1:0, then connect_tcp to the returned port
+  local srv, port, serr = net.listen_tcp(0x7f000001, 0)
+  assert(srv ~= nil, "listen_tcp failed: " .. tostring(serr))
+  assert(port > 0, "expected non-zero port")
+
+  -- Fork: child connects and sends, parent accepts and reads
+  local pid = child.fork()
+  if pid == 0 then
+    local csock = net.connect_tcp(0x7f000001, port)
+    if not csock then
+      os.exit(1)
+    end
+    csock:send("hi")
+    csock:close()
+    os.exit(0)
+  end
+
+  local conn, _, _, aerr = srv:accept()
+  assert(conn ~= nil, "accept failed: " .. tostring(aerr))
+  local data = conn:recv()
+  assert(data == "hi", "expected 'hi', got '" .. tostring(data) .. "'")
+  conn:close()
+  srv:close()
+  child.wait(pid)
+end
+test_listen_tcp_connect_to_returned_port()
+
+local function test_listen_tcp_double_bind_same_port_fails()
+  -- Bind a specific port, then try to bind the same port again without
+  -- REUSEPORT; the second listen_tcp should fail.
+  local srv, port, serr = net.listen_tcp(0x7f000001, 0)
+  assert(srv ~= nil, "first listen_tcp failed: " .. tostring(serr))
+  assert(port > 0, "expected non-zero port")
+
+  -- Second bind to the same explicit port should fail (SO_REUSEADDR alone
+  -- does not allow two listeners on the same port simultaneously)
+  local srv2, _, serr2 = net.listen_tcp(0x7f000001, port)
+  assert(srv2 == nil, "expected second listen_tcp to fail on same port")
+  assert(serr2 ~= nil, "expected error message from second listen_tcp")
+
+  srv:close()
+end
+test_listen_tcp_double_bind_same_port_fails()
+
+local function test_listen_tcp_invalid_ip_bind_fails()
+  -- Attempt to bind to a non-local IP should fail
+  local srv, _, serr = net.listen_tcp(0x01020304, 0) -- 1.2.3.4 is not local
+  assert(srv == nil, "expected listen_tcp to fail on non-local IP")
+  assert(serr ~= nil, "expected error message")
+end
+test_listen_tcp_invalid_ip_bind_fails()

--- a/lib/cosmic/proc.tl
+++ b/lib/cosmic/proc.tl
@@ -1,5 +1,15 @@
 --- Current process management.
 --- Identity, session/group control, exec, and resource usage.
+---
+--- The global `arg` table layout when running a script:
+---   arg[-1]  — path to the cosmic interpreter binary (use this to re-invoke
+---              cosmic, e.g. to spawn a child running another script)
+---   arg[0]   — script path as the runtime sees it (/zip/main.lua when the
+---              script is dispatched by the embedded entry point — NOT the
+---              interpreter path)
+---   arg[1..] — user arguments
+--- `arg` is typed {string}, so negative indices need
+--- `rawget(arg, -1) as string` to pass the strict type checker.
 local unix = require("cosmo.unix")
 local cosmo = require("cosmo")
 

--- a/lib/cosmic/require.tl
+++ b/lib/cosmic/require.tl
@@ -7,29 +7,6 @@ local fuzzy = original_require("cosmic.fuzzy")
 --- Cached module mapping, built lazily on first use.
 local module_map: {string: string} = nil
 
---- Build module mapping from package.preload.
---- Maps short names to full module names (e.g., "argon2" -> "cosmo.argon2").
-local function build_module_map(): {string: string}
-  if module_map then
-    return module_map
-  end
-
-  module_map = {}
-
-  -- Scan package.preload for cosmo.* and cosmic.* modules
-  for name, _ in pairs(package.preload) do
-    local short = name:match("^cosmo%.(.+)$") or name:match("^cosmic%.(.+)$")
-    if short and not short:match("%.") then
-      -- Only map top-level modules (not submodules like cosmo.foo.bar)
-      if not module_map[short] then
-        module_map[short] = name
-      end
-    end
-  end
-
-  return module_map
-end
-
 --- Check if a module exists without loading it.
 --- @param name string Module name to check
 --- @return boolean True if module can be loaded
@@ -49,6 +26,52 @@ local function module_exists(name: string): boolean
   return false
 end
 
+--- Build module mapping from package.preload and package.path.
+--- Maps short names to full module names (e.g., "argon2" -> "cosmo.argon2",
+--- "json" -> "cosmic.json").
+--- Probes known cosmic.* module names so fuzzy matching covers modules loaded
+--- from disk as well (e.g., "cosmic.jsn" -> "cosmic.json").
+local function build_module_map(): {string: string}
+  if module_map then
+    return module_map
+  end
+
+  module_map = {}
+
+  -- Scan package.preload for cosmo.* and cosmic.* modules
+  for name, _ in pairs(package.preload) do
+    local short = name:match("^cosmo%.(.+)$") or name:match("^cosmic%.(.+)$")
+    if short and not short:match("%.") then
+      -- Only map top-level modules (not submodules like cosmo.foo.bar)
+      if not module_map[short] then
+        module_map[short] = name
+      end
+    end
+  end
+
+  -- Probe known cosmic module short names via package.path to cover modules
+  -- that live on disk rather than in package.preload (e.g., cosmic.json).
+  -- This list mirrors the standard library table in CLAUDE.md.
+  local known_cosmic: {string} = {
+    "args", "benchmark", "child", "codec", "compress", "doc", "docs",
+    "embed", "env", "envd", "example", "fetch", "format", "fs", "fuzzy",
+    "getopt", "hash", "html", "io", "ip", "json", "landlock", "net",
+    "pledge", "poll", "proc", "quicksand", "rand", "re", "require",
+    "shm", "signal", "sqlite", "sse", "string", "sys", "syslog", "teal",
+    "testrun", "time", "tty", "unveil", "url", "user", "uuid", "zip",
+  }
+  for _, short_name in ipairs(known_cosmic) do
+    if not module_map[short_name] then
+      local full = "cosmic." .. short_name
+      if module_exists(full) then
+        module_map[short_name] = full
+      end
+    end
+  end
+
+  return module_map
+end
+
 --- Find similar modules using Levenshtein distance.
 --- @param name string The requested module name
 --- @param max_distance integer Maximum edit distance to consider (default 3)
@@ -57,31 +80,35 @@ local function find_similar(name: string, max_distance?: integer): {string}
   max_distance = max_distance or 3
   local results: {{string, integer}} = {} -- {full_name, distance}
 
-  -- Check against all known short module names
+  -- Collect all known full module names (from module_map values and preload)
+  -- to avoid duplicate work in inner loops.
+  local seen_full: {string: boolean} = {}
+  local candidates: {{string, string}} = {} -- {full_name, short_name_or_full}
+
   for short, full in pairs(build_module_map()) do
-    local dist = fuzzy.levenshtein(name:lower(), short:lower())
-    if dist <= max_distance then
-      table.insert(results, {full, dist})
+    if not seen_full[full] then
+      seen_full[full] = true
+      table.insert(candidates, {full, short})
+    end
+  end
+  for full, _ in pairs(package.preload) do
+    if (full:match("^cosmo%.") or full:match("^cosmic%.")) and not seen_full[full] then
+      seen_full[full] = true
+      table.insert(candidates, {full, full})
     end
   end
 
-  -- Also check full module names in package.preload
-  for full, _ in pairs(package.preload) do
-    if full:match("^cosmo%.") or full:match("^cosmic%.") then
-      local dist = fuzzy.levenshtein(name:lower(), full:lower())
-      if dist <= max_distance then
-        -- Avoid duplicates
-        local dominated = false
-        for _, r in ipairs(results) do
-          if r[1] == full then
-            dominated = true
-            break
-          end
-        end
-        if not dominated then
-          table.insert(results, {full, dist})
-        end
-      end
+  -- Compare against both the short name and the full qualified name.
+  -- This catches typos in either the prefix (e.g. "cosm.json") or the
+  -- suffix (e.g. "cosmic.jsn" -> "cosmic.json", distance 1).
+  for _, pair in ipairs(candidates) do
+    local full = pair[1]
+    local short = pair[2]
+    local dist_short = fuzzy.levenshtein(name:lower(), short:lower())
+    local dist_full = fuzzy.levenshtein(name:lower(), full:lower())
+    local dist = math.min(dist_short, dist_full)
+    if dist <= max_distance then
+      table.insert(results, {full, dist})
     end
   end
 
@@ -161,17 +188,23 @@ local function format_error(name: string): string
 end
 
 --- Check if error message indicates module not found.
+--- Matches both Lua's "module 'x' not found" and Teal loader's
+--- "module not found: 'x'" formats.
 --- @param err string Error message
 --- @return boolean True if this is a module-not-found error
 local function is_module_not_found(err: string): boolean
   return err:match("module '[^']+' not found") ~= nil
+  or err:match("module not found: '[^']+'") ~= nil
 end
 
 --- Extract module name from require error.
+--- Handles both Lua's "module 'x' not found" and Teal loader's
+--- "module not found: 'x'" formats.
 --- @param err string Error message
 --- @return string Module name, or nil if not found
 local function extract_module_name(err: string): string
   return err:match("module '([^']+)' not found")
+  or err:match("module not found: '([^']+)'")
 end
 
 --- Enhanced require function that provides helpful suggestions.

--- a/lib/cosmic/run.tl
+++ b/lib/cosmic/run.tl
@@ -1,0 +1,75 @@
+--- Script execution helpers for the cosmic CLI.
+--- Provides require-hint augmentation for compile-time errors and
+--- user-facing traceback trimming for runtime errors.
+
+--- Augment a Teal compile-time error message with require hints.
+--- When Teal reports "module not found: 'x'", appends the same Did-you-mean
+--- suggestions produced by the runtime hint engine so users see them
+--- regardless of whether the error is detected at compile or run time.
+--- Returns the original message unchanged when hints are disabled or
+--- no suggestion is available.
+--- @param err string Compile error message (may be multi-line)
+--- @return string Possibly augmented error message
+local function augment_module_errors(err: string): string
+  if os.getenv("COSMIC_NO_REQUIRE_HINTS") then
+    return err
+  end
+  local mod_name = err:match("module not found: '([^']+)'")
+  if not mod_name then
+    return err
+  end
+  local req_mod = require("cosmic.require")
+  local hint = req_mod.format_error(mod_name)
+  -- hint starts with "module 'x' not found\n\n..." — skip the first two lines
+  -- and append the Did-you-mean block.
+  local hint_lines: {string} = {}
+  local line_idx = 0
+  for line in (hint .. "\n"):gmatch("([^\n]*)\n") do
+    line_idx = line_idx + 1
+    if line_idx > 2 then
+      hint_lines[#hint_lines + 1] = line
+    end
+  end
+  if #hint_lines == 0 then
+    return err
+  end
+  while #hint_lines > 0 and hint_lines[#hint_lines] == "" do
+    hint_lines[#hint_lines] = nil
+  end
+  return err .. "\n" .. table.concat(hint_lines, "\n")
+end
+
+--- Build a traceback for user-visible errors, trimming internal frames.
+--- Strips frames at and below the cosmic entry point (/zip/main.lua) so users
+--- see only their own stack. Set COSMIC_FULL_TRACEBACK=1 to disable trimming.
+--- @param err any The error value
+--- @return string Trimmed traceback string
+local function trim_traceback(err: any): string
+  local tb = debug.traceback(tostring(err), 2)
+  if os.getenv("COSMIC_FULL_TRACEBACK") then
+    return tb
+  end
+  local lines: {string} = {}
+  local trimmed = false
+  for line in (tb .. "\n"):gmatch("([^\n]*)\n") do
+    if not trimmed and line:match("\t/zip/main%.lua:") then
+      trimmed = true
+    end
+    if not trimmed then
+      lines[#lines + 1] = line
+    end
+  end
+  return table.concat(lines, "\n")
+end
+
+local record RunModule
+  augment_module_errors: function(err: string): string
+  trim_traceback: function(err: any): string
+end
+
+local M: RunModule = {
+  augment_module_errors = augment_module_errors,
+  trim_traceback = trim_traceback,
+}
+
+return M

--- a/lib/cosmic/sqlite_example.tl
+++ b/lib/cosmic/sqlite_example.tl
@@ -101,4 +101,23 @@ local function Example_exec_params()
   -- Tokyo	13960000
 end
 
+-- Example_query_like demonstrates substring matching with LIKE
+-- (the SQL wildcard is %, not *)
+local function Example_query_like()
+  local sqlite = require("cosmic.sqlite")
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE files (path TEXT)")
+  db:exec("INSERT INTO files (path) VALUES (?)", "src/main.tl")
+  db:exec("INSERT INTO files (path) VALUES (?)", "src/util.tl")
+  db:exec("INSERT INTO files (path) VALUES (?)", "docs/readme.md")
+
+  for row in db:query("SELECT path FROM files WHERE path LIKE ?", "%src%") do
+    print(row.path)
+  end
+  db:close()
+  -- Output:
+  -- src/main.tl
+  -- src/util.tl
+end
+
 return {}

--- a/lib/cosmic/style.tl
+++ b/lib/cosmic/style.tl
@@ -45,7 +45,9 @@ end
 --- Check that top-level `local function NAME(` is immediately called as `NAME()` on
 --- the next non-blank line after its closing `end`. Heuristic: track depth of
 --- `function`/`end` keywords; when depth returns to 0, check the next line.
-local function check_assert_order(file: string, lines: {string}): {Diagnostic}
+--- This enforces the test/example file convention of calling each test_* function
+--- right after defining it, so failures point to the right function.
+local function check_call_after_define(file: string, lines: {string}): {Diagnostic}
   local diagnostics: {Diagnostic} = {}
   local i = 1
   while i <= #lines do
@@ -81,10 +83,10 @@ local function check_assert_order(file: string, lines: {string}): {Diagnostic}
               file = file,
               line = def_line,
               col = 1,
-              rule = "assert-order",
+              rule = "call-after-define",
               message = string.format(
-                "%s:%d: function '%s' not called immediately after definition",
-                file, def_line, fname
+                "function '%s' must be called immediately after its definition (test/example files call each test_* function right after defining it)",
+                fname
               ),
             })
         end
@@ -138,7 +140,7 @@ local function lint_file(path: string): {Diagnostic}
       table.insert(diagnostics, d)
     end
 
-    local order_diags = check_assert_order(path, lines)
+    local order_diags = check_call_after_define(path, lines)
     for _, d in ipairs(order_diags) do
       table.insert(diagnostics, d)
     end
@@ -153,6 +155,6 @@ return {
   DEFAULT_COLUMN_WIDTH = DEFAULT_COLUMN_WIDTH,
   check_file_length = check_file_length,
   check_column_length = check_column_length,
-  check_assert_order = check_assert_order,
+  check_call_after_define = check_call_after_define,
   lint_file = lint_file,
 }

--- a/lib/cosmic/style_test.tl
+++ b/lib/cosmic/style_test.tl
@@ -38,8 +38,10 @@ local function test_style_long_line()
 end
 test_style_long_line()
 
--- File with out-of-order assert (function not immediately called): should fail
-local function test_style_assert_order()
+-- File with function not called immediately after definition: should fail
+-- The rule is 'call-after-define': each test_* function must be called right
+-- after its definition so failures point to the right function.
+local function test_style_call_after_define()
   local input = write_temp("style_order.tl", [[
 local function foo()
   return 1
@@ -52,9 +54,9 @@ bar()
 ]])
 
   local ok, _ = spawn.spawn({cosmic, "--check-style", input}):read()
-  assert(not ok, "cosmic --check-style should fail on out-of-order assert")
+  assert(not ok, "cosmic --check-style should fail when function not called immediately after definition")
 end
-test_style_assert_order()
+test_style_call_after_define()
 
 -- Missing file: should fail
 local function test_style_missing_file()

--- a/lib/cosmic/teal.tl
+++ b/lib/cosmic/teal.tl
@@ -302,10 +302,69 @@ local function format_issues(issues: {Issue}): string
   return table.concat(lines, "\n")
 end
 
+--- Return a fix-hint line for a known Teal type-check error pattern, or nil.
+--- Matches the three most common traps that cost edit-check cycles:
+---   1. got number, expected integer (string index/length requires integer)
+---   2. got X | nil, expected X (nil not narrowed before use)
+---   3. excess return values (multiple returns captured incorrectly)
+---   4. <any type> operations (ipairs, index, concat on any)
+--- @param msg string The error message to match
+--- @return string|nil A short hint string, or nil if no hint applies
+local function hint_for_message(msg: string): string
+  -- Pattern 1: number/integer mismatch
+  if msg:find("got number, expected integer") then
+    return "  hint: annotate the variable `: number`, or convert with math.tointeger; integer is required for string indices/lengths"
+  end
+  -- Pattern 2: nil union not narrowed (X | nil where X expected)
+  if msg:find("%| nil") and msg:find("expected") then
+    return "  hint: narrow first, e.g. `if v == nil then return nil, \"missing\" end`"
+  end
+  -- Pattern 3: excess return values (wrong number of returns)
+  if msg:find("excess return values") then
+    return "  hint: capture multiple returns first: `local v, err = f(...)`"
+  end
+  -- Pattern 4a: ipairs on any
+  if msg:find("attempting ipairs on something that's not an array") then
+    return "  hint: cast first, e.g. `local items = data as {any}`"
+  end
+  -- Pattern 4b: concat with any type
+  if msg:find("cannot use operator '%.%.'") and msg:find("<any type>") then
+    return "  hint: cast first, e.g. `local s = val as string`"
+  end
+  -- Pattern 4c: index on any type
+  if msg:find("cannot index") and msg:find("<any type>") then
+    return "  hint: cast first, e.g. `local obj = val as {string: any}`"
+  end
+  return nil
+end
+
+--- Format issues with optional fix-hints for known Teal type-check traps.
+--- Appends one hint line after each matching error. No duplicate hints per error.
+--- @param issues {Issue} List of issues to format
+--- @return string Formatted issues with hints, one issue (plus optional hint) per pair of lines
+local function format_issues_with_hints(issues: {Issue}): string
+  local lines: {string} = {}
+  for _, issue in ipairs(issues) do
+    table.insert(lines, string.format("%s:%d:%d: %s: %s",
+        issue.file,
+        issue.line,
+        issue.column,
+        issue.severity,
+        issue.message))
+    local hint = hint_for_message(issue.message)
+    if hint then
+      table.insert(lines, hint)
+    end
+  end
+  return table.concat(lines, "\n")
+end
+
 local record TealModule
   compile: function(input_path: string, opts?: CompileOpts): CompileResult
   check: function(input_path: string, opts?: CheckOpts): CheckResult
   format_issues: function(issues: {Issue}): string
+  format_issues_with_hints: function(issues: {Issue}): string
+  hint_for_message: function(msg: string): string
   get_default_include_dirs: function(): {string}
 end
 
@@ -313,6 +372,8 @@ local M: TealModule = {
   compile = compile,
   check = check,
   format_issues = format_issues,
+  format_issues_with_hints = format_issues_with_hints,
+  hint_for_message = hint_for_message,
   get_default_include_dirs = get_default_include_dirs,
 }
 

--- a/lib/cosmic/testrun.tl
+++ b/lib/cosmic/testrun.tl
@@ -111,6 +111,30 @@ local function run(argv: {string}, output_base: string): integer
     return 1
   end
 
+  -- Best-effort: record the test_* functions defined in the test file so
+  -- report() can show how many a passing file contains (files follow the
+  -- define-then-call-immediately convention enforced by --check-style).
+  local test_names: {string} = {}
+  for _, a in ipairs(argv) do
+    if a:match("_test%.tl$") then
+      local src = cio.slurp(a)
+      if src then
+        for line in src:gmatch("[^\n]+") do
+          local tname = line:match("^local function (test_[%w_]+)")
+          if tname then
+            test_names[#test_names + 1] = tname
+          end
+        end
+      end
+    end
+  end
+  if #test_names > 0 then
+    local tok, terr = cio.barf(output_base .. ".tests", table.concat(test_names, "\n") .. "\n")
+    if not tok then
+      io.stderr:write("testrun: " .. (terr or "failed to write .tests") .. "\n")
+    end
+  end
+
   instrument.finish(span, exit_code)
   return exit_code
 end
@@ -122,6 +146,7 @@ local record TestResult
   stdout: string
   stderr: string
   status: string -- "pass", "fail", "skip"
+  test_count: integer -- test_* functions in the file (0 when unknown)
 end
 
 --- Normalize a path to a .got file base path.
@@ -158,6 +183,7 @@ local function report(paths: {string}): integer
           stdout = "",
           stderr = "cannot read .got file",
           status = "fail",
+          test_count = 0 as integer,
         } as TestResult)
     else
       local exit_code = (tonumber(got_content:match("^(%d+)")) or -1) as integer
@@ -165,6 +191,15 @@ local function report(paths: {string}): integer
       -- Read stdout and stderr
       local stdout_content = cio.slurp(base .. ".out") or ""
       local stderr_content = cio.slurp(base .. ".err") or ""
+
+      -- Read recorded test_* function names, when present
+      local test_count = 0
+      local tests_content = cio.slurp(base .. ".tests")
+      if tests_content then
+        for _ in tests_content:gmatch("[^\n]+") do
+          test_count = test_count + 1
+        end
+      end
 
       local status: string
       if exit_code == 0 then
@@ -184,6 +219,7 @@ local function report(paths: {string}): integer
           stdout = stdout_content,
           stderr = stderr_content,
           status = status,
+          test_count = test_count as integer,
         } as TestResult)
     end
   end
@@ -216,7 +252,11 @@ local function report(paths: {string}): integer
         end
       end
     end
-    io.write(icon .. " " .. result.name .. timing .. "\n")
+    local count_note = ""
+    if result.status == "pass" and result.test_count > 0 then
+      count_note = string.format(" (%d test functions)", result.test_count)
+    end
+    io.write(icon .. " " .. result.name .. count_note .. timing .. "\n")
   end
 
   -- Print summary

--- a/skills/cosmic/SKILL.md
+++ b/skills/cosmic/SKILL.md
@@ -56,6 +56,7 @@ return { greet = greet }
 
 run `cosmic --docs guide.<topic>` or see the files below for deeper coverage:
 
+- [gotchas](gotchas.md) — Teal gotchas for newcomers (integer vs number, any casts, io shadowing)
 - [testing](testing.md) — writing and running tests (`cosmic --test`, assert patterns)
 - [checking](checking.md) — type checking with `cosmic --check-types`
 - [formatting](formatting.md) — code formatting with `cosmic --format` / `--check-format`

--- a/skills/cosmic/formatting.md
+++ b/skills/cosmic/formatting.md
@@ -8,24 +8,40 @@ cosmic enforces consistent code formatting via `cosmic --format` and `cosmic --c
 - LF line endings (no CRLF)
 - consistent spacing around operators and keywords
 - all `.tl` files must be <=500 lines
+- no spaces inside table braces:
+
+```teal
+local t = { a = 1 }   -- wrong
+local t = {a = 1}     -- right
+```
+
+- a table constructor passed as a function argument indents its contents
+  two levels (4 spaces) past the call, with the closing `})` one level in:
+
+```teal
+local f = go({
+    key = 1,
+  })
+```
+
+- anonymous function bodies in argument lists follow the same shape —
+  body two levels in, `end)` one level in:
+
+```teal
+walk(dir, function(p: string)
+    print(p)
+  end)
+```
+
+when in doubt, write the file and run `cosmic --fix file.tl` — the
+formatter is the source of truth for these rules.
 
 ## Commands
 
 ```bash
 cosmic --format file.tl           # print formatted output to stdout
+cosmic --fix file.tl              # format the file in place
 cosmic --check-format file.tl     # check if file matches formatted output
-```
-
-`--format` writes the formatted file to stdout. to update a file in place, redirect:
-
-```bash
-cosmic --format file.tl > file.tl.tmp && mv file.tl.tmp file.tl
-```
-
-or use `--format` with `--output` and `--write-if-changed` for atomic writes:
-
-```bash
-cosmic --format file.tl --output file.tl --write-if-changed
 ```
 
 `--check-format` compares the original file against the formatted output. if they differ, it reports the first mismatched line on stderr and exits nonzero:

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -1,0 +1,136 @@
+# Teal Gotchas for Newcomers
+
+common errors that trip up agents and developers new to Teal. each entry shows the wrong pattern, the error it produces, and the fix.
+
+## 1. integer vs number
+
+Teal distinguishes `integer` from `number`. string indices (`string.sub`, `string.byte`, `table` lookups) and some C bindings require `integer`. arithmetic and C status returns are `number`.
+
+**wrong:**
+```teal
+local n: number = 5
+local s = ("hello"):sub(n, n)  -- error: got number, expected integer
+```
+
+**right:**
+```teal
+-- option A: annotate the literal as integer
+local n: integer = 5
+local s = ("hello"):sub(n, n)
+
+-- option B: convert at call site
+local n: number = some_computation()
+local s = ("hello"):sub(math.tointeger(n), math.tointeger(n))
+```
+
+`WEXITSTATUS` and similar status-decoding functions return `number`, not `integer`:
+```teal
+local code: number = child.WEXITSTATUS(status)
+```
+
+## 2. traversing `any` from json.decode
+
+`json.decode` returns `any`. you cannot index or iterate `any` directly — you must cast to a concrete type first.
+
+**wrong:**
+```teal
+local data = json.decode(input)
+for _, item in ipairs(data) do  -- error: attempting ipairs on something that's not an array: <any type>
+```
+
+**right:**
+```teal
+local data = json.decode(input) as {any}         -- cast to array
+for _, raw in ipairs(data) do
+  local item = raw as {string: any}              -- cast each element
+  print(item["name"] as string)
+end
+```
+
+for nested maps use chained casts:
+```teal
+local obj = json.decode(input) as {string: any}
+local tags = obj["tags"] as {string}
+```
+
+## 3. `arg` elements are `string | nil`
+
+the global `arg` table has type `{string | nil}`. accessing `arg[1]` without a guard may give you `nil`, which causes a type error when used where a `string` is expected.
+
+**wrong:**
+```teal
+local name = arg[1]:upper()  -- error: cannot index nil
+```
+
+**right:**
+```teal
+local name = (arg[1] or "default"):upper()
+
+-- or with an explicit check:
+if not arg[1] then
+  io.stderr:write("usage: myscript <name>\n")
+  os.exit(1)
+end
+local name = (arg[1] as string):upper()
+```
+
+## 4. multi-return capture — `db:query` and similar
+
+functions that return `(iterator, state, initial)` (like `db:query`) cannot be wrapped inside another expression — the extra returns are discarded.
+
+**wrong:**
+```teal
+for row in db:query("SELECT * FROM t"), nil, nil do  -- syntax error / wrong returns
+```
+
+**right:**
+```teal
+for row in db:query("SELECT * FROM t") do
+  print(row.id)
+end
+```
+
+if you need to capture both the iterator and an error return, assign to locals first:
+```teal
+local rows, err = db:query("SELECT * FROM t")
+if not rows then
+  error("query failed: " .. tostring(err))
+end
+for row in rows do
+  print(row.id)
+end
+```
+
+## 5. local modules — `require` path resolution
+
+`require("mymod")` resolves relative to the script's directory, not the current working directory. you do not need a `./` prefix (both work).
+
+```teal
+-- both are equivalent when mymod.tl is in the same directory:
+local m = require("mymod")
+local m2 = require("./mymod")  -- also works
+```
+
+if your module is in a subdirectory:
+```teal
+local m = require("subdir.mymod")   -- loads subdir/mymod.tl
+```
+
+## 6. naming `cosmic.io` as `io`
+
+`require("cosmic.io")` returns the cosmic.io module. if you bind it to a local named `io` you shadow Lua's built-in `io` library and lose access to `io.stderr`, `io.stdin`, `io.stdout`.
+
+**wrong:**
+```teal
+local io = require("cosmic.io")   -- hides io.stderr!
+io.stderr:write("error\n")        -- runtime error: attempt to index nil
+```
+
+**right:**
+```teal
+local cio = require("cosmic.io")  -- keep built-in io accessible
+cio.barf("out.txt", data)
+io.stderr:write("error: " .. msg .. "\n")  -- standard Lua io still works
+```
+
+cosmic.io has no stderr/stdout/stdin handles — use Lua's `io.stderr` directly for stream output.

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -134,3 +134,24 @@ io.stderr:write("error: " .. msg .. "\n")  -- standard Lua io still works
 ```
 
 cosmic.io has no stderr/stdout/stdin handles — use Lua's `io.stderr` directly for stream output.
+
+## 7. `arg[0]` is not the interpreter — use `arg[-1]` to re-invoke cosmic
+
+when a script needs to spawn the cosmic binary itself (e.g. to run another
+script as a child process), `arg[0]` is the script path as the runtime sees
+it (`/zip/main.lua` for the embedded entry point), not the interpreter.
+the interpreter path lives at `arg[-1]`, and because `arg` is typed
+`{string}`, negative indices need `rawget` in strict mode.
+
+**wrong:**
+```teal
+local child = require("cosmic.child")
+local h = child.spawn({arg[0], "worker.tl"})  -- spawns /zip/main.lua: fails
+```
+
+**right:**
+```teal
+local child = require("cosmic.child")
+local cosmic_bin = rawget(arg, -1) as string  -- e.g. "./cosmic"
+local h = child.spawn({cosmic_bin, "worker.tl"})
+```

--- a/skills/cosmic/testing.md
+++ b/skills/cosmic/testing.md
@@ -34,6 +34,18 @@ key rules:
 
 ## Assert Patterns
 
+the preferred way to write assertions is with `cosmic.assert`, which produces auto-formatted failure messages:
+
+```teal
+local a = require("cosmic.assert")
+
+a.eq(result, "expected", "label")      -- equality with diff on failure
+a.ne(result, nil, "should not be nil")
+a.ok(result > 0, "expected positive")
+```
+
+plain `assert()` also works and is fine for simple checks:
+
 ```teal
 -- value equality
 assert(result == "expected", "got: " .. tostring(result))
@@ -80,21 +92,60 @@ test_write_file()
 
 ## Running Tests
 
+`cosmic --test` runs a test file and captures its output. the command form is:
+
 ```bash
 cosmic --test <output_prefix> <cosmic_binary> <test_file>
 ```
 
-`cosmic --test` captures stdout/stderr/exit-code to `.out`/`.err`/`.got` files. use `cosmic --report` to aggregate results:
+**end-to-end example.** given `foo_test.tl`:
 
 ```bash
-cosmic --report o/*.test.got
+# run the test, capturing output to o/foo.{out,err,got}
+cosmic --test o/foo ./cosmic foo_test.tl
 ```
 
-with `cosmic --make`, test targets are generated automatically:
+this produces three files:
+- `o/foo.out` — the test's stdout
+- `o/foo.err` — the test's stderr
+- `o/foo.got` — the exit code (a single integer, e.g. `0` for pass, `1` for fail)
+
+`--test` propagates the test's exit code, so it is safe in shell `&&`-chains:
 
 ```bash
-cosmic --make . test          # generate Makefile and run tests
-make test                     # if you have a saved Makefile
+cosmic --test o/foo ./cosmic foo_test.tl && echo "passed"
+```
+
+to see a passing summary:
+
+```bash
+cosmic --report o/foo.got
+# foo_test.tl ... ok
+```
+
+when a test fails the `.out` and `.err` files contain the failure output:
+
+```bash
+# after a failing run:
+cat o/foo.out
+# assertion failed: expected 1, got 2
+
+cosmic --report o/foo.got
+# foo_test.tl ... FAIL
+# 1 failed
+```
+
+`--report` accepts multiple `.got` files and aggregates results across a whole test suite:
+
+```bash
+cosmic --report o/*.tl.test.got
+```
+
+with `bin/make`, test targets are generated automatically from `*_test.tl` files:
+
+```bash
+bin/make test              # run all tests
+bin/make test only=sqlite  # filter by pattern
 ```
 
 ## Writing Examples

--- a/sys/help.md
+++ b/sys/help.md
@@ -6,6 +6,7 @@ Cosmic options:
   --compile <file.tl>           compile Teal file to Lua, lax mode (stdout)
   --include-dir <dir>           add search path for --compile/--check-types (repeatable)
   --format <file>               format Teal or Lua file (stdout)
+  --fix <file>                  format Teal or Lua file in place
   --write-if-changed            with --compile/--format and --output: skip write if unchanged
   --check-format <file>         check file formatting (diff on stderr)
   --check-types <file.tl>       type-check a Teal file, strict mode
@@ -41,6 +42,7 @@ Documentation:
   cosmic --docs [query]      look up docs from the command line
   cosmic --docs guide        list available guides
   cosmic --docs guide.testing  show a specific guide
+  cosmic --docs guide.gotchas  common pitfalls (integer vs number, any casts, arg)
   help(<query>)              look up docs in the REPL (interactive only)
 
 Low-level cosmo.* bindings are available but hidden by default.

--- a/sys/help.md
+++ b/sys/help.md
@@ -35,6 +35,7 @@ Standard lua options:
 Environment variables:
   COSMIC_NO_REQUIRE_HINTS    disable helpful module-not-found suggestions
   COSMIC_NO_WELCOME          suppress welcome message on first run
+  COSMIC_FULL_TRACEBACK      show full stack traceback including internal frames
 
 Documentation:
   cosmic --docs [query]      look up docs from the command line


### PR DESCRIPTION
## Summary

Agent-usability effort across three rounds, all verified empirically:

1. **Study (round 1):** four Sonnet agents were each given a clean directory with only the cosmic binary (`8c7e138`) and a coding task (JSON CLI, module+tests, sqlite indexer, child-process TCP demo). All completed; 17 prioritized findings were extracted and re-verified against the binary.
2. **Fixes:** all 17 findings addressed.
3. **Re-test (round 2):** identical prompts against the rebuilt binary — sqlite task went from ~17 errors (incl. a silent path-doubling bug) to a first-try type check; no silent bugs anywhere; the new hints/guides were used successfully in the wild. Seven surviving findings were collected.
4. **Round 3:** all seven backlog items fixed.

Full narrative with per-round results: `docs/agent-usability.md`.

## What changed

**Bug fixes (rounds 1–2)**
- Require did-you-mean hints fire for `.tl` scripts; Teal compile-time module errors get the same suggestions
- `--docs` resolves re-exported functions (`cosmic.fs.walk`) and record methods (`cosmic.sqlite.query`); `--examples` accepts bare module names
- Doc renderer no longer garbles multi-line function types in records
- `--test` with missing args reports usage instead of `unknown option`
- Runtime tracebacks trimmed at the cosmic entry point (`COSMIC_FULL_TRACEBACK=1` restores)
- Makefile: doc index generated with this tree's modules, not the bootstrap's stale embedded copies

**Round 3**
- **`--fix <file>`** formats in place; `--check-format`'s hint advertises it
- **Nested records are real docs entries**: `--docs cosmic.fs_types.WalkStat` resolves; the parser previously flattened nested records into one misattributed blob; symbol-not-found now lists available symbols inline; record names join cross-module did-you-mean
- **`--report` shows `✓ foo (14 test functions)`** via a `<out>.tests` sidecar written by `--test`
- `arg` table layout (`arg[-1]` interpreter, `arg[0]` `/zip/main.lua`) documented in `cosmic.proc` + gotchas
- Formatter rules documented empirically in `guide.formatting` (replacing an in-place recipe whose flag order didn't work); `--help` points to `guide.gotchas`
- sqlite `LIKE` example, `ip.parse` cross-ref in net docs, `child.Pipe.fd` note

**Error-message ergonomics**
- `--check-types` appends fix-hints for the common Teal traps (number/integer, nil unions, `any` operations, excess returns)
- `assert-order` style rule renamed to `call-after-define` with a message stating the convention
- `--check-format` renders whitespace-only diffs visibly

**Docs & guides**
- `fs.walk` visitor params correctly documented (full path + basename) with new examples; `WalkStat` import path documented
- New `guide.gotchas` (7 entries); `cosmic.io` shadowing warning; testing guide rewritten around a copy-pasteable `--test`/`--report` block; child+pipe worked example; module pages lead with a quick example

**New stdlib**
- `cosmic.assert`: `eq`/`ne`/`ok`/`err` with deep equality and auto-formatted failure messages
- `cosmic.net.listen_tcp`: bind/listen one-liner returning the actual bound port

## Verification

Each round's changes were verified against a clean rebuild (`--docs` lookups, `--fix` round-trip, hint output, report counts). Round 2 was a full clean-room re-run with fresh agents; round 3 was verified directly (sub-agent capacity unavailable). All CI stages (`format`, `teal`, `test`, `example`, `lint`) pass locally; note `fetch_example.tl` depends on httpbin.org and can flake — flagged in the report as a backlog item.

https://claude.ai/code/session_01LWokrXTjrG6XJSU5uSY5z6