### PR TITLE
Agent usability round 4: docs lookup, net examples, recipes guide (+ round-3 re-test results)

### DIFF
--- a/docs/agent-usability.md
+++ b/docs/agent-usability.md
@@ -243,3 +243,62 @@ clean-room run.
 New backlog candidate observed during this round: `fetch_example.tl`
 examples depend on httpbin.org and fail intermittently in CI; examples
 should avoid third-party services (e.g. spin up a local listener).
+
+---
+
+# Round 3 re-test — clean-room verification
+
+After the round-3 fixes merged (#413), the experiment was repeated a third
+time: four fresh Sonnet agents, identical prompts, sandboxes containing
+only the merged binary.
+
+## Results across all three rounds
+
+| task | round 1 | round 2 | round 3 |
+|------|---------|---------|---------|
+| JSON stats CLI | clean, cycle-burning confusion, ~23 calls | 1 format error, 21 calls | **0 checker errors**, 16 calls |
+| module + tests | 1 type error + `.got.got` maze, ~25 calls | 1 type error, 24 calls | **0 errors of any kind**, 22 calls |
+| sqlite indexer | ~17 errors + silent path bug, ~70 calls | 2 errors, 36 calls | 1 warning + 1 format miss, 26 calls |
+| child + TCP | 2 errors + silent race, ~39 calls | 3 errors, 52 calls | 1 type error, 37 calls |
+
+No silent bugs anywhere in round 3. Round-3 fixes observed working
+in the wild:
+
+- `--report` printed `✓ slug_test (14 test functions)` — the per-function
+  count was used to confirm coverage.
+- The sqlite agent's format mismatch was fixed with a single `--fix`
+  invocation, exactly as the new hint instructed.
+- `--docs cosmic.fs_types.WalkStat` resolved; the fs.walk "do not join"
+  warning and the new sqlite `LIKE` example were both consumed directly.
+- The child+TCP agent used `rawget(arg, -1)` from gotchas entry 7 and
+  explicitly noted it would otherwise have burned time on a silently
+  broken `arg[0]` spawn; it also used `listen_tcp` with port 0 and
+  pipe-based readiness.
+- Agents now front-load `guide.gotchas` and `guide.formatting` before
+  writing code — the two zero-error runs both did this.
+- The one type error that occurred (`os.exit` wants `integer | boolean`)
+  carried the number/integer fix-hint and was resolved in one edit.
+
+## Round-4 backlog
+
+1. **`--docs` exact-module-name queries should short-circuit the fuzzy
+   search** (three independent complaints): `--docs io` / `--docs string` /
+   `--docs fs` dump a flat substring grab-bag instead of leading with the
+   module page. Related inconsistency: `--docs child.Handle` 404s while
+   `--docs cosmic.child` and colon-forms work — short-name symbol lookups
+   should resolve or suggest.
+2. **`cosmic.net` has no examples** — the module most central to the TCP
+   task returns "No examples for cosmic.net"; add a minimal echo
+   server/client pair. Also document `Socket:recv`/`send`/`accept` EOF and
+   blocking semantics (what signals "connection closed").
+3. **New gotchas entries:** `print(f(...))` prints every return of a
+   `(value, error)` function (trailing `nil` trap — capture first);
+   `os.exit` requires `integer | boolean`, so a `number`-returning `main`
+   breaks `os.exit(main())`.
+4. **Cross-reference the `arg[-1]` gotcha from `cosmic.child` spawn docs**
+   — that is where agents look first when spawning cosmic-as-child.
+5. **A `guide.recipes` cookbook** for common module compositions
+   (walk+hash+sqlite indexing; a CLI script skeleton: args → slurp →
+   decode → transform → encode → print with error exits).
+6. **`--check-format` could show context lines** around the mismatch;
+   `--help` could carry one-line argument shapes for `--test`/`--report`.

--- a/lib/cosmic/child.tl
+++ b/lib/cosmic/child.tl
@@ -87,8 +87,6 @@ local function make_pipe(fd: number): Pipe
   return pipe
 end
 
--- Low-level primitives --
-
 --- Creates a new process (fork).
 --- @return number The child process id in parent, 0 in child
 local function fork(): number
@@ -189,6 +187,7 @@ end
 --- Spawns a child process with I/O control. Uses fexecve for /zip/ paths.
 --- When Opts.stdout/stderr are fds they are dup2'd into child (handle fields
 --- nil); MUST close the write end before reading. See Example_spawn_pipe.
