### PR TITLE
quicksand: re-verify pledge/unveil probe with a falsifiable test (Phase 1 step 8b)

### DIFF
--- a/lib/cosmic/quicksand/init.tl
+++ b/lib/cosmic/quicksand/init.tl
@@ -43,13 +43,24 @@ end
 local record QuicksandModule
   capabilities: function(): Capabilities
   is_supported: function(): boolean
+  probe: function(fn: any): boolean
   Box: any -- re-export of cosmic.quicksand.box
 end
 
 --- Probe a pledge/unveil-style binding with a no-op call: available
 --- when the call succeeds, or fails with anything other than ENOSYS
---- (a policy error still proves the syscall is wired up).
-local function probe_nop(fn: any): boolean
+--- (a policy error still proves the syscall is wired up). A nil binding
+--- (not exported on this host) reports unavailable.
+---
+--- This classification is only correct because a failed `unix.*` call now
+--- returns a real `Errno` in its second slot (the Phase 0 annotation fix):
+--- before it, the error was swallowed and every probe reported available
+--- (fail-open, audit §2.3). Exported so the classifier is unit-testable
+--- against synthetic ENOSYS / policy-error / success returns.
+---
+--- @param fn any the binding to probe (e.g. `unix.pledge`), or nil
+--- @return boolean true when the syscall is wired up on this host
+local function probe(fn: any): boolean
   if not fn then return false end
   local call = fn as function(any, any): any, Errno
   local ok, err = call(nil, nil)
@@ -85,8 +96,8 @@ local function capabilities(): Capabilities
     pivot_root = is_linux and unix.pivot_root ~= nil,
     cap_net_admin = is_linux and unix.geteuid ~= nil and unix.geteuid() == 0,
     landlock = is_linux and probe_landlock(),
-    pledge = probe_nop(unix.pledge),
-    unveil = probe_nop(unix.unveil),
+    pledge = probe(unix.pledge),
+    unveil = probe(unix.unveil),
     caps = is_linux and caps.supported(),
   }
   return cached
@@ -103,6 +114,7 @@ end
 local M: QuicksandModule = {
   capabilities = capabilities,
   is_supported = is_supported,
+  probe = probe,
   Box = box,
 }
 

--- a/lib/cosmic/quicksand/init_test.tl
+++ b/lib/cosmic/quicksand/init_test.tl
@@ -1,5 +1,7 @@
 #!/usr/bin/env cosmic
 local quicksand = require("cosmic.quicksand")
+local errno = require("cosmic.errno")
+local a = require("cosmic.assert")
 
 local function test_module_exports()
   assert(type(quicksand.capabilities) == "function", "capabilities should be a function")
@@ -44,6 +46,67 @@ local function test_is_supported_matches_capabilities()
     "is_supported() must agree with capabilities().linux/net_ns/mount_ns")
 end
 test_is_supported_matches_capabilities()
