### PR TITLE
Bump cosmos to 2026.07.04-ad05a7294; drop the last clearenv cast

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "df8f1ede1413a67d84eaf122851a6ba7209b033e75f2dff73b72bb5464729be5"}},
+  platforms = {["*"] = {sha = "f4daba5e781efd813830ecf241ed0202551a7c16123c43237240b413e390640a"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.03-a9e8fcb1f"
+  version = "2026.07.04-ad05a7294"
 }

--- a/lib/cosmic/env.tl
+++ b/lib/cosmic/env.tl
@@ -45,9 +45,7 @@ end
 --- @return boolean True on success
 --- @return string? Error message if clearing failed
 local function clear(): boolean, string
-  -- clearenv is declared `function()` upstream (missing its boolean/Errno
-  -- return), so the cast stays until that annotation is fixed.
-  local ok, err = unix.clearenv() as(boolean, any)
+  local ok, err = unix.clearenv()
   if not ok then
     return false, errstr(err, "clearenv")
   end

--- a/lib/cosmic/user.tl
+++ b/lib/cosmic/user.tl
@@ -33,10 +33,14 @@ local function getegid(): number
 end
 
 --- Get the login name of the user running the process.
---- Returns nil if the login name cannot be determined.
 --- @return string The login name, or nil on failure
-local function getlogin(): string
-  return unix.getlogin()
+--- @return string? Error message if the login name cannot be determined
+local function getlogin(): string, string
+  local name, err = unix.getlogin()
+  if not name then
+    return nil, errstr(err, "getlogin")
+  end
+  return name
 end
 
 --- Set the user ID of the calling process.
@@ -135,7 +139,7 @@ local record UserModule
   getgid: function(): number
   geteuid: function(): number
   getegid: function(): number
-  getlogin: function(): string
+  getlogin: function(): string, string
   setuid: function(uid: number): boolean, string
   setgid: function(gid: number): boolean, string
   setfsuid: function(uid: number): boolean, string

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -231,11 +231,10 @@ local record Rusage
   --- quickly enough within a time slice that it was able to give back the
   --- remaining time to the system.
   nvcsw: function(self: Rusage): number
-  --- @return integer count number of non-consensual context switches.
   --- This number is a bad thing. It means your redbean was preempted by a
   --- higher priority process after failing to finish its work, within the
   --- allotted time slice.
-  nivcsw: function(self: Rusage)
+  nivcsw: function(self: Rusage): number
 end
 
 --- File metadata and attributes.
@@ -1014,15 +1013,11 @@ local record unix
   --- Clears all environment variables.
   --- This wraps the C `clearenv()` function to allow Lua scripts to remove
   --- all environment variables at once.
-  --- @return true
-  --- @overload fun(): nil, error: unix.Errno
-  clearenv: function()
+  clearenv: function(): boolean, Errno
   --- Gets login name of current user.
   --- This wraps the C `getlogin()` function to retrieve the login name
   --- associated with the current session.
-  --- @return string login name
-  --- @overload fun(): nil, error: unix.Errno
-  getlogin: function()
+  getlogin: function(): string, Errno
   --- Creates a new process mitosis style.
   --- This system call returns twice. The parent process gets the nonzero
   --- pid. The child gets zero.


### PR DESCRIPTION
## Summary

Pins the cosmos release built from cosmopolitan master with [whilp/cosmopolitan#129](https://github.com/whilp/cosmopolitan/pull/129), which fixed `unix.clearenv`'s silently-dropped `@return` annotation (a `--- @tag` with a stray space that LuaLS/gentype ignore). Regenerating `unix.d.tl` picks up exactly the three returns that fix restored:

```
clearenv: function()             -> function(): boolean, Errno
getlogin: function()             -> function(): string, Errno
nivcsw:   function(self: Rusage) -> function(self: Rusage): number
```

Consequent in-repo changes:

- **`cosmic.env.clear`**: drop its `as(boolean, any)` cast — the last remaining instance of that idiom after #424. Keeps its `value, string` contract, routes through `errno.str`.
- **`cosmic.user.getlogin`**: now that `unix.getlogin` has its real `string, Errno` return, `return unix.getlogin()` from a `(): string` wrapper fails teal with excess return values. Made it errno-honest to match the rest of the module — returns `nil, "getlogin: <errno>"` on failure (`string, string`).

## Test plan

- `make ci`: **format, teal, test, lint** pass against the new pin (forced a clean teal recheck — the `unix.d.tl` regen changes signatures, which incremental teal can miss). The `gentype` errno-drift test passes; the only `example` failure is `fetch_example.tl` (sandboxed egress), unrelated.
- No `as(boolean, any)` casts remain in `lib/cosmic/*.tl`.
- `unix.d.tl` diff is minimal and additive (only the three returns above); other `.d.tl` files untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)