### PR TITLE
sqlite: surface iterator step errors, fix NULL unpack, guard use-after-close (Phase 1 step 5)

### DIFF
--- a/lib/cosmic/sqlite.tl
+++ b/lib/cosmic/sqlite.tl
@@ -50,415 +50,449 @@ end
 
 local sqlite3 = lsqlite3 as RawSqlite3
 
---- Iterator function type returned by query methods.
-local type RowIter = function(): {string: any}
+--- Callable row iterator with an out-of-band error channel. Use it in a
+--- generic `for row in ... do` loop, then call `:err()` afterward to detect
+--- a step error (SQLITE_BUSY / CORRUPT / a RETURNING constraint failure)
+--- that a for-loop cannot observe inline. `:err()` is nil only when
+--- iteration reached SQLITE_DONE cleanly.
+local record Rows
+  metamethod __call: function(self: Rows): {string: any}
+  err: function(self: Rows): string
+end
 
-  --- Statement handle with automatic cleanup.
-  local record Statement
-    bind: function(self: Statement, ...: any): boolean, string
-    bind_list: function(self: Statement, values: {any}): boolean, string
-    bind_named: function(self: Statement, params: {string: any}): boolean, string
-    rows: function(self: Statement): RowIter
-    values: function(self: Statement): function(): any ...
-    exec: function(self: Statement): boolean, string
-    reset: function(self: Statement)
-    columns: function(self: Statement): number
-    column_name: function(self: Statement, n: number): string
-    close: function(self: Statement)
+--- Callable positional-value iterator, the `Statement:values()` counterpart
+--- to `Rows`. Same `:err()` contract.
+local record Values
+  metamethod __call: function(self: Values): any ...
+  err: function(self: Values): string
+end
+
+--- Statement handle with automatic cleanup.
+local record Statement
+  bind: function(self: Statement, ...: any): boolean, string
+  bind_list: function(self: Statement, values: {any}): boolean, string
+  bind_named: function(self: Statement, params: {string: any}): boolean, string
+  rows: function(self: Statement): Rows
+  values: function(self: Statement): Values
+  exec: function(self: Statement): boolean, string
+  reset: function(self: Statement)
+  columns: function(self: Statement): number
+  column_name: function(self: Statement, n: number): string
+  close: function(self: Statement)
+end
+
+--- Database handle with automatic cleanup.
+local record Database
+  prepare: function(self: Database, sql: string): Statement, string
+  query: function(self: Database, sql: string, ...: any): Rows, string
+  query_list: function(self: Database, sql: string, values: {any}): Rows, string
+  query_named: function(self: Database, sql: string, params: {string: any}): Rows, string
+  query_one: function(self: Database, sql: string, ...: any): {string: any}, string
+  exec: function(self: Database, sql: string, ...: any): boolean, string
+  exec_list: function(self: Database, sql: string, values: {any}): boolean, string
+  exec_named: function(self: Database, sql: string, params: {string: any}): boolean, string
+  transaction: function(self: Database, fn: function(Database)): boolean, string
+  last_insert_rowid: function(self: Database): number
+  changes: function(self: Database): number
+  close: function(self: Database)
+end
+
+local function make_statement(raw_stmt: RawStatement, raw_db: RawDatabase): Statement
+  local stmt: Statement = {}
+  local closed = false
+
+  --- Bind parameters by position. Handles trailing nil values correctly
+  --- (unlike varargs with table.unpack which drops them).
+  function stmt:bind(...: any): boolean, string
+    raw_stmt:reset()
+    local n = select("#", ...) as integer
+    for i = 1, n do
+      local val = select(i, ...)
+      local rc = raw_stmt:bind(i, val)
+      if rc ~= sqlite3.OK then
+        return false, raw_db:errmsg()
+      end
+    end
+    return true
   end
 
