### PR TITLE
Bump cosmos to 2026.07.03-a4bf2e4fd; wrap sysconf/uname in cosmic.sys

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "64561af6517c3cac2427956d0a01d3fe79c2b29fe9407d91a2cde148d21f6ce6"}},
+  platforms = {["*"] = {sha = "d1cf0c9e43a654ffaff6617fb2ef123a9ab4e41cfcddc271d3543727b8857406"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.03-08e46d2f7"
+  version = "2026.07.03-a4bf2e4fd"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,7 +219,7 @@ all modules are under `lib/cosmic/` and imported as `cosmic.*`:
 | sqlite | SQLite with ergonomic query/exec/transaction API |
 | sse | Server-Sent Events parser |
 | string | trim, split, capitalize, starts_with, etc. |
-| sys | OS/architecture detection |
+| sys | OS/architecture detection, sysconf (nproc, page size), uname |
 | syslog | system logging |
 | teal | Teal compilation and type checking |
 | testrun | test execution and reporting |

--- a/lib/cosmic/sys.tl
+++ b/lib/cosmic/sys.tl
@@ -1,6 +1,24 @@
 --- System information utilities.
 --- Wraps cosmo system functions for OS and architecture queries.
 local cosmo = require("cosmo")
+local unix = require("cosmo.unix")
+local Errno = require("cosmic.errno").Errno
+
+--- Operating system and hardware identification returned by `uname`.
+local record Uname
+  --- Operating system name (e.g. "Linux").
+  sysname: string
+  --- Network node hostname.
+  nodename: string
+  --- Operating system release.
+  release: string
+  --- Operating system version.
+  version: string
+  --- Hardware identifier (e.g. "x86_64").
+  machine: string
+  --- NIS or YP domain name.
+  domainname: string
+end
 
 --- Get the operating system name.
 --- Returns lowercase strings: "linux", "macos", "windows", "freebsd", "openbsd", "netbsd".
@@ -23,16 +41,106 @@ local function platform(): string
   return host_os() .. "-" .. host_isa()
 end
 
+--- Query a runtime system configuration value.
+--- `name` is one of the `unix.SC_*` constants (e.g. `unix.SC_PAGESIZE`,
+--- `unix.SC_NPROCESSORS_ONLN`). Returns nil plus an error message on failure.
+--- @param name number One of the unix.SC_* constants
+--- @return number The configuration value
+--- @return string? Error message on failure
+local function sysconf(name: number): number, string
+  local val, err = unix.sysconf(name) as(number, any)
+  if not val then
+    if err then
+      local errno = err as Errno
+      if errno.doc then
+        return nil, "sysconf: " .. errno:doc()
+      end
+      return nil, "sysconf: " .. tostring(err)
+    end
+    return nil, "sysconf failed"
+  end
+  return val
+end
+
+--- Number of processors currently online (available to run threads).
+--- @return number The online processor count
+--- @return string? Error message on failure
+local function nproc(): number, string
+  return sysconf(unix.SC_NPROCESSORS_ONLN)
+end
+
+--- Number of processors configured in the system.
+--- May exceed `nproc()` when some processors are offline.
+--- @return number The configured processor count
+--- @return string? Error message on failure
+local function nproc_configured(): number, string
+  return sysconf(unix.SC_NPROCESSORS_CONF)
+end
+
+--- Memory page size in bytes.
+--- @return number The page size in bytes
+--- @return string? Error message on failure
+local function page_size(): number, string
+  return sysconf(unix.SC_PAGESIZE)
+end
+
+--- Get operating system and hardware identification.
+--- Returns a `Uname` record with `sysname`, `nodename`, `release`, `version`,
+--- `machine`, and `domainname` fields. Returns nil plus an error message on failure.
+--- @return Uname The system identification record
+--- @return string? Error message on failure
+local function uname(): Uname, string
+  local uts, err = unix.uname() as(Uname, any)
+  if not uts then
+    if err then
+      local errno = err as Errno
+      if errno.doc then
+        return nil, "uname: " .. errno:doc()
+      end
+      return nil, "uname: " .. tostring(err)
+    end
+    return nil, "uname failed"
+  end
+  return uts
+end
+
 local record SysModule
+  -- sysconf(3) name constants
+  SC_ARG_MAX: number
+  SC_CHILD_MAX: number
+  SC_CLK_TCK: number
+  SC_OPEN_MAX: number
+  SC_PAGESIZE: number
+  SC_NPROCESSORS_CONF: number
+  SC_NPROCESSORS_ONLN: number
+
   host_os: function(): string
   host_isa: function(): string
   platform: function(): string
+  sysconf: function(name: number): number, string
+  nproc: function(): number, string
+  nproc_configured: function(): number, string
+  page_size: function(): number, string
+  uname: function(): Uname, string
 end
 
 local M: SysModule = {
+  SC_ARG_MAX = unix.SC_ARG_MAX,
+  SC_CHILD_MAX = unix.SC_CHILD_MAX,
+  SC_CLK_TCK = unix.SC_CLK_TCK,
+  SC_OPEN_MAX = unix.SC_OPEN_MAX,
+  SC_PAGESIZE = unix.SC_PAGESIZE,
+  SC_NPROCESSORS_CONF = unix.SC_NPROCESSORS_CONF,
+  SC_NPROCESSORS_ONLN = unix.SC_NPROCESSORS_ONLN,
+
   host_os = host_os,
   host_isa = host_isa,
   platform = platform,
+  sysconf = sysconf,
+  nproc = nproc,
+  nproc_configured = nproc_configured,
+  page_size = page_size,
+  uname = uname,
 }
 
 return M

--- a/lib/cosmic/sys_test.tl
+++ b/lib/cosmic/sys_test.tl
@@ -75,3 +75,55 @@ local function test_platform_is_lowercase()
   assert(plat == plat:lower(), "platform should be lowercase, got " .. plat)
 end
 test_platform_is_lowercase()
+
+-- sysconf / nproc / page_size tests
+
+local function test_nproc_positive()
+  local n, err = sys.nproc()
+  assert(n, "nproc should succeed, got error: " .. tostring(err))
+  assert(math.type(n) == "integer" or type(n) == "number",
+    "nproc should return a number, got " .. type(n))
+  assert(n >= 1, "nproc should be at least 1, got " .. tostring(n))
+end
+test_nproc_positive()
+
+local function test_nproc_configured_at_least_online()
+  local online = sys.nproc()
+  local configured = sys.nproc_configured()
+  assert(online and configured, "nproc/nproc_configured should succeed")
+  assert(configured >= online,
+    "configured (" .. tostring(configured) .. ") should be >= online (" .. tostring(online) .. ")")
+end
+test_nproc_configured_at_least_online()
+
+local function test_page_size_positive()
+  local sz, err = sys.page_size()
+  assert(sz, "page_size should succeed, got error: " .. tostring(err))
+  assert(sz > 0, "page_size should be positive, got " .. tostring(sz))
+  -- Page sizes are always a power of two.
+  assert(sz & (sz - 1) == 0, "page_size should be a power of two, got " .. tostring(sz))
+end
+test_page_size_positive()
+
+local function test_sysconf_direct()
+  local sz = sys.sysconf(sys.SC_PAGESIZE)
+  local direct = sys.page_size()
+  assert(sz == direct, "sysconf(SC_PAGESIZE) should match page_size()")
+end
+test_sysconf_direct()
+
+-- uname tests
+
+local function test_uname_fields()
+  local uts, err = sys.uname()
+  assert(uts, "uname should succeed, got error: " .. tostring(err))
+  assert(type(uts.sysname) == "string" and #uts.sysname > 0,
+    "uname.sysname should be a non-empty string")
+  assert(type(uts.nodename) == "string", "uname.nodename should be a string")
+  assert(type(uts.release) == "string" and #uts.release > 0,
+    "uname.release should be a non-empty string")
+  assert(type(uts.version) == "string", "uname.version should be a string")
+  assert(type(uts.machine) == "string" and #uts.machine > 0,
+    "uname.machine should be a non-empty string")
+end
+test_uname_fields()

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -281,9 +281,12 @@ local record Stat
   --- depending on the operating system. `unix.major()` and `unix.minor()`
   --- may be used to extract the device numbers.
   rdev: function(self: Stat): number
-  nlink: function(self: Stat): any
-  gen: function(self: Stat): any
-  flags: function(self: Stat): any
+  --- Number of hard links to the file.
+  nlink: function(self: Stat): number
+  --- Inode generation number.
+  gen: function(self: Stat): number
+  --- User-defined flags on the file.
+  flags: function(self: Stat): number
 end
 
 --- Filesystem statistics returned by statfs() and fstatfs().
@@ -585,6 +588,13 @@ local record unix
   RUSAGE_CHILDREN: number
   RUSAGE_SELF: number
   RUSAGE_THREAD: number
+  SC_ARG_MAX: number
+  SC_CHILD_MAX: number
+  SC_CLK_TCK: number
+  SC_OPEN_MAX: number
+  SC_PAGESIZE: number
+  SC_NPROCESSORS_CONF: number
+  SC_NPROCESSORS_ONLN: number
   R_OK: number
   SA_NOCLDSTOP: number
   SA_NOCLDWAIT: number
@@ -1797,6 +1807,14 @@ local record unix
   --- UTS namespace; typical callers are sandbox builders that first
   --- `unshare(CLONE_NEWUTS)`. Returns `(nil, Errno)` on failure.
   sethostname: function(name: string): boolean, Errno
+  --- Returns a runtime system configuration value. `name` is one of the
+  --- `unix.SC_*` constants (e.g. `SC_NPROCESSORS_ONLN`, `SC_PAGESIZE`).
+  --- Returns `(nil, Errno)` on failure.
+  sysconf: function(name: number): number
+  --- Returns operating system and hardware identification as a table with
+  --- `sysname`, `nodename`, `release`, `version`, `machine`, and
+  --- `domainname` string fields. Returns `(nil, Errno)` on failure.
+  uname: function(): any
 
   --- Linux isolation primitives (namespaces, landlock, prctl, ioctl).
   --- All return `(nil|false, Errno)` on failure and fail with `ENOSYS`


### PR DESCRIPTION
## Summary

Bumps the `cosmos` dependency to upstream release [`2026.07.03-a4bf2e4fd`](https://github.com/whilp/cosmopolitan/releases/tag/2026.07.03-a4bf2e4fd), regenerates the affected type definitions, and lands the first battery it unblocks (`sysconf`/`uname` in `cosmic.sys`).

The upstream release is a single change — *"lua/unix: add sysconf() and uname() bindings; type Stat fields (#125)"*.

### The bump
- `3p/cosmos/version.lua`: `2026.07.03-08e46d2f7` → `2026.07.03-a4bf2e4fd`, sha256 `d1cf0c9e…857406` (verified against the release's published asset digest).
- `lib/types/cosmo/unix.d.tl`, regenerated to match the new `definitions.lua`:
  - `Stat.nlink/gen/flags`: `any` → `number` (upstream now annotates these).
  - Add the `SC_*` sysconf name constants.
  - Add `unix.sysconf` and `unix.uname`. These render as `sysconf: function(name: number): number` and `uname: function(): any` — matching what `regen-types` produces, since the generator does not read `@overload` annotations and maps record-literal returns to `any`. (Verified by running the actual generator against the upstream annotations.)

### The next phase (audit Phase 4, Wave 1 — declare/wrap C already in the binary)
`cosmic.sys` gains the wrappers the release makes possible (previously blocked upstream per audit §4.2 / U8):
- `sysconf(name)`, with the `SC_*` constants re-exported through the module so callers never touch `cosmo.*`.
- `nproc()` / `nproc_configured()` — `SC_NPROCESSORS_ONLN` / `_CONF`.
- `page_size()` — `SC_PAGESIZE`.
- `uname()` returning a typed `Uname` record (`sysname`, `nodename`, `release`, `version`, `machine`, `domainname`).

All follow the `value, error-string` convention and route errno detail through `errno:doc()`. `sys_test.tl` adds coverage for each.

## Upstream aspects of the plan ([#420](https://github.com/whilp/cosmic/pull/420))

This release addresses a **subset** of the plan's upstream items:

| Item | Status in this release |
|---|---|
| **U8** (declare/expose C surface) | **Partial** — `sysconf`/`uname` landed. The rest of U8 (digests `Md5`/`Sha1`/…, `DecodeHex`, `EncodeJson` opts, lsqlite3 `busy_timeout`, `unix.utime`, `prctl`) is **not** in this release. |
| **U2** (correct wrong annotations) | **Partial** — `Stat.nlink/gen/flags` now typed. The rest of U2 (`fdopendir` signature, `setenv`/`unsetenv` params, `siocgifconf` return) is **not** in this release. |
| **U1** (add `Errno` returns to ~175 fallible functions) | **Not addressed.** This is the primary Phase 0 gate. |
| **U3** (integer-valued constants as integers) | **Not addressed.** |
| **U4–U7, U9** | **Not addressed.** |

**Consequence for sequencing:** Phase 0's main blocker (**U1** — the missing-`Errno` root defect) has **not** landed upstream, so the in-repo cast/errno cleanup (Phase 0 step 4) remains blocked per owner decision **D2** ("block on upstream, do it right"). What *this* release unblocks is the Wave 1 `sysconf`/`uname` slice, which is what this PR implements. Because U1 is absent, the two new function declarations still lack an `Errno` return in the `.d.tl` (generator faithful), and the wrappers cast around it with the established `as(…, any)` / `err as Errno` idiom — those casts will fall away automatically once U1 lands and `cosmos` is bumped again.

## Test plan

The build toolchain (`cosmo-make`, `cosmos.zip`) is gated to a repo this session can't fetch, so `make ci` could not run here. Verified with the pinned bootstrap `cosmic` binary instead:
- `--check-types` passes for `sys.tl`, `sys_test.tl`, and existing `unix.d.tl` consumers (`fs`, `proc`, `fs_types`, `time`, `net`).
- `--check-format` passes for `sys.tl` / `sys_test.tl` (the one `unix.d.tl` format mismatch at the `prctl` line is pre-existing, unrelated to this diff).
- `sys.tl` compiles to Lua.
- Runtime `sys_test.tl` assertions (`nproc >= 1`, power-of-two `page_size`, `uname` field types) run under `make test` in CI, where the new cosmos with `sysconf`/`uname` is present. The bootstrap binary predates those bindings, so runtime execution could not be exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBQJw9k3pqLrxXLZPS2C6C)_