+
+-- Build a synthetic Errno-shaped value carrying a fixed errno number, so
+-- the probe's ENOSYS classification can be exercised without a host that
+-- actually lacks the syscall.
+local function mk_err(n: integer): any
+  return {errno = function(_: any): integer return n end}
+end
+
+-- The probe reports a binding available when a no-op call succeeds or
+-- fails with anything other than ENOSYS, and unavailable when the binding
+-- is absent (nil) or the call returns ENOSYS. This is the classification
+-- that was fail-open before the Phase 0 Errno-return fix (audit §2.3): the
+-- error used to be swallowed, so the ENOSYS branch was dead and every
+-- probe reported available. These cases fail if that regresses.
+local function test_probe_nil_binding_is_unavailable()
+  a.eq(quicksand.probe(nil), false, "a nil binding must probe as unavailable")
+end
+test_probe_nil_binding_is_unavailable()
+
+local function test_probe_success_is_available()
+  a.eq(quicksand.probe(function(): any return true end), true,
+    "a successful no-op call means the syscall is wired up")
+end
+test_probe_success_is_available()
+
+local function test_probe_enosys_is_unavailable()
+  local enosys = errno.code("ENOSYS")
+  assert(enosys, "ENOSYS must be defined on this host")
+  a.eq(quicksand.probe(function(): any, any return nil, mk_err(enosys) end), false,
+    "ENOSYS means the syscall is absent -> unavailable (the branch that was dead pre-fix)")
+end
+test_probe_enosys_is_unavailable()
+
+local function test_probe_policy_error_is_available()
+  local eperm = errno.code("EPERM")
+  assert(eperm, "EPERM must be defined on this host")
+  a.eq(quicksand.probe(function(): any, any return nil, mk_err(eperm) end), true,
+    "a policy error (EPERM) still proves the syscall is wired up")
+end
+test_probe_policy_error_is_available()
+
+-- Re-verify against the real host: on Linux both pledge (seccomp) and,
+-- when the kernel advertises landlock, unveil are genuinely present, so the
+-- probe must report them. The enforce lane (bin/make enforce) separately
+-- proves both mechanisms actually restrict on ubuntu-latest; this pins the
+-- probe's report to that reality instead of the old vacuous always-true.
+local function test_real_pledge_unveil_probe()
+  local c = quicksand.capabilities()
+  if not c.linux then
+    a.skip("quicksand pledge/unveil probe: non-Linux host")
+    return
+  end
+  a.ok(c.pledge, "capabilities().pledge must be true on Linux (pledge via seccomp)")
+  if c.landlock then
+    a.ok(c.unveil, "capabilities().unveil must be true on Linux with landlock")
+  else
+    a.skip("quicksand unveil probe: host kernel lacks landlock")
+  end
+  a.enforced("quicksand pledge/unveil probe")
+end
+test_real_pledge_unveil_probe()
 
 local function test_box_reexported()
   local J = quicksand.Box as {string: any}


### PR DESCRIPTION
## Summary

Executes **Phase 1 step 8b** of the [audit remediation plan](https://github.com/whilp/cosmic/pull/420): re-verify the quicksand pledge/unveil capability probe now that the Phase 0 `Errno`-return foundation has landed. Per the plan this is *a confirming test, not a fix* — the probe logic is byte-identical.

### Background (audit §2.3)

`quicksand.capabilities().pledge`/`unveil` were effectively **fail-open**. The probe classifies a binding as available when a no-op call succeeds or fails with anything other than `ENOSYS`. Before the annotation fix, a failed `unix.*` call swallowed its error, so `err` was always `nil`, the `ENOSYS` branch was dead, and *every* probe reported available regardless of the host.

The `Errno`-return work (Phase 0) made the branch live — `unix.pledge`/`unveil` now return `boolean, Errno`. This PR pins that corrected behavior with a **falsifiable** test; the existing tests only asserted the probe's *shape* (booleans), which the always-true bug passed.

## Changes

- **`lib/cosmic/quicksand/init.tl`** — expose the probe classifier (renamed `probe_nop` → `probe`, **logic unchanged**) so it is unit-testable against synthetic returns; expanded its doc comment to record why the classification is now correct.
- **`lib/cosmic/quicksand/init_test.tl`** — add:
  - classifier unit tests: nil binding → unavailable · success → available · `ENOSYS` `Errno` → unavailable (the branch that was dead pre-fix) · policy error (`EPERM`) → available.
  - a real-host confirming test: on Linux, `pledge` (seccomp) probes true and, when the kernel advertises landlock, `unveil` probes true — routed through the `assert.skip`/`enforced` convention and cross-checked against the enforce lane (#433) that proves both mechanisms genuinely restrict on `ubuntu-latest`.

## Test plan

- `bin/make teal` — 196/196
- `bin/make format` — 196/196
- `bin/make lint` — 256/256
- `bin/make test only=quicksand` — green
- Verified on the (landlock-less) sandbox host: `probe(nil)=false`, `probe(success)=true`, `pledge=true`, `unveil=true`; the landlock-gated `unveil` assertion correctly skips here and asserts on `ubuntu-latest`.

Remaining Phase 1: **8c** (fetch header CRLF validation in-repo + TLS-default upstream) and **step 9** (`child.tl`/`poll` hazards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01E8bf2Y1P1XAEPKpgoEVnpR)_