-  --- Database handle with automatic cleanup.
-  local record Database
-    prepare: function(self: Database, sql: string): Statement, string
-    query: function(self: Database, sql: string, ...: any): RowIter, string
-    query_list: function(self: Database, sql: string, values: {any}): RowIter, string
-    query_named: function(self: Database, sql: string, params: {string: any}): RowIter, string
-    query_one: function(self: Database, sql: string, ...: any): {string: any}, string
-    exec: function(self: Database, sql: string, ...: any): boolean, string
-    exec_list: function(self: Database, sql: string, values: {any}): boolean, string
-    exec_named: function(self: Database, sql: string, params: {string: any}): boolean, string
-    transaction: function(self: Database, fn: function(Database)): boolean, string
-    last_insert_rowid: function(self: Database): number
-    changes: function(self: Database): number
-    close: function(self: Database)
+  --- Bind parameters from a list (table).
+  --- The parameter count is derived from the SQL statement itself, so
+  --- nil values in the table are handled correctly without an explicit count.
+  function stmt:bind_list(values: {any}): boolean, string
+    raw_stmt:reset()
+    local count = raw_stmt:bind_parameter_count() as integer
+    for i = 1, count do
+      local rc = raw_stmt:bind(i, values[i as integer])
+      if rc ~= sqlite3.OK then
+        return false, raw_db:errmsg()
+      end
+    end
+    return true
   end
 
-  local function make_statement(raw_stmt: RawStatement, raw_db: RawDatabase): Statement
-    local stmt: Statement = {}
-    local closed = false
+  --- Bind named parameters from a key/value table.
+  --- SQL should use :name placeholders (e.g. ":foo", ":bar").
+  --- Table keys are names without the colon prefix.
+  function stmt:bind_named(params: {string: any}): boolean, string
+    raw_stmt:reset()
+    local rc = raw_stmt:bind_names(params)
+    if rc ~= sqlite3.OK then
+      return false, raw_db:errmsg()
+    end
+    return true
+  end
 
-    --- Bind parameters by position. Handles trailing nil values correctly
-    --- (unlike varargs with table.unpack which drops them).
-    function stmt:bind(...: any): boolean, string
-      raw_stmt:reset()
-      local n = select("#", ...) as integer
-      for i = 1, n do
-        local val = select(i, ...)
-        local rc = raw_stmt:bind(i, val)
-        if rc ~= sqlite3.OK then
-          return false, raw_db:errmsg()
+  function stmt:rows(): Rows
+    local step_err: string
+    local col_count = raw_stmt:columns()
+    local col_names: {integer: string}
+    local first_call = true
+
+    local iter = setmetatable({} as Rows, {
+        __call = function(_: Rows): {string: any}
+          local rc = raw_stmt:step()
+          if rc == sqlite3.ROW then
+            -- Get column names on first row (requires step to be called first)
+            if first_call then
+              first_call = false
+              col_names = {}
+              for idx = 0, col_count - 1 do
+                col_names[(idx + 1) as integer] = raw_stmt:get_name(idx)
+              end
+            end
+            local row: {string: any} = {}
+            for idx = 0, col_count - 1 do
+              local name = col_names[(idx + 1) as integer]
+              row[name] = raw_stmt:get_value(idx)
+            end
+            return row
+          end
+          -- Only SQLITE_DONE is a clean end; surface anything else.
+          if rc ~= sqlite3.DONE then
+            step_err = raw_db:errmsg()
+          end
+          return nil
+        end,
+      })
+    iter.err = function(_: Rows): string return step_err end
+    return iter
+  end
+
+  function stmt:values(): Values
+    local step_err: string
+    local col_count = raw_stmt:columns() as integer
+
+    local iter = setmetatable({} as Values, {
+        __call = function(_: Values): any ...
+          local rc = raw_stmt:step()
+          if rc == sqlite3.ROW then
+            local vals: {integer: any} = {}
+            for idx = 0, col_count - 1 do
+              vals[(idx + 1) as integer] = raw_stmt:get_value(idx)
+            end
+            -- Bound the unpack: a NULL first column leaves vals[1] == nil,
+            -- and an unbounded unpack would drop the remaining columns.
+            return table.unpack(vals, 1, col_count)
+          end
+          if rc ~= sqlite3.DONE then
+            step_err = raw_db:errmsg()
+          end
+          return nil
+        end,
+      })
+    iter.err = function(_: Values): string return step_err end
+    return iter
+  end
+
+  function stmt:exec(): boolean, string
+    local rc = raw_stmt:step()
+    if rc ~= sqlite3.DONE and rc ~= sqlite3.ROW then
+      return false, raw_db:errmsg()
+    end
+    return true
+  end
+
+  stmt.reset = function(_: Statement)
+    raw_stmt:reset()
+  end
+
+  stmt.columns = function(_: Statement): number
+    return raw_stmt:columns()
+  end
+
+  stmt.column_name = function(_: Statement, n: number): string
+    return raw_stmt:get_name(n - 1)
+  end
+
+  stmt.close = function(_: Statement)
+    if not closed then
+      closed = true
+      local _ = raw_stmt:finalize()
+    end
+  end
+
+  return setmetatable(stmt, {
+      __close = function(self: Statement) self:close() end
+    }) as Statement
+end
+
+-- Wrap a prepared+bound statement's row iterator: finalize the statement
+-- when iteration ends and forward the step error through `:err()`.
+local function make_query_iter(stmt: Statement): Rows
+  local raw_iter = stmt:rows()
+  local done = false
+  local iter = setmetatable({} as Rows, {
+      __call = function(_: Rows): {string: any}
+        if done then
+          return nil
         end
-      end
-      return true
+        local row = raw_iter()
+        if row == nil then
+          done = true
+          stmt:close()
+          return nil
+        end
+        return row
+      end,
+    })
+  iter.err = function(_: Rows): string return raw_iter:err() end
+  return iter
+end
+
+local function make_database(raw_db: RawDatabase): Database
+  local db: Database = {}
+  local closed = false
+
+  function db:prepare(sql: string): Statement, string
+    if closed then
+      return nil, "database is closed"
+    end
+    local raw_stmt, errcode, errmsg = raw_db:prepare(sql)
+    if not raw_stmt then
+      return nil, errmsg or ("error code " .. tostring(errcode))
+    end
+    return make_statement(raw_stmt, raw_db)
+  end
+
+  function db:query(sql: string, ...: any): Rows, string
+    local stmt, err = self:prepare(sql)
+    if not stmt then
+      return nil, "query failed: " .. (err or "unknown error")
     end
 
