### PR TITLE
types: fully reproducible cosmo.* type generation with byte-exact drift enforcement

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "f4daba5e781efd813830ecf241ed0202551a7c16123c43237240b413e390640a"}},
+  platforms = {["*"] = {sha = "c3468582d2fd016dc8869107074d1d534ebdcfcdd1c14dd49f6d4b22cce8aacf"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.04-ad05a7294"
+  version = "2026.07.04-b1577d575"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ lib/
     *_example.tl       runnable examples
   build/               build infrastructure (fetch, stage, reporter)
   docs/                doc publishing
-  types/               .d.tl type definitions for cosmo.* C bindings
+  types/               cosmo.* type declarations (generated) + gentype generator
 3p/
   cosmos/              Cosmopolitan Lua binary + zip tool
   tl/                  Teal compiler
@@ -153,6 +153,35 @@ key concepts:
 - **bootstrap**: a pre-built cosmic binary bootstraps compilation of `.tl` → `.lua`
 - **sandboxing**: landlock-make applies pledge/unveil per-rule for build isolation
 - **output directory**: all build artifacts go to `o/`
+
+## Type Generation
+
+the `cosmo.*` type declarations are GENERATED — never edit them by hand:
+
+- `lib/types/cosmo.d.tl` — the top-level `require("cosmo")` surface
+- `lib/types/cosmo/*.d.tl` — submodules (unix, path, getopt, lsqlite3, re, argon2, zip, repl)
+
+the single source of truth is `tool/net/definitions.lua` in whilp/cosmopolitan,
+embedded in the pinned cosmos release binary at `/zip/.lua/definitions.lua`.
+upstream, per-module annotation-coverage ratchet tests guarantee every C
+binding is annotated; here, `lib/types/gentype.tl` parses those annotations
+into Teal records, and `lib/types/gentype_test.tl` fails if the committed
+files differ byte-for-byte from generator output.
+
+update procedure (after a cosmos bump or generator change):
+
+```bash
+# 1. bump 3p/cosmos/version.lua (url version + sha)
+bin/make regen-types      # regenerate all .d.tl from the new pin
+bin/make test only=gentype
+# 2. fix any lib/cosmic wrappers the new types break; commit everything together
+```
+
+`GENTYPE_DEFS=/path/to/definitions.lua` overrides the definitions source for
+validating against a cosmopolitan checkout before a release is cut.
+
+handcrafted exceptions (not generated, maintained by hand): `lib/types/tl.d.tl`
+(Teal compiler API), `lib/types/make-help.d.tl`.
 
 ## cosmic Binary
 

--- a/Makefile
+++ b/Makefile
@@ -277,20 +277,27 @@ $(o)/%.tl.benchmark.got: %.tl $(cosmic_bin) | $(bootstrap_files)
 	@mkdir -p $(@D)
 	@set +e; $(cosmic_bin) --benchmark $< > $(basename $@).out 2> $(basename $@).err; echo $$? > $@
 
-# Type definition regeneration (manual maintenance task)
-# .d.tl files are checked into the repo and are the source of truth for docs and types.
-# This target is only needed when cosmopolitan's definitions.lua changes.
-# Variables defined in cook.mk
+# Type definition regeneration.
+# The generated .d.tl files are a pure function of (lib/types/gentype*.tl, the
+# definitions.lua embedded in the pinned cosmos release). This target runs the
+# CURRENT generator from the freshly built cosmic binary against the CURRENT
+# pin, so regen is reproducible: bump 3p/cosmos/version.lua, run
+# `bin/make regen-types`, commit. The gentype drift test fails until you do.
+# Module list ($(type_modules)) defined in cook.mk
 
 .PHONY: regen-types
-## Regenerate .d.tl type definitions from cosmopolitan definitions.lua (manual maintenance)
-regen-types: | $(bootstrap_cosmic) $(cosmos_staged)
-	@echo "Regenerating type definitions using bootstrap cosmic..."
+## Regenerate .d.tl type definitions from the pinned cosmos definitions.lua
+regen-types: $(cosmic_bin)
+	@echo "Regenerating type definitions from the pinned cosmos definitions.lua..."
 	@for mod in $(type_modules); do \
-		echo "  $$mod.d.tl"; \
-		$(bootstrap_cosmic) -e "print(require('types.gentype').run('$$mod').output)" > lib/types/cosmo/$$mod.d.tl; \
+		case $$mod in \
+			cosmo) out=lib/types/cosmo.d.tl ;; \
+			*) out=lib/types/cosmo/$$mod.d.tl ;; \
+		esac; \
+		echo "  $$out"; \
+		$(cosmic_bin) -e "local r = require('types.gentype').run('$$mod'); assert(r.success, r.error); io.write(r.output)" > $$out.tmp && mv $$out.tmp $$out || { rm -f $$out.tmp; exit 1; }; \
 	done
-	@echo "Type definitions regenerated from upstream cosmopolitan."
+	@echo "Type definitions regenerated. Verify with: bin/make test only=gentype"
 
 # Documentation generation - render .tl files as markdown
 # Module sources for docs: all _tl files (excludes tests and examples)

--- a/cook.mk
+++ b/cook.mk
@@ -1,9 +1,10 @@
 # cosmic repository module definitions
 # This file aggregates all modules for the build system
 
-# Type definition generation (define early so it's available to all modules)
-type_modules := unix path getopt lsqlite3 re argon2 zip
-type_gen_outputs := $(patsubst %,lib/types/cosmo/%.d.tl,$(type_modules))
+# Type definition generation (define early so it's available to all modules).
+# Must match MODULES in lib/types/gentype.tl: "cosmo" renders the top-level
+# cosmo record (lib/types/cosmo.d.tl); the rest render lib/types/cosmo/<m>.d.tl.
+type_modules := cosmo unix path getopt lsqlite3 re argon2 zip repl
 
 # Bootstrap module: setup cosmic-lua for build process
 modules += bootstrap

--- a/lib/cosmic/args_test.tl
+++ b/lib/cosmic/args_test.tl
@@ -11,7 +11,7 @@ local tmpdir = os.getenv("TEST_TMPDIR")
 
 -- Test script that uses only varargs (...)
 local function test_varargs_only()
