### PR TITLE
security: close fail-open sandbox holes (Phase 1 step 8a)

### DIFF
--- a/lib/cosmic/embed.tl
+++ b/lib/cosmic/embed.tl
@@ -266,6 +266,28 @@ local function run(paths: {string}, output?: string, exe_path?: string): EmbedRe
   }
 end
 
+--- Report whether a zip entry name would escape the extraction root
+--- (zip-slip). Rejects absolute paths — POSIX (`/x`), Windows/UNC
+--- (`\x`, `\\server\share`), and drive-letter (`C:\x`, `C:/x`, `C:x`) —
+--- and any `..` traversal component. Both `/` and `\` are treated as
+--- separators, since cosmic executables also extract on Windows where a
+--- `..\evil` entry would otherwise slip past a POSIX-only guard.
+--- @param name string Archive entry name
+--- @return boolean true if the entry is unsafe to extract
+local function unsafe_entry(name: string): boolean
+  -- Absolute roots escape output_dir.
+  if name:sub(1, 1) == "/" or name:sub(1, 1) == "\\" then return true end
+  if name:match("^%a:") then return true end
+  -- Normalize backslashes so ".." traversal is caught on either
+  -- separator ("..\evil" like "../evil").
+  local slashed = name:gsub("\\", "/")
+  if slashed == ".." or slashed:match("^%.%./") or slashed:match("/%.%./")
+  or slashed:match("/%.%.$") then
+    return true
+  end
+  return false
+end
+
 --- Extract the zip contents of a cosmic executable to a directory.
 --- Creates the output directory if needed. Existing files are overwritten.
 --- @param output_dir string Directory to extract into
@@ -293,10 +315,9 @@ local function extract(output_dir: string, exe_path?: string): EmbedResult
   local count = 0
 
   for _, name in ipairs(entries) do
-    -- Guard against zip-slip: an archive entry with an absolute path or a
-    -- ".." component could otherwise be written outside output_dir.
-    if name:sub(1, 1) == "/" or name:match("^%.%./") or name:match("/%.%./")
-    or name:match("/%.%.$") or name == ".." then
+    -- Guard against zip-slip: an entry with an absolute path or a ".."
+    -- component could otherwise be written outside output_dir.
+    if unsafe_entry(name) then
       reader:close()
       return {ok = false, message = "error: unsafe path in archive: " .. name, file_count = count}
     end
@@ -345,11 +366,13 @@ end
 local record EmbedModule
   run: function(paths: {string}, output?: string, exe_path?: string): EmbedResult
   extract: function(output_dir: string, exe_path?: string): EmbedResult
+  unsafe_entry: function(name: string): boolean
 end
 
 local M: EmbedModule = {
   run = run,
   extract = extract,
+  unsafe_entry = unsafe_entry,
 }
 
 return M

--- a/lib/cosmic/embed_test.tl
+++ b/lib/cosmic/embed_test.tl
@@ -286,3 +286,33 @@ local function test_embed_uses_deflate()
   reader:close()
 end
 test_embed_uses_deflate()
+
+-- Zip-slip: extract() must reject any entry that would land outside the
+-- output directory. cosmic executables also extract on Windows, so the
+-- guard treats "\" as a separator and rejects drive-letter roots too.
+local function test_extract_rejects_zip_slip()
+  local embed = require("cosmic.embed")
+  local unsafe = {
+    "/etc/passwd", -- POSIX absolute
+    "../evil", -- POSIX traversal
+    "a/../../evil", -- traversal mid-path
+    "a/..", -- traversal at tail
+    "..", -- bare traversal
+    "\\windows\\system32", -- Windows/UNC absolute
+    "..\\evil", -- Windows traversal
+    "a\\..\\..\\evil", -- Windows traversal mid-path
+    "C:\\evil", -- drive-letter absolute
+    "C:/evil", -- drive-letter, forward slash
+    "c:evil", -- drive-letter, no separator
+  }
+  for _, name in ipairs(unsafe) do
+    assert(embed.unsafe_entry(name), "should reject unsafe entry: " .. name)
+  end
+  local safe = {
+    "main.lua", "sub/dir/file.txt", "a..b/c", "...", "a/b..c/d",
+  }
+  for _, name in ipairs(safe) do
+    assert(not embed.unsafe_entry(name), "should accept safe entry: " .. name)
+  end
+end
+test_extract_rejects_zip_slip()

--- a/lib/cosmic/landlock.tl
+++ b/lib/cosmic/landlock.tl
@@ -40,14 +40,15 @@ local REFER < const > = unix.LANDLOCK_ACCESS_FS_REFER as integer -- ABI 2+
 local TRUNCATE < const > = unix.LANDLOCK_ACCESS_FS_TRUNCATE as integer -- ABI 3+
 
 --- Convenience masks. `ALL` is the full current set; `RW` covers read
---- + write (including creating and removing files); `READ` and `EXEC`
---- are self-explanatory.
+--- + write (including creating and removing files) but *not* execute —
+--- OR in `EXEC` explicitly if files under the path must be runnable.
+--- `READ` and `EXEC` are self-explanatory.
 local READ < const > = READ_FILE | READ_DIR
 local EXEC < const > = EXECUTE
 local WRITE < const > = WRITE_FILE | REMOVE_FILE | REMOVE_DIR
 | MAKE_REG | MAKE_DIR | MAKE_SYM
 | MAKE_SOCK | MAKE_FIFO | MAKE_CHAR | MAKE_BLOCK
-local RW < const > = READ | WRITE | EXEC
+local RW < const > = READ | WRITE
 local ALL < const > = READ | WRITE | EXEC | REFER | TRUNCATE
 
 --- A single path -> access-mask rule in a restrict() call.

--- a/lib/cosmic/landlock_test.tl
+++ b/lib/cosmic/landlock_test.tl
@@ -29,6 +29,13 @@ local function test_access_mask_composition()
     "RW should include READ")
   assert((landlock.ALL & landlock.RW) == landlock.RW,
     "ALL should include RW")
+  -- RW is read + write only: it must NOT silently grant execute, or a
+  -- box's rw path (e.g. /tmp) would become write+exec (a sandbox
+  -- weakening the caller never asked for).
+  assert((landlock.RW & landlock.EXEC) == 0,
+    "RW must not include EXEC")
+  assert((landlock.RW & landlock.WRITE_FILE) == landlock.WRITE_FILE,
+    "RW should include WRITE_FILE")
 end
 test_access_mask_composition()
 

--- a/lib/cosmic/quicksand/proxy/rules.tl
+++ b/lib/cosmic/quicksand/proxy/rules.tl
@@ -35,6 +35,8 @@ end
 
 --- Split a host-spec into ("host", port or nil). A missing port,
 --- ":*", or ":" all mean "any port". Hosts compare case-insensitively.
+--- A malformed port is *not* handled here — callers must validate keys
+--- with validate_key first, or a typo silently widens to "any port".
 local function parse_rule(key: string): string, integer
   local h, p = key:match("^(.-):(.-)$")
   if not h then
@@ -44,6 +46,31 @@ local function parse_rule(key: string): string, integer
     return h:lower(), nil
   end
   return h:lower(), tonumber(p) as integer
+end
+
+--- Validate an allowlist *key* (host-spec). Returns nil on success or a
+--- human-readable error. The port component, when present, must be `*`,
+--- empty, or a decimal integer in 1..65535 — otherwise `tonumber`
+--- returns nil and parse_rule would silently widen the rule to "any
+--- port" (fail-open in a security boundary). A stray extra colon
+--- (`"host:5432:6"`) trips the digit check for the same reason. The
+--- optional `*.` wildcard prefix is stripped before checking.
+local function validate_key(key: string): string
+  local spec = key:match("^%*%.(.+)$") or key
+  local _, p = spec:match("^(.-):(.-)$")
+  if p == nil or p == "" or p == "*" then
+    return nil
+  end
+  if not p:match("^%d+$") then
+    return string.format("allowed_hosts[%q]: invalid port %q "
+      .. "(expected a decimal number, \"*\", or none)", key, p)
+  end
+  local n = tonumber(p)
+  if n < 1 or n > 65535 then
+    return string.format("allowed_hosts[%q]: port %q out of range "
+      .. "(expected 1..65535)", key, p)
+  end
+  return nil
 end
 
 --- Validate a single allowlist rule. Returns nil on success, or a
@@ -96,6 +123,8 @@ end
 --- the first error found.
 local function validate(allowed_hosts: {string: any}): boolean, string
   for key, rule in pairs(allowed_hosts or {}) do
+    local kerr = validate_key(key)
+    if kerr then return false, kerr end
     local verr = validate_rule(key, rule)
     if verr then return false, verr end
   end
@@ -165,6 +194,7 @@ end
 
 local record RulesModule
   parse_rule: function(key: string): string, integer
+  validate_key: function(key: string): string
   validate_rule: function(key: string, rule: any): string
   validate: function(allowed_hosts: {string: any}): boolean, string
   index: function(allowed_hosts: {string: any}): Index
@@ -174,6 +204,7 @@ end
 
 local M: RulesModule = {
   parse_rule = parse_rule,
+  validate_key = validate_key,
   validate_rule = validate_rule,
   validate = validate,
   index = index,

--- a/lib/cosmic/quicksand/proxy/rules_test.tl
+++ b/lib/cosmic/quicksand/proxy/rules_test.tl
@@ -61,6 +61,44 @@ local function test_validate_rejects_malformed_rules()
 end
 test_validate_rejects_malformed_rules()
 
+-- A malformed port in a *key* must fail loudly, never silently widen to
+-- "any port": in an egress allowlist that is fail-open. parse_rule's
+-- tonumber() returns nil for a bad port, which index() treats as ":*".
+local function test_validate_rejects_malformed_port_keys()
+  local bad_keys = {
+    "db.internal:5432x", -- trailing junk
+    "db.internal:0", -- out of range (low)
+    "db.internal:70000", -- out of range (high)
+    "db.internal:5432:6", -- stray extra colon
+    "db.internal: 443", -- embedded space
+    "*.internal:443x", -- wildcard form, bad port
+  }
+  for _, key in ipairs(bad_keys) do
+    local ok, err = rules.validate({[key] = {} as any})
+    assert(not ok, "key should be rejected: " .. key)
+    assert(err:find(key, 1, true),
+      "error should name the offending key " .. key .. ", got: " .. err)
+  end
+  -- The widening it prevents: a rejected key never reaches index().
+  assert(rules.match(rules.index({["db.internal:5432x"] = {}}),
+      "db.internal", 9999) ~= nil,
+    "sanity: an unvalidated bad port DOES widen to any port (why we validate)")
+end
+test_validate_rejects_malformed_port_keys()
+
+-- Well-formed port keys (and the any-port forms) still pass.
+local function test_validate_accepts_valid_port_keys()
+  local good_keys = {
+    "db.internal:5432", "db.internal:1", "db.internal:65535",
+    "db.internal", "db.internal:*", "db.internal:", "*.internal:8443",
+  }
+  for _, key in ipairs(good_keys) do
+    local ok, err = rules.validate({[key] = {} as any})
+    assert(ok, "key should be accepted: " .. key .. ", got: " .. tostring(err))
+  end
+end
+test_validate_accepts_valid_port_keys()
+
 local function test_validate_accepts_pass_through_and_complete_rules()
   assert(rules.validate({}), "empty allowlist")
   assert(rules.validate({["a.example.com"] = {} as any}), "empty rule table")


### PR DESCRIPTION
## Summary

Executes **Phase 1 step 8a** of the codebase audit ([#420](https://github.com/whilp/cosmic/pull/420), `docs/audit-2026-07.md` §2.3): the three **in-repo, sandbox-weakening, fail-open** security holes. All are independent of the Teal↔C foundation and fully in-repo, which is why the audit sequenced them as the lead of the security work.

## Fixes

- **`landlock.RW` silently included EXECUTE** (`landlock.tl:50`). `RW = READ | WRITE | EXEC` while the doc said "read + write", and `quicksand/box/fs.tl` maps `fs.rw` onto it — so `fs = { rw = {"/tmp"} }` granted **write+exec** on `/tmp`, a sandbox weakening the caller never asked for. Dropped `EXEC` from `RW`; callers OR in `EXEC` explicitly when a path must be runnable. Doc updated.
- **Proxy allowlist port fail-open** (`quicksand/proxy/rules.tl`). A malformed/typo'd port in an allowlist key (`"db:5432x"`, a stray extra colon, or an out-of-range number) made `tonumber` return nil, which `index()` treats as `:*` (**any port**). `validate()` checked rule *values*, not keys. Added `validate_key()` — rejects non-numeric / out-of-range / extra-colon ports — and routed it through `validate()`, which is called at box egress setup (`proxy.tl:123`).
- **Zip-slip via backslash / drive letter** (`embed.tl` extract). The guard rejected absolute POSIX paths and `../` but `..\evil`, `\evil`, and `C:\evil` passed — and cosmic executables also extract on Windows. Factored the check into a pure `unsafe_entry()` that normalizes `\` → `/` for the `..` checks and rejects UNC / drive-letter roots.

Breaking per audit **D4** (pre-1.0, no compatibility guarantees).

## Test plan

Each fix carries a regression test:
- `landlock_test.tl` — asserts `RW & EXEC == 0` (and still includes `WRITE_FILE`).
- `quicksand/proxy/rules_test.tl` — malformed port keys rejected (with the offending key named), valid/any-port keys still accepted, plus a sanity assertion demonstrating the widening the validation prevents.
- `embed_test.tl` — backslash/drive-letter/UNC and `..` zip-slip entries rejected; safe names (`a..b/c`, `...`) accepted.

Verified locally: `bin/make teal` (196/196), `bin/make format` (196/196), `bin/make lint` (256/256), and `bin/make test only=…` for `rules`, `embed`, `landlock` all pass.

## Not in this PR (rest of step 8)

- **8a prerequisite** — the §5.1 CI tripwire + privileged unsandboxed Linux lane that actually exercises enforcement. These fixes are unit-tested (constant values, pure validation/path logic) without needing privilege, but the audit flags the CI lane as the load-bearing sequencing change before the enforcement-dependent work.
- **8b** — re-verify the quicksand pledge/unveil probe now that the `Errno` foundation is in.
- **8c** — fetch header CRLF validation (in-repo) + TLS-default verification (upstream).
- **Owner open question (audit D3):** does anything in production rely on quicksand to contain untrusted code today? If yes, these were an immediate hotfix rather than Phase-1 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xuw5LV9Escvcs3j2zFrZni

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xuw5LV9Escvcs3j2zFrZni)_