-    --- Bind parameters from a list (table).
-    --- The parameter count is derived from the SQL statement itself, so
-    --- nil values in the table are handled correctly without an explicit count.
-    function stmt:bind_list(values: {any}): boolean, string
-      raw_stmt:reset()
-      local count = raw_stmt:bind_parameter_count() as integer
-      for i = 1, count do
-        local rc = raw_stmt:bind(i, values[i as integer])
-        if rc ~= sqlite3.OK then
-          return false, raw_db:errmsg()
-        end
+    local n = select("#", ...) as integer
+    if n > 0 then
+      local ok, bind_err = stmt:bind(...)
+      if not ok then
+        stmt:close()
+        return nil, "bind failed: " .. (bind_err or "unknown error")
       end
-      return true
     end
 
-    --- Bind named parameters from a key/value table.
-    --- SQL should use :name placeholders (e.g. ":foo", ":bar").
-    --- Table keys are names without the colon prefix.
-    function stmt:bind_named(params: {string: any}): boolean, string
-      raw_stmt:reset()
-      local rc = raw_stmt:bind_names(params)
+    return make_query_iter(stmt)
+  end
+
+  function db:exec(sql: string, ...: any): boolean, string
+    if closed then
+      return false, "database is closed"
+    end
+    local n = select("#", ...) as integer
+    if n == 0 then
+      -- no params: use raw exec (faster for DDL)
+      local rc = raw_db:exec(sql)
       if rc ~= sqlite3.OK then
         return false, raw_db:errmsg()
       end
       return true
     end
 
