### PR TITLE
fetch: reject CR/LF/NUL in request header names and values (Phase 1 step 8c, in-repo)

### DIFF
--- a/lib/cosmic/fetch.tl
+++ b/lib/cosmic/fetch.tl
@@ -71,10 +71,47 @@ local function validate_url(url: string): string
   return nil
 end
 
+-- True when s carries a CR, LF, or NUL. Plain-text search (find's 4th arg)
+-- so the bytes are matched literally, not as pattern metacharacters.
+local function has_forbidden_byte(s: string): boolean
+  return s:find("\r", 1, true) ~= nil
+  or s:find("\n", 1, true) ~= nil
+  or s:find("\0", 1, true) ~= nil
+end
+
+--- Reject header names or values that carry a CR, LF, or NUL. HTTP headers
+--- are CRLF-delimited, so an embedded CR/LF in a name or value smuggles
+--- additional header lines (or a body) past cosmo.Fetch — a request-splitting
+--- / header-injection vector (audit §2.3). The error names the offending
+--- header but never echoes the raw control bytes back.
+--- @param headers {string: string} request headers, or nil
+--- @return string? error message, or nil when every header is safe
+local function validate_headers(headers: {string: string}): string
+  if not headers then
+    return nil
+  end
+  for name, value in pairs(headers) do
+    if name == "" then
+      return "invalid header name: must not be empty"
+    end
+    if has_forbidden_byte(name) then
+      return "invalid header name: must not contain CR, LF, or NUL"
+    end
+    if value ~= nil and has_forbidden_byte(value) then
+      return "invalid value for header '" .. name .. "': must not contain CR, LF, or NUL"
+    end
+  end
+  return nil
+end
+
 local function do_fetch(url: string, opts?: Opts): Result
   local verr = validate_url(url)
   if verr then
     return {ok = false, error = verr}
+  end
+  local herr = opts and validate_headers(opts.headers)
+  if herr then
+    return {ok = false, error = herr}
   end
 
   local status: number
@@ -203,6 +240,10 @@ local function stream(url: string, opts?: Opts): StreamResult
   local verr = validate_url(url)
   if verr then
     return {ok = false, error = verr}
+  end
+  local herr = opts and validate_headers(opts.headers)
+  if herr then
+    return {ok = false, error = herr}
   end
 
   local status: number

--- a/lib/cosmic/fetch_headers_test.tl
+++ b/lib/cosmic/fetch_headers_test.tl
@@ -1,0 +1,93 @@
+#!/usr/bin/env cosmic
+-- Header CRLF / injection validation (audit §2.3). HTTP headers are
+-- CRLF-delimited, so a CR or LF embedded in a header name or value smuggles
+-- additional header lines (or a body) past cosmo.Fetch. fetch rejects such
+-- headers before the request is issued. These tests need no network: the
+-- request is rejected during validation, before any connection is attempted.
+local fetch = require("cosmic.fetch")
+
+local has_fetch_stream = fetch.has_stream()
+if not has_fetch_stream then
+  io.stderr:write("SKIP: fetch.stream header tests (FetchStream primitive not available)\n")
+end
+
+-- A dead loopback port: any request that passes validation fails to connect,
+-- so a header-validation error is unambiguously from validation, not the wire.
+local dead = "http://127.0.0.1:1"
+
+local function test_rejects_crlf_in_header_value()
+  local result = fetch.Fetch(dead, {headers = {["X-Test"] = "value\r\nX-Injected: evil"}})
+  assert(result.ok == false, "result.ok should be false for CRLF in header value")
+  assert(result.error ~= nil and result.error:find("X%-Test") ~= nil,
+    "error should name the offending header, got: " .. tostring(result.error))
+  assert(result.error:find("CR, LF, or NUL") ~= nil,
+    "error should explain the forbidden bytes, got: " .. tostring(result.error))
+end
+test_rejects_crlf_in_header_value()
+
+local function test_rejects_lf_only_in_header_value()
+  local result = fetch.Fetch(dead, {headers = {["X-Test"] = "a\nb"}})
+  assert(result.ok == false, "a bare LF in a header value must be rejected")
+end
+test_rejects_lf_only_in_header_value()
+
+local function test_rejects_cr_only_in_header_value()
+  local result = fetch.Fetch(dead, {headers = {["X-Test"] = "a\rb"}})
+  assert(result.ok == false, "a bare CR in a header value must be rejected")
+end
+test_rejects_cr_only_in_header_value()
+
+local function test_rejects_crlf_in_header_name()
+  local result = fetch.Fetch(dead, {headers = {["X-Bad\r\nX-Injected"] = "value"}})
+  assert(result.ok == false, "result.ok should be false for CRLF in header name")
+  assert(result.error ~= nil and result.error:find("header name") ~= nil,
+    "error should mention the header name, got: " .. tostring(result.error))
+end
+test_rejects_crlf_in_header_name()
+
+local function test_rejects_nul_in_header_value()
+  local result = fetch.Fetch(dead, {headers = {["X-Test"] = "a\0b"}})
+  assert(result.ok == false, "a NUL in a header value must be rejected")
+  assert(result.error ~= nil and result.error:find("CR, LF, or NUL") ~= nil,
+    "error should explain the forbidden bytes, got: " .. tostring(result.error))
+end
+test_rejects_nul_in_header_value()
+
+local function test_rejects_empty_header_name()
+  local result = fetch.Fetch(dead, {headers = {[""] = "value"}})
+  assert(result.ok == false, "an empty header name must be rejected")
+  assert(result.error ~= nil and result.error:find("empty") ~= nil,
+    "error should mention the empty name, got: " .. tostring(result.error))
+end
+test_rejects_empty_header_name()
+
+local function test_allows_clean_headers()
+  -- Well-formed headers must pass validation; the connection to the dead
+  -- port then fails, but never with a header-validation error.
+  local result = fetch.Fetch(dead, {
+      headers = {["X-Test"] = "clean-value", ["Accept"] = "application/json"},
+    })
+  if not result.ok then
+    assert(result.error:find("header") == nil,
+      "clean headers must pass validation, got: " .. tostring(result.error))
+  end
+end
+test_allows_clean_headers()
+
+local function test_stream_rejects_crlf_in_header_value()
+  if not has_fetch_stream then return end
+  local result = fetch.stream(dead, {headers = {["X-Test"] = "value\r\nX-Injected: evil"}})
+  assert(result.ok == false, "stream should reject CRLF in a header value")
+  assert(result.error ~= nil and result.error:find("CR, LF, or NUL") ~= nil,
+    "stream error should explain the forbidden bytes, got: " .. tostring(result.error))
+end
+test_stream_rejects_crlf_in_header_value()
+
+local function test_stream_rejects_crlf_in_header_name()
+  if not has_fetch_stream then return end
+  local result = fetch.stream(dead, {headers = {["X-Bad\r\nX-Injected"] = "value"}})
+  assert(result.ok == false, "stream should reject CRLF in a header name")
+  assert(result.error ~= nil and result.error:find("header name") ~= nil,
+    "stream error should mention the header name, got: " .. tostring(result.error))
+end
+test_stream_rejects_crlf_in_header_name()


### PR DESCRIPTION
## Summary

Executes the **in-repo half of Phase 1 step 8c** from the [audit remediation plan](https://github.com/whilp/cosmic/pull/420): validate request header names and values before they reach `cosmo.Fetch`.

### Background (audit §2.3)

HTTP headers are CRLF-delimited. A CR or LF embedded in a caller-supplied header **name or value** smuggles additional header lines (or a body) past `cosmo.Fetch` — a classic HTTP request-splitting / header-injection vector. `fetch` passed `opts.headers` straight through with no validation.

## Changes

- **`lib/cosmic/fetch.tl`** — add `validate_headers`, called on both the buffered (`do_fetch`) and streaming (`stream`) paths right after URL validation. It rejects any header name or value containing **CR, LF, or NUL**, and rejects empty names. Matching uses plain-text `find` so the bytes are matched literally. The error names the offending header but never echoes the raw control bytes back.
- **`lib/cosmic/fetch_headers_test.tl`** (new) — CR/LF/NUL in values, CRLF in names, empty name, and a clean-header pass-through, on both `Fetch` and `stream`. Placed in a new file because `fetch_test.tl` is already at the 500-line limit. The tests need no network: requests are rejected during validation, before any connection is attempted.

## Scope

This is the **in-repo** half of step 8c only. The TLS-default-verification question (confirm certs verify by default; expose a verify/redirect knob) remains **upstream/mbedTLS** work (U9 in the plan) and is deliberately kept off this critical path.

## Test plan

- `bin/make teal` — 197/197
- `bin/make format` — 197/197
- `bin/make lint` — 256/256
- `bin/make test only=fetch` — green (`fetch_test`, `fetch_headers_test`, `build-fetch_test`)
- Verified directly against the built binary: CRLF-in-value/name, NUL, and empty-name are each rejected with a descriptive error; a clean header passes validation and only fails later at the connection layer.

Remaining Phase 1: **step 9** (`child.tl`/`poll` hazards); step 8c's TLS-default question stays upstream (U9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01E8bf2Y1P1XAEPKpgoEVnpR)_