-  local script = path.join(tmpdir, "varargs.lua")
+  local script = path.join(tmpdir, "varargs.lua") as string
   cosmo.Barf(script, [[
 local args = {...}
 print("varargs_count=" .. #args)
@@ -31,7 +31,7 @@ test_varargs_only()
 
 -- Test script that uses only global arg table
 local function test_arg_table_only()
-  local script = path.join(tmpdir, "argtable.lua")
+  local script = path.join(tmpdir, "argtable.lua") as string
   cosmo.Barf(script, [[
 print("arg_count=" .. #arg)
 print("arg[0]=" .. tostring(arg[0]))
@@ -51,7 +51,7 @@ test_arg_table_only()
 
 -- Test that both varargs and arg table work together and match
 local function test_varargs_and_arg_table()
-  local script = path.join(tmpdir, "both.lua")
+  local script = path.join(tmpdir, "both.lua") as string
   cosmo.Barf(script, [[
 local varargs = {...}
 print("varargs_count=" .. #varargs)

--- a/lib/cosmic/codec.tl
+++ b/lib/cosmic/codec.tl
@@ -37,7 +37,7 @@ end
 --- @param opts {string:any}? Optional encoding options
 --- @return string The Lua source code representation
 local function encode_lua(value: any, opts?: {string: any}): string
-  return cosmo.EncodeLua(value, opts)
+  return (cosmo.EncodeLua(value, opts))
 end
 
 --- Decode Lua source code to a value with a restricted environment.

--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -13,6 +13,9 @@ cosmic_deps := cosmos tl teal-types
 cosmic_built := $(o)/cosmic/.built
 cosmic_sys := sys/help.md
 cosmic_skills := $(wildcard skills/cosmic/*.md)
+# lib/types is copied wholesale into the binary (.lua/types); without this
+# dependency, editing the type generator or a .d.tl leaves a stale binary.
+cosmic_types := $(wildcard lib/types/*.tl) $(wildcard lib/types/*.d.tl) $(wildcard lib/types/cosmo/*.d.tl)
 
 cosmic_version_lua := $(o)/cosmic/version.lua
 
@@ -23,7 +26,7 @@ $(cosmic_version_lua): .FORCE | $$(cosmos_staged)
 
 .PHONY: .FORCE
 
-$(cosmic_bin): $$(cosmic_lua) $(cosmic_main) $(cosmic_args) $$(tl_staged) $$(teal-types_staged) $$(doc_index) $(cosmic_version_lua) $(cosmic_sys) $(cosmic_skills)
+$(cosmic_bin): $$(cosmic_lua) $(cosmic_main) $(cosmic_args) $$(tl_staged) $$(teal-types_staged) $$(doc_index) $(cosmic_version_lua) $(cosmic_sys) $(cosmic_skills) $(cosmic_types)
 	@rm -rf $(cosmic_built)
 	@mkdir -p $(cosmic_built)/.lua/cosmic $(cosmic_built)/.tl/cosmic $(@D)
 	@for f in $(cosmic_lua); do \

--- a/lib/cosmic/doc.tl
+++ b/lib/cosmic/doc.tl
@@ -392,7 +392,7 @@ local cosmo = require("cosmo")
 
 --- Serialize a ModuleDoc to Lua source code.
 local function serialize(doc: ModuleDoc): string
-  return cosmo.EncodeLua(doc as table)
+  return (cosmo.EncodeLua(doc as table))
 end
 
 --- A documentation index containing all modules.
@@ -401,7 +401,7 @@ local record DocIndex
 end
 
 local function serialize_index(index: DocIndex): string
-  return cosmo.EncodeLua(index as table)
+  return (cosmo.EncodeLua(index as table))
 end
 
 local function load_index(source: string): DocIndex, string

--- a/lib/cosmic/fs_test.tl
+++ b/lib/cosmic/fs_test.tl
@@ -153,7 +153,7 @@ local function test_mkdir_error_message()
   local test_dir = setup()
 
   -- mkdir with missing parent should fail with descriptive error
-  local missing_parent = path.join(test_dir, "no", "such", "parent")
+  local missing_parent = path.join(test_dir, "no", "such", "parent") as string
   local ok, err = fs.mkdir(missing_parent)
   assert(not ok, "mkdir should fail when parent doesn't exist")
   assert(err, "should return error message")
@@ -187,7 +187,7 @@ local function test_makedirs_error_message()
   local f = io.open(blocker, "w")
   if f then f:close() end
 
-  local through_file = path.join(blocker, "subdir")
+  local through_file = path.join(blocker, "subdir") as string
   local ok, err = fs.makedirs(through_file)
   assert(not ok, "makedirs should fail when path component is a file")
   assert(err, "should return error message")

--- a/lib/cosmic/ip.tl
+++ b/lib/cosmic/ip.tl
@@ -4,11 +4,11 @@ local cosmo = require("cosmo")
 --- A typed IP address.
 --- Wraps the raw integer representation with convenience methods.
 local record Addr
-  _n: integer
+  _n: number
   --- Get the raw integer representation.
   --- Use this when passing to net.Socket:connect() or other APIs that take integer IPs.
   --- @return integer The IP address as an integer
-  int: function(Addr): integer
+  int: function(Addr): number
   --- Format as a dotted-quad string (e.g., "192.168.1.1").
   --- @return string The formatted IP address
   format: function(Addr): string
@@ -26,7 +26,7 @@ local record Addr
   is_public: function(Addr): boolean
 end
 
-local function addr_int(self: Addr): integer
+local function addr_int(self: Addr): number
   return self._n
 end
 
@@ -64,14 +64,14 @@ local Addr_mt: metatable < Addr > = {
   end,
 }
 
-local function make_addr(n: integer): Addr
+local function make_addr(n: number): Addr
   return setmetatable({_n = n} as Addr, Addr_mt)
 end
 
 --- Wrap a raw integer as a typed Addr.
 --- @param n integer The IP address as an integer
 --- @return Addr The typed IP address
-local function addr(n: integer): Addr
+local function addr(n: number): Addr
   return make_addr(n)
 end
 
@@ -79,14 +79,14 @@ end
 --- Returns -1 for invalid or unsupported addresses (including IPv6).
 --- @param str string The IP address string (e.g., "192.168.1.1")
 --- @return integer The IP address as an integer, or -1 on error
-local function parse(str: string): integer
+local function parse(str: string): number
   return cosmo.ParseIp(str)
 end
 
 --- Format an integer IP address as a string.
 --- @param ip integer The IP address as an integer
 --- @return string The formatted IP address string
-local function format(ip: integer): string
+local function format(ip: number): string
   return cosmo.FormatIp(ip)
 end
 
@@ -94,14 +94,14 @@ end
 --- Returns categories like "LOOPBACK", "PRIVATE", "ARIN", etc.
 --- @param ip integer The IP address as an integer
 --- @return string The category name
-local function categorize(ip: integer): string
+local function categorize(ip: number): string
   return cosmo.CategorizeIp(ip)
 end
 
 --- Check if an IP address is a loopback address (127.x.x.x).
 --- @param ip integer The IP address as an integer
 --- @return boolean True if the address is a loopback address
-local function is_loopback(ip: integer): boolean
+local function is_loopback(ip: number): boolean
   return cosmo.IsLoopbackIp(ip)
 end
 
@@ -109,22 +109,23 @@ end
 --- Private ranges: 10.x.x.x, 172.16-31.x.x, 192.168.x.x
 --- @param ip integer The IP address as an integer
 --- @return boolean True if the address is private
-local function is_private(ip: integer): boolean
+local function is_private(ip: number): boolean
   return cosmo.IsPrivateIp(ip)
 end
 
 --- Check if an IP address is a public/routable address.
 --- @param ip integer The IP address as an integer
 --- @return boolean True if the address is public
-local function is_public(ip: integer): boolean
+local function is_public(ip: number): boolean
   return cosmo.IsPublicIp(ip)
 end
 
 --- Resolve a hostname to an IP address.
 --- @param hostname string The hostname to resolve
 --- @return integer The IP address as an integer, or -1 on error
-local function resolve(hostname: string): integer
-  return cosmo.ResolveIp(hostname)
+local function resolve(hostname: string): number
+  local ip = cosmo.ResolveIp(hostname)
+  return ip or -1
 end
 
 --- Look up a hostname and return a typed Addr.
@@ -142,14 +143,14 @@ end
 
 local record IpModule
   Addr: Addr
-  addr: function(n: integer): Addr
-  parse: function(str: string): integer
-  format: function(ip: integer): string
-  categorize: function(ip: integer): string
-  is_loopback: function(ip: integer): boolean
-  is_private: function(ip: integer): boolean
-  is_public: function(ip: integer): boolean
-  resolve: function(hostname: string): integer
+  addr: function(n: number): Addr
+  parse: function(str: string): number
+  format: function(ip: number): string
+  categorize: function(ip: number): string
+  is_loopback: function(ip: number): boolean
+  is_private: function(ip: number): boolean
+  is_public: function(ip: number): boolean
+  resolve: function(hostname: string): number
   lookup: function(hostname: string): Addr, string
 end
 

--- a/lib/cosmic/net.tl
+++ b/lib/cosmic/net.tl
@@ -360,7 +360,6 @@ local record NetModule
   MSG_WAITALL: number
   MSG_OOB: number
   MSG_DONTROUTE: number
-  MSG_MORE: number
   MSG_NOSIGNAL: number
 end
 
@@ -445,7 +444,6 @@ local M: NetModule = {
   MSG_WAITALL = unix.MSG_WAITALL,
   MSG_OOB = unix.MSG_OOB,
   MSG_DONTROUTE = unix.MSG_DONTROUTE,
-  MSG_MORE = unix.MSG_MORE,
   MSG_NOSIGNAL = unix.MSG_NOSIGNAL,
 }
 

--- a/lib/cosmic/quicksand/proxy/dial.tl
+++ b/lib/cosmic/quicksand/proxy/dial.tl
@@ -38,7 +38,7 @@ end
 local function resolve(host: string, timeout_ms: integer,
     resolver: function(string): integer, any): integer, string
   local ip = cosmo.ParseIp(host)
-  if ip and ip ~= -1 then return ip end
+  if ip and ip ~= -1 then return ip as integer end
   if not resolver then
     resolver = cosmo.ResolveIp as function(string): integer, any
   end

--- a/lib/cosmic/quicksand/proxy/serve.tl
+++ b/lib/cosmic/quicksand/proxy/serve.tl
@@ -156,7 +156,7 @@ local function new(opts: ServeModule.ProxyOptions): Server, string
   local logger, lerr = make_logger(opts)
   if not logger then return nil, lerr end
   local idx = rules.index((opts.allowed_hosts or {}) as {string: any})
-  local bind_ip: integer = opts.bind_ip or cosmo.ParseIp("127.0.0.1")
+  local bind_ip: integer = opts.bind_ip or cosmo.ParseIp("127.0.0.1") as integer
   local bind_port: integer = opts.bind_port or 3128
   local backlog: integer = opts.accept_backlog or 32
   local upstream_ns_fd = opts.upstream_ns_fd

--- a/lib/cosmic/rand.tl
+++ b/lib/cosmic/rand.tl
@@ -19,37 +19,37 @@ end
 --- Generate a fast 64-bit pseudo-random integer (non-cryptographic).
 --- Note: result is a signed 64-bit Lua integer; may appear negative if high bit is set.
 --- @return integer Random 64-bit integer
-local function rand64(): integer
+local function rand64(): number
   return cosmo.Rand64()
 end
 
 --- Generate a fast 64-bit pseudo-random integer using Lemire's PRNG (non-cryptographic).
 --- Note: result is a signed 64-bit Lua integer; may appear negative if high bit is set.
 --- @return integer Random 64-bit integer
-local function lemur64(): integer
+local function lemur64(): number
   return cosmo.Lemur64()
 end
 
 --- Generate a hardware random integer using Intel RDRAND instruction.
 --- Returns nil and an error message on CPUs that do not support RDRAND.
 --- @return integer, string Random integer, or nil and error message if unavailable
-local function rdrand(): integer, string
+local function rdrand(): number, string
   return cosmo.Rdrand()
 end
 
 --- Generate a hardware random seed using Intel RDSEED instruction.
 --- Returns nil and an error message on CPUs that do not support RDSEED.
 --- @return integer, string Random seed integer, or nil and error message if unavailable
-local function rdseed(): integer, string
+local function rdseed(): number, string
   return cosmo.Rdseed()
 end
 
 local record RandModule
   bytes: function(n: number): string
-  rand64: function(): integer
-  lemur64: function(): integer
-  rdrand: function(): integer, string
-  rdseed: function(): integer, string
+  rand64: function(): number
+  lemur64: function(): number
+  rdrand: function(): number, string
+  rdseed: function(): number, string
 end
 
 local M: RandModule = {

--- a/lib/cosmic/signal.tl
+++ b/lib/cosmic/signal.tl
@@ -46,22 +46,15 @@ local record SignalModule
   SIGBUS: number
   SIGCHLD: number
   SIGCONT: number
-  SIGEMT: number
   SIGFPE: number
   SIGHUP: number
   SIGILL: number
-  SIGINFO: number
   SIGINT: number
-  SIGIO: number
   SIGKILL: number
   SIGPIPE: number
   SIGPROF: number
-  SIGPWR: number
   SIGQUIT: number
-  SIGRTMAX: number
-  SIGRTMIN: number
   SIGSEGV: number
-  SIGSTKFLT: number
   SIGSTOP: number
   SIGSYS: number
   SIGTERM: number
@@ -223,22 +216,15 @@ M.SIGALRM = unix.SIGALRM as number
 M.SIGBUS = unix.SIGBUS as number
 M.SIGCHLD = unix.SIGCHLD as number
 M.SIGCONT = unix.SIGCONT as number
-M.SIGEMT = unix.SIGEMT as number
 M.SIGFPE = unix.SIGFPE as number
 M.SIGHUP = unix.SIGHUP as number
 M.SIGILL = unix.SIGILL as number
-M.SIGINFO = unix.SIGINFO as number
 M.SIGINT = unix.SIGINT as number
-M.SIGIO = unix.SIGIO as number
 M.SIGKILL = unix.SIGKILL as number
 M.SIGPIPE = unix.SIGPIPE as number
 M.SIGPROF = unix.SIGPROF as number
-M.SIGPWR = unix.SIGPWR as number
 M.SIGQUIT = unix.SIGQUIT as number
-M.SIGRTMAX = unix.SIGRTMAX as number
-M.SIGRTMIN = unix.SIGRTMIN as number
 M.SIGSEGV = unix.SIGSEGV as number
-M.SIGSTKFLT = unix.SIGSTKFLT as number
 M.SIGSTOP = unix.SIGSTOP as number
 M.SIGSYS = unix.SIGSYS as number
 M.SIGTERM = unix.SIGTERM as number

--- a/lib/types/cosmo.d.tl
+++ b/lib/types/cosmo.d.tl
@@ -1,110 +1,718 @@
--- type declarations for cosmo (cosmopolitan lua)
+-- type declarations for cosmo
+-- GENERATED from cosmopolitan's definitions.lua by lib/types/gentype.tl.
+-- Do not edit by hand. Regenerate with: bin/make regen-types
+
+local unix = require("cosmo.unix")
+
+--- represented as the data structure `{{"a", "b"}, {"c"}, ...}`
+local record Url
+  --- e.g. `"http"`
+  scheme: string
+  --- the username string, or nil if absent
+  user: string
+  --- the password string, or nil if absent
+  pass: string
+  --- the hostname string, or nil if `url` was a path
+  host: string
+  --- the port string, or nil if absent
+  port: string
+  --- the path string, or nil if absent
+  path: string
+  --- the URL paramaters e.g. `/?a=b&c` would be
+  params: {{string}}
+  --- the stuff after the `#` character
+  fragment: string
+end
+
+local record EncoderOptions
+  --- defaults to `false`. Encodes the result directly to the output buffer and returns `nil` value. This option is ignored if used outside of request handling code.
+  useoutput: boolean
+  --- defaults to `true`. Lua uses hash tables so the order of object keys is lost in a Lua table. So, by default, we use strcmp to impose a deterministic output order. If you don't care about ordering then setting sorted=false should yield a performance boost in serialization.
+  sorted: boolean
+  --- defaults to `false`. Setting this option to true will cause tables with more than one entry to be formatted across multiple lines for readability.
+  pretty: boolean
+  --- defaults to " ". This option controls the indentation of pretty formatting. This field is ignored if pretty isn't true.
+  indent: string
+  --- defaults to 64. This option controls the maximum amount of recursion the serializer is allowed to perform. The max is 32767. You might not be able to set it that high if there isn't enough C stack memory. Your serializer checks for this and will return an error rather than crashing.
+  maxdepth: number
+end
+
+--- Streaming reader for an HTTP response body, returned by
+--- `cosmo.FetchStream`. The reader owns the underlying connection. It is
+--- closed automatically on garbage collection, but calling `close`
+--- promptly is recommended.
+local record StreamReader
+  --- Reads the next chunk of the response body.
+  --- Returns a string chunk on success. An empty string may be returned
+  --- for chunked transfer encodings when framing data arrived without any
+  --- payload; callers should skip empty chunks rather than treating them
+  --- as EOF. Returns `nil` when the stream ends. Returns `nil` plus an
+  --- error message string if the reader is closed, the connection failed,
+  --- or the response was truncated.
+  read: function(self: StreamReader): string | nil, string | nil
+  --- Closes the reader and releases the connection, buffer, and TLS
+  --- state. Idempotent: closing an already-closed reader is a no-op.
+  --- Returns nothing.
+  close: function(self: StreamReader)
+end
 
 local record cosmo
-  -- http
-  Fetch: function(url: string, opts?: {string: any}): number, {string: string}, string
+  type Url = Url
+  type EncoderOptions = EncoderOptions
+  type StreamReader = StreamReader
 
-  -- streaming http reader
-  record StreamReader
-    read: function(self: StreamReader): string, string
-    close: function(self: StreamReader): boolean
-  end
-
-  -- streaming http
-  FetchStream: function(url: string, opts?: {string: any}): number, {string: string}, StreamReader
-
-  -- file i/o
-  Barf: function(path: string, data: string, mode?: number): boolean
-  Slurp: function(path: string): string
-
-  -- hashing
-  Sha256: function(data: string): string
-
-  -- encoding
-  EncodeHex: function(data: string): string
-  EncodeJson: function(value: any): string, string
-  DecodeJson: function(json: string): any, string
-  EncodeLua: function(value: any, opts?: {string: any}): string
-  EncodeBase64: function(data: string): string
-  DecodeBase64: function(str: string): string
-  EncodeBase32: function(data: string): string
-  DecodeBase32: function(str: string): string
-  EncodeLatin1: function(str: string): string
-  DecodeLatin1: function(data: string): string
-
-  -- compression
-  Compress: function(data: string): string
-  Uncompress: function(data: string): string
-  Deflate: function(data: string): string
-  Inflate: function(data: string, max_size: integer): string
-
-  -- url encoding
-  EscapeParam: function(str: string): string
-  UnescapeParam: function(str: string): string, string
-  ParseParams: function(query: string): {{string, string}}
-
-  -- html/url escaping
-  EscapeHtml: function(str: string): string
-  EscapeHost: function(str: string): string
-  EscapePath: function(str: string): string
-  EscapeSegment: function(str: string): string
+  --- Writes all data to file the easy way.
+  --- This function writes to the local file system.
+  --- For example:
+  ---     assert(Barf('x.txt', 'abc123'))
+  ---     assert(Barf('x.txt', 'XX', 0, 0, 3))
+  ---     assert(assert(Slurp('x.txt', 1, 6)) == 'abXX23')
+  Barf: function(filename: string, data: string, mode?: number, flags?: number, offset?: number): boolean, unix.Errno
+  --- Formats string as binary integer literal string. If the provided value is zero,
+  --- the result will be `"0"`. Otherwise the resulting value will be the
+  --- "0b"-prefixed binary str. The result is currently modulo 2^64. Negative numbers
+  --- are converted to unsigned.
+  bin: function(int: number): string
+  --- Passing `0` will raise an error. Same as the Intel x86 instruction BSF.
+  Bsf: function(x: number): number
+  --- Passing `0` will raise an error. Same as the Intel x86 instruction BSR.
+  Bsr: function(x: number): number
+  CategorizeIp: function(ip: number): string
+  --- Compresses data using zlib DEFLATE with a small framing header.
+  --- By default the result starts with a header that stores the
+  --- uncompressed byte length (as a ULEB64 varint) followed by a `Crc32`
+  --- checksum, so `Uncompress` can decode it without being told the
+  --- original size. If `raw` is truthy then only the raw zlib stream is
+  --- returned, in which case `Uncompress` requires the uncompressed size
+  --- as its second argument.
+  --- This function raises an error if the level is invalid or the system
+  --- runs out of memory.
+  Compress: function(uncompressed: string, level?: number, raw?: boolean): string
+  --- Computes Phil Katz CRC-32 used by zip/zlib/gzip/etc.
+  Crc32: function(initial: number, data: string): number
+  --- Computes 32-bit Castagnoli Cyclic Redundancy Check.
+  Crc32c: function(initial: number, data: string): number
+  --- Computes the Curve25519 elliptic-curve scalar multiplication used
+  --- for Diffie-Hellman key agreement.
+  --- The second argument can be either a public key or a basepoint. Use
+  --- the magic basepoint `"\9"` to derive a public key from a 32-byte
+  --- secret, then multiply your secret against the other party's public
+  --- key to derive a shared key, e.g.
+  ---     >: secret1 = GetRandomBytes(32)
+  ---     >: public1 = Curve25519(secret1, "\9")
+  ---     >: secret2 = GetRandomBytes(32)
+  ---     >: public2 = Curve25519(secret2, "\9")
+  ---     >: Curve25519(secret1, public2) == Curve25519(secret2, public1)
+  ---     true
+  --- Arguments are zero-padded or truncated to 32 bytes.
+  Curve25519: function(secret: string, public_or_basepoint: string): string
+  --- Shrinks byte buffer in half using John Costella's magic kernel. This downscales
+  --- data 2x using an eight-tap convolution, e.g.
+  ---     >: Decimate('\xff\xff\x00\x00\xff\xff\x00\x00\xff\xff\x00\x00')
+  ---     "\xff\x00\xff\x00\xff\x00"
+  --- This is very fast if SSSE3 is available (Intel 2004+ / AMD 2011+).
+  Decimate: function(data: string): string
+  --- Turns ASCII into binary using the provided alphabet. The default
+  --- decoding uses Crockford's base32 alphabet in a permissive way that
+  --- ignores whitespace and dash (`-`) and stops at the first character
+  --- outside of the alphabet. Any alphabet that has a power of 2 length
+  --- (up to 128) may be supplied, which allows alternative base32
+  --- encodings to be decoded. Raises an error if the alphabet length is
+  --- not a power of 2 in the range 2..128.
+  DecodeBase32: function(ascii: string, alphabet?: string): string
+  --- Decodes binary data encoded as base64.
+  --- This turns ASCII into binary, in a permissive way that ignores
+  --- characters outside the base64 alphabet, such as whitespace. See
+  --- `decodebase64.c`.
+  DecodeBase64: function(ascii: string): string
+  --- Turns ASCII base-16 hexadecimal byte string into binary string,
+  --- case-insensitively. Non-hex characters may not appear in string.
+  DecodeHex: function(ascii: string): string
+  --- Turns JSON string into a Lua data structure.
+  --- This is a generally permissive parser, in the sense that like
+  --- v8, it permits scalars as top-level values. Therefore we must
+  --- note that this API can be thought of as special, in the sense
+  ---     val = assert(DecodeJson(str))
+  --- will usually do the right thing, except in cases where `false`
+  --- or `null` are the top-level value. In those cases, it's needed
+  --- to check the second value too in order to discern from error
+  ---     val, err = DecodeJson(str)
+  ---     if not val then
+  ---        if err then
+  ---           print('bad json', err)
+  ---        elseif val == nil then
+  ---           print('val is null')
+  ---        elseif val == false then
+  ---           print('val is false')
+  ---        end
+  ---     end
+  --- This parser supports 64-bit signed integers. If an overflow
+  --- happens, then the integer is silently coerced to double, as
+  --- consistent with v8. If a double overflows into `Infinity`, we
+  --- coerce it to `null` since that's what v8 does, and the same
+  --- goes for underflows which, like v8, are coerced to `0.0`.
+  --- When objects are parsed, your Lua object can't preserve the
+  --- original ordering of fields. As such, they'll be sorted by
+  --- `EncodeJson()` and may not round-trip with original intent.
+  --- This parser has perfect conformance with JSONTestSuite.
+  --- This parser validates utf-8 and utf-16.
+  DecodeJson: function(input: string): any, string
+  --- Turns ISO-8859-1 string into UTF-8.
+  DecodeLatin1: function(iso_8859_1: string): string
+  --- Compresses data.
+  ---     >: Deflate("hello")
+  ---     "\xcbH\xcd\xc9\xc9\x07\x00"
+  ---     >: Inflate("\xcbH\xcd\xc9\xc9\x07\x00", 5)
+  ---     "hello"
+  --- The output format is raw DEFLATE that's suitable for embedding into formats
+  --- like a ZIP file. It's recommended that, like ZIP, you also store separately a
+  --- `Crc32()` checksum in addition to the original uncompressed size.
+  --- Lower numbers go faster (4 for instance is a sweet spot) and higher numbers go
+  --- slower but have better compression.
+  Deflate: function(uncompressed: string, level?: number): string, string
+  --- Turns binary into ASCII using the provided alphabet (Crockford's
+  --- base32 alphabet by default). Any alphabet that has a power of 2
+  --- length (up to 128) may be supplied for encoding and decoding, which
+  --- allows alternative base32 encodings to be produced. Raises an error
+  --- if the alphabet length is not a power of 2 in the range 2..128.
+  EncodeBase32: function(binary: string, alphabet?: string): string
+  --- Turns binary into ASCII. This can be used to create HTML data:
+  --- URIs that do things like embed a PNG file in a web page. See
+  --- encodebase64.c.
+  EncodeBase64: function(binary: string): string
+  --- Turns binary into ASCII base-16 hexadecimal lowercase string.
+  EncodeHex: function(binary: string): string
+  --- Turns Lua data structure into JSON string.
+  --- Since Lua uses tables are both hashmaps and arrays, we use a
+  --- simple fast algorithm for telling the two apart. Tables with
+  --- non-zero length (as reported by `#`) are encoded as arrays,
+  --- and any non-array elements are ignored. For example:
+  ---     >: EncodeJson({2})
+  ---     "[2]"
+  ---     >: EncodeJson({[1]=2, ["hi"]=1})
+  ---     "[2]"
+  --- If there are holes in your array, then the serialized array
+  --- will exclude everything after the first hole. If the beginning
+  --- of your array is a hole, then an error is returned.
+  ---     >: EncodeJson({[1]=1, [3]=3})
+  ---     "[1]"
+  ---     >: EncodeJson({[2]=1, [3]=3})
+  ---     "[]"
+  ---     >: EncodeJson({[2]=1, [3]=3})
+  ---     nil     "json objects must only use string keys"
+  --- If the raw length of a table is reported as zero, then we
+  --- check for the magic element `[0]=false`. If it's present, then
+  --- your table will be serialized as empty array `[]`. An entry is
+  --- inserted by `DecodeJson()` automatically, only when encountering
+  --- empty arrays, and it's necessary in order to make empty arrays
+  --- round-trip. If raw length is zero and `[0]=false` is absent,
+  --- then your table will be serialized as an iterated object.
+  ---     >: EncodeJson({})
+  ---     "{}"
+  ---     >: EncodeJson({[0]=false})
+  ---     "[]"
+  ---     >: EncodeJson({["hi"]=1})
+  ---     "{\"hi\":1}"
+  ---     >: EncodeJson({["hi"]=1, [0]=false})
+  ---     "[]"
+  ---     >: EncodeJson({["hi"]=1, [7]=false})
+  ---     nil     "json objects must only use string keys"
+  --- The following options may be used:
+  --- - `useoutput`: `(bool=false)` encodes the result directly to the output buffer
+  ---   and returns nil value. This option is ignored if used outside of request
+  ---   handling code.
+  --- - `sorted`: `(bool=true)` Lua uses hash tables so the order of object keys is
+  ---   lost in a Lua table. So, by default, we use strcmp to impose a deterministic
+  ---   output order. If you don't care about ordering then setting `sorted=false`
+  ---   should yield a performance boost in serialization.
+  --- - `pretty`: `(bool=false)` Setting this option to true will cause tables with
+  ---   more than one entry to be formatted across multiple lines for readability.
+  --- - `indent`: `(str=" ")` This option controls the indentation of pretty
+  ---    formatting. This field is ignored if pretty isn't `true`.
+  --- - `maxdepth`: `(int=64)` This option controls the maximum amount of recursion
+  ---   the serializer is allowed to perform. The max is 32767. You might not be able
+  ---   to set it that high if there isn't enough C stack memory. Your serializer
+  ---   checks for this and will return an error rather than crashing.
+  --- If the raw length of a table is reported as zero, then we
+  --- check for the magic element `[0]=false`. If it's present, then
+  --- your table will be serialized as empty array `[]`. An entry is
+  --- inserted by `DecodeJson()` automatically, only when encountering
+  --- empty arrays, and it's necessary in order to make empty arrays
+  --- round-trip. If raw length is zero and `[0]=false` is absent,
+  --- then your table will be serialized as an iterated object.
+  --- This function will return an error if:
+  --- - value is cyclic
+  --- - value has depth greater than 64
+  --- - value contains functions, user data, or threads
+  --- - value is table that blends string / non-string keys
+  --- - Your serializer runs out of C heap memory (setrlimit)
+  --- We assume strings in value contain UTF-8. This serializer currently does not
+  --- produce UTF-8 output. The output format is right now ASCII. Your UTF-8 data
+  --- will be safely transcoded to `\uXXXX` sequences which are UTF-16. Overlong
+  --- encodings in your input strings will be canonicalized rather than validated.
+  --- NaNs are serialized as `null` and Infinities are `null` which is consistent
+  --- with the v8 behavior.
+  EncodeJson: function(value: any, options?: any): string, string
+  --- Turns UTF-8 into ISO-8859-1 string.
+  EncodeLatin1: function(utf8: string, flags?: number): string
+  --- Turns Lua data structure into Lua code string.
+  --- Since Lua uses tables as both hashmaps and arrays, tables will only be
+  --- serialized as an array with determinate order, if it's an array in the
+  --- strictest possible sense.
+  --- 1. for all 𝑘=𝑣 in table, 𝑘 is an integer ≥1
+  --- 2. no holes exist between MIN(𝑘) and MAX(𝑘)
+  --- 3. if non-empty, MIN(𝑘) is 1
+  --- In all other cases, your table will be serialized as an object which is
+  --- iterated and displayed as a list of (possibly) sorted entries that have
+  --- equal signs.
+  ---     >: EncodeLua({3, 2})
+  ---     "{3, 2}"
+  ---     >: EncodeLua({[1]=3, [2]=3})
+  ---     "{3, 2}"
+  ---     >: EncodeLua({[1]=3, [3]=3})
+  ---     "{[1]=3, [3]=3}"
+  ---     >: EncodeLua({["hi"]=1, [1]=2})
+  ---     "{[1]=2, hi=1}"
+  --- The following options may be used:
+  --- - `useoutput`: `(bool=false)` encodes the result directly to the output buffer
+  ---   and returns nil value. This option is ignored if used outside of request
+  ---   handling code.
+  --- - `sorted`: `(bool=true)` Lua uses hash tables so the order of object keys is
+  ---   lost in a Lua table. So, by default, we use strcmp to impose a deterministic
+  ---   output order. If you don't care about ordering then setting `sorted=false`
+  ---   should yield a performance boost in serialization.
+  --- - `pretty`: `(bool=false)` Setting this option to true will cause tables with
+  ---   more than one entry to be formatted across multiple lines for readability.
+  --- - `indent`: `(str=" ")` This option controls the indentation of pretty
+  ---    formatting. This field is ignored if pretty isn't `true`.
+  --- - `maxdepth`: `(int=64)` This option controls the maximum amount of recursion
+  ---   the serializer is allowed to perform. The max is 32767. You might not be able
+  ---   to set it that high if there isn't enough C stack memory. Your serializer
+  ---   checks for this and will return an error rather than crashing.
+  --- If a user data object has a `__repr` or `__tostring` meta method, then that'll
+  --- be used to encode the Lua code.
+  --- This serializer is designed primarily to describe data. For example, it's used
+  --- by the REPL where we need to be able to ignore errors when displaying data
+  --- structures, since showing most things imperfectly is better than crashing.
+  --- Therefore this isn't the kind of serializer you'd want to use to persist data
+  --- in prod. Try using the JSON serializer for that purpose.
+  --- Non-encodable value types (e.g. threads, functions) will be represented as a
+  --- string literal with the type name and pointer address. The string description
+  --- is of an unspecified format that could most likely change. This encoder detects
+  --- cyclic tables; however instead of failing, it embeds a string of unspecified
+  --- layout describing the cycle.
+  --- Integer literals are encoded as decimal. However if the int64 number is ≥256
+  --- and has a population count of 1 then we switch to representating the number in
+  --- hexadecimal, for readability. Hex numbers have leading zeroes added in order
+  --- to visualize whether the number fits in a uint16, uint32, or int64. Also some
+  --- numbers can only be encoded expressionally. For example, `NaN`s are serialized
+  --- as `0/0`, and `Infinity` is `math.huge`.
+  ---     >: 7000
+  ---     7000
+  ---     >: 0x100
+  ---     0x0100
+  ---     >: 0x10000
+  ---     0x00010000
+  ---     >: 0x100000000
+  ---     0x0000000100000000
+  ---     >: 0/0
+  ---     0/0
+  ---     >: 1.5e+9999
+  ---     math.huge
+  ---     >: -9223372036854775807 - 1
+  ---     -9223372036854775807 - 1
+  --- The only failure return condition currently implemented is when C runs out of heap memory.
+  EncodeLua: function(value: any, options?: any): string, string
+  --- This function is the inverse of ParseUrl. The output will always be correctly
+  --- formatted. The exception is if illegal characters are supplied in the scheme
+  --- field, since there's no way of escaping those. Opaque parts are escaped as
+  --- though they were paths, since many URI parsers won't understand things like
+  --- an unescaped question mark in path.
+  EncodeUrl: function(url: Url): string
+  --- Escapes URL #fragment. The allowed characters are `-/?.~_@:!$&'()*+,;=0-9A-Za-z`
+  --- and everything else gets `%XX` encoded. Please note that `'&` can still break
+  --- HTML and that `'()` can still break CSS URLs. This function is charset agnostic
+  --- and will not canonicalize overlong encodings. It is assumed that a UTF-8 string
+  --- will be supplied. See `kescapefragment.S`.
   EscapeFragment: function(str: string): string
-  EscapeLiteral: function(str: string): string
-  EscapeUser: function(str: string): string
-  EscapePass: function(str: string): string
+  --- Escapes URL host. See `kescapeauthority.S`.
+  EscapeHost: function(str: string): string
+  --- Escapes HTML entities: The set of entities is `&><"'` which become `&amp;&gt;&lt;&quot;&#39;`. This function is charset agnostic and will not canonicalize overlong encodings. It is assumed that a UTF-8 string will be supplied. See `escapehtml.c`.
+  EscapeHtml: function(str: string): string
+  --- Escapes URL IP-literal. This is the same as `EscapeHost` except
+  --- colon is permitted, so bracketed IPv6 literals stay intact. See
+  --- `escapeip.c`.
   EscapeIp: function(str: string): string
-
-  -- url parsing
-  record ParsedUrl
-    scheme: string
-    user: string
-    pass: string
-    host: string
-    port: string
-    path: string
-    fragment: string
-    params: {{string, string}}
-  end
-  ParseUrl: function(url: string): ParsedUrl
-  ParseHost: function(hostport: string): string
-
-  -- http datetime
-  FormatHttpDateTime: function(timestamp: number): string
-  ParseHttpDateTime: function(str: string): number
-
-  -- ip address utilities
-  ParseIp: function(str: string): integer
-  FormatIp: function(ip: integer): string
-  CategorizeIp: function(ip: integer): string
-  IsLoopbackIp: function(ip: integer): boolean
-  IsPrivateIp: function(ip: integer): boolean
-  IsPublicIp: function(ip: integer): boolean
-  ResolveIp: function(hostname: string): integer
-
-  -- system info
-  GetHostOs: function(): string
+  --- Escapes JavaScript or JSON string literal content. The caller is responsible
+  --- for adding the surrounding quotation marks. This implementation \uxxxx sequences
+  --- for all non-ASCII sequences. HTML entities are also encoded, so the output
+  --- doesn't need `EscapeHtml`. This function assumes UTF-8 input. Overlong
+  --- encodings are canonicalized. Invalid input sequences are assumed to
+  --- be ISO-8859-1. The output is UTF-16 since that's what JavaScript uses. For
+  --- example, some individual codepoints such as emoji characters will encode as
+  --- multiple `\uxxxx` sequences. Ints that are impossible to encode as UTF-16 are
+  --- substituted with the `\xFFFD` replacement character.
+  --- See `escapejsstringliteral.c`.
+  EscapeLiteral: function(str: string): string
+  --- Escapes URL parameter name or value. The allowed characters are `-.*_0-9A-Za-z`
+  --- and everything else gets `%XX` encoded. This function is charset agnostic and
+  --- will not canonicalize overlong encodings. It is assumed that a UTF-8 string
+  --- will be supplied. See `kescapeparam.S`.
+  EscapeParam: function(str: string): string
+  --- Escapes URL password. See `kescapeauthority.S`.
+  EscapePass: function(str: string): string
+  --- Escapes URL path. This is the same as EscapeSegment except slash is allowed.
+  --- The allowed characters are `-.~_@:!$&'()*+,;=0-9A-Za-z/` and everything else
+  --- gets `%XX` encoded. Please note that `'&` can still break HTML, so the output
+  --- may need EscapeHtml too. Also note that `'()` can still break CSS URLs. This
+  --- function is charset agnostic and will not canonicalize overlong encodings.
+  --- It is assumed that a UTF-8 string will be supplied. See `kescapepath.S`.
+  EscapePath: function(str: string): string
+  --- Escapes URL path segment. This is the same as EscapePath except slash isn't
+  --- allowed. The allowed characters are `-.~_@:!$&'()*+,;=0-9A-Za-z` and everything
+  --- else gets `%XX` encoded. Please note that `'&` can still break HTML, so the
+  --- output may need EscapeHtml too. Also note that `'()` can still break CSS URLs.
+  --- This function is charset agnostic and will not canonicalize overlong encodings.
+  --- It is assumed that a UTF-8 string will be supplied. See `kescapesegment.S`.
+  EscapeSegment: function(str: string): string
+  --- Escapes URL username. See `kescapeauthority.S`.
+  EscapeUser: function(str: string): string
+  --- Sends an HTTP/HTTPS request to the specified URL. If only the URL is provided,
+  --- then a GET request is sent. If both URL and body parameters are specified, then
+  --- a POST request is sent. If any other method needs to be specified (for example,
+  --- PUT or DELETE), then passing a table as the second value allows setting method
+  --- and body values as well other options:
+  --- - `method` (default: `"GET"`): sets the method to be used for the request.
+  ---   The specified method is converted to uppercase.
+  --- - `body` (default: `""`): sets the body value to be sent.
+  --- - `followredirect` (default: `true`): forces temporary and permanent redirects
+  ---    to be followed. This behavior can be disabled by passing `false`.
+  --- - `maxredirects` (default: `5`): sets the number of allowed redirects to
+  ---   minimize looping due to misconfigured servers. When the number is exceeded,
+  ---   the result of the last redirect is returned.
+  --- - `keepalive` (default = `false`): configures each request to keep the
+  ---   connection open (unless closed by the server) and reuse for the
+  ---   next request to the same host. This option is disabled when SSL
+  ---   connection is used.
+  ---   The mapping of hosts and their sockets is stored in a table
+  ---   assigned to the `keepalive` field itself, so it can be passed to
+  ---   the next call.
+  ---   If the table includes the `close` field set to a true value,
+  ---   then the connection is closed after the request is made and the
+  ---   host is removed from the mapping table.
+  --- - `proxy` (string): HTTP proxy URL, e.g. `"http://proxy:8080"`.
+  ---   Supports Basic authentication: `"http://user:pass@proxy:8080"`.
+  --- - `maxresponse` (default: `104857600`): maximum response size in bytes.
+  ---   Protects against memory exhaustion from large responses.  Must be >= 0;
+  ---   negative values are rejected.
+  --- - `timeout` (number, seconds): per-operation socket timeout (read/write/
+  ---   connect).  A value of `0` or absent keeps the 60-second default.  There
+  ---   is no "infinite" option — use a large positive value if needed.  The
+  ---   timeout also bounds the TLS handshake.
+  --- - `resettls` (default: `true`): reset TLS state after fork.
+  ---   Ensures child processes get fresh DRBG entropy.
+  --- Environment variables:
+  --- - `http_proxy` / `HTTP_PROXY`: default proxy URL when `proxy` option
+  ---   is not specified. Supports same format as the option.
+  --- - `SSL_CERT_FILE`: path to CA certificate bundle file for TLS verification.
+  ---   Overrides default system CA locations.
+  --- - `SSL_NO_SYSTEM_CERTS`: if set, skip loading system CA certificates.
+  ---   Only embedded certificates will be used.
+  --- When the redirect is being followed, the same method and body values are being
+  --- sent in all cases except when 303 status is returned. In that case the method
+  --- is set to GET and the body is removed before the redirect is followed. Note
+  --- that if these (method/body) values are provided as table fields, they will be
+  --- modified in place.
+  Fetch: function(url: string, body?: string | any): number, {string: string}, string, string
+  --- Sends an HTTP/HTTPS request and returns a streaming reader for the response body.
+  --- Useful for Server-Sent Events (SSE), large downloads, or processing data incrementally.
+  --- Accepts the same options table as `Fetch()`, including `timeout`, `maxresponse`,
+  --- `headers`, `method`, `body`, `proxy`, `followredirect`, and `maxredirects`.
+  --- Note: `timeout=0` (or absent) retains the 60-second default; there is no
+  --- "infinite" option.  `maxresponse` limits per-read buffer growth; negative
+  --- values are rejected.
+  FetchStream: function(url: string, options?: any): number, {string: string}, StreamReader, string
+  --- Converts UNIX timestamp to an RFC1123 string that looks like this:
+  --- `Mon, 29 Mar 2021 15:37:13 GMT`. See `formathttpdatetime.c`.
+  FormatHttpDateTime: function(seconds: number): string
+  --- Turns integer like `0x01020304` into a string like `"1.2.3.4"`. See also
+  --- `ParseIp` for the inverse operation.
+  FormatIp: function(uint32: number): string
+  GetCpuCore: function(): number
+  GetCpuCount: function(): number
+  GetCpuNode: function(): number
+  GetCryptoHash: function(name: string, payload: string, key?: string): string
+  --- Returns string describing host instruction set architecture.
+  --- This can return:
+  --- - `"X86_64"` for Intel and AMD systems
+  --- - `"AARCH64"` for ARM64, M1, and Raspberry Pi systems
+  --- - `"POWERPC64"` for OpenPOWER Raptor Computing Systems
   GetHostIsa: function(): string
-  GetRandomBytes: function(count: number): string
-
-  -- fast pseudo-random number generators (non-cryptographic)
-  Rand64: function(): integer
-  Lemur64: function(): integer
-  Rdrand: function(): integer, string
-  Rdseed: function(): integer, string
-
-  -- uuid
-  UuidV4: function(): string
-  UuidV7: function(): string
-
-  -- script detection
+  GetHostOs: function(): string
+  GetHttpReason: function(code: number): string
+  --- This is useful for fixed-width formatting. For example, CJK characters
+  --- typically take up two cells. This function takes into consideration combining
+  --- characters, which are discounted, as well as control codes and ANSI escape
+  --- sequences.
+  GetMonospaceWidth: function(str: string | number): number
+  GetRandomBytes: function(length?: number): string
+  GetTime: function(): number
+  --- Returns `true` if the string contains forbidden control codes.
+  --- `flags` selects which characters are considered forbidden and may be
+  --- any combination of:
+  --- - `1` (kControlWs): forbid the whitespace controls tab, carriage
+  ---   return, line feed, and vertical tab
+  --- - `2` (kControlC0): forbid the C0 control codes (0x00..0x1F and
+  ---   0x7F), except the whitespace controls above
+  --- - `4` (kControlC1): forbid the C1 control codes (0x80..0x9F), which
+  ---   are decoded from UTF-8 before being checked
+  --- If `flags` is zero (the default) then no characters are forbidden
+  --- and this function returns `false`. Raises an error if `flags` has
+  --- bits outside the values above.
+  HasControlCodes: function(str: string, flags?: number): boolean
+  --- Formats string as hexadecimal integer literal string. If the provided value is
+  --- zero, the result will be `"0"`. Otherwise the resulting value will be the
+  --- "0x"-prefixed hex string. The result is currently modulo 2^64. Negative numbers
+  --- are converted to unsigned.
+  hex: function(int: number): string
+  --- Computes 64-bit Google HighwayHash of a string.
+  --- HighwayHash is a fast keyed pseudorandom function. The four optional
+  --- 64-bit key words default to zero. A zero key isn't a secret key;
+  --- pass four random 64-bit integers if keyed hashing is desired.
+  HighwayHash64: function(str: string, k1?: number, k2?: number, k3?: number, k4?: number): number
+  --- Adds spaces to beginnings of multiline string. If the int parameter is not
+  --- supplied then 1 space will be added.
+  IndentLines: function(str: string, int?: number): string
+  --- Decompresses data.
+  --- This function performs the inverse of Deflate(). It's recommended that you
+  --- perform a `Crc32()` check on the output string after this function succeeds.
+  --- However, it is permissable (although not advised) to specify some large number
+  --- in which case (on success) the byte length of the output string may be less
+  --- than `maxoutsize`.
+  Inflate: function(compressed: string, maxoutsize: number): string, string
+  --- Check if the calling script is being run directly (not require'd).
+  --- This function provides a Python-like `if __name__ == "__main__"` idiom
+  --- for Lua scripts. It returns true when the script is executed directly
+  --- from the command line, and false when the script is loaded via require().
+  --- Example usage:
+  ---     local M = {}
+  ---     function M.main(args)
+  ---       print("Hello, " .. (args[1] or "world"))
+  ---     end
+  ---     if is_main() then
+  ---       M.main(arg)
+  ---     end
+  ---     return M
   is_main: function(): boolean
-
-  -- submodules (for require path hints)
-  record unix end
-  record path end
-  record getopt end
-  record zip end
-  record lsqlite3 end
+  --- Returns `true` if hostname seems legit.
+  --- This validates the host component of a URL, permitting things like
+  --- `""`, `1.2.3.4`, `localservice`, `hello.example`, and
+  --- `hi-there.example`, while rejecting things like `::1`, `1.2.3`,
+  --- `1.2.3.4.5`, `.hi.example`, and `hi..example`. Fully numerical names
+  --- must be valid IPv4 addresses. There's currently no support for IPv6
+  --- literals. See `isacceptablehost.c`.
+  IsAcceptableHost: function(str: string): boolean
+  IsAcceptablePath: function(str: string): boolean
+  --- Returns `true` if port string seems legit, i.e. it's either empty or
+  --- a string of digits that fits in the range 0..65535, e.g. `""`,
+  --- `"0"`, `"65535"`. Named services like `"https"`, negative values,
+  --- and numbers greater than 65535 are rejected. See
+  --- `isacceptableport.c`.
+  IsAcceptablePort: function(str: string): boolean
+  --- Returns `true` if the given HTTP header name is a standard header
+  --- that the RFCs define as storing comma-separated values and may
+  --- therefore appear multiple times in a message, e.g.
+  --- `Accept-Encoding`. Returns `false` for non-repeatable and
+  --- unrecognized headers. See `khttprepeatable.c`.
+  IsHeaderRepeatable: function(name: string): boolean
+  IsLoopbackIp: function(uint32: number): boolean
+  IsPrivateIp: function(uint32: number): boolean
+  --- Note: we intentionally regard TEST-NET IPs as public.
+  IsPublicIp: function(uint32: number): boolean
+  IsReasonablePath: function(str: string): boolean
+  --- Returns `true` if the string is a valid HTTP token, i.e. a nonempty
+  --- ASCII string without separators or control codes, as defined by
+  --- RFC7230. Tokens are used for things like HTTP methods and header
+  --- names. See `isvalidhttptoken.c`.
+  IsValidHttpToken: function(str: string): boolean
+  --- This linear congruential generator passes practrand and bigcrush.
+  Lemur64: function(): number
+  --- Compresses data using LZ4.
+  --- LZ4 is an extremely fast compression algorithm, trading compression ratio
+  --- for speed. It's particularly well-suited for real-time compression scenarios.
+  --- The compressed output is not compatible with other compression formats (use
+  --- Deflate/Inflate for standard zlib compatibility).
+  --- produce faster compression but with worse compression ratio. Range is 1-65537.
+  Lz4Compress: function(data: string, acceleration?: number): string, string
+  --- Decompresses LZ4-compressed data.
+  --- You must know the maximum size of the decompressed output beforehand.
+  --- This is a limitation of the LZ4 format which doesn't store the original size.
+  Lz4Decompress: function(compressed: string, maxoutsize: number): string, string
+  --- Computes MD5 checksum, returning 16 bytes of binary.
+  Md5: function(str: string): string
+  --- This gives you an idea of the density of information. Cryptographic random
+  --- should be in the ballpark of `7.9` whereas plaintext will be more like `4.5`.
+  MeasureEntropy: function(data: string): number
+  --- Formats string as octal integer literal string. If the provided value is zero,
+  --- the result will be `"0"`. Otherwise the resulting value will be the
+  --- zero-prefixed octal string. The result is currently modulo 2^64. Negative
+  --- numbers are converted to unsigned.
+  oct: function(int: number): string
+  --- Parses a `host[:port]` string, e.g. `"example.com:8080"`.
+  --- Please note a longstanding quirk inherited from redbean: only the
+  --- port component is currently returned. This function yields the port
+  --- string (e.g. `"8080"`), or `nil` if no port is present; the host
+  --- component is parsed but not returned. This function is
+  --- nil-propagating: passing `nil` returns `nil`. Raises an error if the
+  --- system runs out of memory.
+  ParseHost: function(str: string): string | nil
+  --- Converts RFC1123 string that looks like this: Mon, 29 Mar 2021 15:37:13 GMT to
+  --- a UNIX timestamp. See `parsehttpdatetime.c`.
+  ParseHttpDateTime: function(rfc1123: string): number
+  --- Converts IPv4 address string to integer, e.g. "1.2.3.4" → 0x01020304, or
+  --- returns -1 for invalid inputs. See also `FormatIp` for the inverse operation.
+  ParseIp: function(ip: string): number
+  --- Parses `application/x-www-form-urlencoded` key/value parameters,
+  --- e.g. `"a=b&c"` becomes `{{"a", "b"}, {"c"}}`. This returns the same
+  --- data structure as the `params` field of the `Url` object returned by
+  --- `ParseUrl`. Keys and values are percent-decoded. This function is
+  --- nil-propagating: passing `nil` returns `nil`. Raises an error if the
+  --- system runs out of memory.
+  ParseParams: function(paramstring: string): any
+  --- Parses URL.
+  --- - `scheme` is a string, e.g. `"http"`
+  --- - `user` is the username string, or nil if absent
+  --- - `pass` is the password string, or nil if absent
+  --- - `host` is the hostname string, or nil if `url` was a path
+  --- - `port` is the port string, or nil if absent
+  --- - `path` is the path string, or nil if absent
+  --- - `params` is the URL paramaters, e.g. `/?a=b&c` would be
+  ---   represented as the data structure `{{"a", "b"}, {"c"}, ...}`
+  --- - `fragment` is the stuff after the `#` character
+  --- - `kUrlPlus` to turn `+` into space
+  --- - `kUrlLatin1` to transcode ISO-8859-1 input into UTF-8
+  --- This parser is charset agnostic. Percent encoded bytes are
+  --- decoded for all fields. Returned values might contain things
+  --- like NUL characters, spaces, control codes, and non-canonical
+  --- encodings. Absent can be discerned from empty by checking if
+  --- the pointer is set.
+  --- There's no failure condition for this routine. This is a
+  --- permissive parser. This doesn't normalize path segments like
+  --- `.` or `..` so use IsAcceptablePath() to check for those. No
+  --- restrictions are imposed beyond that which is strictly
+  --- necessary for parsing. All the data that is provided will be
+  --- consumed to the one of the fields. Strict conformance is
+  --- enforced on some fields more than others, like scheme, since
+  --- it's the most non-deterministically defined field of them all.
+  --- Please note this is a URL parser, not a URI parser. Which
+  --- means we support everything the URI spec says we should do
+  --- except for the things we won't do, like tokenizing path
+  --- segments into an array and then nesting another array beneath
+  --- each of those for storing semicolon parameters. So this parser
+  --- won't make SIP easy. What it can do is parse HTTP URLs and most
+  --- URIs like data:opaque, better in fact than most things which
+  --- claim to be URI parsers.
+  ParseUrl: function(url: string, flags?: number): Url
+  --- Returns number of bits set in integer.
+  Popcnt: function(x: number): number
+  --- This linear congruential generator passes practrand and bigcrush. This
+  --- generator is safe across `fork()`, threads, and signal handlers.
+  Rand64: function(): number
+  --- read raw hardware RDRAND; it returns output from the OS CSPRNG (arc4random64), which is
+  --- seeded from hardware entropy but is safer (no RNG fault exposure).
+  Rdrand: function(): number
+  --- read raw hardware RDSEED; it returns output from the OS CSPRNG (arc4random64), which is
+  --- seeded from hardware entropy but is safer (no RNG fault exposure).
+  Rdseed: function(): number
+  --- Gets IP address associated with hostname.
+  --- This function first checks if hostname is already an IP address, in which case
+  --- it returns the result of `ParseIp`. Otherwise, it checks HOSTS.TXT on the local
+  --- system and returns the first IPv4 address associated with hostname. If no such
+  --- entry is found, a DNS lookup is performed using the system configured (e.g.
+  --- `/etc/resolv.conf`) DNS resolution service. If the service returns multiple IN
+  --- A records then only the first one is returned.
+  --- The returned address is word-encoded in host endian order. For example,
+  --- 1.2.3.4 is encoded as 0x01020304. The `FormatIp` function may be used to turn
+  --- this value back into a string.
+  --- If no IP address could be found, then `nil` is returned alongside a string of
+  --- unspecified format describing the error. Calls to this function may be wrapped
+  --- in `assert()` if an exception is desired.
+  ResolveIp: function(hostname: string): number, string
+  --- Computes SHA1 checksum, returning 20 bytes of binary.
+  Sha1: function(str: string): string
+  --- Computes SHA224 checksum, returning 28 bytes of binary.
+  Sha224: function(str: string): string
+  --- Computes SHA256 checksum, returning 32 bytes of binary.
+  Sha256: function(str: string): string
+  --- Computes SHA384 checksum, returning 48 bytes of binary.
+  Sha384: function(str: string): string
+  --- Computes SHA512 checksum, returning 64 bytes of binary.
+  Sha512: function(str: string): string
+  --- Sleeps the specified number of seconds (can be fractional).
+  --- The smallest interval is a microsecond.
+  Sleep: function(seconds: number)
+  --- Reads all data from file the easy way.
+  --- This function reads file data from local file system. Zip file assets can be
+  --- accessed using the `/zip/...` prefix.
+  --- `i` and `j` may be used to slice a substring in filename. These parameters are
+  --- 1-indexed and behave consistently with Lua's `string.sub()` API. For example:
+  ---     assert(Barf('x.txt', 'abc123'))
+  ---     assert(assert(Slurp('x.txt', 2, 3)) == 'bc')
+  --- This function is uninterruptible so `unix.EINTR` errors will be ignored. This
+  --- should only be a concern if you've installed signal handlers. Use the UNIX API
+  --- if you need to react to it.
+  Slurp: function(filename: string, i?: number, j?: number): string, unix.Errno
+  --- Formats a timestamp using strftime(3) format specifiers.
+  --- Common format specifiers:
+  --- - `%Y` four-digit year
+  --- - `%m` two-digit month (01-12)
+  --- - `%d` two-digit day (01-31)
+  --- - `%H` two-digit hour (00-23)
+  --- - `%M` two-digit minute (00-59)
+  --- - `%S` two-digit second (00-59)
+  --- - `%F` equivalent to `%Y-%m-%d`
+  --- - `%T` equivalent to `%H:%M:%S`
+  --- - `%a` abbreviated weekday name
+  --- - `%b` abbreviated month name
+  --- Example:
+  ---     Strftime("%Y-%m-%d %H:%M:%S")           -- "2024-12-29 15:30:00"
+  ---     Strftime("%F %T", os.time())            -- "2024-12-29 15:30:00"
+  ---     Strftime("%a, %d %b %Y", 0)             -- "Thu, 01 Jan 1970"
+  ---     Strftime("%F %T", os.time(), true)      -- local time instead of UTC
+  Strftime: function(format: string, timestamp?: number, localtime?: boolean): string | nil
+  --- Parses a datetime string using strptime(3) format specifiers.
+  --- Returns a table with parsed components and any unparsed remainder.
+  --- Uses the same format specifiers as `Strftime`.
+  --- Example:
+  ---     local t = Strptime("2024-12-29", "%Y-%m-%d")
+  ---     -- t = {year=2024, month=12, day=29, hour=0, min=0, sec=0, ...}
+  ---     local t = Strptime("2024-12-29 15:30", "%Y-%m-%d %H:%M")
+  ---     -- t.rest = "" (nothing unparsed)
+  ---     local t = Strptime("2024-12-29 extra", "%Y-%m-%d")
+  ---     -- t.rest = " extra"
+  Strptime: function(str: string, format: string): table | nil, string | nil
+  --- Decompresses data produced by `Compress`.
+  --- If `maxoutsize` is absent, the input is expected to begin with the
+  --- header that `Compress` writes by default; the embedded length and
+  --- `Crc32` checksum are verified. If `maxoutsize` is given, the input
+  --- must be a raw zlib stream that decompresses to exactly `maxoutsize`
+  --- bytes.
+  --- This function raises an error if the input is truncated or corrupt.
+  Uncompress: function(compressed: string, maxoutsize?: number): string
+  --- Canonicalizes overlong encodings.
+  Underlong: function(str: string): string
+  --- Unescapes URL parameter name or value. Decodes `%XX` hex sequences and
+  --- converts `+` to space (common in application/x-www-form-urlencoded).
+  --- This is the inverse of EscapeParam.
+  UnescapeParam: function(str: string): string
+  --- Generate a uuid_v4
+  UuidV4: function(): string
+  --- Generate a uuid_v7
+  UuidV7: function(): string
+  --- Replaces C0 control codes and trojan source characters with descriptive
+  --- UNICODE pictorial representation. This function also canonicalizes overlong
+  --- encodings. C1 control codes are replaced with a JavaScript-like escape sequence.
+  VisualizeControlCodes: function(str: string): string
 end
 
 return cosmo

--- a/lib/types/cosmo/argon2.d.tl
+++ b/lib/types/cosmo/argon2.d.tl
@@ -1,25 +1,31 @@
 -- type declarations for cosmo.argon2
+-- GENERATED from cosmopolitan's definitions.lua by lib/types/gentype.tl.
+-- Do not edit by hand. Regenerate with: bin/make regen-types
 
+--- An opaque handle identifying an Argon2 hashing variant. The available
+--- variants live in the `argon2.variants` table.
 local record Variant
-  -- Opaque variant type (userdata)
 end
 
 local record Variants
+  --- blend of other two methods [default]
   argon2_id: Variant
+  --- maximize resistance to side-channel attacks
   argon2_i: Variant
+  --- maximize resistance to gpu cracking attacks
   argon2_d: Variant
 end
 
 local record Config
-  --- Memory cost in kibibytes (default: 4096)
+  --- the memory hardness in kibibytes, which defaults to 4096 (4 mibibytes). It's recommended that this be tuned upwards.
   m_cost: number
-  --- Time cost / iterations (default: 3)
+  --- the number of iterations, which defaults to `3`.
   t_cost: number
-  --- Parallelism factor (default: 1)
+  --- the parallelism factor, which defaults to `1`.
   parallelism: number
-  --- Output hash length in bytes (default: 32)
+  --- the number of desired bytes in hash output, which defaults to 32.
   hash_len: number
-  --- Variant type (default: argon2_id)
+  --- may be `argon2.variants.argon2_id` blend of other two methods [default], `argon2.variants.argon2_i` maximize resistance to side-channel attacks, or `argon2.variants.argon2_d` maximize resistance to gpu cracking attacks
   variant: Variant
 end
 
@@ -28,16 +34,17 @@ local record argon2
   type Variants = Variants
   type Config = Config
 
-  --- Argon2 algorithm variants
+  --- Argon2 hashing variants. The fields are opaque read-only userdata
+  --- values that can be fed to `config.variant` or `argon2.variant`.
   variants: Variants
 
   --- Hashes password.
   --- This is consistent with the README of the reference implementation:
-  --- >: assert(argon2.hash_encoded("password", "somesalt", {
-  --- variant = argon2.variants.argon2_i,
-  --- hash_len = 24,
-  --- t_cost = 2,
-  --- }))
+  ---     >: assert(argon2.hash_encoded("password", "somesalt", {
+  ---         variant = argon2.variants.argon2_i,
+  ---         hash_len = 24,
+  ---         t_cost = 2,
+  ---     }))
   --- `salt` is a nonce value used to hash the string.
   --- `config.m_cost` is the memory hardness in kibibytes, which defaults
   --- to 4096 (4 mibibytes). It's recommended that this be tuned upwards.
@@ -49,12 +56,33 @@ local record argon2
   --- - `argon2.variants.argon2_id` blend of other two methods [default]
   --- - `argon2.variants.argon2_i` maximize resistance to side-channel attacks
   --- - `argon2.variants.argon2_d` maximize resistance to gpu cracking attacks
-  hash_encoded: function(pass: string, salt: string, config: Config): string
+  hash_encoded: function(pass: string, salt: string, config: Config): string, string
   --- Verifies password, e.g.
-  --- >: argon2.verify(
-  --- "p=4$c29tZXNhbHQ$RdescudvJCsgt3ub+b+dWRWJTmaaJObG",
-  --- true
-  verify: function(encoded: string, pass: string): boolean
+  ---     >: argon2.verify(
+  ---         "p=4$c29tZXNhbHQ$RdescudvJCsgt3ub+b+dWRWJTmaaJObG",
+  ---     true
+  verify: function(encoded: string, pass: string): boolean, string
+  --- Gets or sets the default memory hardness in kibibytes used by
+  --- `argon2.hash_encoded` when its config omits `m_cost`. Called with no
+  --- argument (or `nil`), it returns the current default (initially 4096).
+  m_cost: function(m_cost?: number): number
+  --- Gets or sets the default number of iterations used by
+  --- `argon2.hash_encoded` when its config omits `t_cost`. Called with no
+  --- argument (or `nil`), it returns the current default (initially 3).
+  t_cost: function(t_cost?: number): number
+  --- Gets or sets the default parallelism factor used by
+  --- `argon2.hash_encoded` when its config omits `parallelism`. Called with
+  --- no argument (or `nil`), it returns the current default (initially 1).
+  parallelism: function(parallelism?: number): number
+  --- Gets or sets the default hash output length in bytes used by
+  --- `argon2.hash_encoded` when its config omits `hash_len`. Called with no
+  --- argument (or `nil`), it returns the current default (initially 32).
+  hash_len: function(hash_len?: number): number
+  --- Sets the default variant used by `argon2.hash_encoded` when its config
+  --- omits `variant`, e.g. `argon2.variant(argon2.variants.argon2_id)`.
+  --- Unlike the other configuration functions, the argument is required.
+  --- The default is `argon2.variants.argon2_id`.
+  variant: function(variant: Variant): Variant
 end
 
 return argon2

--- a/lib/types/cosmo/getopt.d.tl
+++ b/lib/types/cosmo/getopt.d.tl
@@ -1,5 +1,9 @@
 -- type declarations for cosmo.getopt
+-- GENERATED from cosmopolitan's definitions.lua by lib/types/gentype.tl.
+-- Do not edit by hand. Regenerate with: bin/make regen-types
 
+--- A parser object returned by `getopt.new` for iterating through
+--- command-line options.
 local record parser
   --- Get the next option from the parser.
   --- Returns the next option character or long name, along with its argument
@@ -14,6 +18,8 @@ local record parser
 end
 
 local record getopt
+  type parser = parser
+
   --- Create a new getopt parser for iterating through command-line options.
   --- The optstring uses standard getopt format:
   --- - A letter means that option takes no argument

--- a/lib/types/cosmo/lsqlite3.d.tl
+++ b/lib/types/cosmo/lsqlite3.d.tl
@@ -1,123 +1,675 @@
 -- type declarations for cosmo.lsqlite3
+-- GENERATED from cosmopolitan's definitions.lua by lib/types/gentype.tl.
+-- Do not edit by hand. Regenerate with: bin/make regen-types
 
---- Statement object returned by Database:prepare()
-local record Statement
-  --- Binds a sequence of values to sequential parameters (1, 2, 3, ...)
-  --- Returns sqlite3.OK on success or error code on failure
-  bind_values: function(Statement, any ...): number
-
-  --- Binds value to parameter n (1-indexed)
-  --- String/number become text/double; nil clears binding
-  --- Returns sqlite3.OK on success or error code on failure
-  bind: function(Statement, n: number, value?: any): number
-
-  --- Executes next iteration of prepared statement
-  --- Returns sqlite3.ROW (data ready), sqlite3.DONE (finished), or error code
-  step: function(Statement): number
-
-  --- Resets statement to initial state for re-execution
-  --- Retains parameter bindings from previous bind calls
-  reset: function(Statement)
-
-  --- Deallocates prepared statement resources
-  --- Returns sqlite3.OK on success or error code if execution failed
-  finalize: function(Statement): number
-
-  --- Returns value of column n (0-indexed) from current row
-  get_value: function(Statement, n: number): any
-
-  --- Returns count of columns in result set (or 0 for non-query statements)
-  columns: function(Statement): number
-
-  --- Returns column name for column n (0-indexed)
-  get_name: function(Statement, n: number): string
-
-  --- Returns the number of SQL parameters in the prepared statement
-  bind_parameter_count: function(Statement): number
-
-  --- Returns the name of the n-th parameter (1-indexed), or nil for positional (?) params
-  bind_parameter_name: function(Statement, n: number): string
-
-  --- Binds named parameters from a key/value table.
-  --- Keys are parameter names without the prefix (e.g. "foo" for ":foo").
-  --- Returns sqlite3.OK on success or error code on failure.
-  bind_names: function(Statement, params: {string: any}): number
+--- A callback context is available as a parameter inside the callback functions
+--- `db:create_aggregate()` and `db:create_function()`. It can be used to get
+--- further information about the state of a query.
+local record Context
+  get_aggregate_data: function(self: Context): any
+  --- Set the user-definable data field for callback funtions to `udata`.
+  set_aggregate_data: function(self: Context, udata: any)
+  --- Sets the result of a callback function to `res`. The type of the result
+  --- depends on the type of `res` and is either a number or a string or `nil`.
+  --- All other values will raise an error message.
+  result: function(self: Context, res?: string | number)
+  --- Sets the result of a callback function to the binary string in blob.
+  result_blob: function(self: Context, blob: string)
+  --- Sets the result of a callback function to the value number.
+  result_double: function(self: Context, double: number)
+  --- Sets the result of a callback function to the value number. Alias for
+  --- `lsqlite3.Context:result_double()`.
+  result_number: function(self: Context, double: number)
+  --- Sets the result of a callback function to the error value in `err`.
+  result_error: function(self: Context, err: any)
+  --- Sets the result of a callback function to the integer `number`
+  result_int: function(self: Context, number: number)
+  --- Sets the result of a callback function to `nil`.
+  result_null: function(self: Context)
+  --- Sets the result of a callback function to the string in `str`.
+  result_text: function(self: Context, str: string)
+  --- Returns the userdata parameter given in the call to install the callback
+  --- function (see db:create_aggregate() and db:create_function() for details).
+  user_data: function(self: Context): any
 end
 
---- Database handle returned by lsqlite3.open() and lsqlite3.open_memory()
+--- After opening a database with `lsqlite3.open()` or `lsqlite3.open_memory()`
+--- the returned database object should be used for all further method calls in
+--- connection with that database.
 local record Database
-  --- Closes database connection
-  --- Returns sqlite3.OK on success or error code on failure
-  close: function(Database): number
+  apply_changeset: function(self: Database, changeset: string, conflict_cb: function, filter_cb: function, udata?: any, rebaser?: Rebaser, flags?: number): boolean, number
+  --- Sets or removes a busy handler for a database.
+  --- The handler function is called with two parameters: `udata` and the number
+  --- of (re-)tries for a pending transaction. It should return `nil`, `false` or
+  --- `0` if the transaction is to be aborted. All other values will result in
+  --- another attempt to perform the transaction. (See the SQLite documentation
+  --- for important hints about writing busy handlers.)
+  busy_handler: function(self: Database, func?: function(udata: any, tries: number), udata?: any)
+  --- Sets a busy handler that waits for `milliseconds` if a transaction cannot proceed.
+  --- Calling this function will remove any busy handler set by `db:busy_handler()`;
+  --- calling it with an argument less than or equal to `0` will turn off all busy handlers.
+  busy_timeout: function(self: Database, milliseconds: number)
+  --- Only changes that are directly specified by INSERT, UPDATE, or DELETE
+  --- statements are counted. Auxiliary changes caused by triggers are not
+  --- counted. Use `db:total_changes()` to find the total number of changes.
+  changes: function(self: Database): number
+  --- Closes a database. All SQL statements prepared using `db:prepare()` should
+  --- have been finalized before this function is called. The function returns
+  --- `lsqlite3.OK` on success or else a numerical error code.
+  close: function(self: Database): number
+  --- Finalizes all statements that have not been explicitly finalized. If
+  --- `temponly` is `true`, only internal, temporary statements are finalized.
+  close_vm: function(self: Database, temponly?: boolean)
+  --- This function installs a `commit_hook` callback handler.
+  --- If `func` returns `false` or `nil` the COMMIT is allowed to proceed,
+  --- otherwise the COMMIT is converted to a ROLLBACK.
+  --- See: `db:rollback_hook` and `db:update_hook`
+  commit_hook: function(self: Database, func: function(udata: any), udata: any)
+  --- Concatenate a list of changesets.
+  concat_changeset: function(self: Database, changesets: {string}): string
+  --- It should accept a function context (see Methods for callback contexts) plus
+  --- the same number of parameters as given in `nargs`.
+  --- It receives one argument, the function context.
+  --- The function context can be used inside the two callback functions to
+  --- communicate with SQLite3. Here is a simple example:
+  ---     db:exec[=[
+  ---         CREATE TABLE numbers(num1,num2);
+  ---         INSERT INTO numbers VALUES(1,11);
+  ---         INSERT INTO numbers VALUES(2,22);
+  ---         INSERT INTO numbers VALUES(3,33);
+  ---     ]=]
+  ---     local num_sum=0
+  ---     local function oneRow(context, num)  -- add one column in all rows
+  ---         num_sum = num_sum + num
+  ---     end
+  ---     local function afterLast(context)   -- return sum after last row has been processed
+  ---         context:result_number(num_sum)
+  ---         num_sum = 0
+  ---     end
+  ---     db:create_aggregate("do_the_sums", 1, oneRow, afterLast)
+  ---     for sum in db:urows('SELECT do_the_sums(num1) FROM numbers') do print("Sum of col 1:",sum) end
+  ---     for sum in db:urows('SELECT do_the_sums(num2) FROM numbers') do print("Sum of col 2:",sum) end
+  --- This prints:
+  ---     Sum of col 1:   6
+  ---     Sum of col 2:   66
+  create_aggregate: function(self: Database, name: string, nargs: number, step: function(ctx: Context, ...: string | number), final: function(ctx: Context), userdata?: any): boolean
+  --- This creates a collation callback. A collation callback is used to establish
+  --- a collation order, mostly for string comparisons and sorting purposes.
+  --- A simple example:
+  ---    local function collate(s1,s2)
+  ---      s1=s1:lower()
+  ---      s2=s2:lower()
+  ---      if s1==s2 then return 0
+  ---      elseif s1<s2 then return -1
+  ---      else return 1 end
+  ---    end
+  ---    db:exec[=[
+  ---      CREATE TABLE test(id INTEGER PRIMARY KEY,content COLLATE CINSENS);
+  ---      INSERT INTO test VALUES(NULL,'hello world');
+  ---      INSERT INTO test VALUES(NULL,'Buenos dias');
+  ---      INSERT INTO test VALUES(NULL,'HELLO WORLD');
+  ---    ]=]
+  ---    db:create_collation('CINSENS',collate)
+  ---    for row in db:nrows('SELECT * FROM test') do
+  ---      print(row.id, row.content)
+  ---    end
+  create_collation: function(self: Database, name: string, func: (function(s1: string, s2: string): number))
+  --- This function creates a callback function. Callback function are called by
+  --- SQLite3 once for every row in a query.
+  --- It should accept a function context (see Methods for callback contexts) plus
+  --- the same number of parameters as given in `nargs`.
+  --- Here is an example:
+  ---     db:exec'CREATE TABLE test(col1,col2,col3)'
+  ---     db:exec'INSERT INTO test VALUES(1,2,4)'
+  ---     db:exec'INSERT INTO test VALUES(2,4,9)'
+  ---     db:exec'INSERT INTO test VALUES(3,6,16)'
+  ---     db:create_function('sum_cols',3,function(ctx,a,b,c)
+  ---       ctx:result_number(a+b+c)
+  ---     end))
+  ---     for col1,col2,col3,sum in db:urows('SELECT *,sum_cols(col1,col2,col3) FROM test') do
+  ---       util.printf('%2i+%2i+%2i=%2i\n',col1,col2,col3,sum)
+  ---     end
+  create_function: function(self: Database, name: string, nargs: number, func: function(ctx: Context, ...: any), userdata?: any): boolean
+  create_rebaser: function(self: Database): Rebaser, number
+  create_session: function(self: Database, name?: string): Session, number
+  --- If there is no attached database name on the database connection, then no value is
+  --- returned; if database name is a temporary or in-memory database, then an
+  --- empty string is returned.
+  db_filename: function(self: Database, name: string): string | nil
+  --- Deserializes data from a string which was created by `db:serialize`.
+  deserialize: function(self: Database, s: string)
+  --- See https://lua.sqlite.org/home/doc/tip/doc/lsqlite3.wiki#numerical_error_and_result_codes for details.
+  error_code: function(self: Database): number
+  --- Alias for `lsqlite3.Database:error_code()`.
+  errcode: function(self: Database): number
+  error_message: function(self: Database): string
+  --- Alias for `lsqlite3.Database:error_message()`.
+  errmsg: function(self: Database): string
+  --- Compiles and executes the SQL statement(s) given in string sql. The statements
+  --- are simply executed one after the other and not stored. The function returns
+  --- `lsqlite3.OK` on success or else a numerical error code.
+  --- If one or more of the SQL statements are queries, then the callback function
+  --- specified in func is invoked once for each row of the query result (if func is
+  --- `nil`, no callback is invoked).
+  --- The callback receives four arguments:
+  --- -  `udata (the third parameter of the db:exec() call),
+  --- - the number of columns in the row
+  --- - a table with the column values
+  --- - another table with the column names.
+  --- The callback function should return `0`. If the callback returns a non-zero
+  --- value then the query is aborted, all subsequent SQL statements are skipped
+  --- and `db:exec()` returns `lsqlite3.ABORT`. Here is a simple example:
+  ---     sql=[=[
+  ---         CREATE TABLE numbers(num1,num2,str);
+  ---         INSERT INTO numbers VALUES(1,11,"ABC");
+  ---         INSERT INTO numbers VALUES(2,22,"DEF");
+  ---         INSERT INTO numbers VALUES(3,33,"UVW");
+  ---         INSERT INTO numbers VALUES(4,44,"XYZ");
+  ---         SELECT * FROM numbers;
+  ---     ]=]
+  ---     function showrow(udata,cols,values,names)
+  ---         assert(udata=='test_udata')
+  ---         print('exec:')
+  ---         for i=1,cols do print('',names[i],values[i]) end
+  ---         return 0
+  ---     end
+  ---     db:exec(sql,showrow,'test_udata')
+  execute: function(self: Database, sql: string, func?: (function(udata: any, cols: number, values: {string}, names: {string}): number), udata?: any)
+  --- Alias for `lsqlite3.Database:execute()`.
+  exec: function(self: Database, sql: string, func?: (function(udata: any, cols: number, values: {string}, names: {string}): number), udata?: any)
+  --- This function causes any pending database operation to abort and return at
+  --- the next opportunity.
+  interrupt: function(self: Database)
+  invert_changeset: function(self: Database, changeset: string): string
+  isopen: function(self: Database): boolean
+  iterate_changeset: function(self: Database, name: string, flags?: number): Iterator, number
+  --- Each row in an SQLite table has a unique 64-bit signed integer key called
+  --- the rowid. This id is always available as an undeclared column named ROWID,
+  --- OID, or _ROWID_. If the table has a column of type INTEGER PRIMARY KEY then
+  --- that column is another alias for the rowid.
+  --- If an INSERT occurs within a trigger, then the rowid of the inserted row is
+  --- returned as long as the trigger is running. Once the trigger terminates, the
+  --- value returned reverts to the last value inserted before the trigger fired.
+  last_insert_rowid: function(self: Database): number
+  --- Creates an iterator that returns the successive rows selected by the
+  --- SQL statement given in string `sql`. Each call to the iterator
+  --- returns a table in which the named fields correspond to the columns
+  --- in the database. Here is an example:
+  ---     db:exec[=[
+  ---         CREATE TABLE numbers(num1,num2);
+  ---         INSERT INTO numbers VALUES(1,11);
+  ---         INSERT INTO numbers VALUES(2,22);
+  ---         INSERT INTO numbers VALUES(3,33);
+  ---     ]=]
+  ---     for a in db:nrows('SELECT * FROM numbers') do table.print(a) end
+  --- This script prints:
+  ---     num2: 11
+  ---     num1: 1
+  ---     num2: 22
+  ---     num1: 2
+  ---     num2: 33
+  ---     num1: 3
+  nrows: function(self: Database, sql: string): function(vm: VM), VM
+  --- This function compiles the SQL statement in string sql into an internal
+  --- representation and returns this as userdata. The returned object should be
+  --- used for all further method calls in connection with this specific SQL
+  --- statement.
+  --- See https://lua.sqlite.org/home/doc/tip/doc/lsqlite3.wiki#methods_for_prepared_statements for details.
+  prepare: function(self: Database, sql: string): Statement
+  --- Returns `true` if the database `name` of connection `db` is read-only,
+  --- `false` if it is read/write. Returns `nil` plus an error message if
+  --- `name` is not the name of a database on connection `db`.
+  readonly: function(self: Database, name?: string): boolean, string
+  --- This function installs a rollback_hook callback handler.
+  --- See: `db:commit_hook` and `db:update_hook`
+  rollback_hook: function(self: Database, func: function(udata: any), udata: any)
+  --- Creates an iterator that returns the successive rows selected by the SQL
+  --- statement given in string `sql`. Each call to the iterator returns a table in
+  --- which the numerical indices 1 to n correspond to the selected columns 1 to n in
+  --- the database. Here is an example:
+  ---     db:exec[=[
+  ---         CREATE TABLE numbers(num1,num2);
+  ---         INSERT INTO numbers VALUES(1,11);
+  ---         INSERT INTO numbers VALUES(2,22);
+  ---         INSERT INTO numbers VALUES(3,33);
+  ---     ]=]
+  ---     for a in db:rows('SELECT * FROM numbers') do table.print(a) end
+  --- This script prints:
+  ---     1: 1
+  ---     2: 11
+  ---     1: 2
+  ---     2: 22
+  ---     1: 3
+  ---     2: 33
+  rows: function(self: Database, sql: string): function, VM
+  --- Serialize a database to be restored later with `Database:deserialize`.
+  serialize: function(self: Database): string | nil
+  --- This includes UPDATE, INSERT and DELETE statements executed as part of trigger
+  --- programs. All changes are counted as soon as the statement that produces them
+  --- is completed by calling either `stmt:reset()` or `stmt:finalize()`.
+  total_changes: function(self: Database): number
+  --- This function installs an update_hook Data Change Notification
+  --- Callback handler. See: `db:commit_hook` and `db:rollback_hook`
+  --- whenever a row is updated, inserted or deleted. This callback
+  --- receives five arguments: the first is the `udata` argument used
+  --- when the callback was installed; the second is an integer
+  --- indicating the operation that caused the callback to be invoked
+  --- (one of `lsqlite3.UPDATE`, `lsqlite3.INSERT`, or
+  --- `lsqlite3.DELETE`). The third and fourth arguments are the
+  --- database and table name containing the affected row. The final
+  --- callback parameter is the rowid of the row. In the case of an
+  --- update, this is the rowid after the update takes place.
+  update_hook: function(self: Database, func: function(udata: any, op: number, db: Database, name: string, rowid: number), udata: any)
+  --- Creates an iterator that returns the successive rows selected by the SQL
+  --- statement given in string sql. Each call to the iterator returns the values
+  --- that correspond to the columns in the currently selected row.
+  --- Here is an example:
+  ---     db:exec[=[
+  ---         CREATE TABLE numbers(num1,num2);
+  ---         INSERT INTO numbers VALUES(1,11);
+  ---         INSERT INTO numbers VALUES(2,22);
+  ---         INSERT INTO numbers VALUES(3,33);
+  ---     ]=]
+  ---     for num1,num2 in db:urows('SELECT * FROM numbers') do print(num1,num2) end
+  --- This script prints:
+  ---     1       11
+  ---     2       22
+  ---     3       33
+  urows: function(self: Database, sql: string): function, VM
+  wal_checkpoint: function(self: Database, mode?: number, name?: string): number, number, number
+  wal_hook: function(self: Database, func?: (function(udata: any, db: Database, name: string, page_count: number): number), udata?: any)
+end
 
-  --- Compiles and executes one or more SQL statements
-  --- Optional callback invoked per result row with (udata, colcount, values, names)
-  --- Returns sqlite3.OK on success or error code on failure
-  exec: function(Database, sql: string, func?: function, udata?: any): number
+--- Returned by `db:iterate_changeset`
+local record Iterator
+  conflict: function(self: Iterator): {string | number | boolean}, number
+  fk_conflicts: function(self: Iterator): number, number
+  finalize: function(self: Iterator): boolean, number
+  next: function(self: Iterator): number, number
+  new: function(self: Iterator): {string | number | boolean | nil}, number
+  old: function(self: Iterator): {string | number | boolean | nil}, number
+  op: function(self: Iterator): string, number, boolean, number
+  pk: function(self: Iterator): {boolean}, number
+end
 
-  --- Compiles SQL statement into prepared statement for reuse
-  --- Returns Statement on success, or (nil, errcode, errmsg) on failure
-  prepare: function(Database, sql: string): Statement | nil, number | nil, string | nil
+--- Returned by `db:create_rebaser`.
+local record Rebaser
+  delete: function(self: Rebaser)
+  rebase: function(self: Rebaser, changeset: string): string, number
+end
 
-  --- Creates iterator yielding rows as tables with named fields (column_name: value)
-  --- Each iteration returns one row as associative table
-  nrows: function(Database, sql: string): function(): {string: any}
+--- Returned by `db:create_session`.
+local record Session
+  attach: function(self: Session, filter_cb?: function(udata: any), udata?: any): boolean, number
+  changeset: function(self: Session): string
+  --- Closes the session. Further method calls on the session will throw errors.
+  delete: function(self: Session)
+  diff: function(self: Session, s1: string, s2: string): boolean
+  enable: function(self: Session): boolean
+  indirect: function(self: Session): boolean
+  isempty: function(self: Session): boolean
+  patchset: function(self: Session): string
+end
 
-  --- Creates iterator yielding rows as indexed tables (1: value1, 2: value2, ...)
-  --- Each iteration returns one row as array with numeric indices
-  rows: function(Database, sql: string): function(): {any}
+--- After creating a prepared statement with `db:prepare()` the returned statement
+--- object should be used for all further calls in connection with that statement.
+local record Statement
+  --- Binds `value` to statement parameter `n`. If the type of `value` is
+  --- string it is bound as text. If the type of value is number, it is
+  --- bound as an integer or double depending on its subtype using
+  --- `lua_isinteger`. If `value` is a boolean then it is bound as `0` for
+  --- `false` or `1` for `true`. If `value` is `nil` or missing, any
+  --- previous binding is removed.
+  bind: function(self: Statement, n: number, value: string | number | boolean): number
+  --- Binds string `blob` (which can be a binary string) as a blob to
+  --- statement parameter `n`.
+  bind_blob: function(self: Statement, n: number, blob: string): number
+  --- Binds the values in `nametable` to statement parameters. If the
+  --- statement parameters are named (i.e., of the form `":AAA"` or
+  --- `"$AAA"`) then this function looks for appropriately named fields in
+  --- nametable; if the statement parameters are not named, it looks for
+  --- numerical fields 1 to the number of statement parameters.
+  bind_names: function(self: Statement, nametable: table): number, number
+  --- When the statement parameters are of the forms `":AAA"` or `"?"`, then they are
+  --- assigned sequentially increasing numbers beginning with one, so the value
+  --- returned is the number of parameters. However if the same statement parameter
+  --- name is used multiple times, each occurrence is given the same number, so the
+  --- value returned is the number of unique statement parameter names.
+  --- If statement parameters of the form `"?NNN"` are used (where `NNN` is an
+  --- integer) then there might be gaps in the numbering and the value returned by
+  --- this interface is the index of the statement parameter with the largest index
+  --- value.
+  bind_parameter_count: function(self: Statement): any
+  --- Statement parameters of the form `":AAA"` or `"@AAA"` or `"$VVV"` have a name
+  --- which is the string `":AAA"` or `"@AAA"` or `"$VVV"`. In other words, the
+  --- initial `":"` or `"$"` or `"@"` is included as part of the name. Parameters of
+  --- the form `"?"` or `"?NNN"` have no name. The first bound parameter has an index
+  --- of `1`. If the value `n` is out of range or if the `n`-th parameter is nameless,
+  --- then `nil` is returned.
+  bind_parameter_name: function(self: Statement, n: number): string | nil
+  --- Binds the given values to statement parameters.
+  bind_values: function(self: Statement, ...: string | number): number
+  columns: function(self: Statement): number
+  --- This function frees the prepared statement.
+  finalize: function(self: Statement): number
+  get_name: function(self: Statement, n: any): any
+  get_named_types: function(self: Statement): table
+  --- Alias for `lsqlite3.Statement:get_named_types()`.
+  type: function(self: Statement): table
+  get_named_values: function(self: Statement): table
+  --- Alias for `lsqlite3.Statement:get_named_values()`.
+  data: function(self: Statement): table
+  get_names: function(self: Statement): {string}
+  --- Alias for `lsqlite3.Statement:get_names()`.
+  inames: function(self: Statement): {string}
+  get_type: function(self: Statement, n: any): any
+  get_types: function(self: Statement): {any}
+  --- Alias for `lsqlite3.Statement:get_types()`.
+  itypes: function(self: Statement): {any}
+  get_unames: function(self: Statement): {any}
+  get_utypes: function(self: Statement): {any}
+  get_uvalues: function(self: Statement): {any}
+  get_value: function(self: Statement, n: any): any
+  get_values: function(self: Statement): {any}
+  --- Alias for `lsqlite3.Statement:get_values()`.
+  idata: function(self: Statement): {any}
+  isopen: function(self: Statement): boolean
+  nrows: function(self: Statement): function
+  --- Returns `true` if the prepared statement makes no direct changes to
+  --- the content of the database file, `false` otherwise.
+  readonly: function(self: Statement): boolean
+  --- This function resets the SQL statement, so that it is ready to be re-executed. Any statement variables that had values bound to them using the `stmt:bind*()` functions retain their values.
+  reset: function(self: Statement)
+  rows: function(self: Statement): function
+  --- This function must be called to evaluate the (next iteration of the) prepared statement.
+  --- - `lsqlite3.BUSY`: the engine was unable to acquire the locks needed.
+  ---   If the statement is a COMMIT or occurs outside of an explicit transaction,
+  ---   then you can retry the statement. If the statement is not a COMMIT and occurs
+  ---   within a explicit transaction then you should rollback the transaction before
+  ---   continuing.
+  --- - `lsqlite3.DONE`: the statement has finished executing successfully.
+  ---   `stmt:step()` should not be called again on this statement without first
+  ---   calling `stmt:reset()` to reset the virtual machine back to the initial state.
+  --- - `lsqlite3.ROW`: this is returned each time a new row of data is ready for
+  ---    processing by the caller. The values may be accessed using the column access
+  ---    functions. `stmt:step()` can be called again to retrieve the next
+  ---    row of data.
+  --- - `lsqlite3.ERROR`: a run-time error (such as a constraint violation) has
+  ---    occurred. `stmt:step()` should not be called again. More
+  ---    information may be found by calling `db:errmsg()`. A more specific error
+  ---    code (can be obtained by calling `stmt:reset()`.
+  --- - `lsqlite3.MISUSE`: the function was called inappropriately, perhaps because
+  ---    the statement has already been finalized or a previous call to `stmt:step()`
+  ---    has returned `lsqlite3.ERROR` or `lsqlite3.DONE`.
+  step: function(self: Statement): number
+  --- Each iteration returns the values for the current row. This is the prepared
+  --- statement equivalent of `db:urows()`.
+  urows: function(self: Statement): function
+  last_insert_rowid: function(self: Statement): any
+end
 
-  --- Creates iterator yielding column values directly (value1, value2, ...)
-  --- Each iteration returns unpacked values for one row
-  urows: function(Database, sql: string): function(): any ...
-
-  --- Returns rowid of most recent INSERT operation
-  --- Returns 0 if no inserts have occurred
-  last_insert_rowid: function(Database): number
-
-  --- Returns count of rows modified by most recent INSERT, UPDATE, or DELETE
-  --- Excludes trigger-caused changes
-  changes: function(Database): number
-
-  --- Returns cumulative count of all rows modified since database opened
-  --- Includes changes in triggers
-  total_changes: function(Database): number
-
-  --- Retrieves numerical error code from most recent failed operation
-  errcode: function(Database): number
-
-  --- Retrieves human-readable error message for most recent failed call
-  errmsg: function(Database): string
+local record VM
+  bind: function(self: VM, index: number, value: string | number | boolean): number
+  bind_blob: function(self: VM, index: number, value: string): number
+  bind_names: function(self: VM, names: {string}): number
+  bind_parameter_count: function(self: VM): number
+  bind_parameter_name: function(self: VM, index: number): string
+  bind_values: function(self: VM, ...: string | number): number
+  columns: function(self: VM): number
+  finalize: function(self: VM): number
+  get_name: function(self: VM, index: number): string
+  get_named_types: function(self: VM): {string}
+  --- Alias for `lsqlite3.VM:get_named_types()`.
+  type: function(self: VM): {string}
+  get_named_values: function(self: VM): {string | number | nil}
+  --- Alias for `lsqlite3.VM:get_named_values()`.
+  data: function(self: VM): {string | number | nil}
+  get_names: function(self: VM): {string}
+  --- Alias for `lsqlite3.VM:get_names()`.
+  inames: function(self: VM): {string}
+  get_type: function(self: VM, index: number): string
+  get_types: function(self: VM): {string}
+  --- Alias for `lsqlite3.VM:get_types()`.
+  itypes: function(self: VM): {string}
+  get_unames: function(self: VM): string...
+  get_utypes: function(self: VM): string...
+  get_uvalues: function(self: VM): string | number | nil
+  get_value: function(self: VM, index: number): string | number | nil
+  get_values: function(self: VM): {string | number | nil}
+  --- Alias for `lsqlite3.VM:get_values()`.
+  idata: function(self: VM): {string | number | nil}
+  isopen: function(self: VM): boolean
+  last_insert_rowid: function(self: VM): number
+  nrows: function(self: VM, sql: string): function(self: VM): {string: string | number}
+  --- Returns `true` if the prepared statement makes no direct changes to
+  --- the content of the database file, `false` otherwise.
+  readonly: function(self: VM): boolean
+  reset: function(self: VM): number
+  rows: function(self: VM, sql: string): function(self: VM): {string | number}
+  step: function(self: VM): number
+  urows: function(self: VM, sql: string): function(self: VM): any...
 end
 
 local record lsqlite3
+  type Context = Context
+  type Database = Database
+  type Iterator = Iterator
+  type Rebaser = Rebaser
+  type Session = Session
+  type Statement = Statement
+  type VM = VM
+
+  --- The `lsqlite3.OK` result code means that the operation was successful
+  --- and that there were no errors. Most other result codes indicate an
+  --- error.
   OK: number
+  --- The `lsqlite3.ERROR` result code is a generic error code that is used
+  --- when no other more specific error code is available.
   ERROR: number
+  --- The `lsqlite3.INTERNAL` result code indicates an internal malfunction.
+  --- In a working version of SQLite, an application should never see this
+  --- result code. If application does encounter this result code, it shows
+  --- that there is a bug in the database engine.
+  --- SQLite does not currently generate this result code. However,
+  --- application-defined SQL functions or virtual tables, or VFSes, or other
+  --- extensions might cause this result code to be returned.
   INTERNAL: number
+  --- The `lsqlite3.PERM` result code indicates that the requested access mode
+  --- for a newly created database could not be provided.
   PERM: number
+  --- The `lsqlite3.ABORT` result code indicates that an operation was aborted
+  --- prior to completion, usually be application request. See also:
+  --- `lsqlite3.INTERRUPT`.
+  --- If the callback function to `exec()` returns non-zero, then `exec()`
+  --- will return `lsqlite3.ABORT`.
+  --- If a ROLLBACK operation occurs on the same database connection as a
+  --- pending read or write, then the pending read or write may fail with an
+  --- `lsqlite3.ABORT` error.
   ABORT: number
+  --- The lsqlite3.BUSY result code indicates that the database file could not
+  --- be written (or in some cases read) because of concurrent activity by
+  --- some other database connection, usually a database connection in a
+  --- separate process.
+  --- For example, if process A is in the middle of a large write transaction
+  --- and at the same time process B attempts to start a new write
+  --- transaction, process B will get back an `lsqlite3.BUSY` result because
+  --- SQLite only supports one writer at a time. Process B will need to wait
+  --- for process A to finish its transaction before starting a new
+  --- transaction. The `db:busy_timeout()` and `db:busy_handler()` interfaces
+  --- are available to process B to help it deal with `lsqlite3.BUSY` errors.
+  --- An `lsqlite3.BUSY` error can occur at any point in a transaction: when
+  --- the transaction is first started, during any write or update operations,
+  --- or when the transaction commits. To avoid encountering `lsqlite3.BUSY`
+  --- errors in the middle of a transaction, the application can use
+  --- `BEGIN IMMEDIATE` instead of just `BEGIN` to start a transaction. The
+  --- `BEGIN IMMEDIATE` command might itself return `lsqlite3.BUSY`, but if it
+  --- succeeds, then SQLite guarantees that no subsequent operations on the same database through the next COMMIT will return `lsqlite3.BUSY`.
+  --- The `lsqlite3.BUSY` result code differs from `lsqlite3.LOCKED` in that
+  --- `lsqlite3.BUSY` indicates a conflict with a separate database
+  --- connection, probably in a separate process, whereas `lsqlite3.LOCKED`
+  --- indicates a conflict within the same database connection (or sometimes
+  --- a database connection with a shared cache).
   BUSY: number
+  --- The `lsqlite3.LOCKED` result code indicates that a write operation could
+  --- not continue because of a conflict within the same database connection
+  --- or a conflict with a different database connection that uses a shared
+  --- cache.
+  --- For example, a DROP TABLE statement cannot be run while another thread
+  --- is reading from that table on the same database connection because
+  --- dropping the table would delete the table out from under the concurrent
+  --- reader.
+  --- The `lsqlite3.LOCKED` result code differs from `lsqlite3.BUSY` in that
+  --- `lsqlite3.LOCKED` indicates a conflict on the same database connection
+  --- (or on a connection with a shared cache) whereas `lsqlite3.BUSY`
+  --- indicates a conflict with a different database connection, probably in
+  --- a different process.
   LOCKED: number
+  --- The `lsqlite3.NOMEM` result code indicates that SQLite was unable to
+  --- allocate all the memory it needed to complete the operation. In other
+  --- words, an internal call to `sqlite3_malloc()` or `sqlite3_realloc()` has
+  --- failed in a case where the memory being allocated was required in order
+  --- to continue the operation.
   NOMEM: number
+  --- The `lsqlite3.READONLY` result code is returned when an attempt is made
+  --- to alter some data for which the current database connection does not
+  --- have write permission.
   READONLY: number
+  --- The `lsqlite3.INTERRUPT` result code indicates that an operation was
+  --- interrupted by the `sqlite3_interrupt()` interface. See also:
+  --- `lsqlite3.ABORT`
   INTERRUPT: number
+  --- The `lsqlite3.IOERR` result code says that the operation could not
+  --- finish because the operating system reported an I/O error.
+  --- A full disk drive will normally give an `lsqlite3.FULL` error rather
+  --- than an `lsqlite3.IOERR` error.
+  --- There are many different extended result codes for I/O errors that
+  --- identify the specific I/O operation that failed.
   IOERR: number
+  --- The `lsqlite3.CORRUPT` result code indicates that the database file has
+  --- been corrupted. See [How To Corrupt Your Database Files](https://www.sqlite.org/lockingv3.html#how_to_corrupt)
+  --- for further discussion on how corruption can occur.
   CORRUPT: number
+  --- The `lsqlite3.NOTFOUND` result code is exposed in three ways:
+  --- `lsqlite3.NOTFOUND` can be returned by the `sqlite3_file_control()`
+  --- interface to indicate that the file control opcode passed as the third
+  --- argument was not recognized by the underlying VFS.
+  --- `lsqlite3.NOTFOUND` can also be returned by the xSetSystemCall() method
+  --- of an sqlite3_vfs object.
+  --- `lsqlite3.NOTFOUND` an be returned by sqlite3_vtab_rhs_value() to
+  --- indicate that the right-hand operand of a constraint is not available
+  --- to the xBestIndex method that made the call.
+  --- The `lsqlite3.NOTFOUND` result code is also used internally by the
+  --- SQLite implementation, but those internal uses are not exposed to the
+  --- application.
   NOTFOUND: number
+  --- The `lsqlite3.FULL` result code indicates that a write could not
+  --- complete because the disk is full. Note that this error can occur when
+  --- trying to write information into the main database file, or it can also
+  --- occur when writing into temporary disk files.
+  --- Sometimes applications encounter this error even though there is an
+  --- abundance of primary disk space because the error occurs when writing
+  --- into temporary disk files on a system where temporary files are stored
+  --- on a separate partition with much less space that the primary disk.
   FULL: number
+  --- The `lsqlite3.CANTOPEN` result code indicates that SQLite was unable to
+  --- open a file. The file in question might be a primary database file or
+  --- one of several temporary disk files.
   CANTOPEN: number
+  --- The `lsqlite3.PROTOCOL` result code indicates a problem with the file
+  --- locking protocol used by SQLite. The `lsqlite3.PROTOCOL` error is
+  --- currently only returned when using WAL mode and attempting to start a
+  --- new transaction. There is a race condition that can occur when two
+  --- separate database connections both try to start a transaction at the
+  --- same time in WAL mode. The loser of the race backs off and tries again,
+  --- after a brief delay. If the same connection loses the locking race
+  --- dozens of times over a span of multiple seconds, it will eventually give
+  --- up and return `lsqlite3.PROTOCOL`. The `lsqlite3.PROTOCOL` error should
+  --- appear in practice very, very rarely, and only when there are many
+  --- separate processes all competing intensely to write to the same
+  --- database.
   PROTOCOL: number
+  --- The `lsqlite3.EMPTY` result code is not currently used.
   EMPTY: number
+  --- The `lsqlite3.SCHEMA` result code indicates that the database schema has
+  --- changed. This result code can be returned from `Statement:step()`. If
+  --- the database schema was changed by some other process in between the
+  --- time that the statement was prepared and the time the statement was run,
+  --- this error can result.
+  --- The statement is automatically re-prepared if the schema changes, up to
+  --- `SQLITE_MAX_SCHEMA_RETRY` times (default: 50). The `step()` interface
+  --- will only return `lsqlite3.SCHEMA` back to the application if the
+  --- failure persists after these many retries.
   SCHEMA: number
+  --- The `lsqlite3.TOOBIG` error code indicates that a string or BLOB was too
+  --- large. The default maximum length of a string or BLOB in SQLite is
+  --- 1,000,000,000 bytes. This maximum length can be changed at compile-time
+  --- using the `SQLITE_MAX_LENGTH` compile-time option. The `lsqlite3.TOOBIG`
+  --- error results when SQLite encounters a string or BLOB that exceeds the
+  --- compile-time limit.
+  --- The `lsqlite3.TOOBIG` error code can also result when an oversized SQL
+  --- statement is passed into one of the `db:prepare()` interface. The
+  --- maximum length of an SQL statement defaults to a much smaller value of
+  --- 1,000,000,000 bytes.
   TOOBIG: number
+  --- The `lsqlite3.CONSTRAINT` error code means that an SQL constraint
+  --- violation occurred while trying to process an SQL statement. Additional
+  --- information about the failed constraint can be found by consulting the
+  --- accompanying error message (returned via `errmsg()`) or by looking at
+  --- the extended error code.
+  --- The `lsqlite3.CONSTRAINT` code can also be used as the return value from
+  --- the `xBestIndex()` method of a virtual table implementation. When
+  --- `xBestIndex()` returns `lsqlite3.CONSTRAINT`, that indicates that the
+  --- particular combination of inputs submitted to `xBestIndex()` cannot
+  --- result in a usable query plan and should not be given further
+  --- consideration.
   CONSTRAINT: number
+  --- SQLite is normally very forgiving about mismatches between the type of a
+  --- value and the declared type of the container in which that value is to
+  --- be stored. For example, SQLite allows the application to store a large
+  --- BLOB in a column with a declared type of BOOLEAN. But in a few cases,
+  --- SQLite is strict about types. The `lsqlite3.MISMATCH` error is returned
+  --- in those few cases when the types do not match.
+  --- The rowid of a table must be an integer. Attempt to set the rowid to
+  --- anything other than an integer (or a NULL which will be automatically
+  --- converted into the next available integer rowid) results in an
+  --- `lsqlite3.MISMATCH` error.
   MISMATCH: number
+  --- The `lsqlite3.MISUSE` return code might be returned if the application
+  --- uses any SQLite interface in a way that is undefined or unsupported. For
+  --- example, using a prepared statement after that prepared statement has
+  --- been finalized might result in an `lsqlite3.MISUSE` error.
+  --- SQLite tries to detect misuse and report the misuse using this result
+  --- code. However, there is no guarantee that the detection of misuse will
+  --- be successful. Misuse detection is probabilistic. Applications should
+  --- never depend on an `lsqlite3.MISUSE` return value.
+  --- If SQLite ever returns `lsqlite3.MISUSE` from any interface, that means
+  --- that the application is incorrectly coded and needs to be fixed. Do not
+  --- ship an application that sometimes returns `lsqlite3.MISUSE` from a
+  --- standard SQLite interface because that application contains potentially
+  --- serious bugs.
   MISUSE: number
+  --- The `lsqlite3.NOLFS` error can be returned on systems that do not
+  --- support large files when the database grows to be larger than what the
+  --- filesystem can handle. "NOLFS" stands for "NO Large File Support".
   NOLFS: number
+  --- The `lsqlite3.FORMAT` error code is not currently used by SQLite.
   FORMAT: number
+  --- The `lsqlite3.RANGE` error indices that the parameter number argument to
+  --- one of the `bind` routines or the column number in one of the `column`
+  --- routines is out of range.
   RANGE: number
+  --- When attempting to open a file, the `lsqlite3.NOTADB` error indicates
+  --- that the file being opened does not appear to be an SQLite database
+  --- file.
   NOTADB: number
+  --- The `lsqlite3.ROW` result code returned by sqlite3_step() indicates that
+  --- another row of output is available.
   ROW: number
+  --- The `lsqlite3.DONE` result code indicates that an operation has
+  --- completed. The `lsqlite3.DONE` result code is most commonly seen as a
+  --- return value from `step()` indicating that the SQL statement has run to
+  --- completion, but `lsqlite3.DONE` can also be returned by other multi-step
+  --- interfaces.
   DONE: number
   CREATE_INDEX: number
   CREATE_TABLE: number
@@ -151,38 +703,112 @@ local record lsqlite3
   DROP_VTABLE: number
   FUNCTION: number
   SAVEPOINT: number
+  --- The database is created if it does not already exist.
   OPEN_CREATE: number
+  --- The database is opened with shared cache disabled, overriding the
+  --- default shared cache setting provided by sqlite3_enable_shared_cache().
   OPEN_PRIVATECACHE: number
+  --- The new database connection will use the "serialized" threading mode.
+  --- This means the multiple threads can safely attempt to use the same
+  --- database connection at the same time. (Mutexes will block any actual
+  --- concurrency, but in this mode there is no harm in trying.)
   OPEN_FULLMUTEX: number
+  --- The new database connection will use the "multi-thread" threading mode.
+  --- This means that separate threads are allowed to use SQLite at the same
+  --- time, as long as each thread is using a different database connection.
   OPEN_NOMUTEX: number
+  --- The database will be opened as an in-memory database. The database is
+  --- named by the "filename" argument for the purposes of cache-sharing, if
+  --- shared cache mode is enabled, but the "filename" is otherwise ignored.
   OPEN_MEMORY: number
+  --- The filename can be interpreted as a URI if this flag is set. See
+  --- https://www.sqlite.org/c3ref/open.html
   OPEN_URI: number
+  --- The database is opened for reading and writing if possible, or reading
+  --- only if the file is write protected by the operating system. In either
+  --- case the database must already exist, otherwise an error is returned.
   OPEN_READWRITE: number
+  --- The database is opened in read-only mode. If the database does not
+  --- already exist, an error is returned.
   OPEN_READONLY: number
+  --- The database is opened shared cache enabled, overriding the default
+  --- shared cache setting provided by sqlite3_enable_shared_cache(). The use
+  --- of shared cache mode is discouraged and hence shared cache capabilities
+  --- may be omitted from many builds of SQLite. In such cases, this option is
+  --- a no-op.
   OPEN_SHAREDCACHE: number
   TEXT: number
   BLOB: number
   NULL: number
   FLOAT: number
+  INTEGER: number
+  CONFIG_SINGLETHREAD: number
+  CONFIG_MULTITHREAD: number
+  CONFIG_SERIALIZED: number
+  CONFIG_LOG: number
+  --- for any database readers or writers to finish. See `db:wal_checkpoint`.
+  CHECKPOINT_PASSIVE: number
+  --- reading from the most recent database snapshot, then checkpoints all
+  --- frames. See `db:wal_checkpoint`.
+  CHECKPOINT_FULL: number
+  --- blocks until all readers are reading from the database file only.
+  --- See `db:wal_checkpoint`.
+  CHECKPOINT_RESTART: number
+  --- truncates the log file before returning. See `db:wal_checkpoint`.
+  CHECKPOINT_TRUNCATE: number
+  --- changeset while iterating it.
+  CHANGESETSTART_INVERT: number
+  --- SAVEPOINT that is otherwise used to rollback partially applied changes.
+  CHANGESETAPPLY_NOSAVEPOINT: number
+  --- before applying it.
+  CHANGESETAPPLY_INVERT: number
+  --- "before" values. See `db:apply_changeset`.
+  CHANGESET_DATA: number
+  --- database. See `db:apply_changeset`.
+  CHANGESET_NOTFOUND: number
+  --- See `db:apply_changeset`.
+  CHANGESET_CONFLICT: number
+  --- constraint. See `db:apply_changeset`.
+  CHANGESET_CONSTRAINT: number
+  --- after all changes were applied. See `db:apply_changeset`.
+  CHANGESET_FOREIGN_KEY: number
+  --- change. See `db:apply_changeset`.
+  CHANGESET_OMIT: number
+  --- row with the change. See `db:apply_changeset`.
+  CHANGESET_REPLACE: number
+  --- changeset. See `db:apply_changeset`.
+  CHANGESET_ABORT: number
 
   --- Opens (or creates if it does not exist) an SQLite database with name filename
   --- and returns its handle as userdata (the returned object should be used for all
   --- further method calls in connection with this specific database, see Database
   --- methods). Example:
-  --- myDB = lsqlite3.open('MyDatabase.sqlite3')  -- open
-  --- -- do some database calls...
-  --- myDB:close()  -- close
+  ---     myDB = lsqlite3.open('MyDatabase.sqlite3')  -- open
+  ---     -- do some database calls...
+  ---     myDB:close()  -- close
   --- In case of an error, the function returns `nil`, an error code and an error message.
   --- Since `0.9.4`, there is a second optional `flags` argument to `lsqlite3.open`.
   --- See https://www.sqlite.org/c3ref/open.html for an explanation of these flags and options.
-  --- local db = lsqlite3.open('foo.db', lsqlite3.OPEN_READWRITE + lsqlite3.OPEN_CREATE + lsqlite3.OPEN_SHAREDCACHE)
-  open: function(filename: string, flags?: number): Database
+  ---     local db = lsqlite3.open('foo.db', lsqlite3.OPEN_READWRITE + lsqlite3.OPEN_CREATE + lsqlite3.OPEN_SHAREDCACHE)
+  open: function(filename: string, flags?: number): Database, number
   --- Opens an SQLite database in memory and returns its handle as userdata. In case
   --- of an error, the function returns `nil`, an error code and an error message.
   --- (In-memory databases are volatile as they are never stored on disk.)
-  open_memory: function(): Database
+  open_memory: function(): Database, number
   lversion: function(): string
   version: function(): string
+  --- Sets global SQLite3 library configuration options.
+  --- `option` may be one of:
+  --- - `lsqlite3.CONFIG_SINGLETHREAD`, `lsqlite3.CONFIG_MULTITHREAD`, or
+  ---   `lsqlite3.CONFIG_SERIALIZED`: selects the global threading mode.
+  ---   Returns `lsqlite3.OK` on success, or `nil` plus a numerical error
+  ---   code on failure.
+  --- - `lsqlite3.CONFIG_LOG`: installs a Lua callback that is invoked as
+  ---   `func(udata, errcode, message)` for every SQLite3 log event, or
+  ---   removes the current callback when `func` is `nil`. Returns
+  ---   `lsqlite3.OK` followed by the previously installed callback and its
+  ---   user data.
+  config: function(option: number, func?: function, udata?: any): number, function | nil, any, number
 end
 
 return lsqlite3

--- a/lib/types/cosmo/path.d.tl
+++ b/lib/types/cosmo/path.d.tl
@@ -1,41 +1,43 @@
 -- type declarations for cosmo.path
+-- GENERATED from cosmopolitan's definitions.lua by lib/types/gentype.tl.
+-- Do not edit by hand. Regenerate with: bin/make regen-types
 
 local record path
   --- Strips final component of path, e.g.
-  --- path      │ dirname
-  --- ───────────────────
-  --- .         │ .
-  --- ..        │ .
-  --- /         │ /
-  --- usr       │ .
-  --- /usr/     │ /
-  --- /usr/lib  │ /usr
-  --- /usr/lib/ │ /usr
+  ---     path      │ dirname
+  ---     ───────────────────
+  ---     .         │ .
+  ---     ..        │ .
+  ---     /         │ /
+  ---     usr       │ .
+  ---     /usr/     │ /
+  ---     /usr/lib  │ /usr
+  ---     /usr/lib/ │ /usr
   dirname: function(str: string): string
   --- Returns final component of path, e.g.
-  --- path      │ basename
-  --- ─────────────────────
-  --- .         │ .
-  --- ..        │ ..
-  --- /         │ /
-  --- usr       │ usr
-  --- /usr/     │ usr
-  --- /usr/lib  │ lib
-  --- /usr/lib/ │ lib
+  ---     path      │ basename
+  ---     ─────────────────────
+  ---     .         │ .
+  ---     ..        │ ..
+  ---     /         │ /
+  ---     usr       │ usr
+  ---     /usr/     │ usr
+  ---     /usr/lib  │ lib
+  ---     /usr/lib/ │ lib
   basename: function(str: string): string
   --- Concatenates path components, e.g.
-  --- x         │ y        │ joined
-  --- ─────────────────────────────────
-  --- /         │ /        │ /
-  --- /usr      │ lib      │ /usr/lib
-  --- /usr/     │ lib      │ /usr/lib
-  --- /usr/lib  │ /lib     │ /lib
+  ---     x         │ y        │ joined
+  ---     ─────────────────────────────────
+  ---     /         │ /        │ /
+  ---     /usr      │ lib      │ /usr/lib
+  ---     /usr/     │ lib      │ /usr/lib
+  ---     /usr/lib  │ /lib     │ /lib
   --- You may specify 1+ arguments.
   --- Specifying no arguments will raise an error. If `nil` arguments are specified,
   --- then they're skipped over. If exclusively `nil` arguments are passed, then `nil`
   --- is returned. Empty strings behave similarly to `nil`, but unlike `nil` may
   --- coerce a trailing slash.
-  join: function(str?: string, ...: string): string
+  join: function(str?: string, ...: string): string | nil
   --- Returns `true` if path exists.
   --- This function is inclusive of regular files, directories, and special files.
   --- Symbolic links are followed are resolved. On error, `false` is returned.

--- a/lib/types/cosmo/re.d.tl
+++ b/lib/types/cosmo/re.d.tl
@@ -1,4 +1,6 @@
 -- type declarations for cosmo.re
+-- GENERATED from cosmopolitan's definitions.lua by lib/types/gentype.tl.
+-- Do not edit by hand. Regenerate with: bin/make regen-types
 
 local record Errno
   --- - `unix.NOMATCH` No match
@@ -29,34 +31,73 @@ local record Regex
   --- - `re.NOTBOL`
   --- - `re.NOTEOL`
   --- This has an O(𝑛) cost.
-  search: function(self: Regex, str: string, flags?: number): string
+  search: function(self: Regex, str: string, flags?: number): string, string...
 end
 
 local record re
-  -- Error codes
+  type Errno = Errno
+  type Regex = Regex
+
+  --- No match
   NOMATCH: number
+  --- Invalid regex
   BADPAT: number
+  --- Unknown collating element
   ECOLLATE: number
+  --- Unknown character class name
   ECTYPE: number
+  --- Trailing backslash
   EESCAPE: number
+  --- Invalid back reference
   ESUBREG: number
+  --- Missing ]
   EBRACK: number
+  --- Missing )
   EPAREN: number
-
-  -- Compile flags
-  BASIC: number -- Use basic (obsolete) regex syntax instead of extended
-  ICASE: number -- Case-insensitive matching
-  NEWLINE: number -- Treat newline as special (affects ^ and $)
-  NOSUB: number -- Report only success/failure, not match position
-
-  -- Search flags
-  NOTBOL: number -- First character is not at beginning of line
-  NOTEOL: number -- Last character is not at end of line
+  --- Missing }
+  EBRACE: number
+  --- Invalid contents of {}
+  BADBR: number
+  --- Invalid character range.
+  ERANGE: number
+  --- Out of memory
+  ESPACE: number
+  --- Repetition not preceded by valid expression
+  BADRPT: number
+  --- Use this flag if you prefer the default POSIX regex syntax.
+  --- We use extended regex notation by default. For example, an extended regular
+  --- expression for matching an IP address might look like
+  --- `([0-9]*)\.([0-9]*)\.([0-9]*)\.([0-9]*)` whereas with basic syntax it would
+  --- look like `\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)`.
+  --- This flag may only be used with `re.compile` and `re.search`.
+  BASIC: number
+  --- Use this flag if you prefer the default POSIX regex syntax. We use extended
+  ---  regex notation by default. For example, an extended regular expression for
+  --- matching an IP address might look like `([0-9]*)\.([0-9]*)\.([0-9]*)\.([0-9]*)`
+  --- whereas with basic syntax it would look like `\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)`.
+  --- This flag may only be used with `re.compile` and `re.search`.
+  ICASE: number
+  --- Use this flag to change the handling of NEWLINE (\x0a) characters. When this
+  --- flag is set, (1) a NEWLINE shall not be matched by a "." or any form of a
+  --- non-matching list, (2) a "^" shall match the zero-length string immediately
+  --- after a NEWLINE (regardless of `re.NOTBOL`), and (3) a "$" shall match the
+  --- zero-length string immediately before a NEWLINE (regardless of `re.NOTEOL`).
+  NEWLINE: number
+  --- Causes `re.search` to only report success and failure. This is reported via
+  --- the API by returning empty string for success. This flag may only be used
+  --- ` with `re.compile` and `re.search`.
+  NOSUB: number
+  --- The first character of the string pointed to by string is not the beginning
+  --- of the line. This flag may only be used with `re.search` and `regex_t*:search`.
+  NOTBOL: number
+  --- The last character of the string pointed to by string is not the end of the
+  --- line. This flag may only be used with `re.search` and `regex_t*:search`.
+  NOTEOL: number
 
   --- Searches for regular expression match in text.
   --- This is a shorthand notation roughly equivalent to:
-  --- preg = re.compile(regex)
-  --- patt = preg:search(re, text)
+  ---     preg = re.compile(regex)
+  ---     patt = preg:search(re, text)
   --- - `re.BASIC`
   --- - `re.ICASE`
   --- - `re.NEWLINE`
@@ -65,7 +106,7 @@ local record re
   --- - `re.NOTEOL`
   --- This has exponential complexity. Please use `re.compile()` to compile your regular expressions once from `/.init.lua`. This API exists for convenience. This isn't recommended for prod.
   --- This uses POSIX extended syntax by default.
-  search: function(regex: string, text: string, flags?: number): string
+  search: function(regex: string, text: string, flags?: number): string, string...
   --- Compiles regular expression.
   --- - `re.BASIC`
   --- - `re.ICASE`
@@ -76,7 +117,6 @@ local record re
   --- If regex is an untrusted user value, then `unix.setrlimit` should be
   --- used to impose cpu and memory quotas for security.
   --- This uses POSIX extended syntax by default.
-  --- Returns nil and an Errno on failure.
   compile: function(regex: string, flags?: number): Regex, Errno
 end
 

--- a/lib/types/cosmo/repl.d.tl
+++ b/lib/types/cosmo/repl.d.tl
@@ -1,9 +1,13 @@
 -- type declarations for cosmo.repl
+-- GENERATED from cosmopolitan's definitions.lua by lib/types/gentype.tl.
+-- Do not edit by hand. Regenerate with: bin/make regen-types
 
 local record repl
-  --- Start the interactive REPL.
-  --- Enters a Read-Eval-Print Loop with tab completion, history, and line editing.
-  --- The REPL continues until the user presses Ctrl-D (EOF) or Ctrl-C twice.
+  --- Starts an interactive read-eval-print-loop (REPL) on standard input
+  --- and output, with line editing, history, and tab completion. Each
+  --- input line is evaluated as an expression (printing its results) or
+  --- as a statement. The loop runs until end of input (Ctrl-D). Takes no
+  --- arguments and returns nothing.
   start: function()
 end
 

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -1,4 +1,6 @@
 -- type declarations for cosmo.unix
+-- GENERATED from cosmopolitan's definitions.lua by lib/types/gentype.tl.
+-- Do not edit by hand. Regenerate with: bin/make regen-types
 
 local record Termios
   --- Input mode flags (e.g. `unix.BRKINT`, `unix.ICRNL`).
@@ -302,8 +304,8 @@ local record Stat
   flags: function(self: Stat): number
 end
 
+--- Filesystem statistics returned by `statfs()` and `fstatfs()`.
 local record Statfs
-  --- Filesystem statistics returned by `statfs()` and `fstatfs()`.
   --- Returns filesystem type identifier.
   type: function(self: Statfs): number
   --- Returns optimal transfer block size.
@@ -379,235 +381,634 @@ local record Errno
 end
 
 local record unix
+  type Termios = Termios
+  type Memory = Memory
+  type Dir = Dir
+  type Rusage = Rusage
+  type Stat = Stat
+  type Statfs = Statfs
+  type Errno = Errno
+
+  --- @type integer
   AF_INET: number
+  --- @type integer
   AF_UNIX: number
+  --- @type integer
   AF_UNSPEC: number
+  --- @type integer Returns maximum length of arguments for new processes.
+  --- This is the character limit when calling `execve()`. It's the sum of
+  --- the lengths of `argv` and `envp` including any nul terminators and
+  --- pointer arrays. For example to see how much your shell `envp` uses
+  ---     $ echo $(($(env | wc -c) + 1 + ($(env | wc -l) + 1) * 8))
+  ---     758
+  --- POSIX mandates this be 4096 or higher. On Linux this it's 128*1024.
+  --- On Windows NT it's 32767*2 because CreateProcess lpCommandLine and
+  --- environment block are separately constrained to 32,767 characters.
+  --- Most other systems define this limit much higher.
   ARG_MAX: number
-  AT_EACCES: number
+  --- @type integer
   AT_EACCESS: number
+  --- @type integer
   AT_FDCWD: number
+  --- @type integer
   AT_SYMLINK_NOFOLLOW: number
+  --- @type integer Returns default buffer size.
+  --- The UNIX module does not perform any buffering between calls.
+  --- Each time a read or write is performed via the UNIX API your redbean
+  --- will allocate a buffer of this size by default. This current default
+  --- would be 4096 across platforms.
   BUFSIZ: number
+  --- @type integer Returns the scheduler frequency.
+  --- This is granularity at which the kernel does work. For example, the
+  --- Linux kernel normally operates at 100hz so its CLK_TCK will be 100.
+  --- This value is useful for making sense out of unix.Rusage data.
   CLK_TCK: number
+  --- @type integer
   CLOCK_REALTIME: number
+  --- @type integer
   CLOCK_MONOTONIC: number
+  --- @type integer
   CLOCK_BOOTTIME: number
+  --- @type integer
   CLOCK_MONOTONIC_RAW: number
+  --- @type integer
   CLOCK_REALTIME_COARSE: number
+  --- @type integer
   CLOCK_MONOTONIC_COARSE: number
   CLOCK_THREAD_CPUTIME_ID: number
+  --- @type integer
   CLOCK_PROCESS_CPUTIME_ID: number
+  --- @type integer
   DT_BLK: number
+  --- @type integer
   DT_CHR: number
+  --- @type integer
   DT_DIR: number
+  --- @type integer
   DT_FIFO: number
+  --- @type integer
   DT_LNK: number
+  --- @type integer
   DT_REG: number
+  --- @type integer
   DT_SOCK: number
+  --- @type integer
   DT_UNKNOWN: number
+  --- @type integer Argument list too long.
+  --- Raised by `execve`, `sched_setattr`.
   E2BIG: number
+  --- @type integer Permission denied.
+  --- Raised by `access`, `bind`, `chdir`, `chmod`, `chown`, `chroot`,
+  --- `clock_getres`, `connect`, `execve`, `fcntl`, `getpriority`,
+  --- `link`, `mkdir`, `mknod`, `mmap`, `mprotect`, `msgctl`, `open`,
+  --- `prctl`, `ptrace`, `readlink`, `rename`, `rmdir`, `semget`,
+  --- `send`, `setpgid`, `socket`, `stat`, `symlink`, `truncate`,
+  --- `unlink`, `uselib`, `utime`, `utimensat`.
   EACCES: number
+  --- @type integer Address already in use. Raised by `bind`, `connect`, `listen`.
   EADDRINUSE: number
+  --- @type integer Address not available. Raised by `bind`, `connect`.
   EADDRNOTAVAIL: number
+  --- @type integer Address family not supported. Raised by `connect`, `socket`, `socketpair`.
   EAFNOSUPPORT: number
+  --- @type integer
+  --- Resource temporarily unavailable (e.g. SO_RCVTIMEO expired, too many
+  --- processes, too much memory locked, read or write with O_NONBLOCK
+  --- needs polling, etc.).
+  --- Raised by `accept`, `connect`, `fcntl`, `fork`, `getrandom`,
+  --- `mincore`, `mlock`, `mmap`, `mremap`, `poll`, `read`, `select`,
+  --- `send`, `setresuid`, `setreuid`, `setuid`, `sigwaitinfo`,
+  --- `splice`, `tee`, `timer_create`, `timerfd_create`, `tkill`,
+  --- `write`,
   EAGAIN: number
+  --- @type integer Connection already in progress. Raised by `connect`, `send`.
   EALREADY: number
+  --- @type integer Bad file descriptor; cf. EBADFD.
+  --- Raised by `accept`, `access`, `bind`, `chdir`, `chmod`, `chown`,
+  --- `close`, `connect`, `copy_file_range`, `dup`, `fcntl`, `flock`,
+  --- `fsync`, `futimesat`, `opendir`, `getpeername`, `getsockname`,
+  --- `getsockopt`, `ioctl`, `link`, `listen`, `lseek`, `mkdir`,
+  --- `mknod`, `mmap`, `open`, `prctl`, `read`, `readahead`,
+  --- `readlink`, `recv`, `rename`, `select`, `send`, `shutdown`,
+  --- `splice`, `stat`, `symlink`, `sync`, `sync_file_range`,
+  --- `timerfd_create`, `truncate`, `unlink`, `utimensat`, `write`.
   EBADF: number
+  --- @type integer
   EBADFD: number
+  --- @type integer
   EBADMSG: number
+  --- @type integer Device or resource busy.
+  --- Raised by dup, fcntl, msync, prctl, ptrace, rename,
+  --- rmdir.
   EBUSY: number
+  --- @type integer
   ECANCELED: number
+  --- @type integer No child process.
+  --- Raised by `wait`, `waitpid`, `waitid`, `wait3`, `wait4`.
   ECHILD: number
+  --- @type integer Connection reset before accept. Raised by `accept`.
   ECONNABORTED: number
+  --- @type integer System-imposed limit on the number of threads was encountered.
+  --- Raised by connect, listen, recv.
   ECONNREFUSED: number
   ECONNRESET: number
+  --- @type integer Resource deadlock avoided.
+  --- Raised by `fcntl`.
   EDEADLK: number
+  --- @type integer Destination address required. Raised by `send`, `write`.
   EDESTADDRREQ: number
+  --- @type integer
   EDOM: number
+  --- @type integer Disk quota exceeded.
+  --- Raised by link, mkdir, mknod, open, rename, symlink,
+  --- write.
   EDQUOT: number
+  --- @type integer File exists.
+  --- Raised by `link`, `mkdir`, `mknod`, `mmap`, `open`, `rename`,
+  --- `rmdir`, `symlink`.
   EEXIST: number
+  --- @type integer
   EFAULT: number
+  --- @type integer File too large.
+  --- Raised by `copy_file_range`, `open`, `truncate`, `write`.
   EFBIG: number
+  --- @type integer Inappropriate file type or format.
   EFTYPE: number
+  --- @type integer Host is down. Raised by `accept`.
   EHOSTDOWN: number
+  --- @type integer Host is unreachable. Raised by `accept`.
   EHOSTUNREACH: number
+  --- @type integer Memory page has hardware error.
   EHWPOISON: number
+  --- @type integer Identifier removed. Raised by `msgctl`.
   EIDRM: number
+  --- @type integer
   EILSEQ: number
+  --- @type integer
   EINPROGRESS: number
+  --- @type integer The greatest of all errnos; crucial for building real time reliable software.
+  --- Raised by `accept`, `clock_nanosleep`, `close`, `connect`, `dup`, `fcntl`,
+  --- `flock`, `getrandom`, `nanosleep`, `open`, `pause`, `poll`, `ptrace`, `read`, `recv`,
+  --- `select`, `send`, `sigsuspend`, `sigwaitinfo`, `truncate`, `wait`, `write`.
   EINTR: number
+  --- @type integer Invalid argument.
+  --- Raised by [pretty much everything].
   EINVAL: number
+  --- @type integer
+  --- Raised by `access`, `acct`, `chdir`, `chmod`, `chown`, `chroot`, `close`,
+  --- `copy_file_range`, `execve`, `fallocate`, `fsync`, `ioperm`, `link`, `madvise`,
+  --- `mbind`, `pciconfig_read`, `ptrace`, `read`, `readlink`, `sendfile`, `statfs`,
+  --- `symlink`, `sync_file_range`, `truncate`, `unlink`, `write`.
   EIO: number
   EISCONN: number
+  --- @type integer Is a directory.
+  --- Raised by `copy_file_range`, `execve`, `open`, `read`, `rename`, `truncate`,
+  --- `unlink`.
   EISDIR: number
+  --- @type integer Too many levels of symbolic links.
+  --- Raised by access, bind, chdir, chmod, chown, chroot, execve, link,
+  --- mkdir, mknod, open, readlink, rename, rmdir, stat, symlink,
+  --- truncate, unlink, utimensat.
   ELOOP: number
+  --- @type integer Wrong medium type. Raised by `mount`.
   EMEDIUMTYPE: number
+  --- @type integer Too many open files.
+  --- Raised by `accept`, `dup`, `execve`, `fanotify_init`, `fcntl`,
+  --- `open`, `pipe`, `socket`, `socketpair`, `timerfd_create`.
   EMFILE: number
+  --- @type integer Too many links;
+  --- Raised by `link`, `mkdir`, `rename`.
   EMLINK: number
+  --- @type integer Message too long. Raised by `send`.
   EMSGSIZE: number
+  --- @type integer Multihop attempted.
   EMULTIHOP: number
+  --- @type integer Filename too long. Cosmopolitan Libc currently defines `PATH_MAX` as
+  --- 1024 characters. On UNIX that limit should only apply to system call
+  --- wrappers like realpath. On Windows NT it's observed by all system
+  --- calls that accept a pathname.
+  --- Raised by `access`, `bind`, `chdir`, `chmod`, `chown`, `chroot`,
+  --- `execve`, `gethostname`, `link`, `mkdir`, `mknod`, `open`,
+  --- `readlink`, `rename`, `rmdir`, `stat`, `symlink`, `truncate`,
+  --- `unlink`, `utimensat`.
   ENAMETOOLONG: number
+  --- @type integer Network is down. Raised by `accept`.
   ENETDOWN: number
+  --- @type integer Connection reset by network.
   ENETRESET: number
+  --- @type integer Host is unreachable. Raised by `accept`, `connect`.
   ENETUNREACH: number
+  --- @type integer Too many open files in system.
+  --- Raised by `accept`, `execve`, `mmap`, `open`, `pipe`, `socket`,
+  --- `socketpair`, `swapon`, `timerfd_create`, `uselib`,
+  --- `userfaultfd`.
   ENFILE: number
+  --- @type integer No buffer space available;
+  --- Raised by `getpeername`, `getsockname`, `send`.
   ENOBUFS: number
+  --- @type integer No message is available in xsi stream or named pipe is being closed;
+  --- no data available; barely in posix; returned by ioctl; very close in
+  --- spirit to EPIPE?
   ENODATA: number
+  --- @type integer No such device.
+  --- Raised by `arch_prctl`, `mmap`, `open`, `prctl`, `timerfd_create`.
   ENODEV: number
+  --- @type integer No such file or directory.
+  --- Raised by `access`, `bind`, `chdir`, `chmod`, `chown`, `chroot`,
+  --- `clock_getres`, `execve`, `opendir`, `link`, `mkdir`, `mknod`,
+  --- `open`, `readlink`, `rename`, `rmdir`, `stat`, `swapon`,
+  --- `symlink`, `truncate`, `unlink`, `utime`, `utimensat`.
   ENOENT: number
+  --- @type integer Exec format error. Raised by `execve`, `uselib`.
   ENOEXEC: number
+  --- @type integer No locks available. Raised by `fcntl`, `flock`.
   ENOLCK: number
+  --- @type integer Link has been severed.
   ENOLINK: number
+  --- @type integer No medium found. Raised by `mount`.
   ENOMEDIUM: number
+  --- @type integer
   ENOMEM: number
+  --- @type integer Raised by `msgop`.
   ENOMSG: number
+  --- @type integer
   ENONET: number
+  --- @type integer Protocol not available. Raised by `getsockopt`, `accept`.
   ENOPROTOOPT: number
+  --- @type integer No space left on device.
+  --- Raised by `copy_file_range`, `fsync`, `link`, `mkdir`, `mknod`,
+  --- `open`, `rename`, `symlink`, `sync_file_range`, `write`.
   ENOSPC: number
+  --- @type integer Out of streams resources.
   ENOSR: number
+  --- @type integer Device not a stream.
   ENOSTR: number
+  --- @type integer System call not available on this platform. On
+  ---     Windows this is raised by `chroot`, `setuid`, `setgid`,
+  ---     `getsid`, `setsid`, and others we're doing our best to
+  ---     document.
   ENOSYS: number
+  --- @type integer Block device required. Raised by `umount`.
   ENOTBLK: number
+  --- @type integer Socket is not connected.
+  --- Raised by `getpeername`, `recv`, `send`, `shutdown`.
   ENOTCONN: number
+  --- @type integer Not a directory. This means that a directory
+  ---     component in a supplied path *existed* but wasn't a
+  ---     directory. For example, if you try to `open("foo/bar")` and
+  ---     `foo` is a regular file, then `ENOTDIR` will be returned.
+  --- Raised by `open`, `access`, `chdir`, `chroot`, `execve`, `link`,
+  --- `mkdir`, `mknod`, `opendir`, `readlink`, `rename`, `rmdir`,
+  --- `stat`, `symlink`, `truncate`, `unlink`, `utimensat`, `bind`,
+  --- `chmod`, `chown`, `fcntl`, `futimesat`.
   ENOTDIR: number
+  --- @type integer Directory not empty. Raised by `rmdir`.
   ENOTEMPTY: number
+  --- @type integer
   ENOTRECOVERABLE: number
+  --- @type integer Not a socket.
+  --- Raised by `accept`, `bind`, `connect`, `getpeername`,
+  --- `getsockname`, `getsockopt`, `listen`, `recv`, `send`,
+  --- `shutdown`.
   ENOTSOCK: number
+  --- @type integer Operation not supported.
+  --- Raised by `chmod`, `clock_getres`, `clock_nanosleep`,
+  --- `timer_create`.
   ENOTSUP: number
+  --- @type integer Inappropriate i/o control operation. Raised by `ioctl`.
   ENOTTY: number
+  --- @type integer No such device or address. Raised by `lseek`, `open`, `prctl`.
   ENXIO: number
+  --- @type integer Socket operation not supported.
+  --- Raised by accept, listen, mmap, prctl, readv, send,
+  --- socketpair.
   EOPNOTSUPP: number
+  --- @type integer Raised by `copy_file_range`, `fanotify_init`, `lseek`, `mmap`,
+  --- `open`, `stat`, `statfs`
   EOVERFLOW: number
+  --- @type integer
   EOWNERDEAD: number
+  --- @type integer Operation not permitted.
+  --- Raised by `accept`, `chmod`, `chown`, `chroot`,
+  --- `copy_file_range`, `execve`, `fallocate`, `fanotify_init`,
+  --- `fcntl`, `futex`, `get_robust_list`, `getdomainname`,
+  --- `getgroups`, `gethostname`, `getpriority`, `getrlimit`,
+  --- `getsid`, `gettimeofday`, `idle`, `init_module`, `io_submit`,
+  --- `ioctl_console`, `ioctl_ficlonerange`, `ioctl_fideduperange`,
+  --- `ioperm`, `iopl`, `ioprio_set`, `keyctl`, `kill`, `link`,
+  --- `lookup_dcookie`, `madvise`, `mbind`, `membarrier`,
+  --- `migrate_pages`, `mkdir`, `mknod`, `mlock`, `mmap`, `mount`,
+  --- `move_pages`, `msgctl`, `nice`, `open`, `open_by_handle_at`,
+  --- `pciconfig_read`, `perf_event_open`, `pidfd_getfd`,
+  --- `pidfd_send_signal`, `pivot_root`, `prctl`, `process_vm_readv`,
+  --- `ptrace`, `quotactl`, `reboot`, `rename`, `request_key`,
+  --- `rmdir`, `rt_sigqueueinfo`, `sched_setaffinity`,
+  --- `sched_setattr`, `sched_setparam`, `sched_setscheduler`,
+  --- `seteuid`, `setfsgid`, `setfsuid`, `setgid`, `setns`, `setpgid`,
+  --- `setresuid`, `setreuid`, `setsid`, `setuid`, `setup`,
+  --- `setxattr`, `sigaltstack`, `spu_create`, `stime`, `swapon`,
+  --- `symlink`, `syslog`, `truncate`, `unlink`, `utime`, `utimensat`,
+  --- `write`.
   EPERM: number
+  --- @type integer Protocol family not supported.
   EPFNOSUPPORT: number
+  --- @type integer Broken pipe.
+  --- Returned by `write`, `send`. This happens when you try
+  --- to write data to a subprocess via a pipe but the reader end has
+  --- already closed, possibly because the process died. Normally i/o
+  --- routines only return this if `SIGPIPE` doesn't kill the process.
+  --- Unlike default UNIX programs, redbean currently ignores `SIGPIPE` by
+  --- default, so this error code is a distinct possibility when pipes or
+  --- sockets are being used.
   EPIPE: number
+  --- @type integer Raised by `accept`, `connect`, `socket`, `socketpair`.
   EPROTO: number
+  --- @type integer Protocol not supported. Raised by `socket`, `socketpair`.
   EPROTONOSUPPORT: number
+  --- @type integer Protocol wrong type for socket. Raised by `connect`.
   EPROTOTYPE: number
+  --- @type integer Result too large.
+  --- Raised by `prctl`.
   ERANGE: number
+  --- @type integer
   EREMOTE: number
+  --- @type integer
   ERESTART: number
+  --- @type integer Operation not possible due to RF-kill.
   ERFKILL: number
+  --- @type integer Read-only filesystem.
+  --- Raised by access, bind, chmod, chown, link, mkdir, mknod, open,
+  --- rename, rmdir, symlink, truncate, unlink, utime, utimensat.
   EROFS: number
+  --- @type integer Cannot send after transport endpoint shutdown; note that shutdown write is an `EPIPE`.
   ESHUTDOWN: number
+  --- @type integer Socket type not supported.
   ESOCKTNOSUPPORT: number
+  --- @type integer Invalid seek.
+  --- Raised by `lseek`, `splice`, `sync_file_range`.
   ESPIPE: number
+  --- @type integer No such process.
+  --- Raised by `getpriority`, `getrlimit`, `getsid`, `ioprio_set`, `kill`, `setpgid`, `tkill`, `utimensat`.
   ESRCH: number
+  --- @type integer
   ESTALE: number
+  --- @type integer Timer expired. Raised by `connect`.
   ETIME: number
+  --- @type integer Connection timed out. Raised by `connect`.
   ETIMEDOUT: number
+  --- @type integer Too many references: cannot splice. Raised by `sendmsg`.
   ETOOMANYREFS: number
+  --- @type integer Won't open executable that's executing in write mode.
+  --- Raised by access, copy_file_range, execve, mmap, open, truncate.
   ETXTBSY: number
+  --- @type integer
   EUSERS: number
+  --- @type integer Improper link.
+  --- Raised by copy_file_range, link, rename.
   EXDEV: number
+  --- @type integer
   FD_CLOEXEC: number
+  --- @type integer
   F_GETFD: number
+  --- @type integer
   F_GETFL: number
+  --- @type integer
   F_GETLK: number
+  --- @type integer
   F_OK: number
+  --- @type integer
   F_RDLCK: number
+  --- @type integer
   F_SETFD: number
+  --- @type integer
   F_SETFL: number
+  --- @type integer
   F_SETLK: number
+  --- @type integer
   F_SETLKW: number
+  --- @type integer
   F_UNLCK: number
+  --- @type integer
   F_WRLCK: number
+  --- @type integer
   IPPROTO_ICMP: number
+  --- @type integer
   IPPROTO_IP: number
+  --- @type integer
   IPPROTO_RAW: number
+  --- @type integer
   IPPROTO_TCP: number
+  --- @type integer
   IPPROTO_UDP: number
+  --- @type integer
   IP_ADD_MEMBERSHIP: number
+  --- @type integer
   IP_DROP_MEMBERSHIP: number
+  --- @type integer
   IP_HDRINCL: number
+  --- @type integer
   IP_MTU: number
+  --- @type integer
   IP_MULTICAST_IF: number
+  --- @type integer
   IP_MULTICAST_LOOP: number
+  --- @type integer
   IP_MULTICAST_TTL: number
+  --- @type integer
   IP_OPTIONS: number
+  --- @type integer
   IP_PKTINFO: number
+  --- @type integer
   IP_RECVTOS: number
+  --- @type integer
   IP_RECVTTL: number
+  --- @type integer
   IP_TOS: number
+  --- @type integer
   IP_TTL: number
+  --- @type integer
   ITIMER_PROF: number
+  --- @type integer
   ITIMER_REAL: number
+  --- @type integer
   ITIMER_VIRTUAL: number
+  --- @type integer
   LOG_ALERT: number
+  --- @type integer
   LOG_CRIT: number
+  --- @type integer
   LOG_DEBUG: number
+  --- @type integer
   LOG_EMERG: number
+  --- @type integer
   LOG_ERR: number
+  --- @type integer
   LOG_INFO: number
+  --- @type integer
   LOG_NOTICE: number
+  --- @type integer
   LOG_WARNING: number
+  --- @type integer
   MSG_CTRUNC: number
+  --- @type integer
   MSG_DONTROUTE: number
+  --- @type integer
   MSG_DONTWAIT: number
-  MSG_MORE: number
+  --- @type integer
   MSG_NOSIGNAL: number
+  --- @type integer
   MSG_OOB: number
+  --- @type integer
   MSG_PEEK: number
+  --- @type integer
   MSG_TRUNC: number
+  --- @type integer
   MSG_WAITALL: number
+  --- @type integer  Returns maximum length of file path component.
+  --- POSIX requires this be at least 14. Most operating systems define it
+  --- as 255. It's a good idea to not exceed 253 since that's the limit on
+  --- DNS labels.
   NAME_MAX: number
+  --- @type integer Returns maximum number of signals supported by underlying system.
+  --- The limit for unix.Sigset is 128 to support FreeBSD, but most
+  --- operating systems define this much lower, like 32. This constant
+  --- reflects the value chosen by the underlying operating system.
   NSIG: number
+  --- @type integer open for reading (default)
   O_RDONLY: number
+  --- @type integer open for writing
   O_WRONLY: number
+  --- @type integer open for reading and writing
   O_RDWR: number
+  --- @type integer create file if it doesn't exist
   O_CREAT: number
+  --- @type integer automatic `ftruncate(fd, 0)` if exists
   O_TRUNC: number
+  --- @type integer automatic `close()` upon `execve()`
   O_CLOEXEC: number
+  --- @type integer exclusive access (see below)
   O_EXCL: number
+  --- @type integer open file for append only
   O_APPEND: number
+  --- @type integer asks read/write to fail with EAGAIN rather than block
   O_NONBLOCK: number
+  --- @type integer it's complicated (not supported on Apple and OpenBSD)
   O_DIRECT: number
+  --- @type integer useful for stat'ing (hint on UNIX but required on NT)
   O_DIRECTORY: number
-  O_TMPFILE: number
+  --- @type integer fail if it's a symlink (zero on Windows)
   O_NOFOLLOW: number
+  --- @type integer automatically delete file upon close()
   O_UNLINK: number
+  --- @type integer open a path reference only, without read/write access
+  --- (Linux only; fails with EINVAL elsewhere). Usable with landlock
+  --- rule paths and *at() calls even when the path itself is unreadable.
   O_PATH: number
+  --- @type integer it's complicated (zero on non-Linux/Apple)
   O_DSYNC: number
-  O_RSYNC: number
+  --- @type integer synchronize i/o operations appropriately
   O_SYNC: number
+  --- @type integer don't record access time (zero on non-Linux)
   O_NOATIME: number
+  --- @type integer
   O_ACCMODE: number
-  O_EXEC: number
+  --- @type integer
   O_NOCTTY: number
+  --- @type integer Returns maximum length of file path.
+  --- This applies to a complete path being passed to system calls.
+  --- POSIX.1 XSI requires this be at least 1024 so that's what most
+  --- platforms support. On Windows NT, the limit is technically 260
+  --- characters. Your redbean works around that by prefixing `//?/`
+  --- to your paths as needed. On Linux this limit will be 4096, but
+  --- that won't be the case for functions such as realpath that are
+  --- implemented at the C library level; however such functions are
+  --- the exception rather than the norm, and report `enametoolong()`,
+  --- when exceeding the libc limit.
   PATH_MAX: number
+  --- the default on Linux. It's effectively the same as killing the
+  --- process, since redbean has no threads. The termination signal
+  --- can't be caught and will be either `SIGSYS` or `SIGABRT`.
+  --- Consider enabling stderr logging below so you'll know why your
+  --- program failed. Otherwise check the system log.
   PLEDGE_PENALTY_KILL_THREAD: number
+  --- This is always the case on OpenBSD.
   PLEDGE_PENALTY_KILL_PROCESS: number
+  --- instead of killing. This is a gentler solution that allows code to
+  --- display a friendly warning. Please note this may lead to weird
+  --- behaviors if the software being sandboxed is lazy about checking
+  --- error results.
   PLEDGE_PENALTY_RETURN_EPERM: number
+  --- know which promises are needed whenever violations occur. Without
+  --- this, violations will be logged to `dmesg` on Linux if the penalty
+  --- is to kill the process. You would then need to manually look up
+  --- the system call number and then cross reference it with the
+  --- cosmopolitan libc `pledge()` documentation. You can also use
+  --- `strace -ff` which is easier. This is ignored OpenBSD, which
+  --- already has a good system log. Turning on stderr logging (which
+  --- uses SECCOMP trapping) also means that the `unix.WTERMSIG()` on
+  --- your killed processes will always be `unix.SIGABRT` on both Linux
+  --- and OpenBSD. Otherwise, Linux prefers to raise `unix.SIGSYS`.
   PLEDGE_STDERR_LOGGING: number
+  --- @type integer Returns maximum size at which pipe i/o is guaranteed atomic.
+  --- POSIX requires this be at least 512. Linux is more generous and
+  --- allows 4096. On Windows NT this is currently 4096, and it's the
+  --- parameter redbean passes to `CreateNamedPipe()`.
   PIPE_BUF: number
+  --- @type integer
   POLLERR: number
+  --- @type integer
   POLLHUP: number
+  --- @type integer
   POLLIN: number
+  --- @type integer
   POLLNVAL: number
+  --- @type integer
   POLLOUT: number
+  --- @type integer
   POLLPRI: number
+  --- @type integer
   POLLRDBAND: number
+  --- @type integer
   POLLRDHUP: number
+  --- @type integer
   POLLRDNORM: number
+  --- @type integer
   POLLWRBAND: number
+  --- @type integer
   POLLWRNORM: number
+  --- @type integer
   RLIMIT_AS: number
+  --- @type integer
   RLIMIT_CPU: number
+  --- @type integer
   RLIMIT_FSIZE: number
+  --- @type integer
   RLIMIT_NOFILE: number
+  --- @type integer
   RLIMIT_NPROC: number
+  --- @type integer
   RLIMIT_RSS: number
+  --- @type integer getpriority/setpriority: target is a process id
   PRIO_PROCESS: number
+  --- @type integer getpriority/setpriority: target is a process group id
   PRIO_PGRP: number
+  --- @type integer getpriority/setpriority: target is a user id
   PRIO_USER: number
+  --- @type integer sysconf: maximum length of arguments to exec()
   SC_ARG_MAX: number
+  --- @type integer sysconf: maximum simultaneous processes per user id
   SC_CHILD_MAX: number
+  --- @type integer sysconf: clock ticks per second
   SC_CLK_TCK: number
+  --- @type integer sysconf: maximum number of open files per process
   SC_OPEN_MAX: number
+  --- @type integer sysconf: size of a memory page in bytes
   SC_PAGESIZE: number
+  --- @type integer sysconf: number of processors configured
   SC_NPROCESSORS_CONF: number
+  --- @type integer sysconf: number of processors currently online
   SC_NPROCESSORS_ONLN: number
+  --- @type integer termios input mode flags (Termios.iflag)
   BRKINT: number
   ICRNL: number
   IGNBRK: number
@@ -620,11 +1021,13 @@ local record unix
   IXOFF: number
   IXON: number
   PARMRK: number
+  --- @type integer termios output mode flags (Termios.oflag)
   OPOST: number
   OCRNL: number
   ONLCR: number
   ONLRET: number
   ONOCR: number
+  --- @type integer termios control mode flags (Termios.cflag)
   CLOCAL: number
   CREAD: number
   CS5: number
@@ -636,6 +1039,7 @@ local record unix
   HUPCL: number
   PARENB: number
   PARODD: number
+  --- @type integer termios local mode flags (Termios.lflag)
   ECHO: number
   ECHOE: number
   ECHOK: number
@@ -645,6 +1049,7 @@ local record unix
   ISIG: number
   NOFLSH: number
   TOSTOP: number
+  --- @type integer termios control-character indices (Termios.cc)
   VEOF: number
   VEOL: number
   VERASE: number
@@ -656,9 +1061,11 @@ local record unix
   VSTOP: number
   VTIME: number
   NCCS: number
+  --- @type integer tcsetattr() action values
   TCSANOW: number
   TCSADRAIN: number
   TCSAFLUSH: number
+  --- @type integer network interface ioctls (siocgifconf/ifreq)
   IFNAMSIZ: number
   IFF_ALLMULTI: number
   IFF_AUTOMEDIA: number
@@ -692,6 +1099,7 @@ local record unix
   SIOCSIFMETRIC: number
   SIOCSIFMTU: number
   SIOCSIFNETMASK: number
+  --- @type integer unshare()/setns() namespace flags
   CLONE_NEWCGROUP: number
   CLONE_NEWIPC: number
   CLONE_NEWNET: number
@@ -700,6 +1108,7 @@ local record unix
   CLONE_NEWTIME: number
   CLONE_NEWUSER: number
   CLONE_NEWUTS: number
+  --- @type integer landlock access-rights bits (landlock_add_rule)
   LANDLOCK_ACCESS_FS_EXECUTE: number
   LANDLOCK_ACCESS_FS_WRITE_FILE: number
   LANDLOCK_ACCESS_FS_READ_FILE: number
@@ -717,6 +1126,7 @@ local record unix
   LANDLOCK_ACCESS_FS_TRUNCATE: number
   LANDLOCK_CREATE_RULESET_VERSION: number
   LANDLOCK_RULE_PATH_BENEATH: number
+  --- @type integer prctl() options
   PR_CAPBSET_DROP: number
   PR_CAPBSET_READ: number
   PR_GET_CHILD_SUBREAPER: number
@@ -731,6 +1141,7 @@ local record unix
   PR_SET_NAME: number
   PR_SET_NO_NEW_PRIVS: number
   PR_SET_PDEATHSIG: number
+  --- @type integer Linux capability bits (prctl PR_CAPBSET_*, capget/capset).
   CAP_AUDIT_CONTROL: number
   CAP_AUDIT_READ: number
   CAP_AUDIT_WRITE: number
@@ -773,6 +1184,7 @@ local record unix
   CAP_SYS_TIME: number
   CAP_SYS_TTY_CONFIG: number
   CAP_WAKE_ALARM: number
+  --- @type integer mount()/umount2() flags
   MS_BIND: number
   MS_DIRSYNC: number
   MS_LAZYTIME: number
@@ -799,6 +1211,7 @@ local record unix
   MNT_EXPIRE: number
   MNT_FORCE: number
   UMOUNT_NOFOLLOW: number
+  --- @type integer statvfs f_flag bits (unix.Statfs / statvfs)
   ST_APPEND: number
   ST_IMMUTABLE: number
   ST_MANDLOCK: number
@@ -811,111 +1224,202 @@ local record unix
   ST_RELATIME: number
   ST_SYNCHRONOUS: number
   ST_WRITE: number
+  --- @type integer
   RUSAGE_BOTH: number
+  --- @type integer
   RUSAGE_CHILDREN: number
+  --- @type integer
   RUSAGE_SELF: number
+  --- @type integer
   RUSAGE_THREAD: number
+  --- @type integer
   R_OK: number
+  --- @type integer
   SA_NOCLDSTOP: number
+  --- @type integer
   SA_NOCLDWAIT: number
+  --- @type integer
   SA_NODEFER: number
+  --- @type integer
   SA_RESETHAND: number
+  --- @type integer
   SA_RESTART: number
+  --- @type integer
   SEEK_CUR: number
+  --- @type integer
   SEEK_END: number
+  --- @type integer
   SEEK_SET: number
   SHUT_RD: number
   SHUT_WR: number
   SHUT_RDWR: number
+  --- @type integer Process aborted.
   SIGABRT: number
+  --- @type integer Sent by setitimer().
   SIGALRM: number
+  --- @type integer Valid memory access that went beyond underlying end of file.
   SIGBUS: number
+  --- @type integer Child process exited or terminated and is now a zombie (unless this
+  --- is `SIG_IGN` or `SA_NOCLDWAIT`) or child process stopped due to terminal
+  --- i/o or profiling/debugging (unless you used `SA_NOCLDSTOP`)
   SIGCHLD: number
+  --- @type integer Child process resumed from profiling/debugging.
   SIGCONT: number
-  SIGEMT: number
+  --- @type integer Illegal math.
   SIGFPE: number
+  --- @type integer Terminal hangup or daemon reload; auto-broadcasted to process group.
   SIGHUP: number
+  --- @type integer Illegal instruction.
   SIGILL: number
-  SIGINFO: number
+  --- @type integer Terminal CTRL-C keystroke.
   SIGINT: number
-  SIGIO: number
+  --- @type integer Terminate with extreme prejudice.
   SIGKILL: number
+  --- @type integer Write to closed file descriptor.
   SIGPIPE: number
+  --- @type integer Profiling timer expired.
   SIGPROF: number
-  SIGPWR: number
+  --- @type integer Terminal CTRL-\ keystroke.
   SIGQUIT: number
-  SIGRTMAX: number
-  SIGRTMIN: number
+  --- @type integer Invalid memory access.
   SIGSEGV: number
-  SIGSTKFLT: number
+  --- @type integer Child process stopped due to profiling/debugging.
   SIGSTOP: number
+  --- @type integer
   SIGSYS: number
+  --- @type integer Terminate.
   SIGTERM: number
+  --- @type integer INT3 instruction.
   SIGTRAP: number
+  --- @type integer Terminal CTRL-Z keystroke.
   SIGTSTP: number
+  --- @type integer Terminal input for background process.
   SIGTTIN: number
+  --- @type integer Terminal input for background process.
   SIGTTOU: number
+  --- @type integer
   SIGURG: number
+  --- @type integer Do whatever you want.
   SIGUSR1: number
+  --- @type integer Do whatever you want.
   SIGUSR2: number
+  --- @type integer Virtual alarm clock.
   SIGVTALRM: number
+  --- @type integer Terminal resized.
   SIGWINCH: number
+  --- @type integer CPU time limit exceeded.
   SIGXCPU: number
+  --- @type integer File size limit exceeded.
   SIGXFSZ: number
+  --- @type integer
   SIG_BLOCK: number
+  --- @type integer
   SIG_DFL: number
+  --- @type integer
   SIG_IGN: number
+  --- @type integer
   SIG_SETMASK: number
+  --- @type integer
   SIG_UNBLOCK: number
+  --- @type integer
   SOCK_CLOEXEC: number
+  --- @type integer
   SOCK_DGRAM: number
+  --- @type integer
   SOCK_NONBLOCK: number
+  --- @type integer
   SOCK_RAW: number
+  --- @type integer
   SOCK_RDM: number
+  --- @type integer
   SOCK_SEQPACKET: number
+  --- @type integer
   SOCK_STREAM: number
+  --- @type integer
   SOL_IP: number
+  --- @type integer
   SOL_SOCKET: number
+  --- @type integer
   SOL_TCP: number
+  --- @type integer
   SOL_UDP: number
+  --- @type integer
   SO_ACCEPTCONN: number
+  --- @type integer
   SO_BROADCAST: number
+  --- @type integer
   SO_DEBUG: number
+  --- @type integer
   SO_DONTROUTE: number
+  --- @type integer
   SO_ERROR: number
+  --- @type integer
   SO_KEEPALIVE: number
+  --- @type integer
   SO_LINGER: number
+  --- @type integer
   SO_OOBINLINE: number
+  --- @type integer
   SO_RCVBUF: number
+  --- @type integer
   SO_RCVLOWAT: number
+  --- @type integer
   SO_RCVTIMEO: number
+  --- @type integer
   SO_REUSEADDR: number
+  --- @type integer
   SO_REUSEPORT: number
+  --- @type integer
   SO_SNDBUF: number
+  --- @type integer
   SO_SNDLOWAT: number
+  --- @type integer
   SO_SNDTIMEO: number
+  --- @type integer
   SO_TYPE: number
+  --- @type integer
   TCP_CORK: number
+  --- @type integer
   TCP_DEFER_ACCEPT: number
+  --- @type integer
   TCP_FASTOPEN: number
+  --- @type integer
   TCP_FASTOPEN_CONNECT: number
+  --- @type integer
   TCP_KEEPCNT: number
+  --- @type integer
   TCP_KEEPIDLE: number
+  --- @type integer
   TCP_KEEPINTVL: number
+  --- @type integer
   TCP_MAXSEG: number
+  --- @type integer
   TCP_NODELAY: number
+  --- @type integer
   TCP_NOTSENT_LOWAT: number
+  --- @type integer
   TCP_QUICKACK: number
+  --- @type integer
   TCP_SAVED_SYN: number
+  --- @type integer
   TCP_SAVE_SYN: number
+  --- @type integer
   TCP_SYNCNT: number
+  --- @type integer
   TCP_WINDOW_CLAMP: number
+  --- @type integer
   UTIME_NOW: number
+  --- @type integer
   UTIME_OMIT: number
+  --- @type integer
   WNOHANG: number
+  --- @type integer
   WUNTRACED: number
+  --- @type integer Report continued child processes.
   WCONTINUED: number
+  --- @type integer
   W_OK: number
+  --- @type integer
   X_OK: number
 
   --- Opens file.
@@ -1073,7 +1577,7 @@ local record unix
   --- Hence it should come as no surprise that `fork()` would go slower on
   --- operating systems that have more security features. So depending on
   --- your use case, you can choose the operating system that suits you.
-  fork: function(): number | number, Errno
+  fork: function(): number, Errno
   --- Performs `$PATH` lookup of executable.
   ---     unix = require 'unix'
   ---     prog = assert(unix.commandv('ls'))
@@ -1509,7 +2013,7 @@ local record unix
   ---   Returned `pid` is the process id of the current lock owner.
   ---   This function is currently not supported on Windows.
   ---   Returns `EBADF` if `fd` wasn't open.
-  fcntl: function(fd: number, cmd: number, ...: any): any, Errno
+  fcntl: function(fd: number, cmd: number, ...: any): any...
   --- Gets session id.
   getsid: function(pid: number): number, Errno
   --- Gets process group id.
@@ -2483,7 +2987,7 @@ local record unix
   setns: function(fd: number, nstype?: number): boolean, Errno
   --- Mounts a filesystem. `flags` is a bitwise OR of `unix.MS_*`
   --- constants; `data` is a filesystem-specific options string.
-  mount: function(source?: string, target: string, fstype?: string, flags?: number, data?: string): boolean, Errno
+  mount: function(source?: string, target?: string, fstype?: string, flags?: number, data?: string): boolean, Errno
   --- Unmounts a filesystem. On Linux this is the `umount2` syscall.
   --- `flags` may include `unix.MNT_FORCE`, `unix.MNT_DETACH`,
   --- `unix.MNT_EXPIRE`, `unix.UMOUNT_NOFOLLOW`.
@@ -2593,4 +3097,3 @@ local record unix
 end
 
 return unix
-

--- a/lib/types/cosmo/zip.d.tl
+++ b/lib/types/cosmo/zip.d.tl
@@ -1,4 +1,6 @@
 -- type declarations for cosmo.zip
+-- GENERATED from cosmopolitan's definitions.lua by lib/types/gentype.tl.
+-- Do not edit by hand. Regenerate with: bin/make regen-types
 
 local record OpenOptions
   --- Compression level 0-9 (for "w" and "a" modes)
@@ -56,18 +58,44 @@ end
 local record Appender
   --- Adds a file to the ZIP archive.
   add: function(self: Appender, name: string, content: string, options?: AddOptions): boolean | nil, string | nil
-  --- Removes a file from the ZIP archive by name.
+  --- Removes entries by name from the archive.
+  --- If `name` ends with `/`, all entries whose names start with that
+  --- directory prefix are removed; otherwise the single entry whose name
+  --- matches exactly is removed. Both entries already present in the
+  --- archive and entries added via `add` but not yet flushed are matched.
+  --- The local file data of removed existing entries remains as dead space
+  --- in the archive; only the central directory reference is removed.
+  --- Fails with an error if no entry matched or the appender is closed.
   remove: function(self: Appender, name: string): boolean | nil, string | nil
   --- Closes the ZIP archive and writes the updated central directory.
   close: function(self: Appender)
 end
 
 local record zip
+  type OpenOptions = OpenOptions
+  type Stat = Stat
+  type AddOptions = AddOptions
+  type Reader = Reader
+  type Writer = Writer
+  type Appender = Appender
+
   --- Opens a ZIP archive for reading, writing, or appending.
   --- The first argument can be a file path string or a file descriptor integer.
   open: function(path: string | number, mode?: string, options?: OpenOptions): any, string | nil
   --- Opens a ZIP archive from in-memory data for reading.
   from: function(data: string, options?: OpenOptions): Reader | nil, string | nil
+  --- Creates a new ZIP archive for writing. This is equivalent to
+  --- `zip.open(path, "w", options)`. Any existing file is truncated.
+  create: function(path: string | number, options?: OpenOptions): Writer | nil, string | nil
+  --- Opens an existing ZIP archive for appending. This is equivalent to
+  --- `zip.open(path, "a", options)`. Unlike `zip.open` and `zip.create`,
+  --- a file descriptor is not accepted; the archive must be given as a
+  --- path.
+  append: function(path: string, options?: OpenOptions): Appender | nil, string | nil
+  --- Validates a ZIP entry name without adding it to an archive, applying
+  --- the same rules that `add` enforces (relative path, no `..` segments,
+  --- no control characters, etc.).
+  validate_name: function(name: string): boolean | nil, string | nil
 end
 
 return zip

--- a/lib/types/gentype.tl
+++ b/lib/types/gentype.tl
@@ -20,197 +20,24 @@ local record GentypeRender
 end
 local render = require("types.gentype_render") as GentypeRender
 
--- Modules to generate (in order)
-local MODULES = {"unix", "path", "getopt", "lsqlite3", "re", "argon2", "zip"}
+local record GentypeParse
+  parse_annotations: function(raw_lines: {string}): {string}, {Param}, {Return}, boolean, string, {Field}, boolean, string
+end
+local parse = require("types.gentype_parse") as GentypeParse
+local parse_annotations = parse.parse_annotations
 
---- Split the text following an `@param name` (or a `@return` entry) into its
---- type and trailing description. Handles parenthesized union types such as
---- `(integer | string)?` whose internal spaces would otherwise truncate the
---- type at the first whitespace.
-local function split_type_desc(rest: string): string, string
-  if rest:sub(1, 1) == "(" then
-    local depth = 0
-    for k = 1, #rest do
-      local c = rest:sub(k, k)
-      if c == "(" then
-        depth = depth + 1
-      elseif c == ")" then
-        depth = depth - 1
-        if depth == 0 then
-          local after = rest:sub(k + 1)
-          local q = after:match("^%?") and "?" or ""
-          local desc = after:sub(#q + 1):match("^%s*(.-)%s*$")
-          return rest:sub(1, k) .. q, desc
-        end
-      end
-    end
-  end
-  local t, d = rest:match("^([^%s]+)%s*(.-)%s*$")
-  return t or rest, d or ""
+-- Modules to generate (in order). "cosmo" is the top-level cosmo record
+-- (kCosmoFuncs surface); the rest are require("cosmo.<name>") submodules.
+local MODULES = {"cosmo", "unix", "path", "getopt", "lsqlite3", "re", "argon2", "zip", "repl"}
+
+-- Default definitions.lua source: the copy embedded in the running binary,
+-- which is always the one the pinned cosmos release was built with. The
+-- GENTYPE_DEFS env var overrides it for pre-release validation against a
+-- cosmopolitan checkout.
+local function defs_path(): string
+  return os.getenv("GENTYPE_DEFS") or "/zip/.lua/definitions.lua"
 end
 
---- Parse annotations from a block of text before a declaration.
-local function parse_annotations(lines: {string}): {string}, {Param}, {Return}, boolean, string, {Field}, boolean, string
-  local desc: {string} = {}
-  local params: {Param} = {}
-  local returns: {Return} = {}
-  local fields: {Field} = {}
-  local nodiscard = false
-  local class_annotation: string = nil
-  -- A fallible function's failure return is expressed upstream as an
-  -- `@overload fun(...): nil, <error> unix.Errno`. LuaLS renders that as a
-  -- second signature; the generator instead folds it into a trailing `, Errno`
-  -- return so callers see `value, Errno`. Detect any overload whose return list
-  -- carries an Errno type.
-  local fallible = false
-  local error_type: string = nil
-
-  for _, line in ipairs(lines) do
-    if not line:match("^%-%-%-@") then
-      local desc_text = line:match("^%-%-%-(.*)$")
-      if desc_text then
-        if desc_text:sub(1, 1) == " " then
-          desc_text = desc_text:sub(2)
-        end
-        if desc_text ~= "" then
-          table.insert(desc, desc_text)
-        end
-      end
-    end
-
-    local pname, prest = line:match("^%-%-%-@param%s+([%w_%.%?]+)%s+(.+)$")
-    if pname then
-      local ptype, pdesc = split_type_desc(prest)
-      local optional = ptype:match("%?$") ~= nil
-      if optional then
-        ptype = ptype:sub(1, -2)
-      end
-      if pname:match("%?$") then
-        optional = true
-        pname = pname:sub(1, -2)
-      end
-      table.insert(params, {name = pname, param_type = ptype, description = pdesc or "", optional = optional})
-    end
-
-    local fname, ftype, fdesc = line:match("^%-%-%-@field%s+([%w_%.%?]+)%s+([^%s]+)%s*(.*)$")
-    if fname then
-      local optional = false
-      if fname:match("%?$") then
-        optional = true
-        fname = fname:sub(1, -2)
-      end
-      if ftype:match("%?$") then
-        optional = true
-        ftype = ftype:sub(1, -2)
-      end
-      table.insert(fields, {name = fname, field_type = ftype, description = {fdesc or ""}})
-    end
-
-    local full_return = line:match("^%-%-%-@return%s+(.+)$")
-    if full_return then
-      full_return = full_return:match("^%s*(.-)%s*$")
-
-      local parts = {}
-      local in_angle = 0
-      local in_brace = 0
-      local in_paren = 0
-      local current = ""
-      for i = 1, #full_return do
-        local c = full_return:sub(i, i)
-        if c == "<" then in_angle = in_angle + 1
-        elseif c == ">" then in_angle = in_angle - 1
-        elseif c == "{" then in_brace = in_brace + 1
-        elseif c == "}" then in_brace = in_brace - 1
-        elseif c == "(" then in_paren = in_paren + 1
-        elseif c == ")" then in_paren = in_paren - 1
-        end
-        if c == "," and in_angle == 0 and in_brace == 0 and in_paren == 0 then
-          local rest_after_comma = full_return:sub(i + 1)
-          local next_word = rest_after_comma:match("^%s*([%w_%.]+)")
-          local lua_keywords = {
-            ["and"] = true, ["or"] = true, ["not"] = true,
-            ["if"] = true, ["then"] = true, ["else"] = true, ["elseif"] = true,
-            ["end"] = true, ["while"] = true, ["do"] = true, ["for"] = true,
-            ["repeat"] = true, ["until"] = true, ["break"] = true, ["return"] = true,
-            ["local"] = true, ["in"] = true,
-          }
-          local is_function_call = rest_after_comma:match("^%s*" .. (next_word or "") .. "%s*%(")
-          if next_word and not lua_keywords[next_word] and not is_function_call and (
-            next_word:match("^[%l_]") or next_word:match("^[%u]") or next_word:match("%.")
-          ) then
-            table.insert(parts, current)
-            current = ""
-          else
-            current = current .. c
-          end
-        else
-          current = current .. c
-        end
-      end
-      table.insert(parts, current)
-
-      for _, return_part in ipairs(parts) do
-        return_part = return_part:match("^%s*(.-)%s*$")
-        local part_type: string = nil
-        local part_desc: string = nil
-        if return_part:match("^%(") then
-          part_type, part_desc = split_type_desc(return_part)
-        elseif return_part:match("^{") then
-          part_type, part_desc = return_part:match("^({.-%}%[?%]?)%s+(.*)$")
-          if not part_type then
-            part_type = return_part:match("^({.-%}%[?%]?)%s*$")
-          end
-        elseif return_part:match("<.->") then
-          part_type, part_desc = return_part:match("^([^%s]+<.->)%s+(.*)$")
-          if not part_type then
-            part_type = return_part:match("^([^%s]+<.->)%s*$")
-          end
-        end
-        if not part_type then
-          part_type, part_desc = return_part:match("^([^%s]+)%s+(.*)$")
-          if not part_type then
-            part_type = return_part
-          end
-        end
-        if part_type and part_type ~= "" then
-          if part_type == "table" and part_desc then
-            local specific_type = part_desc:match("^([%w_]+)")
-            if specific_type and specific_type:match("^[%l_]") then
-              part_type = specific_type
-              part_desc = part_desc:match("^[%w_]+%s*(.*)") or part_desc
-            end
-          end
-          table.insert(returns, {return_type = part_type, description = part_desc or ""})
-        end
-      end
-    end
-
-    if line:match("^%-%-%-@nodiscard") then
-      nodiscard = true
-    end
-
-    local overload_ret = line:match("^%-%-%-@overload%s+fun%b()%s*:%s*(.+)$")
-    if overload_ret then
-      local et = overload_ret:match("([%w_]+%.Errno)") or overload_ret:match("(Errno)")
-      if et then
-        fallible = true
-        error_type = et
-      end
-    end
-
-    local cname = line:match("^%-%-%-@class%s+([%w_%.]+)")
-    if cname then
-      class_annotation = cname
-    end
-
-    local ttype = line:match("^%-%-%-?%s*@type%s+([%w_]+)")
-    if ttype then
-      table.insert(returns, {return_type = ttype, description = "type"})
-    end
-  end
-
-  return desc, params, returns, nodiscard, class_annotation, fields, fallible, error_type
-end
 
 --- Helper to process a class annotation block.
 local function process_class_block(anno_lines: {string}, module_name: string, classes: {ClassDecl})
@@ -246,6 +73,17 @@ local function process_class_block(anno_lines: {string}, module_name: string, cl
   end
 end
 
+--- True when an annotation block carries a `---@type` tag (used to surface
+--- lowercase module-table fields such as `argon2.variants`).
+local function has_type_annotation(anno_lines: {string}): boolean
+  for _, line in ipairs(anno_lines) do
+    if line:match("^%s*%-%-%-?%s*@type%s") then
+      return true
+    end
+  end
+  return false
+end
+
 --- Parse a module from definitions.lua source.
 local function parse_module(source: string, module_name: string): ModuleDecl
   local content = render.extract_module_content(source, module_name)
@@ -256,8 +94,10 @@ local function parse_module(source: string, module_name: string): ModuleDecl
     functions = {}, classes = {}, constants = {},
   }
 
+  -- Keep empty lines: a blank line terminates an annotation block (e.g. a
+  -- standalone @class block emitted by extract_module_content).
   local lines: {string} = {}
-  for line in content:gmatch("[^\n]+") do
+  for line in (content .. "\n"):gmatch("([^\n]*)\n") do
     table.insert(lines, line)
   end
 
@@ -278,6 +118,21 @@ local function parse_module(source: string, module_name: string): ModuleDecl
       if line:match("^%-%-%-@class%s+") then
         in_class_block = true
       end
+      i = i + 1
+    elseif line:match("^%s*[%l_][%w_]*%s*=%s*") and not line:match("^%s*local%s") and
+      has_type_annotation(anno_lines) then
+      -- A lowercase module-table field annotated with `---@type <T>` (e.g.
+      -- `argon2.variants`) becomes a typed field on the module record.
+      local fname = line:match("^%s*([%l_][%w_]*)%s*=")
+      if fname and fname ~= module_name then
+        local desc, _, returns, _, _, _ = parse_annotations(anno_lines)
+        if #returns > 0 and returns[1].description == "type" then
+          table.insert(module.constants, {
+              name = fname, const_type = returns[1].return_type, description = desc,
+            })
+        end
+      end
+      anno_lines = {}
       i = i + 1
     elseif line:match("^%s*([A-Z][A-Z0-9_]*)%s*=%s*") then
       local name = line:match("^%s*([A-Z][A-Z0-9_]*)%s*=")
@@ -412,9 +267,9 @@ end
 
 --- Run the generator for a specific module or all modules.
 local function run(module_name: string): Result
-  local source = cosmo.Slurp("/zip/.lua/definitions.lua")
+  local source = cosmo.Slurp(defs_path())
   if not source then
-    return {success = false, error = "Failed to read /zip/.lua/definitions.lua"}
+    return {success = false, error = "Failed to read " .. defs_path()}
   end
 
   if module_name then

--- a/lib/types/gentype.tl
+++ b/lib/types/gentype.tl
@@ -84,6 +84,44 @@ local function has_type_annotation(anno_lines: {string}): boolean
   return false
 end
 
+--- Reconcile annotated params with the declaration's parameter list. The
+--- declaration is authoritative for names and order; annotations attach
+--- types. A declared-but-unannotated param becomes `any` (required, unless a
+--- preceding param is optional — Teal forbids required-after-optional).
+local function reconcile_params(params: {Param}, params_str: string): {Param}
+  if not params_str or params_str == "" then return params end
+  local by_name: {string: Param} = {}
+  for _, p in ipairs(params) do by_name[p.name] = p end
+  local result: {Param} = {}
+  local used: {string: boolean} = {}
+  for token in params_str:gmatch("[^,]+") do
+    local pname = token:match("^%s*(.-)%s*$")
+    if pname ~= "" then
+      local p = by_name[pname]
+      if p then
+        table.insert(result, p)
+        used[pname] = true
+      else
+        table.insert(result, {name = pname, param_type = "any", description = "", optional = false})
+      end
+    end
+  end
+  for _, p in ipairs(params) do
+    if not used[p.name] then
+      table.insert(result, p)
+    end
+  end
+  local seen_optional = false
+  for _, p in ipairs(result) do
+    if p.optional then
+      seen_optional = true
+    elseif seen_optional then
+      p.optional = true
+    end
+  end
+  return result
+end
+
 --- Parse a module from definitions.lua source.
 local function parse_module(source: string, module_name: string): ModuleDecl
   local content = render.extract_module_content(source, module_name)
@@ -197,11 +235,7 @@ local function parse_module(source: string, module_name: string): ModuleDecl
       end
 
       local desc, params, returns, nodiscard, _, _, fallible, error_type = parse_annotations(anno_lines)
-      if #params == 0 and params_str and params_str ~= "" then
-        for pname in params_str:gmatch("([%w_]+)") do
-          table.insert(params, {name = pname, param_type = "any", description = "", optional = true})
-        end
-      end
+      params = reconcile_params(params, params_str)
       table.insert(module.functions, {
           name = fname, module = module_name, description = desc,
           params = params, returns = returns, is_method = false, nodiscard = nodiscard,
@@ -214,11 +248,7 @@ local function parse_module(source: string, module_name: string): ModuleDecl
       local class_name = full_class_name:match("%.([%w_]+)$") or full_class_name
       local method_params_str = line:match("%((.-)%)")
       local desc, params, returns, nodiscard, _, _, fallible, error_type = parse_annotations(anno_lines)
-      if #params == 0 and method_params_str and method_params_str ~= "" then
-        for pname in method_params_str:gmatch("([%w_]+)") do
-          table.insert(params, {name = pname, param_type = "any", description = "", optional = true})
-        end
-      end
+      params = reconcile_params(params, method_params_str)
       local method: FuncDecl = {
         name = method_name, module = module_name, description = desc,
         params = params, returns = returns, is_method = true,

--- a/lib/types/gentype_parse.tl
+++ b/lib/types/gentype_parse.tl
@@ -6,30 +6,35 @@ local Param = gt.Param
 local Return = gt.Return
 local Field = gt.Field
 
---- Split the text following an `@param name` (or a `@return` entry) into its
---- type and trailing description. Handles parenthesized union types such as
---- `(integer | string)?` whose internal spaces would otherwise truncate the
---- type at the first whitespace.
-local function split_type_desc(rest: string): string, string
-  if rest:sub(1, 1) == "(" then
-    local depth = 0
-    for k = 1, #rest do
-      local c = rest:sub(k, k)
-      if c == "(" then
-        depth = depth + 1
-      elseif c == ")" then
-        depth = depth - 1
-        if depth == 0 then
-          local after = rest:sub(k + 1)
-          local q = after:match("^%?") and "?" or ""
-          local desc = after:sub(#q + 1):match("^%s*(.-)%s*$")
-          return rest:sub(1, k) .. q, desc
-        end
-      end
+--- Consume one type token from the head of `s`, treating whitespace inside
+--- balanced (), {}, <> as part of the token (inline table types such as
+--- `{ useoutput: boolean }?` and grouped unions carry internal spaces).
+--- Returns the token and the remaining (trimmed) text.
+local function scan_token(s: string): string, string
+  local depth = 0
+  local stop = 0
+  for k = 1, #s do
+    local c = s:sub(k, k)
+    if c == "(" or c == "{" or c == "<" then
+      depth = depth + 1
+    elseif c == ")" or c == "}" or c == ">" then
+      depth = depth - 1
+    elseif c:match("%s") and depth == 0 then
+      break
     end
+    stop = k
   end
-  -- `fun(...)` types carry internal spaces; scan to the balanced close paren,
-  -- then take an optional `?` and an optional `: <ret>` return annotation.
+  if stop > 0 then
+    return s:sub(1, stop), s:sub(stop + 1):match("^%s*(.-)%s*$")
+  end
+  return s, ""
+end
+
+--- Split the text following an `@param name` (or a `@return` entry) into its
+--- type and trailing description. `fun(...)` types get their optional `?` and
+--- `: <ret>` return annotation folded into the type token; the return itself
+--- may be a braced or grouped type with internal spaces.
+local function split_type_desc(rest: string): string, string
   if rest:match("^fun%(") then
     local depth = 0
     for k = 1, #rest do
@@ -39,23 +44,29 @@ local function split_type_desc(rest: string): string, string
       elseif c == ")" then
         depth = depth - 1
         if depth == 0 then
-          local stop = k
+          local head = rest:sub(1, k)
           local after = rest:sub(k + 1)
           local q = after:match("^%?") and "?" or ""
           after = after:sub(#q + 1)
-          local ret = after:match("^:%s*([^%s]+)")
-          if ret then
-            local ret_at = after:find(ret, 1, true)
-            after = after:sub(ret_at + #ret)
-            return rest:sub(1, stop) .. ": " .. ret .. q, after:match("^%s*(.-)%s*$")
+          local colon = after:match("^:%s*")
+          if colon then
+            after = after:sub(#colon + 1)
+            local ret: string
+            if after:match("^%.%.%.") then
+              -- A typed vararg return (`fun(...): ...: string|nil`).
+              ret = after:match("^(%.%.%.:%s*[^%s]+)") or "..."
+              after = after:sub(#ret + 1)
+            else
+              ret, after = scan_token(after)
+            end
+            return head .. ": " .. ret .. q, after:match("^%s*(.-)%s*$")
           end
-          return rest:sub(1, stop) .. q, after:match("^%s*(.-)%s*$")
+          return head .. q, after:match("^%s*(.-)%s*$")
         end
       end
     end
   end
-  local t, d = rest:match("^([^%s]+)%s*(.-)%s*$")
-  return t or rest, d or ""
+  return scan_token(rest)
 end
 
 --- Parse annotations from a block of text before a declaration.
@@ -141,19 +152,29 @@ local function parse_annotations(raw_lines: {string}): {string}, {Param}, {Retur
         elseif c == ")" then in_paren = in_paren - 1
         end
         if c == "," and in_angle == 0 and in_brace == 0 and in_paren == 0 then
+          -- Split into another return only when the comma is followed by a
+          -- genuine type token: a builtin type name or a module-dotted type
+          -- (`unix.Errno`). Prose in a trailing description ("ARIN, APNIC,
+          -- DOD, etc.") must stay in the description.
           local rest_after_comma = full_return:sub(i + 1)
           local next_word = rest_after_comma:match("^%s*([%w_%.]+)")
-          local lua_keywords = {
-            ["and"] = true, ["or"] = true, ["not"] = true,
-            ["if"] = true, ["then"] = true, ["else"] = true, ["elseif"] = true,
-            ["end"] = true, ["while"] = true, ["do"] = true, ["for"] = true,
-            ["repeat"] = true, ["until"] = true, ["break"] = true, ["return"] = true,
-            ["local"] = true, ["in"] = true,
+          local builtin_types: {string: boolean} = {
+            ["integer"] = true, ["string"] = true, ["number"] = true,
+            ["boolean"] = true, ["any"] = true, ["nil"] = true,
+            ["table"] = true, ["function"] = true, ["userdata"] = true,
+            ["uint32"] = true, ["uint16"] = true, ["int64"] = true,
+            ["true"] = true, ["false"] = true, ["fun"] = true,
           }
-          local is_function_call = rest_after_comma:match("^%s*" .. (next_word or "") .. "%s*%(")
-          if next_word and not lua_keywords[next_word] and not is_function_call and (
-            next_word:match("^[%l_]") or next_word:match("^[%u]") or next_word:match("%.")
-          ) then
+          local is_type_token = false
+          if next_word then
+            local first = next_word:match("^([%w_]+)")
+            if first and builtin_types[first] then
+              is_type_token = true
+            elseif next_word:match("^[%l_][%w_]*%.[%w_]") then
+              is_type_token = true
+            end
+          end
+          if is_type_token then
             table.insert(parts, current)
             current = ""
           else
@@ -177,25 +198,7 @@ local function parse_annotations(raw_lines: {string}): {string}, {Param}, {Retur
           table.insert(returns, {return_type = va_type .. "...", description = ""})
           break
         end
-        if return_part:match("^%(") then
-          part_type, part_desc = split_type_desc(return_part)
-        elseif return_part:match("^{") then
-          part_type, part_desc = return_part:match("^({.-%}%[?%]?)%s+(.*)$")
-          if not part_type then
-            part_type = return_part:match("^({.-%}%[?%]?)%s*$")
-          end
-        elseif return_part:match("<.->") then
-          part_type, part_desc = return_part:match("^([^%s]+<.->)%s+(.*)$")
-          if not part_type then
-            part_type = return_part:match("^([^%s]+<.->)%s*$")
-          end
-        end
-        if not part_type then
-          part_type, part_desc = return_part:match("^([^%s]+)%s+(.*)$")
-          if not part_type then
-            part_type = return_part
-          end
-        end
+        part_type, part_desc = split_type_desc(return_part)
         if part_type and part_type ~= "" then
           if part_type == "table" and part_desc then
             local specific_type = part_desc:match("^([%w_]+)")
@@ -218,12 +221,19 @@ local function parse_annotations(raw_lines: {string}): {string}, {Param}, {Retur
       generics[gname] = true
     end
 
+    -- A failure overload's return list starts with `nil`; the error value
+    -- follows, optionally labeled (`nil, error: string`, `nil, errno:
+    -- integer`, `nil, unix.Errno`). Success-variant overloads (e.g. a
+    -- useoutput=true encoding overload returning `true`) must not trigger.
     local overload_ret = line:match("^%-%-%-@overload%s+fun%b()%s*:%s*(.+)$")
     if overload_ret then
-      local et = overload_ret:match("([%w_]+%.Errno)") or overload_ret:match("(Errno)")
-      if et then
-        fallible = true
-        error_type = et
+      local after_nil = overload_ret:match("^nil%s*,%s*(.+)$")
+      if after_nil then
+        local et = after_nil:match("^[%w_]+:%s*([%w_%.]+)") or after_nil:match("^([%w_%.]+)")
+        if et then
+          fallible = true
+          error_type = et
+        end
       end
     end
 

--- a/lib/types/gentype_parse.tl
+++ b/lib/types/gentype_parse.tl
@@ -1,0 +1,269 @@
+--- Annotation-block parsing for gentype.
+--- Splits `@param`/`@return` text into types and descriptions and parses a
+--- LuaLS annotation block into structured declarations.
+local gt = require("types.gentype_types")
+local Param = gt.Param
+local Return = gt.Return
+local Field = gt.Field
+
+--- Split the text following an `@param name` (or a `@return` entry) into its
+--- type and trailing description. Handles parenthesized union types such as
+--- `(integer | string)?` whose internal spaces would otherwise truncate the
+--- type at the first whitespace.
+local function split_type_desc(rest: string): string, string
+  if rest:sub(1, 1) == "(" then
+    local depth = 0
+    for k = 1, #rest do
+      local c = rest:sub(k, k)
+      if c == "(" then
+        depth = depth + 1
+      elseif c == ")" then
+        depth = depth - 1
+        if depth == 0 then
+          local after = rest:sub(k + 1)
+          local q = after:match("^%?") and "?" or ""
+          local desc = after:sub(#q + 1):match("^%s*(.-)%s*$")
+          return rest:sub(1, k) .. q, desc
+        end
+      end
+    end
+  end
+  -- `fun(...)` types carry internal spaces; scan to the balanced close paren,
+  -- then take an optional `?` and an optional `: <ret>` return annotation.
+  if rest:match("^fun%(") then
+    local depth = 0
+    for k = 1, #rest do
+      local c = rest:sub(k, k)
+      if c == "(" then
+        depth = depth + 1
+      elseif c == ")" then
+        depth = depth - 1
+        if depth == 0 then
+          local stop = k
+          local after = rest:sub(k + 1)
+          local q = after:match("^%?") and "?" or ""
+          after = after:sub(#q + 1)
+          local ret = after:match("^:%s*([^%s]+)")
+          if ret then
+            local ret_at = after:find(ret, 1, true)
+            after = after:sub(ret_at + #ret)
+            return rest:sub(1, stop) .. ": " .. ret .. q, after:match("^%s*(.-)%s*$")
+          end
+          return rest:sub(1, stop) .. q, after:match("^%s*(.-)%s*$")
+        end
+      end
+    end
+  end
+  local t, d = rest:match("^([^%s]+)%s*(.-)%s*$")
+  return t or rest, d or ""
+end
+
+--- Parse annotations from a block of text before a declaration.
+local function parse_annotations(raw_lines: {string}): {string}, {Param}, {Return}, boolean, string, {Field}, boolean, string
+  local desc: {string} = {}
+  local params: {Param} = {}
+  local returns: {Return} = {}
+  local fields: {Field} = {}
+  local nodiscard = false
+  local class_annotation: string = nil
+  -- Annotations inside a module table (constants, @type fields) are indented;
+  -- strip leading whitespace so the anchored tag patterns below see them.
+  local lines: {string} = {}
+  local generics: {string: boolean} = {}
+  for _, raw in ipairs(raw_lines) do
+    table.insert(lines, raw:match("^%s*(%-%-%-.*)$") or raw)
+  end
+  -- A fallible function's failure return is expressed upstream as an
+  -- `@overload fun(...): nil, <error> unix.Errno`. LuaLS renders that as a
+  -- second signature; the generator instead folds it into a trailing `, Errno`
+  -- return so callers see `value, Errno`. Detect any overload whose return list
+  -- carries an Errno type.
+  local fallible = false
+  local error_type: string = nil
+
+  for _, line in ipairs(lines) do
+    if not line:match("^%-%-%-@") then
+      local desc_text = line:match("^%-%-%-(.*)$")
+      if desc_text then
+        if desc_text:sub(1, 1) == " " then
+          desc_text = desc_text:sub(2)
+        end
+        if desc_text ~= "" then
+          table.insert(desc, desc_text)
+        end
+      end
+    end
+
+    local pname, prest = line:match("^%-%-%-@param%s+([%w_%.%?]+)%s+(.+)$")
+    if pname then
+      local ptype, pdesc = split_type_desc(prest)
+      local optional = ptype:match("%?$") ~= nil
+      if optional then
+        ptype = ptype:sub(1, -2)
+      end
+      if pname:match("%?$") then
+        optional = true
+        pname = pname:sub(1, -2)
+      end
+      table.insert(params, {name = pname, param_type = ptype, description = pdesc or "", optional = optional})
+    end
+
+    local fname, ftype, fdesc = line:match("^%-%-%-@field%s+([%w_%.%?]+)%s+([^%s]+)%s*(.*)$")
+    if fname then
+      local optional = false
+      if fname:match("%?$") then
+        optional = true
+        fname = fname:sub(1, -2)
+      end
+      if ftype:match("%?$") then
+        optional = true
+        ftype = ftype:sub(1, -2)
+      end
+      table.insert(fields, {name = fname, field_type = ftype, description = {fdesc or ""}})
+    end
+
+    local full_return = line:match("^%-%-%-@return%s+(.+)$")
+    if full_return then
+      full_return = full_return:match("^%s*(.-)%s*$")
+
+      local parts = {}
+      local in_angle = 0
+      local in_brace = 0
+      local in_paren = 0
+      local current = ""
+      for i = 1, #full_return do
+        local c = full_return:sub(i, i)
+        if c == "<" then in_angle = in_angle + 1
+        elseif c == ">" then in_angle = in_angle - 1
+        elseif c == "{" then in_brace = in_brace + 1
+        elseif c == "}" then in_brace = in_brace - 1
+        elseif c == "(" then in_paren = in_paren + 1
+        elseif c == ")" then in_paren = in_paren - 1
+        end
+        if c == "," and in_angle == 0 and in_brace == 0 and in_paren == 0 then
+          local rest_after_comma = full_return:sub(i + 1)
+          local next_word = rest_after_comma:match("^%s*([%w_%.]+)")
+          local lua_keywords = {
+            ["and"] = true, ["or"] = true, ["not"] = true,
+            ["if"] = true, ["then"] = true, ["else"] = true, ["elseif"] = true,
+            ["end"] = true, ["while"] = true, ["do"] = true, ["for"] = true,
+            ["repeat"] = true, ["until"] = true, ["break"] = true, ["return"] = true,
+            ["local"] = true, ["in"] = true,
+          }
+          local is_function_call = rest_after_comma:match("^%s*" .. (next_word or "") .. "%s*%(")
+          if next_word and not lua_keywords[next_word] and not is_function_call and (
+            next_word:match("^[%l_]") or next_word:match("^[%u]") or next_word:match("%.")
+          ) then
+            table.insert(parts, current)
+            current = ""
+          else
+            current = current .. c
+          end
+        else
+          current = current .. c
+        end
+      end
+      table.insert(parts, current)
+
+      for _, return_part in ipairs(parts) do
+        return_part = return_part:match("^%s*(.-)%s*$")
+        local part_type: string = nil
+        local part_desc: string = nil
+        -- A variadic return (`@return string ... desc`) is rendered as a Teal
+        -- vararg return type. Nothing can follow a vararg, so stop here.
+        local va_type = return_part:match("^([%w_%.]+)%s+%.%.%.") or
+          (return_part == "..." and "any" or nil)
+        if va_type then
+          table.insert(returns, {return_type = va_type .. "...", description = ""})
+          break
+        end
+        if return_part:match("^%(") then
+          part_type, part_desc = split_type_desc(return_part)
+        elseif return_part:match("^{") then
+          part_type, part_desc = return_part:match("^({.-%}%[?%]?)%s+(.*)$")
+          if not part_type then
+            part_type = return_part:match("^({.-%}%[?%]?)%s*$")
+          end
+        elseif return_part:match("<.->") then
+          part_type, part_desc = return_part:match("^([^%s]+<.->)%s+(.*)$")
+          if not part_type then
+            part_type = return_part:match("^([^%s]+<.->)%s*$")
+          end
+        end
+        if not part_type then
+          part_type, part_desc = return_part:match("^([^%s]+)%s+(.*)$")
+          if not part_type then
+            part_type = return_part
+          end
+        end
+        if part_type and part_type ~= "" then
+          if part_type == "table" and part_desc then
+            local specific_type = part_desc:match("^([%w_]+)")
+            if specific_type and specific_type:match("^[%l_]") then
+              part_type = specific_type
+              part_desc = part_desc:match("^[%w_]+%s*(.*)") or part_desc
+            end
+          end
+          table.insert(returns, {return_type = part_type, description = part_desc or ""})
+        end
+      end
+    end
+
+    if line:match("^%-%-%-@nodiscard") then
+      nodiscard = true
+    end
+
+    local gname = line:match("^%-%-%-@generic%s+([%w_]+)")
+    if gname then
+      generics[gname] = true
+    end
+
+    local overload_ret = line:match("^%-%-%-@overload%s+fun%b()%s*:%s*(.+)$")
+    if overload_ret then
+      local et = overload_ret:match("([%w_]+%.Errno)") or overload_ret:match("(Errno)")
+      if et then
+        fallible = true
+        error_type = et
+      end
+    end
+
+    local cname = line:match("^%-%-%-@class%s+([%w_%.]+)")
+    if cname then
+      class_annotation = cname
+    end
+
+    local ttype = line:match("^%-%-%-?%s*@type%s+([%w_%.]+)")
+    if ttype then
+      table.insert(returns, {return_type = ttype, description = "type"})
+    end
+  end
+
+  -- LuaLS generics (`---@generic T`) have no Teal equivalent in a record
+  -- field type; degrade each generic name to `any` wherever it appears.
+  if next(generics) then
+    local function degrade(t: string): string
+      if not t then return t end
+      for g in pairs(generics) do
+        t = t:gsub("%f[%w_]" .. g .. "%f[^%w_]", "any")
+      end
+      return t
+    end
+    for _, p in ipairs(params) do p.param_type = degrade(p.param_type) end
+    for _, r in ipairs(returns) do r.return_type = degrade(r.return_type) end
+    for _, f in ipairs(fields) do f.field_type = degrade(f.field_type) end
+  end
+
+  return desc, params, returns, nodiscard, class_annotation, fields, fallible, error_type
+end
+
+local record GentypeParseModule
+  split_type_desc: function(rest: string): string, string
+  parse_annotations: function(raw_lines: {string}): {string}, {Param}, {Return}, boolean, string, {Field}, boolean, string
+end
+
+local M: GentypeParseModule = {
+  split_type_desc = split_type_desc,
+  parse_annotations = parse_annotations,
+}
+
+return M

--- a/lib/types/gentype_render.tl
+++ b/lib/types/gentype_render.tl
@@ -2,10 +2,18 @@
 --- Generates Teal .d.tl content from parsed module declarations.
 local gt = require("types.gentype_types")
 local Param = gt.Param
+local Return = gt.Return
 local FuncDecl = gt.FuncDecl
 local Constant = gt.Constant
 local ClassDecl = gt.ClassDecl
 local ModuleDecl = gt.ModuleDecl
+
+-- The module currently being rendered. A dotted type reference whose prefix
+-- is this module (`lsqlite3.Database` inside lsqlite3) collapses to the bare
+-- class name; a foreign prefix (`unix.Errno` inside cosmo) stays dotted and
+-- resolves through a `local <mod> = require("cosmo.<mod>")` emitted in the
+-- file header.
+local current_module: string = nil
 
 -- Type conversion from LuaLS to Teal
 local TYPE_ALIASES = {
@@ -21,7 +29,13 @@ local TYPE_ALIASES = {
   ["FILE"] = "FILE",
   ["uint32"] = "number",
   ["uint16"] = "number",
+  ["uint8"] = "number",
+  ["int8"] = "number",
   ["int64"] = "number",
+  -- definitions.lua declares these via ---@alias; the recursive JSON aliases
+  -- have no Teal equivalent.
+  ["JsonValue"] = "any",
+  ["JsonEl"] = "any",
 }
 
 --- Convert a LuaLS type to Teal type.
@@ -33,33 +47,26 @@ local function convert_type(t: string): string
   -- `fun(...)` which also contains parens but never starts with one.
   local grouped = t:match("^%((.+)%)$")
   if grouped then return convert_type(grouped) end
-  -- Variadic type (`string...`): convert the base, keep the ellipsis.
+  -- Variadic type (`string...`): convert the base, keep the ellipsis. A bare
+  -- or union-typed vararg (`...` / `...: string|nil`) degrades to `any...`.
+  if t:match("^%.%.%.") then return "any..." end
   local va_base = t:match("^(.+)%.%.%.$")
   if va_base then return convert_type(va_base) .. "..." end
-  if t:match("^{%s*[%w_]+%s*:%s*") then return "any" end
+  -- A string-literal type (`"MD5"`) has no Teal inline equivalent.
+  if t:match('^".*"$') or t:match("^'.*'$") then return "string" end
+  -- LuaLS map/array table types have direct Teal equivalents.
+  local map_v = t:match("^{%s*%[string%]%s*:%s*(.+)%s*}$")
+  if map_v then return "{string: " .. convert_type(map_v) .. "}" end
+  local arr_v = t:match("^{%s*%[integer%]%s*:%s*(.+)%s*}$")
+  if arr_v then return "{" .. convert_type(arr_v) .. "}" end
+  -- Other inline struct-table types (`{ name: string }`, `{ [1]: string }`)
+  -- have no Teal inline equivalent.
+  if t:match("^{.*:") then return "any" end
   if t:match("`") then return "any" end
   if TYPE_ALIASES[t] then return TYPE_ALIASES[t] end
   if t == "true" or t == "false" then return "boolean" end
   if t:match("^%-?%d+$") then return "number" end
   if t == "integer" then return "number" end
-  local base = t:match("^(.+)%?$")
-  if base then
-    if base:match("|") then
-      local table_count = 0
-      for part in base:gmatch("[^|]+") do
-        part = part:match("^%s*(.-)%s*$")
-        if part:match("^[%u]") or part:match("%.([%u][%w_]*)$") then
-          table_count = table_count + 1
-        end
-      end
-      if table_count > 1 then return "any" end
-    end
-    return convert_type(base) .. " | nil"
-  end
-  base = t:match("^(.+)%[%]$")
-  if base then return "{" .. convert_type(base) .. "}" end
-  local k, v = t:match("^table<([^,]+),%s*(.+)>$")
-  if k and v then return "{" .. convert_type(k) .. ": " .. convert_type(v) .. "}" end
   local fun_args, fun_ret = t:match("^fun%((.*)%)%s*:%s*(.+)$")
   if not fun_args then
     fun_args = t:match("^fun%((.*)%)$")
@@ -94,10 +101,31 @@ local function convert_type(t: string): string
     flush()
     local sig = "function(" .. table.concat(converted, ", ") .. ")"
     if fun_ret then
-      sig = sig .. ": " .. convert_type(fun_ret)
+      -- Parenthesize a function type that has a return: when it appears in a
+      -- param or return list, a following `, next` would otherwise parse as
+      -- another return of the nested function.
+      sig = "(" .. sig .. ": " .. convert_type(fun_ret) .. ")"
     end
     return sig
   end
+  local base = t:match("^(.+)%?$")
+  if base then
+    if base:match("|") then
+      local table_count = 0
+      for part in base:gmatch("[^|]+") do
+        part = part:match("^%s*(.-)%s*$")
+        if part:match("^[%u]") or part:match("%.([%u][%w_]*)$") then
+          table_count = table_count + 1
+        end
+      end
+      if table_count > 1 then return "any" end
+    end
+    return convert_type(base) .. " | nil"
+  end
+  base = t:match("^(.+)%[%]$")
+  if base then return "{" .. convert_type(base) .. "}" end
+  local k, v = t:match("^table<([^,]+),%s*(.+)>$")
+  if k and v then return "{" .. convert_type(k) .. ": " .. convert_type(v) .. "}" end
   if t:match("|") then
     local parts: {string} = {}
     local seen: {string: boolean} = {}
@@ -116,8 +144,68 @@ local function convert_type(t: string): string
     else return table.concat(parts, " | ") end
   end
   local prefix, suffix = t:match("^([%w_]+)%.([%w_]+)$")
-  if prefix and suffix then return suffix end
+  if prefix and suffix then
+    if current_module and prefix ~= current_module then
+      return t
+    end
+    return suffix
+  end
   return t
+end
+
+--- Render a parameter list (optionally with a self receiver).
+local function render_params(params: {Param}, self_name: string): string
+  local parts: {string} = {}
+  if self_name then
+    table.insert(parts, "self: " .. self_name)
+  end
+  for _, p in ipairs(params) do
+    local ptype = convert_type(p.param_type)
+    if p.name == "..." then
+      table.insert(parts, "...: " .. ptype)
+    else
+      local opt = p.optional and "?" or ""
+      table.insert(parts, p.name .. opt .. ": " .. ptype)
+    end
+  end
+  return table.concat(parts, ", ")
+end
+
+--- Render a return-type list. convert_type parenthesizes a function type
+--- that itself has returns, which Teal only accepts inside a param list: in a
+--- return list the LAST entry drops the parens (unambiguous) and earlier
+--- entries degrade to bare `function` (Teal cannot express them).
+local function render_returns(returns: {Return}, fallible: boolean, error_type: string): string
+  local ret_types: {string} = {}
+  for _, r in ipairs(returns) do
+    if r.description ~= "type" then
+      table.insert(ret_types, convert_type(r.return_type))
+    end
+  end
+  -- A fallible function folds its failure overload into a trailing error
+  -- return. Nothing may follow a Teal vararg return, so skip the fold there.
+  -- A class-typed error (Errno) already present as the last @return is not
+  -- duplicated; builtin error types (string) always append, since a trailing
+  -- `string` return is a value, not the error slot.
+  if fallible and #ret_types > 0 and not ret_types[#ret_types]:match("%.%.%.$") then
+    local et = convert_type(error_type or "unix.Errno")
+    if not (ret_types[#ret_types] == et and et:match("^%u")) then
+      table.insert(ret_types, et)
+    end
+  end
+  for i, rt in ipairs(ret_types) do
+    if rt:match("^%(function") then
+      if i == #ret_types then
+        ret_types[i] = rt:sub(2, -2)
+      else
+        ret_types[i] = "function"
+      end
+    end
+  end
+  if #ret_types > 0 then
+    return ": " .. table.concat(ret_types, ", ")
+  end
+  return ""
 end
 
 --- Format description lines as comments.
@@ -135,8 +223,40 @@ local function format_description(desc: {string}, indent: string): {string}
   return result
 end
 
+--- Collect foreign module prefixes referenced from the module's types
+--- (e.g. `unix.Errno` inside cosmo), so requires can be emitted for them.
+local function foreign_modules(module: ModuleDecl): {string}
+  local seen: {string: boolean} = {}
+  local function scan(t: string)
+    if not t then return end
+    for prefix in t:gmatch("([%l_][%w_]*)%.[%u]") do
+      if prefix ~= module.name then
+        seen[prefix] = true
+      end
+    end
+  end
+  local function scan_funcs(funcs: {FuncDecl})
+    for _, f in ipairs(funcs) do
+      for _, p in ipairs(f.params) do scan(p.param_type) end
+      for _, r in ipairs(f.returns) do scan(r.return_type) end
+      if f.fallible then scan(f.error_type or "unix.Errno") end
+    end
+  end
+  scan_funcs(module.functions)
+  for _, cls in ipairs(module.classes) do
+    scan_funcs(cls.methods)
+    for _, f in ipairs(cls.fields) do scan(f.field_type) end
+  end
+  for _, c in ipairs(module.constants) do scan(c.const_type) end
+  local result: {string} = {}
+  for prefix in pairs(seen) do table.insert(result, prefix) end
+  table.sort(result)
+  return result
+end
+
 --- Generate Teal .d.tl content for a module.
 local function generate_dtl(module: ModuleDecl): string
+  current_module = module.name
   local out: {string} = {}
   if module.name == "cosmo" then
     table.insert(out, "-- type declarations for cosmo")
@@ -146,6 +266,15 @@ local function generate_dtl(module: ModuleDecl): string
   table.insert(out, "-- GENERATED from cosmopolitan's definitions.lua by lib/types/gentype.tl.")
   table.insert(out, "-- Do not edit by hand. Regenerate with: bin/make regen-types")
   table.insert(out, "")
+
+  -- Foreign class references resolve through the exporting module's record.
+  local foreign = foreign_modules(module)
+  for _, m in ipairs(foreign) do
+    table.insert(out, "local " .. m .. " = require(\"cosmo." .. m .. "\")")
+  end
+  if #foreign > 0 then
+    table.insert(out, "")
+  end
 
   -- Every class renders, even when empty: an opaque userdata handle (e.g.
   -- argon2.Variant) is still referenced from signatures.
@@ -163,6 +292,9 @@ local function generate_dtl(module: ModuleDecl): string
           end
         end
         local ftype = convert_type(field.field_type)
+        if ftype:match("^%(function") then
+          ftype = ftype:sub(2, -2)
+        end
         table.insert(out, "  " .. field.name .. ": " .. ftype)
       end
 
@@ -176,39 +308,8 @@ local function generate_dtl(module: ModuleDecl): string
             table.insert(out, line)
           end
         end
-        local params_parts: {string} = {"self: " .. cls.name}
-        for _, p in ipairs(method.params) do
-          local ptype = convert_type(p.param_type)
-          if p.name == "..." then
-            table.insert(params_parts, "...: " .. ptype)
-          else
-            local opt = p.optional and "?" or ""
-            table.insert(params_parts, p.name .. opt .. ": " .. ptype)
-          end
-        end
-        local params_str = table.concat(params_parts, ", ")
-
-        local ret_str = ""
-        do
-          local ret_types: {string} = {}
-          for _, r in ipairs(method.returns) do
-            if r.description ~= "type" then
-              table.insert(ret_types, convert_type(r.return_type))
-            end
-          end
-          -- Nothing may follow a Teal vararg return, so skip the Errno fold.
-          if method.fallible and #ret_types > 0 and
-            not ret_types[#ret_types]:match("%.%.%.$") then
-            local et = convert_type(method.error_type or "unix.Errno")
-            if ret_types[#ret_types] ~= et then
-              table.insert(ret_types, et)
-            end
-          end
-          if #ret_types > 0 then
-            ret_str = ": " .. table.concat(ret_types, ", ")
-          end
-        end
-
+        local params_str = render_params(method.params, cls.name)
+        local ret_str = render_returns(method.returns, method.fallible, method.error_type)
         table.insert(out, "  " .. method.name .. ": function(" .. params_str .. ")" .. ret_str)
       end
       table.insert(out, "end")
@@ -256,39 +357,8 @@ local function generate_dtl(module: ModuleDecl): string
         table.insert(out, line)
       end
     end
-    local params_parts: {string} = {}
-    for _, p in ipairs(func.params) do
-      local ptype = convert_type(p.param_type)
-      if p.name == "..." then
-        table.insert(params_parts, "...: " .. ptype)
-      else
-        local opt = p.optional and "?" or ""
-        table.insert(params_parts, p.name .. opt .. ": " .. ptype)
-      end
-    end
-    local params_str = table.concat(params_parts, ", ")
-
-    local ret_str = ""
-    do
-      local ret_types: {string} = {}
-      for _, r in ipairs(func.returns) do
-        if r.description ~= "type" then
-          table.insert(ret_types, convert_type(r.return_type))
-        end
-      end
-      -- Nothing may follow a Teal vararg return, so skip the Errno fold.
-      if func.fallible and #ret_types > 0 and
-        not ret_types[#ret_types]:match("%.%.%.$") then
-        local et = convert_type(func.error_type or "unix.Errno")
-        if ret_types[#ret_types] ~= et then
-          table.insert(ret_types, et)
-        end
-      end
-      if #ret_types > 0 then
-        ret_str = ": " .. table.concat(ret_types, ", ")
-      end
-    end
-
+    local params_str = render_params(func.params, nil)
+    local ret_str = render_returns(func.returns, func.fallible, func.error_type)
     table.insert(out, "  " .. func.name .. ": function(" .. params_str .. ")" .. ret_str)
   end
 
@@ -297,6 +367,7 @@ local function generate_dtl(module: ModuleDecl): string
   table.insert(out, "return " .. module.name)
   table.insert(out, "")
 
+  current_module = nil
   return table.concat(out, "\n")
 end
 

--- a/lib/types/gentype_render.tl
+++ b/lib/types/gentype_render.tl
@@ -33,6 +33,9 @@ local function convert_type(t: string): string
   -- `fun(...)` which also contains parens but never starts with one.
   local grouped = t:match("^%((.+)%)$")
   if grouped then return convert_type(grouped) end
+  -- Variadic type (`string...`): convert the base, keep the ellipsis.
+  local va_base = t:match("^(.+)%.%.%.$")
+  if va_base then return convert_type(va_base) .. "..." end
   if t:match("^{%s*[%w_]+%s*:%s*") then return "any" end
   if t:match("`") then return "any" end
   if TYPE_ALIASES[t] then return TYPE_ALIASES[t] end
@@ -57,28 +60,55 @@ local function convert_type(t: string): string
   if base then return "{" .. convert_type(base) .. "}" end
   local k, v = t:match("^table<([^,]+),%s*(.+)>$")
   if k and v then return "{" .. convert_type(k) .. ": " .. convert_type(v) .. "}" end
-  local fun_match = t:match("^fun%((.*)%)$")
-  if fun_match then return "function(" .. fun_match .. ")" end
-  fun_match = t:match("^fun%((.*)%):(.+)$")
-  if fun_match then
-    local args, ret = t:match("^fun%((.*)%):(.+)$")
-    return "function(" .. (args or "") .. "): " .. convert_type(ret or "")
+  local fun_args, fun_ret = t:match("^fun%((.*)%)%s*:%s*(.+)$")
+  if not fun_args then
+    fun_args = t:match("^fun%((.*)%)$")
   end
-  if t:match("^fun%(") then
-    local inside = t:match("^fun%((.*)%):%s*(.+)$")
-    if inside then
-      local args_part, ret_part = t:match("^fun%((.*)%):%s*(.+)$")
-      return "function(" .. (args_part or "") .. "): " .. convert_type(ret_part or "")
+  if fun_args then
+    -- Convert each `name: type` argument's type (LuaLS `integer` etc. are not
+    -- valid Teal). Split on top-level commas only.
+    local converted: {string} = {}
+    local depth = 0
+    local cur = ""
+    local function flush()
+      local part = cur:match("^%s*(.-)%s*$")
+      if part ~= "" then
+        local aname, atype = part:match("^([%w_%.]+%??)%s*:%s*(.+)$")
+        if aname then
+          table.insert(converted, aname .. ": " .. convert_type(atype))
+        elseif part == "..." then
+          table.insert(converted, "...: any")
+        else
+          table.insert(converted, part)
+        end
+      end
+      cur = ""
     end
-    inside = t:match("^fun%((.*)%)$")
-    if inside then return "function(" .. inside .. ")" end
+    for i = 1, #fun_args do
+      local c = fun_args:sub(i, i)
+      if c == "<" or c == "{" or c == "(" then depth = depth + 1
+      elseif c == ">" or c == "}" or c == ")" then depth = depth - 1
+      end
+      if c == "," and depth == 0 then flush() else cur = cur .. c end
+    end
+    flush()
+    local sig = "function(" .. table.concat(converted, ", ") .. ")"
+    if fun_ret then
+      sig = sig .. ": " .. convert_type(fun_ret)
+    end
+    return sig
   end
   if t:match("|") then
     local parts: {string} = {}
+    local seen: {string: boolean} = {}
     for part in t:gmatch("[^|]+") do
       part = part:match("^%s*(.-)%s*$")
       if part ~= "nil" and part ~= "" then
-        table.insert(parts, convert_type(part))
+        local converted = convert_type(part)
+        if not seen[converted] then
+          seen[converted] = true
+          table.insert(parts, converted)
+        end
       end
     end
     if #parts == 0 then return "any"
@@ -108,11 +138,19 @@ end
 --- Generate Teal .d.tl content for a module.
 local function generate_dtl(module: ModuleDecl): string
   local out: {string} = {}
-  table.insert(out, "-- type declarations for cosmo." .. module.name)
+  if module.name == "cosmo" then
+    table.insert(out, "-- type declarations for cosmo")
+  else
+    table.insert(out, "-- type declarations for cosmo." .. module.name)
+  end
+  table.insert(out, "-- GENERATED from cosmopolitan's definitions.lua by lib/types/gentype.tl.")
+  table.insert(out, "-- Do not edit by hand. Regenerate with: bin/make regen-types")
   table.insert(out, "")
 
+  -- Every class renders, even when empty: an opaque userdata handle (e.g.
+  -- argon2.Variant) is still referenced from signatures.
   for _, cls in ipairs(module.classes) do
-    if #cls.methods > 0 or #cls.fields > 0 then
+    do
       for _, line in ipairs(format_description(cls.description, "")) do
         table.insert(out, line)
       end
@@ -158,7 +196,9 @@ local function generate_dtl(module: ModuleDecl): string
               table.insert(ret_types, convert_type(r.return_type))
             end
           end
-          if method.fallible and #ret_types > 0 then
+          -- Nothing may follow a Teal vararg return, so skip the Errno fold.
+          if method.fallible and #ret_types > 0 and
+            not ret_types[#ret_types]:match("%.%.%.$") then
             local et = convert_type(method.error_type or "unix.Errno")
             if ret_types[#ret_types] ~= et then
               table.insert(ret_types, et)
@@ -177,6 +217,24 @@ local function generate_dtl(module: ModuleDecl): string
   end
 
   table.insert(out, "local record " .. module.name)
+
+  -- Export each class type on the module record so consumers can name it
+  -- (e.g. `local db: lsqlite3.Database`). A class whose name is also a module
+  -- function (e.g. the `unix.Sigset` constructor) or constant keeps the value
+  -- binding; the alias would collide.
+  local taken: {string: boolean} = {}
+  for _, f in ipairs(module.functions) do taken[f.name] = true end
+  for _, c in ipairs(module.constants) do taken[c.name] = true end
+  local aliased = 0
+  for _, cls in ipairs(module.classes) do
+    if not taken[cls.name] then
+      table.insert(out, "  type " .. cls.name .. " = " .. cls.name)
+      aliased = aliased + 1
+    end
+  end
+  if aliased > 0 and (#module.constants > 0 or #module.functions > 0) then
+    table.insert(out, "")
+  end
 
   if #module.constants > 0 then
     for _, c in ipairs(module.constants) do
@@ -218,7 +276,9 @@ local function generate_dtl(module: ModuleDecl): string
           table.insert(ret_types, convert_type(r.return_type))
         end
       end
-      if func.fallible and #ret_types > 0 then
+      -- Nothing may follow a Teal vararg return, so skip the Errno fold.
+      if func.fallible and #ret_types > 0 and
+        not ret_types[#ret_types]:match("%.%.%.$") then
         local et = convert_type(func.error_type or "unix.Errno")
         if ret_types[#ret_types] ~= et then
           table.insert(ret_types, et)
@@ -241,73 +301,80 @@ local function generate_dtl(module: ModuleDecl): string
 end
 
 --- Extract a module's content from definitions.lua.
+--- Selects, line-based: (1) the `<mod> = { ... }` table section, with brace
+--- depth counted only outside comments (a stray `}` in a doc comment must not
+--- terminate the table early); (2) every annotation block followed by a
+--- `function <mod>.<name>(` or `function <mod>.<Class>:<method>(` declaration,
+--- wherever it appears in the file; (3) every standalone `---@class <mod>.*`
+--- data-class block. Blocks belonging to other modules never leak in, so no
+--- boundary heuristics are needed.
 local function extract_module_content(source: string, module_name: string): string
-  local pattern = "\n" .. module_name .. " = {"
-  local start_pos = source:find(pattern, 1, true)
-  if not start_pos then
-    pattern = "^" .. module_name .. " = {"
-    if source:match(pattern) then
-      start_pos = 1
-    else
-      return nil
-    end
+  local lines: {string} = {}
+  for line in (source .. "\n"):gmatch("([^\n]*)\n") do
+    table.insert(lines, line)
   end
 
-  local brace_count = 0
-  local in_module = false
-  local end_pos = start_pos
+  -- 1) module table section
+  local start_idx: integer = nil
+  for idx, line in ipairs(lines) do
+    if line:match("^" .. module_name .. "%s*=%s*{") then
+      start_idx = idx
+      break
+    end
+  end
+  if not start_idx then return nil end
 
-  for i = start_pos, #source do
-    local c = source:sub(i, i)
-    if c == "{" then
-      brace_count = brace_count + 1
-      in_module = true
-    elseif c == "}" then
-      brace_count = brace_count - 1
-      if in_module and brace_count == 0 then
-        end_pos = i
+  local out: {string} = {}
+  local depth = 0
+  local table_end = start_idx
+  for idx = start_idx, #lines do
+    local code = lines[idx]:gsub("%-%-.*$", "")
+    for brace in code:gmatch("[{}]") do
+      depth = depth + (brace == "{" and 1 or -1)
+    end
+    table.insert(out, lines[idx])
+    table_end = idx
+    if depth <= 0 then break end
+  end
+
+  -- 2) + 3) annotation blocks and declarations for this module
+  local fn_pattern = "^function%s+" .. module_name .. "%."
+  local class_pattern = "^%-%-%-@class%s+" .. module_name .. "%."
+  local pending: {string} = {}
+  local function flush_standalone_class()
+    local is_class = false
+    for _, a in ipairs(pending) do
+      if a:match(class_pattern) then
+        is_class = true
         break
       end
     end
+    if is_class then
+      for _, a in ipairs(pending) do table.insert(out, a) end
+      table.insert(out, "")
+    end
+    pending = {}
   end
 
-  local content = source:sub(start_pos, end_pos)
-
-  local search_start = end_pos
-  local first_func = source:find("\nfunction " .. module_name .. "%.", search_start)
-  if first_func then
-    content = content .. source:sub(end_pos, first_func - 1)
-    search_start = first_func
-  end
-
-  while true do
-    local func_start = source:find("\nfunction " .. module_name .. "%.", search_start)
-    if not func_start then break end
-
-    local next_module_start = source:find("\n[%w_]+ = {", func_start + 1)
-    if next_module_start and func_start > next_module_start then
-      break
-    end
-
-    local func_end = source:find("\nfunction ", func_start + 1)
-    local next_module = next_module_start
-
-    if func_end and next_module then
-      func_end = math.min(func_end, next_module)
-    elseif next_module then
-      func_end = next_module
-    end
-
-    if func_end then
-      content = content .. "\n" .. source:sub(func_start, func_end - 1)
-      search_start = func_end
+  for idx = 1, #lines do
+    if idx >= start_idx and idx <= table_end then
+      pending = {}
     else
-      content = content .. "\n" .. source:sub(func_start)
-      break
+      local line = lines[idx]
+      if line:match("^%-%-%-") then
+        table.insert(pending, line)
+      elseif line:match(fn_pattern) then
+        for _, a in ipairs(pending) do table.insert(out, a) end
+        table.insert(out, line)
+        pending = {}
+      else
+        flush_standalone_class()
+      end
     end
   end
+  flush_standalone_class()
 
-  return content
+  return table.concat(out, "\n")
 end
 
 local record GentypeRenderModule

--- a/lib/types/gentype_test.tl
+++ b/lib/types/gentype_test.tl
@@ -1,8 +1,30 @@
 #!/usr/bin/env cosmic
 --- Tests for gentype.tl type definition generator.
+---
+--- The drift tests compare generator output byte-for-byte against the
+--- committed .d.tl files, so any change to the generator or to the pinned
+--- cosmos definitions.lua fails here until `bin/make regen-types` is run and
+--- the regenerated files are committed. GENTYPE_DEFS overrides the
+--- definitions.lua source (default: the copy embedded in this binary) for
+--- validating against a cosmopolitan checkout before a release is cut.
 
 local cosmo = require("cosmo")
 local gentype = require("types.gentype")
+
+local function defs_source(): string
+  local path = os.getenv("GENTYPE_DEFS") or "/zip/.lua/definitions.lua"
+  local source = cosmo.Slurp(path)
+  assert(source, "Failed to read definitions.lua from " .. path)
+  return source
+end
+
+--- Committed location for a generated module's type declarations.
+local function committed_path(module_name: string): string
+  if module_name == "cosmo" then
+    return "lib/types/cosmo.d.tl"
+  end
+  return "lib/types/cosmo/" .. module_name .. ".d.tl"
+end
 
 -- Test type conversion from LuaLS to Teal
 local function test_convert_type()
@@ -33,6 +55,16 @@ local function test_convert_type()
   assert(gentype.convert_type("(true | string)") == "boolean | string", "(true | string) union")
   assert(gentype.convert_type("(integer | string)?") == "number | string | nil", "optional paren union")
 
+  -- Variadic types keep the ellipsis with a converted base.
+  assert(gentype.convert_type("string...") == "string...", "string... passthrough")
+  assert(gentype.convert_type("integer...") == "number...", "integer... -> number...")
+
+  -- Function types convert their argument and return types.
+  assert(gentype.convert_type("fun(udata: integer, tries: integer)")
+    == "function(udata: number, tries: number)", "fun arg types convert")
+  assert(gentype.convert_type("fun(x: integer): integer")
+    == "function(x: number): number", "fun return type converts")
+
   -- Module-prefixed types
   assert(gentype.convert_type("lsqlite3.Database") == "Database", "lsqlite3.Database -> Database")
   assert(gentype.convert_type("unix.Errno") == "Errno", "unix.Errno -> Errno")
@@ -40,47 +72,30 @@ local function test_convert_type()
   print("test_convert_type: PASS")
 end
 
--- Test module parsing
+-- Test module parsing against the real definitions.lua
 local function test_parse_path_module()
-  local source = cosmo.Slurp("/zip/.lua/definitions.lua")
-  assert(source, "Failed to read definitions.lua")
-
-  local module = gentype.parse_module(source, "path")
+  local module = gentype.parse_module(defs_source(), "path")
   assert(module, "Failed to parse path module")
   assert(module.name == "path", "module name should be path")
-
-  -- Check that functions were parsed
   assert(#module.functions > 0, "path should have functions")
 
-  -- Look for specific functions
-  local found_dirname = false
-  local found_basename = false
-  local found_join = false
+  local found: {string: boolean} = {}
   for _, f in ipairs(module.functions) do
-    if f.name == "dirname" then found_dirname = true end
-    if f.name == "basename" then found_basename = true end
-    if f.name == "join" then found_join = true end
+    found[f.name] = true
   end
-  assert(found_dirname, "path.dirname should exist")
-  assert(found_basename, "path.basename should exist")
-  assert(found_join, "path.join should exist")
+  assert(found["dirname"], "path.dirname should exist")
+  assert(found["basename"], "path.basename should exist")
+  assert(found["join"], "path.join should exist")
 
   print("test_parse_path_module: PASS")
 end
 
 -- Test unix module parsing (more complex with constants)
 local function test_parse_unix_module()
-  local source = cosmo.Slurp("/zip/.lua/definitions.lua")
-  assert(source, "Failed to read definitions.lua")
-
-  local module = gentype.parse_module(source, "unix")
+  local module = gentype.parse_module(defs_source(), "unix")
   assert(module, "Failed to parse unix module")
-  assert(module.name == "unix", "module name should be unix")
-
-  -- Check that constants were parsed
   assert(#module.constants > 0, "unix should have constants, got " .. #module.constants)
 
-  -- Look for specific constants
   local found_eacces = false
   local found_af_unix = false
   for _, c in ipairs(module.constants) do
@@ -91,80 +106,6 @@ local function test_parse_unix_module()
   assert(found_af_unix, "unix.AF_UNIX should exist")
 
   print("test_parse_unix_module: PASS")
-end
-
--- Test DTL generation
-local function test_generate_dtl()
-  local source = cosmo.Slurp("/zip/.lua/definitions.lua")
-  assert(source, "Failed to read definitions.lua")
-
-  local module = gentype.parse_module(source, "path")
-  assert(module, "Failed to parse path module")
-
-  local dtl = gentype.generate_dtl(module)
-  assert(dtl, "Failed to generate DTL")
-
-  -- Check for expected content
-  assert(dtl:match("local record path"), "DTL should contain 'local record path'")
-  assert(dtl:match("return path"), "DTL should contain 'return path'")
-  assert(dtl:match("dirname: function"), "DTL should contain dirname function")
-
-  print("test_generate_dtl: PASS")
-end
-
--- Test run function
-local function test_run()
-  local result = gentype.run("path")
-  assert(result.success, "run should succeed: " .. (result.error or ""))
-  assert(result.output, "run should produce output")
-  assert(result.output:match("local record path"), "output should contain path record")
-
-  print("test_run: PASS")
-end
-
--- Test getting module list
-local function test_get_modules()
-  local modules = gentype.get_modules()
-  assert(#modules > 0, "should have modules")
-
-  local found_unix = false
-  local found_path = false
-  for _, m in ipairs(modules) do
-    if m == "unix" then found_unix = true end
-    if m == "path" then found_path = true end
-  end
-  assert(found_unix, "modules should include unix")
-  assert(found_path, "modules should include path")
-
-  print("test_get_modules: PASS")
-end
-
--- Normalize whitespace for comparison
-local function normalize(s: string): string
-  -- Remove trailing whitespace from lines
-  s = s:gsub("[ \t]+\n", "\n")
-  -- Normalize multiple newlines
-  s = s:gsub("\n\n+", "\n\n")
-  -- Remove trailing newline
-  s = s:gsub("\n+$", "")
-  return s
-end
-
--- Drift detection test - verify generated matches committed file
-local function test_drift_detection_path()
-  local result = gentype.run("path")
-  assert(result.success, "run should succeed for path")
-
-  local committed = cosmo.Slurp("lib/types/cosmo/path.d.tl")
-  if not committed then
-    print("test_drift_detection_path: SKIP (no committed file)")
-    return
-  end
-
-  -- For now, just check that we can generate something
-  -- Full drift detection would require the generated output to match exactly
-  assert(result.output:match("local record path"), "generated should have path record")
-  print("test_drift_detection_path: PASS (basic check)")
 end
 
 -- A fallible unix.* function expresses its failure return upstream as an
@@ -236,83 +177,166 @@ function unix.ioctl(fd, request, arg) end
   print("test_paren_union_types: PASS")
 end
 
--- Drift guard: every unix.* function the generator renders with a trailing
--- `, Errno` must also declare `, Errno` in the committed unix.d.tl. Fails if a
--- regen or hand-edit drops the errno failure returns, leaving the checked-in
--- type definitions out of sync with the upstream @overload annotations.
-local function test_errno_drift_unix()
-  local result = gentype.run("unix")
-  assert(result.success, "run should succeed for unix: " .. (result.error or ""))
-
-  local committed = cosmo.Slurp("lib/types/cosmo/unix.d.tl")
-  if not committed then
-    print("test_errno_drift_unix: SKIP (no committed file)")
-    return
-  end
-
-  -- The committed file hand-wraps long signatures across lines, while the
-  -- generator emits one line per function. Collapse continuation lines (those
-  -- indented four or more spaces) onto the preceding line so a single-line
-  -- regex sees whole signatures in either text.
-  local function collapse(text: string): {string}
-    local out: {string} = {}
-    for line in (text .. "\n"):gmatch("([^\n]*)\n") do
-      if line:match("^    %S") and #out > 0 then
-        out[#out] = out[#out] .. " " .. line:match("^%s*(.-)%s*$")
-      else
-        table.insert(out, line)
-      end
-    end
-    return out
-  end
-
-  local function declared(text: string): {string: boolean}, {string: boolean}
-    local all: {string: boolean} = {}
-    local errno: {string: boolean} = {}
-    for _, line in ipairs(collapse(text)) do
-      local name = line:match("^%s*([%w_]+): function")
-      if name then
-        all[name] = true
-        if line:match(", Errno[ \t]*$") then
-          errno[name] = true
-        end
-      end
-    end
-    return all, errno
-  end
-
-  local committed_all, committed_errno = declared(committed)
-  local _, generated_errno = declared(result.output)
-
-  -- Every function the generator marks fallible AND that the committed file
-  -- also declares must carry the `, Errno` return. (Functions the committed
-  -- file omits entirely are a separate concern and are not flagged here.)
-  local missing: {string} = {}
-  for name in pairs(generated_errno) do
-    if committed_all[name] and not committed_errno[name] then
-      table.insert(missing, name)
-    end
-  end
-
-  if #missing > 0 then
-    table.sort(missing)
-    error("unix.d.tl is out of sync with the generator: these functions declare "
-      .. "no `, Errno` return but the generator (from the upstream @overload "
-      .. "annotations) marks them fallible: " .. table.concat(missing, ", ")
-      .. "\nRe-apply the errno returns (see U1) to sync.")
-  end
-
-  print("test_errno_drift_unix: PASS")
+-- A variadic return (`@return string match, string ... captures`) renders as
+-- a Teal vararg return type. Nothing can follow a vararg, so the Errno fold
+-- from a failure overload must be skipped.
+local function test_vararg_return()
+  local source = [==[
+re = {}
+--- Searches a string.
+---@param regex string
+---@param text string
+---@return string match, string ... the match, followed by any captured groups
+---@overload fun(regex: string, text: string): nil, re.Errno
+function re.search(regex, text) end
+]==]
+  local dtl = gentype.generate_dtl(gentype.parse_module(source, "re"))
+  assert(dtl:match("search: function%(regex: string, text: string%): string, string%.%.%."),
+    "vararg return should render as `string, string...`:\n" .. dtl)
+  assert(not dtl:match("search[^\n]*followed"),
+    "return description must not leak into the type list:\n" .. dtl)
+  assert(not dtl:match("search[^\n]*%.%.%., Errno"),
+    "no Errno fold after a vararg return:\n" .. dtl)
+  print("test_vararg_return: PASS")
 end
 
--- Validate that hardcoded module list matches definitions.lua
-local function test_module_list_completeness()
-  local source = cosmo.Slurp("/zip/.lua/definitions.lua")
-  assert(source, "Failed to read definitions.lua")
+-- LuaLS generics (`---@generic T`) have no Teal record-field equivalent; each
+-- generic name degrades to `any` wherever it appears.
+local function test_generic_degrades_to_any()
+  local source = [==[
+lsqlite3 = {}
+--- Sets a busy handler.
+---@generic Udata
+---@param func fun(udata: Udata, tries: integer)? handler
+---@param udata? Udata
+function lsqlite3.busy_handler(func, udata) end
+]==]
+  local dtl = gentype.generate_dtl(gentype.parse_module(source, "lsqlite3"))
+  assert(dtl:match("busy_handler: function%(func%?: function%(udata: any, tries: number%), udata%?: any%)"),
+    "generic types should degrade to any:\n" .. dtl)
+  print("test_generic_degrades_to_any: PASS")
+end
 
-  -- Find all modules in definitions.lua by looking for lines like "modulename = {"
-  -- Accept both "module = {" and "module={"
-  -- Pattern must match module names with numbers (e.g., lsqlite3, argon2)
+-- Constants inside the module table are indented, and so are their doc
+-- comments; both must survive into the rendered record. A stray `}` inside a
+-- doc comment must not terminate the module table extraction.
+local function test_constant_docs_and_comment_braces()
+  local source = [==[
+re = {
+    --- Missing }
+    EBRACE = 9,
+    --- Invalid contents of {}
+    BADBR = 10,
+}
+]==]
+  local dtl = gentype.generate_dtl(gentype.parse_module(source, "re"))
+  assert(dtl:match("%-%-%- Missing }\n  EBRACE: number"),
+    "constant doc comments should render above the constant:\n" .. dtl)
+  assert(dtl:match("BADBR: number"),
+    "constants after a stray `}` in a comment must still parse:\n" .. dtl)
+  print("test_constant_docs_and_comment_braces: PASS")
+end
+
+-- A standalone data class (`---@class mod.Name` + `---@field ...`) renders as
+-- a record even when empty (opaque userdata handles), and every class type is
+-- exported on the module record unless a function shares its name.
+local function test_data_class_and_type_export()
+  local source = [==[
+argon2 = {
+    --- Argon2 algorithm variants.
+    ---@type argon2.Variants
+    variants = {},
+}
+
+---@class argon2.Variant: userdata
+--- Opaque variant handle.
+
+---@class argon2.Variants
+---@field argon2_id argon2.Variant blend of the other two methods
+---@field argon2_i argon2.Variant side-channel resistant
+---@field argon2_d argon2.Variant gpu-cracking resistant
+
+--- Hashes a password.
+---@param pass string
+---@param config argon2.Config
+---@class argon2.Config
+---@field m_cost integer? memory cost in kibibytes
+---@field variant argon2.Variant? algorithm variant
+---@return string encoded
+---@overload fun(pass: string, config?: argon2.Config): nil, error: string
+function argon2.hash_encoded(pass, config) end
+]==]
+  local dtl = gentype.generate_dtl(gentype.parse_module(source, "argon2"))
+  assert(dtl:match("local record Variant"), "opaque Variant class should render:\n" .. dtl)
+  assert(dtl:match("local record Variants"), "Variants class should render:\n" .. dtl)
+  assert(dtl:match("argon2_id: Variant"), "@field entries should render:\n" .. dtl)
+  assert(dtl:match("type Variant = Variant"), "class types should be exported:\n" .. dtl)
+  assert(dtl:match("variants: Variants"),
+    "@type-annotated module field should render on the record:\n" .. dtl)
+  assert(dtl:match("m_cost: number"), "Config fields should render:\n" .. dtl)
+  print("test_data_class_and_type_export: PASS")
+end
+
+-- Module-qualified class methods (`function mod.Class:method()`) attach to
+-- their class wherever they appear in the file.
+local function test_qualified_class_methods()
+  local source = [==[
+lsqlite3 = {}
+
+---@class lsqlite3.Database: userdata
+--- A database handle.
+
+---@return integer # rows changed
+---@nodiscard
+function lsqlite3.Database:changes() end
+
+--- Opens a database.
+---@param filename string
+---@return lsqlite3.Database
+function lsqlite3.open(filename) end
+]==]
+  local dtl = gentype.generate_dtl(gentype.parse_module(source, "lsqlite3"))
+  assert(dtl:match("local record Database"), "Database class should render:\n" .. dtl)
+  assert(dtl:match("changes: function%(self: Database%): number"),
+    "qualified class method should attach to its class:\n" .. dtl)
+  assert(dtl:match("open: function%(filename: string%): Database"),
+    "module function should reference the class type:\n" .. dtl)
+  print("test_qualified_class_methods: PASS")
+end
+
+-- Drift: generator output must match the committed .d.tl byte-for-byte for
+-- every module. Fails after a cosmos bump or generator change until
+-- `bin/make regen-types` is run and the result committed.
+local function test_drift_all_modules()
+  for _, m in ipairs(gentype.get_modules()) do
+    local result = gentype.run(m)
+    assert(result.success, "generator failed for " .. m .. ": " .. (result.error or ""))
+    local path = committed_path(m)
+    local committed = cosmo.Slurp(path)
+    assert(committed, "missing committed type file " .. path
+      .. " -- run `bin/make regen-types` and commit the result")
+    if committed ~= result.output then
+      -- Locate the first differing line for a readable failure.
+      local cl: {string} = {}
+      for line in (committed .. "\n"):gmatch("([^\n]*)\n") do table.insert(cl, line) end
+      local gl: {string} = {}
+      for line in (result.output .. "\n"):gmatch("([^\n]*)\n") do table.insert(gl, line) end
+      local at = 1
+      while cl[at] == gl[at] and at <= math.max(#cl, #gl) do at = at + 1 end
+      error(path .. " drifted from generator output at line " .. at
+        .. "\n  committed: " .. tostring(cl[at])
+        .. "\n  generated: " .. tostring(gl[at])
+        .. "\nRun `bin/make regen-types` and commit the result.")
+    end
+  end
+  print("test_drift_all_modules: PASS (" .. #gentype.get_modules() .. " modules)")
+end
+
+-- MODULES must cover definitions.lua: every module section upstream is either
+-- generated or explicitly skipped, and nothing in MODULES is missing upstream.
+local function test_module_list_completeness()
+  local source = defs_source()
+
   local found_modules: {string} = {}
   for line in source:gmatch("[^\n]+") do
     local module_name = line:match("^([a-z0-9_]+)%s*=%s*%{")
@@ -320,68 +344,41 @@ local function test_module_list_completeness()
       table.insert(found_modules, module_name)
     end
   end
-
-  -- Sort both lists for comparison
   table.sort(found_modules)
 
-  local hardcoded = gentype.get_modules()
-  local hardcoded_sorted: {string} = {}
-  for _, m in ipairs(hardcoded) do
-    table.insert(hardcoded_sorted, m)
-  end
-  table.sort(hardcoded_sorted)
-
-  -- Modules in definitions.lua that we intentionally skip generating types for
-  -- because no code in the codebase uses them
+  -- Modules in definitions.lua that we intentionally skip generating types
+  -- for because the cosmos lua binary does not expose them.
   local skip_modules: {string: boolean} = {
     ["finger"] = true,
     ["goodsocket"] = true,
     ["maxmind"] = true,
   }
 
-  -- Check for missing modules (in definitions.lua but not in MODULES and not skipped)
+  local have: {string: boolean} = {}
+  for _, h in ipairs(gentype.get_modules()) do have[h] = true end
+  local found: {string: boolean} = {}
+  for _, m in ipairs(found_modules) do found[m] = true end
+
   local missing: {string} = {}
   for _, m in ipairs(found_modules) do
-    if skip_modules[m] then
-      -- intentionally skipped
-    else
-      local found = false
-      for _, h in ipairs(hardcoded_sorted) do
-        if m == h then
-          found = true
-          break
-        end
-      end
-      if not found then
-        table.insert(missing, m)
-      end
+    if not skip_modules[m] and not have[m] then
+      table.insert(missing, m)
     end
   end
-
-  -- Check for extra modules (in MODULES but not in definitions.lua)
   local extra: {string} = {}
-  for _, h in ipairs(hardcoded_sorted) do
-    local found = false
-    for _, m in ipairs(found_modules) do
-      if h == m then
-        found = true
-        break
-      end
-    end
-    if not found then
+  for _, h in ipairs(gentype.get_modules()) do
+    if not found[h] then
       table.insert(extra, h)
     end
   end
 
   if #missing > 0 then
-    local msg = "Missing modules in gentype.tl MODULES list: " .. table.concat(missing, ", ")
-    msg = msg .. "\nUpdate lib/types/gentype.tl MODULES and cook.mk type_modules"
-    error(msg)
+    error("Missing modules in gentype.tl MODULES list: " .. table.concat(missing, ", ")
+      .. "\nUpdate lib/types/gentype.tl MODULES and cook.mk type_modules")
   end
-
   if #extra > 0 then
-    local msg = "Extra modules in gentype.tl MODULES list (not in definitions.lua): " .. table.concat(extra, ", ")
-    error(msg)
+    error("Extra modules in gentype.tl MODULES list (no section in definitions.lua): "
+      .. table.concat(extra, ", "))
   end
 
   print("test_module_list_completeness: PASS (found: " .. table.concat(found_modules, ", ") .. ")")
@@ -392,14 +389,15 @@ local function run_tests()
   test_convert_type()
   test_parse_path_module()
   test_parse_unix_module()
-  test_generate_dtl()
-  test_run()
-  test_get_modules()
-  test_module_list_completeness()
-  test_drift_detection_path()
   test_errno_overload_render()
   test_paren_union_types()
-  test_errno_drift_unix()
+  test_vararg_return()
+  test_generic_degrades_to_any()
+  test_constant_docs_and_comment_braces()
+  test_data_class_and_type_export()
+  test_qualified_class_methods()
+  test_module_list_completeness()
+  test_drift_all_modules()
 
   print("\nAll tests passed!")
 end

--- a/lib/types/gentype_test.tl
+++ b/lib/types/gentype_test.tl
@@ -59,11 +59,13 @@ local function test_convert_type()
   assert(gentype.convert_type("string...") == "string...", "string... passthrough")
   assert(gentype.convert_type("integer...") == "number...", "integer... -> number...")
 
-  -- Function types convert their argument and return types.
+  -- Function types convert their argument and return types. A function type
+  -- with a return is parenthesized so a following `, next` in a type list
+  -- cannot parse as another return of the nested function.
   assert(gentype.convert_type("fun(udata: integer, tries: integer)")
     == "function(udata: number, tries: number)", "fun arg types convert")
   assert(gentype.convert_type("fun(x: integer): integer")
-    == "function(x: number): number", "fun return type converts")
+    == "(function(x: number): number)", "fun return type converts, parenthesized")
 
   -- Module-prefixed types
   assert(gentype.convert_type("lsqlite3.Database") == "Database", "lsqlite3.Database -> Database")


### PR DESCRIPTION
## What

Ends the drift between handcrafted and generated types: every `cosmo.*` type declaration (`lib/types/cosmo.d.tl` + all of `lib/types/cosmo/*.d.tl`, now including `repl`) is generated from cosmopolitan's `definitions.lua`, byte-exact, and enforced in CI. Companion PR whilp/cosmopolitan#130 (merged) made definitions.lua the enforced source of truth upstream; this PR pins the release cut from it (`2026.07.04-b1577d575`).

## The mess this fixes

- `regen-types` ran `require('types.gentype')` under the **bootstrap** binary, so it used the March generator *and* the March definitions.lua embedded in it — regen output depended on the bootstrap pin, not the cosmos pin.
- CI had no byte-exact drift gate, so hand edits accumulated: lsqlite3.d.tl carried 90 hand-written lines (upstream had richer annotations the parser couldn't read), argon2.d.tl's records were handcrafted, zip's `Appender.remove` was typed by hand, re.search's return type was a misparse patched by hand, `cosmo.d.tl` and `repl.d.tl` were entirely handcrafted.
- `$(cosmic_bin)` didn't depend on `lib/types`, so generator edits silently didn't rebuild.

## How it works now

- **Source of truth**: the definitions.lua embedded in the pinned cosmos release (can't disagree with the runtime by construction). Upstream, #130's coverage ratchets guarantee every C binding is annotated — 272 functions, 217 methods, 638 constants, checked in both directions.
- **regen is a pure function of (generator source, cosmos pin)**: `regen-types` runs the current generator from the freshly built cosmic binary against the pinned definitions. Verified: regenerating against the new pin is a **byte-exact no-op**.
- **Drift is a test failure**: `gentype_test.tl` compares generator output byte-for-byte against every committed file, and checks MODULES ↔ definitions.lua completeness both ways. Bump procedure documented in AGENTS.md: bump `3p/cosmos/version.lua` → `bin/make regen-types` → commit; the drift test fails until you do.
- Generated files carry a `-- GENERATED … Do not edit by hand` header. Remaining handcrafted files (`tl.d.tl`, `make-help.d.tl`) are documented as such.
- `GENTYPE_DEFS=/path/to/definitions.lua` overrides the source for pre-release validation against a cosmopolitan checkout.

## Generator improvements

Comment-aware module extraction (a `}` in a doc comment no longer truncates parsing); module-qualified class methods and standalone `@class` blocks; param reconciliation against declaration lists; generalized failure-overload folding (`nil, error: string` and `nil, errno: integer`, not just Errno); variadic returns; `@generic` degradation; inline-table, string-literal, and alias types; nested function types parenthesized/stripped per Teal grammar position; constant doc comments; exported `type X = X` aliases so consumers can name class types; cross-module refs (`unix.Errno` from cosmo) via generated requires. Parsing split into `gentype_parse.tl` (500-line rule).

## Real bugs the honest types exposed

- `cosmic.net.MSG_MORE` and `cosmic.signal.SIGEMT/SIGINFO/SIGIO/SIGPWR/SIGRTMAX/SIGRTMIN/SIGSTKFLT` were re-exports of constants that are **nil at runtime** — removed.
- `ip.resolve` ignored `ResolveIp`'s error return; `EncodeLua` wrappers ignored its error return; `path.join` is honestly `string | nil` now (upstream `@return string?`).

## Validation

- `bin/make ci` locally: format ✓, teal 195/195 ✓, tests **92/92** ✓ (including the byte-exact drift gate against the pinned release), lint 255/255 ✓. The only local example failure is `fetch_example`, which needs network egress this environment doesn't have (fails identically on a clean checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDwMc7ggg6ak4GFPDUGNxw