### PR TITLE
correctness: closed-socket guards, fdopendir fix, netns i2 overflow (Phase 1 step 7)

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "c3468582d2fd016dc8869107074d1d534ebdcfcdd1c14dd49f6d4b22cce8aacf"}},
+  platforms = {["*"] = {sha = "998cc3799a681550ae19b8500e3ed3d7933eca54877ad957c20ef9d5bad0dd8f"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.04-b1577d575"
+  version = "2026.07.04-43dc2d1dc"
 }

--- a/lib/cosmic/fs.tl
+++ b/lib/cosmic/fs.tl
@@ -231,11 +231,18 @@ end
 --- @return Dir Directory handle, or nil on error
 --- @return string Error message if failed
 local function fdopendir(fd: number): Dir, string
-  local _, raw, err = unix.fdopendir(fd)
+  -- The C binding (ReturnDir) yields exactly one value on success — the
+  -- Dir — and (nil, Errno) on failure, identical to opendir. The pinned
+  -- cosmos annotation over-declares a phantom leading iterator function,
+  -- so narrow the call to its real (Dir, Errno) runtime shape; without
+  -- this, `raw` is nil on success and fdopendir wrongly reports an error.
+  -- The upstream annotation fix drops this cast on the next cosmos bump.
+  local open = unix.fdopendir as function(number): (RawDir, unix.Errno)
+  local raw, err = open(fd)
   if not raw then
     return nil, errstr(err, "fdopendir")
   end
-  return make_dir(raw as RawDir)
+  return make_dir(raw)
 end
 
 -- Re-export walk functions from fs_walk submodule

--- a/lib/cosmic/fs.tl
+++ b/lib/cosmic/fs.tl
@@ -231,18 +231,11 @@ end
 --- @return Dir Directory handle, or nil on error
 --- @return string Error message if failed
 local function fdopendir(fd: number): Dir, string
-  -- The C binding (ReturnDir) yields exactly one value on success — the
-  -- Dir — and (nil, Errno) on failure, identical to opendir. The pinned
-  -- cosmos annotation over-declares a phantom leading iterator function,
-  -- so narrow the call to its real (Dir, Errno) runtime shape; without
-  -- this, `raw` is nil on success and fdopendir wrongly reports an error.
-  -- The upstream annotation fix drops this cast on the next cosmos bump.
-  local open = unix.fdopendir as function(number): (RawDir, unix.Errno)
-  local raw, err = open(fd)
+  local raw, err = unix.fdopendir(fd)
   if not raw then
     return nil, errstr(err, "fdopendir")
   end
-  return make_dir(raw)
+  return make_dir(raw as RawDir)
 end
 
 -- Re-export walk functions from fs_walk submodule

--- a/lib/cosmic/fs_dir_test.tl
+++ b/lib/cosmic/fs_dir_test.tl
@@ -1,5 +1,6 @@
 #!/usr/bin/env cosmic
 local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
 local unix = require("cosmo.unix")
 
 local record Statfs
@@ -248,3 +249,40 @@ local function test_major_minor_regular_file()
   teardown(test_dir)
 end
 test_major_minor_regular_file()
+
+local function test_fdopendir()
+  local test_dir = setup()
+  touch(fs.join(test_dir, "file1.txt"))
+  touch(fs.join(test_dir, "file2.txt"))
+
+  -- fdopendir must return a working Dir (not an error) on success; it
+  -- takes ownership of the fd and closes it via dir:close().
+  local h, oerr = cio.open(test_dir, cio.O_RDONLY | cio.O_DIRECTORY)
+  assert(h, "opening directory fd failed: " .. (oerr or ""))
+  local dir, err = fs.fdopendir(h:fd())
+  assert(dir, "fdopendir should succeed: " .. (err or ""))
+
+  local entries: {string: boolean} = {}
+  while true do
+    local entry = dir:read()
+    if not entry then break end
+    if entry ~= "." and entry ~= ".." then
+      entries[entry] = true
+    end
+  end
+  dir:close()
+
+  assert(entries["file1.txt"], "expected file1.txt")
+  assert(entries["file2.txt"], "expected file2.txt")
+
+  teardown(test_dir)
+end
+test_fdopendir()
+
+local function test_fdopendir_bad_fd()
+  -- An invalid fd must return nil + error, never throw from the binding.
+  local dir, err = fs.fdopendir(-1)
+  assert(dir == nil, "fdopendir(-1) should fail, not return a Dir")
+  assert(type(err) == "string", "failure must carry an error string")
+end
+test_fdopendir_bad_fd()

--- a/lib/cosmic/fs_test.tl
+++ b/lib/cosmic/fs_test.tl
@@ -1,6 +1,5 @@
 #!/usr/bin/env cosmic
 local fs = require("cosmic.fs")
-local cio = require("cosmic.io")
 local unix = require("cosmo.unix")
 
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
@@ -263,43 +262,6 @@ local function test_opendir()
   teardown(test_dir)
 end
 test_opendir()
-
-local function test_fdopendir()
-  local test_dir = setup()
-  touch(fs.join(test_dir, "file1.txt"))
-  touch(fs.join(test_dir, "file2.txt"))
-
-  -- fdopendir must return a working Dir (not an error) on success; it
-  -- takes ownership of the fd and closes it via dir:close().
-  local h, oerr = cio.open(test_dir, cio.O_RDONLY | cio.O_DIRECTORY)
-  assert(h, "opening directory fd failed: " .. (oerr or ""))
-  local dir, err = fs.fdopendir(h:fd())
-  assert(dir, "fdopendir should succeed: " .. (err or ""))
-
-  local entries: {string: boolean} = {}
-  while true do
-    local entry = dir:read()
-    if not entry then break end
-    if entry ~= "." and entry ~= ".." then
-      entries[entry] = true
-    end
-  end
-  dir:close()
-
-  assert(entries["file1.txt"], "expected file1.txt")
-  assert(entries["file2.txt"], "expected file2.txt")
-
-  teardown(test_dir)
-end
-test_fdopendir()
-
-local function test_fdopendir_bad_fd()
-  -- An invalid fd must return nil + error, never throw from the binding.
-  local dir, err = fs.fdopendir(-1)
-  assert(dir == nil, "fdopendir(-1) should fail, not return a Dir")
-  assert(type(err) == "string", "failure must carry an error string")
-end
-test_fdopendir_bad_fd()
 
 -- File operations
 

--- a/lib/cosmic/fs_test.tl
+++ b/lib/cosmic/fs_test.tl
@@ -1,5 +1,6 @@
 #!/usr/bin/env cosmic
 local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
 local unix = require("cosmo.unix")
 
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
@@ -262,6 +263,43 @@ local function test_opendir()
   teardown(test_dir)
 end
 test_opendir()
+
+local function test_fdopendir()
+  local test_dir = setup()
+  touch(fs.join(test_dir, "file1.txt"))
+  touch(fs.join(test_dir, "file2.txt"))
+
+  -- fdopendir must return a working Dir (not an error) on success; it
+  -- takes ownership of the fd and closes it via dir:close().
+  local h, oerr = cio.open(test_dir, cio.O_RDONLY | cio.O_DIRECTORY)
+  assert(h, "opening directory fd failed: " .. (oerr or ""))
+  local dir, err = fs.fdopendir(h:fd())
+  assert(dir, "fdopendir should succeed: " .. (err or ""))
+
+  local entries: {string: boolean} = {}
+  while true do
+    local entry = dir:read()
+    if not entry then break end
+    if entry ~= "." and entry ~= ".." then
+      entries[entry] = true
+    end
+  end
+  dir:close()
+
+  assert(entries["file1.txt"], "expected file1.txt")
+  assert(entries["file2.txt"], "expected file2.txt")
+
+  teardown(test_dir)
+end
+test_fdopendir()
+
+local function test_fdopendir_bad_fd()
+  -- An invalid fd must return nil + error, never throw from the binding.
+  local dir, err = fs.fdopendir(-1)
+  assert(dir == nil, "fdopendir(-1) should fail, not return a Dir")
+  assert(type(err) == "string", "failure must carry an error string")
+end
+test_fdopendir_bad_fd()
 
 -- File operations
 

--- a/lib/cosmic/net_socket.tl
+++ b/lib/cosmic/net_socket.tl
@@ -68,6 +68,7 @@ local function make_socket(fd: number): Socket
   end
 
   function sock:shutdown(how?: number): boolean, string
+    if not self.fd then return false, "socket closed" end
     how = how or unix.SHUT_RDWR
     local ok = unix.shutdown(self.fd, how)
     if not ok then
@@ -77,6 +78,7 @@ local function make_socket(fd: number): Socket
   end
 
   function sock:send(data: string, flags?: number): number, string
+    if not self.fd then return nil, "socket closed" end
     local n = unix.send(self.fd, data, flags or 0)
     if not n then
       return nil, "send failed"
@@ -85,6 +87,7 @@ local function make_socket(fd: number): Socket
   end
 
   function sock:sendto(data: string, ip: number, port: number, flags?: number): number, string
+    if not self.fd then return nil, "socket closed" end
     local n = unix.sendto(self.fd, data, ip, port, flags or 0)
     if not n then
       return nil, "sendto failed"
@@ -93,6 +96,7 @@ local function make_socket(fd: number): Socket
   end
 
   function sock:recv(bufsiz?: number, flags?: number): string, string
+    if not self.fd then return nil, "socket closed" end
     local data = unix.recv(self.fd, bufsiz or 65536, flags or 0)
     if not data then
       return nil, "recv failed"
@@ -101,6 +105,7 @@ local function make_socket(fd: number): Socket
   end
 
   function sock:recvfrom(bufsiz?: number, flags?: number): string, number, number, string
+    if not self.fd then return nil, nil, nil, "socket closed" end
     local data, ip, port = unix.recvfrom(self.fd, bufsiz or 65536, flags or 0)
     if not data then
       return nil, nil, nil, "recvfrom failed"
@@ -109,6 +114,7 @@ local function make_socket(fd: number): Socket
   end
 
   function sock:getsockname(): number, number, string
+    if not self.fd then return nil, nil, "socket closed" end
     local ip, port = unix.getsockname(self.fd)
     if not ip then
       return nil, nil, "getsockname failed"
@@ -117,6 +123,7 @@ local function make_socket(fd: number): Socket
   end
 
   function sock:getpeername(): number, number, string
+    if not self.fd then return nil, nil, "socket closed" end
     local ip, port = unix.getpeername(self.fd)
     if not ip then
       return nil, nil, "getpeername failed"
@@ -125,6 +132,7 @@ local function make_socket(fd: number): Socket
   end
 
   function sock:bind(ip?: number, port?: number): boolean, string
+    if not self.fd then return false, "socket closed" end
     local ok = unix.bind(self.fd, ip or 0, port or 0)
     if not ok then
       return false, "bind failed"
@@ -133,6 +141,7 @@ local function make_socket(fd: number): Socket
   end
 
   function sock:bind_unix(path: string): boolean, string
+    if not self.fd then return false, "socket closed" end
     local ok = (unix.bind as function(number, string): boolean)(self.fd, path)
     if not ok then
       return false, "bind_unix failed"
@@ -141,6 +150,7 @@ local function make_socket(fd: number): Socket
   end
 
   function sock:listen(backlog?: number): boolean, string
+    if not self.fd then return false, "socket closed" end
     local ok = unix.listen(self.fd, backlog or 128)
     if not ok then
       return false, "listen failed"
@@ -149,6 +159,7 @@ local function make_socket(fd: number): Socket
   end
 
   function sock:accept(flags?: number): Socket, number, number, string
+    if not self.fd then return nil, nil, nil, "socket closed" end
     local clientfd, ip, port = unix.accept(self.fd, flags or 0)
     if not clientfd then
       return nil, nil, nil, "accept failed"
@@ -157,6 +168,7 @@ local function make_socket(fd: number): Socket
   end
 
   function sock:connect(ip: number, port: number): boolean, string
+    if not self.fd then return false, "socket closed" end
     local ok, err = unix.connect(self.fd, ip, port)
     if not ok then
       return false, errstr(err, "connect")
@@ -165,6 +177,7 @@ local function make_socket(fd: number): Socket
   end
 
   function sock:connect_unix(path: string): boolean, string
+    if not self.fd then return false, "socket closed" end
     local ok, err = (unix.connect as function(number, string): (boolean, any))(self.fd, path)
     if not ok then
       return false, errstr(err, "connect_unix")
@@ -173,6 +186,7 @@ local function make_socket(fd: number): Socket
   end
 
   function sock:getsockopt(level: number, optname: number): number | boolean, string
+    if not self.fd then return nil, "socket closed" end
     local val = unix.getsockopt(self.fd, level, optname)
     if val == nil then
       return nil, "getsockopt failed"
@@ -181,6 +195,7 @@ local function make_socket(fd: number): Socket
   end
 
   function sock:setsockopt(level: number, optname: number, value: number | boolean): boolean, string
+    if not self.fd then return false, "socket closed" end
     local ok = unix.setsockopt(self.fd, level, optname, value)
     if not ok then
       return false, "setsockopt failed"

--- a/lib/cosmic/net_test.tl
+++ b/lib/cosmic/net_test.tl
@@ -291,6 +291,29 @@ local function test_socket_closed_method()
 end
 test_socket_closed_method()
 
+local function test_socket_methods_after_close()
+  local sock, err = net.socket()
+  assert(sock ~= nil, "socket creation failed: " .. tostring(err))
+  sock:close()
+
+  -- Every operation on a closed socket must return its error shape, never
+  -- throw from the C binding (unix.send(nil, ...) etc.).
+  local n, serr = sock:send("x")
+  assert(n == nil and serr == "socket closed", "send: " .. tostring(serr))
+  local d, rerr = sock:recv()
+  assert(d == nil and rerr == "socket closed", "recv: " .. tostring(rerr))
+  local ip, port, gerr = sock:getsockname()
+  assert(ip == nil and port == nil and gerr == "socket closed",
+    "getsockname: " .. tostring(gerr))
+  local bok, berr = sock:bind()
+  assert(bok == false and berr == "socket closed", "bind: " .. tostring(berr))
+  local lok, lerr = sock:listen()
+  assert(lok == false and lerr == "socket closed", "listen: " .. tostring(lerr))
+  local shok, sherr = sock:shutdown()
+  assert(shok == false and sherr == "socket closed", "shutdown: " .. tostring(sherr))
+end
+test_socket_methods_after_close()
+
 local function test_socket_has_close_metamethod()
   -- Verify socket has __close metamethod for Lua 5.4 to-be-closed support
   local sock, err = net.socket()

--- a/lib/cosmic/quicksand/netns.tl
+++ b/lib/cosmic/quicksand/netns.tl
@@ -36,14 +36,16 @@ end
 local function build_ifreq(name: string, flags: integer): string
   assert(#name < IFNAMSIZ, "interface name too long")
   local name_field = name .. string.rep("\0", IFNAMSIZ - #name)
-  local flags_field = string.pack("<i2", flags)
+  -- Pack the 16-bit ifr_flags unsigned: IFF_* bits above 0x7fff (the sign
+  -- bit of a signed i2) would overflow "<i2" and raise from string.pack.
+  local flags_field = string.pack("<I2", flags)
   return name_field .. flags_field
   .. string.rep("\0", IFREQ_UNION_SIZE - #flags_field)
 end
 
 --- Parse the 16-bit flags field out of an ifreq returned by ioctl().
 local function parse_ifreq_flags(ifr: string): integer
-  return (string.unpack("<i2", ifr, IFNAMSIZ + 1)) as integer
+  return (string.unpack("<I2", ifr, IFNAMSIZ + 1)) as integer
 end
 
 --- Open an AF_INET dgram socket for the SIOC* interface ioctls.

--- a/lib/cosmic/quicksand/netns_test.tl
+++ b/lib/cosmic/quicksand/netns_test.tl
@@ -91,6 +91,17 @@ local function test_get_flags_bad_interface()
 end
 test_get_flags_bad_interface()
 
+-- A flag with the 0x8000 bit set must not overflow the ifreq packing:
+-- "<i2" (signed) would raise "integer overflow" from string.pack, "<I2"
+-- (unsigned) packs it cleanly. The interface is nonexistent so
+-- SIOCSIFFLAGS can never mutate a real device, regardless of privilege.
+local function test_set_flags_high_bit_no_overflow()
+  local ok, err = netns.set_flags("nope0", 0x8000)
+  assert(ok == false, "set_flags on a nonexistent interface should fail")
+  assert(type(err) == "string", "failure must carry an error string")
+end
+test_set_flags_high_bit_no_overflow()
+
 local function test_get_flags_name_too_long()
   local flags, err = netns.get_flags(string.rep("x", 20))
   assert(flags == nil, "oversized interface name should fail, not throw")

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -2924,7 +2924,7 @@ local record unix
   --- Opens directory for listing its contents, via an fd.
   --- The returned `unix.Dir` takes ownership of the file descriptor
   --- and will close it automatically when garbage collected.
-  fdopendir: function(fd: number): function, Dir, Errno
+  fdopendir: function(fd: number): Dir, Errno
   --- Returns true if file descriptor is a teletypewriter. Otherwise nil
   --- with an Errno object holding one of the following values:
   --- - `ENOTTY` if `fd` is valid but not a teletypewriter


### PR DESCRIPTION
## Summary

Executes **Phase 1 step 7** of the [audit-2026-07 remediation plan](https://github.com/whilp/cosmic/pull/420): three P1 never-throw / correctness fixes at the Teal↔C boundary. Follows #428 (step 5) and #429 (step 6).

### 1. Closed-socket guards — `net_socket.tl` (§2.1)

Every `Socket` method except `close`/`closed` called `unix.send(nil, …)`, `unix.recv(nil, …)`, etc. after `close()` set `self.fd = nil`, **raising from the C binding** and violating never-throw. `io.Handle` already guards every method; `Socket` did not. Each method now short-circuits with its own return shape (`nil`/`false` + `"socket closed"`).

### 2. `fdopendir` returned an error on success — `fs.tl` (§1.2)

The C binding (`ReturnDir`) yields **exactly one value** on success — the `Dir` — and `(nil, Errno)` on failure, identical to `opendir`. The pinned cosmos annotation over-declares a phantom leading iterator `function`, so the wrapper's `local _, raw, err = unix.fdopendir(fd)` left `raw` **nil on success** and reported an error on every successful open (and, on failure, `raw` was a truthy `Errno` → a broken `Dir` whose `read()` throws). Narrowed the call to its real `(Dir, Errno)` runtime shape.

The phantom-return annotation is fixed upstream in [whilp/cosmopolitan](https://github.com/whilp/cosmopolitan) (`tool/net/definitions.lua`); the local cast drops on the next `cosmos` bump. `fdopendir` was previously called nowhere and wholly untested.

### 3. `netns` flag packing overflowed on high bits — `quicksand/netns.tl` (§1.6)

`ifr_flags` was packed/unpacked as **signed `<i2`**, so any `IFF_*` flag with bit `0x8000` set raised `"integer overflow"` from `string.pack`. Switched to unsigned `<I2`.

## Test plan

- `bin/make format` ✓ · `bin/make teal` ✓ · `bin/make test` ✓ (93/93)
- New regression tests:
  - `net_test.tl` — closed-socket methods return their error shape across the `nil`/`false` variants, no throw.
  - `fs_test.tl` — `fdopendir` success reads directory entries; invalid fd returns `nil, error`.
  - `netns_test.tl` — `set_flags` with the `0x8000` bit no longer overflows (nonexistent interface, so no device is mutated).
- `net`/`fs`/`netns` examples pass. The only failing example, `fetch_example.tl:Example_retry_on_status`, is a pre-existing network-dependent flake (fails identically on `main`; untouched by this PR — see #430).

## Remaining in Phase 1

Step 7's third item's upstream half (the `fdopendir` annotation) is a companion cosmopolitan PR; step 8 (fail-open security holes) and step 9 (`child`/`poll` hazards) are still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GU1VyZcfzXAhFzmii6unca)_