### PR TITLE
test: privileged enforcement CI lane + visible sandbox skips (Phase 1 step 8 prerequisite)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,3 +37,28 @@ jobs:
               echo
             fi
           done
+
+  # Privileged, unsandboxed lane that actually exercises the sandbox
+  # primitives (audit §5.1). `make ci` runs under landlock-make, where the
+  # sandbox tests skip their enforcement assertions; this lane runs them with
+  # no outer sandbox and COSMIC_ENFORCE=1 so a silent skip becomes a failure,
+  # and a tripwire fails the lane if nothing enforced at all.
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: make enforce
+        shell: bash -x {0}
+        run: bin/make -j enforce
+
+      - name: dump enforcement output
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          for f in $(find o/enforce -name '*.out' -o -name '*.err' 2>/dev/null); do
+            echo "===== $f ====="
+            cat "$f" 2>/dev/null || true
+            echo
+          done

--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,42 @@ $(foreach m,$(filter-out bootstrap,$(modules)),\
       $(eval $(patsubst %,$(o)/%.test.got,$($(m)_tests)): TEST_DEPS += $($(d)_dir)))\
     $(eval $(patsubst %,$(o)/%.test.got,$($(m)_tests)): $($(d)_files) $($(d)_lua))))
 
+# Privileged enforcement lane (Phase 1 step 8 prerequisite, audit §5.1).
+# The sandbox tests carry "outer sandbox blocked this -> skip" escape hatches,
+# so under CI's own landlock-make sandbox their enforcement assertions silently
+# degrade to no-ops and nothing alarms when everything skips. This lane runs the
+# sandbox-primitive tests with NO outer sandbox (empty .PLEDGE/.UNVEIL, like the
+# quicksand namespace tests) and COSMIC_ENFORCE=1, so a test that cannot exercise
+# real enforcement fails loudly instead of skipping. The tripwire then fails the
+# lane if *nothing* enforced (the "unexpectedly-everything-skipped" alarm), which
+# would mean the lane is not actually unsandboxed and is silently a no-op.
+enforce_srcs := \
+  lib/cosmic/pledge_test.tl \
+  lib/cosmic/landlock_test.tl \
+  lib/cosmic/unveil_test.tl
+enforce_got := $(patsubst %,$(o)/enforce/%.test.got,$(enforce_srcs))
+
+.PHONY: enforce
+## Run sandbox enforcement tests unsandboxed with COSMIC_ENFORCE=1 (privileged lane)
+enforce: $(o)/enforce-summary.txt
+
+# Drop the outer sandbox for these targets so enforcement actually runs.
+$(enforce_got): .PLEDGE =
+$(enforce_got): .UNVEIL =
+
+$(o)/enforce/%.tl.test.got: $(o)/%.lua $(cosmic_bin) | $(cosmic_bin)
+	@mkdir -p $(@D)
+	@TEST_BIN=$(o)/bin COSMIC_ENFORCE=1 PATH=$(CURDIR)/$(o)/bin:$$PATH \
+	  $(cosmic_bin) --test $(basename $@) $(cosmic_bin) $<
+
+$(o)/enforce-summary.txt: $(enforce_got) | $(cosmic_bin)
+	@$(cosmic_bin) --report $^ | tee $@
+	@if ! grep -rqs "enforce-ran:" $(o)/enforce/; then \
+	  echo "enforce tripwire: no enforcement ran — every sandbox test skipped."; \
+	  echo "  the privileged lane is not exercising enforcement (outer sandbox still active?)."; \
+	  exit 1; \
+	fi
+
 all_built_files := $(call filter-only,$(foreach x,$(modules),$($(x)_files)))
 all_built_files += $(all_lua)
 all_source_files := $(call filter-only,$(foreach x,$(modules),$($(x)_tests)))

--- a/lib/cosmic/assert.tl
+++ b/lib/cosmic/assert.tl
@@ -111,11 +111,50 @@ local function err(value: any, e: string, label?: string)
   end
 end
 
