### PR TITLE
tests: migrate off cosmo.* onto cosmic.* wrappers (audit Phase 0 step 3)

### DIFF
--- a/lib/cosmic/args_test.tl
+++ b/lib/cosmic/args_test.tl
@@ -1,18 +1,17 @@
 #!/usr/bin/env cosmic
 -- test cosmic script argument passing (varargs and arg table)
 
-local unix = require("cosmo.unix")
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
+local cio = require("cosmic.io")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 -- Test script that uses only varargs (...)
 local function test_varargs_only()
-  local script = path.join(tmpdir, "varargs.lua") as string
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "varargs.lua") as string
+  cio.barf(script, [[
 local args = {...}
 print("varargs_count=" .. #args)
 for i, v in ipairs(args) do
@@ -31,8 +30,8 @@ test_varargs_only()
 
 -- Test script that uses only global arg table
 local function test_arg_table_only()
-  local script = path.join(tmpdir, "argtable.lua") as string
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "argtable.lua") as string
+  cio.barf(script, [[
 print("arg_count=" .. #arg)
 print("arg[0]=" .. tostring(arg[0]))
 for i = 1, #arg do
@@ -51,8 +50,8 @@ test_arg_table_only()
 
 -- Test that both varargs and arg table work together and match
 local function test_varargs_and_arg_table()
-  local script = path.join(tmpdir, "both.lua") as string
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "both.lua") as string
+  cio.barf(script, [[
 local varargs = {...}
 print("varargs_count=" .. #varargs)
 print("arg_count=" .. #arg)
@@ -75,8 +74,8 @@ test_varargs_and_arg_table()
 
 -- Test the common pattern: function main(...) os.exit(main(...))
 local function test_main_function_with_varargs()
-  local script = path.join(tmpdir, "main_varargs.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "main_varargs.lua")
+  cio.barf(script, [[
 local function main(...)
   local args = {...}
   print("main_varargs_count=" .. #args)
@@ -99,8 +98,8 @@ test_main_function_with_varargs()
 
 -- Test function main(param) with single optional parameter
 local function test_main_function_with_single_param()
-  local script = path.join(tmpdir, "main_param.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "main_param.lua")
+  cio.barf(script, [[
 local function main(dir)
   dir = dir or "default"
   print("param=" .. dir)
@@ -124,8 +123,8 @@ test_main_function_with_single_param()
 
 -- Test script with no arguments
 local function test_no_arguments()
-  local script = path.join(tmpdir, "noargs.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "noargs.lua")
+  cio.barf(script, [[
 local args = {...}
 print("varargs_count=" .. #args)
 print("arg_count=" .. #arg)
@@ -142,8 +141,8 @@ test_no_arguments()
 
 -- Test arguments containing spaces
 local function test_arguments_with_spaces()
-  local script = path.join(tmpdir, "spaces.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "spaces.lua")
+  cio.barf(script, [[
 local args = {...}
 for i, v in ipairs(args) do
   print("arg[" .. i .. "]=" .. v)
@@ -159,8 +158,8 @@ test_arguments_with_spaces()
 
 -- Test arguments with special characters (use -- to separate from cosmic options)
 local function test_arguments_with_special_chars()
-  local script = path.join(tmpdir, "special.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "special.lua")
+  cio.barf(script, [[
 local args = {...}
 for i, v in ipairs(args) do
   print("arg[" .. i .. "]=" .. v)
@@ -177,9 +176,9 @@ test_arguments_with_special_chars()
 
 -- Test that cosmo.is_main() still works with new varargs approach
 local function test_cosmo_is_main_compatibility()
-  local script = path.join(tmpdir, "is_main.lua")
-  cosmo.Barf(script, [[
-local cosmo = require("cosmo")
+  local script = fs.join(tmpdir, "is_main.lua")
+  cio.barf(script, [[
+local proc = require("cosmic.proc")
 
 local function main(...)
   local args = {...}
@@ -188,7 +187,7 @@ local function main(...)
   return 0
 end
 
-if cosmo.is_main() then
+if proc.is_main() then
   os.exit(main(...))
 end
 ]])
@@ -202,8 +201,8 @@ test_cosmo_is_main_compatibility()
 
 -- Test that --version after script name is passed to script (not consumed by cosmic)
 local function test_version_flag_after_script()
-  local script = path.join(tmpdir, "version_arg.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "version_arg.lua")
+  cio.barf(script, [[
 local args = {...}
 print("args_count=" .. #arg)
 for i, v in ipairs(args) do
@@ -220,8 +219,8 @@ test_version_flag_after_script()
 
 -- Test that --help after script name is passed to script (not consumed by cosmic)
 local function test_help_flag_after_script()
-  local script = path.join(tmpdir, "help_arg.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "help_arg.lua")
+  cio.barf(script, [[
 local args = {...}
 print("args_count=" .. #arg)
 for i, v in ipairs(args) do
@@ -238,8 +237,8 @@ test_help_flag_after_script()
 
 -- Test that -v after script name is passed to script (not consumed by cosmic)
 local function test_v_flag_after_script()
-  local script = path.join(tmpdir, "v_arg.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "v_arg.lua")
+  cio.barf(script, [[
 local args = {...}
 print("args_count=" .. #arg)
 for i, v in ipairs(args) do
@@ -256,8 +255,8 @@ test_v_flag_after_script()
 
 -- Test cosmic options before script and script options after
 local function test_mixed_cosmic_and_script_options()
-  local script = path.join(tmpdir, "mixed.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "mixed.lua")
+  cio.barf(script, [[
 local args = {...}
 print("args_count=" .. #arg)
 for i, v in ipairs(args) do
@@ -277,8 +276,8 @@ test_mixed_cosmic_and_script_options()
 
 -- Test multiple option-like arguments after script name
 local function test_multiple_option_like_args()
-  local script = path.join(tmpdir, "multi_opts.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "multi_opts.lua")
+  cio.barf(script, [[
 local args = {...}
 print("args_count=" .. #arg)
 for i, v in ipairs(args) do
@@ -299,8 +298,8 @@ test_multiple_option_like_args()
 
 -- Test that -- separator works without script options after it
 local function test_separator_with_no_following_options()
-  local script = path.join(tmpdir, "separator_simple.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "separator_simple.lua")
+  cio.barf(script, [[
 local args = {...}
 print("args_count=" .. #arg)
 for i, v in ipairs(args) do
@@ -320,8 +319,8 @@ test_separator_with_no_following_options()
 
 -- Test real-world nvim-like case: script.lua --version
 local function test_nvim_version_pattern()
-  local script = path.join(tmpdir, "nvim_like.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "nvim_like.lua")
+  cio.barf(script, [[
 -- Simulate nvim-like wrapper that checks for --version
 for i = 1, #arg do
   if arg[i] == "--version" then

--- a/lib/cosmic/benchmark_test.tl
+++ b/lib/cosmic/benchmark_test.tl
@@ -1,17 +1,17 @@
 #!/usr/bin/env cosmic
 -- test cosmic.benchmark module
 
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
+local cio = require("cosmic.io")
 local benchmark = require("cosmic.benchmark")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function write_temp(name: string, content: string): string
-  local filepath = path.join(tmpdir, name)
-  cosmo.Barf(filepath, content)
+  local filepath = fs.join(tmpdir, name)
+  cio.barf(filepath, content)
   return filepath
 end
 

--- a/lib/cosmic/binary_test.tl
+++ b/lib/cosmic/binary_test.tl
@@ -1,17 +1,17 @@
 #!/usr/bin/env cosmic
 -- test cosmic bundled binary
 
-local unix = require("cosmo.unix")
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
+local cenv = require("cosmic.env")
 local spawn = require("cosmic.child")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 
 -- helper to create clean environment without LUA_PATH
 -- this ensures we test the bundled libraries, not the repo
 local function clean_env(): {string}
   local env: {string} = {}
-  for _, entry in ipairs(unix.environ()) do
+  for _, entry in ipairs(cenv.list()) do
     if not entry:match("^LUA_PATH=") and not entry:match("^LUA_CPATH=") then
       env[#env + 1] = entry
     end

--- a/lib/cosmic/check_test.tl
+++ b/lib/cosmic/check_test.tl
@@ -1,17 +1,17 @@
 #!/usr/bin/env cosmic
 -- test cosmic --check-types option
 
-local path = require("cosmo.path")
-local unix = require("cosmo.unix")
+local fs = require("cosmic.fs")
+local env = require("cosmic.env")
+local cio = require("cosmic.io")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function write_temp(name: string, content: string): string
-  local filepath = path.join(tmpdir, name)
-  cosmo.Barf(filepath, content)
+  local filepath = fs.join(tmpdir, name)
+  cio.barf(filepath, content)
   return filepath
 end
 
@@ -72,9 +72,8 @@ test_check_missing_file()
 -- Test check with cosmic module types
 local function test_check_with_cosmic_types()
   local input = write_temp("cosmic_check.tl", [[
-local cosmo = require("cosmo")
-local path = require("cosmo.path")
-local result: string = path.join("a", "b")
+local fs = require("cosmic.fs")
+local result: string = fs.join("a", "b")
 print(result)
 ]])
 
@@ -100,10 +99,10 @@ test_check_strict_mode()
 -- Test that TL_PATH env var is picked up by --check-types
 local function test_check_with_tl_path()
   -- Write a type definition file in a custom directory
-  local typedir = path.join(tmpdir, "mytypes")
-  unix.makedirs(typedir, 0x1ed) -- 0755
-  local deffile = path.join(typedir, "mymod.d.tl")
-  cosmo.Barf(deffile, [[
+  local typedir = fs.join(tmpdir, "mytypes")
+  fs.makedirs(typedir, 0x1ed) -- 0755
+  local deffile = fs.join(typedir, "mymod.d.tl")
+  cio.barf(deffile, [[
 local record mymod
   greet: function(name: string): string
 end
@@ -122,7 +121,7 @@ print(s)
   assert(not ok_without, "check should fail without TL_PATH set for custom module")
 
   -- With TL_PATH pointing at the custom type dir it should succeed
-  local base_env = unix.environ()
+  local base_env = env.list()
   local env_with: {string} = {}
   for _, entry in ipairs(base_env) do
     if not entry:match("^TL_PATH=") then
@@ -138,10 +137,10 @@ test_check_with_tl_path()
 -- Test that ;; in TL_PATH is treated as a placeholder for existing package.path
 local function test_check_with_tl_path_double_semicolon()
   -- Write a type definition file in a custom directory
-  local typedir = path.join(tmpdir, "mytypes2")
-  unix.makedirs(typedir, 0x1ed) -- 0755
-  local deffile = path.join(typedir, "mymod2.d.tl")
-  cosmo.Barf(deffile, [[
+  local typedir = fs.join(tmpdir, "mytypes2")
+  fs.makedirs(typedir, 0x1ed) -- 0755
+  local deffile = fs.join(typedir, "mymod2.d.tl")
+  cio.barf(deffile, [[
 local record mymod2
   hello: function(): string
 end
@@ -156,7 +155,7 @@ print(s)
 ]])
 
   -- Set TL_PATH with ;; before paths: custom_dir;;<existing paths would go here>
-  local base_env = unix.environ()
+  local base_env = env.list()
   local env_with: {string} = {}
   for _, entry in ipairs(base_env) do
     if not entry:match("^TL_PATH=") then

--- a/lib/cosmic/child_test.tl
+++ b/lib/cosmic/child_test.tl
@@ -1,10 +1,15 @@
 #!/usr/bin/env cosmic
-local cosmo = require("cosmo")
-local path = require("cosmo.path")
 local child = require("cosmic.child")
+local fs = require("cosmic.fs")
+local proc = require("cosmic.proc")
+local env = require("cosmic.env")
+local time = require("cosmic.time")
+-- cosmo.unix is required directly only for raw fd ops (unix.close) and to
+-- monkey-patch unix.fork for fault injection (test_spawn_fork_failure), which
+-- must share the exact module table that child.tl uses.
 local unix = require("cosmo.unix")
 
-local lua_bin = path.join(os.getenv("TEST_BIN"), "cosmic")
+local lua_bin = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
 
 -- High-level spawn tests --
@@ -71,7 +76,7 @@ test_cwd_option()
 local function test_fork_and_wait()
   local pid = child.fork()
   if pid == 0 then
-    unix.exit(42)
+    proc.exit(42)
   else
     assert(pid > 0, "expected positive child pid in parent, got " .. tostring(pid))
     local waited_pid, status = child.wait(pid)
@@ -84,18 +89,18 @@ end
 test_fork_and_wait()
 
 local function test_fork_child_has_different_pid()
-  local parent_pid = unix.getpid()
-  local marker_file = path.join(TEST_TMPDIR, "fork_test_" .. tostring(parent_pid))
+  local parent_pid = proc.getpid()
+  local marker_file = fs.join(TEST_TMPDIR, "fork_test_" .. tostring(parent_pid))
 
   local pid = child.fork()
   if pid == 0 then
-    local child_pid = unix.getpid()
+    local child_pid = proc.getpid()
     local f = io.open(marker_file, "w")
     if f then
       f:write(tostring(child_pid))
       f:close()
     end
-    unix.exit(0)
+    proc.exit(0)
   else
     child.wait(pid)
     local f = io.open(marker_file, "r")
@@ -115,7 +120,7 @@ test_fork_child_has_different_pid()
 local function test_wifexited_normal_exit()
   local pid = child.fork()
   if pid == 0 then
-    unix.exit(0)
+    proc.exit(0)
   else
     local _, status = child.wait(pid)
     assert(child.WIFEXITED(status), "expected WIFEXITED to be true")
@@ -127,7 +132,7 @@ local function test_wexitstatus_values()
   for _, expected_code in ipairs({0, 1, 42, 127, 255}) do
     local pid = child.fork()
     if pid == 0 then
-      unix.exit(expected_code)
+      proc.exit(expected_code)
     else
       local _, status = child.wait(pid)
       assert(child.WIFEXITED(status), "expected WIFEXITED to be true for code " .. tostring(expected_code))
@@ -160,8 +165,8 @@ test_wifsignaled_on_kill()
 local function test_wnohang_returns_zero_for_running_process()
   local pid = child.fork()
   if pid == 0 then
-    unix.nanosleep(0, 100000000) -- 100ms
-    unix.exit(0)
+    time.sleep(0, 100000000) -- 100ms
+    proc.exit(0)
   else
     local waited_pid = child.wait(pid, child.WNOHANG)
     assert(waited_pid == 0 or waited_pid == pid, "expected 0 or pid, got " .. tostring(waited_pid))
@@ -175,7 +180,7 @@ test_wnohang_returns_zero_for_running_process()
 -- posix_spawn tests --
 
 local function test_posix_spawn_returns_pid()
-  local ls_path = unix.commandv("ls")
+  local ls_path = proc.commandv("ls")
   if ls_path then
     local pid = child.posix_spawn(ls_path, {"ls"})
     assert(pid > 0, "expected positive pid, got " .. tostring(pid))
@@ -200,8 +205,8 @@ local function test_spawn_inherits_env()
   -- child.spawn should pass the parent's environment to the child unchanged.
   -- regression: environ() returns {string} ("KEY=VALUE" entries) but spawn()
   -- iterated it as {string:string} producing "1=KEY=VALUE" garbage.
-  local sentinel = "cosmic_test_inherit_" .. tostring(unix.getpid())
-  unix.setenv("COSMIC_TEST_SENTINEL", sentinel)
+  local sentinel = "cosmic_test_inherit_" .. tostring(proc.getpid())
+  env.set("COSMIC_TEST_SENTINEL", sentinel)
   local handle = child.spawn({lua_bin, "-e", [[
     io.write(os.getenv("COSMIC_TEST_SENTINEL") or "")
   ]]})
@@ -215,8 +220,8 @@ test_spawn_inherits_env()
 local function test_spawn_with_env_map()
   -- child.spawn should accept {string:string} map from env.all()
   local env = require("cosmic.env")
-  local sentinel = "cosmic_test_map_" .. tostring(unix.getpid())
-  unix.setenv("COSMIC_TEST_MAP", sentinel)
+  local sentinel = "cosmic_test_map_" .. tostring(proc.getpid())
+  env.set("COSMIC_TEST_MAP", sentinel)
   local vars = env.all()
   local handle = child.spawn({lua_bin, "-e", [[
     io.write(os.getenv("COSMIC_TEST_MAP") or "")
@@ -231,8 +236,8 @@ test_spawn_with_env_map()
 local function test_spawn_with_env_list()
   -- child.spawn should still accept {string} list format
   local env_mod = require("cosmic.env")
-  local sentinel = "cosmic_test_list_" .. tostring(unix.getpid())
-  unix.setenv("COSMIC_TEST_LIST", sentinel)
+  local sentinel = "cosmic_test_list_" .. tostring(proc.getpid())
+  env.set("COSMIC_TEST_LIST", sentinel)
   local vars = env_mod.list()
   local handle = child.spawn({lua_bin, "-e", [[
     io.write(os.getenv("COSMIC_TEST_LIST") or "")

--- a/lib/cosmic/compile_test.tl
+++ b/lib/cosmic/compile_test.tl
@@ -1,16 +1,16 @@
 #!/usr/bin/env cosmic
 -- test cosmic --compile option
 
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
+local cio = require("cosmic.io")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function write_temp(name: string, content: string): string
-  local filepath = path.join(tmpdir, name)
-  cosmo.Barf(filepath, content)
+  local filepath = fs.join(tmpdir, name)
+  cio.barf(filepath, content)
   return filepath
 end
 
@@ -98,12 +98,12 @@ local function add(a: number, b: number): number
 end
 print("result=" .. add(2, 3))
 ]])
-  local output = path.join(tmpdir, "runnable.lua")
+  local output = fs.join(tmpdir, "runnable.lua")
 
   local ok, lua_code = spawn.spawn({cosmic, "--compile", input}):read()
   assert(ok, "compilation should succeed")
 
-  cosmo.Barf(output, lua_code as string)
+  cio.barf(output, lua_code as string)
 
   local run_ok, run_out = spawn.spawn({cosmic, output}):read()
   assert(run_ok, "compiled output should run")
@@ -171,7 +171,7 @@ local function test_compile_write_if_changed()
 local x: number = 42
 print(x)
 ]])
-  local output = path.join(tmpdir, "wic.lua")
+  local output = fs.join(tmpdir, "wic.lua")
 
   -- First run: file does not exist, should be created
   local ok1, _ = spawn.spawn({cosmic, "--write-if-changed", "--output", output, "--compile", input}):read()
@@ -203,7 +203,7 @@ test_compile_write_if_changed()
 -- Test write-if-changed with --format: skips write when formatted output is identical
 local function test_format_write_if_changed()
   local input = write_temp("wic_fmt.lua", "local x = 42\n")
-  local output = path.join(tmpdir, "wic_fmt_out.lua")
+  local output = fs.join(tmpdir, "wic_fmt_out.lua")
 
   -- First run: output file does not exist, should be created
   local ok1, _ = spawn.spawn({cosmic, "--write-if-changed", "--output", output, "--format", input}):read()

--- a/lib/cosmic/cosmic_debug_test.tl
+++ b/lib/cosmic/cosmic_debug_test.tl
@@ -2,12 +2,12 @@
 --- Tests for cosmic-debug binary
 
 local spawn = require("cosmic.child")
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
 
 global TEST_BIN: string
 
 local function test_cosmic_debug_version()
-  local bin = path.join(TEST_BIN, "cosmic-debug")
+  local bin = fs.join(TEST_BIN, "cosmic-debug")
   local ok, got = spawn.spawn({bin, "-v"}):read()
   assert(ok, "cosmic-debug -v failed: " .. tostring(got))
   local want = "Lua"
@@ -16,7 +16,7 @@ end
 test_cosmic_debug_version()
 
 local function test_cosmic_debug_runs_lua()
-  local bin = path.join(TEST_BIN, "cosmic-debug")
+  local bin = fs.join(TEST_BIN, "cosmic-debug")
   local ok, got = spawn.spawn({bin, "-e", "print('hello from debug')"}):read()
   assert(ok, "cosmic-debug -e failed: " .. tostring(got))
   local want = "hello from debug"
@@ -25,7 +25,7 @@ end
 test_cosmic_debug_runs_lua()
 
 local function test_cosmic_debug_help()
-  local bin = path.join(TEST_BIN, "cosmic-debug")
+  local bin = fs.join(TEST_BIN, "cosmic-debug")
   local ok, got = spawn.spawn({bin, "--help"}):read()
   assert(ok, "cosmic-debug --help failed: " .. tostring(got))
   local want = "cosmic"

--- a/lib/cosmic/cosmic_test.tl
+++ b/lib/cosmic/cosmic_test.tl
@@ -1,6 +1,4 @@
 #!/usr/bin/env cosmic
-local unix = require("cosmo.unix")
-local path = require("cosmo.path")
 
 -- Note: TEST_DEPS tests removed - TEST_DEPS is a Make variable not passed to Lua tests
 

--- a/lib/cosmic/doc_test.tl
+++ b/lib/cosmic/doc_test.tl
@@ -1,17 +1,17 @@
 #!/usr/bin/env cosmic
 -- test cosmic.doc module
 
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
+local cio = require("cosmic.io")
 local doc = require("cosmic.doc")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function write_temp(name: string, content: string): string
-  local filepath = path.join(tmpdir, name)
-  cosmo.Barf(filepath, content)
+  local filepath = fs.join(tmpdir, name)
+  cio.barf(filepath, content)
   return filepath
 end
 

--- a/lib/cosmic/docs_guide_test.tl
+++ b/lib/cosmic/docs_guide_test.tl
@@ -1,15 +1,15 @@
 #!/usr/bin/env cosmic
 -- test cosmic --docs guide
 
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
+local cenv = require("cosmic.env")
 local spawn = require("cosmic.child")
-local unix = require("cosmo.unix")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 
 local function clean_env(): {string}
   local env: {string} = {}
-  for _, entry in ipairs(unix.environ()) do
+  for _, entry in ipairs(cenv.list()) do
     if not entry:match("^LUA_PATH=") and not entry:match("^LUA_CPATH=") then
       env[#env + 1] = entry
     end

--- a/lib/cosmic/embed_advanced_test.tl
+++ b/lib/cosmic/embed_advanced_test.tl
@@ -1,14 +1,14 @@
 #!/usr/bin/env cosmic
 -- advanced embed tests: extract, roundtrip, overwrite, permissions, corruption
 
-local path = require("cosmo.path")
-local unix = require("cosmo.unix")
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
+local time = require("cosmic.time")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
-local zip = require("cosmo.zip")
+local zip = require("cosmic.zip")
 local embed = require("cosmic.embed")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 -- Local declaration of Reader interface for type casting
@@ -31,58 +31,58 @@ local record Writer
 end
 
 local function write_temp(name: string, content: string): string
-  local filepath = path.join(tmpdir, name)
-  local dir = path.dirname(filepath)
+  local filepath = fs.join(tmpdir, name)
+  local dir = fs.dirname(filepath)
   if dir ~= tmpdir then
-    unix.makedirs(dir)
+    fs.makedirs(dir)
   end
-  cosmo.Barf(filepath, content)
+  cio.barf(filepath, content)
   return filepath
 end
 
 -- Test --extract extracts zip contents
 local function test_extract()
-  local extractdir = path.join(tmpdir, "extracted")
+  local extractdir = fs.join(tmpdir, "extracted")
 
   local ok, out = spawn.spawn({cosmic, "--extract", extractdir}):read()
   assert(ok, "extract should succeed: " .. (out or ""))
 
   -- main.lua should be extracted
-  assert(path.isfile(path.join(extractdir, "main.lua")), "main.lua should be extracted")
+  assert(fs.isfile(fs.join(extractdir, "main.lua")), "main.lua should be extracted")
 
   -- .args should be extracted
-  assert(path.isfile(path.join(extractdir, ".args")), ".args should be extracted")
+  assert(fs.isfile(fs.join(extractdir, ".args")), ".args should be extracted")
 
   -- bundled libraries should be extracted
-  assert(path.isdir(path.join(extractdir, ".lua")), ".lua directory should be extracted")
+  assert(fs.isdir(fs.join(extractdir, ".lua")), ".lua directory should be extracted")
 end
 test_extract()
 
 -- Test extract-then-embed roundtrip preserves file contents
 local function test_extract_embed_roundtrip()
   -- Extract the cosmic binary
-  local extractdir = path.join(tmpdir, "roundtrip-extract")
+  local extractdir = fs.join(tmpdir, "roundtrip-extract")
   local ok, out = spawn.spawn({cosmic, "--extract", extractdir}):read()
   assert(ok, "extract should succeed: " .. (out or ""))
 
   -- Read original main.lua from the zip
-  local orig_data = cosmo.Slurp(cosmic)
+  local orig_data = cio.slurp(cosmic)
   local orig_reader = zip.from(orig_data) as Reader
   local orig_main = orig_reader:read("main.lua")
   assert(orig_main, "original should have main.lua")
   orig_reader:close()
 
   -- Read extracted main.lua from disk
-  local extracted_main = cosmo.Slurp(path.join(extractdir, "main.lua"))
+  local extracted_main = cio.slurp(fs.join(extractdir, "main.lua"))
   assert(extracted_main == orig_main, "extracted main.lua should match original")
 
   -- Re-embed the extracted directory
-  local output = path.join(tmpdir, "roundtrip-output")
+  local output = fs.join(tmpdir, "roundtrip-output")
   ok, out = spawn.spawn({cosmic, "--embed", extractdir, "--output", output}):read()
   assert(ok, "re-embed should succeed: " .. (out or ""))
 
   -- Read main.lua from the re-embedded binary
-  local new_data = cosmo.Slurp(output)
+  local new_data = cio.slurp(output)
   local new_reader = zip.from(new_data) as Reader
   local new_main = new_reader:read("main.lua")
   assert(new_main == orig_main, "roundtripped main.lua should match original")
@@ -93,15 +93,15 @@ test_extract_embed_roundtrip()
 -- Test extract-modify-embed workflow
 local function test_extract_modify_embed()
   -- Extract
-  local extractdir = path.join(tmpdir, "modify-extract")
+  local extractdir = fs.join(tmpdir, "modify-extract")
   local ok, out = spawn.spawn({cosmic, "--extract", extractdir}):read()
   assert(ok, "extract should succeed: " .. (out or ""))
 
   -- Modify main.lua
-  cosmo.Barf(path.join(extractdir, "main.lua"), 'io.write("modified\\n")\n')
+  cio.barf(fs.join(extractdir, "main.lua"), 'io.write("modified\\n")\n')
 
   -- Re-embed
-  local output = path.join(tmpdir, "modified-cosmic")
+  local output = fs.join(tmpdir, "modified-cosmic")
   ok, out = spawn.spawn({cosmic, "--embed", extractdir, "--output", output}):read()
   assert(ok, "embed modified should succeed: " .. (out or ""))
 
@@ -115,7 +115,7 @@ test_extract_modify_embed()
 -- Test that embed overwrites existing zip entries cleanly
 local function test_embed_overwrites_cleanly()
   -- Read original zip file list
-  local orig_data = cosmo.Slurp(cosmic)
+  local orig_data = cio.slurp(cosmic)
   local orig_reader = zip.from(orig_data) as Reader
   local orig_files: {string: boolean} = {}
   for _, name in ipairs(orig_reader:list()) do
@@ -127,16 +127,16 @@ local function test_embed_overwrites_cleanly()
   orig_reader:close()
 
   -- Embed a directory that overrides main.lua
-  local appdir = path.join(tmpdir, "overwrite-app")
-  unix.makedirs(appdir)
-  cosmo.Barf(path.join(appdir, "main.lua"), 'print("new")\n')
+  local appdir = fs.join(tmpdir, "overwrite-app")
+  fs.makedirs(appdir)
+  cio.barf(fs.join(appdir, "main.lua"), 'print("new")\n')
 
-  local output = path.join(tmpdir, "cosmic-overwrite")
+  local output = fs.join(tmpdir, "cosmic-overwrite")
   local ok, out = spawn.spawn({cosmic, "--embed", appdir, "--output", output}):read()
   assert(ok, "embed should succeed: " .. (out or ""))
 
   -- The new zip should have main.lua with the new content
-  local new_data = cosmo.Slurp(output)
+  local new_data = cio.slurp(output)
   local new_reader = zip.from(new_data) as Reader
   local new_main = new_reader:read("main.lua")
   assert(new_main == 'print("new")\n', "main.lua should have new content: " .. tostring(new_main))
@@ -153,29 +153,29 @@ test_embed_overwrites_cleanly()
 
 -- Test that file modes are preserved in the zip archive
 local function test_embed_preserves_file_modes()
-  local appdir = path.join(tmpdir, "modeapp")
-  unix.makedirs(appdir)
+  local appdir = fs.join(tmpdir, "modeapp")
+  fs.makedirs(appdir)
 
   -- Create files with different modes
-  local script = path.join(appdir, "run.sh")
-  local config = path.join(appdir, "config.txt")
-  local secret = path.join(appdir, "secret.key")
+  local script = fs.join(appdir, "run.sh")
+  local config = fs.join(appdir, "config.txt")
+  local secret = fs.join(appdir, "secret.key")
 
-  cosmo.Barf(script, "#!/bin/sh\necho hello\n")
-  cosmo.Barf(config, "setting=value\n")
-  cosmo.Barf(secret, "private-key-data\n")
+  cio.barf(script, "#!/bin/sh\necho hello\n")
+  cio.barf(config, "setting=value\n")
+  cio.barf(secret, "private-key-data\n")
 
   -- Set specific modes
-  unix.chmod(script, tonumber("755", 8))
-  unix.chmod(config, tonumber("644", 8))
-  unix.chmod(secret, tonumber("600", 8))
+  fs.chmod(script, tonumber("755", 8))
+  fs.chmod(config, tonumber("644", 8))
+  fs.chmod(secret, tonumber("600", 8))
 
-  local output = path.join(tmpdir, "cosmic-modes")
+  local output = fs.join(tmpdir, "cosmic-modes")
   local ok, out = spawn.spawn({cosmic, "--embed", appdir, "--output", output}):read()
   assert(ok, "embed should succeed: " .. (out or ""))
 
   -- Check modes in the zip archive
-  local data = cosmo.Slurp(output)
+  local data = cio.slurp(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
   local reader = reader_maybe as Reader
@@ -207,30 +207,30 @@ test_embed_preserves_file_modes()
 -- Test that file modes are restored on extract
 local function test_extract_preserves_file_modes()
   -- First embed files with specific modes
-  local appdir = path.join(tmpdir, "extract-modeapp")
-  unix.makedirs(appdir)
+  local appdir = fs.join(tmpdir, "extract-modeapp")
+  fs.makedirs(appdir)
 
-  local script = path.join(appdir, "run.sh")
-  local secret = path.join(appdir, "secret.key")
+  local script = fs.join(appdir, "run.sh")
+  local secret = fs.join(appdir, "secret.key")
 
-  cosmo.Barf(script, "#!/bin/sh\necho hello\n")
-  cosmo.Barf(secret, "private-key-data\n")
+  cio.barf(script, "#!/bin/sh\necho hello\n")
+  cio.barf(secret, "private-key-data\n")
 
-  unix.chmod(script, tonumber("755", 8))
-  unix.chmod(secret, tonumber("600", 8))
+  fs.chmod(script, tonumber("755", 8))
+  fs.chmod(secret, tonumber("600", 8))
 
-  local embedded = path.join(tmpdir, "cosmic-extract-modes")
+  local embedded = fs.join(tmpdir, "cosmic-extract-modes")
   local ok, out = spawn.spawn({cosmic, "--embed", appdir, "--output", embedded}):read()
   assert(ok, "embed should succeed: " .. (out or ""))
 
   -- Extract to a new directory
-  local extractdir = path.join(tmpdir, "extracted-modes")
+  local extractdir = fs.join(tmpdir, "extracted-modes")
   ok, out = spawn.spawn({embedded, "--extract", extractdir}):read()
   assert(ok, "extract should succeed: " .. (out or ""))
 
   -- Check modes of extracted files
-  local script_stat = unix.stat(path.join(extractdir, "run.sh"))
-  local secret_stat = unix.stat(path.join(extractdir, "secret.key"))
+  local script_stat = fs.stat(fs.join(extractdir, "run.sh"))
+  local secret_stat = fs.stat(fs.join(extractdir, "secret.key"))
 
   assert(script_stat, "run.sh should exist after extract")
   assert(secret_stat, "secret.key should exist after extract")
@@ -252,12 +252,12 @@ test_extract_preserves_file_modes()
 -- ensures the old inode stays valid for the running process.
 local function test_embed_does_not_corrupt_running_process()
   -- Create a program that sleeps, then exercises code pages
-  local appdir = path.join(tmpdir, "running-app")
-  unix.makedirs(appdir)
-  cosmo.Barf(path.join(appdir, "main.lua"), [[
-local unix = require("cosmo.unix")
+  local appdir = fs.join(tmpdir, "running-app")
+  fs.makedirs(appdir)
+  cio.barf(fs.join(appdir, "main.lua"), [[
+local time = require("cosmic.time")
 -- Sleep to give the test time to overwrite the binary
-unix.nanosleep(1)
+time.sleep(1)
 -- Exercise code paths that touch mmapped pages (string ops, table ops, format)
 local t = {}
 for i = 1, 100 do t[i] = string.format("item_%04d", i) end
@@ -266,7 +266,7 @@ local result = table.concat(t, ",")
 io.write("OK:" .. #result)
 ]])
 
-  local binary = path.join(tmpdir, "cosmic-running")
+  local binary = fs.join(tmpdir, "cosmic-running")
   local ok, out = spawn.spawn({cosmic, "--embed", appdir, "--output", binary}):read()
   assert(ok, "initial embed should succeed: " .. (out or ""))
 
@@ -274,7 +274,7 @@ io.write("OK:" .. #result)
   local handle = spawn.spawn({binary})
 
   -- Wait briefly for the process to start and mmap its pages
-  unix.nanosleep(0, 100000000) -- 100ms
+  time.sleep(0, 100000000) -- 100ms
 
   -- Re-embed over the same path while the process is running.
   -- Without atomic write, this would corrupt the running process.
@@ -298,41 +298,41 @@ local function test_extract_rejects_path_traversal()
   -- produced by another tool: write a same-length placeholder name and
   -- byte-patch it to a traversal name (no offsets change, so the zip stays
   -- valid). "XX/escaped.txt" -> "../escaped.txt".
-  local safe = path.join(tmpdir, "patched.zip")
+  local safe = fs.join(tmpdir, "patched.zip")
   local w = zip.open(safe, "w") as Writer
   assert(w, "should open zip for writing")
   w:add("XX/escaped.txt", "pwned")
   w:close()
-  local raw = cosmo.Slurp(safe)
+  local raw = cio.slurp(safe)
   local patched = (raw as string):gsub("XX/escaped%.txt", "../escaped.txt")
-  local malicious = path.join(tmpdir, "malicious.zip")
-  cosmo.Barf(malicious, patched)
+  local malicious = fs.join(tmpdir, "malicious.zip")
+  cio.barf(malicious, patched)
 
-  local outdir = path.join(tmpdir, "extract-target")
+  local outdir = fs.join(tmpdir, "extract-target")
   local result = embed.extract(outdir, malicious)
   assert(not result.ok, "extract should reject path traversal entry")
   assert(result.message:match("unsafe path"), "expected unsafe path error, got: " .. result.message)
 
   -- The escaping file must not have been written next to the target dir.
-  local escaped = path.join(tmpdir, "escaped.txt")
-  assert(not path.isfile(escaped), "traversal file should not be written outside target")
+  local escaped = fs.join(tmpdir, "escaped.txt")
+  assert(not fs.isfile(escaped), "traversal file should not be written outside target")
 end
 test_extract_rejects_path_traversal()
 
 -- FIX 2: collect_dir must not recurse into symlinked directories.
 -- A symlink loop inside the embed dir must terminate without error.
 local function test_embed_symlink_loop_terminates()
-  local appdir = path.join(tmpdir, "symlinkloop")
-  unix.makedirs(path.join(appdir, "sub"))
-  cosmo.Barf(path.join(appdir, "sub", "real.txt"), "data")
+  local appdir = fs.join(tmpdir, "symlinkloop")
+  fs.makedirs(fs.join(appdir, "sub"))
+  cio.barf(fs.join(appdir, "sub", "real.txt"), "data")
   -- Create a cycle: sub/loop -> ..  (points back to appdir)
-  unix.symlink("..", path.join(appdir, "sub", "loop"))
+  fs.symlink("..", fs.join(appdir, "sub", "loop"))
 
   -- embed.collect_dir is called internally; run via the module directly
-  local result = embed.run({appdir}, path.join(tmpdir, "cosmic-symlinkloop"), cosmic)
+  local result = embed.run({appdir}, fs.join(tmpdir, "cosmic-symlinkloop"), cosmic)
   assert(result.ok, "embed of dir with symlink loop should succeed: " .. (result.message or ""))
   -- Only real.txt should be embedded, not any path through the loop
-  local data = cosmo.Slurp(path.join(tmpdir, "cosmic-symlinkloop"))
+  local data = cio.slurp(fs.join(tmpdir, "cosmic-symlinkloop"))
   local reader = zip.from(data) as Reader
   local files = reader:list()
   for _, f in ipairs(files) do
@@ -345,19 +345,19 @@ test_embed_symlink_loop_terminates()
 -- FIX 2: a symlink to a file *outside* the embed dir must NOT be embedded.
 local function test_embed_symlink_to_outside_file_skipped()
   -- Create a file outside the embed dir
-  local outside = path.join(tmpdir, "outside_secret.txt")
-  cosmo.Barf(outside, "secret-content")
+  local outside = fs.join(tmpdir, "outside_secret.txt")
+  cio.barf(outside, "secret-content")
 
-  local appdir = path.join(tmpdir, "symlinkoutside")
-  unix.makedirs(appdir)
-  cosmo.Barf(path.join(appdir, "main.lua"), 'print("hi")\n')
+  local appdir = fs.join(tmpdir, "symlinkoutside")
+  fs.makedirs(appdir)
+  cio.barf(fs.join(appdir, "main.lua"), 'print("hi")\n')
   -- Symlink inside the embed dir pointing outside
-  unix.symlink(outside, path.join(appdir, "leaked.txt"))
+  fs.symlink(outside, fs.join(appdir, "leaked.txt"))
 
-  local result = embed.run({appdir}, path.join(tmpdir, "cosmic-symlinkoutside"), cosmic)
+  local result = embed.run({appdir}, fs.join(tmpdir, "cosmic-symlinkoutside"), cosmic)
   assert(result.ok, "embed should succeed even with outside symlink: " .. (result.message or ""))
   -- "leaked.txt" (the symlink) must not appear in the zip
-  local data = cosmo.Slurp(path.join(tmpdir, "cosmic-symlinkoutside"))
+  local data = cio.slurp(fs.join(tmpdir, "cosmic-symlinkoutside"))
   local reader = zip.from(data) as Reader
   local files = reader:list()
   for _, f in ipairs(files) do

--- a/lib/cosmic/embed_env_test.tl
+++ b/lib/cosmic/embed_env_test.tl
@@ -1,13 +1,13 @@
 #!/usr/bin/env cosmic
 -- test cosmic env var fallbacks: COSMIC_EMBED, COSMIC_OUTPUT, COSMIC_EXTRACT
 
-local path = require("cosmo.path")
-local unix = require("cosmo.unix")
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
+local cenv = require("cosmic.env")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
-local zip = require("cosmo.zip")
+local zip = require("cosmic.zip")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 -- Local declaration of Reader interface for type casting
@@ -24,23 +24,22 @@ local record Stat
 end
 
 local function write_temp(name: string, content: string): string
-  local filepath = path.join(tmpdir, name)
-  local dir = path.dirname(filepath)
+  local filepath = fs.join(tmpdir, name)
+  local dir = fs.dirname(filepath)
   if dir ~= tmpdir then
-    unix.makedirs(dir)
+    fs.makedirs(dir)
   end
-  cosmo.Barf(filepath, content)
+  cio.barf(filepath, content)
   return filepath
 end
 
 -- Test embed via COSMIC_EMBED and COSMIC_OUTPUT env vars
 local function test_embed_via_env()
   local input = write_temp("env-hello.txt", "env hello world")
-  local output = path.join(tmpdir, "cosmic-env-embed")
+  local output = fs.join(tmpdir, "cosmic-env-embed")
 
   -- Build env: inherit parent + add COSMIC_EMBED, COSMIC_OUTPUT
-  local unix2 = require("cosmo.unix")
-  local parent_env = unix2.environ()
+  local parent_env = cenv.list()
   local env: {string} = {}
   for _, e in ipairs(parent_env) do
     env[#env + 1] = e
@@ -53,10 +52,10 @@ local function test_embed_via_env()
   assert(ok, "cosmic with COSMIC_EMBED env should succeed: " .. (out or ""))
 
   -- Verify output exists and content is embedded
-  local stat = unix.stat(output)
+  local stat = fs.stat(output)
   assert(stat, "output file should exist")
 
-  local data = cosmo.Slurp(output)
+  local data = cio.slurp(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
   local reader = reader_maybe as Reader
@@ -70,11 +69,10 @@ test_embed_via_env()
 
 -- Test extract via COSMIC_EXTRACT env var
 local function test_extract_via_env()
-  local extractdir = path.join(tmpdir, "env-extracted")
+  local extractdir = fs.join(tmpdir, "env-extracted")
 
   -- Build env: inherit parent + add COSMIC_EXTRACT
-  local unix2 = require("cosmo.unix")
-  local parent_env = unix2.environ()
+  local parent_env = cenv.list()
   local env: {string} = {}
   for _, e in ipairs(parent_env) do
     env[#env + 1] = e
@@ -86,7 +84,7 @@ local function test_extract_via_env()
   assert(ok, "cosmic with COSMIC_EXTRACT env should succeed: " .. (out or ""))
 
   -- main.lua should be extracted
-  assert(path.isfile(path.join(extractdir, "main.lua")), "main.lua should be extracted via env var")
+  assert(fs.isfile(fs.join(extractdir, "main.lua")), "main.lua should be extracted via env var")
 end
 test_extract_via_env()
 
@@ -94,11 +92,10 @@ test_extract_via_env()
 local function test_cli_priority_over_env()
   local env_input = write_temp("env-priority.txt", "from env")
   local cli_input = write_temp("cli-priority.txt", "from cli")
-  local output = path.join(tmpdir, "cosmic-priority")
+  local output = fs.join(tmpdir, "cosmic-priority")
 
   -- Build env: inherit parent + COSMIC_EMBED pointing to env_input
-  local unix2 = require("cosmo.unix")
-  local parent_env = unix2.environ()
+  local parent_env = cenv.list()
   local env: {string} = {}
   for _, e in ipairs(parent_env) do
     env[#env + 1] = e
@@ -110,7 +107,7 @@ local function test_cli_priority_over_env()
   local ok, out = spawn.spawn({cosmic, "--embed", cli_input, "--output", output}, {env = env}):read()
   assert(ok, "cosmic --embed with env override should succeed: " .. (out or ""))
 
-  local data = cosmo.Slurp(output)
+  local data = cio.slurp(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
   local reader = reader_maybe as Reader

--- a/lib/cosmic/embed_test.tl
+++ b/lib/cosmic/embed_test.tl
@@ -1,13 +1,12 @@
 #!/usr/bin/env cosmic
 -- test cosmic --embed and --extract options
 
-local path = require("cosmo.path")
-local unix = require("cosmo.unix")
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
-local zip = require("cosmo.zip")
+local zip = require("cosmic.zip")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 -- Local declaration of Reader interface for type casting
@@ -27,30 +26,30 @@ local record Stat
 end
 
 local function write_temp(name: string, content: string): string
-  local filepath = path.join(tmpdir, name)
-  local dir = path.dirname(filepath)
+  local filepath = fs.join(tmpdir, name)
+  local dir = fs.dirname(filepath)
   if dir ~= tmpdir then
-    unix.makedirs(dir)
+    fs.makedirs(dir)
   end
-  cosmo.Barf(filepath, content)
+  cio.barf(filepath, content)
   return filepath
 end
 
 -- Test basic embed of single file
 local function test_embed_single_file()
   local input = write_temp("hello.txt", "hello world")
-  local output = path.join(tmpdir, "cosmic-single")
+  local output = fs.join(tmpdir, "cosmic-single")
 
   local ok, out = spawn.spawn({cosmic, "--embed", input, "--output", output}):read()
   assert(ok, "cosmic --embed should succeed: " .. (out or ""))
 
   -- Verify output exists and is executable
-  local stat = unix.stat(output)
+  local stat = fs.stat(output)
   assert(stat, "output file should exist")
   assert(stat:mode() & 73 ~= 0, "output should be executable")
 
   -- Verify file is in the zip
-  local data = cosmo.Slurp(output)
+  local data = cio.slurp(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
   local reader = reader_maybe as Reader
@@ -77,12 +76,12 @@ test_embed_single_file()
 local function test_embed_multiple_files()
   local file1 = write_temp("multi/one.txt", "content one")
   local file2 = write_temp("multi/two.txt", "content two")
-  local output = path.join(tmpdir, "cosmic-multi")
+  local output = fs.join(tmpdir, "cosmic-multi")
 
   local ok, out = spawn.spawn({cosmic, "--embed", file1, "--embed", file2, "--output", output}):read()
   assert(ok, "cosmic --embed with multiple files should succeed: " .. (out or ""))
 
-  local data = cosmo.Slurp(output)
+  local data = cio.slurp(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
   local reader = reader_maybe as Reader
@@ -101,20 +100,20 @@ test_embed_multiple_files()
 -- Test custom output path (covers the output option)
 local function test_embed_custom_output()
   local input = write_temp("custom.txt", "custom content")
-  local output = path.join(tmpdir, "subdir/myapp")
-  unix.makedirs(path.dirname(output))
+  local output = fs.join(tmpdir, "subdir/myapp")
+  fs.makedirs(fs.dirname(output))
 
   local ok, out = spawn.spawn({cosmic, "--embed", input, "--output", output}):read()
   assert(ok, "cosmic --embed with custom output path should succeed: " .. (out or ""))
 
-  local stat = unix.stat(output)
+  local stat = fs.stat(output)
   assert(stat, "custom output path should exist")
 end
 test_embed_custom_output()
 
 -- Test error on missing input file
 local function test_embed_missing_file()
-  local output = path.join(tmpdir, "cosmic-missing")
+  local output = fs.join(tmpdir, "cosmic-missing")
   local ok, _out = spawn.spawn({cosmic, "--embed", "/nonexistent/file.txt", "--output", output}):read()
   assert(not ok, "cosmic --embed should fail on missing file")
 end
@@ -123,13 +122,13 @@ test_embed_missing_file()
 -- Test embedding lua files
 local function test_embed_lua_file()
   local modfile = write_temp("mymod.lua", [[return { value = 42 }]])
-  local output = path.join(tmpdir, "cosmic-lua")
+  local output = fs.join(tmpdir, "cosmic-lua")
 
   local ok, out = spawn.spawn({cosmic, "--embed", modfile, "--output", output}):read()
   assert(ok, "embed should succeed: " .. (out or ""))
 
   -- Verify the lua file is in the zip with correct content
-  local data = cosmo.Slurp(output)
+  local data = cio.slurp(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
   local reader = reader_maybe as Reader
@@ -145,12 +144,12 @@ local function test_embed_binary_file()
   -- Create a file with binary content
   local binary = "\x00\x01\x02\xff\xfe\xfd"
   local input = write_temp("binary.bin", binary)
-  local output = path.join(tmpdir, "cosmic-binary")
+  local output = fs.join(tmpdir, "cosmic-binary")
 
   local ok, out = spawn.spawn({cosmic, "--embed", input, "--output", output}):read()
   assert(ok, "embed binary should succeed: " .. (out or ""))
 
-  local data = cosmo.Slurp(output)
+  local data = cio.slurp(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
   local reader = reader_maybe as Reader
@@ -164,18 +163,18 @@ test_embed_binary_file()
 -- Test embedding a directory
 local function test_embed_directory()
   -- Create a directory structure
-  local appdir = path.join(tmpdir, "testapp")
-  unix.makedirs(path.join(appdir, "lib"))
-  cosmo.Barf(path.join(appdir, "main.lua"), 'print("hello")\n')
-  cosmo.Barf(path.join(appdir, "lib/util.lua"), 'return {x=1}\n')
-  cosmo.Barf(path.join(appdir, "data.txt"), "some data")
+  local appdir = fs.join(tmpdir, "testapp")
+  fs.makedirs(fs.join(appdir, "lib"))
+  cio.barf(fs.join(appdir, "main.lua"), 'print("hello")\n')
+  cio.barf(fs.join(appdir, "lib/util.lua"), 'return {x=1}\n')
+  cio.barf(fs.join(appdir, "data.txt"), "some data")
 
-  local output = path.join(tmpdir, "cosmic-dir")
+  local output = fs.join(tmpdir, "cosmic-dir")
   local ok, out = spawn.spawn({cosmic, "--embed", appdir, "--output", output}):read()
   assert(ok, "embed directory should succeed: " .. (out or ""))
 
   -- Verify files are stored relative to directory root
-  local data = cosmo.Slurp(output)
+  local data = cio.slurp(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
   local reader = reader_maybe as Reader
@@ -195,17 +194,17 @@ test_embed_directory()
 
 -- Test embedding a directory with nested subdirectories
 local function test_embed_nested_directory()
-  local appdir = path.join(tmpdir, "nested")
-  unix.makedirs(path.join(appdir, "a/b/c"))
-  cosmo.Barf(path.join(appdir, "top.txt"), "top")
-  cosmo.Barf(path.join(appdir, "a/mid.txt"), "mid")
-  cosmo.Barf(path.join(appdir, "a/b/c/deep.txt"), "deep")
+  local appdir = fs.join(tmpdir, "nested")
+  fs.makedirs(fs.join(appdir, "a/b/c"))
+  cio.barf(fs.join(appdir, "top.txt"), "top")
+  cio.barf(fs.join(appdir, "a/mid.txt"), "mid")
+  cio.barf(fs.join(appdir, "a/b/c/deep.txt"), "deep")
 
-  local output = path.join(tmpdir, "cosmic-nested")
+  local output = fs.join(tmpdir, "cosmic-nested")
   local ok, out = spawn.spawn({cosmic, "--embed", appdir, "--output", output}):read()
   assert(ok, "embed nested directory should succeed: " .. (out or ""))
 
-  local data = cosmo.Slurp(output)
+  local data = cio.slurp(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
   local reader = reader_maybe as Reader
@@ -219,17 +218,17 @@ test_embed_nested_directory()
 
 -- Test mixing directory and file embedding
 local function test_embed_mixed()
-  local appdir = path.join(tmpdir, "mixapp")
-  unix.makedirs(appdir)
-  cosmo.Barf(path.join(appdir, "main.lua"), 'print("mixed")\n')
+  local appdir = fs.join(tmpdir, "mixapp")
+  fs.makedirs(appdir)
+  cio.barf(fs.join(appdir, "main.lua"), 'print("mixed")\n')
 
   local extra = write_temp("extra.txt", "extra content")
-  local output = path.join(tmpdir, "cosmic-mixed")
+  local output = fs.join(tmpdir, "cosmic-mixed")
 
   local ok, out = spawn.spawn({cosmic, "--embed", appdir, "--embed", extra, "--output", output}):read()
   assert(ok, "embed mixed should succeed: " .. (out or ""))
 
-  local data = cosmo.Slurp(output)
+  local data = cio.slurp(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
   local reader = reader_maybe as Reader
@@ -246,11 +245,11 @@ test_embed_mixed()
 
 -- Test that embedded directory produces a working executable
 local function test_embed_directory_executable()
-  local appdir = path.join(tmpdir, "runapp")
-  unix.makedirs(appdir)
-  cosmo.Barf(path.join(appdir, "main.lua"), 'io.write("it works\\n")\n')
+  local appdir = fs.join(tmpdir, "runapp")
+  fs.makedirs(appdir)
+  cio.barf(fs.join(appdir, "main.lua"), 'io.write("it works\\n")\n')
 
-  local output = path.join(tmpdir, "cosmic-runapp")
+  local output = fs.join(tmpdir, "cosmic-runapp")
   local ok, out = spawn.spawn({cosmic, "--embed", appdir, "--output", output}):read()
   assert(ok, "embed should succeed: " .. (out or ""))
 
@@ -266,12 +265,12 @@ local function test_embed_uses_deflate()
   -- Use compressible content (repeated pattern) to ensure deflate is applied
   local compressible = string.rep("abcdefghij", 100)
   local input = write_temp("deflate_test.txt", compressible)
-  local output = path.join(tmpdir, "cosmic-deflate")
+  local output = fs.join(tmpdir, "cosmic-deflate")
 
   local ok, out = spawn.spawn({cosmic, "--embed", input, "--output", output}):read()
   assert(ok, "embed should succeed: " .. (out or ""))
 
-  local data = cosmo.Slurp(output)
+  local data = cio.slurp(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
   local reader = reader_maybe as Reader

--- a/lib/cosmic/example_test.tl
+++ b/lib/cosmic/example_test.tl
@@ -1,17 +1,17 @@
 #!/usr/bin/env cosmic
 -- test cosmic.example module
 
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
+local cio = require("cosmic.io")
 local example = require("cosmic.example")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function write_temp(name: string, content: string): string
-  local filepath = path.join(tmpdir, name)
-  cosmo.Barf(filepath, content)
+  local filepath = fs.join(tmpdir, name)
+  cio.barf(filepath, content)
   return filepath
 end
 

--- a/lib/cosmic/fetch.tl
+++ b/lib/cosmic/fetch.tl
@@ -223,6 +223,13 @@ local function stream(url: string, opts?: Opts): StreamResult
   }
 end
 
+--- Report whether the streaming fetch primitive is available in this build.
+--- When false, stream() cannot be used; callers should fall back to Fetch().
+--- @return boolean true if fetch.stream() is supported
+local function has_stream(): boolean
+  return cosmo.FetchStream ~= nil
+end
+
 --- Build a unix domain socket proxy URL from a socket path.
 --- @param path string Absolute path to the unix domain socket
 --- @return string proxy URL in unix:// format
@@ -247,6 +254,7 @@ end
 local record fetch
   Fetch: function(url: string, opts?: Opts): Result
   stream: function(url: string, opts?: Opts): StreamResult
+  has_stream: function(): boolean
   unix_proxy: function(path: string): string, string
   Opts: Opts
   Result: Result
@@ -257,6 +265,7 @@ end
 local M: fetch = {
   Fetch = Fetch,
   stream = stream,
+  has_stream = has_stream,
   unix_proxy = unix_proxy,
 }
 

--- a/lib/cosmic/fetch_test.tl
+++ b/lib/cosmic/fetch_test.tl
@@ -92,9 +92,8 @@ local function test_stream_module_exports()
 end
 test_stream_module_exports()
 
--- Check if FetchStream primitive is available (PR #88)
-local cosmo = require("cosmo")
-local has_fetch_stream = cosmo.FetchStream ~= nil
+-- Check if the streaming fetch primitive is available in this build.
+local has_fetch_stream = fetch.has_stream()
 if not has_fetch_stream then
   io.stderr:write("SKIP: streaming tests (FetchStream primitive not available)\n")
 end

--- a/lib/cosmic/fs_dir_test.tl
+++ b/lib/cosmic/fs_dir_test.tl
@@ -1,7 +1,6 @@
 #!/usr/bin/env cosmic
 local fs = require("cosmic.fs")
 local unix = require("cosmo.unix")
-local path = require("cosmo.path")
 
 local record Statfs
   type: function(self: Statfs): number
@@ -20,14 +19,14 @@ end
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
 
 local function setup(): string
-  local test_dir = path.join(TEST_TMPDIR, "fs_dir_test")
-  unix.makedirs(test_dir)
+  local test_dir = fs.join(TEST_TMPDIR, "fs_dir_test")
+  fs.makedirs(test_dir)
   return test_dir
 end
 
 local function teardown(test_dir: string)
   if test_dir then
-    unix.rmrf(test_dir)
+    fs.rmrf(test_dir)
   end
 end
 
@@ -96,7 +95,7 @@ test_dir_close_idempotent()
 
 local function test_dir_methods_after_close()
   local test_dir = setup()
-  touch(path.join(test_dir, "file.txt"))
+  touch(fs.join(test_dir, "file.txt"))
 
   local dir = fs.opendir(test_dir)
   assert(dir, "opendir should succeed")
@@ -123,8 +122,8 @@ test_dir_methods_after_close()
 
 local function test_dir_rewind_and_tell()
   local test_dir = setup()
-  touch(path.join(test_dir, "file1.txt"))
-  touch(path.join(test_dir, "file2.txt"))
+  touch(fs.join(test_dir, "file1.txt"))
+  touch(fs.join(test_dir, "file2.txt"))
 
   local dir = fs.opendir(test_dir)
   assert(dir, "opendir should succeed")
@@ -233,7 +232,7 @@ test_major_minor()
 
 local function test_major_minor_regular_file()
   local test_dir = setup()
-  local filepath = path.join(test_dir, "file.txt")
+  local filepath = fs.join(test_dir, "file.txt")
   touch(filepath)
 
   local st = fs.stat(filepath)

--- a/lib/cosmic/fs_path_test.tl
+++ b/lib/cosmic/fs_path_test.tl
@@ -1,7 +1,5 @@
 #!/usr/bin/env cosmic
 local fs = require("cosmic.fs")
-local unix = require("cosmo.unix")
-local path = require("cosmo.path")
 
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
 
@@ -17,7 +15,7 @@ end
 
 local function teardown(test_dir: string)
   if test_dir then
-    unix.rmrf(test_dir)
+    fs.rmrf(test_dir)
   end
 end
 
@@ -95,14 +93,14 @@ local record WalkContext
 end
 
 local function setup_walk(): string
-  local walk_dir = path.join(TEST_TMPDIR, "walk_test")
-  unix.makedirs(path.join(walk_dir, "subdir"))
-  unix.makedirs(path.join(walk_dir, "subdir/nested"))
+  local walk_dir = fs.join(TEST_TMPDIR, "walk_test")
+  fs.makedirs(fs.join(walk_dir, "subdir"))
+  fs.makedirs(fs.join(walk_dir, "subdir/nested"))
 
-  touch(path.join(walk_dir, "file1.lua"))
-  touch(path.join(walk_dir, "file2.txt"))
-  touch(path.join(walk_dir, "subdir/file3.lua"))
-  touch(path.join(walk_dir, "subdir/nested/file4.lua"))
+  touch(fs.join(walk_dir, "file1.lua"))
+  touch(fs.join(walk_dir, "file2.txt"))
+  touch(fs.join(walk_dir, "subdir/file3.lua"))
+  touch(fs.join(walk_dir, "subdir/nested/file4.lua"))
 
   return walk_dir
 end
@@ -152,7 +150,7 @@ local function test_walk_with_visitor()
       local wctx = c as WalkContext
       wctx.count = wctx.count + 1
       local stat_obj = st as WalkStat
-      if unix.S_ISDIR(stat_obj:mode()) then
+      if fs.is_dir(stat_obj:mode()) then
         wctx.dirs = wctx.dirs + 1
       end
       return true
@@ -207,11 +205,11 @@ end
 test_files_iterator_all()
 
 local function test_walk_empty_directory()
-  local empty_dir = path.join(TEST_TMPDIR, "walk_empty")
-  unix.makedirs(empty_dir)
+  local empty_dir = fs.join(TEST_TMPDIR, "walk_empty")
+  fs.makedirs(empty_dir)
   local found = fs.collect(empty_dir, "*.lua")
   assert(#found == 0, "expected 0 files, got " .. #found)
-  unix.rmrf(empty_dir)
+  fs.rmrf(empty_dir)
 end
 test_walk_empty_directory()
 
@@ -309,7 +307,7 @@ test_normalize_multiple_up_and_down()
 
 -- abspath tests
 
-local cwd = unix.getcwd()
+local cwd = fs.getcwd()
 
 local function test_abspath_relative()
   local result = fs.abspath("foo")
@@ -459,42 +457,42 @@ test_ext_hidden()
 -- symlink behavior tests: exists follows symlinks (stat), isfile/isdir do not (lstat)
 
 local function test_exists_symlink_to_file()
-  local tmpdir = path.join(TEST_TMPDIR, "symlink_exists_test")
-  unix.makedirs(tmpdir)
-  local target = path.join(tmpdir, "real.txt")
+  local tmpdir = fs.join(TEST_TMPDIR, "symlink_exists_test")
+  fs.makedirs(tmpdir)
+  local target = fs.join(tmpdir, "real.txt")
   touch(target, "hello")
-  local link = path.join(tmpdir, "link.txt")
-  local ok = unix.symlink(target, link)
+  local link = fs.join(tmpdir, "link.txt")
+  local ok = fs.symlink(target, link)
   assert(ok, "symlink creation should succeed")
   assert(fs.exists(link), "exists() should follow symlink and return true")
-  unix.rmrf(tmpdir)
+  fs.rmrf(tmpdir)
 end
 test_exists_symlink_to_file()
 
 local function test_isfile_symlink_to_file()
-  local tmpdir = path.join(TEST_TMPDIR, "symlink_isfile_test")
-  unix.makedirs(tmpdir)
-  local target = path.join(tmpdir, "real.txt")
+  local tmpdir = fs.join(TEST_TMPDIR, "symlink_isfile_test")
+  fs.makedirs(tmpdir)
+  local target = fs.join(tmpdir, "real.txt")
   touch(target, "hello")
-  local link = path.join(tmpdir, "link.txt")
-  local ok = unix.symlink(target, link)
+  local link = fs.join(tmpdir, "link.txt")
+  local ok = fs.symlink(target, link)
   assert(ok, "symlink creation should succeed")
   assert(not fs.isfile(link), "isfile() should return false for a symlink (uses lstat)")
   assert(fs.isfile(target), "isfile() should return true for the target file")
-  unix.rmrf(tmpdir)
+  fs.rmrf(tmpdir)
 end
 test_isfile_symlink_to_file()
 
 local function test_isdir_symlink_to_dir()
-  local tmpdir = path.join(TEST_TMPDIR, "symlink_isdir_test")
-  unix.makedirs(tmpdir)
-  local target = path.join(tmpdir, "realdir")
-  unix.makedirs(target)
-  local link = path.join(tmpdir, "linkdir")
-  local ok = unix.symlink(target, link)
+  local tmpdir = fs.join(TEST_TMPDIR, "symlink_isdir_test")
+  fs.makedirs(tmpdir)
+  local target = fs.join(tmpdir, "realdir")
+  fs.makedirs(target)
+  local link = fs.join(tmpdir, "linkdir")
+  local ok = fs.symlink(target, link)
   assert(ok, "symlink creation should succeed")
   assert(not fs.isdir(link), "isdir() should return false for a symlink (uses lstat)")
   assert(fs.isdir(target), "isdir() should return true for the target dir")
-  unix.rmrf(tmpdir)
+  fs.rmrf(tmpdir)
 end
 test_isdir_symlink_to_dir()

--- a/lib/cosmic/fs_test.tl
+++ b/lib/cosmic/fs_test.tl
@@ -1,19 +1,18 @@
 #!/usr/bin/env cosmic
 local fs = require("cosmic.fs")
 local unix = require("cosmo.unix")
-local path = require("cosmo.path")
 
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
 
 local function setup(): string
-  local test_dir = path.join(TEST_TMPDIR, "fs_test")
-  unix.makedirs(test_dir)
+  local test_dir = fs.join(TEST_TMPDIR, "fs_test")
+  fs.makedirs(test_dir)
   return test_dir
 end
 
 local function teardown(test_dir: string)
   if test_dir then
-    unix.rmrf(test_dir)
+    fs.rmrf(test_dir)
   end
 end
 
@@ -31,7 +30,7 @@ end
 
 local function test_stat_file()
   local test_dir = setup()
-  local filepath = path.join(test_dir, "file.txt")
+  local filepath = fs.join(test_dir, "file.txt")
   touch(filepath, "hello")
 
   local st, err = fs.stat(filepath)
@@ -58,10 +57,10 @@ test_stat_directory()
 
 local function test_stat_symlink()
   local test_dir = setup()
-  local filepath = path.join(test_dir, "file.txt")
-  local linkpath = path.join(test_dir, "link")
+  local filepath = fs.join(test_dir, "file.txt")
+  local linkpath = fs.join(test_dir, "link")
   touch(filepath, "hello")
-  unix.symlink(filepath, linkpath)
+  fs.symlink(filepath, linkpath)
 
   -- Follow symlinks by default
   local st = fs.stat(linkpath)
@@ -86,7 +85,7 @@ test_stat_nonexistent()
 
 local function test_fstat()
   local test_dir = setup()
-  local filepath = path.join(test_dir, "file.txt")
+  local filepath = fs.join(test_dir, "file.txt")
   touch(filepath, "hello world")
 
   local fd = unix.open(filepath, unix.O_RDONLY)
@@ -105,7 +104,7 @@ test_fstat()
 
 local function test_mkdir()
   local test_dir = setup()
-  local newdir = path.join(test_dir, "newdir")
+  local newdir = fs.join(test_dir, "newdir")
 
   local ok, err = fs.mkdir(newdir)
   assert(ok, "mkdir should succeed: " .. (err or ""))
@@ -120,7 +119,7 @@ test_mkdir()
 
 local function test_mkdir_with_mode()
   local test_dir = setup()
-  local newdir = path.join(test_dir, "newdir")
+  local newdir = fs.join(test_dir, "newdir")
 
   local ok, err = fs.mkdir(newdir, tonumber("700", 8))
   assert(ok, "mkdir should succeed: " .. (err or ""))
@@ -136,7 +135,7 @@ test_mkdir_with_mode()
 
 local function test_makedirs()
   local test_dir = setup()
-  local nested = path.join(test_dir, "a", "b", "c")
+  local nested = fs.join(test_dir, "a", "b", "c")
 
   local ok, err = fs.makedirs(nested)
   assert(ok, "makedirs should succeed: " .. (err or ""))
@@ -153,7 +152,7 @@ local function test_mkdir_error_message()
   local test_dir = setup()
 
   -- mkdir with missing parent should fail with descriptive error
-  local missing_parent = path.join(test_dir, "no", "such", "parent") as string
+  local missing_parent = fs.join(test_dir, "no", "such", "parent") as string
   local ok, err = fs.mkdir(missing_parent)
   assert(not ok, "mkdir should fail when parent doesn't exist")
   assert(err, "should return error message")
@@ -183,11 +182,11 @@ local function test_makedirs_error_message()
   local test_dir = setup()
 
   -- Create a regular file, then try to makedirs through it
-  local blocker = path.join(test_dir, "blocker")
+  local blocker = fs.join(test_dir, "blocker")
   local f = io.open(blocker, "w")
   if f then f:close() end
 
-  local through_file = path.join(blocker, "subdir") as string
+  local through_file = fs.join(blocker, "subdir") as string
   local ok, err = fs.makedirs(through_file)
   assert(not ok, "makedirs should fail when path component is a file")
   assert(err, "should return error message")
@@ -202,7 +201,7 @@ test_makedirs_error_message()
 
 local function test_rmdir()
   local test_dir = setup()
-  local newdir = path.join(test_dir, "newdir")
+  local newdir = fs.join(test_dir, "newdir")
   fs.mkdir(newdir)
 
   local ok, err = fs.rmdir(newdir)
@@ -239,9 +238,9 @@ test_getcwd_and_chdir()
 
 local function test_opendir()
   local test_dir = setup()
-  touch(path.join(test_dir, "file1.txt"))
-  touch(path.join(test_dir, "file2.txt"))
-  fs.mkdir(path.join(test_dir, "subdir"))
+  touch(fs.join(test_dir, "file1.txt"))
+  touch(fs.join(test_dir, "file2.txt"))
+  fs.mkdir(fs.join(test_dir, "subdir"))
 
   local dir, err = fs.opendir(test_dir)
   assert(dir, "opendir should succeed: " .. (err or ""))
@@ -268,7 +267,7 @@ test_opendir()
 
 local function test_unlink()
   local test_dir = setup()
-  local filepath = path.join(test_dir, "file.txt")
+  local filepath = fs.join(test_dir, "file.txt")
   touch(filepath)
 
   local ok, err = fs.unlink(filepath)
@@ -283,8 +282,8 @@ test_unlink()
 
 local function test_rename()
   local test_dir = setup()
-  local oldpath = path.join(test_dir, "old.txt")
-  local newpath = path.join(test_dir, "new.txt")
+  local oldpath = fs.join(test_dir, "old.txt")
+  local newpath = fs.join(test_dir, "new.txt")
   touch(oldpath, "content")
 
   local ok, err = fs.rename(oldpath, newpath)
@@ -299,8 +298,8 @@ test_rename()
 
 local function test_link()
   local test_dir = setup()
-  local filepath = path.join(test_dir, "original.txt")
-  local linkpath = path.join(test_dir, "hardlink.txt")
+  local filepath = fs.join(test_dir, "original.txt")
+  local linkpath = fs.join(test_dir, "hardlink.txt")
   touch(filepath, "content")
 
   local ok, err = fs.link(filepath, linkpath)
@@ -317,8 +316,8 @@ test_link()
 
 local function test_symlink_and_readlink()
   local test_dir = setup()
-  local filepath = path.join(test_dir, "target.txt")
-  local linkpath = path.join(test_dir, "symlink")
+  local filepath = fs.join(test_dir, "target.txt")
+  local linkpath = fs.join(test_dir, "symlink")
   touch(filepath, "content")
 
   local ok, err = fs.symlink(filepath, linkpath)
@@ -334,11 +333,11 @@ test_symlink_and_readlink()
 
 local function test_realpath()
   local test_dir = setup()
-  local subdir = path.join(test_dir, "subdir")
+  local subdir = fs.join(test_dir, "subdir")
   fs.mkdir(subdir)
 
   -- Create a path with .. that should be resolved
-  local messy_path = path.join(subdir, "..", "subdir")
+  local messy_path = fs.join(subdir, "..", "subdir")
   local resolved, err = fs.realpath(messy_path)
   assert(resolved, "realpath should succeed: " .. (err or ""))
 
@@ -351,15 +350,15 @@ test_realpath()
 
 local function test_rmrf()
   local test_dir = setup()
-  local nested = path.join(test_dir, "a", "b", "c")
+  local nested = fs.join(test_dir, "a", "b", "c")
   fs.makedirs(nested)
-  touch(path.join(nested, "file.txt"))
-  touch(path.join(test_dir, "a", "file.txt"))
+  touch(fs.join(nested, "file.txt"))
+  touch(fs.join(test_dir, "a", "file.txt"))
 
-  local ok, err = fs.rmrf(path.join(test_dir, "a"))
+  local ok, err = fs.rmrf(fs.join(test_dir, "a"))
   assert(ok, "rmrf should succeed: " .. (err or ""))
 
-  assert(fs.stat(path.join(test_dir, "a")) == nil, "directory tree should not exist")
+  assert(fs.stat(fs.join(test_dir, "a")) == nil, "directory tree should not exist")
 
   teardown(test_dir)
 end
@@ -369,13 +368,13 @@ test_rmrf()
 
 local function test_access()
   local test_dir = setup()
-  local filepath = path.join(test_dir, "file.txt")
+  local filepath = fs.join(test_dir, "file.txt")
   touch(filepath)
 
   assert(fs.access(filepath, fs.F_OK), "file should exist")
   assert(fs.access(filepath, fs.R_OK), "file should be readable")
   assert(fs.access(filepath, fs.W_OK), "file should be writable")
-  assert(not fs.access(path.join(test_dir, "does_not_exist"), fs.F_OK), "nonexistent file should not exist")
+  assert(not fs.access(fs.join(test_dir, "does_not_exist"), fs.F_OK), "nonexistent file should not exist")
 
   teardown(test_dir)
 end
@@ -383,7 +382,7 @@ test_access()
 
 local function test_chmod()
   local test_dir = setup()
-  local filepath = path.join(test_dir, "file.txt")
+  local filepath = fs.join(test_dir, "file.txt")
   touch(filepath)
 
   local ok, err = fs.chmod(filepath, tonumber("600", 8))
@@ -443,10 +442,10 @@ test_tmpfd()
 
 local function test_is_type_functions()
   local test_dir = setup()
-  local filepath = path.join(test_dir, "file.txt")
+  local filepath = fs.join(test_dir, "file.txt")
   touch(filepath)
-  local linkpath = path.join(test_dir, "link")
-  unix.symlink(filepath, linkpath)
+  local linkpath = fs.join(test_dir, "link")
+  fs.symlink(filepath, linkpath)
 
   local file_st = fs.stat(filepath)
   assert(file_st, "stat should succeed")

--- a/lib/cosmic/fs_walk_test.tl
+++ b/lib/cosmic/fs_walk_test.tl
@@ -2,7 +2,6 @@
 --- Tests for fs_walk module (symlink cycle safety)
 local fs_walk = require("cosmic.fs_walk")
 local fs = require("cosmic.fs")
-local unix = require("cosmo.unix")
 
 local tmpdir = os.getenv("TEST_TMPDIR") as string
 
@@ -29,7 +28,7 @@ local function test_walk_symlink_cycle_terminates()
   fs.makedirs(subdir)
   write_file(fs.join(subdir, "real.txt"), "hello")
   -- Create a symlink cycle: sub/loop -> ..  (points back to base)
-  unix.symlink("..", fs.join(subdir, "loop"))
+  fs.symlink("..", fs.join(subdir, "loop"))
 
   local count = 0
   local max_depth_seen = 0
@@ -62,7 +61,7 @@ local function test_collect_all_symlink_cycle_terminates()
   local subdir = fs.join(base, "sub")
   fs.makedirs(subdir)
   write_file(fs.join(subdir, "real.txt"), "data")
-  unix.symlink("..", fs.join(subdir, "loop"))
+  fs.symlink("..", fs.join(subdir, "loop"))
 
   local files = fs_walk.collect_all(base)
   -- Should contain sub/real.txt but NOT any path with loop/ in it
@@ -80,7 +79,7 @@ local function test_files_symlink_cycle_terminates()
   local subdir = fs.join(base, "sub")
   fs.makedirs(subdir)
   write_file(fs.join(subdir, "real.lua"), "-- lua")
-  unix.symlink("..", fs.join(subdir, "loop"))
+  fs.symlink("..", fs.join(subdir, "loop"))
 
   local collected: {string} = {}
   for p in fs_walk.files(base, "*.lua") do
@@ -100,7 +99,7 @@ local function test_walk_symlink_file_visited()
   local base = mksubdir("walk_symlink_file")
   write_file(fs.join(base, "real.txt"), "content")
   -- Symlink to a file in same dir
-  unix.symlink("real.txt", fs.join(base, "alias.txt"))
+  fs.symlink("real.txt", fs.join(base, "alias.txt"))
 
   local found: {string: boolean} = {}
   fs_walk.walk(base, function(full_path: string, entry: string, _st: any, ctx: {string: boolean})

--- a/lib/cosmic/include_dir_test.tl
+++ b/lib/cosmic/include_dir_test.tl
@@ -1,26 +1,25 @@
 #!/usr/bin/env cosmic
 -- test --include-dir flag for --compile and --check-types
 
-local path = require("cosmo.path")
-local unix = require("cosmo.unix")
+local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
+local cio = require("cosmic.io")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function write_temp(name: string, content: string): string
-  local filepath = path.join(tmpdir, name)
-  cosmo.Barf(filepath, content)
+  local filepath = fs.join(tmpdir, name)
+  cio.barf(filepath, content)
   return filepath
 end
 
 -- Setup: create a custom type definition directory with a module
 local function setup_custom_types(): string, string
-  local typedir = path.join(tmpdir, "customtypes")
-  unix.makedirs(typedir, 0x1ed) -- 0755
-  local deffile = path.join(typedir, "custommod.d.tl")
-  cosmo.Barf(deffile, [[
+  local typedir = fs.join(tmpdir, "customtypes")
+  fs.makedirs(typedir, 0x1ed) -- 0755
+  local deffile = fs.join(typedir, "custommod.d.tl")
+  cio.barf(deffile, [[
 local record custommod
   greet: function(name: string): string
 end
@@ -69,18 +68,18 @@ test_check_types_include_dir()
 
 -- Test multiple --include-dir flags
 local function test_multiple_include_dirs()
-  local typedir1 = path.join(tmpdir, "types1")
-  unix.makedirs(typedir1, 0x1ed)
-  cosmo.Barf(path.join(typedir1, "mod_a.d.tl"), [[
+  local typedir1 = fs.join(tmpdir, "types1")
+  fs.makedirs(typedir1, 0x1ed)
+  cio.barf(fs.join(typedir1, "mod_a.d.tl"), [[
 local record mod_a
   hello: function(): string
 end
 return mod_a
 ]])
 
-  local typedir2 = path.join(tmpdir, "types2")
-  unix.makedirs(typedir2, 0x1ed)
-  cosmo.Barf(path.join(typedir2, "mod_b.d.tl"), [[
+  local typedir2 = fs.join(tmpdir, "types2")
+  fs.makedirs(typedir2, 0x1ed)
+  cio.barf(fs.join(typedir2, "mod_b.d.tl"), [[
 local record mod_b
   world: function(): string
 end
@@ -110,7 +109,7 @@ local function test_compile_include_dir_with_output()
 local custommod = require("custommod")
 print(custommod.greet("test"))
 ]])
-  local output = path.join(tmpdir, "include_dir_output.lua")
+  local output = fs.join(tmpdir, "include_dir_output.lua")
 
   local ok, _ = spawn.spawn({
       cosmic, "--write-if-changed",
@@ -132,13 +131,12 @@ test_compile_include_dir_with_output()
 local function test_include_dir_merges_with_defaults()
   local typedir, _ = setup_custom_types()
 
-  -- This file uses both a custom module and a built-in cosmo type
+  -- This file uses both a custom module and a built-in cosmic type
   local input = write_temp("merge_defaults.tl", [[
 local custommod = require("custommod")
-local cosmo = require("cosmo")
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
 local s: string = custommod.greet("world")
-local p: string = path.join("a", "b")
+local p: string = fs.join("a", "b")
 print(s, p)
 ]])
 

--- a/lib/cosmic/io_test.tl
+++ b/lib/cosmic/io_test.tl
@@ -1,11 +1,11 @@
 #!/usr/bin/env cosmic
 local io_m = require("cosmic.io")
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
 
 global TEST_TMPDIR: string
 
 local function test_open_read_write_close()
-  local filepath = path.join(TEST_TMPDIR, "io_test_basic.txt")
+  local filepath = fs.join(TEST_TMPDIR, "io_test_basic.txt")
   local content = "hello, cosmic.io!"
 
   local f, err = io_m.open(filepath, io_m.O_WRONLY | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8))
@@ -27,7 +27,7 @@ end
 test_open_read_write_close()
 
 local function test_seek()
-  local filepath = path.join(TEST_TMPDIR, "io_test_seek.txt")
+  local filepath = fs.join(TEST_TMPDIR, "io_test_seek.txt")
   local content = "0123456789"
 
   local f = assert(io_m.open(filepath, io_m.O_WRONLY | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
@@ -54,7 +54,7 @@ end
 test_seek()
 
 local function test_handle_truncate()
-  local filepath = path.join(TEST_TMPDIR, "io_test_htrunc.txt")
+  local filepath = fs.join(TEST_TMPDIR, "io_test_htrunc.txt")
   local content = "0123456789"
 
   local f = assert(io_m.open(filepath, io_m.O_RDWR | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
@@ -73,7 +73,7 @@ end
 test_handle_truncate()
 
 local function test_truncate()
-  local filepath = path.join(TEST_TMPDIR, "io_test_trunc.txt")
+  local filepath = fs.join(TEST_TMPDIR, "io_test_trunc.txt")
   local content = "0123456789"
 
   local f = assert(io_m.open(filepath, io_m.O_WRONLY | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
@@ -93,7 +93,7 @@ end
 test_truncate()
 
 local function test_dup()
-  local filepath = path.join(TEST_TMPDIR, "io_test_dup.txt")
+  local filepath = fs.join(TEST_TMPDIR, "io_test_dup.txt")
   local content = "dup test"
 
   local f = assert(io_m.open(filepath, io_m.O_RDWR | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
@@ -133,7 +133,7 @@ end
 test_pipe()
 
 local function test_sync()
-  local filepath = path.join(TEST_TMPDIR, "io_test_sync.txt")
+  local filepath = fs.join(TEST_TMPDIR, "io_test_sync.txt")
 
   local f = assert(io_m.open(filepath, io_m.O_WRONLY | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
   assert(f:write("sync test"))
@@ -177,7 +177,7 @@ end
 test_constants()
 
 local function test_fcntl()
-  local filepath = path.join(TEST_TMPDIR, "io_test_fcntl.txt")
+  local filepath = fs.join(TEST_TMPDIR, "io_test_fcntl.txt")
 
   local f = assert(io_m.open(filepath, io_m.O_RDWR | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
 
@@ -203,7 +203,7 @@ end
 test_open_nonexistent_fails()
 
 local function test_append_mode()
-  local filepath = path.join(TEST_TMPDIR, "io_test_append.txt")
+  local filepath = fs.join(TEST_TMPDIR, "io_test_append.txt")
 
   local f = assert(io_m.open(filepath, io_m.O_WRONLY | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
   assert(f:write("hello"))
@@ -223,7 +223,7 @@ end
 test_append_mode()
 
 local function test_slurp_barf()
-  local filepath = path.join(TEST_TMPDIR, "io_test_slurp.txt")
+  local filepath = fs.join(TEST_TMPDIR, "io_test_slurp.txt")
   local content = "hello from slurp test\nwith multiple lines"
 
   local ok, err = io_m.barf(filepath, content)
@@ -245,7 +245,7 @@ end
 test_slurp_nonexistent()
 
 local function test_closed_handle()
-  local filepath = path.join(TEST_TMPDIR, "io_test_closed.txt")
+  local filepath = fs.join(TEST_TMPDIR, "io_test_closed.txt")
 
   local f = assert(io_m.open(filepath, io_m.O_WRONLY | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
   assert(not f:closed(), "handle should not be closed yet")
@@ -266,7 +266,7 @@ end
 test_closed_handle()
 
 local function test_fd_method()
-  local filepath = path.join(TEST_TMPDIR, "io_test_fd.txt")
+  local filepath = fs.join(TEST_TMPDIR, "io_test_fd.txt")
 
   local f = assert(io_m.open(filepath, io_m.O_WRONLY | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
   local fd = f:fd()
@@ -280,7 +280,7 @@ end
 test_fd_method()
 
 local function test_close_metamethod_exists()
-  local filepath = path.join(TEST_TMPDIR, "io_test_meta.txt")
+  local filepath = fs.join(TEST_TMPDIR, "io_test_meta.txt")
 
   local f = assert(io_m.open(filepath, io_m.O_WRONLY | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
   local mt = getmetatable(f)
@@ -306,7 +306,7 @@ end
 test_pipe_close_metamethod_exists()
 
 local function test_read_write_with_offset()
-  local filepath = path.join(TEST_TMPDIR, "io_test_pread.txt")
+  local filepath = fs.join(TEST_TMPDIR, "io_test_pread.txt")
 
   local f = assert(io_m.open(filepath, io_m.O_RDWR | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
   assert(f:write("0123456789"))
@@ -331,7 +331,7 @@ end
 test_read_write_with_offset()
 
 local function test_barf_with_mode()
-  local filepath = path.join(TEST_TMPDIR, "io_test_barf_mode.txt")
+  local filepath = fs.join(TEST_TMPDIR, "io_test_barf_mode.txt")
   local content = "file with specific mode"
 
   local ok, err = io_m.barf(filepath, content, tonumber("600", 8))
@@ -345,7 +345,7 @@ end
 test_barf_with_mode()
 
 local function test_datasync()
-  local filepath = path.join(TEST_TMPDIR, "io_test_datasync.txt")
+  local filepath = fs.join(TEST_TMPDIR, "io_test_datasync.txt")
 
   local f = assert(io_m.open(filepath, io_m.O_WRONLY | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
   assert(f:write("datasync test"))
@@ -364,7 +364,7 @@ test_datasync()
 -- returns true, and (c) the return type is boolean (not always true when
 -- unix.close would fail on a bad fd).
 local function test_close_returns_boolean_and_is_idempotent()
-  local filepath = path.join(TEST_TMPDIR, "io_test_close_bool.txt")
+  local filepath = fs.join(TEST_TMPDIR, "io_test_close_bool.txt")
 
   local f = assert(io_m.open(filepath, io_m.O_WRONLY | io_m.O_CREAT | io_m.O_TRUNC, tonumber("644", 8)))
   assert(f:write("x"))

--- a/lib/cosmic/landlock_test.tl
+++ b/lib/cosmic/landlock_test.tl
@@ -1,10 +1,10 @@
 #!/usr/bin/env cosmic
 local landlock = require("cosmic.landlock")
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function test_module_exports()
@@ -49,13 +49,13 @@ local function test_restrict_denies_outside_allowlist()
     return
   end
 
-  local allowed = path.join(tmpdir, "allowed.txt")
-  local denied = path.join(tmpdir, "denied.txt")
-  cosmo.Barf(allowed, "allowed-content")
-  cosmo.Barf(denied, "denied-content")
+  local allowed = fs.join(tmpdir, "allowed.txt")
+  local denied = fs.join(tmpdir, "denied.txt")
+  cio.barf(allowed, "allowed-content")
+  cio.barf(denied, "denied-content")
 
-  local script = path.join(tmpdir, "landlock_restrict.lua")
-  cosmo.Barf(script, string.format([[
+  local script = fs.join(tmpdir, "landlock_restrict.lua")
+  cio.barf(script, string.format([[
 local ll = require("cosmic.landlock")
 local ok, err = ll.restrict{ rules = { { path = %q, access = ll.READ } } }
 if not ok then
@@ -94,7 +94,7 @@ test_restrict_denies_outside_allowlist()
 local function test_restrict_bad_rule_path_returns_error()
   if not landlock.available() then return end
   local ok, err = landlock.restrict {
-    rules = {{path = path.join(tmpdir, "no-such-dir-xyz"),
+    rules = {{path = fs.join(tmpdir, "no-such-dir-xyz"),
         access = landlock.READ}},
   }
   assert(not ok, "restrict with a missing rule path must fail")

--- a/lib/cosmic/pledge_test.tl
+++ b/lib/cosmic/pledge_test.tl
@@ -1,10 +1,10 @@
 #!/usr/bin/env cosmic
 local pledge = require("cosmic.pledge")
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
+local cio = require("cosmic.io")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function test_module_exports()
@@ -13,8 +13,8 @@ end
 test_module_exports()
 
 local function test_stdio_allows_write()
-  local script = path.join(tmpdir, "pledge_stdio.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "pledge_stdio.lua")
+  cio.barf(script, [[
 local pledge = require("cosmic.pledge")
 local ok, err = pledge.apply("stdio")
 if not ok then
@@ -30,8 +30,8 @@ end
 test_stdio_allows_write()
 
 local function test_restricts_filesystem()
-  local script = path.join(tmpdir, "pledge_no_fs.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "pledge_no_fs.lua")
+  cio.barf(script, [[
 local pledge = require("cosmic.pledge")
 local ok, err = pledge.apply("stdio")
 if not ok then

--- a/lib/cosmic/proc_test.tl
+++ b/lib/cosmic/proc_test.tl
@@ -1,10 +1,10 @@
 #!/usr/bin/env cosmic
-local cosmo = require("cosmo")
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
 local proc = require("cosmic.proc")
 local child = require("cosmic.child")
 
-local lua_bin = path.join(os.getenv("TEST_BIN"), "cosmic")
+local lua_bin = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
 
 -- getpid tests --
@@ -107,10 +107,10 @@ end
 test_is_main_returns_boolean()
 
 local function test_is_main_true_when_run_directly()
-  local script_path = path.join(TEST_TMPDIR, "is_main_direct.lua")
-  cosmo.Barf(script_path, [[
-local cosmo = require("cosmo")
-if cosmo.is_main() then
+  local script_path = fs.join(TEST_TMPDIR, "is_main_direct.lua")
+  cio.barf(script_path, [[
+local proc = require("cosmic.proc")
+if proc.is_main() then
   os.exit(0)
 else
   os.exit(1)
@@ -126,8 +126,8 @@ end
 test_is_main_true_when_run_directly()
 
 local function test_proc_is_main_true_when_run_directly()
-  local script_path = path.join(TEST_TMPDIR, "proc_is_main_direct.lua")
-  cosmo.Barf(script_path, [[
+  local script_path = fs.join(TEST_TMPDIR, "proc_is_main_direct.lua")
+  cio.barf(script_path, [[
 local proc = require("cosmic.proc")
 if proc.is_main() then
   os.exit(0)
@@ -145,14 +145,14 @@ end
 test_proc_is_main_true_when_run_directly()
 
 local function test_is_main_false_when_required()
-  local mod_path = path.join(TEST_TMPDIR, "is_main_module.lua")
-  cosmo.Barf(mod_path, [[
-local cosmo = require("cosmo")
-return cosmo.is_main()
+  local mod_path = fs.join(TEST_TMPDIR, "is_main_module.lua")
+  cio.barf(mod_path, [[
+local proc = require("cosmic.proc")
+return proc.is_main()
 ]])
 
-  local script_path = path.join(TEST_TMPDIR, "is_main_requirer.lua")
-  cosmo.Barf(script_path, string.format([[
+  local script_path = fs.join(TEST_TMPDIR, "is_main_requirer.lua")
+  cio.barf(script_path, string.format([[
 package.path = %q .. "/?.lua;" .. package.path
 local result = require("is_main_module")
 if result == false then

--- a/lib/cosmic/quicksand/box/run_test.tl
+++ b/lib/cosmic/quicksand/box/run_test.tl
@@ -8,19 +8,19 @@
 --- same "ok | skipped | signal death = skip" pattern the raw netns /
 --- proc tests use.
 local quicksand = require("cosmic.quicksand")
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
+local cio = require("cosmic.io")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function test_run_true_in_subprocess()
   local c = quicksand.capabilities()
   if not (c.linux and c.user_ns and c.net_ns) then return end
 
-  local script = path.join(tmpdir, "box_run_true.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "box_run_true.lua")
+  cio.barf(script, [[
 local qs = require("cosmic.quicksand")
 local j, nerr = qs.Box.new({})
 if not j then io.stderr:write("new: " .. tostring(nerr) .. "\n"); os.exit(1) end
@@ -56,8 +56,8 @@ local function test_uid_drop_sets_no_new_privs_subprocess()
   local c = quicksand.capabilities()
   if not (c.linux and c.user_ns and c.net_ns) then return end
 
-  local script = path.join(tmpdir, "box_nnp_uid.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "box_nnp_uid.lua")
+  cio.barf(script, [[
 local qs = require("cosmic.quicksand")
 local j, nerr = qs.Box.new({ proc = { uid = 65534 } })
 if not j then io.stderr:write("new: " .. tostring(nerr) .. "\n"); os.exit(1) end
@@ -85,8 +85,8 @@ local function test_pid_namespace_workload_has_low_pid_subprocess()
   local c = quicksand.capabilities()
   if not (c.linux and c.user_ns and c.net_ns and c.pid_ns) then return end
 
-  local script = path.join(tmpdir, "box_pidns.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "box_pidns.lua")
+  cio.barf(script, [[
 local qs = require("cosmic.quicksand")
 local j, nerr = qs.Box.new({})
 if not j then io.stderr:write("new: " .. tostring(nerr) .. "\n"); os.exit(1) end
@@ -112,8 +112,8 @@ local function test_pid_namespace_opt_out_subprocess()
   local c = quicksand.capabilities()
   if not (c.linux and c.user_ns and c.net_ns) then return end
 
-  local script = path.join(tmpdir, "box_nopidns.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "box_nopidns.lua")
+  cio.barf(script, [[
 local qs = require("cosmic.quicksand")
 local j, nerr = qs.Box.new({ pid_ns = false })
 if not j then io.stderr:write("new: " .. tostring(nerr) .. "\n"); os.exit(1) end

--- a/lib/cosmic/quicksand/netns.tl
+++ b/lib/cosmic/quicksand/netns.tl
@@ -119,9 +119,23 @@ local function enter(fd: integer): boolean, string
   return true
 end
 
+--- Create and enter a new user namespace in the current thread.
+--- Equivalent to `unshare(CLONE_NEWUSER)`; grants the thread the
+--- capabilities needed to unshare a network namespace unprivileged.
+--- unshare is irreversible for the calling thread, so run it in a
+--- subprocess when the original namespace must be preserved.
+---
+--- @return boolean true on success
+--- @return string? error message on failure
+local function unshare_user(): boolean, string
+  local ok, err = unix.unshare(unix.CLONE_NEWUSER)
+  if not ok then return false, wrap_err(err, "unshare_user failed") end
+  return true
+end
+
 --- Create and enter a new network namespace in the current thread.
 --- Equivalent to `unshare(CLONE_NEWNET)`; requires either root or
---- CLONE_NEWUSER beforehand.
+--- unshare_user() beforehand.
 ---
 --- @return boolean true on success
 --- @return string? error message on failure
@@ -172,6 +186,7 @@ end
 local record NetnsModule
   open: function(pid: integer): integer, string
   enter: function(fd: integer): boolean, string
+  unshare_user: function(): boolean, string
   unshare: function(): boolean, string
   bring_up: function(name: string): boolean, string
   bring_down: function(name: string): boolean, string
@@ -183,6 +198,7 @@ end
 local M: NetnsModule = {
   open = open,
   enter = enter,
+  unshare_user = unshare_user,
   unshare = unshare,
   bring_up = bring_up,
   bring_down = bring_down,

--- a/lib/cosmic/quicksand/netns_example.tl
+++ b/lib/cosmic/quicksand/netns_example.tl
@@ -24,9 +24,8 @@ local function Example_unshare_in_subprocess()
   local spawn = require("cosmic.child")
   local cosmic = arg[-1]
   local script = [[
-local unix = require("cosmo.unix")
 local ns = require("cosmic.quicksand.netns")
-if not unix.unshare(unix.CLONE_NEWUSER) then return end
+if not ns.unshare_user() then return end
 assert(ns.unshare())
 assert(ns.bring_up("lo"))
 ]]

--- a/lib/cosmic/quicksand/netns_test.tl
+++ b/lib/cosmic/quicksand/netns_test.tl
@@ -1,11 +1,11 @@
 #!/usr/bin/env cosmic
 local netns = require("cosmic.quicksand.netns")
 local quicksand = require("cosmic.quicksand")
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function test_module_exports()
@@ -40,15 +40,15 @@ local function test_unshare_subprocess()
   if not (c.linux and c.net_ns and (c.user_ns or c.cap_net_admin)) then
     return
   end
-  local script = path.join(tmpdir, "unshare.lua")
-  cosmo.Barf(script, [[
-local unix = require("cosmo.unix")
+  local script = fs.join(tmpdir, "unshare.lua")
+  cio.barf(script, [[
 local ns = require("cosmic.quicksand.netns")
 -- Drop into a fresh userns first so unprivileged callers can create a netns.
 -- An outer sandbox (pledge/seccomp) may block unshare entirely; tolerate
--- that by skipping rather than failing.
-local pok, u = pcall(function() return unix.unshare(unix.CLONE_NEWUSER) end)
-if not pok or not u then
+-- that by skipping rather than failing (unshare_user returns nil+err, and a
+-- seccomp SIGSYS kills the subprocess, handled by the parent below).
+local u = ns.unshare_user()
+if not u then
   io.write("skipped\n")
   os.exit(0)
 end

--- a/lib/cosmic/quicksand/proc_test.tl
+++ b/lib/cosmic/quicksand/proc_test.tl
@@ -1,11 +1,11 @@
 #!/usr/bin/env cosmic
 local proc = require("cosmic.quicksand.proc")
 local quicksand = require("cosmic.quicksand")
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function test_module_exports()
@@ -26,8 +26,8 @@ test_module_exports()
 local function test_setup_userns_maps_returns_error_outside_userns()
   local c = quicksand.capabilities()
   if not c.linux then return end
-  local script = path.join(tmpdir, "userns_maps.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "userns_maps.lua")
+  cio.barf(script, [[
 local proc = require("cosmic.quicksand.proc")
 local ok, err = proc.setup_userns_maps(nil, nil)
 if ok then
@@ -65,8 +65,8 @@ test_drop_privs_nil_is_noop()
 local function test_no_new_privs_subprocess()
   local c = quicksand.capabilities()
   if not c.linux then return end
-  local script = path.join(tmpdir, "nnp.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "nnp.lua")
+  cio.barf(script, [[
 local proc = require("cosmic.quicksand.proc")
 local ok, err = proc.no_new_privs()
 if not ok then
@@ -89,8 +89,8 @@ test_no_new_privs_subprocess()
 local function test_barrier_signal_wait()
   local c = quicksand.capabilities()
   if not c.linux then return end
-  local script = path.join(tmpdir, "barrier.lua")
-  cosmo.Barf(script, [[
+  local script = fs.join(tmpdir, "barrier.lua")
+  cio.barf(script, [[
 local unix = require("cosmo.unix")
 local proc = require("cosmic.quicksand.proc")
 local b, err = proc.barrier()

--- a/lib/cosmic/rand.tl
+++ b/lib/cosmic/rand.tl
@@ -44,12 +44,21 @@ local function rdseed(): number, string
   return cosmo.Rdseed()
 end
 
+--- Report whether the CPU provides a hardware random number generator.
+--- Probes the RDRAND instruction; rdrand/rdseed return nil, err when this is false.
+--- @return boolean true if hardware randomness (rdrand/rdseed) is usable
+local function has_hwrng(): boolean
+  local n = cosmo.Rdrand()
+  return n ~= nil
+end
+
 local record RandModule
   bytes: function(n: number): string
   rand64: function(): number
   lemur64: function(): number
   rdrand: function(): number, string
   rdseed: function(): number, string
+  has_hwrng: function(): boolean
 end
 
 local M: RandModule = {
@@ -58,6 +67,7 @@ local M: RandModule = {
   lemur64 = lemur64,
   rdrand = rdrand,
   rdseed = rdseed,
+  has_hwrng = has_hwrng,
 }
 
 return M

--- a/lib/cosmic/rand_test.tl
+++ b/lib/cosmic/rand_test.tl
@@ -1,6 +1,5 @@
 #!/usr/bin/env cosmic
 local rand = require("cosmic.rand")
-local cosmo = require("cosmo")
 
 local function test_bytes_returns_requested_length()
   local b = rand.bytes(16)
@@ -23,19 +22,9 @@ local function test_bytes_various_sizes()
 end
 test_bytes_various_sizes()
 
--- Fast pseudo-random tests (non-cryptographic)
--- These skip gracefully if the cosmo bindings are not yet available.
-
-local has_rand64 = cosmo.Rand64 ~= nil
-local has_lemur64 = cosmo.Lemur64 ~= nil
-local has_rdrand = cosmo.Rdrand ~= nil
-local has_rdseed = cosmo.Rdseed ~= nil
+-- Fast pseudo-random tests (non-cryptographic).
 
 local function test_rand64()
-  if not has_rand64 then
-    io.stderr:write("SKIP: rand64 (Rand64 primitive not available)\n")
-    return
-  end
   local n = rand.rand64()
   assert(math.type(n) == "integer", "rand64 should return integer, got " .. type(n))
   -- Two calls should almost certainly differ (false positive rate: 1/2^64)
@@ -45,10 +34,6 @@ end
 test_rand64()
 
 local function test_lemur64()
-  if not has_lemur64 then
-    io.stderr:write("SKIP: lemur64 (Lemur64 primitive not available)\n")
-    return
-  end
   local n = rand.lemur64()
   assert(math.type(n) == "integer", "lemur64 should return integer, got " .. type(n))
   local n2 = rand.lemur64()
@@ -56,32 +41,29 @@ local function test_lemur64()
 end
 test_lemur64()
 
+-- Hardware RNG tests: skip gracefully when the CPU lacks RDRAND/RDSEED.
+
 local function test_rdrand()
-  if not has_rdrand then
-    io.stderr:write("SKIP: rdrand (Rdrand primitive not available)\n")
+  if not rand.has_hwrng() then
+    io.stderr:write("SKIP: rdrand (hardware RNG not available)\n")
     return
   end
   local n, err = rand.rdrand()
-  if n == nil then
-    -- Hardware unavailable on this CPU; error message should be present
-    assert(type(err) == "string" and #err > 0, "rdrand should return error string when unavailable")
-    io.stderr:write("SKIP: rdrand (hardware not available: " .. err .. ")\n")
-    return
-  end
+  assert(n ~= nil, "rdrand should return a value when hardware RNG is available: " .. tostring(err))
   assert(math.type(n) == "integer", "rdrand should return integer, got " .. type(n))
 end
 test_rdrand()
 
 local function test_rdseed()
-  if not has_rdseed then
-    io.stderr:write("SKIP: rdseed (Rdseed primitive not available)\n")
+  if not rand.has_hwrng() then
+    io.stderr:write("SKIP: rdseed (hardware RNG not available)\n")
     return
   end
   local n, err = rand.rdseed()
   if n == nil then
-    -- Hardware unavailable on this CPU; error message should be present
-    assert(type(err) == "string" and #err > 0, "rdseed should return error string when unavailable")
-    io.stderr:write("SKIP: rdseed (hardware not available: " .. err .. ")\n")
+    -- RDSEED can transiently fail even when present; require an error message.
+    assert(type(err) == "string" and #err > 0, "rdseed should return error string on transient failure")
+    io.stderr:write("SKIP: rdseed (transient hardware failure: " .. err .. ")\n")
     return
   end
   assert(math.type(n) == "integer", "rdseed should return integer, got " .. type(n))

--- a/lib/cosmic/script_test.tl
+++ b/lib/cosmic/script_test.tl
@@ -1,24 +1,22 @@
 #!/usr/bin/env cosmic
 -- test cosmic script execution with .tl and .lua files
 
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
 
-local unix = require("cosmo.unix")
-
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 -- Create a unique subdirectory for this test run to avoid conflicts
-local test_subdir = unix.mkdtemp(path.join(tmpdir, "cosmic_script_test_XXXXXX"))
+local test_subdir = fs.mkdtemp(fs.join(tmpdir, "cosmic_script_test_XXXXXX"))
 
 local function write_temp(name: string, content: string): string
-  local filepath = path.join(test_subdir, name)
-  cosmo.Barf(filepath, content)
+  local filepath = fs.join(test_subdir, name)
+  cio.barf(filepath, content)
 
   -- Verify the file was written correctly
-  local written = cosmo.Slurp(filepath)
+  local written = cio.slurp(filepath)
   assert(written == content, "write_temp: file content mismatch for " .. name)
 
   return filepath
@@ -160,7 +158,7 @@ print("shebang=" .. x)
 ]])
 
   -- Verify the file exists and has correct content
-  local verify = cosmo.Slurp(script)
+  local verify = cio.slurp(script)
   assert(verify:find("shebang="), "script file should contain shebang test code, got: " .. verify:sub(1, 100))
 
   local ok, out = spawn.spawn({cosmic, script}, {stderr = 1}):read()

--- a/lib/cosmic/signal_test.tl
+++ b/lib/cosmic/signal_test.tl
@@ -1,6 +1,7 @@
 #!/usr/bin/env cosmic
 local signal = require("cosmic.signal")
-local unix = require("cosmo.unix")
+local proc = require("cosmic.proc")
+local time = require("cosmic.time")
 
 local function test_strsignal()
   assert(signal.strsignal(signal.SIGKILL) == "SIGKILL", "expected SIGKILL")
@@ -104,7 +105,7 @@ local function test_sigaction_handler()
   signal.sigprocmask(signal.SIG_SETMASK, oldmask)
 
   -- Allow time for signal delivery
-  unix.nanosleep(0, 1000000) -- 1ms
+  time.sleep(0, 1000000) -- 1ms
 
   assert(received_signal == signal.SIGUSR1,
     "handler should have received SIGUSR1, got " .. tostring(received_signal))
@@ -116,7 +117,7 @@ test_sigaction_handler()
 
 local function test_kill()
   -- Test kill by sending signal 0 (which just checks permissions)
-  local pid = unix.getpid()
+  local pid = proc.getpid()
   local ok = signal.kill(pid, 0)
   assert(ok, "kill with signal 0 should succeed for own process")
 end
@@ -132,7 +133,7 @@ local function test_raise()
   signal.raise(signal.SIGUSR2)
 
   -- Small delay to ensure signal is delivered
-  unix.nanosleep(0, 1000000) -- 1ms
+  time.sleep(0, 1000000) -- 1ms
 
   assert(received, "should have received SIGUSR2")
 
@@ -167,7 +168,7 @@ local function test_setitimer()
   signal.sigprocmask(signal.SIG_SETMASK, oldmask)
 
   -- Wait 200ms for signal delivery
-  unix.nanosleep(0, 200000000)
+  time.sleep(0, 200000000)
 
   assert(received, "SIGALRM handler should have been called")
 

--- a/lib/cosmic/skill_test.tl
+++ b/lib/cosmic/skill_test.tl
@@ -1,18 +1,17 @@
 #!/usr/bin/env cosmic
 -- test cosmic --skill
 
-local path = require("cosmo.path")
 local spawn = require("cosmic.child")
-local unix = require("cosmo.unix")
 local fs = require("cosmic.fs")
 local cio = require("cosmic.io")
+local cenv = require("cosmic.env")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function clean_env(): {string}
   local env: {string} = {}
-  for _, entry in ipairs(unix.environ()) do
+  for _, entry in ipairs(cenv.list()) do
     if not entry:match("^LUA_PATH=") and not entry:match("^LUA_CPATH=") then
       env[#env + 1] = entry
     end

--- a/lib/cosmic/sqlite_test.tl
+++ b/lib/cosmic/sqlite_test.tl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cosmic
 --- Tests for cosmic.sqlite wrapper module.
 
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
 local sqlite = require("cosmic.sqlite")
 
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
@@ -16,7 +16,7 @@ end
 test_open_memory()
 
 local function test_open_file()
-  local dbpath = path.join(TEST_TMPDIR, "test.db")
+  local dbpath = fs.join(TEST_TMPDIR, "test.db")
   local db, err = sqlite.open(dbpath)
   assert(db, "should open file db: " .. tostring(err))
   db:close()

--- a/lib/cosmic/sse_test.tl
+++ b/lib/cosmic/sse_test.tl
@@ -342,9 +342,8 @@ test_utf8_data()
 
 -- Network test with real SSE endpoint (skip if unavailable)
 local function test_real_sse_endpoint()
-  local cosmo = require("cosmo")
-  if not cosmo.FetchStream then
-    io.stderr:write("SKIP: test_real_sse_endpoint (FetchStream not available)\n")
+  if not fetch.has_stream() then
+    io.stderr:write("SKIP: test_real_sse_endpoint (streaming fetch not available)\n")
     return
   end
 

--- a/lib/cosmic/style_test.tl
+++ b/lib/cosmic/style_test.tl
@@ -1,16 +1,16 @@
 #!/usr/bin/env cosmic
 -- test cosmic --check-style option
 
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
+local cio = require("cosmic.io")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function write_temp(name: string, content: string): string
-  local filepath = path.join(tmpdir, name)
-  cosmo.Barf(filepath, content)
+  local filepath = fs.join(tmpdir, name)
+  cio.barf(filepath, content)
   return filepath
 end
 

--- a/lib/cosmic/testrun_test.tl
+++ b/lib/cosmic/testrun_test.tl
@@ -1,17 +1,16 @@
 #!/usr/bin/env cosmic
-local path = require("cosmo.path")
 local testrun = require("cosmic.testrun")
 local cio = require("cosmic.io")
 local fs = require("cosmic.fs")
 
 local TEST_BIN = os.getenv("TEST_BIN")
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
-local cosmic_bin = path.join(TEST_BIN, "cosmic")
+local cosmic_bin = fs.join(TEST_BIN, "cosmic")
 
 -- Test running cosmic with a script
 local function test_run_cosmic_script()
-  local script = path.join(TEST_TMPDIR, "test_script.lua")
-  local output_base = path.join(TEST_TMPDIR, "result_script")
+  local script = fs.join(TEST_TMPDIR, "test_script.lua")
+  local output_base = fs.join(TEST_TMPDIR, "result_script")
 
   cio.barf(script, [[print("hello from script")]])
 
@@ -25,7 +24,7 @@ test_run_cosmic_script()
 
 -- Test run with nested output directory
 local function test_run_creates_parent_dirs()
-  local output_base = path.join(TEST_TMPDIR, "nested", "dir", "result")
+  local output_base = fs.join(TEST_TMPDIR, "nested", "dir", "result")
 
   local exit_code = testrun.run({"/bin/true"}, output_base)
   assert(exit_code == 0, "expected exit code 0, got " .. exit_code)
@@ -41,14 +40,14 @@ local function test_run_creates_parent_dirs()
   assert(err ~= nil, "expected .err file to exist")
 
   -- Cleanup
-  fs.rmrf(path.join(TEST_TMPDIR, "nested"))
+  fs.rmrf(fs.join(TEST_TMPDIR, "nested"))
 end
 test_run_creates_parent_dirs()
 
 -- Test run with executable that writes to stdout/stderr
 local function test_run_captures_output()
-  local script = path.join(TEST_TMPDIR, "test_output.sh")
-  local output_base = path.join(TEST_TMPDIR, "result_output")
+  local script = fs.join(TEST_TMPDIR, "test_output.sh")
+  local output_base = fs.join(TEST_TMPDIR, "result_output")
 
   cio.barf(script, [[#!/bin/sh
 echo "stdout line"
@@ -72,8 +71,8 @@ test_run_captures_output()
 
 -- Test that TEST_TMPDIR is set and is a directory
 local function test_run_sets_test_tmpdir()
-  local script = path.join(TEST_TMPDIR, "test_tmpdir.sh")
-  local output_base = path.join(TEST_TMPDIR, "result_tmpdir")
+  local script = fs.join(TEST_TMPDIR, "test_tmpdir.sh")
+  local output_base = fs.join(TEST_TMPDIR, "result_tmpdir")
 
   -- Script checks TEST_TMPDIR exists and is a directory
   cio.barf(script, [[#!/bin/sh
@@ -105,7 +104,7 @@ test_run_sets_test_tmpdir()
 
 -- Test run with nonexistent executable
 local function test_run_nonexistent()
-  local output_base = path.join(TEST_TMPDIR, "result_nonexistent")
+  local output_base = fs.join(TEST_TMPDIR, "result_nonexistent")
 
   local exit_code = testrun.run({"/nonexistent/path/to/exe"}, output_base)
   -- Child process exits 127 when execve fails (command not found)
@@ -119,7 +118,7 @@ test_run_nonexistent()
 
 -- Test report with passing test
 local function test_report_pass()
-  local base = path.join(TEST_TMPDIR, "report_pass")
+  local base = fs.join(TEST_TMPDIR, "report_pass")
 
   cio.barf(base .. ".got", "0\n")
   cio.barf(base .. ".out", "")
@@ -133,7 +132,7 @@ test_report_pass()
 
 -- Test report with failing test
 local function test_report_fail()
-  local base = path.join(TEST_TMPDIR, "report_fail")
+  local base = fs.join(TEST_TMPDIR, "report_fail")
 
   cio.barf(base .. ".got", "1\n")
   cio.barf(base .. ".out", "stdout output\n")
@@ -146,7 +145,7 @@ test_report_fail()
 
 -- Test report with skipped test
 local function test_report_skip()
-  local base = path.join(TEST_TMPDIR, "report_skip")
+  local base = fs.join(TEST_TMPDIR, "report_skip")
 
   cio.barf(base .. ".got", "2\n")
   cio.barf(base .. ".out", "")
@@ -159,9 +158,9 @@ test_report_skip()
 
 -- Test report with multiple tests
 local function test_report_multiple()
-  local base1 = path.join(TEST_TMPDIR, "report_multi_1")
-  local base2 = path.join(TEST_TMPDIR, "report_multi_2")
-  local base3 = path.join(TEST_TMPDIR, "report_multi_3")
+  local base1 = fs.join(TEST_TMPDIR, "report_multi_1")
+  local base2 = fs.join(TEST_TMPDIR, "report_multi_2")
+  local base3 = fs.join(TEST_TMPDIR, "report_multi_3")
 
   cio.barf(base1 .. ".got", "0\n")
   cio.barf(base1 .. ".out", "")
@@ -182,7 +181,7 @@ test_report_multiple()
 
 -- Test report with .got extension
 local function test_report_with_got_extension()
-  local base = path.join(TEST_TMPDIR, "report_ext")
+  local base = fs.join(TEST_TMPDIR, "report_ext")
 
   cio.barf(base .. ".got", "0\n")
   cio.barf(base .. ".out", "")
@@ -196,7 +195,7 @@ test_report_with_got_extension()
 
 -- Test report with missing .got file
 local function test_report_missing_got()
-  local base = path.join(TEST_TMPDIR, "report_missing")
+  local base = fs.join(TEST_TMPDIR, "report_missing")
 
   -- Don't create any files
   local exit_code = testrun.report({base})

--- a/lib/cosmic/tl_loader_test.tl
+++ b/lib/cosmic/tl_loader_test.tl
@@ -2,17 +2,16 @@
 -- test that tl_package_loader is not at position 2 in package.searchers
 -- (issue #377: tl_package_loader recompiles .tl sources when TL_PATH is set)
 
-local path = require("cosmo.path")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
+local cio = require("cosmic.io")
 local fs = require("cosmic.fs")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function write_temp(name: string, content: string): string
-  local filepath = path.join(tmpdir, name)
-  cosmo.Barf(filepath, content)
+  local filepath = fs.join(tmpdir, name)
+  cio.barf(filepath, content)
   return filepath
 end
 
@@ -66,9 +65,9 @@ test_tl_loader_not_at_position_2()
 --- so that .tl-only modules can still be loaded.
 local function test_tl_loader_still_available()
   -- Create a .tl-only module (no .lua version)
-  local moddir = path.join(tmpdir, "tlonly")
+  local moddir = fs.join(tmpdir, "tlonly")
   fs.makedirs(moddir)
-  cosmo.Barf(path.join(moddir, "mymod.tl"), [[
+  cio.barf(fs.join(moddir, "mymod.tl"), [[
 return { answer = 42 }
 ]])
 

--- a/lib/cosmic/unveil_test.tl
+++ b/lib/cosmic/unveil_test.tl
@@ -1,10 +1,10 @@
 #!/usr/bin/env cosmic
 local unveil = require("cosmic.unveil")
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
+local cio = require("cosmic.io")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function test_module_exports()
@@ -13,11 +13,11 @@ end
 test_module_exports()
 
 local function test_unveil_restricts_paths()
-  local allowed_file = path.join(tmpdir, "unveiled.txt")
-  cosmo.Barf(allowed_file, "visible")
+  local allowed_file = fs.join(tmpdir, "unveiled.txt")
+  cio.barf(allowed_file, "visible")
 
-  local script = path.join(tmpdir, "unveil_test.lua")
-  cosmo.Barf(script, string.format([[
+  local script = fs.join(tmpdir, "unveil_test.lua")
+  cio.barf(script, string.format([[
 local unveil = require("cosmic.unveil")
 local ok, err = unveil.apply(%q, "r")
 if not ok then

--- a/lib/cosmic/version_test.tl
+++ b/lib/cosmic/version_test.tl
@@ -1,10 +1,10 @@
 #!/usr/bin/env cosmic
 -- tests for cosmic --version / -v output
 
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 
 --- cosmic -v should output version info and exit 0
 local function test_v_flag()

--- a/lib/cosmic/welcome_test.tl
+++ b/lib/cosmic/welcome_test.tl
@@ -1,12 +1,12 @@
 #!/usr/bin/env cosmic
 -- Test first-run welcome experience
 
-local path = require("cosmo.path")
+local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
-local cosmo = require("cosmo")
+local cio = require("cosmic.io")
 local sys = require("cosmic.sys")
 
-local cosmic = path.join(os.getenv("TEST_BIN"), "cosmic")
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 -- Test --welcome shows message
@@ -35,8 +35,8 @@ test_help_mentions_welcome()
 
 -- Test COSMIC_NO_WELCOME suppresses welcome in scripts
 local function test_no_welcome_env()
-  local test_script = path.join(tmpdir, "no_welcome_test.lua")
-  cosmo.Barf(test_script, [[
+  local test_script = fs.join(tmpdir, "no_welcome_test.lua")
+  cio.barf(test_script, [[
 -- Just check the env var is accessible
 local no_welcome = os.getenv("COSMIC_NO_WELCOME")
 if no_welcome then
@@ -64,7 +64,7 @@ end
 -- Check if PTY creation is available AND cosmic can detect the TTY inside it
 local function pty_available(): boolean
   -- Write a tiny probe script that prints tty detection result to stderr
-  local probe = path.join(tmpdir, "pty_probe.lua")
+  local probe = fs.join(tmpdir, "pty_probe.lua")
   local io_mod = require("cosmic.io")
   local write_ok, _ = io_mod.barf(probe, "local tty = require('cosmic.tty'); io.stderr:write(tostring(tty.stderr_isatty()))\n")
   if not write_ok then
@@ -95,7 +95,7 @@ end
 -- Helper to run cosmic in a PTY (using script command) to trigger TTY-based welcome
 local function run_with_pty(args: {string}): boolean, string
   -- Copy binary to temp location so it's fresh (no embedded marker)
-  local fresh_cosmic = path.join(tmpdir, "cosmic-fresh-" .. tostring(os.time()))
+  local fresh_cosmic = fs.join(tmpdir, "cosmic-fresh-" .. tostring(os.time()))
   local copy_ok = spawn.spawn({"cp", cosmic, fresh_cosmic}):wait()
   assert(copy_ok, "failed to copy cosmic binary")
 
@@ -134,7 +134,7 @@ test_welcome_skipped_with_v_flag()
 -- Test welcome does NOT appear on second run (marker embedded)
 local function test_welcome_not_shown_twice()
   -- Copy binary to temp location
-  local fresh_cosmic = path.join(tmpdir, "cosmic-twice-test")
+  local fresh_cosmic = fs.join(tmpdir, "cosmic-twice-test")
   local copy_ok = spawn.spawn({"cp", cosmic, fresh_cosmic}):wait()
   assert(copy_ok, "failed to copy cosmic binary")
 
@@ -158,7 +158,7 @@ test_welcome_not_shown_twice()
 -- Test COSMIC_NO_WELCOME suppresses welcome even on first run
 local function test_no_welcome_env_suppresses()
   -- Copy binary to temp location
-  local fresh_cosmic = path.join(tmpdir, "cosmic-no-welcome-test")
+  local fresh_cosmic = fs.join(tmpdir, "cosmic-no-welcome-test")
   local copy_ok = spawn.spawn({"cp", cosmic, fresh_cosmic}):wait()
   assert(copy_ok, "failed to copy cosmic binary")
 

--- a/lib/cosmic/zip_test.tl
+++ b/lib/cosmic/zip_test.tl
@@ -1,15 +1,15 @@
 #!/usr/bin/env cosmic
 --- Tests for cosmic.zip wrapper module.
 
-local cosmo = require("cosmo")
-local path = require("cosmo.path")
+local cio = require("cosmic.io")
+local fs = require("cosmic.fs")
 local zip = require("cosmic.zip")
 
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
 
 -- Helper to create a zip file path
 local function zip_path(name: string): string
-  return path.join(TEST_TMPDIR, name)
+  return fs.join(TEST_TMPDIR, name)
 end
 
 -- Basic write operations
@@ -24,7 +24,7 @@ local function test_open_write()
   writer:close()
 
   -- Verify the file exists
-  local data = cosmo.Slurp(p)
+  local data = cio.slurp(p)
   assert(data and #data > 0, "zip file should exist and have content")
 end
 test_open_write()
@@ -39,7 +39,7 @@ local function test_open_write_multiple_files()
   writer:add("subdir/file3.txt", "Content 3")
   writer:close()
 
-  local data = cosmo.Slurp(p)
+  local data = cio.slurp(p)
   assert(data and #data > 0, "zip file should exist")
 end
 test_open_write_multiple_files()
@@ -172,7 +172,7 @@ local function test_from_memory()
   w:close()
 
   -- Read the zip data
-  local zip_data = cosmo.Slurp(p)
+  local zip_data = cio.slurp(p)
   assert(zip_data, "should read zip data")
 
   -- Open from memory


### PR DESCRIPTION
## Summary

Executes **Phase 0 step 3** of the codebase audit plan (#420): the cosmo-ban test migration — the last remaining Phase-0 box, called out as the "highest-leverage next" in the audit's progress log. Per owner decision **D4**, this migration is pulled forward ahead of the Phase 1 breaking changes so that return-shape changes become observable through tests (a test that sets up through `cosmo.Barf` won't fail when a wrapper's shape changes).

Project rule (CLAUDE.md): tests and examples must never `require("cosmo")` — they must use the typed `cosmic.*` wrappers so the wrappers' own code paths get dogfooded.

## What changed

**Migrated 36 test/example files** off the low-level `cosmo.*` C bindings onto `cosmic.*`:
- `cosmo.Barf`/`cosmo.Slurp` → `cio.barf`/`cio.slurp` (bound as `cio` to avoid shadowing the Lua `io` global)
- `cosmo.path.*` → `cosmic.fs.*` (`join`/`dirname`/`basename`/`isfile`/`isdir`)
- `unix.makedirs`/`rmrf`/`symlink`/`chmod`/`mkdtemp`/`mkdir`/`stat`/`getcwd`/`S_ISDIR` → `cosmic.fs.*`
- `unix.getpid`/`exit`/`commandv`/`is_main` → `cosmic.proc.*`
- `unix.setenv`/`clearenv`/`environ` → `cosmic.env.*` (bound as `cenv` where a local `env` variable exists)
- `unix.nanosleep` → `cosmic.time.sleep`

**Added the two capability APIs** the plan specifies, replacing legitimate raw-binding feature-detects:
- `rand.has_hwrng()` — probes RDRAND; gates the `rdrand`/`rdseed` tests.
- `fetch.has_stream()` — reports `FetchStream` availability; gates the streaming tests.

**Added `netns.unshare_user()`** — a typed wrapper over `unshare(CLONE_NEWUSER)`, sibling to the existing `netns.unshare()` for `CLONE_NEWNET`. This removes the one **example-file** cosmo violation the audit specifically flagged (`netns_example.tl`) and the matching raw call in `netns_test.tl`.

## Intentionally kept (7 sites)

These match the exact legitimate exceptions the audit's §1.7 allowlists, and are the targets of the permanent lint rule scheduled for Phase 3:
- **Raw fd ops** — `fs_test.tl`, `fs_dir_test.tl`, `child_test.tl` (`unix.open`/`close`/`O_*`)
- **fork/wait needing errno detail** — `quicksand/proc_test.tl` (`child.fork()` drops the errno the barrier payload reports)
- **fork fault-injection monkey-patch** — `child_test.tl` (must share the exact module table `child.tl` uses)
- **require-machinery test** — `require_test.tl` (`require("cosmo.unix")` is the subject under test)
- **heredoc user-code payloads** — `script_test.tl`, `compile_test.tl` (verify user scripts can require cosmo)

## Test plan

- `bin/make teal` — 195 passed, 0 failed
- `bin/make test` — 92 passed
- `bin/make format` — 195 passed
- Directly executed every migrated test file (rc=0)
- `bin/make example` — the only failures are the pre-existing network-dependent `fetch_example` cases (`httpbin.org` unreachable in this environment); this change does not touch `fetch_example.tl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ap7uRC47wxDSVEJhZcRxab)_