-    function stmt:rows(): RowIter
-      local col_count = raw_stmt:columns()
-      local col_names: {integer: string}
-      local first_call = true
-
-      return function(): {string: any}
-        local rc = raw_stmt:step()
-        if rc == sqlite3.ROW then
-          -- Get column names on first row (requires step to be called first)
-          if first_call then
-            first_call = false
-            col_names = {}
-            for idx = 0, col_count - 1 do
-              col_names[(idx + 1) as integer] = raw_stmt:get_name(idx)
-            end
-          end
-          local row: {string: any} = {}
-          for idx = 0, col_count - 1 do
-            local name = col_names[(idx + 1) as integer]
-            row[name] = raw_stmt:get_value(idx)
-          end
-          return row
-        end
-        return nil
-      end
+    -- has params: prepare/bind/exec
+    local stmt, err = self:prepare(sql)
+    if not stmt then
+      return false, err or "prepare failed"
     end
 
-    function stmt:values(): function(): any ...
-      local col_count = raw_stmt:columns()
-
-      return function(): any ...
-        local rc = raw_stmt:step()
-        if rc == sqlite3.ROW then
-          local vals: {integer: any} = {}
-          for idx = 0, col_count - 1 do
-            vals[(idx + 1) as integer] = raw_stmt:get_value(idx)
-          end
-          return table.unpack(vals)
-        end
-        return nil
-      end
-    end
-
-    function stmt:exec(): boolean, string
-      local rc = raw_stmt:step()
-      if rc ~= sqlite3.DONE and rc ~= sqlite3.ROW then
-        return false, raw_db:errmsg()
-      end
-      return true
-    end
-
-    stmt.reset = function(_: Statement)
-      raw_stmt:reset()
-    end
-
-    stmt.columns = function(_: Statement): number
-      return raw_stmt:columns()
-    end
-
-    stmt.column_name = function(_: Statement, n: number): string
-      return raw_stmt:get_name(n - 1)
-    end
-
-    stmt.close = function(_: Statement)
-      if not closed then
-        closed = true
-        local _ = raw_stmt:finalize()
-      end
-    end
-
-    return setmetatable(stmt, {
-        __close = function(self: Statement) self:close() end
-      }) as Statement
-  end
-
-  local function make_database(raw_db: RawDatabase): Database
-    local db: Database = {}
-    local closed = false
-
-    function db:prepare(sql: string): Statement, string
-      local raw_stmt, errcode, errmsg = raw_db:prepare(sql)
-      if not raw_stmt then
-        return nil, errmsg or ("error code " .. tostring(errcode))
-      end
-      return make_statement(raw_stmt, raw_db)
-    end
-
-    function db:query(sql: string, ...: any): RowIter, string
-      local stmt, err = self:prepare(sql)
-      if not stmt then
-        return nil, "query failed: " .. (err or "unknown error")
-      end
-
-      local n = select("#", ...) as integer
-      if n > 0 then
-        local ok, bind_err = stmt:bind(...)
-        if not ok then
-          stmt:close()
-          return nil, "bind failed: " .. (bind_err or "unknown error")
-        end
-      end
-
-      local raw_iter = stmt:rows()
-      local done = false
-      return function(): {string: any}
-        if done then
-          return nil
-        end
-        local row = raw_iter()
-        if row == nil then
-          done = true
-          stmt:close()
-          return nil
-        end
-        return row
-      end
-    end
-
-    function db:exec(sql: string, ...: any): boolean, string
-      local n = select("#", ...) as integer
-      if n == 0 then
-        -- no params: use raw exec (faster for DDL)
-        local rc = raw_db:exec(sql)
-        if rc ~= sqlite3.OK then
-          return false, raw_db:errmsg()
-        end
-        return true
-      end
-
-      -- has params: prepare/bind/exec
-      local stmt, err = self:prepare(sql)
-      if not stmt then
-        return false, err or "prepare failed"
-      end
-
-      local ok, bind_err = stmt:bind(...)
-      if not ok then
-        stmt:close()
-        return false, bind_err or "bind failed"
-      end
-
-      local exec_ok, exec_err = stmt:exec()
+    local ok, bind_err = stmt:bind(...)
+    if not ok then
       stmt:close()
-      return exec_ok, exec_err
+      return false, bind_err or "bind failed"
     end
 