+--- Report whether the enforcement lane is active.
+--- True when COSMIC_ENFORCE=1, which the privileged, unsandboxed CI lane
+--- (`bin/make enforce`) sets. In that mode a sandbox test that cannot
+--- exercise real enforcement must fail loudly rather than skip silently,
+--- since there is no outer sandbox left to blame.
+--- @return boolean True when strict enforcement is required
+local function enforcing(): boolean
+  return os.getenv("COSMIC_ENFORCE") == "1"
+end
+
+--- Record that a sandbox test could not exercise real enforcement.
+--- Writes a machine-readable marker to stderr so the enforce-lane tripwire
+--- can see the skip (a silent `return` is indistinguishable from a pass).
+--- When `strict` is set and enforcement is required (COSMIC_ENFORCE=1) the
+--- skip is escalated to a hard failure — use `strict=true` only where the
+--- mechanism was probed *available* yet the operation was still blocked,
+--- which on the unsandboxed lane can only mean an outer sandbox is present.
+--- Callers still `return` after calling this; it does not exit the process.
+--- @param reason string Why enforcement could not run
+--- @param strict boolean? Escalate to failure under COSMIC_ENFORCE=1
+local function skip(reason: string, strict?: boolean)
+  local tag = strict and "enforce-skip[strict]" or "enforce-skip"
+  io.stderr:write("→ " .. tag .. ": " .. reason .. "\n")
+  if strict and enforcing() then
+    error("enforcement required but skipped: " .. reason, 2)
+  end
+end
+
+--- Record that a sandbox test actually exercised real enforcement.
+--- Writes a marker the enforce-lane tripwire counts to confirm the lane is
+--- not a silent no-op (every test skipping would otherwise look green).
+--- @param label string Short name of the mechanism that enforced
+local function enforced(label: string)
+  io.stderr:write("✓ enforce-ran: " .. label .. "\n")
+end
+
 local record AssertModule
   eq: function(actual: any, expected: any, label?: string)
   ne: function(actual: any, expected: any, label?: string)
   ok: function(value: any, label?: string)
   err: function(value: any, e: string, label?: string)
