### PR TITLE
time: return errors instead of throwing/swallowing; fix ISO-8601 parsing (Phase 1 step 6)

### DIFF
--- a/lib/cosmic/time.tl
+++ b/lib/cosmic/time.tl
@@ -11,10 +11,10 @@ local record DateTime
   day: number -- Day of month (1-31)
   hour: number -- Hour (0-23)
   min: number -- Minute (0-59)
-  sec: number -- Second (0-59)
+  sec: number -- Second (0-60, 60 for a leap second)
   gmtoff: number -- Offset from UTC in seconds
-  wday: number -- Day of week (1=Sunday, 7=Saturday)
-  yday: number -- Day of year (1-366)
+  wday: number -- Day of week (0=Sunday, 6=Saturday)
+  yday: number -- Day of year (0-365)
   isdst: number -- Daylight saving time flag (1=DST, 0=standard)
   zone: string -- Timezone name (e.g., "UTC", "PDT")
 end
@@ -131,14 +131,6 @@ local function format_http(timestamp: number): string
   return cosmo.FormatHttpDateTime(timestamp)
 end
 
---- Parse an HTTP date string (RFC 7231) into a UNIX timestamp.
---- Returns 0 for invalid input.
---- @param str string HTTP date string
---- @return number UNIX timestamp, or 0 if parsing failed
-local function parse_http(str: string): number
-  return cosmo.ParseHttpDateTime(str)
-end
-
 --- Return true if year is a leap year.
 local function is_leap_year(year: number): boolean
   return year % 4 == 0 and (year % 100 ~= 0 or year % 400 == 0)
@@ -147,16 +139,44 @@ end
 --- Days in each month for a non-leap year.
 local MONTH_DAYS: {integer} = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
 
+--- Number of days in the given month, accounting for leap years.
+local function days_in_month(year: number, month: number): number
+  if month == 2 and is_leap_year(year) then
+    return 29
+  end
+  return MONTH_DAYS[month as integer]
+end
+
 --- Convert UTC broken-down time to UNIX epoch seconds.
+--- Fields are range-checked; out-of-range values (e.g. month 13, Feb 30)
+--- return nil plus an error rather than throwing.
 --- @param year number Full year (e.g., 2025)
 --- @param month number Month (1-12)
 --- @param day number Day of month (1-31)
 --- @param hour number Hour (0-23)
 --- @param min number Minute (0-59)
---- @param sec number Second (0-59)
---- @return number UNIX epoch seconds
+--- @param sec number Second (0-60)
+--- @return number UNIX epoch seconds, or nil on invalid input
+--- @return string Error message when input is out of range
 local function timegm(year: number, month: number, day: number,
-    hour: number, min: number, sec: number): number
+    hour: number, min: number, sec: number): number, string
+  if month < 1 or month > 12 then
+    return nil, "timegm: month out of range (1-12): " .. tostring(month)
+  end
+  local dim = days_in_month(year, month)
+  if day < 1 or day > dim then
+    return nil, "timegm: day out of range (1-" .. tostring(dim) .. "): "
+    .. tostring(day)
+  end
+  if hour < 0 or hour > 23 then
+    return nil, "timegm: hour out of range (0-23): " .. tostring(hour)
+  end
+  if min < 0 or min > 59 then
+    return nil, "timegm: minute out of range (0-59): " .. tostring(min)
+  end
+  if sec < 0 or sec > 60 then
+    return nil, "timegm: second out of range (0-60): " .. tostring(sec)
+  end
   local days: number = 0
   -- count days for complete years since 1970
   if year >= 1970 then