-    --- Execute SQL with parameters from a list (table).
-    --- The parameter count is derived from the SQL itself, so nil values
-    --- in the table are handled correctly.
-    function db:exec_list(sql: string, values: {any}): boolean, string
-      local stmt, err = self:prepare(sql)
-      if not stmt then
-        return false, err or "prepare failed"
-      end
+    local exec_ok, exec_err = stmt:exec()
+    stmt:close()
+    return exec_ok, exec_err
+  end
 
-      local ok, bind_err = stmt:bind_list(values)
-      if not ok then
-        stmt:close()
-        return false, bind_err or "bind failed"
-      end
+  --- Execute SQL with parameters from a list (table).
+  --- The parameter count is derived from the SQL itself, so nil values
+  --- in the table are handled correctly.
+  function db:exec_list(sql: string, values: {any}): boolean, string
+    local stmt, err = self:prepare(sql)
+    if not stmt then
+      return false, err or "prepare failed"
+    end
 
-      local exec_ok, exec_err = stmt:exec()
+    local ok, bind_err = stmt:bind_list(values)
+    if not ok then
       stmt:close()
-      return exec_ok, exec_err
+      return false, bind_err or "bind failed"
     end
 
-    --- Execute SQL with named parameters.
-    --- SQL should use :name placeholders. Table keys are names without the colon.
-    function db:exec_named(sql: string, params: {string: any}): boolean, string
-      local stmt, err = self:prepare(sql)
-      if not stmt then
-        return false, err or "prepare failed"
-      end
+    local exec_ok, exec_err = stmt:exec()
+    stmt:close()
+    return exec_ok, exec_err
+  end
 
-      local ok, bind_err = stmt:bind_named(params)
-      if not ok then
-        stmt:close()
-        return false, bind_err or "bind failed"
-      end
+  --- Execute SQL with named parameters.
+  --- SQL should use :name placeholders. Table keys are names without the colon.
+  function db:exec_named(sql: string, params: {string: any}): boolean, string
+    local stmt, err = self:prepare(sql)
+    if not stmt then
+      return false, err or "prepare failed"
+    end
 
-      local exec_ok, exec_err = stmt:exec()
+    local ok, bind_err = stmt:bind_named(params)
+    if not ok then
       stmt:close()
-      return exec_ok, exec_err
+      return false, bind_err or "bind failed"
     end
 
-    --- Query with parameters from a list (table).
-    --- The parameter count is derived from the SQL itself, so nil values
-    --- in the table are handled correctly.
-    function db:query_list(sql: string, values: {any}): RowIter, string
-      local stmt, err = self:prepare(sql)
-      if not stmt then
-        return nil, "query failed: " .. (err or "unknown error")
-      end
-
-      local ok, bind_err = stmt:bind_list(values)
-      if not ok then
-        stmt:close()
-        return nil, "bind failed: " .. (bind_err or "unknown error")
-      end
-
-      local raw_iter = stmt:rows()
-      local done = false
-      return function(): {string: any}
-        if done then
-          return nil
-        end
-        local row = raw_iter()
-        if row == nil then
-          done = true
-          stmt:close()
-          return nil
-        end
-        return row
-      end
-    end
-
-    --- Query with named parameters.
-    --- SQL should use :name placeholders. Table keys are names without the colon.
-    function db:query_named(sql: string, params: {string: any}): RowIter, string
-      local stmt, err = self:prepare(sql)
-      if not stmt then
-        return nil, "query failed: " .. (err or "unknown error")
-      end
-
-      local ok, bind_err = stmt:bind_named(params)
-      if not ok then
-        stmt:close()
-        return nil, "bind failed: " .. (bind_err or "unknown error")
-      end
-
-      local raw_iter = stmt:rows()
-      local done = false
-      return function(): {string: any}
-        if done then
-          return nil
-        end
-        local row = raw_iter()
-        if row == nil then
-          done = true
-          stmt:close()
-          return nil
-        end
-        return row
-      end
-    end
-
-    --- Return the first row matching a query, or nil if no rows match.
-    --- Convenience method for single-row lookups.
-    --- The underlying prepared statement is always finalized before returning,
-    --- even when only the first row is consumed, preventing statement leaks.
-    function db:query_one(sql: string, ...: any): {string: any}, string
-      local iter, err = self:query(sql, ...)
-      if not iter then
-        return nil, err
-      end
-      -- Capture the first row, then drain the iterator so the statement is
-      -- finalized deterministically (returning early from a for-loop leaves
-      -- the iterator open and the prepared statement unfinalized until GC).
-      local first: {string: any} = nil
-      for row in iter do
-        first = row
-        break
-      end
-      -- Drain remaining rows so the wrapping closure calls stmt:close().
-      if first ~= nil then
-        while iter() ~= nil do end
-      end
-      return first
-    end
-
-    --- Execute fn within a transaction. Calls BEGIN before fn, COMMIT after
-    --- fn returns, and ROLLBACK if fn raises an error.
-    --- Returns true on success, or false and an error message on failure.
-    function db:transaction(fn: function(Database)): boolean, string
-      local ok, err = self:exec("BEGIN IMMEDIATE")
-      if not ok then
-        return false, err or "begin failed"
-      end
-      local success, call_err = pcall(fn, self) as(boolean, string)
-      if not success then
-        self:exec("ROLLBACK")
-        return false, call_err or "transaction failed"
-      end
-      return self:exec("COMMIT")
-    end
-
-    function db:last_insert_rowid(): number
-      return raw_db:last_insert_rowid()
-    end
-
-    function db:changes(): number
-      return raw_db:changes()
-    end
-
-    db.close = function(_: Database)
-      if not closed then
-        closed = true
-        local _ = raw_db:close()
-      end
-    end
-
-    return setmetatable(db, {
-        __close = function(self: Database) self:close() end
-      }) as Database
+    local exec_ok, exec_err = stmt:exec()
+    stmt:close()
+    return exec_ok, exec_err
   end
 