+  enforcing: function(): boolean
+  skip: function(reason: string, strict?: boolean)
+  enforced: function(label: string)
 end
 
 local M: AssertModule = {
@@ -123,6 +162,9 @@ local M: AssertModule = {
   ne = ne,
   ok = ok,
   err = err,
+  enforcing = enforcing,
+  skip = skip,
+  enforced = enforced,
 }
 
 return M

--- a/lib/cosmic/assert_test.tl
+++ b/lib/cosmic/assert_test.tl
@@ -1,5 +1,6 @@
 #!/usr/bin/env cosmic
 local a = require("cosmic.assert")
+local env = require("cosmic.env")
 
 -- must_fail wraps a function that is expected to throw and returns
 -- (true, error_message) or (false, "did not throw").
@@ -236,3 +237,54 @@ local function test_eq_error_points_at_caller()
   assert(type(msg) == "string", "expected string error, got: " .. tostring(msg))
 end
 test_eq_error_points_at_caller()
+
+-- enforcing / skip / enforced: enforcement-lane helpers
+
+local function with_enforce(on: boolean, f: function())
+  local prev = env.get("COSMIC_ENFORCE")
+  if on then env.set("COSMIC_ENFORCE", "1", true) else env.unset("COSMIC_ENFORCE") end
+  local ok, e = pcall(f as function(): any)
+  if prev then env.set("COSMIC_ENFORCE", prev, true) else env.unset("COSMIC_ENFORCE") end
+  if not ok then error(e, 0) end
+end
+
+local function test_enforcing_reflects_env()
+  with_enforce(false, function() a.eq(a.enforcing(), false, "unset") end)
+  with_enforce(true, function() a.eq(a.enforcing(), true, "set") end)
+end
+test_enforcing_reflects_env()
+
+local function test_skip_soft_never_throws()
+  -- A non-strict skip is visibility-only: it must never throw, even when
+  -- enforcement is required (genuine platform gaps still skip on the lane).
+  with_enforce(true, function()
+      local threw = must_fail(function(): string a.skip("kernel too old") return "" end)
+      assert(not threw, "soft skip must not throw under enforcement")
+    end)
+end
+test_skip_soft_never_throws()
+
+local function test_skip_strict_throws_only_under_enforce()
+  -- Off the lane, even a strict skip is tolerated (the outer sandbox is
+  -- expected). On the lane it is a hard failure.
+  with_enforce(false, function()
+      local threw = must_fail(function(): string a.skip("blocked", true) return "" end)
+      assert(not threw, "strict skip must not throw off the enforce lane")
+    end)
+  with_enforce(true, function()
+      local threw, msg = must_fail(function(): string a.skip("blocked", true) return "" end)
+      assert(threw, "strict skip must throw under enforcement")
+      assert(msg:match("enforcement required but skipped"),
+        "expected enforcement message, got: " .. msg)
+      assert(msg:match("blocked"), "expected reason in message, got: " .. msg)
+    end)
+end
+test_skip_strict_throws_only_under_enforce()
+
+local function test_enforced_never_throws()
+  with_enforce(true, function()
+      local threw = must_fail(function(): string a.enforced("pledge") return "" end)
+      assert(not threw, "enforced() is a marker and must not throw")
+    end)
+end
+test_enforced_never_throws()

--- a/lib/cosmic/landlock_test.tl
+++ b/lib/cosmic/landlock_test.tl
@@ -3,6 +3,7 @@ local landlock = require("cosmic.landlock")
 local fs = require("cosmic.fs")
 local cio = require("cosmic.io")
 local spawn = require("cosmic.child")
+local a = require("cosmic.assert")
 
 local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
@@ -49,10 +50,13 @@ test_available_returns_boolean()
 local function test_restrict_denies_outside_allowlist()
   if not landlock.available() then
     -- Kernel lacks landlock; skip the live enforcement check but assert
-    -- that abi() consistently reports the limitation.
+    -- that abi() consistently reports the limitation. A genuine platform
+    -- gap: soft skip even on the enforce lane (an old kernel can't be
+    -- made to enforce).
     local v, err = landlock.abi()
     assert(v == nil, "abi() should return nil when landlock is unavailable")
     assert(err, "abi() should return an error string when unavailable")
+    a.skip("landlock unavailable (kernel lacks landlock)")
     return
   end
 
@@ -82,15 +86,26 @@ local g = io.open(%q, "r")
 if g then io.write("denied-leaked\n"); g:close() else io.write("denied-blocked\n") end
 ]], allowed, allowed, denied))
 
+  -- landlock probed available here, so any failure to enforce below means
+  -- an outer sandbox is blocking an otherwise-supported mechanism — a
+  -- strict skip that the enforce lane (COSMIC_ENFORCE=1, no outer sandbox)
+  -- turns into a hard failure.
   local ok, out = spawn.spawn({cosmic, script}):read()
   -- Under an outer seccomp/pledge filter the landlock syscall may be
   -- blocked with SIGSYS rather than EPERM, killing the subprocess
-  -- before it can emit "skipped". Accept that too.
-  if not ok then return end
+  -- before it can emit "skipped".
+  if not ok then
+    a.skip("landlock restrict blocked (subprocess died before enforcing)", true)
+    return
+  end
   local s = out as string
-  if s:find("skipped") then return end
+  if s:find("skipped") then
+    a.skip("landlock restrict blocked: " .. s, true)
+    return
+  end
   assert(s:find("allowed-ok"), "allowed path should still read: " .. s)
   assert(s:find("denied-blocked"), "denied path must be blocked: " .. s)
+  a.enforced("landlock")
 end
 test_restrict_denies_outside_allowlist()
 

--- a/lib/cosmic/landlock_test.tl
+++ b/lib/cosmic/landlock_test.tl
@@ -60,7 +60,14 @@ local function test_restrict_denies_outside_allowlist()
     return
   end
 
-  local allowed = fs.join(tmpdir, "allowed.txt")
+  -- Allowlist a *directory* subtree, not a bare file: ll.READ bundles
+  -- READ_DIR, and landlock returns EINVAL if a directory-only right is
+  -- added on a regular file. So the allowed path is a directory and the
+  -- denied file is a sibling left outside it (both exist, so the denial is
+  -- a real landlock effect rather than a missing path).
+  local allowed_dir = fs.join(tmpdir, "allowed")
+  fs.makedirs(allowed_dir)
+  local allowed = fs.join(allowed_dir, "ok.txt")
   local denied = fs.join(tmpdir, "denied.txt")
   cio.barf(allowed, "allowed-content")
   cio.barf(denied, "denied-content")
