### PR TITLE
Vendor cosmo.sandbox Lua modules from whilp/cosmopolitan

### DIFF
--- a/3p/cosmos/cook.mk
+++ b/3p/cosmos/cook.mk
@@ -1,6 +1,15 @@
 modules += cosmos
 cosmos_version := 3p/cosmos/version.lua
-cosmos_tests := 3p/cosmos/cosmos_test.tl
+cosmos_tests := 3p/cosmos/cosmos_test.tl 3p/cosmos/sandbox_test.tl
 cosmos_lua_bin = $(cosmos_dir)/lua
 cosmos_lua_debug_bin = $(cosmos_dir)/lua-debug
 cosmos_zip_bin = $(cosmos_dir)/zip
+
+# Vendored cosmo.sandbox Lua modules, embedded into the cosmic binary at
+# /zip/.lua/cosmo/sandbox/. These moved here from whilp/cosmopolitan (see
+# whilp/cosmopolitan#123): the C fork keeps only the syscall primitives
+# (unshare, setns, pivot_root, mount, landlock, ...) and this pure-Lua
+# orchestration layer lives with its consumer. Appended zip entries replace
+# same-name entries in the base binary, so these win over any copy still
+# embedded in the pinned cosmos release.
+cosmos_sandbox_lua := $(wildcard 3p/cosmos/sandbox/*.lua)

--- a/3p/cosmos/sandbox/fs.lua
+++ b/3p/cosmos/sandbox/fs.lua
@@ -1,0 +1,290 @@
+--- cosmo.sandbox.fs: filesystem-isolation helpers.
+---
+--- Composable pieces built on the `unix.*` mount + pivot_root +
+--- chroot primitives. The two main consumers are the netns-proxy and
+--- claude-code examples, but any caller building a private mount
+--- namespace can use them.
+---
+--- All helpers return `nil, unix.Errno` on failure, matching the
+--- rest of cosmo's lunix API. Callers add their own context string
+--- at the call site (they know what operation they were doing);
+--- programmatic errno checks use `err:errno() == unix.EACCES` and
+--- human-readable strings come from `tostring(err)`.
+---
+--- Linux-only.
+
+local unix = require "unix"
+
+local M = {}
+
+--- Octal mode constants. Lua has no octal literal, so define them once
+--- explicitly (instead of accidentally writing `0x755` and getting
+--- decimal 1877 / octal 03525).
+M.MODE_DIR        = tonumber("755",  8)  -- 0o755 = 493 = rwxr-xr-x
+M.MODE_DIR_PRIV   = tonumber("700",  8)  -- 0o700 = 448 = rwx------
+M.MODE_FILE       = tonumber("644",  8)  -- 0o644 = 420 = rw-r--r--
+M.MODE_TMP_STICKY = tonumber("1777", 8)  -- 0o1777      = sticky+rwxrwxrwx
+
+--- True if `path` exists (any type).
+function M.exists(path)
+  return unix.stat(path) ~= nil
+end
+
+-- Return the parent dir of `path` (or "/" for top-level).
+local function parent_dir(path)
+  return string.match(path, "(.+)/[^/]+$") or "/"
+end
+
+-- Create a mount-point at `dst` matching the type of `src` — a
+-- directory if src is a directory, else an empty file. Used internally
+-- by bind() to ensure dst exists with the right kind before mounting.
+local function ensure_mountpoint(src, dst)
+  local st, err = unix.stat(src)
+  if not st then return nil, err end
+  if (st:mode() & 0xf000) == 0x4000 then
+    -- Directory: makedirs is idempotent.
+    local ok, err = unix.makedirs(dst, M.MODE_DIR)
+    if not ok then return nil, err end
+  else
+    -- File-like: ensure parent dir, then touch the dst as an empty file.
+    local ok, err = unix.makedirs(parent_dir(dst), M.MODE_DIR)
+    if not ok then return nil, err end
+    if not M.exists(dst) then
+      local fd, ferr = unix.open(dst, unix.O_WRONLY | unix.O_CREAT,
+                                 M.MODE_FILE)
+      if not fd then return nil, ferr end
+      unix.close(fd)
+    end
+  end
+  return true
+end
+
+-- Parse /proc/self/mountinfo and return an array of mount-point paths
+-- that are strictly under `prefix` (i.e. prefix is a proper ancestor).
+-- mountinfo format (kernel Documentation/filesystems/proc.rst, field 5):
+--   <mountid> <parentid> <major>:<minor> <root> <mountpoint> <mountopts>
+--   [optional fields] - <fstype> <source> <superopts>
+-- Field 5 (1-indexed) is the mount point; spaces inside paths are encoded
+-- as the octal escape \040. We use io.open so this has no dependency on
+-- any unix.* extension beyond what the rest of this module already needs.
+local function submounts_under(prefix)
+  -- Normalise prefix: strip trailing slash unless it is the root itself.
+  local norm = prefix:gsub("/+$", "")
+  if norm == "" then norm = "/" end
+  local result = {}
+  local f = io.open("/proc/self/mountinfo", "r")
+  if not f then return result end
+  for line in f:lines() do
+    -- Split on spaces; field 5 is the encoded mount point.
+    local fields = {}
+    for tok in line:gmatch("%S+") do
+      fields[#fields + 1] = tok
+    end
+    local mp_enc = fields[5]
+    if mp_enc then
+      -- Decode octal-encoded spaces (\040 → " ").
+      local mp = mp_enc:gsub("\\040", " ")
+      -- Include this mount if its path is strictly under norm:
+      --   norm == "/" means everything qualifies
+      --   otherwise the path must start with norm .. "/" (not just norm itself,
+      --   which is the top-level bind we already handled).
+      local is_sub
+      if norm == "/" then
+        is_sub = mp ~= "/"
+      else
+        is_sub = mp:sub(1, #norm + 1) == norm .. "/"
+      end
+      if is_sub then
+        result[#result + 1] = mp
+      end
+    end
+  end
+  f:close()
+  return result
+end
+
+--- fs.bind(src, dst[, opts]) → true | nil, err
+---
+--- Bind-mount `src` onto `dst` (creating dst as a file or directory as
+--- needed), optionally remounting read-only. opts.ro = true requests a
+--- read-only bind. opts.rec = false disables MS_REC (default true).
+---
+--- Read-only guarantee: MS_REC on a *remount* does NOT recursively
+--- re-apply MS_RDONLY to sub-mounts that exist within the bound tree
+--- (it only sets the flag on the top-level bind mount). To ensure the
+--- entire subtree is truly read-only, we parse /proc/self/mountinfo
+--- after the top-level RO remount and individually remount each
+--- sub-mount read-only. On the common "no sub-mounts" path the extra
+--- step finds nothing and adds no overhead.
+---
+--- The clean alternative — mount_setattr(2) with AT_RECURSIVE — would
+--- accomplish this atomically in a single syscall, but unix.mount_setattr
+--- is not currently exposed by lunix.c; exposing it would be a welcome
+--- future improvement.
+function M.bind(src, dst, opts)
+  opts = opts or {}
+  local rec = opts.rec ~= false
+  local ok, err = ensure_mountpoint(src, dst)
+  if not ok then return nil, err end
+  local flags = unix.MS_BIND | (rec and unix.MS_REC or 0)
+  ok, err = unix.mount(src, dst, nil, flags, nil)
+  if not ok then return nil, err end
+  if opts.ro then
+    -- Step 1: remount the top-level bind mount read-only.
+    flags = unix.MS_REMOUNT | unix.MS_BIND | unix.MS_RDONLY
+    ok, err = unix.mount("none", dst, nil, flags, nil)
+    if not ok then return nil, err end
+    -- Step 2: walk any sub-mounts visible under dst and remount each
+    -- read-only. MS_REC on a remount does not propagate MS_RDONLY into
+    -- sub-mounts, so without this step a nested filesystem (e.g. if src
+    -- is "/" or a directory with other filesystems mounted under it)
+    -- would remain writable inside the jail.
+    if rec then
+      local subs = submounts_under(dst)
+      for _, mp in ipairs(subs) do
+        ok, err = unix.mount("none", mp, nil,
+                             unix.MS_REMOUNT | unix.MS_BIND | unix.MS_RDONLY,
+                             nil)
+        if not ok then return nil, err end
+      end
+    end
+  end
+  return true
+end
+
+--- fs.bind_ro(src, dst) → true | nil, err
+---
+--- Convenience: read-only recursive bind.
+function M.bind_ro(src, dst)
+  return M.bind(src, dst, {ro = true})
+end
+
+--- fs.tmpfs(dst, size_or_data) → true | nil, err
+---
+--- Mount a tmpfs at `dst`. `size_or_data` is either a size string
+--- ("128m") or a full mount-data string ("size=128m,mode=755").
+--- Creates `dst` if missing.
+function M.tmpfs(dst, size_or_data)
+  local data
+  if type(size_or_data) == "string" then
+    if size_or_data:find("=") then
+      data = size_or_data
+    else
+      data = "size=" .. size_or_data
+    end
+  end
+  local ok, err = unix.makedirs(dst, M.MODE_DIR)
+  if not ok then return nil, err end
+  ok, err = unix.mount("tmpfs", dst, "tmpfs", 0, data)
+  if not ok then return nil, err end
+  return true
+end
+
+--- fs.private_root() → true | nil, err
+---
+--- Mark the existing root mount tree as MS_PRIVATE recursively, so
+--- subsequent mounts in this namespace don't propagate to the host.
+--- Many distros default to "shared". Call this immediately after
+--- unshare(CLONE_NEWNS).
+function M.private_root()
+  local ok, err = unix.mount("none", "/", nil,
+                             unix.MS_REC | unix.MS_PRIVATE, nil)
+  if not ok then return nil, err end
+  return true
+end
+
+--- fs.pivot_to(jail) → true | nil, err
+---
+--- Pivot the current mount namespace's root into `jail`. Detaches the
+--- old root via unmount(MNT_DETACH) and removes the temporary
+--- /.old mountpoint. Caller must have already populated `jail` with
+--- the desired contents.
+---
+--- NOTE: on failure, the mount state is not unwound. A failed
+--- pivot_root may leave `/.old` as an empty dir; a failed unmount
+--- may leave the old root mounted at `/.old`. These only matter if
+--- the caller intends to keep running in the same mount namespace.
+--- The normal failure recovery is to exit the child process, which
+--- the kernel cleans up when the mount namespace's last reference
+--- goes away.
+function M.pivot_to(jail)
+  local old = jail .. "/.old"
+  local ok, err = unix.makedirs(old, M.MODE_DIR_PRIV)
+  if not ok then return nil, err end
+  ok, err = unix.chdir(jail)
+  if not ok then return nil, err end
+  ok, err = unix.pivot_root(".", ".old")
+  if not ok then return nil, err end
+  ok, err = unix.chdir("/")
+  if not ok then return nil, err end
+  ok, err = unix.unmount("/.old", unix.MNT_DETACH)
+  if not ok then return nil, err end
+  unix.rmdir("/.old")
+  return true
+end
+
+--- fs.proc(dir) → true | nil, err
+---
+--- Mount a private procfs at `dir` (default "/proc") using hardened
+--- flags: MS_NOSUID | MS_NODEV | MS_NOEXEC.
+---
+--- PRECONDITION — PID namespace: this function is most useful when the
+--- calling process is PID 1 of a freshly created PID namespace.  On
+--- Linux, after `unshare(CLONE_NEWPID)` the CURRENT process is NOT
+--- moved into the new namespace — only its future children are.  To
+--- mount a procfs that shows only the sandbox's own processes you must:
+---
+---   1. Call `unix.unshare(unix.CLONE_NEWPID)` in the jail-setup process.
+---   2. Fork a child — that child is PID 1 of the new namespace.
+---   3. Call `fs.proc()` from inside that child (after pivot_root,
+---      within the new mount namespace).
+---
+--- When called correctly the mounted procfs is fully isolated: the
+--- sandboxed processes can only see each other's PIDs, preventing
+--- information leakage via /proc/<pid>/environ, /proc/<pid>/cmdline,
+--- /proc/<pid>/root, and /proc/sys of HOST processes.
+---
+--- HAZARD — binding the host /proc: if a consumer bind-mounts the host
+--- /proc into the jail (e.g. `fs.bind("/proc", jail.."/proc")`), ALL
+--- host-process information is visible inside the sandbox:
+---   - /proc/<pid>/environ leaks environment variables of host processes
+---   - /proc/<pid>/cmdline leaks command-line arguments
+---   - /proc/<pid>/root is a traversable fd into each process's root
+---   - /proc/sys exposes writable kernel tunables to the sandboxed process
+--- Always prefer `fs.proc()` (called from within a CLONE_NEWPID child)
+--- over binding the host /proc.  See proc.fork_pidns() for the helper
+--- that creates the correctly-placed child.
+---
+--- If mounting procfs fails (e.g. the caller is not in a PID namespace
+--- or there is a policy denial), the error is surfaced as nil, err so
+--- the caller can decide to abort the jail setup.
+function M.proc(dir)
+  dir = dir or "/proc"
+  local ok, err = unix.makedirs(dir, M.MODE_DIR)
+  if not ok then return nil, err end
+  local flags = unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC
+  ok, err = unix.mount("proc", dir, "proc", flags, nil)
+  if not ok then return nil, err end
+  return true
+end
+
+--- fs.pivot_to_or_exit(jail[, exit_code])
+---
+--- Like pivot_to, but enforces the documented failure contract: on
+--- error, write a diagnostic to stderr and terminate the current
+--- process with unix.exit(exit_code or 127). Use from a forked child
+--- that has already committed to running inside the jail and cannot
+--- meaningfully recover from a half-unwound mount namespace.
+---
+--- Never returns on failure. Returns true on success.
+function M.pivot_to_or_exit(jail, exit_code)
+  local ok, err = M.pivot_to(jail)
+  if not ok then
+    io.stderr:write("pivot_to " .. tostring(jail) .. ": "
+                    .. tostring(err) .. "\n")
+    unix.exit(exit_code or 127)
+  end
+  return true
+end
+
+return M

--- a/3p/cosmos/sandbox/init.lua
+++ b/3p/cosmos/sandbox/init.lua
@@ -1,0 +1,101 @@
+--- cosmo.sandbox: Linux process-isolation primitives.
+---
+--- This module is the entry point for the Cosmopolitan Lua sandbox
+--- library. The pieces it exposes are thin wrappers around `unix.*`
+--- syscalls plus higher-level helpers:
+---
+---     cosmo.sandbox.netns     network namespace helpers
+---     cosmo.sandbox.fs        filesystem (bind/tmpfs/pivot) helpers
+---     cosmo.sandbox.proc      process setup (no_new_privs, drop_privs,
+---                             become_init supervisor, fork barrier)
+---     cosmo.sandbox.landlock  unprivileged filesystem allowlist
+---     cosmo.sandbox.proxy     HTTP CONNECT + plain-HTTP allowlist proxy
+---
+--- All helpers and their underlying `unix.*` syscalls return
+--- `nil, unix.Errno` on failure (matching the rest of cosmo's lunix
+--- conventions). Callers can `:errno()` the Errno object for the
+--- integer code or `tostring()` for a human-readable string.
+---
+--- The whole library is Linux-only. On non-Linux hosts the syscalls
+--- return ENOSYS and `is_supported()` returns false.
+---
+--- Status: `unix.*` wrappers are the stable API tier; everything under
+--- `cosmo.sandbox.*` is experimental and may evolve based on usage.
+
+local unix = require "unix"
+local cosmo = require "cosmo"
+
+local M = {
+  _VERSION = "0.0.3",
+}
+
+--- cosmo.sandbox.capabilities() → table
+---
+--- Probe the host for fine-grained feature availability. Each field
+--- is a boolean. The probe is cached after the first call so repeated
+--- queries are free.
+---
+--- Fields:
+---   linux          host is Linux (cosmo.GetHostOs() == "LINUX")
+---   user_ns        unshare(CLONE_NEWUSER) works without root
+---   mount_ns       CLONE_NEWNS is defined (kernel supports it)
+---   net_ns         CLONE_NEWNET is defined
+---   uts_ns         CLONE_NEWUTS is defined (for sethostname isolation)
+---   pid_ns         CLONE_NEWPID is defined
+---   pivot_root     unix.pivot_root is exported by lunix
+---   cap_net_admin  geteuid() == 0 (veth pair creation needs root or
+---                  a network-namespace that owns its own netlink)
+---   landlock       kernel advertises landlock ABI >= 1 (Linux ≥ 5.13)
+---   pledge         unix.pledge is exported and does not ENOSYS on a
+---                  no-op call (true on Linux via seccomp and on
+---                  OpenBSD via the native syscall)
+---   unveil         unix.unveil is exported and does not ENOSYS on a
+---                  no-op call (true on OpenBSD, and on Linux when
+---                  Landlock-backed unveil is available)
+---
+--- Higher-level helpers use these to fail fast with a specific reason
+--- rather than bail out on ENOSYS partway through a setup sequence.
+local function probe_nop(fn)
+  if not fn then return false end
+  local ok, err = fn(nil, nil)
+  if ok then return true end
+  if err and err.errno and err:errno() == unix.ENOSYS then return false end
+  return true
+end
+local _caps
+function M.capabilities()
+  if _caps then return _caps end
+  local is_linux = cosmo.GetHostOs() == "LINUX"
+  local ll_ok = false
+  if is_linux and unix.landlock_create_ruleset then
+    local abi = unix.landlock_create_ruleset()
+    ll_ok = type(abi) == "number" and abi >= 1
+  end
+  _caps = {
+    linux         = is_linux,
+    user_ns       = is_linux and unix.CLONE_NEWUSER ~= nil,
+    mount_ns      = is_linux and unix.CLONE_NEWNS   ~= nil,
+    net_ns        = is_linux and unix.CLONE_NEWNET  ~= nil,
+    uts_ns        = is_linux and unix.CLONE_NEWUTS  ~= nil,
+    pid_ns        = is_linux and unix.CLONE_NEWPID  ~= nil,
+    pivot_root    = is_linux and unix.pivot_root    ~= nil,
+    cap_net_admin = is_linux and unix.geteuid and unix.geteuid() == 0,
+    landlock      = ll_ok,
+    pledge        = probe_nop(unix.pledge),
+    unveil        = probe_nop(unix.unveil),
+  }
+  return _caps
+end
+
+--- cosmo.sandbox.is_supported() → bool
+---
+--- True when the primitives in this module can do real work — i.e.
+--- we're running on Linux and the namespace bindings are linked in.
+--- Kept for backwards compatibility; prefer capabilities() for
+--- fine-grained feature detection.
+function M.is_supported()
+  local c = M.capabilities()
+  return c.linux and c.net_ns and c.mount_ns
+end
+
+return M

--- a/3p/cosmos/sandbox/landlock.lua
+++ b/3p/cosmos/sandbox/landlock.lua
@@ -1,0 +1,152 @@
+--- cosmo.sandbox.landlock: Linux landlock filesystem sandbox.
+---
+--- Landlock is an unprivileged filesystem sandbox: any process (even
+--- one running as a regular user) can restrict its own file access to
+--- a declared allowlist. Once applied, the restriction is inherited
+--- by children and cannot be relaxed — only further narrowed.
+---
+--- This module wraps the raw `unix.landlock_*` syscalls with a
+--- declarative path-allowlist builder. Typical flow:
+---
+---     local ll = require "cosmo.sandbox.landlock"
+---     assert(ll.restrict{
+---       handled = ll.ALL,
+---       rules = {
+---         {path = "/usr",  access = ll.READ | ll.EXEC},
+---         {path = "/lib",  access = ll.READ | ll.EXEC},
+---         {path = "/bin",  access = ll.READ | ll.EXEC},
+---         {path = "/home/me/project", access = ll.RW},
+---         {path = "/tmp",  access = ll.RW},
+---       },
+---     })
+---
+--- Requires Linux ≥ 5.13. `available()` returns false on older kernels
+--- (or non-Linux hosts); callers should gate jail setup on it.
+---
+--- API-stability note: the wire protocol between the kernel and this
+--- module is versioned (`abi()`), and access categories added in
+--- later ABIs (REFER, TRUNCATE) are masked out automatically when the
+--- kernel doesn't support them, so `ll.ALL` stays portable.
+
+local unix = require "unix"
+
+local M = {}
+
+--------------------------------------------------------------------------------
+-- Flag exports (so callers don't have to reach into unix.*).
+
+M.EXECUTE     = unix.LANDLOCK_ACCESS_FS_EXECUTE
+M.WRITE_FILE  = unix.LANDLOCK_ACCESS_FS_WRITE_FILE
+M.READ_FILE   = unix.LANDLOCK_ACCESS_FS_READ_FILE
+M.READ_DIR    = unix.LANDLOCK_ACCESS_FS_READ_DIR
+M.REMOVE_DIR  = unix.LANDLOCK_ACCESS_FS_REMOVE_DIR
+M.REMOVE_FILE = unix.LANDLOCK_ACCESS_FS_REMOVE_FILE
+M.MAKE_CHAR   = unix.LANDLOCK_ACCESS_FS_MAKE_CHAR
+M.MAKE_DIR    = unix.LANDLOCK_ACCESS_FS_MAKE_DIR
+M.MAKE_REG    = unix.LANDLOCK_ACCESS_FS_MAKE_REG
+M.MAKE_SOCK   = unix.LANDLOCK_ACCESS_FS_MAKE_SOCK
+M.MAKE_FIFO   = unix.LANDLOCK_ACCESS_FS_MAKE_FIFO
+M.MAKE_BLOCK  = unix.LANDLOCK_ACCESS_FS_MAKE_BLOCK
+M.MAKE_SYM    = unix.LANDLOCK_ACCESS_FS_MAKE_SYM
+M.REFER       = unix.LANDLOCK_ACCESS_FS_REFER     -- ABI 2+
+M.TRUNCATE    = unix.LANDLOCK_ACCESS_FS_TRUNCATE  -- ABI 3+
+
+--- Convenience masks. `ALL` is the full current set; `RW` covers read
+--- + write (including creating and removing files); `READ` and `EXEC`
+--- are self-explanatory.
+M.READ = M.READ_FILE | M.READ_DIR
+M.EXEC = M.EXECUTE
+M.WRITE = M.WRITE_FILE | M.REMOVE_FILE | M.REMOVE_DIR
+       | M.MAKE_REG | M.MAKE_DIR | M.MAKE_SYM
+       | M.MAKE_SOCK | M.MAKE_FIFO | M.MAKE_CHAR | M.MAKE_BLOCK
+M.RW = M.READ | M.WRITE | M.EXEC
+M.ALL = M.READ | M.WRITE | M.EXEC | M.REFER | M.TRUNCATE
+
+-- Per-ABI "max access" mask. Categories above the kernel's supported
+-- ABI MUST be stripped before create_ruleset or it returns EINVAL.
+local function abi_mask(abi)
+  local mask = M.READ | M.WRITE_FILE | M.REMOVE_DIR | M.REMOVE_FILE
+             | M.MAKE_CHAR | M.MAKE_DIR | M.MAKE_REG | M.MAKE_SOCK
+             | M.MAKE_FIFO | M.MAKE_BLOCK | M.MAKE_SYM | M.EXECUTE
+  if abi >= 2 then mask = mask | M.REFER end
+  if abi >= 3 then mask = mask | M.TRUNCATE end
+  return mask
+end
+
+--- landlock.abi() → int | nil, unix.Errno
+---
+--- Returns the kernel's supported landlock ABI (≥ 1 when landlock is
+--- enabled). Returns nil,Errno on ENOSYS/EOPNOTSUPP — treat that as
+--- "landlock not available here".
+function M.abi()
+  return unix.landlock_create_ruleset()
+end
+
+--- landlock.available() → bool
+---
+--- True when `abi() >= 1`. Use this to gate jail setup.
+function M.available()
+  local a = M.abi()
+  return type(a) == "number" and a >= 1
+end
+
+--- landlock.restrict(opts) → true | nil, err
+---
+--- Apply a path-allowlist to the current thread (and future children).
+--- Once applied, access outside the allowlist fails with EACCES and
+--- the restriction cannot be undone.
+---
+--- Options:
+---   handled     int mask of access categories to restrict. Categories
+---               not in `handled` are left unrestricted. Defaults to
+---               `landlock.ALL` (full current set, masked by ABI).
+---   rules       {{path=str, access=int}, ...}  per-path allow rules.
+---               `access` is an OR of landlock.READ / WRITE / EXEC /
+---               or explicit landlock.ACCESS_* flags. Access must be
+---               a subset of `handled`.
+---   no_new_privs  bool. If true (default), call prctl(PR_SET_NO_NEW_PRIVS,
+---               1) before landlock_restrict_self. Required unless the
+---               caller already set it or holds CAP_SYS_ADMIN.
+---
+--- Returns true on success; nil,err (string) on any error. The ruleset
+--- fd is always closed before return.
+function M.restrict(opts)
+  opts = opts or {}
+  local abi, aerr = M.abi()
+  if not abi then return nil, tostring(aerr) end
+  if abi < 1 then return nil, "landlock unavailable" end
+  local mask = abi_mask(abi)
+  local handled = (opts.handled or M.ALL) & mask
+  local rs, cerr = unix.landlock_create_ruleset(handled, 0)
+  if not rs then return nil, tostring(cerr) end
+  local function fail(msg)
+    unix.close(rs)
+    return nil, msg
+  end
+  for i, rule in ipairs(opts.rules or {}) do
+    if type(rule) ~= "table" or not rule.path then
+      return fail(string.format("rule[%d] missing path", i))
+    end
+    local access = (rule.access or 0) & mask
+    local pfd, perr = unix.open(rule.path, unix.O_PATH | unix.O_CLOEXEC)
+    if not pfd then
+      return fail(string.format("open(%q): %s", rule.path, tostring(perr)))
+    end
+    local ok, rerr = unix.landlock_add_rule(rs, pfd, access, 0)
+    unix.close(pfd)
+    if not ok then
+      return fail(string.format("add_rule(%q): %s",
+                                rule.path, tostring(rerr)))
+    end
+  end
+  if opts.no_new_privs ~= false then
+    local ok, err = unix.prctl(unix.PR_SET_NO_NEW_PRIVS, 1)
+    if not ok then return fail("PR_SET_NO_NEW_PRIVS: " .. tostring(err)) end
+  end
+  local ok, rerr = unix.landlock_restrict_self(rs, 0)
+  unix.close(rs)
+  if not ok then return nil, "restrict_self: " .. tostring(rerr) end
+  return true
+end
+
+return M

--- a/3p/cosmos/sandbox/netns.lua
+++ b/3p/cosmos/sandbox/netns.lua
@@ -1,0 +1,119 @@
+--- cosmo.sandbox.netns: network-namespace helpers.
+---
+--- Composable pieces built on the `unix.*` namespace + ioctl
+--- primitives. Each function returns `nil, unix.Errno` on failure,
+--- matching the rest of the cosmo lunix API.
+---
+--- Typical flow inside a forked child:
+---
+---     local netns = require "cosmo.sandbox.netns"
+---     assert(unix.unshare(unix.CLONE_NEWNET))
+---     assert(netns.bring_up("lo"))
+---     -- loopback is now reachable at 127.0.0.1 in this namespace
+---
+--- Typical flow in the parent (to enter a child's namespace fd-wise):
+---
+---     local fd = assert(netns.open(child_pid))
+---     assert(unix.setns(fd, unix.CLONE_NEWNET))
+---
+--- Linux-only.
+
+local unix = require "unix"
+
+local M = {}
+
+--- netns.build_ifreq(name, flags) → string
+---
+--- Build a `struct ifreq` suitable for passing to SIOCSIFFLAGS /
+--- SIOCGIFFLAGS. The Linux layout is char ifr_name[16] followed by a
+--- 24-byte union; we populate ifr_name and ifr_flags at offsets 0 and
+--- 16 respectively. `name` must be at most IFNAMSIZ-1 bytes; `flags`
+--- is an int16 bitmask of IFF_* values.
+function M.build_ifreq(name, flags)
+  assert(type(name) == "string", "interface name must be a string")
+  assert(#name < unix.IFNAMSIZ, "interface name too long")
+  local name_field = name .. string.rep("\0", unix.IFNAMSIZ - #name)
+  local flags_field = string.pack("<i2", flags or 0)
+  -- Pad the union to 24 bytes (largest union member).
+  return name_field .. flags_field .. string.rep("\0", 24 - #flags_field)
+end
+
+--- netns.parse_ifreq_flags(ifr) → int
+---
+--- Parse the 16-bit flags field out of an ifreq returned by ioctl().
+function M.parse_ifreq_flags(ifr)
+  return (string.unpack("<i2", ifr, unix.IFNAMSIZ + 1))
+end
+
+--- netns.control_socket() → fd | nil, unix.Errno
+---
+--- Open an AF_INET dgram socket suitable as the "fd" argument to the
+--- SIOC* interface-configuration ioctls. The caller owns the fd and
+--- should close it.
+function M.control_socket()
+  -- SOCK_CLOEXEC: prevent this short-lived control socket from leaking
+  -- into any exec'd child (e.g. the sandboxed command) via an accidental
+  -- fork/exec ordering change.
+  return unix.socket(unix.AF_INET, unix.SOCK_DGRAM | unix.SOCK_CLOEXEC, 0)
+end
+
+--- netns.get_flags(name) → flags:int | nil, unix.Errno
+---
+--- Read the current IFF_* flags on `name` in the current net namespace.
+function M.get_flags(name)
+  local sk, err = M.control_socket()
+  if not sk then return nil, err end
+  local result, ioerr = unix.ioctl(sk, unix.SIOCGIFFLAGS,
+                                   M.build_ifreq(name, 0))
+  unix.close(sk)
+  if not result then return nil, ioerr end
+  return M.parse_ifreq_flags(result)
+end
+
+--- netns.set_flags(name, flags) → true | nil, unix.Errno
+---
+--- Set the IFF_* flags on `name` in the current net namespace.
+function M.set_flags(name, flags)
+  local sk, err = M.control_socket()
+  if not sk then return nil, err end
+  local ok, ioerr = unix.ioctl(sk, unix.SIOCSIFFLAGS,
+                               M.build_ifreq(name, flags))
+  unix.close(sk)
+  if not ok then return nil, ioerr end
+  return true
+end
+
+--- netns.bring_up(name) → true | nil, unix.Errno
+---
+--- Bring `name` up in the current net namespace (reads flags, sets
+--- IFF_UP, writes them back). Idempotent.
+function M.bring_up(name)
+  local flags, err = M.get_flags(name)
+  if not flags then return nil, err end
+  return M.set_flags(name, flags | unix.IFF_UP)
+end
+
+--- netns.bring_down(name) → true | nil, unix.Errno
+---
+--- Bring `name` down in the current net namespace. Idempotent.
+function M.bring_down(name)
+  local flags, err = M.get_flags(name)
+  if not flags then return nil, err end
+  return M.set_flags(name, flags & ~unix.IFF_UP)
+end
+
+--- netns.open([pid]) → fd:int | nil, unix.Errno
+---
+--- Open the network namespace of `pid` as a file descriptor. For the
+--- current process, omit `pid` (or pass nil/"self").
+function M.open(pid)
+  local tag = pid and tostring(pid) or "self"
+  -- O_CLOEXEC: a namespace fd that leaks across exec into the sandboxed
+  -- child gives it a setns(2) handle back to the parent network namespace —
+  -- a direct sandbox escape. setns() calls in THIS process are unaffected
+  -- (CLOEXEC only fires across exec, not fork or plain syscalls).
+  return unix.open("/proc/" .. tag .. "/ns/net",
+                   unix.O_RDONLY | unix.O_CLOEXEC)
+end
+
+return M

--- a/3p/cosmos/sandbox/proc.lua
+++ b/3p/cosmos/sandbox/proc.lua
@@ -1,0 +1,322 @@
+--- cosmo.sandbox.proc: process-setup helpers.
+---
+--- Composable pieces for the "after fork, before exec" portion of a
+--- jailed child, plus the PID-1 supervisor loop used by the netns-proxy
+--- and claude-code examples. All helpers return `nil, unix.Errno` on
+--- failure, matching the rest of the cosmo.sandbox.* library.
+---
+--- Linux-only.
+
+local unix = require "unix"
+
+local M = {}
+
+--- proc.no_new_privs() → true | nil, unix.Errno
+---
+--- Set PR_SET_NO_NEW_PRIVS on the current process. Once set:
+---   * execve() no longer grants setuid/setgid/file-cap privileges,
+---   * the bit is inherited by all children (and cannot be cleared),
+---   * seccomp filters can be installed without CAP_SYS_ADMIN.
+---
+--- Call this before pivot_root / execve in any jail that doesn't
+--- explicitly need privilege escalation.
+function M.no_new_privs()
+  local ok, err = unix.prctl(unix.PR_SET_NO_NEW_PRIVS, 1)
+  if not ok then return nil, err end
+  return true
+end
+
+--- proc.drop_privs(uid, gid) → true | nil, unix.Errno
+---
+--- Drop to (uid, gid) and clear capabilities. Full dance:
+---
+---   1. PR_SET_KEEPCAPS — preserve capabilities across setuid, so we
+---      can explicitly clear them after switching uid. Without this,
+---      the kernel drops caps silently on setuid(non-zero) and we'd
+---      have no chance to inspect what was kept.
+---   2. setresgid(gid, gid, gid)
+---   3. setresuid(uid, uid, uid) — all three (real/effective/saved)
+---      so there's no path back.
+---   4. capset(0, 0, 0) — clear the effective, permitted, and
+---      inheritable capability sets.
+---
+--- Argument semantics:
+---   uid == nil   no-op. Caller explicitly does not want to change uid
+---                or clear capabilities.
+---   uid == 0     don't setuid (we're staying root) but still clear
+---                capabilities — "root without superpowers".
+---   uid > 0      full drop: switch to uid, switch gid (defaults to uid
+---                when gid is nil), clear caps.
+---
+--- Returns true on success or when uid is nil. Returns nil,Errno on
+--- syscall failure at any step.
+function M.drop_privs(uid, gid)
+  if uid == nil then return true end
+  gid = gid or uid
+  if uid ~= 0 then
+    local ok, err = unix.prctl(unix.PR_SET_KEEPCAPS, 1)
+    if not ok then return nil, err end
+    ok, err = unix.setresgid(gid, gid, gid)
+    if not ok then return nil, err end
+    ok, err = unix.setresuid(uid, uid, uid)
+    if not ok then return nil, err end
+  end
+  local ok, err = unix.capset(0, 0, 0)
+  if not ok then
+    -- On non-Linux hosts capset is ENOSYS; there are no Linux caps to
+    -- clear, so treat that as success. Any other errno is real.
+    if err and err:errno() == unix.ENOSYS then return true end
+    return nil, err
+  end
+  return true
+end
+
+--- proc.setup_userns_maps(uid, gid) → true | nil, unix.Errno
+---
+--- Write uid_map / setgroups / gid_map for the current process so that
+--- inner uid 0 maps to the host `uid` (and inner gid 0 to host `gid`).
+--- Must be called after `unshare(CLONE_NEWUSER)` and before any
+--- operation that requires a valid identity (setresuid, capset, mount,
+--- etc). Equivalent to the canonical three-step incantation:
+---
+---     echo "0 $uid 1" > /proc/self/uid_map
+---     echo "deny"     > /proc/self/setgroups   # kernel ≥ 3.19
+---     echo "0 $gid 1" > /proc/self/gid_map
+---
+--- The setgroups "deny" write must come before the gid_map write on
+--- kernels ≥3.19; an unprivileged writer is rejected from gid_map
+--- otherwise. On kernels old enough not to expose setgroups as a
+--- proc file the write fails with ENOENT, which is benign and
+--- silently ignored.
+---
+--- Arguments default to the current euid/egid, matching the common
+--- "map my host identity to root inside the new user ns" case.
+local function write_all(path, data)
+  local fd, err = unix.open(path, unix.O_WRONLY)
+  if not fd then return nil, err end
+  local ok, werr = unix.write(fd, data)
+  unix.close(fd)
+  if not ok then return nil, werr end
+  return true
+end
+
+function M.setup_userns_maps(uid, gid)
+  uid = uid or unix.geteuid()
+  gid = gid or unix.getegid()
+  local ok, err = write_all("/proc/self/uid_map", "0 "..uid.." 1\n")
+  if not ok then return nil, err end
+  local sg, sgerr = write_all("/proc/self/setgroups", "deny")
+  if not sg and sgerr and sgerr:errno() ~= unix.ENOENT then
+    return nil, sgerr
+  end
+  return write_all("/proc/self/gid_map", "0 "..gid.." 1\n")
+end
+
+--- proc.barrier() → {signal, wait, drop_read, drop_write} | nil, err
+---
+--- Cross-process synchronization primitive: a one-shot pipe-based
+--- barrier. The common use case is closing the fork + unshare race in
+--- examples: a parent that forks a child and wants to observe the
+--- child's namespace fd in /proc must wait for the child to finish
+--- `unshare()` before opening `/proc/<pid>/ns/<kind>` — otherwise the
+--- fd may point at the parent's namespace.
+---
+--- After fork, each side drops the end it won't use, then uses the
+--- end it kept:
+---
+---     local b = assert(proc.barrier())
+---     local pid = assert(unix.fork())
+---     if pid == 0 then
+---       b:drop_read()                 -- child will signal, never wait
+---       assert(unix.unshare(flags))
+---       b:signal()                    -- tell parent "I've unshared"
+---       unix.execvp(cmd[1], cmd)
+---     end
+---     b:drop_write()                  -- parent will wait, never signal
+---     b:wait()                        -- blocks until child signal
+---     local nsfd = assert(netns.open(pid))   -- safe: child has unshared
+---
+--- `signal()` writes one byte and closes the write end. `wait()`
+--- reads one byte from the read end (EOF counts as signaled, which
+--- propagates child crashes) and closes the read end. `drop_read()`
+--- / `drop_write()` are idempotent.
+local Barrier = {__name = "cosmo.sandbox.proc.Barrier"}
+Barrier.__index = Barrier
+
+function Barrier:signal()
+  if self._w then unix.write(self._w, "x"); unix.close(self._w); self._w = nil end
+end
+function Barrier:wait()
+  if self._r then unix.read(self._r, 1); unix.close(self._r); self._r = nil end
+end
+function Barrier:drop_read()
+  if self._r then unix.close(self._r); self._r = nil end
+end
+function Barrier:drop_write()
+  if self._w then unix.close(self._w); self._w = nil end
+end
+
+function M.barrier()
+  local r, w, err = unix.pipe()
+  if not r then return nil, w or err end
+  return setmetatable({_r = r, _w = w}, Barrier)
+end
+
+--- proc.fork_pidns() → child_pid | nil, err
+---
+--- Enter a new PID namespace and fork a child that becomes PID 1
+--- inside it. Returns the child PID to the caller (the parent); the
+--- child runs `child_fn()` (if given) and then exits with unix.exit(0).
+--- If `child_fn` is omitted, only the fork+unshare mechanics are
+--- performed — the child returns nil (indicating "I am the child") and
+--- is expected to exec or call unix.exit() itself.
+---
+--- Why fork is required: `unshare(CLONE_NEWPID)` does NOT move the
+--- calling process into the new PID namespace — it only causes the
+--- process's FUTURE CHILDREN to be born into it.  The first such child
+--- is PID 1 of the new namespace.  Only that child (PID 1 of the new
+--- pidns) can mount a fresh procfs that shows only the sandbox's own
+--- processes.  Attempting to mount procfs from the parent (which remains
+--- in the outer pidns) produces a procfs that leaks all host processes.
+---
+--- Typical usage in a jail-setup child (already in CLONE_NEWNS):
+---
+---     -- Step 1: enter new PID namespace and fork the grandchild.
+---     local child_pid, err = proc.fork_pidns()
+---     if child_pid == nil then
+---       -- We are the grandchild (PID 1 in the new pidns).
+---       -- Mount private /proc, then exec the jailed command.
+---       assert(fs.proc())
+---       local _, e = unix.execvp(cmd[1], cmd)
+---       unix.exit(127)
+---     end
+---     -- We are the wrapper child (parent of grandchild).
+---     -- Run a minimal PID-1 supervisor loop so the grandchild's
+---     -- exit status is properly reaped (PID 1 must reap all zombies).
+---     os.exit(proc.become_init(child_pid))
+---
+--- Returns:
+---   parent side: child_pid (integer > 0), or nil, err on unshare/fork failure.
+---   child side:  nil (i.e. child_pid == false/nil from unix.fork check)
+---     — but NOTE: the child never returns from fork_pidns in the normal
+---     flow above because it immediately execs or calls unix.exit().
+---
+--- Security note: the parent (wrapper child) remains in the OUTER PID
+--- namespace, but because it is inside CLONE_NEWNS it cannot re-enter
+--- the outer procfs.  The child (grandchild) is the only process that
+--- mounts and uses the private procfs.
+function M.fork_pidns()
+  -- Calling unshare(CLONE_NEWPID) here makes the *next* fork's child
+  -- land in a fresh PID namespace as PID 1.
+  local ok, err = unix.unshare(unix.CLONE_NEWPID)
+  if not ok then return nil, err end
+
+  local child_pid, ferr = unix.fork()
+  if not child_pid then return nil, ferr end
+
+  -- child_pid == 0: we are the grandchild, PID 1 of the new pidns.
+  -- Return nil so the caller can distinguish child from parent.
+  if child_pid == 0 then
+    return nil
+  end
+
+  -- child_pid > 0: we are the parent.  Return the child's PID.
+  return child_pid
+end
+
+--- Default signal set forwarded by become_init.
+M.DEFAULT_SIGNALS = { "SIGINT", "SIGTERM", "SIGHUP" }
+
+--- proc.become_init(main_pid, opts) → exit_code
+---
+--- Run a PID-1-style supervisor loop:
+---   * forward signals in opts.signals (default: SIGINT/SIGTERM/SIGHUP)
+---     to `main_pid` — the user-visible child,
+---   * reap zombies with unix.wait() in a loop,
+---   * when `main_pid` exits, kill each pid in opts.sidecars and reap
+---     them, then return main_pid's exit status,
+---   * if any sidecar pid exits unexpectedly first, kill main_pid and
+---     return 1.
+---
+--- EINTR during wait() is handled internally.
+---
+--- The installed signal handler runs a Lua closure that pcalls
+--- `unix.kill`. This is intentionally simple: the process is expected
+--- to be in the supervisor loop (blocked in `unix.wait()`) when a
+--- signal arrives, so handler execution is serialized against the
+--- main loop by the kernel's standard "signal delivered between
+--- syscalls" semantics. Do NOT call this from inside a threaded
+--- program — lunix's sigaction is process-wide.
+---
+--- Returns an integer exit code suitable for `os.exit()`:
+---   * 0..255         main_pid exited with that status
+---   * 128 + signum   main_pid was terminated by signum
+---   * 1              unexpected supervisor failure
+---
+--- opts:
+---   sidecars   {pid, ...}   processes to kill+reap when main exits
+---   signals    {string|int} signal names/numbers to forward
+---   on_sidecar_exit  callable(pid, ws)  — hook for logging
+function M.become_init(main_pid, opts)
+  opts = opts or {}
+  local sidecars = opts.sidecars or {}
+  local signals = opts.signals or M.DEFAULT_SIGNALS
+  local on_sidecar_exit = opts.on_sidecar_exit
+
+  local function signum(s)
+    if type(s) == "number" then return s end
+    return unix[s]
+  end
+
+  -- Forward our interrupt/terminate signals to the main child.
+  local function forward(sig)
+    pcall(unix.kill, main_pid, sig)
+  end
+  for _, s in ipairs(signals) do
+    local n = signum(s)
+    if n then
+      unix.sigaction(n, function() forward(n) end)
+    end
+  end
+
+  local function kill_and_reap(pid)
+    pcall(unix.kill, pid, unix.SIGTERM)
+    pcall(unix.wait, pid)
+  end
+
+  while true do
+    local pid, ws = unix.wait()
+    if not pid then
+      -- ws is a unix.Errno on failure. EINTR = a forwarded signal
+      -- arrived mid-wait; loop and reap.
+      if ws and ws:errno() == unix.EINTR then
+        -- continue
+      else
+        return 1
+      end
+    elseif pid == main_pid then
+      for _, s in ipairs(sidecars) do kill_and_reap(s) end
+      if unix.WIFEXITED(ws) then
+        return unix.WEXITSTATUS(ws)
+      elseif unix.WIFSIGNALED(ws) then
+        return 128 + unix.WTERMSIG(ws)
+      else
+        return 1
+      end
+    else
+      -- A sidecar exited. Kill the main child and return non-zero.
+      for _, s in ipairs(sidecars) do
+        if s == pid then
+          if on_sidecar_exit then
+            pcall(on_sidecar_exit, pid, ws)
+          end
+          kill_and_reap(main_pid)
+          return 1
+        end
+      end
+      -- Unknown child (spurious reap); keep waiting.
+    end
+  end
+end
+
+return M

--- a/3p/cosmos/sandbox/proxy.lua
+++ b/3p/cosmos/sandbox/proxy.lua
@@ -1,0 +1,1011 @@
+--- cosmo.sandbox.proxy: an HTTP CONNECT + plain-HTTP allowlist proxy.
+---
+--- Designed for the netns-isolated sandbox use case: the proxy listens
+--- inside a child network namespace (the only thing the sandboxed
+--- process can reach) and dials upstream in a *different* namespace —
+--- typically the parent's. Cross-namespace dialing is handled by setns()
+--- in per-connection forks, so a slow upstream never blocks others and
+--- there is no global namespace-state contention.
+---
+--- Features (v1):
+---   - HTTP/1.1 CONNECT method (HTTPS tunnels — opaque, allowlist only)
+---   - HTTP/1.1 GET/POST/HEAD/PUT/DELETE/PATCH forwarding with auth
+---     header injection
+---   - Allowlist with exact host:port, host (any port), and host:*
+---     matching
+---   - Per-host auth rules: bearer / basic / arbitrary header
+---   - Configurable logging: level (quiet/info/debug), format
+---     (text/json), destination (callable / file path / stderr)
+---
+--- Out of scope (v1): keep-alive reuse upstream, HTTP/2, MITM TLS
+--- interception. Chunked-encoded request bodies are detected and
+--- rejected with 411 Length Required.
+---
+--- Returns nil,unix.Errno on failure for non-fatal API; raises on
+--- programmer errors (bad config schema).
+
+local unix = require "unix"
+local cosmo = require "cosmo"
+
+local M = {_VERSION = "0.0.3"}
+
+--------------------------------------------------------------------------------
+-- Logging
+
+local function ts()
+  local s, ns = unix.clock_gettime(unix.CLOCK_REALTIME)
+  return string.format("%d.%09d", s, ns)
+end
+
+local LEVELS = {quiet = 0, info = 1, debug = 2}
+
+local function make_logger(opts)
+  local level = LEVELS[opts.log_level or "info"]
+  local format = opts.log_format or "text"
+  local sink = opts.on_log
+  local out
+  -- Only set up an output stream when no callable sink was supplied.
+  if not sink then
+    if type(opts.log_file) == "string" then
+      local f, err = io.open(opts.log_file, "a")
+      if not f then
+        return nil, "cannot open log file: " .. tostring(err)
+      end
+      f:setvbuf("line")
+      out = f
+    else
+      out = io.stderr
+    end
+  end
+  local function emit(ev, fields)
+    if sink then
+      -- emit() runs inside the per-connection worker. A raising
+      -- user sink would abort the handler mid-request; swallow it.
+      pcall(sink, fields)
+      return
+    end
+    if format == "json" then
+      local parts = {}
+      parts[#parts + 1] = string.format('{"ts":"%s"', ts())
+      parts[#parts + 1] = string.format(',"event":%q', ev)
+      for k, v in pairs(fields) do
+        if type(v) == "number" then
+          parts[#parts + 1] = string.format(',%q:%d', k, v)
+        else
+          parts[#parts + 1] = string.format(',%q:%q', k, tostring(v))
+        end
+      end
+      parts[#parts + 1] = "}\n"
+      out:write(table.concat(parts))
+    else
+      local kv = {}
+      for k, v in pairs(fields) do
+        kv[#kv + 1] = string.format("%s=%s", k, tostring(v))
+      end
+      out:write(string.format("%s %s %s\n", ts(), ev, table.concat(kv, " ")))
+    end
+  end
+  return {
+    info  = function(ev, f) if level >= 1 then emit(ev, f or {}) end end,
+    debug = function(ev, f) if level >= 2 then emit(ev, f or {}) end end,
+    warn  = function(ev, f) if level >= 1 then emit(ev, f or {}) end end,
+  }
+end
+M._make_logger = make_logger
+
+--------------------------------------------------------------------------------
+-- Allowlist matching
+
+-- Normalize a rule key into ("host", port_or_nil) where port is nil if any.
+local function parse_rule(key)
+  local h, p = key:match("^(.-):(.-)$")
+  if not h then
+    return key:lower(), nil
+  end
+  if p == "*" or p == "" then
+    return h:lower(), nil
+  end
+  return h:lower(), tonumber(p)
+end
+M._parse_rule = parse_rule
+
+-- Build a fast lookup index from a {[key]=rule} table.
+-- The result is a table with two shapes:
+--   idx.exact[host][port|"*"]  = rule   (exact-host matches)
+--   idx.suffix[i]              = {suffix = ".x", port = p|"*", rule = ...}
+--                                       (wildcard *.suffix matches)
+-- Suffixes are stored with a leading "." and matched via string.sub
+-- at the tail of the candidate host. The list is kept in insertion
+-- order; match() walks it and returns the first hit.
+local function build_index(allowed_hosts)
+  local idx = {exact = {}, suffix = {}}
+  for k, rule in pairs(allowed_hosts or {}) do
+    -- Detect "*.suffix" or "*.suffix:port" form.
+    local wild = k:match("^%*%.(.+)$")
+    if wild then
+      local h, p = parse_rule(wild)
+      idx.suffix[#idx.suffix + 1] = {
+        suffix = "." .. h, port = p or "*", rule = rule,
+      }
+    else
+      local h, p = parse_rule(k)
+      idx.exact[h] = idx.exact[h] or {}
+      idx.exact[h][p or "*"] = rule
+    end
+  end
+  return idx
+end
+M._build_index = build_index
+
+-- Look up a (host, port) pair. Returns the rule table on a hit, or nil.
+-- Tries exact-host match first, then walks suffix patterns.
+local function match(idx, host, port)
+  host = host:lower()
+  local entry = idx.exact[host]
+  if entry then
+    local hit = entry[port] or entry["*"]
+    if hit then return hit end
+  end
+  for _, s in ipairs(idx.suffix) do
+    if host:sub(-#s.suffix) == s.suffix
+       and (s.port == "*" or s.port == port) then
+      return s.rule
+    end
+  end
+  return nil
+end
+M._match = match
+
+--------------------------------------------------------------------------------
+-- Auth header construction
+
+local function auth_header(rule)
+  -- Accept the shorthand forms `true` / non-table as pass-through
+  -- (allowed, no injection). Only a real table with a known `type`
+  -- produces an injected header.
+  if type(rule) ~= "table" then return nil end
+  if rule.type == "bearer" then
+    return "Authorization", "Bearer " .. tostring(rule.token)
+  elseif rule.type == "basic" then
+    local enc = cosmo.EncodeBase64(rule.username .. ":" .. rule.password)
+    return "Authorization", "Basic " .. enc
+  elseif rule.type == "header" then
+    return rule.header_name, rule.header_value
+  end
+  return nil
+end
+M._auth_header = auth_header
+
+-- Validate a single allowlist rule. Returns nil on success, a
+-- human-readable error string on failure. Invoked on every rule at
+-- proxy.new time so operators can't silently typo their way out of
+-- header injection — a sandbox proxy is security-sensitive and a
+-- misspelled `type` must fail loudly, not degrade to pass-through.
+--
+-- Bare pass-through values (nil, true, {}) are accepted as "allow,
+-- no auth injection". A table with a `type` field must use a known
+-- type and carry the fields that auth_header() would dereference.
+local function validate_rule(key, rule)
+  if rule == nil or rule == true then return nil end
+  if type(rule) ~= "table" then
+    return string.format("allowed_hosts[%q]: rule must be a table, true, "
+                         .. "or nil (got %s)", key, type(rule))
+  end
+  if rule.type == nil then return nil end   -- {} is explicit pass-through
+  if rule.type == "bearer" then
+    if type(rule.token) ~= "string" or rule.token == "" then
+      return string.format("allowed_hosts[%q]: bearer rule requires "
+                           .. "non-empty string `token`", key)
+    end
+  elseif rule.type == "basic" then
+    if type(rule.username) ~= "string" or rule.username == "" then
+      return string.format("allowed_hosts[%q]: basic rule requires "
+                           .. "non-empty string `username`", key)
+    end
+    if type(rule.password) ~= "string" then
+      return string.format("allowed_hosts[%q]: basic rule requires "
+                           .. "string `password`", key)
+    end
+  elseif rule.type == "header" then
+    if type(rule.header_name) ~= "string" or rule.header_name == "" then
+      return string.format("allowed_hosts[%q]: header rule requires "
+                           .. "non-empty string `header_name`", key)
+    end
+    if type(rule.header_value) ~= "string" then
+      return string.format("allowed_hosts[%q]: header rule requires "
+                           .. "string `header_value`", key)
+    end
+  else
+    return string.format("allowed_hosts[%q]: unknown rule type %q "
+                         .. "(expected \"bearer\", \"basic\", or \"header\")",
+                         key, tostring(rule.type))
+  end
+  return nil
+end
+M._validate_rule = validate_rule
+
+--------------------------------------------------------------------------------
+-- Wire I/O helpers
+
+-- Read until "\r\n\r\n" or EOF. Returns (header_block, leftover_after).
+-- Bounds the read to `max` bytes to avoid memory blowups from junk input.
+local function read_headers(fd, max)
+  max = max or 65536
+  local buf = ""
+  while #buf < max do
+    local chunk, err = unix.recv(fd, math.min(4096, max - #buf))
+    if not chunk then return nil, tostring(err) end
+    if chunk == "" then return nil, "eof" end
+    buf = buf .. chunk
+    local i, j = buf:find("\r\n\r\n", 1, true)
+    if i then
+      return buf:sub(1, j), buf:sub(j + 1)
+    end
+  end
+  return nil, "header block exceeds " .. max .. " bytes"
+end
+M._read_headers = read_headers
+
+-- Send all bytes (handles short writes). Uses the send() offset
+-- parameter so we don't reallocate a tail substring every iteration.
+local function send_all(fd, data)
+  local total = #data
+  local off = 0
+  while off < total do
+    local n, err = unix.send(fd, data, 0, off)
+    if not n then return nil, tostring(err) end
+    if n == 0 then return nil, "short write" end
+    off = off + n
+  end
+  return true
+end
+M._send_all = send_all
+
+-- Helper: shutdown one direction, mark side closed, drop from poll set.
+local function close_side(fds, fd, peer, sides, which)
+  pcall(unix.shutdown, peer, unix.SHUT_WR)
+  fds[fd] = nil
+  sides[which] = false
+end
+
+-- Bidirectional byte pump between two TCP fds. Returns when both
+-- sides hit EOF or one side errors. Uses unix.poll so the work
+-- happens in a single process. shutdown(SHUT_WR) is issued in the
+-- appropriate direction so the peer sees a clean half-close.
+local function pump(a, b)
+  local fds = {[a] = unix.POLLIN, [b] = unix.POLLIN}
+  local sides = {a = true, b = true}
+  while sides.a or sides.b do
+    local ready = unix.poll(fds)
+    if not ready then return end
+    for fd, ev in pairs(ready) do
+      local which = (fd == a) and "a" or "b"
+      local peer = (fd == a) and b or a
+      local readable = (ev & unix.POLLIN) ~= 0
+      local hup = (ev & (unix.POLLHUP | unix.POLLERR | unix.POLLNVAL)) ~= 0
+      if readable then
+        local chunk = unix.recv(fd, 16384)
+        if not chunk or chunk == "" then
+          close_side(fds, fd, peer, sides, which)
+        else
+          if not send_all(peer, chunk) then return end
+        end
+      elseif hup then
+        close_side(fds, fd, peer, sides, which)
+      end
+    end
+  end
+end
+M._pump = pump
+
+--------------------------------------------------------------------------------
+-- Upstream dialing across namespaces
+
+-- Resolve `host` to an IPv4 integer suitable for unix.connect. Uses
+-- cosmo.ResolveIp which goes through the system resolver in the
+-- *current* netns (so call this AFTER setns() to the upstream netns).
+--
+-- cosmo.ParseIp returns -1 (not nil) when the string isn't a literal
+-- IP, so we explicitly fall back to ResolveIp on -1.
+--
+-- When `timeout_ms` is non-nil, DNS resolution is bounded: the actual
+-- lookup runs in a forked helper and the parent polls the result pipe
+-- with ppoll(timeout_ms). If the deadline elapses the helper is
+-- SIGKILL'd and (nil, "resolve timeout") is returned, so a hostile or
+-- tarpitting upstream resolver can't wedge a per-connection worker
+-- past the configured budget. Literal IPs skip the fork entirely.
+--
+-- `resolver` is an injection seam for tests: it defaults to
+-- cosmo.ResolveIp and takes `(host)` → ip | nil, err. Passing a fake
+-- slow/failing resolver lets the timeout path be exercised without a
+-- working DNS stack.
+local function resolve_v4(host, timeout_ms, resolver)
+  local ip = cosmo.ParseIp(host)
+  if ip and ip ~= -1 then return ip end
+  resolver = resolver or cosmo.ResolveIp
+  if not timeout_ms then
+    return resolver(host)
+  end
+  local r, w, perr = unix.pipe()
+  if not r then return nil, w or perr end
+  local pid, ferr = unix.fork()
+  if not pid then
+    unix.close(r); unix.close(w)
+    return nil, ferr
+  end
+  if pid == 0 then
+    unix.close(r)
+    local resolved, rerr = resolver(host)
+    if resolved then
+      unix.write(w, "O" .. string.pack("<i8", resolved))
+    else
+      unix.write(w, "E" .. tostring(rerr or "resolve failed"))
+    end
+    unix.close(w)
+    unix.exit(0)
+  end
+  unix.close(w)
+  local ready = unix.poll({[r] = unix.POLLIN}, timeout_ms)
+  if not ready or not ready[r] then
+    pcall(unix.kill, pid, unix.SIGKILL)
+    pcall(unix.wait, pid)
+    unix.close(r)
+    return nil, "resolve timeout"
+  end
+  -- Drain the pipe. The helper writes at most 9 bytes (1 status byte +
+  -- 8-byte packed int) on success, or "E" + a short error string.
+  local data = unix.read(r, 4096) or ""
+  unix.close(r)
+  pcall(unix.wait, pid)
+  local tag = data:sub(1, 1)
+  if tag == "O" and #data >= 9 then
+    return string.unpack("<i8", data, 2)
+  elseif tag == "E" then
+    return nil, data:sub(2)
+  end
+  return nil, "resolve failed"
+end
+M._resolve_v4 = resolve_v4
+
+-- Open a TCP connection to (host, port) in the namespace identified by
+-- `upstream_ns_fd`, falling back to the current namespace if the fd is
+-- nil. `resolve_timeout_ms` (optional) bounds DNS resolution per dial.
+-- Returns fd | nil,err.
+local function dial(host, port, upstream_ns_fd, resolve_timeout_ms)
+  if upstream_ns_fd then
+    local ok, err = unix.setns(upstream_ns_fd, unix.CLONE_NEWNET)
+    if not ok then return nil, err end
+  end
+  local ip, rerr = resolve_v4(host, resolve_timeout_ms)
+  if not ip then return nil, rerr end
+  -- Block non-public IPs to prevent SSRF. This covers loopback (127/8),
+  -- link-local (169.254/16) including the cloud metadata endpoint
+  -- 169.254.169.254, RFC1918, CGNAT (100.64/10), 0.0.0.0/8, and other
+  -- reserved ranges. Applies to both CONNECT and plain-HTTP paths.
+  if not cosmo.IsPublicIp(ip) then
+    return nil, "request to private network blocked (SSRF protection)"
+  end
+  -- SOCK_CLOEXEC: prevent this upstream connection socket from leaking
+  -- into any exec'd child via an accidental fork/exec ordering change.
+  -- setns() in this process (before connect) is unaffected by CLOEXEC.
+  local sk, serr = unix.socket(unix.AF_INET, unix.SOCK_STREAM | unix.SOCK_CLOEXEC, 0)
+  if not sk then return nil, serr end
+  local ok, cerr = unix.connect(sk, ip, port)
+  if not ok then
+    unix.close(sk)
+    return nil, cerr
+  end
+  return sk
+end
+M._dial = dial
+
+--------------------------------------------------------------------------------
+-- HTTP request/response handling
+
+local DENY = "HTTP/1.1 403 Forbidden\r\n" ..
+             "Content-Length: 0\r\n" ..
+             "Connection: close\r\n\r\n"
+
+local BAD_REQUEST = "HTTP/1.1 400 Bad Request\r\n" ..
+                    "Content-Length: 0\r\n" ..
+                    "Connection: close\r\n\r\n"
+
+local LENGTH_REQUIRED = "HTTP/1.1 411 Length Required\r\n" ..
+                        "Content-Length: 0\r\n" ..
+                        "Connection: close\r\n\r\n"
+
+local UPSTREAM_FAIL = "HTTP/1.1 502 Bad Gateway\r\n" ..
+                      "Content-Length: 0\r\n" ..
+                      "Connection: close\r\n\r\n"
+
+-- Parse an HTTP request line: "METHOD TARGET HTTP/x.y\r\n".
+-- Returns method, target, version | nil.
+local function parse_request_line(line)
+  local m, t, v = line:match("^(%u+) (%S+) (HTTP/%d%.%d)\r\n")
+  return m, t, v
+end
+M._parse_request_line = parse_request_line
+
+-- Parse a CONNECT target "host:port".
+local function parse_connect_target(t)
+  local h, p = t:match("^([^:]+):(%d+)$")
+  if not h then return nil end
+  return h, tonumber(p)
+end
+M._parse_connect_target = parse_connect_target
+
+-- Parse an absolute URI of the form "http://host[:port]/path".
+-- HTTP proxies receive these (RFC 7230 §5.3.2) instead of origin-form.
+-- Returns scheme, host, port (default 80), path.
+local function parse_absolute_uri(t)
+  local s, hp, path = t:match("^(https?)://([^/]+)(/.*)$")
+  if not s then
+    s, hp = t:match("^(https?)://([^/]+)$")
+    path = "/"
+  end
+  if not s then return nil end
+  local h, p = hp:match("^([^:]+):(%d+)$")
+  if h then
+    return s, h, tonumber(p), path
+  end
+  return s, hp, (s == "https") and 443 or 80, path
+end
+M._parse_absolute_uri = parse_absolute_uri
+
+-- Parse a header block (everything after the request line, up to the
+-- blank \r\n) into a list of {orig_name, lower_name, value} triples.
+-- Cheaper than re-scanning the block multiple times.
+local function parse_headers(block)
+  local out = {}
+  -- Skip the request line, then iterate header lines.
+  local skip = true
+  for line in block:gmatch("([^\r\n]+)\r\n") do
+    if skip then
+      skip = false
+    else
+      local n, v = line:match("^([^:]+):%s*(.*)$")
+      if n then out[#out + 1] = {n, n:lower(), v} end
+    end
+  end
+  return out
+end
+M._parse_headers = parse_headers
+
+-- Find the first header value (case-insensitive). Returns nil if absent.
+local function header_get(headers, lower_name)
+  for _, h in ipairs(headers) do
+    if h[2] == lower_name then return h[3] end
+  end
+  return nil
+end
+M._header_get = header_get
+
+-- Parse Content-Length out of a parsed header list (or a raw block,
+-- for backward compat / convenience). Returns 0 if absent.
+local function content_length(headers)
+  if type(headers) == "string" then headers = parse_headers(headers) end
+  local v = header_get(headers, "content-length")
+  return v and tonumber(v) or 0
+end
+M._content_length = content_length
+
+-- Hop-by-hop headers per RFC 7230 §6.1, plus content-length (which we
+-- always reissue ourselves to avoid duplicates) and host (which we
+-- rewrite). transfer-encoding triggers a 411 path before we get here.
+local HOP_BY_HOP = {
+  ["connection"] = true,
+  ["proxy-connection"] = true,
+  ["keep-alive"] = true,
+  ["te"] = true,
+  ["trailer"] = true,
+  ["transfer-encoding"] = true,
+  ["upgrade"] = true,
+  ["content-length"] = true,
+  ["host"] = true,
+}
+
+-- Construct the forwarded HTTP request: method + origin-form target +
+-- HTTP/1.1, with our injected auth header (replacing any existing one
+-- of the same name), Host rewritten to the upstream target, and
+-- Connection: close. Strips proxy-only headers.
+local function rebuild_request(method, path, headers, body,
+                               inject_name, inject_value, host_hdr)
+  -- `headers` may be either a parsed list (from parse_headers) or a
+  -- raw block — accept both for backward compat.
+  if type(headers) == "string" then headers = parse_headers(headers) end
+  local injected_lower = inject_name and inject_name:lower() or nil
+  local out = {string.format("%s %s HTTP/1.1\r\n", method, path)}
+  out[#out + 1] = "Host: " .. host_hdr .. "\r\n"
+  for _, h in ipairs(headers) do
+    local oname, lname, value = h[1], h[2], h[3]
+    if HOP_BY_HOP[lname] then
+      -- skip
+    elseif injected_lower and lname == injected_lower then
+      -- replaced below
+    else
+      out[#out + 1] = oname .. ": " .. value .. "\r\n"
+    end
+  end
+  if inject_name then
+    out[#out + 1] = inject_name .. ": " .. inject_value .. "\r\n"
+  end
+  out[#out + 1] = "Connection: close\r\n"
+  if body and #body > 0 then
+    out[#out + 1] = "Content-Length: " .. #body .. "\r\n"
+  else
+    out[#out + 1] = "Content-Length: 0\r\n"
+  end
+  out[#out + 1] = "\r\n"
+  if body then out[#out + 1] = body end
+  return table.concat(out)
+end
+M._rebuild_request = rebuild_request
+
+-- Read exactly `n` bytes from `fd`, given an optional already-buffered
+-- prefix. Returns the body string, plus any leftover from `prefix`.
+local function read_body(fd, n, prefix)
+  local buf = prefix or ""
+  while #buf < n do
+    local chunk, err = unix.recv(fd, math.min(16384, n - #buf))
+    if not chunk then return nil, tostring(err) end
+    if chunk == "" then return nil, "eof in body" end
+    buf = buf .. chunk
+  end
+  return buf:sub(1, n), buf:sub(n + 1)
+end
+M._read_body = read_body
+
+--------------------------------------------------------------------------------
+-- Per-connection handler
+
+-- Handle one accepted client connection. Closes `client_fd` before
+-- returning. Designed to be called in a forked worker process so it
+-- can call setns() without affecting the parent.
+local function handle(self, client_fd)
+  local logger = self._logger
+  local hdr, leftover = read_headers(client_fd)
+  if not hdr then
+    logger.warn("malformed", {reason = leftover or "truncated"})
+    send_all(client_fd, BAD_REQUEST)
+    unix.close(client_fd)
+    return
+  end
+  local first = hdr:match("^([^\r\n]+)\r\n")
+  if not first then
+    send_all(client_fd, BAD_REQUEST)
+    unix.close(client_fd)
+    return
+  end
+  local method, target = parse_request_line(first .. "\r\n")
+  if not method then
+    send_all(client_fd, BAD_REQUEST)
+    unix.close(client_fd)
+    return
+  end
+
+  if method == "CONNECT" then
+    local host, port = parse_connect_target(target)
+    if not host then
+      send_all(client_fd, BAD_REQUEST)
+      unix.close(client_fd)
+      return
+    end
+    local rule = match(self._index, host, port)
+    if not rule then
+      logger.warn("deny", {method = "CONNECT", host = host, port = port})
+      send_all(client_fd, DENY)
+      unix.close(client_fd)
+      return
+    end
+    logger.debug("dial", {method = "CONNECT", host = host, port = port})
+    local up, derr = dial(host, port, self._upstream_ns_fd,
+                          self._resolve_timeout_ms)
+    if not up then
+      logger.warn("upstream_fail",
+                  {method = "CONNECT", host = host, port = port, err = derr})
+      send_all(client_fd, UPSTREAM_FAIL)
+      unix.close(client_fd)
+      return
+    end
+    logger.info("allow", {method = "CONNECT", host = host, port = port})
+    if not send_all(client_fd, "HTTP/1.1 200 Connection Established\r\n\r\n") then
+      unix.close(up); unix.close(client_fd); return
+    end
+    -- If the client already sent payload after the CONNECT line (rare
+    -- but possible for racy clients), forward it to upstream first.
+    if leftover and #leftover > 0 then
+      if not send_all(up, leftover) then
+        unix.close(up); unix.close(client_fd); return
+      end
+    end
+    pump(client_fd, up)
+    unix.close(up)
+    unix.close(client_fd)
+    return
+  end
+
+  -- Plain HTTP. Target is absolute-form for proxy requests.
+  local scheme, host, port, path = parse_absolute_uri(target)
+  if not host then
+    send_all(client_fd, BAD_REQUEST)
+    unix.close(client_fd)
+    return
+  end
+  local parsed = parse_headers(hdr)
+  -- Reject chunked-encoded request bodies — we don't dechunk in v1.
+  local te = header_get(parsed, "transfer-encoding")
+  if te and te:lower():find("chunked", 1, true) then
+    logger.warn("chunked_unsupported",
+                {method = method, host = host, path = path})
+    send_all(client_fd, LENGTH_REQUIRED)
+    unix.close(client_fd)
+    return
+  end
+  local rule = match(self._index, host, port)
+  if not rule then
+    logger.warn("deny",
+                {method = method, host = host, port = port, path = path})
+    send_all(client_fd, DENY)
+    unix.close(client_fd)
+    return
+  end
+  -- Read the request body (Content-Length only).
+  local clen = content_length(parsed)
+  local body
+  if clen > 0 then
+    local b, err = read_body(client_fd, clen, leftover)
+    if not b then
+      send_all(client_fd, BAD_REQUEST)
+      unix.close(client_fd)
+      return
+    end
+    body = b
+  end
+  local up, derr = dial(host, port, self._upstream_ns_fd, self._resolve_timeout_ms)
+  if not up then
+    logger.warn("upstream_fail",
+                {method = method, host = host, port = port, err = derr})
+    send_all(client_fd, UPSTREAM_FAIL)
+    unix.close(client_fd)
+    return
+  end
+  local injn, injv = auth_header(rule)
+  local host_hdr = host
+  if (scheme == "http"  and port ~= 80) or
+     (scheme == "https" and port ~= 443) then
+    host_hdr = host .. ":" .. port
+  end
+  local req = rebuild_request(method, path, parsed, body, injn, injv, host_hdr)
+  if not send_all(up, req) then
+    unix.close(up); unix.close(client_fd); return
+  end
+  logger.info("allow", {method = method, host = host, port = port,
+                        path = path,
+                        injected = injn ~= nil and injn or false})
+  -- Stream the response back. We pump bidirectionally for symmetry;
+  -- after the client's body is forwarded the cli→up direction quickly
+  -- EOFs.
+  pump(client_fd, up)
+  unix.close(up)
+  unix.close(client_fd)
+end
+
+--------------------------------------------------------------------------------
+-- Public Proxy object
+
+--- Allowlist rule schema
+--- ----------------------
+---
+--- `opts.allowed_hosts` is a map from host-spec string to a rule value:
+---
+---     opts.allowed_hosts = {
+---       -- Pass-through: host is allowed, no auth header injection.
+---       ["api.anthropic.com:443"]         = {},
+---       ["*.githubusercontent.com"]       = true,
+---
+---       -- Bearer token injection (plain-HTTP only; HTTPS is opaque).
+---       ["api.internal.example.com:80"]   = {
+---         type  = "bearer",
+---         token = os.getenv("TOKEN") or "",
+---       },
+---
+---       -- Basic auth.
+---       ["legacy.example.com:80"]         = {
+---         type = "basic", username = "u", password = "p",
+---       },
+---
+---       -- Arbitrary header injection.
+---       ["api.internal.example.com:80"]   = {
+---         type         = "header",
+---         header_name  = "x-api-key",
+---         header_value = os.getenv("INTERNAL_API_KEY") or "",
+---       },
+---     }
+---
+--- Host-spec forms:
+---   host              any port on exact host
+---   host:port         exact host + exact port
+---   host:*            any port on exact host (explicit)
+---   *.suffix          any host ending in ".suffix", any port
+---   *.suffix:port     any host ending in ".suffix", exact port
+---
+--- Rule values:
+---   Any non-table (e.g. `true`, or an empty table `{}`) means "allow,
+---   do not inject auth". A table with a recognized `type` field
+---   injects the corresponding header on plain-HTTP requests only —
+---   HTTPS (CONNECT) tunnels are end-to-end encrypted, so no injection
+---   is possible. The rule is still consulted as the allowlist gate
+---   for CONNECT, and serves as documentation of which credentials the
+---   child process is expected to use.
+---
+---   type="bearer", token=STRING
+---     → "Authorization: Bearer <token>"
+---
+---   type="basic", username=STRING, password=STRING
+---     → "Authorization: Basic base64(user:pass)"
+---
+---   type="header", header_name=STRING, header_value=STRING
+---     → "<header_name>: <header_value>"
+---
+--- Every rule is validated at proxy.new time: unknown `type` values
+--- and missing required fields raise immediately. This is
+--- deliberate — a typo'd rule silently degrading to pass-through
+--- would strip auth from an otherwise-authenticated egress path.
+--- Unknown *non-type* fields are ignored (forward compatibility).
+
+local Proxy = {__name = "cosmo.sandbox.proxy.Proxy"}
+Proxy.__index = Proxy
+
+--- Create a new proxy. `opts` fields:
+---
+---   bind_ip          uint32 IPv4 (default cosmo.ParseIp("127.0.0.1"))
+---   bind_port        uint16 (default 3128; 0 = ephemeral)
+---   allowed_hosts    table {host_spec = rule} — see schema above
+---   upstream_ns_fd   int (open fd to the netns to dial in; default
+---                    nil means dial in the current namespace)
+---   on_log           function(fields) — overrides default sink
+---   log_level        "quiet"|"info"|"debug"  (default "info")
+---   log_format       "text"|"json"           (default "text")
+---   log_file         path                    (default stderr)
+---   accept_backlog   int                     (default 32)
+---   resolve_timeout_ms int | false            (default 5000)
+---                    Per-dial DNS resolution deadline in milliseconds.
+---                    A hostile or slow upstream resolver is capped at
+---                    this budget; on timeout the dial fails with
+---                    "resolve timeout" and the connection gets 502.
+---                    Pass `false` to opt out of the timeout entirely
+---                    (restores pre-v0.0.3 unbounded behaviour).
+---
+--- Raises if any allowed_hosts rule has an unknown `type` or is
+--- missing a required field — see "Allowlist rule schema" above.
+---
+--- Returns the Proxy object.
+function M.new(opts)
+  opts = opts or {}
+  for key, rule in pairs(opts.allowed_hosts or {}) do
+    local verr = validate_rule(key, rule)
+    if verr then error(verr) end
+  end
+  local logger, lerr = make_logger(opts)
+  if not logger then error(lerr) end
+  -- `resolve_timeout_ms = false` opts out of the timeout; a nil key
+  -- falls back to the 5000ms default.
+  local resolve_timeout_ms
+  if opts.resolve_timeout_ms == nil then
+    resolve_timeout_ms = 5000
+  elseif opts.resolve_timeout_ms then
+    resolve_timeout_ms = opts.resolve_timeout_ms
+  end
+  return setmetatable({
+    _bind_ip = opts.bind_ip or cosmo.ParseIp("127.0.0.1"),
+    _bind_port = opts.bind_port or 3128,
+    _index = build_index(opts.allowed_hosts or {}),
+    _upstream_ns_fd = opts.upstream_ns_fd,
+    _logger = logger,
+    _backlog = opts.accept_backlog or 32,
+    _resolve_timeout_ms = resolve_timeout_ms,
+    _listen_fd = nil,
+  }, Proxy)
+end
+
+--- Bind + listen. Returns the listening fd, or nil, unix.Errno.
+function Proxy:listen()
+  -- SOCK_CLOEXEC: the listening socket must not be inherited by the
+  -- sandboxed exec'd child (it would allow rebinding or probing the
+  -- proxy from inside the jail). Per-connection forks already explicitly
+  -- close it; CLOEXEC adds defense-in-depth against ordering accidents.
+  local fd, err = unix.socket(unix.AF_INET, unix.SOCK_STREAM | unix.SOCK_CLOEXEC, 0)
+  if not fd then return nil, err end
+  unix.setsockopt(fd, unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+  local ok, berr = unix.bind(fd, self._bind_ip, self._bind_port)
+  if not ok then unix.close(fd); return nil, berr end
+  ok, err = unix.listen(fd, self._backlog)
+  if not ok then unix.close(fd); return nil, err end
+  -- Refresh bind_port if the caller asked for 0.
+  local _, port = unix.getsockname(fd)
+  if port then self._bind_port = port end
+  self._listen_fd = fd
+  self._logger.info("listen",
+                    {ip = cosmo.FormatIp(self._bind_ip),
+                     port = self._bind_port})
+  return fd
+end
+
+--- Accept one connection. Returns the client fd | nil, unix.Errno.
+function Proxy:accept()
+  return unix.accept(self._listen_fd)
+end
+
+--- Handle one accepted fd in this process. Does NOT fork.
+function Proxy:handle(client_fd)
+  return handle(self, client_fd)
+end
+
+--- Run the accept loop forever, forking per connection. Reaps zombies
+--- non-blockingly between accepts. Breaks out of the loop on EBADF
+--- (listening fd was closed externally) or other persistent errors;
+--- the caller is responsible for SIGTERM/SIGINT handling.
+function Proxy:serve_forever()
+  if not self._listen_fd then assert(self:listen()) end
+  local function reap()
+    while true do
+      local pid = unix.wait(-1, unix.WNOHANG)
+      if not pid or pid == 0 then return end
+    end
+  end
+  while true do
+    local cli, aerr = self:accept()
+    if not cli then
+      local errno = aerr and aerr:errno()
+      if errno == unix.EINTR then
+        reap()
+      elseif errno == unix.EBADF or errno == unix.EINVAL then
+        -- Listener went away. Stop the loop; the supervisor will
+        -- decide what to do next.
+        self._logger.warn("accept_fatal", {err = tostring(aerr)})
+        return
+      else
+        self._logger.warn("accept_fail", {err = tostring(aerr)})
+      end
+    else
+      local pid = unix.fork()
+      if pid == 0 then
+        unix.close(self._listen_fd)
+        self:handle(cli)
+        unix.exit(0)
+      else
+        unix.close(cli)
+        reap()
+      end
+    end
+  end
+end
+
+--------------------------------------------------------------------------------
+-- Convenience: fork + listen + serve in one call.
+
+local Handle = {__name = "cosmo.sandbox.proxy.Handle"}
+Handle.__index = Handle
+
+local function now_ms()
+  local s, ns = unix.clock_gettime(unix.CLOCK_MONOTONIC)
+  return s * 1000 + ns // 1000000
+end
+
+--- handle:stop([timeout_ms]) → true
+---
+--- Send SIGTERM and reap. Idempotent: once the child has been reaped
+--- (self.pid == 0), subsequent calls short-circuit without re-
+--- signalling — critical because `kill(0, ...)` targets the caller's
+--- whole process group, and a reused pid would receive a spurious
+--- signal. Escalates to SIGKILL if the child hasn't exited within
+--- `timeout_ms` (default 5000), so a hung or SIGTERM-ignoring worker
+--- can't wedge the supervisor forever.
+---
+--- Always returns true; signal/wait failures are swallowed via pcall
+--- since the post-condition (pid cleared, child no longer our
+--- responsibility) is reached regardless.
+function Handle:stop(timeout_ms)
+  if self.pid == 0 then return true end
+  timeout_ms = timeout_ms or 5000
+  local pid = self.pid
+  pcall(unix.kill, pid, unix.SIGTERM)
+  local deadline = now_ms() + timeout_ms
+  while true do
+    local gone = unix.wait(pid, unix.WNOHANG)
+    if gone == pid then
+      self.pid = 0
+      return true
+    end
+    if now_ms() >= deadline then break end
+    unix.nanosleep(0, 10 * 1000 * 1000)
+  end
+  pcall(unix.kill, pid, unix.SIGKILL)
+  pcall(unix.wait, pid)
+  self.pid = 0
+  return true
+end
+
+--- handle:alive() → boolean
+---
+--- Non-blocking health check: true while the proxy child is still
+--- running, false once it has exited. Uses waitpid(WNOHANG) so it
+--- returns immediately whether or not the child is ready.
+---
+--- Once alive() has observed an exit, it reaps the child (consuming
+--- the zombie) and clears self.pid to 0. Subsequent calls short-
+--- circuit to false without a waitpid syscall — avoiding races
+--- against pid reuse.
+function Handle:alive()
+  if self.pid == 0 then return false end
+  local gone = unix.wait(self.pid, unix.WNOHANG)
+  if gone == self.pid then
+    self.pid = 0
+    return false
+  end
+  return true
+end
+
+M._Handle = Handle
+
+--- proxy.start(opts) → {pid, port, stop()} | nil, unix.Errno
+---
+--- Fork a child process, bring the proxy up in it, and return a
+--- handle the caller can use to address the listening proxy:
+---
+---   p.pid      child pid (for waitpid / signal forwarding)
+---   p.port     the port the proxy is listening on (resolved even if
+---              opts.bind_port was 0)
+---   p:stop()   send SIGTERM and waitpid(p.pid)
+---   p:alive()  non-blocking health check (true while running)
+---
+--- The parent blocks until the child has bound-and-listened, so
+--- p.port is valid immediately. The port is communicated back via a
+--- pipe so the parent doesn't have to poll.
+---
+--- This is the common case: spawn a proxy alongside a jailed
+--- workload. Callers that need finer control (custom dispatch,
+--- non-forking mode, shared listener) should use proxy.new() +
+--- listen() + serve_forever() directly.
+function M.start(opts)
+  local r, w, perr = unix.pipe()
+  if not r then return nil, w or perr end
+  local pid, ferr = unix.fork()
+  if not pid then
+    unix.close(r); unix.close(w)
+    return nil, ferr
+  end
+  if pid == 0 then
+    -- Child: listen, report the bound port to the parent, then serve.
+    unix.close(r)
+    local p = M.new(opts)
+    local fd, lerr = p:listen()
+    if not fd then
+      unix.write(w, string.pack("<i4", -1))
+      unix.close(w)
+      io.stderr:write("proxy.start: listen: " .. tostring(lerr) .. "\n")
+      unix.exit(1)
+    end
+    unix.write(w, string.pack("<i4", p._bind_port))
+    unix.close(w)
+    p:serve_forever()
+    unix.exit(0)
+  end
+  -- Parent: read the bound port, then return the handle.
+  unix.close(w)
+  local packed = unix.read(r, 4)
+  unix.close(r)
+  if not packed or #packed < 4 then
+    pcall(unix.kill, pid, unix.SIGTERM)
+    pcall(unix.wait, pid)
+    return nil, unix.EIO
+  end
+  local port = string.unpack("<i4", packed)
+  if port < 0 then
+    pcall(unix.wait, pid)
+    return nil, unix.EIO
+  end
+  return setmetatable({pid = pid, port = port}, Handle)
+end
+
+return M

--- a/3p/cosmos/sandbox_test.tl
+++ b/3p/cosmos/sandbox_test.tl
@@ -1,0 +1,48 @@
+#!/usr/bin/env cosmic
+
+-- Verifies the vendored cosmo.sandbox modules (3p/cosmos/sandbox/*.lua,
+-- embedded at /zip/.lua/cosmo/sandbox/) load from this binary and expose
+-- their documented surface. Behavior is covered by the quicksand tests;
+-- this guards the vendoring itself (a missing or shadowed module fails
+-- here even on hosts without namespace support).
+
+local function test_umbrella()
+  local sandbox = require("cosmo.sandbox")
+  assert(type(sandbox.capabilities) == "function", "sandbox.capabilities missing")
+  assert(type(sandbox.is_supported) == "function", "sandbox.is_supported missing")
+  local caps = sandbox.capabilities()
+  assert(type(caps) == "table", "capabilities() should return a table")
+  for _, key in ipairs({"linux", "user_ns", "net_ns", "landlock", "pledge", "unveil"}) do
+    assert(type((caps as {string: any})[key]) == "boolean", "capabilities()." .. key)
+  end
+end
+test_umbrella()
+
+local function test_submodules()
+  local want: {string: {string}} = {
+    ["cosmo.sandbox.fs"] = {"pivot_to", "pivot_to_or_exit"},
+    ["cosmo.sandbox.netns"] = {"bring_up", "control_socket"},
+    ["cosmo.sandbox.proc"] = {"setup_userns_maps"},
+    ["cosmo.sandbox.landlock"] = {"restrict"},
+    ["cosmo.sandbox.proxy"] = {"start", "new"},
+  }
+  for name, fns in pairs(want) do
+    local mod = require(name)
+    assert(type(mod) == "table", name .. " should be a table")
+    for _, fn in ipairs(fns) do
+      local got = (mod as {string: any})[fn]
+      assert(type(got) == "function", name .. "." .. fn .. " missing")
+    end
+  end
+end
+test_submodules()
+
+local function test_vendored_source_embedded()
+  local cosmo = require("cosmo")
+  for _, name in ipairs({"init", "fs", "netns", "proc", "landlock", "proxy"}) do
+    local path = "/zip/.lua/cosmo/sandbox/" .. name .. ".lua"
+    local data = cosmo.Slurp(path)
+    assert(type(data) == "string" and #data > 0, path .. " not embedded")
+  end
+end
+test_vendored_source_embedded()

--- a/lib/build/lint.tl
+++ b/lib/build/lint.tl
@@ -139,10 +139,17 @@ local function check_call_after_define(file: string, lines: {string}): {Diagnost
   return diagnostics
 end
 
+--- Files exempt from lint: .d.tl type declaration files (they describe C
+--- binding interfaces and cannot be split due to Teal's record system) and
+--- vendored Lua under 3p/ (imported verbatim from upstream projects; kept
+--- byte-identical to ease diffing until rewritten in Teal).
+local function is_exempt(path: string): boolean
+  return path:match("%.d%.tl$") ~= nil
+    or path:match("^3p/.*%.lua$") ~= nil
+end
+
 local function lint_file(path: string): {Diagnostic}
-  -- Skip .d.tl type declaration files — they describe C binding interfaces
-  -- and cannot be split due to Teal's record system.
-  if path:match("%.d%.tl$") then
+  if is_exempt(path) then
     return {}
   end
 
@@ -201,7 +208,7 @@ local function main(...: string): integer
   for _, file in ipairs(files) do
     -- The standalone lint binary only enforces file-length (run on all tracked files).
     -- Column-length and assert-order are enforced via --check-style on .tl files.
-    if not file:match("%.d%.tl$") then
+    if not is_exempt(file) then
       local n = count_lines(file)
       local diags = check_file_length(file, n, DEFAULT_FILE_LINES)
       for _, d in ipairs(diags) do

--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -23,9 +23,13 @@ $(cosmic_version_lua): .FORCE | $$(cosmos_staged)
 
 .PHONY: .FORCE
 
-$(cosmic_bin): $$(cosmic_lua) $(cosmic_main) $(cosmic_args) $$(tl_staged) $$(teal-types_staged) $$(doc_index) $(cosmic_version_lua) $(cosmic_sys) $(cosmic_skills)
+$(cosmic_bin): $$(cosmic_lua) $(cosmic_main) $(cosmic_args) $$(tl_staged) $$(teal-types_staged) $$(doc_index) $(cosmic_version_lua) $(cosmic_sys) $(cosmic_skills) $(cosmos_sandbox_lua)
 	@rm -rf $(cosmic_built)
 	@mkdir -p $(cosmic_built)/.lua/cosmic $(cosmic_built)/.tl/cosmic $(@D)
+	@mkdir -p $(cosmic_built)/.lua/cosmo/sandbox
+	@for f in $(cosmos_sandbox_lua); do \
+		$(cp) "$$f" $(cosmic_built)/.lua/cosmo/sandbox/; \
+	done
 	@for f in $(cosmic_lua); do \
 		rel="$${f#$(o)/lib/cosmic/}"; \
 		dst="$(cosmic_built)/.lua/cosmic/$$rel"; \


### PR DESCRIPTION
# Summary

Companion to whilp/cosmopolitan#123, which slims the cosmopolitan fork to its C core. The pure-Lua sandbox orchestration layer (`cosmo.sandbox`: namespaces + `pivot_root` + landlock + HTTP egress proxy) moves here, next to its consumer (`cosmic.quicksand`), so the layering is: focused C primitives in the fork, Lua/teal policy in cosmic.

**This PR is required before bumping the cosmos pin past the fork's slimming change** — future cosmos releases no longer embed these modules.

## What's in it

- `3p/cosmos/sandbox/{init,fs,netns,proc,landlock,proxy}.lua` — vendored verbatim from whilp/cosmopolitan at `fc5677e12` (the security-fixed tip: SSRF + sandbox-confinement hardening from #121, newer than the currently pinned `97f550ca9` release).
- Build wiring: the modules are embedded into the cosmic binary at `/zip/.lua/cosmo/sandbox/`. InfoZIP append replaces same-name entries, so the vendored copies override the (older) ones still embedded in the pinned cosmos binary today, and become the only copy after the pin bump — verified both ways.
- `3p/cosmos/sandbox_test.tl` — guards the vendoring: each module loads from the built binary, its documented surface is intact (`capabilities()`, `fs.pivot_to_or_exit`, `proc.setup_userns_maps`, `proxy.start`/`new`, …), and the sources are embedded. Behavior remains covered by the existing quicksand tests (`netns_test`, `proxy_test`, `box/run_test`).
- Lint: vendored Lua under `3p/` is exempt from the 500-line limit (like `.d.tl` files) — `proxy.lua` is 1011 lines and stays byte-identical to upstream history for easy diffing until it's rewritten in Teal.

## Verification

`make ci` green: format 185/185, teal 185/185, tests **87/87** (86 baseline + new sandbox test), examples 18/18, lint 250/250 — run against the current cosmos pin. Separately, the full suite was also run against a locally built post-slimming cosmos binary with these vendored files (in the cosmopolitan PR): 86/86.

## Follow-ups (not this PR)

- Bump `3p/cosmos/version.lua` to the first release cut after whilp/cosmopolitan#123 merges.
- Incrementally rewrite the vendored modules in Teal (they only depend on `unix` + `cosmo` + each other; `lib/types/cosmo/sandbox/*.d.tl` already declares their types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R49PXA2xphxt7mfNjqwJ2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01R49PXA2xphxt7mfNjqwJ2T)_