-  --- Open or create an SQLite database.
-  --- Relative paths are resolved against the current working directory.
-  --- Absolute paths (e.g. "/var/data/app.db") work as expected.
-  --- Use ":memory:" for an in-memory database that is not written to disk.
-  --- The file is created if it does not already exist.
-  --- @param filename string Database path (use ":memory:" for in-memory)
-  --- @return Database Database handle with __close support
-  --- @return string Error message on failure
-  local function open(filename: string): Database, string
-    local raw_db, errcode, errmsg = sqlite3.open(filename)
-    if not raw_db then
-      return nil, errmsg or ("error code " .. tostring(errcode))
+  --- Query with parameters from a list (table).
+  --- The parameter count is derived from the SQL itself, so nil values
+  --- in the table are handled correctly.
+  function db:query_list(sql: string, values: {any}): Rows, string
+    local stmt, err = self:prepare(sql)
+    if not stmt then
+      return nil, "query failed: " .. (err or "unknown error")
     end
-    return make_database(raw_db)
+
+    local ok, bind_err = stmt:bind_list(values)
+    if not ok then
+      stmt:close()
+      return nil, "bind failed: " .. (bind_err or "unknown error")
+    end
+
+    return make_query_iter(stmt)
   end
 
-  local record sqlite
-    open: function(filename: string): Database, string
-    Database: Database
-    Statement: Statement
+  --- Query with named parameters.
+  --- SQL should use :name placeholders. Table keys are names without the colon.
+  function db:query_named(sql: string, params: {string: any}): Rows, string
+    local stmt, err = self:prepare(sql)
+    if not stmt then
+      return nil, "query failed: " .. (err or "unknown error")
+    end
+
+    local ok, bind_err = stmt:bind_named(params)
+    if not ok then
+      stmt:close()
+      return nil, "bind failed: " .. (bind_err or "unknown error")
+    end
+
+    return make_query_iter(stmt)
   end
 
