### PR TITLE
quicksand: capability bounding-set API on the a9e8fcb1f cosmos bump

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "023d7799013892649e197e074322e6b61b14bf063fc59c4dfd2125e061897039"}},
+  platforms = {["*"] = {sha = "df8f1ede1413a67d84eaf122851a6ba7209b033e75f2dff73b72bb5464729be5"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.03-c0e89062d"
+  version = "2026.07.03-a9e8fcb1f"
 }

--- a/lib/cosmic/quicksand/box/init.tl
+++ b/lib/cosmic/quicksand/box/init.tl
@@ -63,6 +63,8 @@ local record ProcOpts
   uid: integer
   gid: integer
   pledge: string
+  drop_caps: boolean -- drop the entire capability bounding set before exec
+  keep_caps: {string} -- capability names to retain (implies drop_caps)
 end
 
 local record EnvOpts
@@ -114,6 +116,9 @@ local function validate(opts: BoxOpts): boolean, string
     if proc.pledge ~= nil and type(proc.pledge) ~= "string" then
       return false, "proc.pledge must be a string"
     end
+    if proc.keep_caps ~= nil and type(proc.keep_caps) ~= "table" then
+      return false, "proc.keep_caps must be a list of capability names"
+    end
   end
   local net = opts.net
   if net and net.allow ~= nil and type(net.allow) ~= "table" then
@@ -159,6 +164,11 @@ local function preflight(opts: BoxOpts): boolean, string
     end
     if opts.proc and opts.proc.pledge and not c.pledge then
       return false, "quicksand: pledge unavailable"
+    end
+    local pr = opts.proc
+    local wants_caps = pr and (pr.drop_caps or (pr.keep_caps and #pr.keep_caps > 0))
+    if wants_caps and not c.caps then
+      return false, "quicksand: capability bounding-set control unavailable (proc.drop_caps/keep_caps requested)"
     end
   end
   return true

--- a/lib/cosmic/quicksand/box/init_test.tl
+++ b/lib/cosmic/quicksand/box/init_test.tl
@@ -38,6 +38,7 @@ local function test_new_rejects_bad_types()
     {opts = {hostname = {}}, want = "hostname"},
     {opts = {proc = {uid = "x"}}, want = "proc.uid"},
     {opts = {proc = {pledge = 1}}, want = "proc.pledge"},
+    {opts = {proc = {keep_caps = "x"}}, want = "proc.keep_caps"},
     {opts = {net = {allow = "x"}}, want = "net.allow"},
     {opts = {fs = {ro = "x"}}, want = "fs.ro"},
   }

--- a/lib/cosmic/quicksand/box/run.tl
+++ b/lib/cosmic/quicksand/box/run.tl
@@ -23,6 +23,7 @@ local unix = require("cosmo.unix")
 local cosmo = require("cosmo")
 local netns = require("cosmic.quicksand.netns")
 local qproc = require("cosmic.quicksand.proc")
+local qcaps = require("cosmic.quicksand.caps")
 local proxy = require("cosmic.quicksand.proxy")
 local landlock = require("cosmic.landlock")
 local pledge = require("cosmic.pledge")
@@ -110,6 +111,12 @@ local function workload_setup(opts: {string: any}): string
   if pr and (pr.no_new_privs or pr.uid ~= nil) then
     local ok, err = qproc.no_new_privs()
     if not ok then return "no_new_privs: " .. tostring(err) end
+  end
+  -- Drop the capability bounding set before drop_privs: that step's
+  -- capset(0,0,0) clears CAP_SETPCAP, which PR_CAPBSET_DROP requires.
+  if pr and (pr.drop_caps or (pr.keep_caps and #(pr.keep_caps as {string}) > 0)) then
+    local ok, err = qcaps.drop_bounding({keep = pr.keep_caps as {string}})
+    if not ok then return "drop_caps: " .. tostring(err) end
   end
   if pr and pr.uid ~= nil then
     local gid = pr.gid

--- a/lib/cosmic/quicksand/caps.tl
+++ b/lib/cosmic/quicksand/caps.tl
@@ -1,0 +1,214 @@
+--- Linux capability bounding-set control for box assembly.
+---
+--- Typed wrapper over cosmo.unix prctl(2) capability operations. The
+--- companion to cosmic.quicksand.proc: where proc.drop_privs clears the
+--- *current* capability set (effective/permitted/inheritable via
+--- capset), this module manipulates the capability *bounding set* — the
+--- ceiling that limits which capabilities a process (or anything it
+--- execve's) can ever hold. Dropping a capability from the bounding set
+--- is irreversible and inherited across fork/exec, so a workload can
+--- never regain it, even by executing a setuid or file-capability
+--- binary.
+---
+--- Intended for the "after fork, before exec" window of a boxed child,
+--- while it still holds CAP_SETPCAP in its user namespace. Call
+--- drop_bounding() before proc.drop_privs (which clears CAP_SETPCAP and
+--- would make subsequent PR_CAPBSET_DROP calls fail with EPERM).
+---
+--- Linux-only. On non-Linux hosts (or a cosmos build without the CAP_*
+--- constants) the constants are nil; drop_bounding() is then a
+--- successful no-op and supported() returns false.
+local unix = require("cosmo.unix")
+local Errno = require("cosmic.errno").Errno
+
+--- Turn a unix.Errno-shaped error into a human string, or `fallback`.
+local function wrap_err(err: any, fallback: string): string
+  if not err then return fallback end
+  local e = err as Errno
+  if e.doc then return e:doc() end
+  return tostring(err)
+end
+
+--- Extract the errno number from a unix.Errno-shaped error, or nil.
+local function errno_of(err: any): integer
+  if err == nil then return nil end
+  local e = err as Errno
+  if e.errno == nil then return nil end
+  return e:errno() as integer
+end
+
+--- The Linux capability names, matching unix.CAP_*. CAP_LAST_CAP is the
+--- highest valid capability *number* (a bound, not a capability) and is
+--- intentionally excluded. A name absent from the running cosmos build
+--- resolves to nil and is skipped by the enumerating helpers.
+local NAMES: {string} = {
+  "CAP_AUDIT_CONTROL", "CAP_AUDIT_READ", "CAP_AUDIT_WRITE",
+  "CAP_BLOCK_SUSPEND", "CAP_BPF", "CAP_CHECKPOINT_RESTORE", "CAP_CHOWN",
+  "CAP_DAC_OVERRIDE", "CAP_DAC_READ_SEARCH", "CAP_FOWNER", "CAP_FSETID",
+  "CAP_IPC_LOCK", "CAP_IPC_OWNER", "CAP_KILL", "CAP_LEASE",
+  "CAP_LINUX_IMMUTABLE", "CAP_MAC_ADMIN", "CAP_MAC_OVERRIDE", "CAP_MKNOD",
+  "CAP_NET_ADMIN", "CAP_NET_BIND_SERVICE", "CAP_NET_BROADCAST",
+  "CAP_NET_RAW", "CAP_PERFMON", "CAP_SETFCAP", "CAP_SETGID", "CAP_SETPCAP",
+  "CAP_SETUID", "CAP_SYSLOG", "CAP_SYS_ADMIN", "CAP_SYS_BOOT",
+  "CAP_SYS_CHROOT", "CAP_SYS_MODULE", "CAP_SYS_NICE", "CAP_SYS_PACCT",
+  "CAP_SYS_PTRACE", "CAP_SYS_RAWIO", "CAP_SYS_RESOURCE", "CAP_SYS_TIME",
+  "CAP_SYS_TTY_CONFIG", "CAP_WAKE_ALARM",
+}
+
+--- Options for drop_bounding().
+local record DropOpts
+  keep: {string} -- capability names to retain in the bounding set
+end
+
+--- Resolve a capability name (e.g. "CAP_NET_RAW") to its integer number
+--- for the running host, or nil + error if the name is unknown or the
+--- host does not define it.
+---
+--- @param name string capability name
+--- @return integer? capability number
+--- @return string? error message
+local function number_of(name: string): integer, string
+  if type(name) ~= "string" then
+    return nil, "capability name must be a string"
+  end
+  local n = (unix as {string: any})[name] as integer
+  if n == nil then
+    return nil, "unknown capability: " .. name
+  end
+  return n
+end
+
+--- True when the capability bounding-set API is wired up on this host
+--- (Linux with prctl + the CAP_* / PR_CAPBSET_* constants). A true
+--- result means the calls exist; actually dropping from the bounding
+--- set additionally requires CAP_SETPCAP at runtime.
+---
+--- @return boolean supported
+local function supported(): boolean
+  return unix.prctl ~= nil
+  and unix.PR_CAPBSET_DROP ~= nil
+  and unix.PR_CAPBSET_READ ~= nil
+  and unix.CAP_LAST_CAP ~= nil
+end
+
+--- Build a capset(2) bitmask from capability names: bit N (1 << number)
+--- is set for each named capability. Suitable for the effective /
+--- permitted / inheritable arguments of unix.capset.
+---
+--- @param names {string} capability names
+--- @return integer? bitmask
+--- @return string? error message if a name is unknown
+local function mask(names: {string}): integer, string
+  local m: integer = 0
+  for _, name in ipairs(names) do
+    local n, err = number_of(name)
+    if n == nil then return nil, err end
+    m = m | (1 << n)
+  end
+  return m
+end
+
+--- Read whether a capability is present in the current bounding set via
+--- PR_CAPBSET_READ.
+---
+--- @param cap string capability name
+--- @return boolean? true if in the bounding set, false if not
+--- @return string? error message on failure
+local function bounding_read(cap: string): boolean, string
+  local n, nerr = number_of(cap)
+  if n == nil then return nil, nerr end
+  local r, err = unix.prctl(unix.PR_CAPBSET_READ, n)
+  if r == nil then
+    return nil, wrap_err(err, "PR_CAPBSET_READ " .. cap .. " failed")
+  end
+  return r == 1
+end
+
+--- Remove a single capability from the current bounding set via
+--- PR_CAPBSET_DROP. Irreversible and inherited across execve. Requires
+--- CAP_SETPCAP.
+---
+--- @param cap string capability name
+--- @return boolean true on success
+--- @return string? error message on failure
+local function bounding_drop(cap: string): boolean, string
+  local n, nerr = number_of(cap)
+  if n == nil then return false, nerr end
+  local rc, err = unix.prctl(unix.PR_CAPBSET_DROP, n)
+  if rc == nil then
+    return false, wrap_err(err, "PR_CAPBSET_DROP " .. cap .. " failed")
+  end
+  return true
+end
+
+--- Drop every capability from the bounding set, optionally retaining
+--- the names in `opts.keep`. Iterates 0..CAP_LAST_CAP calling
+--- PR_CAPBSET_DROP. Irreversible and inherited across execve, so a
+--- workload can never acquire a dropped capability afterwards — not
+--- even by executing a setuid / file-capability binary.
+---
+--- Must run while the caller still holds CAP_SETPCAP (e.g. immediately
+--- after unshare(CLONE_NEWUSER) with a uid map, before proc.drop_privs
+--- clears the capability set). A cap number the kernel does not know
+--- (EINVAL) is skipped; ENOSYS ends the sweep successfully. On a host
+--- without the CAP_* constants (non-Linux) this is a successful no-op.
+---
+--- @param opts DropOpts? optional keep-set
+--- @return boolean true on success
+--- @return string? error message on failure
+local function drop_bounding(opts?: DropOpts): boolean, string
+  local last = unix.CAP_LAST_CAP as integer
+  if last == nil then
+    -- No capability constants (non-Linux, or a cosmos without them):
+    -- there is nothing to drop.
+    return true
+  end
+  local keep: {integer: boolean} = {}
+  if opts and opts.keep then
+    for _, name in ipairs(opts.keep) do
+      local n, err = number_of(name)
+      if n == nil then return false, err end
+      keep[n] = true
+    end
+  end
+  for c = 0, last do
+    if not keep[c] then
+      local rc, err = unix.prctl(unix.PR_CAPBSET_DROP, c)
+      if rc == nil then
+        local en = errno_of(err)
+        if en == unix.EINVAL then
+          -- Capability number unknown to this kernel; skip it.
+        elseif en == unix.ENOSYS then
+          -- Capabilities unsupported on this host; done.
+          return true
+        else
+          return false, wrap_err(err,
+            "PR_CAPBSET_DROP " .. tostring(c) .. " failed")
+        end
+      end
+    end
+  end
+  return true
+end
+
+local record CapsModule
+  NAMES: {string}
+  supported: function(): boolean
+  number_of: function(name: string): integer, string
+  mask: function(names: {string}): integer, string
+  bounding_read: function(cap: string): boolean, string
+  bounding_drop: function(cap: string): boolean, string
+  drop_bounding: function(opts?: DropOpts): boolean, string
+end
+
+local M: CapsModule = {
+  NAMES = NAMES,
+  supported = supported,
+  number_of = number_of,
+  mask = mask,
+  bounding_read = bounding_read,
+  bounding_drop = bounding_drop,
+  drop_bounding = drop_bounding,
+}
+
+return M

--- a/lib/cosmic/quicksand/caps_test.tl
+++ b/lib/cosmic/quicksand/caps_test.tl
@@ -1,0 +1,119 @@
+#!/usr/bin/env cosmic
+local caps = require("cosmic.quicksand.caps")
+local quicksand = require("cosmic.quicksand")
+local io_mod = require("cosmic.io")
+local fs = require("cosmic.fs")
+local spawn = require("cosmic.child")
+
+local test_bin = os.getenv("TEST_BIN")
+local tmpdir = os.getenv("TEST_TMPDIR")
+
+local function test_module_exports()
+  assert(type(caps.supported) == "function")
+  assert(type(caps.number_of) == "function")
+  assert(type(caps.mask) == "function")
+  assert(type(caps.bounding_read) == "function")
+  assert(type(caps.bounding_drop) == "function")
+  assert(type(caps.drop_bounding) == "function")
+  assert(type(caps.NAMES) == "table")
+end
+test_module_exports()
+
+-- Every curated name resolves to a number on a host that ships the CAP_*
+-- constants; CAP_LAST_CAP (a bound, not a capability) is deliberately
+-- excluded from NAMES.
+local function test_names_resolve()
+  if not caps.supported() then return end
+  assert(#caps.NAMES > 0, "NAMES should be non-empty")
+  for _, name in ipairs(caps.NAMES) do
+    local n, err = caps.number_of(name)
+    assert(n ~= nil, "should resolve " .. name .. ": " .. tostring(err))
+    assert(n >= 0, name .. " should be non-negative")
+  end
+  for _, name in ipairs(caps.NAMES) do
+    assert(name ~= "CAP_LAST_CAP", "NAMES must not include the CAP_LAST_CAP bound")
+  end
+end
+test_names_resolve()
+
+-- number_of rejects unknown names and non-strings without throwing.
+local function test_number_of_unknown()
+  local n, err = caps.number_of("CAP_NOT_A_REAL_CAPABILITY")
+  assert(n == nil, "unknown cap should not resolve")
+  assert(type(err) == "string", "should return an error string")
+  local n2, err2 = caps.number_of(nil as string)
+  assert(n2 == nil and type(err2) == "string", "nil name should error, not throw")
+end
+test_number_of_unknown()
+
+-- mask sets bit N (1 << number) per name; unknown names error; empty is 0.
+local function test_mask()
+  if not caps.supported() then return end
+  assert(caps.mask({}) == 0, "empty mask should be 0")
+  local chown = caps.number_of("CAP_CHOWN")
+  local m = caps.mask({"CAP_CHOWN"})
+  assert(m == (1 << chown), "mask should set the CAP_CHOWN bit")
+  local both = caps.mask({"CAP_CHOWN", "CAP_KILL"})
+  local kill = caps.number_of("CAP_KILL")
+  assert(both == ((1 << chown) | (1 << kill)), "mask should OR the named bits")
+  local bad, err = caps.mask({"CAP_BOGUS"})
+  assert(bad == nil and type(err) == "string", "unknown name should error")
+end
+test_mask()
+
+-- bounding_read is non-destructive: it returns a boolean (or a graceful
+-- nil + error under an outer sandbox), never throws.
+local function test_bounding_read()
+  if not caps.supported() then return end
+  local present, err = caps.bounding_read("CAP_CHOWN")
+  assert(present ~= nil or type(err) == "string",
+    "bounding_read should return a boolean or nil+err")
+  local bad, berr = caps.bounding_read("CAP_BOGUS")
+  assert(bad == nil and type(berr) == "string", "unknown cap should error")
+end
+test_bounding_read()
+
+-- drop_bounding validates the keep-set BEFORE touching the bounding set,
+-- so an unknown keep name returns false + err and drops nothing. This is
+-- safe to run in-process precisely because it never reaches a real drop.
+local function test_drop_bounding_bad_keep()
+  local ok, err = caps.drop_bounding({keep = {"CAP_BOGUS"}})
+  assert(not ok, "bad keep name should fail")
+  assert(type(err) == "string" and err:find("CAP_BOGUS"),
+    "error should name the bad capability: " .. tostring(err))
+end
+test_drop_bounding_bad_keep()
+
+-- The real, irreversible drop path is exercised in a subprocess so it
+-- cannot strip this test runner's own bounding set. After a successful
+-- PR_CAPBSET_DROP, the capability must read back as absent. Unprivileged
+-- hosts (no CAP_SETPCAP) return a graceful error and the child skips.
+local function test_drop_bounding_child()
+  local c = quicksand.capabilities()
+  if not c.linux or not test_bin then return end
+  local script = fs.join(tmpdir, "caps_drop.lua")
+  local ok_write = io_mod.barf(script, [[
+local caps = require("cosmic.quicksand.caps")
+if not caps.supported() then io.write("skipped: unsupported\n") os.exit(0) end
+local ok, err = caps.bounding_drop("CAP_CHOWN")
+if not ok then io.write("skipped: " .. tostring(err) .. "\n") os.exit(0) end
+local after = caps.bounding_read("CAP_CHOWN")
+if after == false then
+  io.write("dropped\n")
+else
+  io.write("bad: after=" .. tostring(after) .. "\n")
+end
+]])
+  assert(ok_write, "should write child script")
+  local cosmic = fs.join(test_bin, "cosmic")
+  local ok, out = spawn.spawn({cosmic, script}):read()
+  if not ok then return end
+  local s = out as string
+  assert(s:find("dropped") or s:find("skipped"),
+    "expected dropped or skipped, got: " .. s)
+  assert(not s:find("bad:"),
+    "drop must leave the capability absent from the bounding set: " .. s)
+end
+test_drop_bounding_child()
+
+print("caps_test: PASS")

--- a/lib/cosmic/quicksand/caps_test.tl
+++ b/lib/cosmic/quicksand/caps_test.tl
@@ -1,12 +1,10 @@
 #!/usr/bin/env cosmic
 local caps = require("cosmic.quicksand.caps")
 local quicksand = require("cosmic.quicksand")
-local io_mod = require("cosmic.io")
 local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
 
 local test_bin = os.getenv("TEST_BIN")
-local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function test_module_exports()
   assert(type(caps.supported) == "function")
@@ -88,25 +86,22 @@ test_drop_bounding_bad_keep()
 -- cannot strip this test runner's own bounding set. After a successful
 -- PR_CAPBSET_DROP, the capability must read back as absent. Unprivileged
 -- hosts (no CAP_SETPCAP) return a graceful error and the child skips.
+-- Run via `cosmic -e` so the test needs no writable temp file (the outer
+-- build sandbox does not always grant one).
+local CHILD_DROP = table.concat({
+    'local caps = require("cosmic.quicksand.caps")',
+    'if not caps.supported() then io.write("skipped: unsupported\\n") os.exit(0) end',
+    'local ok, err = caps.bounding_drop("CAP_CHOWN")',
+    'if not ok then io.write("skipped: " .. tostring(err) .. "\\n") os.exit(0) end',
+    'local after = caps.bounding_read("CAP_CHOWN")',
+    'if after == false then io.write("dropped\\n") else io.write("bad: after=" .. tostring(after) .. "\\n") end',
+  }, "\n")
+
 local function test_drop_bounding_child()
   local c = quicksand.capabilities()
   if not c.linux or not test_bin then return end
-  local script = fs.join(tmpdir, "caps_drop.lua")
-  local ok_write = io_mod.barf(script, [[
-local caps = require("cosmic.quicksand.caps")
-if not caps.supported() then io.write("skipped: unsupported\n") os.exit(0) end
-local ok, err = caps.bounding_drop("CAP_CHOWN")
-if not ok then io.write("skipped: " .. tostring(err) .. "\n") os.exit(0) end
-local after = caps.bounding_read("CAP_CHOWN")
-if after == false then
-  io.write("dropped\n")
-else
-  io.write("bad: after=" .. tostring(after) .. "\n")
-end
-]])
-  assert(ok_write, "should write child script")
   local cosmic = fs.join(test_bin, "cosmic")
-  local ok, out = spawn.spawn({cosmic, script}):read()
+  local ok, out = spawn.spawn({cosmic, "-e", CHILD_DROP}):read()
   if not ok then return end
   local s = out as string
   assert(s:find("dropped") or s:find("skipped"),

--- a/lib/cosmic/quicksand/init.tl
+++ b/lib/cosmic/quicksand/init.tl
@@ -18,6 +18,7 @@
 local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
 local box = require("cosmic.quicksand.box")
+local caps = require("cosmic.quicksand.caps")
 local Errno = require("cosmic.errno").Errno
 
 --- Fine-grained feature availability on the current host.
@@ -36,6 +37,7 @@ local record Capabilities
   landlock: boolean -- kernel advertises landlock ABI >= 1
   pledge: boolean -- unix.pledge non-ENOSYS (Linux via seccomp + OpenBSD)
   unveil: boolean -- unix.unveil non-ENOSYS (OpenBSD, or Linux+Landlock)
+  caps: boolean -- prctl capability bounding-set API available (PR_CAPBSET_*)
 end
 
 local record QuicksandModule
@@ -85,6 +87,7 @@ local function capabilities(): Capabilities
     landlock = is_linux and probe_landlock(),
     pledge = probe_nop(unix.pledge),
     unveil = probe_nop(unix.unveil),
+    caps = is_linux and caps.supported(),
   }
   return cached
 end

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -385,6 +385,7 @@ local record unix
   AF_UNSPEC: number
   ARG_MAX: number
   AT_EACCES: number
+  AT_EACCESS: number
   AT_FDCWD: number
   AT_SYMLINK_NOFOLLOW: number
   BUFSIZ: number
@@ -428,8 +429,10 @@ local record unix
   EEXIST: number
   EFAULT: number
   EFBIG: number
+  EFTYPE: number
   EHOSTDOWN: number
   EHOSTUNREACH: number
+  EHWPOISON: number
   EIDRM: number
   EILSEQ: number
   EINPROGRESS: number
@@ -439,9 +442,11 @@ local record unix
   EISCONN: number
   EISDIR: number
   ELOOP: number
+  EMEDIUMTYPE: number
   EMFILE: number
   EMLINK: number
   EMSGSIZE: number
+  EMULTIHOP: number
   ENAMETOOLONG: number
   ENETDOWN: number
   ENETRESET: number
@@ -453,11 +458,15 @@ local record unix
   ENOENT: number
   ENOEXEC: number
   ENOLCK: number
+  ENOLINK: number
+  ENOMEDIUM: number
   ENOMEM: number
   ENOMSG: number
   ENONET: number
   ENOPROTOOPT: number
   ENOSPC: number
+  ENOSR: number
+  ENOSTR: number
   ENOSYS: number
   ENOTBLK: number
   ENOTCONN: number
@@ -480,6 +489,7 @@ local record unix
   ERANGE: number
   EREMOTE: number
   ERESTART: number
+  ERFKILL: number
   EROFS: number
   ESHUTDOWN: number
   ESOCKTNOSUPPORT: number
@@ -495,6 +505,7 @@ local record unix
   FD_CLOEXEC: number
   F_GETFD: number
   F_GETFL: number
+  F_GETLK: number
   F_OK: number
   F_RDLCK: number
   F_SETFD: number
@@ -508,8 +519,17 @@ local record unix
   IPPROTO_RAW: number
   IPPROTO_TCP: number
   IPPROTO_UDP: number
+  IP_ADD_MEMBERSHIP: number
+  IP_DROP_MEMBERSHIP: number
   IP_HDRINCL: number
   IP_MTU: number
+  IP_MULTICAST_IF: number
+  IP_MULTICAST_LOOP: number
+  IP_MULTICAST_TTL: number
+  IP_OPTIONS: number
+  IP_PKTINFO: number
+  IP_RECVTOS: number
+  IP_RECVTTL: number
   IP_TOS: number
   IP_TTL: number
   ITIMER_PROF: number
@@ -523,11 +543,14 @@ local record unix
   LOG_INFO: number
   LOG_NOTICE: number
   LOG_WARNING: number
+  MSG_CTRUNC: number
   MSG_DONTROUTE: number
+  MSG_DONTWAIT: number
   MSG_MORE: number
   MSG_NOSIGNAL: number
   MSG_OOB: number
   MSG_PEEK: number
+  MSG_TRUNC: number
   MSG_WAITALL: number
   NAME_MAX: number
   NSIG: number
@@ -638,12 +661,44 @@ local record unix
   TCSADRAIN: number
   TCSAFLUSH: number
   IFNAMSIZ: number
+  IFF_ALLMULTI: number
+  IFF_AUTOMEDIA: number
+  IFF_BROADCAST: number
+  IFF_DEBUG: number
+  IFF_DYNAMIC: number
+  IFF_LOOPBACK: number
+  IFF_MASTER: number
+  IFF_MULTICAST: number
+  IFF_NOARP: number
+  IFF_NOTRAILERS: number
+  IFF_POINTOPOINT: number
+  IFF_PORTSEL: number
+  IFF_PROMISC: number
+  IFF_RUNNING: number
+  IFF_SLAVE: number
   IFF_UP: number
+  SIOCGIFADDR: number
+  SIOCGIFBRDADDR: number
+  SIOCGIFDSTADDR: number
   SIOCGIFFLAGS: number
+  SIOCGIFINDEX: number
+  SIOCGIFMETRIC: number
+  SIOCGIFMTU: number
+  SIOCGIFNAME: number
+  SIOCGIFNETMASK: number
+  SIOCSIFADDR: number
+  SIOCSIFBRDADDR: number
+  SIOCSIFDSTADDR: number
   SIOCSIFFLAGS: number
+  SIOCSIFMETRIC: number
+  SIOCSIFMTU: number
+  SIOCSIFNETMASK: number
+  CLONE_NEWCGROUP: number
+  CLONE_NEWIPC: number
   CLONE_NEWNET: number
   CLONE_NEWNS: number
   CLONE_NEWPID: number
+  CLONE_NEWTIME: number
   CLONE_NEWUSER: number
   CLONE_NEWUTS: number
   LANDLOCK_ACCESS_FS_EXECUTE: number
@@ -661,8 +716,102 @@ local record unix
   LANDLOCK_ACCESS_FS_MAKE_SYM: number
   LANDLOCK_ACCESS_FS_REFER: number
   LANDLOCK_ACCESS_FS_TRUNCATE: number
+  LANDLOCK_CREATE_RULESET_VERSION: number
+  LANDLOCK_RULE_PATH_BENEATH: number
+  PR_CAPBSET_DROP: number
+  PR_CAPBSET_READ: number
+  PR_GET_CHILD_SUBREAPER: number
+  PR_GET_DUMPABLE: number
+  PR_GET_KEEPCAPS: number
+  PR_GET_NAME: number
+  PR_GET_NO_NEW_PRIVS: number
+  PR_GET_PDEATHSIG: number
+  PR_SET_CHILD_SUBREAPER: number
+  PR_SET_DUMPABLE: number
   PR_SET_KEEPCAPS: number
+  PR_SET_NAME: number
   PR_SET_NO_NEW_PRIVS: number
+  PR_SET_PDEATHSIG: number
+  CAP_AUDIT_CONTROL: number
+  CAP_AUDIT_READ: number
+  CAP_AUDIT_WRITE: number
+  CAP_BLOCK_SUSPEND: number
+  CAP_BPF: number
+  CAP_CHECKPOINT_RESTORE: number
+  CAP_CHOWN: number
+  CAP_DAC_OVERRIDE: number
+  CAP_DAC_READ_SEARCH: number
+  CAP_FOWNER: number
+  CAP_FSETID: number
+  CAP_IPC_LOCK: number
+  CAP_IPC_OWNER: number
+  CAP_KILL: number
+  CAP_LAST_CAP: number
+  CAP_LEASE: number
+  CAP_LINUX_IMMUTABLE: number
+  CAP_MAC_ADMIN: number
+  CAP_MAC_OVERRIDE: number
+  CAP_MKNOD: number
+  CAP_NET_ADMIN: number
+  CAP_NET_BIND_SERVICE: number
+  CAP_NET_BROADCAST: number
+  CAP_NET_RAW: number
+  CAP_PERFMON: number
+  CAP_SETFCAP: number
+  CAP_SETGID: number
+  CAP_SETPCAP: number
+  CAP_SETUID: number
+  CAP_SYSLOG: number
+  CAP_SYS_ADMIN: number
+  CAP_SYS_BOOT: number
+  CAP_SYS_CHROOT: number
+  CAP_SYS_MODULE: number
+  CAP_SYS_NICE: number
+  CAP_SYS_PACCT: number
+  CAP_SYS_PTRACE: number
+  CAP_SYS_RAWIO: number
+  CAP_SYS_RESOURCE: number
+  CAP_SYS_TIME: number
+  CAP_SYS_TTY_CONFIG: number
+  CAP_WAKE_ALARM: number
+  MS_BIND: number
+  MS_DIRSYNC: number
+  MS_LAZYTIME: number
+  MS_MANDLOCK: number
+  MS_MOVE: number
+  MS_NOATIME: number
+  MS_NODEV: number
+  MS_NODIRATIME: number
+  MS_NOEXEC: number
+  MS_NOSUID: number
+  MS_POSIXACL: number
+  MS_PRIVATE: number
+  MS_RDONLY: number
+  MS_REC: number
+  MS_RELATIME: number
+  MS_REMOUNT: number
+  MS_SHARED: number
+  MS_SILENT: number
+  MS_SLAVE: number
+  MS_STRICTATIME: number
+  MS_SYNCHRONOUS: number
+  MS_UNBINDABLE: number
+  MNT_DETACH: number
+  MNT_EXPIRE: number
+  MNT_FORCE: number
+  UMOUNT_NOFOLLOW: number
+  ST_APPEND: number
+  ST_IMMUTABLE: number
+  ST_MANDLOCK: number
+  ST_NOATIME: number
+  ST_NODEV: number
+  ST_NODIRATIME: number
+  ST_NOEXEC: number
+  ST_NOSUID: number
+  ST_RDONLY: number
+  ST_RELATIME: number
+  ST_SYNCHRONOUS: number
+  ST_WRITE: number
   RUSAGE_BOTH: number
   RUSAGE_CHILDREN: number
   RUSAGE_SELF: number
@@ -737,6 +886,7 @@ local record unix
   SO_ERROR: number
   SO_KEEPALIVE: number
   SO_LINGER: number
+  SO_OOBINLINE: number
   SO_RCVBUF: number
   SO_RCVLOWAT: number
   SO_RCVTIMEO: number
@@ -1435,6 +1585,8 @@ local record unix
   setuid: function(uid: number): boolean, Errno
   --- Sets user id for file system ops.
   setfsuid: function(uid: number): boolean, Errno
+  --- Sets group id for file system ops.
+  setfsgid: function(gid: number): boolean, Errno
   --- Sets group id.
   --- Returns `ENOSYS` on Windows NT if `gid` isn't `getgid()`.
   setgid: function(gid: number): boolean, Errno
@@ -1949,6 +2101,9 @@ local record unix
   --- Waits for signal to be delivered.
   --- The signal mask is temporarily replaced with `mask` during this system call.
   sigsuspend: function(mask?: Sigset): nil, Errno
+  --- Returns the set of signals pending delivery to the calling process
+  --- that are currently blocked.
+  sigpending: function(): Sigset, Errno
   --- Causes `SIGALRM` signals to be generated at some point(s) in the
   --- future. The `which` parameter should be `ITIMER_REAL`.
   --- Here's an example of how to create a 400 ms interval timer:
@@ -2005,6 +2160,10 @@ local record unix
   --- Returns the new nice value on success. Note that -1 is a valid return
   --- value, so errors must be detected by checking the second return value.
   nice: function(inc: number): number, Errno
+  --- Lowers the calling process to the lowest scheduling priority.
+  --- On Linux this additionally requests the idle scheduling policy and a
+  --- best-effort idle i/o priority. This function does not fail.
+  verynice: function()
   --- Gets the scheduling priority of a process, process group, or user.
   --- `which` specifies what `who` refers to:
   --- - `PRIO_PROCESS`: `who` is a process id (0 = calling process)
@@ -2439,3 +2598,4 @@ local record unix
 end
 
 return unix
+


### PR DESCRIPTION
## Summary

Executes the next release-gated item on the [audit plan (#420)](https://github.com/whilp/cosmic/pull/420): after the Phase 0 foundation, its "highest-leverage next" list names *"chip the #127 allowlist (start with the `CAP_*` set → a real capabilities API for quicksand)."* That item only became possible with the release that just landed.

### 1. Bump cosmos to `2026.07.03-a9e8fcb1f`

The new release builds on the fork's **#128** (full `unix.*` annotation surface, emptying the #127 coverage ratchet). Regenerating `unix.d.tl` against it is **purely additive (+160 lines, 0 removed)**:

- 40 `CAP_*` capability constants + `CAP_LAST_CAP`
- `PR_CAPBSET_DROP` / `PR_CAPBSET_READ`, `PR_SET_PDEATHSIG`, `PR_SET_CHILD_SUBREAPER`
- `SIOC*` / `IFF_*` (ifreq/netns, U7), `IP_*` multicast + `MSG_*`, `CLONE_NEW*`, `LANDLOCK_*`, and new errno codes

Only `unix.d.tl` is regenerated — the other `.d.tl` files carry unrelated pre-existing gentype drift (hand-enriched records `gentype` doesn't reproduce) and their `definitions.lua` sections were unchanged by #128, so they're left alone. The `gentype` errno-drift test passes against the new release.

### 2. `cosmic.quicksand.caps` — a real capability API

A typed wrapper over `prctl(2)` capability operations, the companion to `quicksand.proc`:

- `number_of(name)` — resolve `"CAP_NET_RAW"` → its number for the running host
- `mask(names)` — build a `capset(2)` bitmask
- `bounding_read(cap)` — `PR_CAPBSET_READ` (non-destructive)
- `bounding_drop(cap)` / `drop_bounding({keep=...})` — `PR_CAPBSET_DROP`, one or wholesale with a keep-set
- `supported()`, `NAMES`

Errno-honest (`nil, string` / `false, string`), and a graceful no-op on non-Linux / `ENOSYS`, mirroring `quicksand.proc`.

### 3. Integration

- **`quicksand.capabilities()`** gains a `caps` field so callers and the box preflight can fail fast when the API is unavailable.
- **Box** gains `proc.drop_caps` / `proc.keep_caps`. This closes the gap where a boxed child cleared only its *current* caps (`capset(0,0,0)`) and relied solely on `no_new_privs`: dropping the **bounding set** is irreversible and inherited across `execve`, so a dropped capability can never be reacquired — not even via a setuid/file-capability binary. The drop runs after `no_new_privs` but **before** `drop_privs`, whose `capset(0,0,0)` clears the `CAP_SETPCAP` that `PR_CAPBSET_DROP` requires. Default off → zero behavior change for existing boxes.

## Test plan

- `make ci` — **format, teal (194/194), test, lint (251/251) all pass** against the bumped dependency. The one `example` failure is `fetch_example.tl` (HTTP egress returns `status: nil` in the sandboxed environment) — network-dependent and unrelated to this change.
- `caps_test.tl` exercises name resolution, mask building, keep-set validation, the non-destructive read path, and the **real irreversible drop in an isolated subprocess** so it cannot strip the test runner's own bounding set.
- `box/init_test.tl` gains a `proc.keep_caps` validation case.
- `gentype_test` (errno drift) passes against the new `unix.d.tl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM5Z3Qq9bc7XXVCuh4NiQG)_