### PR TITLE
Bump cosmos to 2026.07.03-08e46d2f7; use unix.O_PATH in landlock

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "4785fe49f3a2d49dcdee3c701bc7772151d68b7338f735c5d6497867c67a8cf8"}},
+  platforms = {["*"] = {sha = "0000000000000000000000000000000000000000000000000000000000000000"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.03-dff6be237"
+  version = "2026.07.03-08e46d2f7"
 }

--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,6 +1,6 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "0000000000000000000000000000000000000000000000000000000000000000"}},
+  platforms = {["*"] = {sha = "64561af6517c3cac2427956d0a01d3fe79c2b29fe9407d91a2cde148d21f6ce6"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
   version = "2026.07.03-08e46d2f7"

--- a/lib/cosmic/landlock.tl
+++ b/lib/cosmic/landlock.tl
@@ -23,13 +23,6 @@
 --- network isolation.
 local unix = require("cosmo.unix")
 
---- Linux O_PATH (0x00200000): open a pure path reference, usable even
---- for paths the caller cannot read. lunix does not export this
---- constant yet; landlock is Linux-only so the Linux value is safe to
---- pin here. (The vendored Lua predecessor read unix.O_PATH, which is
---- nil — any restrict() call with rules crashed on the bitwise-or.)
-local O_PATH < const > = 0x00200000
-
 local EXECUTE < const > = unix.LANDLOCK_ACCESS_FS_EXECUTE as integer
 local WRITE_FILE < const > = unix.LANDLOCK_ACCESS_FS_WRITE_FILE as integer
 local READ_FILE < const > = unix.LANDLOCK_ACCESS_FS_READ_FILE as integer
@@ -157,7 +150,8 @@ local function restrict(opts: RestrictOpts): boolean, string
       return fail(string.format("rule[%d] missing path", i))
     end
     local access = (rule.access or 0) & mask
-    local pfd, perr = unix.open(rule.path, O_PATH | unix.O_CLOEXEC)
+    local pfd, perr = unix.open(rule.path,
+      (unix.O_PATH as integer) | (unix.O_CLOEXEC as integer))
     if not pfd then
       return fail(string.format("open(%q): %s", rule.path, tostring(perr)))
     end

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -548,6 +548,10 @@ local record unix
   O_RSYNC: number
   O_SYNC: number
   O_NOATIME: number
+  --- Open a pure path reference: usable for fstat/openat-style
+  --- operations (and landlock rule fds) even when the caller cannot
+  --- read the file. Linux-only; 0 elsewhere.
+  O_PATH: number
   O_ACCMODE: number
   O_EXEC: number
   O_NOCTTY: number


### PR DESCRIPTION
# Summary

Closes out the last follow-up from #417: the whilp/cosmopolitan fork now exports `O_PATH` from `lunix.c` (verified at tag `2026.07.03-08e46d2f7`, `third_party/lua/lunix.c:4371`), so:

- **`3p/cosmos/version.lua`**: pin bumped `2026.07.03-dff6be237` → `2026.07.03-08e46d2f7`.
- **`lib/cosmic/landlock.tl`**: the locally-pinned `O_PATH < const > = 0x00200000` workaround is gone; rule fds now open with `unix.O_PATH | unix.O_CLOEXEC` like every other flag.
- **`lib/types/cosmo/unix.d.tl`**: `O_PATH` declared.

## sha256 bootstrap note

This session's egress policy blocks the release-asset download, so the initial commit pins a placeholder digest. `build-fetch` fails with `sha256 mismatch: expected …, got <actual>`, and the follow-up commit records the real digest from that CI output. The final revision of this PR must show a real sha and green CI before merge.

## Verification

- `landlock.tl` type- and format-checks clean locally.
- `O_PATH` export confirmed by reading `lunix.c` at the pinned tag (sparse clone).
- The landlock enforcement + `restrict{rules=…}` regression tests from #417 exercise the `unix.O_PATH` open path in CI (`landlock_test.tl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWvJtEgFSrDvFqLwiFTamG

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWvJtEgFSrDvFqLwiFTamG)_