-  local M: sqlite = {
-    open = open,
-  }
+  --- Return the first row matching a query, or nil if no rows match.
+  --- Convenience method for single-row lookups.
+  --- The underlying prepared statement is always finalized before returning,
+  --- even when only the first row is consumed, preventing statement leaks.
+  function db:query_one(sql: string, ...: any): {string: any}, string
+    local iter, err = self:query(sql, ...)
+    if not iter then
+      return nil, err
+    end
+    -- Capture the first row, then drain the iterator so the statement is
+    -- finalized deterministically (returning early from a for-loop leaves
+    -- the iterator open and the prepared statement unfinalized until GC).
+    local first: {string: any} = nil
+    for row in iter do
+      first = row
+      break
+    end
+    -- Drain remaining rows so the wrapping closure calls stmt:close().
+    if first ~= nil then
+      while iter() ~= nil do end
+    end
+    -- Surface a step error rather than a partial row that looks clean.
+    local step_err = iter:err()
+    if step_err then
+      return nil, step_err
+    end
+    return first
+  end
 
-  return M
+  --- Execute fn within a transaction. Calls BEGIN before fn, COMMIT after
+  --- fn returns, and ROLLBACK if fn raises an error.
+  --- Returns true on success, or false and an error message on failure.
+  function db:transaction(fn: function(Database)): boolean, string
+    local ok, err = self:exec("BEGIN IMMEDIATE")
+    if not ok then
+      return false, err or "begin failed"
+    end
+    local success, call_err = pcall(fn, self) as(boolean, string)
+    if not success then
+      self:exec("ROLLBACK")
+      return false, call_err or "transaction failed"
+    end
+    return self:exec("COMMIT")
+  end
+
+  function db:last_insert_rowid(): number
+    if closed then
+      return 0
+    end
+    return raw_db:last_insert_rowid()
+  end
+
+  function db:changes(): number
+    if closed then
+      return 0
+    end
+    return raw_db:changes()
+  end
+
+  db.close = function(_: Database)
+    if not closed then
+      closed = true
+      local _ = raw_db:close()
+    end
+  end
+
+  return setmetatable(db, {
+      __close = function(self: Database) self:close() end
+    }) as Database
+end
+
+--- Open or create an SQLite database.
+--- Relative paths are resolved against the current working directory.
+--- Absolute paths (e.g. "/var/data/app.db") work as expected.
+--- Use ":memory:" for an in-memory database that is not written to disk.
+--- The file is created if it does not already exist.
+--- @param filename string Database path (use ":memory:" for in-memory)
+--- @return Database Database handle with __close support
+--- @return string Error message on failure
+local function open(filename: string): Database, string
+  local raw_db, errcode, errmsg = sqlite3.open(filename)
+  if not raw_db then
+    return nil, errmsg or ("error code " .. tostring(errcode))
+  end
+  return make_database(raw_db)
+end
+
+local record sqlite
+  open: function(filename: string): Database, string
+  Database: Database
+  Statement: Statement
+end
+
+local M: sqlite = {
+  open = open,
+}
+
+return M

--- a/lib/cosmic/sqlite_test.tl
+++ b/lib/cosmic/sqlite_test.tl
@@ -233,6 +233,73 @@ local function test_statement_values()
 end
 test_statement_values()
 