@@ -179,6 +199,34 @@ local function timegm(year: number, month: number, day: number,
   return days * 86400 + hour * 3600 + min * 60 + sec
 end
 
+--- Month abbreviation (RFC 7231 IMF-fixdate) to month number.
+local MONTH_ABBR: {string: number} = {
+  Jan = 1, Feb = 2, Mar = 3, Apr = 4, May = 5, Jun = 6,
+  Jul = 7, Aug = 8, Sep = 9, Oct = 10, Nov = 11, Dec = 12,
+}
+
+--- Parse an HTTP date string (RFC 7231) into a UNIX timestamp.
+--- Accepts the IMF-fixdate format that format_http emits and that RFC 7231
+--- requires senders to generate (e.g. "Sun, 06 Nov 1994 08:49:37 GMT").
+--- The obsolete RFC 850 and asctime forms are not accepted.
+--- @param str string HTTP date string
+--- @return number UNIX timestamp, or nil if parsing failed
+--- @return string Error message on failure
+local function parse_http(str: string): number, string
+  local d, mon, y, h, mi, s = str:match(
+    "^%a%a%a, (%d%d) (%a%a%a) (%d%d%d%d) (%d%d):(%d%d):(%d%d) GMT$")
+  if not d then
+    return nil, "parse_http: not an RFC 7231 date: " .. str
+  end
+  local month = MONTH_ABBR[mon]
+  if not month then
+    return nil, "parse_http: unknown month: " .. mon
+  end
+  return timegm(
+    tonumber(y) as number, month, tonumber(d) as number,
+    tonumber(h) as number, tonumber(mi) as number, tonumber(s) as number)
+end
+
 --- Format a UNIX timestamp as a date string in UTC.
 --- @param timestamp number UNIX timestamp (seconds since epoch)
 --- @return string Date string (e.g., "2025-01-01")
@@ -189,12 +237,14 @@ local function format_date(timestamp: number): string
 end
 
 --- Parse a YYYY-MM-DD date string into a UNIX timestamp (midnight UTC).
---- Returns 0 for invalid input.
 --- @param str string Date string (e.g., "2025-01-01")
---- @return number UNIX timestamp, or 0 if parsing failed
-local function parse_date(str: string): number
+--- @return number UNIX timestamp, or nil if parsing failed
+--- @return string Error message on failure
+local function parse_date(str: string): number, string
   local y, mo, d = str:match("^(%d%d%d%d)-(%d%d)-(%d%d)$")
-  if not y then return 0 end
+  if not y then
+    return nil, "parse_date: not a YYYY-MM-DD date: " .. str
+  end
   return timegm(
     tonumber(y) as number, tonumber(mo) as number, tonumber(d) as number,
     0, 0, 0)
@@ -210,13 +260,42 @@ local function format_iso8601(timestamp: number): string
     dt.hour as integer, dt.min as integer, dt.sec as integer)
 end
 
+--- Resolve an ISO 8601 timezone suffix into a signed offset in seconds.
+--- Accepts "", "Z"/"z" (UTC), "±HH:MM", "±HHMM", and "±HH".
+--- @return number Offset east of UTC in seconds, or nil if unparseable
+local function parse_offset(tz: string): number, string
+  if tz == "" or tz == "Z" or tz == "z" then
+    return 0
+  end
+  local sign, oh, om = tz:match("^([%+%-])(%d%d):(%d%d)$")
+  if not sign then
+    sign, oh, om = tz:match("^([%+%-])(%d%d)(%d%d)$")
+  end
+  if not sign then
+    sign, oh = tz:match("^([%+%-])(%d%d)$")
+    om = "00"
+  end
+  if not sign then
+    return nil, "invalid timezone offset: " .. tz
+  end
+  local h = tonumber(oh) as number
+  local m = tonumber(om) as number
+  if h > 23 or m > 59 then
+    return nil, "timezone offset out of range: " .. tz
+  end
+  local offset = h * 3600 + m * 60
+  return sign == "+" and offset or -offset
+end
+
 --- Parse an ISO 8601 timestamp string into a UNIX epoch seconds value.
---- Accepts full timestamps with "Z" suffix, "+HH:MM"/"-HH:MM" offsets, or no
---- suffix (treated as UTC). Also accepts date-only "YYYY-MM-DD" (midnight UTC).
---- Returns 0 for invalid input.
---- @param str string ISO 8601 string (e.g., "2025-01-01T00:00:00Z" or "2025-01-01")
---- @return number UNIX timestamp, or 0 if parsing failed
-local function parse_iso8601(str: string): number
+--- Accepts full timestamps with a "Z" suffix, "±HH:MM"/"±HHMM"/"±HH" offsets,
+--- or no suffix (treated as UTC). Optional fractional seconds are accepted and
+--- truncated to whole seconds. Also accepts date-only "YYYY-MM-DD" (midnight
+--- UTC).
+--- @param str string ISO 8601 string (e.g., "2025-01-01T00:00:00.5Z")
+--- @return number UNIX timestamp, or nil if parsing failed
+--- @return string Error message on failure
+local function parse_iso8601(str: string): number, string
   -- try date-only format first
   local dy, dmo, dd = str:match("^(%d%d%d%d)-(%d%d)-(%d%d)$")
   if dy then
@@ -224,25 +303,25 @@ local function parse_iso8601(str: string): number
       tonumber(dy) as number, tonumber(dmo) as number, tonumber(dd) as number,
       0, 0, 0)
   end