@@ -77,14 +84,14 @@ if not ok then
   os.exit(0)
 end
 
--- Reading the allowed path must still work.
+-- Reading a file inside the allowed directory must still work.
 local f = io.open(%q, "r")
 if f then io.write("allowed-ok\n"); f:close() else io.write("allowed-fail\n") end
 
--- Reading the denied path must fail.
+-- Reading the sibling outside the allowed directory must fail.
 local g = io.open(%q, "r")
 if g then io.write("denied-leaked\n"); g:close() else io.write("denied-blocked\n") end
-]], allowed, allowed, denied))
+]], allowed_dir, allowed, denied))
 
   -- landlock probed available here, so any failure to enforce below means
   -- an outer sandbox is blocking an otherwise-supported mechanism — a

--- a/lib/cosmic/landlock_test.tl
+++ b/lib/cosmic/landlock_test.tl
@@ -110,8 +110,10 @@ if g then io.write("denied-leaked\n"); g:close() else io.write("denied-blocked\n
     a.skip("landlock restrict blocked: " .. s, true)
     return
   end
-  assert(s:find("allowed-ok"), "allowed path should still read: " .. s)
-  assert(s:find("denied-blocked"), "denied path must be blocked: " .. s)
+  -- Plain-text find: "-" is a Lua pattern metacharacter, so a pattern
+  -- search for "allowed-ok" would not match the literal marker.
+  assert(s:find("allowed-ok", 1, true), "allowed path should still read: " .. s)
+  assert(s:find("denied-blocked", 1, true), "denied path must be blocked: " .. s)
   a.enforced("landlock")
 end
 test_restrict_denies_outside_allowlist()

--- a/lib/cosmic/pledge_test.tl
+++ b/lib/cosmic/pledge_test.tl
@@ -3,6 +3,7 @@ local pledge = require("cosmic.pledge")
 local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
 local cio = require("cosmic.io")
+local a = require("cosmic.assert")
 
 local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
@@ -30,30 +31,42 @@ end
 test_stdio_allows_write()
 
 local function test_restricts_filesystem()
+  -- Status is written to stdout (not stderr) so the parent can read it via
+  -- handle:read(); on Linux a pledge violation raises SIGSYS and kills the
+  -- process, so a leak/skip cannot be signalled through the exit code alone.
   local script = fs.join(tmpdir, "pledge_no_fs.lua")
   cio.barf(script, [[
 local pledge = require("cosmic.pledge")
 local ok, err = pledge.apply("stdio")
 if not ok then
-  io.stderr:write("pledge failed: " .. tostring(err) .. "\n")
-  os.exit(1)
+  io.write("skipped: pledge apply failed: " .. tostring(err) .. "\n")
+  os.exit(0)
 end
-local f, open_err = io.open("/dev/null", "r")
+local f = io.open("/dev/null", "r")
 if f then
   f:close()
-  io.stderr:write("ERROR: file open should have been blocked\n")
-  os.exit(1)
+  io.write("leaked\n")
+  os.exit(0)
 end
 io.write("restricted\n")
 ]])
-  local handle = spawn.spawn({cosmic, script})
-  handle.stdin:close()
-  local out = handle.stdout:read()
-  local code = handle:wait()
-  -- Linux: disallowed calls return EPERM, script runs to completion.
-  -- OpenBSD: kernel kills the process outright.
-  if code == 0 then
-    assert(out:find("restricted"), "should report restriction: " .. out)
+  local ok, out = spawn.spawn({cosmic, script}):read()
+  local s = (out or "") as string
+  if s:find("skipped") then
+    -- pledge is supported on every platform cosmic targets (Linux via
+    -- seccomp, OpenBSD native); an apply failure means an outer sandbox
+    -- pre-empted it. Strict: a hard failure on the enforce lane.
+    a.skip("pledge apply failed: " .. s, true)
+    return
   end
+  assert(not s:find("leaked"), "pledge must block filesystem open: " .. s)
+  if ok then
+    -- EPERM mode: the blocked open returned nil, script printed restricted.
+    assert(s:find("restricted"), "pledged process should report restriction: " .. s)
+  end
+  -- Otherwise the process was killed (SIGSYS on Linux / kernel on OpenBSD)
+  -- attempting the blocked open: enforcement by signal. It did not leak
+  -- (asserted above) nor report pledge unavailable, so enforcement held.
+  a.enforced("pledge")
 end
 test_restricts_filesystem()

--- a/lib/cosmic/unveil_test.tl
+++ b/lib/cosmic/unveil_test.tl
@@ -3,6 +3,7 @@ local unveil = require("cosmic.unveil")
 local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
 local cio = require("cosmic.io")
+local a = require("cosmic.assert")
 
 local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
@@ -12,22 +13,32 @@ local function test_module_exports()
 end
 test_module_exports()
 
+-- Unveil only a sub-directory, then confirm both that the unveiled file
+-- reads AND that a sibling file left outside the unveil is hidden. Both
+-- files exist, so the denial is a genuine unveil effect, not a missing
+-- path. unveil is OpenBSD-only; on Linux apply() returns ENOSYS and the
+-- subprocess reports "skipped" — a genuine platform gap, so it is a soft
+-- skip even on the enforce lane (a Linux runner cannot exercise unveil).
 local function test_unveil_restricts_paths()
-  local allowed_file = fs.join(tmpdir, "unveiled.txt")
+  local allowed_dir = fs.join(tmpdir, "vis")
+  fs.makedirs(allowed_dir)
+  local allowed_file = fs.join(allowed_dir, "unveiled.txt")
+  local hidden_file = fs.join(tmpdir, "secret.txt")
   cio.barf(allowed_file, "visible")
+  cio.barf(hidden_file, "secret")
 
   local script = fs.join(tmpdir, "unveil_test.lua")
   cio.barf(script, string.format([[
 local unveil = require("cosmic.unveil")
 local ok, err = unveil.apply(%q, "r")
 if not ok then
-  io.stderr:write("unveil failed: " .. tostring(err) .. "\n")
-  os.exit(1)
+  io.write("skipped: unveil unavailable: " .. tostring(err) .. "\n")
+  os.exit(0)
 end
 ok, err = unveil.apply(nil, nil)
 if not ok then
-  io.stderr:write("unveil commit failed: " .. tostring(err) .. "\n")
-  os.exit(1)
+  io.write("skipped: unveil commit failed: " .. tostring(err) .. "\n")
+  os.exit(0)
 end
 local f = io.open(%q, "r")
 if f then
@@ -37,14 +48,38 @@ if f then
 else
   io.write("read:failed\n")
 end
-]], tmpdir, allowed_file))
+-- A sibling file outside the unveiled directory must be invisible. On Linux
+-- cosmopolitan backs unveil with Landlock; if Landlock is unavailable the
+-- apply() call succeeds but does not actually restrict (a no-op), so treat a
+-- leak-without-backing as a skip rather than a failure.
+local g = io.open(%q, "r")
+if g then
+  g:close()
+  if require("cosmic.landlock").available() then
+    io.write("denied-leaked\n")
+  else
+    io.write("skipped: unveil applied but did not restrict (no backing sandbox)\n")
+  end
+else
+  io.write("denied-blocked\n")
+end
+]], allowed_dir, allowed_file, hidden_file))
 
   local ok, out = spawn.spawn({cosmic, script}):read()