+--- To spawn cosmic itself, use `rawget(arg, -1)` — NOT arg[0] (gotchas #7).
 --- @param argv {string} Command and arguments
 --- @param opts Opts? Spawn options
 --- @return Handle, string? Process handle or nil + error

--- a/lib/cosmic/docs.tl
+++ b/lib/cosmic/docs.tl
@@ -400,6 +400,12 @@ local function run(query?: string): DocsResult
     return {ok = true, output = docs_render.render_module(query, index.modules[query])}
   end
 
+  -- Bare module names short-circuit to their cosmic.* page, not fuzzy search
+  if index.modules["cosmic." .. query] then
+    local full = "cosmic." .. query
+    return {ok = true, output = docs_render.render_module(full, index.modules[full])}
+  end
+
   -- Try splitting query into module + remainder by iterating splits longest-to-shortest
   local parts: {string} = {}
   for part in query:gmatch("[^%.]+") do
@@ -410,6 +416,9 @@ local function run(query?: string): DocsResult
   local remainder: {string} = {}
   for i = #parts - 1, 1, -1 do
     local candidate = table.concat(parts, ".", 1, i)
+    if not index.modules[candidate] and index.modules["cosmic." .. candidate] then
+      candidate = "cosmic." .. candidate
+    end
     if index.modules[candidate] then
       matched_mod = candidate
       for j = i + 1, #parts do

--- a/lib/cosmic/main_handlers.tl
+++ b/lib/cosmic/main_handlers.tl
@@ -220,6 +220,10 @@ local function handle_check_format(file: string): integer
       local have = orig_lines[i] or "<eof>"
       local want = fmt_lines[i] or "<eof>"
       io.stderr:write(string.format("%s:%d: format mismatch\n", file, i))
+      -- Context before the mismatch makes indentation-level errors legible
+      for c = math.max(1, i - 2), i - 1 do
+        io.stderr:write(string.format("        %s\n", orig_lines[c]))
+      end
       -- When lines look identical but differ only in whitespace, render it visibly
       if have:gsub("%s", "") == want:gsub("%s", "") then
         io.stderr:write(string.format("  have: %s  (whitespace differs)\n", render_whitespace(have)))

--- a/lib/cosmic/net_example.tl
+++ b/lib/cosmic/net_example.tl
@@ -1,0 +1,49 @@
+--- Examples for cosmic.net module.
+
+-- Example_echo demonstrates a minimal TCP echo exchange on loopback:
+-- listen on an OS-assigned port, connect, accept, echo one message back
+local function Example_echo()
+  local net = require("cosmic.net")
+  local srv, port, err = net.listen_tcp(0x7f000001, 0)
+  assert(srv, err)
+  assert(port > 0)
+
+  local client, cerr = net.connect_tcp(0x7f000001, port)
+  assert(client, cerr)
+
+  local conn, _, _, aerr = srv:accept()
+  assert(conn, aerr)
+
+  client:send("hello")
+  local msg = conn:recv()
+  conn:send("echo: " .. msg)
+  print(client:recv())
+
+  client:close()
+  conn:close()
+  srv:close()
+  -- Output:
+  -- echo: hello
+end
+
+-- Example_recv_eof demonstrates end-of-stream detection: recv returns an
+-- empty string (not nil) when the peer closes the connection
+local function Example_recv_eof()
+  local net = require("cosmic.net")
+  local srv, port, err = net.listen_tcp(0x7f000001, 0)
+  assert(srv, err)
+
+  local client = net.connect_tcp(0x7f000001, port)
+  local conn = srv:accept()
+
+  client:close()
+  local data = conn:recv()
+  print(data == "" and "eof" or "data")
+
+  conn:close()
+  srv:close()
+  -- Output:
+  -- eof
+end
+
+return {}

--- a/lib/cosmic/net_socket.tl
+++ b/lib/cosmic/net_socket.tl
@@ -4,25 +4,47 @@ local unix = require("cosmo.unix")
 local Errno = require("cosmic.errno").Errno
 
 --- Socket handle for network I/O.
---- Supports Lua 5.4's to-be-closed via __close metamethod.
+--- Sockets are BLOCKING by default: recv and accept wait until data or a
+--- connection arrives. Supports Lua 5.4's to-be-closed via __close.
 local record Socket
+  --- The underlying file descriptor.
   fd: number
+  --- Close the socket.
   close: function(self: Socket): boolean
+  --- True when the socket has been closed.
   closed: function(self: Socket): boolean
+  --- Shut down reading and/or writing (unix.SHUT_RD/WR/RDWR).
   shutdown: function(self: Socket, how?: number): boolean, string
+  --- Send data; returns bytes sent, or nil + error.
   send: function(self: Socket, data: string, flags?: number): number, string
+  --- Send a datagram to ip:port; returns bytes sent, or nil + error.
   sendto: function(self: Socket, data: string, ip: number, port: number, flags?: number): number, string
+  --- Receive up to bufsiz bytes (blocks until data arrives).
+  --- Returns "" (empty string) with no error when the peer closed the
+  --- connection (EOF); returns nil + error message on failure.
   recv: function(self: Socket, bufsiz?: number, flags?: number): string, string
+  --- Receive a datagram; returns data, sender ip, sender port.
   recvfrom: function(self: Socket, bufsiz?: number, flags?: number): string, number, number, string
+  --- Local address as (ip, port); use after bind(0) for the real port.
   getsockname: function(self: Socket): number, number, string
+  --- Peer address as (ip, port).
   getpeername: function(self: Socket): number, number, string
+  --- Bind to a local ip:port (integers; port 0 = OS-assigned).
   bind: function(self: Socket, ip?: number, port?: number): boolean, string
+  --- Bind to a unix-domain socket path.
   bind_unix: function(self: Socket, path: string): boolean, string
+  --- Start listening for connections.
   listen: function(self: Socket, backlog?: number): boolean, string
+  --- Accept one connection (blocks until a client connects).
+  --- Returns the connection socket, peer ip, peer port.
   accept: function(self: Socket, flags?: number): Socket, number, number, string
+  --- Connect to ip:port (integers; see cosmic.ip.parse for strings).
   connect: function(self: Socket, ip: number, port: number): boolean, string
+  --- Connect to a unix-domain socket path.
   connect_unix: function(self: Socket, path: string): boolean, string
+  --- Read a socket option value.
   getsockopt: function(self: Socket, level: number, optname: number): number | boolean, string
+  --- Set a socket option value.
   setsockopt: function(self: Socket, level: number, optname: number, value: number | boolean): boolean, string
 end
 

--- a/skills/cosmic/SKILL.md
+++ b/skills/cosmic/SKILL.md
@@ -57,6 +57,7 @@ return { greet = greet }
 run `cosmic --docs guide.<topic>` or see the files below for deeper coverage:
 
 - [gotchas](gotchas.md) — Teal gotchas for newcomers (integer vs number, any casts, io shadowing)
+- [recipes](recipes.md) — end-to-end patterns (CLI skeleton, walk+hash+sqlite, self-spawn, TCP echo)
 - [testing](testing.md) — writing and running tests (`cosmic --test`, assert patterns)
 - [checking](checking.md) — type checking with `cosmic --check-types`
 - [formatting](formatting.md) — code formatting with `cosmic --format` / `--check-format`

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -155,3 +155,51 @@ local child = require("cosmic.child")
 local cosmic_bin = rawget(arg, -1) as string  -- e.g. "./cosmic"
 local h = child.spawn({cosmic_bin, "worker.tl"})
 ```
+
+## 8. `print(f(...))` prints every return value
+
+most cosmic functions return `(value, error)`. passing such a call directly
+as the last argument to `print` (or any function) passes BOTH returns —
+`print` renders the trailing `nil` as literal text, tab-separated. this
+passes the type checker and only shows up in the output.
+
+**wrong:**
+```teal
+print(json.encode(result))
+-- prints: {"count":6}	nil
+```
+
+**right:**
+```teal
+local encoded, err = json.encode(result)
+if err then
+  io.stderr:write("encode failed: " .. err .. "\n")
+  os.exit(1)
+end
+print(encoded)
+```
+
+(parenthesizing the call — `print((json.encode(result)))` — also truncates
+to one value, but capturing lets you check the error.)
+
+## 9. `os.exit` requires `integer | boolean`, not `number`
+
+a `main` function declared to return `number` breaks `os.exit(main())`
+with `got number, expected integer | boolean`.
+
+**wrong:**
+```teal
+local function main(): number
+  return 0
+end
+os.exit(main())
+```
+
+**right:**
+```teal
+local function main(): integer
+  return 0
+end
+os.exit(main())
+-- or convert at the call site: os.exit(math.tointeger(code) or 1)
+```

--- a/skills/cosmic/recipes.md
+++ b/skills/cosmic/recipes.md
@@ -1,0 +1,116 @@
+# Recipes
+
+end-to-end patterns composing several `cosmic.*` modules. each recipe is a
+complete script shape — adapt names and drop pieces you don't need.
+
+## CLI script skeleton
+
+args → read file → decode → transform → encode → print, with an error exit
+at every stage. this is the shape of most small cosmic tools.
+
+```teal
+local json = require("cosmic.json")
+local cio = require("cosmic.io")
+
+local function die(msg: string)
+  io.stderr:write("error: " .. msg .. "\n")
+  os.exit(1)
+end
+
+local function main(): integer
+  local path = arg[1]
+  if path == nil then
+    die("usage: tool.tl <input.json>")
+  end
+  local data, read_err = cio.slurp(path as string)
+  if not data then
+    die("cannot read '" .. tostring(path) .. "': " .. read_err)
+  end
+  local decoded, decode_err = json.decode(data)
+  if decode_err then
+    die("invalid JSON: " .. decode_err)
+  end
+  local items = decoded as {any}
+
+  -- transform: count the items
+  local result = {count = #items}
+
+  local encoded, encode_err = json.encode(result)
+  if encode_err then
+    die("encode failed: " .. encode_err)
+  end
+  print(encoded)
+  return 0
+end
+
+os.exit(main())
+```
+
+key details: `arg[1]` is `string | nil` (guard before use), `json.decode`
+returns `any` (cast before iterating), capture `encode`'s error return
+instead of passing the call straight to `print`, and `main` returns
+`integer` because `os.exit` rejects `number`.
+
+## index files into sqlite (walk + hash + sqlite)
+
+walk a tree, store path/size/digest with upsert semantics, query by
+substring.
+
+```teal
+local fs = require("cosmic.fs")
+local hash = require("cosmic.hash")
+local cio = require("cosmic.io")
+local sqlite = require("cosmic.sqlite")
+
+local db = sqlite.open("index.db")
+db:exec("CREATE TABLE IF NOT EXISTS files (" ..
+  "path TEXT PRIMARY KEY, size INTEGER, digest TEXT)")
+
+fs.walk("testdata", function(path: string, _name: string, st: any, _ctx: any)
+    -- path is the FULL path; do not join it with the basename
+    local stat = st as {mode: function(any): number, size: function(any): number}
+    if fs.is_file(stat:mode()) then
+      local data = cio.slurp(path)
+      if data then
+        db:exec("INSERT INTO files (path, size, digest) VALUES (?, ?, ?) " ..
+          "ON CONFLICT(path) DO UPDATE SET size = excluded.size, " ..
+          "digest = excluded.digest", path, stat:size(), hash.sha256_hex(data))
+      end
+    end
+  end)
+
+-- substring query: LIKE uses % as the wildcard, not *
+for row in db:query("SELECT * FROM files WHERE path LIKE ?", "%src%") do
+  print(row.path, row.size, row.digest)
+end
+db:close()
+```
+
+for the precise `WalkStat` type, import it:
+`local types = require("cosmic.fs_types")` and annotate the visitor's third
+parameter as `types.WalkStat`.
+
+## spawn cosmic as a child (self-reinvocation)
+
+run another script in a child process and read its output through a pipe.
+
+```teal
+local child = require("cosmic.child")
+
+local cosmic_bin = rawget(arg, -1) as string  -- NOT arg[0]; see gotchas #7
+local h, err = child.spawn({cosmic_bin, "worker.tl"})
+assert(h, err)
+local _, out = h:read()
+print(out)
+h:wait()
+```
+
+for a server child, have it print a readiness line (e.g. `READY <port>`)
+and block on `h.stdout:read(64)` instead of sleeping. see
+`cosmic --examples child` for the pipe-capture variant.
+
+## TCP echo pair (net)
+
+see `cosmic --examples net` for a runnable single-process echo exchange:
+`listen_tcp(0x7f000001, 0)` for an OS-assigned port, `connect_tcp`,
+`accept`, then `send`/`recv`. `recv` returns `""` on peer close.

--- a/sys/help.md
+++ b/sys/help.md
@@ -18,8 +18,10 @@ Cosmic options:
   --extract <dir>               extract zip contents to directory
   --benchmark <file.tl[:pat]>   run Benchmark_* functions, report timing
   --docs [query]                show documentation for module, symbol, or guide
-  --test <output> <cmd>...      run command, write .got/.out/.err
-  --report <paths>...           report on test results
+  --test <output> <cmd>...      run test, write <output>.{got,out,err}
+                                e.g. cosmic --test o/foo ./cosmic foo_test.tl
+  --report <paths>...           report on .got files written by --test
+                                e.g. cosmic --report o/foo.got
   --make [dir] [target]         generate Makefile, pipe to make -f -
   --skill <dir>                 write agent skill file (SKILL.md) to directory
   --welcome                     show welcome message


### PR DESCRIPTION
## Summary

Round-3 clean-room re-test results **plus the round-4 fixes for everything that re-test surfaced** — the backlog is fixed directly in this PR rather than recorded for later.

## Round-3 re-test (docs/agent-usability.md)

Four fresh Sonnet agents, identical prompts to rounds 1–2, sandboxes containing only the merged binary:

| task | round 1 | round 2 | round 3 |
|------|---------|---------|---------|
| JSON stats CLI | confusion cycles, ~23 calls | 1 format error | **0 checker errors**, 16 calls |
| module + tests | 1 type error + `.got.got` maze | 1 type error | **0 errors of any kind** |
| sqlite indexer | ~17 errors + silent path bug, ~70 calls | 2 errors, 36 | 1 warning + 1 format miss, 26 |
| child + TCP | 2 errors + silent race | 3 errors | 1 type error, no silent bugs |

## Round-4 fixes (this PR)

- **`--docs` exact-match lookup** (three independent complaints): bare module names short-circuit to their `cosmic.*` page (`--docs io` renders cosmic.io instead of a fuzzy grab-bag), and dotted lookups resolve short module names (`child.Handle` → `cosmic.child.Handle`)
- **`cosmic.net` examples + socket docs**: new runnable loopback-echo and recv-EOF examples; every `Socket` method documented, including blocking behavior and that `recv` returns `""` (not nil) on peer close — semantics verified empirically before documenting
- **Two new gotchas**: `print(f(...))` prints the trailing `nil` from `(value, error)` returns; `os.exit` requires `integer | boolean`
- **`child.spawn` docs cross-reference `rawget(arg, -1)`** so the re-invocation rule is visible where agents look first
- **New `guide.recipes`**: CLI script skeleton, walk+hash+sqlite indexing, cosmic self-spawn with pipe readiness, TCP echo pointers
- **`--check-format` shows two context lines** before the mismatch; **`--help` carries example invocations** for `--test`/`--report`

All CI stages pass locally (`fetch_test`/`fetch_example` can flake on external endpoints via the proxy — pre-existing, noted in the report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWokrXTjrG6XJSU5uSY5z6