-  local y, mo, d, h, mi, s, tz = str:match(
-    "^(%d%d%d%d)-(%d%d)-(%d%d)T(%d%d):(%d%d):(%d%d)(.*)")
-  if not y then return 0 end
-  local epoch = timegm(
+  local y, mo, d, h, mi, s, rest = str:match(
+    "^(%d%d%d%d)-(%d%d)-(%d%d)T(%d%d):(%d%d):(%d%d)(.*)$")
+  if not y then
+    return nil, "parse_iso8601: not an ISO 8601 timestamp: " .. str
+  end
+  -- optional fractional seconds are accepted and dropped (whole-second epoch)
+  local after = rest:match("^%.%d+(.*)$")
+  local tz = after or rest
+  local epoch, err = timegm(
     tonumber(y) as number, tonumber(mo) as number, tonumber(d) as number,
     tonumber(h) as number, tonumber(mi) as number, tonumber(s) as number)
-  -- parse timezone offset
-  if tz == "Z" or tz == "z" or tz == "" then
-    return epoch
+  if not epoch then
+    return nil, err
   end
-  local sign, oh, om = tz:match("^([%+%-])(%d%d):(%d%d)$")
-  if not sign then return 0 end
-  local offset = (tonumber(oh) as number) * 3600 + (tonumber(om) as number) * 60
-  if sign == "+" then
-    epoch = epoch - offset
-  else
-    epoch = epoch + offset
+  local offset, oerr = parse_offset(tz)
+  if not offset then
+    return nil, "parse_iso8601: " .. oerr
   end
-  return epoch
+  return epoch - offset
 end
 
 local record TimeModule
@@ -265,12 +344,12 @@ local record TimeModule
   gmtime: function(unixts: number): DateTime
   localtime: function(unixts: number): DateTime
   format_http: function(timestamp: number): string
-  parse_http: function(str: string): number
+  parse_http: function(str: string): number, string
   format_date: function(timestamp: number): string
-  parse_date: function(str: string): number
+  parse_date: function(str: string): number, string
   format_iso8601: function(timestamp: number): string
-  parse_iso8601: function(str: string): number
-  timegm: function(year: number, month: number, day: number, hour: number, min: number, sec: number): number
+  parse_iso8601: function(str: string): number, string
+  timegm: function(year: number, month: number, day: number, hour: number, min: number, sec: number): number, string
 end
 
 local M: TimeModule = {

--- a/lib/cosmic/time_parse_test.tl
+++ b/lib/cosmic/time_parse_test.tl
@@ -1,0 +1,281 @@
+#!/usr/bin/env cosmic
+local time = require("cosmic.time")
+
+-- HTTP, date, and ISO 8601 formatting and parsing tests
+
+-- format_http tests
+
+local function test_format_http_epoch()
+  local http_date = time.format_http(0)
+  assert(http_date == "Thu, 01 Jan 1970 00:00:00 GMT", "expected epoch format, got " .. http_date)
+end
+test_format_http_epoch()
+
+local function test_format_http_known_date()
+  -- 2000-01-01 00:00:00 UTC = 946684800
+  local http_date = time.format_http(946684800)
+  assert(http_date == "Sat, 01 Jan 2000 00:00:00 GMT", "expected Y2K format, got " .. http_date)
+end
+test_format_http_known_date()
+
+local function test_format_http_format()
+  local secs, _ = time.now()
+  local http_date = time.format_http(secs)
+  -- Should match RFC 7231 format: "Day, DD Mon YYYY HH:MM:SS GMT"
+  assert(http_date:match("^%a%a%a, %d%d %a%a%a %d%d%d%d %d%d:%d%d:%d%d GMT$"),
+    "expected RFC 7231 format, got " .. http_date)
+end
+test_format_http_format()
+
+-- parse_http tests
+
+local function test_parse_http_epoch()
+  local ts = time.parse_http("Thu, 01 Jan 1970 00:00:00 GMT")
+  assert(ts == 0, "expected 0, got " .. tostring(ts))
+end
+test_parse_http_epoch()
+
+local function test_parse_http_known_date()
+  local ts = time.parse_http("Sat, 01 Jan 2000 00:00:00 GMT")
+  assert(ts == 946684800, "expected 946684800, got " .. tostring(ts))
+end
+test_parse_http_known_date()
+
+local function test_parse_http_invalid()
+  local ts, err = time.parse_http("invalid")
+  assert(ts == nil, "expected nil for invalid input, got " .. tostring(ts))
+  assert(type(err) == "string", "expected error string, got " .. tostring(err))
+end
+test_parse_http_invalid()
+
+local function test_parse_http_bad_month()
+  -- structurally valid but with an unknown month name
+  local ts, err = time.parse_http("Xxx, 99 Zzz 1970 99:99:99 GMT")
+  assert(ts == nil, "expected nil for bad month, got " .. tostring(ts))
+  assert(type(err) == "string", "expected error string, got " .. tostring(err))
+end
+test_parse_http_bad_month()
+
+local function test_parse_http_out_of_range()
+  -- valid month name but an impossible day: must not return a bogus timestamp
+  local ts, err = time.parse_http("Mon, 99 Jan 1970 00:00:00 GMT")
+  assert(ts == nil, "expected nil for out-of-range day, got " .. tostring(ts))
+  assert(type(err) == "string", "expected error string, got " .. tostring(err))
+end
+test_parse_http_out_of_range()
+
+local function test_format_parse_roundtrip()
+  local original = 1705322245
+  local formatted = time.format_http(original)
+  local parsed = time.parse_http(formatted)
+  assert(parsed == original, "roundtrip failed: " .. tostring(original) .. " -> " .. formatted .. " -> " .. tostring(parsed))
+end
+test_format_parse_roundtrip()
+
+-- format_date tests
+
+local function test_format_date_epoch()
+  local s = time.format_date(0)
+  assert(s == "1970-01-01", "expected 1970-01-01, got " .. s)
+end
+test_format_date_epoch()
+
+local function test_format_date_y2k()
+  local s = time.format_date(946684800)
+  assert(s == "2000-01-01", "expected 2000-01-01, got " .. s)
+end
+test_format_date_y2k()
+
+local function test_format_date_known()
+  -- 2025-01-02T10:00:00Z = 1735812000 -> date should be 2025-01-02
+  local s = time.format_date(1735812000)
+  assert(s == "2025-01-02", "expected 2025-01-02, got " .. s)
+end
+test_format_date_known()
+
+local function test_format_date_format()
+  local secs, _ = time.now()
+  local s = time.format_date(secs)
+  assert(s:match("^%d%d%d%d%-%d%d%-%d%d$"),
+    "expected YYYY-MM-DD format, got " .. s)
+end
+test_format_date_format()
+
+-- parse_date tests
+
+local function test_parse_date_basic()
+  local ts = time.parse_date("2025-01-01")
+  assert(ts == 1735689600, "expected 1735689600, got " .. tostring(ts))
+end
+test_parse_date_basic()
+
+local function test_parse_date_epoch()
+  local ts = time.parse_date("1970-01-01")
+  assert(ts == 0, "expected 0, got " .. tostring(ts))
+end
+test_parse_date_epoch()
+
+local function test_parse_date_y2k()
+  local ts = time.parse_date("2000-01-01")
+  assert(ts == 946684800, "expected 946684800, got " .. tostring(ts))
+end
+test_parse_date_y2k()
+
+local function test_parse_date_invalid()
+  local ts, err = time.parse_date("not-a-date")
+  assert(ts == nil, "expected nil for invalid input, got " .. tostring(ts))
+  assert(type(err) == "string", "expected error string, got " .. tostring(err))
+end
+test_parse_date_invalid()
+
+local function test_parse_date_rejects_datetime()
+  -- parse_date should reject full ISO 8601 timestamps
+  local ts = time.parse_date("2025-01-01T00:00:00Z")
+  assert(ts == nil, "expected nil for datetime input, got " .. tostring(ts))
+end
+test_parse_date_rejects_datetime()
+
+local function test_parse_date_out_of_range()
+  -- structurally well-formed but semantically invalid: no longer swallowed
+  assert(time.parse_date("2025-14-01") == nil, "month 14 should be rejected")
+  assert(time.parse_date("2025-01-99") == nil, "day 99 should be rejected")
+end
+test_parse_date_out_of_range()
+
+local function test_date_roundtrip()
+  local original = 1735689600 -- 2025-01-01 midnight UTC
+  local formatted = time.format_date(original)
+  local parsed = time.parse_date(formatted)
+  assert(parsed == original,
+    "roundtrip failed: " .. tostring(original) .. " -> " .. formatted .. " -> " .. tostring(parsed))
+end
+test_date_roundtrip()
+
+-- format_iso8601 tests
+
+local function test_format_iso8601_epoch()
+  local s = time.format_iso8601(0)
+  assert(s == "1970-01-01T00:00:00Z", "expected epoch, got " .. s)
+end
+test_format_iso8601_epoch()
+
+local function test_format_iso8601_y2k()
+  local s = time.format_iso8601(946684800)
+  assert(s == "2000-01-01T00:00:00Z", "expected Y2K, got " .. s)
+end
+test_format_iso8601_y2k()
+
+local function test_format_iso8601_known()
+  -- 2025-01-02T10:00:00Z (same timestamp used in working PR tests)
+  local s = time.format_iso8601(1735812000)
+  assert(s == "2025-01-02T10:00:00Z", "expected 2025-01-02T10:00:00Z, got " .. s)
+end
+test_format_iso8601_known()
+
+local function test_format_iso8601_format()
+  local secs, _ = time.now()
+  local s = time.format_iso8601(secs)
+  assert(s:match("^%d%d%d%d%-%d%d%-%d%dT%d%d:%d%d:%d%dZ$"),
+    "expected ISO 8601 format, got " .. s)
+end
+test_format_iso8601_format()
+
+-- parse_iso8601 tests
+
+local function test_parse_iso8601_z_suffix()
+  local ts = time.parse_iso8601("2025-01-01T00:00:00Z")
+  assert(ts == 1735689600, "expected 1735689600, got " .. tostring(ts))
+end
+test_parse_iso8601_z_suffix()
+
+local function test_parse_iso8601_no_suffix()
+  local ts = time.parse_iso8601("2025-01-01T00:00:00")
+  assert(ts == 1735689600, "expected 1735689600 (treat as UTC), got " .. tostring(ts))
+end
+test_parse_iso8601_no_suffix()
+
+local function test_parse_iso8601_positive_offset()
+  -- 2025-01-01T05:30:00+05:30 = 2025-01-01T00:00:00Z
+  local ts = time.parse_iso8601("2025-01-01T05:30:00+05:30")
+  assert(ts == 1735689600, "expected 1735689600, got " .. tostring(ts))
+end
+test_parse_iso8601_positive_offset()
+
+local function test_parse_iso8601_negative_offset()
+  -- 2024-12-31T19:00:00-05:00 = 2025-01-01T00:00:00Z
+  local ts = time.parse_iso8601("2024-12-31T19:00:00-05:00")
+  assert(ts == 1735689600, "expected 1735689600, got " .. tostring(ts))
+end
+test_parse_iso8601_negative_offset()
+
+local function test_parse_iso8601_date_only()
+  local ts = time.parse_iso8601("2025-01-01")
+  assert(ts == 1735689600, "expected 1735689600, got " .. tostring(ts))
+end
+test_parse_iso8601_date_only()
+
+local function test_parse_iso8601_invalid()
+  local ts, err = time.parse_iso8601("not-a-date")
+  assert(ts == nil, "expected nil for invalid input, got " .. tostring(ts))
+  assert(type(err) == "string", "expected error string, got " .. tostring(err))
+end
+test_parse_iso8601_invalid()
+
+local function test_parse_iso8601_invalid_offset()
+  local ts, err = time.parse_iso8601("2025-01-01T00:00:00+garbage")
+  assert(ts == nil, "expected nil for invalid offset, got " .. tostring(ts))
+  assert(type(err) == "string", "expected error string, got " .. tostring(err))
+end
+test_parse_iso8601_invalid_offset()
+
+local function test_parse_iso8601_out_of_range()
+  -- was silently accepted as a bogus epoch before; must now be rejected
+  assert(time.parse_iso8601("2025-01-99T00:00:00Z") == nil,
+    "day 99 should be rejected")
+  assert(time.parse_iso8601("2025-13-01T00:00:00Z") == nil,
+    "month 13 should be rejected")
+end
+test_parse_iso8601_out_of_range()
+
+local function test_parse_iso8601_fractional_seconds()
+  -- fractional seconds are accepted (truncated to whole seconds)
+  local ts = time.parse_iso8601("2025-01-01T00:00:00.500Z")
+  assert(ts == 1735689600,
+    "expected 1735689600 with fractional seconds, got " .. tostring(ts))
+  local ts2 = time.parse_iso8601("2025-01-01T00:00:00.123456+00:00")
+  assert(ts2 == 1735689600,
+    "expected 1735689600 with fractional + offset, got " .. tostring(ts2))
+end
+test_parse_iso8601_fractional_seconds()
+
+local function test_parse_iso8601_offset_no_colon()
+  -- +HHMM / -HHMM (no colon) offset forms
+  local ts = time.parse_iso8601("2025-01-01T05:30:00+0530")
+  assert(ts == 1735689600, "expected 1735689600 for +0530, got " .. tostring(ts))
+  local ts2 = time.parse_iso8601("2024-12-31T19:00:00-0500")
+  assert(ts2 == 1735689600, "expected 1735689600 for -0500, got " .. tostring(ts2))
+end
+test_parse_iso8601_offset_no_colon()
+
+local function test_parse_iso8601_offset_hours_only()
+  -- +HH / -HH offset forms
+  local ts = time.parse_iso8601("2025-01-01T05:00:00+05")
+  assert(ts == 1735689600, "expected 1735689600 for +05, got " .. tostring(ts))
+end
+test_parse_iso8601_offset_hours_only()
+
+local function test_iso8601_roundtrip()
+  local original = 1705322245
+  local formatted = time.format_iso8601(original)
+  local parsed = time.parse_iso8601(formatted)
+  assert(parsed == original,
+    "roundtrip failed: " .. tostring(original) .. " -> " .. formatted .. " -> " .. tostring(parsed))
+end
+test_iso8601_roundtrip()
+
+local function test_iso8601_epoch_roundtrip()
+  local formatted = time.format_iso8601(0)
+  local parsed = time.parse_iso8601(formatted)
+  assert(parsed == 0, "epoch roundtrip failed: " .. formatted .. " -> " .. tostring(parsed))
+end
+test_iso8601_epoch_roundtrip()

--- a/lib/cosmic/time_test.tl
+++ b/lib/cosmic/time_test.tl
@@ -118,8 +118,8 @@ local function test_gmtime_fields()
   local dt = time.gmtime(1705322245)
   assert(dt.gmtoff == 0, "expected gmtoff 0 for UTC, got " .. tostring(dt.gmtoff))
   assert(dt.zone == "UTC" or dt.zone == "GMT", "expected UTC or GMT timezone, got " .. tostring(dt.zone))
-  assert(dt.wday >= 1 and dt.wday <= 7, "expected wday 1-7, got " .. tostring(dt.wday))
-  assert(dt.yday >= 1 and dt.yday <= 366, "expected yday 1-366, got " .. tostring(dt.yday))
+  assert(dt.wday >= 0 and dt.wday <= 6, "expected wday 0-6, got " .. tostring(dt.wday))
+  assert(dt.yday >= 0 and dt.yday <= 365, "expected yday 0-365, got " .. tostring(dt.yday))
 end
 test_gmtime_fields()
 
@@ -164,58 +164,6 @@ local function test_clock_realtime_is_zero()
   assert(time.CLOCK_REALTIME == 0, "CLOCK_REALTIME should be 0, got " .. tostring(time.CLOCK_REALTIME))
 end
 test_clock_realtime_is_zero()
-
--- format_http tests
-
-local function test_format_http_epoch()
-  local http_date = time.format_http(0)
-  assert(http_date == "Thu, 01 Jan 1970 00:00:00 GMT", "expected epoch format, got " .. http_date)
-end
-test_format_http_epoch()
-
-local function test_format_http_known_date()
-  -- 2000-01-01 00:00:00 UTC = 946684800
-  local http_date = time.format_http(946684800)
-  assert(http_date == "Sat, 01 Jan 2000 00:00:00 GMT", "expected Y2K format, got " .. http_date)
-end
-test_format_http_known_date()
-
-local function test_format_http_format()
-  local secs, _ = time.now()
-  local http_date = time.format_http(secs)
-  -- Should match RFC 7231 format: "Day, DD Mon YYYY HH:MM:SS GMT"
-  assert(http_date:match("^%a%a%a, %d%d %a%a%a %d%d%d%d %d%d:%d%d:%d%d GMT$"),
-    "expected RFC 7231 format, got " .. http_date)
-end
-test_format_http_format()
-
--- parse_http tests
-
-local function test_parse_http_epoch()
-  local ts = time.parse_http("Thu, 01 Jan 1970 00:00:00 GMT")
-  assert(ts == 0, "expected 0, got " .. tostring(ts))
-end
-test_parse_http_epoch()
-
-local function test_parse_http_known_date()
-  local ts = time.parse_http("Sat, 01 Jan 2000 00:00:00 GMT")
-  assert(ts == 946684800, "expected 946684800, got " .. tostring(ts))
-end
-test_parse_http_known_date()
-
-local function test_parse_http_invalid()
-  local ts = time.parse_http("invalid")
-  assert(ts == 0, "expected 0 for invalid input, got " .. tostring(ts))
-end
-test_parse_http_invalid()
-
-local function test_format_parse_roundtrip()
-  local original = 1705322245
-  local formatted = time.format_http(original)
-  local parsed = time.parse_http(formatted)
-  assert(parsed == original, "roundtrip failed: " .. tostring(original) .. " -> " .. formatted .. " -> " .. tostring(parsed))
-end
-test_format_parse_roundtrip()
 
 -- timegm tests
 
@@ -292,164 +240,59 @@ local function test_timegm_pre_epoch_roundtrip()
 end
 test_timegm_pre_epoch_roundtrip()
 
--- format_date tests
-
-local function test_format_date_epoch()
-  local s = time.format_date(0)
-  assert(s == "1970-01-01", "expected 1970-01-01, got " .. s)
+local function test_timegm_bad_month_no_throw()
+  -- month 14 must return nil, err rather than throwing an arithmetic error
+  local ts, err = time.timegm(2025, 14, 1, 0, 0, 0)
+  assert(ts == nil, "expected nil for month 14, got " .. tostring(ts))
+  assert(type(err) == "string", "expected error string, got " .. tostring(err))
 end
-test_format_date_epoch()
+test_timegm_bad_month_no_throw()
 
-local function test_format_date_y2k()
-  local s = time.format_date(946684800)
-  assert(s == "2000-01-01", "expected 2000-01-01, got " .. s)
+local function test_timegm_month_thirteen()
+  -- month 13 must not silently roll into next January
+  local ts = time.timegm(2025, 13, 1, 0, 0, 0)
+  assert(ts == nil, "expected nil for month 13, got " .. tostring(ts))
 end
-test_format_date_y2k()
+test_timegm_month_thirteen()
 
-local function test_format_date_known()
-  -- 2025-01-02T10:00:00Z = 1735812000 -> date should be 2025-01-02
-  local s = time.format_date(1735812000)
-  assert(s == "2025-01-02", "expected 2025-01-02, got " .. s)
+local function test_timegm_bad_day()
+  -- Feb 30 does not exist
+  local ts, err = time.timegm(2025, 2, 30, 0, 0, 0)
+  assert(ts == nil, "expected nil for Feb 30, got " .. tostring(ts))
+  assert(type(err) == "string", "expected error string, got " .. tostring(err))
 end
-test_format_date_known()
+test_timegm_bad_day()
 
-local function test_format_date_format()
-  local secs, _ = time.now()
-  local s = time.format_date(secs)
-  assert(s:match("^%d%d%d%d%-%d%d%-%d%d$"),
-    "expected YYYY-MM-DD format, got " .. s)
+local function test_timegm_feb29_non_leap()
+  -- 2025 is not a leap year, so Feb 29 is invalid
+  local ts = time.timegm(2025, 2, 29, 0, 0, 0)
+  assert(ts == nil, "expected nil for Feb 29 in 2025, got " .. tostring(ts))
 end
-test_format_date_format()
+test_timegm_feb29_non_leap()
 
--- parse_date tests
-
-local function test_parse_date_basic()
-  local ts = time.parse_date("2025-01-01")
-  assert(ts == 1735689600, "expected 1735689600, got " .. tostring(ts))
+local function test_timegm_feb29_leap_ok()
+  -- 2024 is a leap year, so Feb 29 is valid
+  local ts = time.timegm(2024, 2, 29, 0, 0, 0)
+  assert(ts ~= nil, "expected valid timestamp for Feb 29 in 2024")
 end
-test_parse_date_basic()
+test_timegm_feb29_leap_ok()
 
-local function test_parse_date_epoch()
-  local ts = time.parse_date("1970-01-01")
-  assert(ts == 0, "expected 0, got " .. tostring(ts))
+local function test_timegm_zero_day()
+  local ts = time.timegm(2025, 1, 0, 0, 0, 0)
+  assert(ts == nil, "expected nil for day 0, got " .. tostring(ts))
 end
-test_parse_date_epoch()
+test_timegm_zero_day()
 
-local function test_parse_date_y2k()
-  local ts = time.parse_date("2000-01-01")
-  assert(ts == 946684800, "expected 946684800, got " .. tostring(ts))
+local function test_timegm_bad_time_fields()
+  assert(time.timegm(2025, 1, 1, 24, 0, 0) == nil, "hour 24 should be invalid")
+  assert(time.timegm(2025, 1, 1, 0, 60, 0) == nil, "minute 60 should be invalid")
+  assert(time.timegm(2025, 1, 1, 0, 0, 61) == nil, "second 61 should be invalid")
 end
-test_parse_date_y2k()
+test_timegm_bad_time_fields()
 
-local function test_parse_date_invalid()
-  local ts = time.parse_date("not-a-date")
-  assert(ts == 0, "expected 0 for invalid input, got " .. tostring(ts))
+local function test_timegm_leap_second_ok()
+  -- second 60 (leap second) is accepted for gmtime roundtrip compatibility
+  local ts = time.timegm(2025, 1, 1, 0, 0, 60)
+  assert(ts ~= nil, "expected leap second (sec 60) to be accepted")
 end
-test_parse_date_invalid()
-
-local function test_parse_date_rejects_datetime()
-  -- parse_date should reject full ISO 8601 timestamps
-  local ts = time.parse_date("2025-01-01T00:00:00Z")
-  assert(ts == 0, "expected 0 for datetime input, got " .. tostring(ts))
-end
-test_parse_date_rejects_datetime()
-
-local function test_date_roundtrip()
-  local original = 1735689600 -- 2025-01-01 midnight UTC
-  local formatted = time.format_date(original)
-  local parsed = time.parse_date(formatted)
-  assert(parsed == original,
-    "roundtrip failed: " .. tostring(original) .. " -> " .. formatted .. " -> " .. tostring(parsed))
-end
-test_date_roundtrip()
-
--- format_iso8601 tests
-
-local function test_format_iso8601_epoch()
-  local s = time.format_iso8601(0)
-  assert(s == "1970-01-01T00:00:00Z", "expected epoch, got " .. s)
-end
-test_format_iso8601_epoch()
-
-local function test_format_iso8601_y2k()
-  local s = time.format_iso8601(946684800)
-  assert(s == "2000-01-01T00:00:00Z", "expected Y2K, got " .. s)
-end
-test_format_iso8601_y2k()
-
-local function test_format_iso8601_known()
-  -- 2025-01-02T10:00:00Z (same timestamp used in working PR tests)
-  local s = time.format_iso8601(1735812000)
-  assert(s == "2025-01-02T10:00:00Z", "expected 2025-01-02T10:00:00Z, got " .. s)
-end
-test_format_iso8601_known()
-
-local function test_format_iso8601_format()
-  local secs, _ = time.now()
-  local s = time.format_iso8601(secs)
-  assert(s:match("^%d%d%d%d%-%d%d%-%d%dT%d%d:%d%d:%d%dZ$"),
-    "expected ISO 8601 format, got " .. s)
-end
-test_format_iso8601_format()
-
--- parse_iso8601 tests
-
-local function test_parse_iso8601_z_suffix()
-  local ts = time.parse_iso8601("2025-01-01T00:00:00Z")
-  assert(ts == 1735689600, "expected 1735689600, got " .. tostring(ts))
-end
-test_parse_iso8601_z_suffix()
-
-local function test_parse_iso8601_no_suffix()
-  local ts = time.parse_iso8601("2025-01-01T00:00:00")
-  assert(ts == 1735689600, "expected 1735689600 (treat as UTC), got " .. tostring(ts))
-end
-test_parse_iso8601_no_suffix()
-
-local function test_parse_iso8601_positive_offset()
-  -- 2025-01-01T05:30:00+05:30 = 2025-01-01T00:00:00Z
-  local ts = time.parse_iso8601("2025-01-01T05:30:00+05:30")
-  assert(ts == 1735689600, "expected 1735689600, got " .. tostring(ts))
-end
-test_parse_iso8601_positive_offset()
-
-local function test_parse_iso8601_negative_offset()
-  -- 2024-12-31T19:00:00-05:00 = 2025-01-01T00:00:00Z
-  local ts = time.parse_iso8601("2024-12-31T19:00:00-05:00")
-  assert(ts == 1735689600, "expected 1735689600, got " .. tostring(ts))
-end
-test_parse_iso8601_negative_offset()
-
-local function test_parse_iso8601_date_only()
-  local ts = time.parse_iso8601("2025-01-01")
-  assert(ts == 1735689600, "expected 1735689600, got " .. tostring(ts))
-end
-test_parse_iso8601_date_only()
-
-local function test_parse_iso8601_invalid()
-  local ts = time.parse_iso8601("not-a-date")
-  assert(ts == 0, "expected 0 for invalid input, got " .. tostring(ts))
-end
-test_parse_iso8601_invalid()
-
-local function test_parse_iso8601_invalid_offset()
-  local ts = time.parse_iso8601("2025-01-01T00:00:00+garbage")
-  assert(ts == 0, "expected 0 for invalid offset, got " .. tostring(ts))
-end
-test_parse_iso8601_invalid_offset()
-
-local function test_iso8601_roundtrip()
-  local original = 1705322245
-  local formatted = time.format_iso8601(original)
-  local parsed = time.parse_iso8601(formatted)
-  assert(parsed == original,
-    "roundtrip failed: " .. tostring(original) .. " -> " .. formatted .. " -> " .. tostring(parsed))
-end
-test_iso8601_roundtrip()
-
-local function test_iso8601_epoch_roundtrip()
-  local formatted = time.format_iso8601(0)
-  local parsed = time.parse_iso8601(formatted)
-  assert(parsed == 0, "epoch roundtrip failed: " .. formatted .. " -> " .. tostring(parsed))
-end
-test_iso8601_epoch_roundtrip()
+test_timegm_leap_second_ok()


### PR DESCRIPTION
## Summary

Executes **Phase 1, step 6** of the [#420](https://github.com/whilp/cosmic/pull/420) audit plan: fix the `time` module's convention violations (throwing / `0`-sentinel swallowing) and the ISO-8601 parsing gaps (audit §2.1, §2.4, §4.2).

Follows [#428](https://github.com/whilp/cosmic/pull/428) (step 5, SQLite iterator errors) and, like it, is a deliberate breaking contract change (D4): the parsers now signal failure with `nil, err` instead of a value that collides with a legitimate result.

## What changed

- **`timegm` no longer throws.** It range-checks month/day/hour/min/sec (day validation is leap-year aware) and returns `nil, err`. Previously `timegm(2025, 14, 1, ...)` raised an arithmetic-on-nil error from library code, and `month == 13` silently rolled into the next January.
- **`parse_http` / `parse_date` / `parse_iso8601` return `nil, err`** on invalid input instead of `0` — which is a valid epoch (1970-01-01), making bad input indistinguishable from a real timestamp. They also reject out-of-range fields (`2025-01-99`) instead of computing a bogus epoch.
- **`parse_http` parses the RFC 7231 IMF-fixdate format directly** (via `timegm` + a month-abbreviation map) rather than delegating to the lossy `cosmo.ParseHttpDateTime`, which returned `0` for both the epoch and garbage and happily accepted impossible dates like `"Xxx, 99 Zzz 1970 99:99:99 GMT"`.
- **`parse_iso8601` accepts fractional seconds** (truncated to whole seconds — virtually every JSON API emits them) and the `±HHMM` / `±HH` offset forms in addition to `±HH:MM`.
- **Corrected `DateTime` doc comments:** `gmtime` returns `wday` 0–6 (0 = Sunday) and `yday` 0–365, not the 1-based ranges previously documented. Verified empirically against the binding.

The grown test file was split into `time_test.tl` (clocks / gmtime / timegm) and `time_parse_test.tl` (http / date / iso8601) to stay under the 500-line file limit, following the existing `fs_*` / `sqlite_*` / `net_*` split-test precedent.

## Test plan

- `bin/make teal` — passes (196 checks)
- `bin/make format` — passes
- `bin/make lint` — passes (both test files under the 500-line limit)
- `bin/make test only=time` — both `time_test.tl` and `time_parse_test.tl` pass
- New tests cover: `timegm` out-of-range month/day/time (no throw), Feb 29 leap/non-leap, leap second, `nil, err` from all three parsers, out-of-range rejection, fractional seconds, and `±HHMM`/`±HH` offsets.
- End-to-end verified that valid `format`↔`parse` roundtrips (http and iso8601) still hold and that errors propagate without throwing.

The pre-existing `docs_test` (child-module examples index) and `fetch_example` (network-dependent) failures reproduce on the clean tree and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xn4qYqHkAGzDrzuWf95SYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xn4qYqHkAGzDrzuWf95SYW)_