-  -- unveil is OpenBSD-only at runtime; on Linux it returns ENOSYS. Accept
-  -- either the expected "read:visible" (when unveil works) or a non-zero
-  -- exit (when unveil is unavailable).
-  if ok then
-    assert((out as string):find("read:visible"), "should read unveiled file: " .. tostring(out))
+  local s = (out or "") as string
+  if s:find("skipped") then
+    a.skip("unveil unavailable / not enforcing (OpenBSD-only, or no backing): " .. s)
+    return
   end
+  assert(ok, "unveil subprocess should exit cleanly: " .. s)
+  assert(s:find("read:visible"), "should read unveiled file: " .. s)
+  -- Backing sandbox present but the sibling still leaked: a real failure
+  -- off the lane it stays tolerant, on the enforce lane it is fatal.
+  if s:find("denied%-leaked") then
+    a.skip("unveil did not hide the non-unveiled sibling despite backing: " .. s, true)
+    return
+  end
+  assert(s:find("denied%-blocked"), "expected denial of the non-unveiled sibling: " .. s)
+  a.enforced("unveil")
 end
 test_unveil_restricts_paths()


### PR DESCRIPTION
## Summary

Executes the **step-8 CI prerequisite** from the `docs/audit-2026-07.md` remediation plan (#420, audit §5.1) — the load-bearing item the plan pulls forward to *gate* the remaining Phase 1 security work (8b probe re-verify, step 9 child/poll hazards):

> the sandbox tests skip under CI's own landlock-make sandbox, so security fixes landed without this lane are *unverified in CI*.

Nearly every sandbox test has an "outer sandbox blocked this → skip" escape hatch (`if not ok then return end`, `if code == 0 then assert ... end`). Under `make ci` (which runs beneath landlock-make's per-recipe pledge/unveil) those enforcement assertions silently degrade to **exit-0 passes**, and nothing alarms when everything skips. This PR makes skips visible and adds a privileged lane that actually exercises enforcement.

## What changed

- **`cosmic.assert` enforcement-lane helpers** (unit-tested in both modes):
  - `enforcing()` — reads `COSMIC_ENFORCE`.
  - `skip(reason, strict?)` — writes a machine-readable marker to stderr (a bare `return` is indistinguishable from a pass); when `strict` **and** enforcing, escalates to a hard failure.
  - `enforced(label)` — marks that real enforcement ran (the tripwire counts these).
- **`landlock` / `pledge` / `unveil` tests** now report skips through `assert.skip` instead of returning silently. `strict` is used **only** where the mechanism was probed *available* yet still blocked (which, with no outer sandbox, can only mean an outer sandbox is present); genuine platform gaps (old kernel, OpenBSD-only unveil, no landlock backing) stay soft — so the lane is robust to runners that legitimately lack a mechanism.
  - `pledge_test` classifies via stdout markers and now **actually asserts on Linux**, where a pledge violation `SIGSYS`-kills the process — the old `if code == 0` guard asserted nothing there.
  - `unveil_test` gains a real **denial** check (a sibling file left outside the unveil must be hidden), closing the §5.2 "unveil has no denial test" gap.
- **`bin/make enforce`** — runs these tests with no outer sandbox (empty `.PLEDGE`/`.UNVEIL`, like the existing quicksand namespace tests) and `COSMIC_ENFORCE=1`. A **tripwire** fails the lane if *nothing* enforced at all (the "unexpectedly-everything-skipped" alarm), which would mean the lane is silently a no-op.
- **`pr.yml`** gains an `enforce` job running the privileged lane.

## Scope note

This lands the prerequisite for the three canonical sandbox primitives (landlock/pledge/unveil), which is what anchors the tripwire (pledge enforces on any Linux). Converting the broader quicksand namespace/box suite (netns, `become_init`, proxy allow-path) to the same visible-skip convention is follow-on §5.2 test-coverage work (Phase 3 step 14). The remaining Phase 1 items (8b, 8c, step 9) are unaffected and now have a CI lane to verify against.

## Test plan

Verified locally (build works in this environment):
- `bin/make ci` green — format 196/196, teal 196/196, test 93/93, example 18/18, lint 256/256.
- `bin/make enforce` passes: pledge enforces (`✓ enforce-ran: pledge`), landlock/unveil soft-skip cleanly (this box lacks landlock), tripwire green.
- Tripwire verified to **fire** when no `enforce-ran` marker is present and **pass** when one is.
- The three converted tests still pass on the normal sandboxed lane, now emitting visible skip markers instead of silent passes.

The `enforce` job's behaviour on GitHub's `ubuntu-latest` runners (where landlock *is* expected available) will be confirmed by this PR's own CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJhqeK4tHSkidWAiojZc45)_