### PR TITLE
Bump cosmos to 2026.07.03-dff6be237 (slimmed C-core release)

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "98a915c93a454991f2162e0ec9382d782cea8441c1d809e86ef51e348ee7d515"}},
+  platforms = {["*"] = {sha = "4785fe49f3a2d49dcdee3c701bc7772151d68b7338f735c5d6497867c67a8cf8"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.04.19-97f550ca9"
+  version = "2026.07.03-dff6be237"
 }


### PR DESCRIPTION
# Summary

Final step of the re-layering (whilp/cosmopolitan#123 + #415): bump the cosmos pin to `2026.07.03-dff6be237`, the first release cut from the slimmed fork. The lua binary no longer embeds the `cosmo.{sandbox,help,skill,embed,http}` Lua modules or the `lhttp`/`lgoodsocket` C bindings — the vendored `3p/cosmos/sandbox/` modules from #415 are now the only copy of the sandbox layer, and `cosmo.zip` is the C module directly (same `open`/`from` contract).

## Verification (full clean `make ci` against the new pin)

- format 185/185, teal 185/185, **tests 87/87** (including `sandbox_test` and all quicksand namespace/proxy tests), lint 257/257, examples 18/18.

## Heads-up: TLS trust behavior changed since the previous pin

The previous pin (`2026.04.19-97f550ca9`) predates the fork's security-review commit (whilp/cosmopolitan `fc5677e12`), so this bump also picks up: **system CA loading is now opt-in.** By default only the embedded pinned Mozilla roots are trusted; `SSL_CERT_FILE`/system bundles are honored only when `SSL_USE_SYSTEM_CERTS` is set (read via `secure_getenv`). Practical impact: environments behind a TLS-intercepting proxy must set `SSL_USE_SYSTEM_CERTS=1` for `cosmic.fetch` to verify. (This is exactly how the `fetch_example` failure surfaced in my sandboxed dev container — normal networks, including GitHub CI, are unaffected.) May be worth a line in `docs/stdlib.md` for `cosmic.fetch` — happy to add here if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R49PXA2xphxt7mfNjqwJ2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01R49PXA2xphxt7mfNjqwJ2T)_