+-- Iterator error surfacing (step errors must not masquerade as end-of-rows)
+
+-- abs() of the most-negative int64 overflows at step() time (not prepare).
+local OVERFLOW = "SELECT abs(-9223372036854775808) AS x"
+
+local function test_query_err_nil_on_clean_iteration()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+  db:exec("INSERT INTO t (id) VALUES (1), (2)")
+  local iter = db:query("SELECT * FROM t")
+  local count = 0
+  for _ in iter do count = count + 1 end
+  assert(count == 2, "should iterate all rows")
+  assert(iter:err() == nil, "clean iteration should report no error")
+  db:close()
+end
+test_query_err_nil_on_clean_iteration()
+
+local function test_query_step_error_surfaced()
+  local db = sqlite.open(":memory:")
+  local iter = db:query(OVERFLOW)
+  for _ in iter do end
+  local err = iter:err()
+  assert(err ~= nil, "step error must be surfaced, not swallowed as end-of-rows")
+  assert(err:find("overflow"), "error should mention overflow: " .. tostring(err))
+  db:close()
+end
+test_query_step_error_surfaced()
+
+local function test_query_one_step_error()
+  local db = sqlite.open(":memory:")
+  local row, err = db:query_one(OVERFLOW)
+  assert(row == nil, "query_one should return nil on a step error")
+  assert(type(err) == "string", "query_one should surface the step error")
+  db:close()
+end
+test_query_one_step_error()
+
+-- values(): a NULL first column must not truncate the row (bounded unpack)
+local function test_values_null_first_column()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (a TEXT, b INTEGER, c TEXT)")
+  db:exec("INSERT INTO t VALUES (NULL, 42, 'z')")
+  local stmt = db:prepare("SELECT * FROM t")
+  local a, b, c = stmt:values()()
+  assert(a == nil, "first column should be nil")
+  assert(b == 42, "second column should survive NULL-first-column unpack")
+  assert(c == "z", "third column should survive NULL-first-column unpack")
+  stmt:close()
+  db:close()
+end
+test_values_null_first_column()
+
+-- Use-after-close returns errors instead of throwing/crashing
+local function test_use_after_close()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (id INTEGER)")
+  db:close()
+  local ok, exec_err = db:exec("INSERT INTO t (id) VALUES (1)")
+  assert(not ok and type(exec_err) == "string", "exec after close should error")
+  local iter, query_err = db:query("SELECT * FROM t")
+  assert(iter == nil and type(query_err) == "string", "query after close should error")
+  assert(db:last_insert_rowid() == 0, "last_insert_rowid after close should not crash")
+  assert(db:changes() == 0, "changes after close should not crash")
+end
+test_use_after_close()
+
 -- Index conversion (1-indexed)
 
 local function test_column_name_1indexed()


### PR DESCRIPTION
## Summary

Executes **step 5** of the remediation plan in #420 (Phase 1 — correctness & security, §2.1 / §2.2). Fixes three SQLite correctness bugs, the headline one being a **P0 silent-data-loss** defect.

### 1. Iterator error-swallowing (P0 — silent data loss)
`Statement:rows()` / `Statement:values()` returned `nil` on *any* step rc that wasn't `ROW`, so `SQLITE_BUSY` / `SQLITE_CORRUPT` / a constraint failure from a `RETURNING` clause was indistinguishable from end-of-results. A loop over a busy or corrupt DB silently terminated early and the caller believed it saw every row.

Fix: the iterators now treat **only `SQLITE_DONE`** as a clean end and capture any other rc's message. Because a generic `for row in ... do` loop cannot observe a second return value, the iterators are now **callable records** (`Rows` / `Values`) carrying an out-of-band `:err()` channel:

```teal
local rows = db:query("SELECT ...")
for row in rows do ... end          -- unchanged ergonomics
if rows:err() then ... end          -- step error, nil only on a clean DONE
```

`db:query_one` now returns `nil, err` on a step error instead of a partial row. No throwing — the never-throw convention is preserved.

### 2. NULL unpack (§2.2)
`values()` used `table.unpack(vals)`, which stops at the first hole — a `NULL` first column dropped every remaining column. Now bounded: `table.unpack(vals, 1, col_count)`.

### 3. Use-after-close (§2.1)
`db:exec` / `db:prepare` (and the query/exec paths that route through `prepare`) after `db:close()` hit the freed raw handle and threw; `last_insert_rowid` / `changes` did too. Each now guards on the `closed` flag and returns an error (or `0` for the numeric accessors).

## Test plan

- Adds regression tests for all four fixes: step error surfaced (via an int64-overflow query that fails at `step()` time), `query_one` step error, `NULL`-first-column round-trip, and use-after-close returning errors rather than crashing.
- `bin/make format` ✅ · `bin/make lint` ✅ (255/255) · `bin/make teal` ✅ (full tree, 195/195) · `bin/make test only=sqlite` ✅ · `bin/make example` (sqlite) ✅

## Note on diff size

`sqlite.tl` shows a large whitespace-only diff: the old `local type RowIter = function(): {...}` had been confusing the formatter's indent tracker into a spurious +2 on the entire file body, which the proper `record` type no longer triggers, so the formatter de-indents it. Review with `git diff -w` to see the ~50-line logical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgmwcfUs8ZokFNvESFghTi)_