### PR TITLE
child/poll: fix stdin deadlock, SIGPIPE, silent EOF, fd leaks, EINTR spin (Phase 1 step 9)

### DIFF
--- a/lib/cosmic/child.tl
+++ b/lib/cosmic/child.tl
@@ -1,7 +1,7 @@
 --- Child process management.
 --- Spawn and manage child processes with I/O control.
 local unix = require("cosmo.unix")
-local poll = require("cosmic.poll")
+local childio = require("cosmic.child_io")
 
 --- Process resource usage statistics.
 local record Rusage
@@ -23,22 +23,17 @@ local record Rusage
   nivcsw: function(self: Rusage): number
 end
 
---- Pipe for process I/O. fd is a plain field (not a method like io.Handle:fd()).
-local record Pipe
-  fd: number
-  write: function(self: Pipe, data: string): number
-  read: function(self: Pipe, size?: number): string
-  close: function(self: Pipe)
-end
-
 --- Handle for a spawned process.
+--- stdin/stdout/stderr are cosmic.child_io Pipe wrappers (or nil when the
+--- corresponding stream was redirected to a raw fd via Opts).
 local record Handle
   pid: number
-  stdin: Pipe
-  stdout: Pipe
-  stderr: Pipe
+  stdin: childio.Pipe
+  stdout: childio.Pipe
+  stderr: childio.Pipe
   wait: function(self: Handle): number, string
   read: function(self: Handle, size?: number): boolean | string, string, number
+  communicate: function(self: Handle): string, string, number, string
 end
 
 --- Options for spawning a process.
@@ -50,41 +45,6 @@ local record Opts
   stderr: number -- raw fd -> fd 2; handle.stderr becomes nil
   env: {string}
   cwd: string
-end
-
-local function make_pipe(fd: number): Pipe
-  if not fd then
-    return nil
-  end
-  local pipe: Pipe = {fd = fd}
-
-  function pipe:write(data: string): number
-    return (unix.write(self.fd, data))
-  end
-
-  function pipe:read(size?: number): string
-    if size then
-      return (unix.read(self.fd, size))
-    end
-    local chunks: {string} = {}
-    while true do
-      local chunk = unix.read(self.fd, 65536)
-      if not chunk or chunk == "" then
-        break
-      end
-      table.insert(chunks, chunk)
-    end
-    return table.concat(chunks)
-  end
-
-  pipe.close = function(self: Pipe)
-    if self.fd then
-      local _ = unix.close(self.fd)
-      self.fd = nil
-    end
-  end
-
-  return pipe
 end
 
 --- Creates a new process (fork).
@@ -210,25 +170,47 @@ local function spawn(argv: {string}, opts?: Opts): Handle, string
     argv[1] = cmd
   end
 
+  -- Track every fd we open so a mid-way pipe() failure (fd exhaustion) can be
+  -- unwound cleanly instead of leaking descriptors — including any exec fd,
+  -- which would otherwise leak on this early-return path.
+  local opened: {number} = {}
+  local function fail(msg: string): Handle, string
+    for _, fd in ipairs(opened) do unix.close(fd) end
+    if exec_fd then unix.close(exec_fd) end
+    return nil, msg
+  end
+  local function new_pipe(): number, number
+    local r, w = unix.pipe()
+    if r == nil or w == nil then
+      return nil, nil
+    end
+    table.insert(opened, r)
+    table.insert(opened, w)
+    return r, w
+  end
+
   local stdin_r: number
   local stdin_w: number
   local stdin_is_fd = type(opts.stdin) == "number"
   if not stdin_is_fd then
-    stdin_r, stdin_w = unix.pipe()
+    stdin_r, stdin_w = new_pipe()
+    if not stdin_w then return fail("pipe failed (stdin)") end
   end
 
   local stdout_r: number
   local stdout_w: number
   local stdout_is_fd = type(opts.stdout) == "number"
   if not stdout_is_fd then
-    stdout_r, stdout_w = unix.pipe()
+    stdout_r, stdout_w = new_pipe()
+    if not stdout_w then return fail("pipe failed (stdout)") end
   end
 
   local stderr_r: number
   local stderr_w: number
   local stderr_is_fd = type(opts.stderr) == "number"
   if not stderr_is_fd then
-    stderr_r, stderr_w = unix.pipe()
+    stderr_r, stderr_w = new_pipe()
+    if not stderr_w then return fail("pipe failed (stderr)") end
   end
 
   local pid = unix.fork()
@@ -330,99 +312,91 @@ local function spawn(argv: {string}, opts?: Opts): Handle, string
     unix.close(stderr_w)
   end
 
-  -- Drain stdout and stderr concurrently using poll to avoid deadlock.
-  local function drain_pipes(out_pipe: Pipe, err_pipe: Pipe): string, string
-    local out_chunks: {string} = {}
-    local err_chunks: {string} = {}
-    if not out_pipe and not err_pipe then
-      return "", ""
-    end
-    local poller = poll.new()
-    if out_pipe then poller:add(out_pipe.fd, poll.POLLIN) end
-    if err_pipe then poller:add(err_pipe.fd, poll.POLLIN) end
-    while not poller:empty() do
-      for fd, events in poller:wait(-1) do
-        if events.readable then
-          local chunk = unix.read(fd, 65536)
-          if not chunk or chunk == "" then
-            poller:remove(fd)
-          else
-            if out_pipe and fd == out_pipe.fd then
-              table.insert(out_chunks, chunk)
-            elseif err_pipe and fd == err_pipe.fd then
-              table.insert(err_chunks, chunk)
-            end
-          end
-        end
-        if events.hangup or events.error then
-          poller:remove(fd)
-        end
-      end
-    end
-    if out_pipe then out_pipe:close() end
-    if err_pipe then err_pipe:close() end
-    return table.concat(out_chunks), table.concat(err_chunks)
+  -- An opts.stdin string is delivered lazily by wait()/read()/communicate()
+  -- via the pump, NOT written synchronously here: a >pipe-buffer write before
+  -- anyone drains stdout/stderr would deadlock, and a child that exits early
+  -- would SIGPIPE-kill this process. The pump feeds stdin and drains both
+  -- output streams in one poll loop, so neither can happen.
+  local stdin_data: string = nil
+  if type(opts.stdin) == "string" then
+    stdin_data = opts.stdin as string
   end
 
   local handle: Handle = {
     pid = pid,
-    stdin = make_pipe(stdin_w),
-    stdout = make_pipe(stdout_r),
-    stderr = make_pipe(stderr_r),
+    stdin = childio.make_pipe(stdin_w),
+    stdout = childio.make_pipe(stdout_r),
+    stderr = childio.make_pipe(stderr_r),
   }
 
+  -- Run the process to completion: pump stdin in / stdout+stderr out without
+  -- deadlock, then reap. Returns stdout, stderr, exit code (-1 if the process
+  -- did not exit normally), and an error string (signal/abnormal exit, or a
+  -- pump I/O error) that is nil on a clean normal exit.
+  local function finish(): string, string, number, string
+    local sfd = handle.stdin and handle.stdin.fd or nil
+    handle.stdin = nil
+    local out_fd = handle.stdout and handle.stdout.fd or nil
+    local err_fd = handle.stderr and handle.stderr.fd or nil
+    local out, err_out, io_err = childio.pump(out_fd, err_fd, sfd, stdin_data)
+    if handle.stdout then handle.stdout:close(); handle.stdout = nil end
+    if handle.stderr then handle.stderr:close(); handle.stderr = nil end
+    local _, status = unix.wait(handle.pid)
+    local code: number = -1
+    local err: string = nil
+    if type(status) ~= "number" then
+      err = "wait failed: " .. tostring(status)
+    elseif unix.WIFEXITED(status) then
+      code = unix.WEXITSTATUS(status)
+    elseif unix.WIFSIGNALED(status) then
+      err = "killed by signal " .. tostring(unix.WTERMSIG(status))
+    else
+      err = "process terminated abnormally"
+    end
+    return out, err_out, code, err or io_err
+  end
+
   --- Wait for the process to exit and return its exit code.
-  --- Closes stdin and drains stdout and stderr concurrently before waiting.
+  --- Feeds any stdin and drains stdout/stderr first so it cannot deadlock.
   --- @return number The exit code if the process exited normally
   --- @return string Error message if the process terminated abnormally
   function handle:wait(): number, string
-    if self.stdin then self.stdin:close() end
-    drain_pipes(self.stdout, self.stderr)
-    self.stdout = nil
-    self.stderr = nil
-    local _, status = unix.wait(self.pid)
-    if type(status) ~= "number" then
-      return nil, "wait failed: " .. tostring(status)
+    local _, _, code, err = finish()
+    if err then
+      return nil, err
     end
-    if unix.WIFEXITED(status) then
-      return unix.WEXITSTATUS(status)
-    end
-    if unix.WIFSIGNALED(status) then
-      return nil, "killed by signal " .. tostring(unix.WTERMSIG(status))
-    end
-    return nil, "process terminated abnormally"
+    return code
   end
 
   --- Read output from the process.
-  --- If size is specified, reads that many bytes and returns the data as a string.
-  --- If size is not specified, drains stdout and stderr concurrently, waits for
-  --- process to exit, and returns success status, stdout output, and exit code.
-  --- @param size number Optional number of bytes to read
-  --- @return boolean|string Success status (true if exit code is 0) or output string if size specified
-  --- @return string The stdout output from the process
+  --- With a size, reads that many bytes from stdout and returns them (or
+  --- nil, err). Without a size, runs the process to completion (feeding stdin,
+  --- draining stdout+stderr) and returns success, stdout, and the exit code.
+  --- To also capture stderr, use communicate().
+  --- @param size number Optional number of bytes to read from stdout
+  --- @return boolean|string Success (exit code 0) or, with size, the data read
+  --- @return string The stdout output, or the error when size read fails
   --- @return number The exit code of the process
   function handle:read(size?: number): boolean | string, string, number
     if not self.stdout then
       return nil, "stdout not captured"
     end
-    if self.stdin then self.stdin:close() end
     if size then
+      if self.stdin then self.stdin:close(); self.stdin = nil end
       return self.stdout:read(size)
     end
-    local out, _ = drain_pipes(self.stdout, self.stderr)
-    self.stdout = nil
-    self.stderr = nil
-    local _, status = unix.wait(self.pid)
-    if type(status) ~= "number" then
-      return false, out, -1
-    end
-    local exit_code = unix.WIFEXITED(status) and unix.WEXITSTATUS(status) or -1
-    return exit_code == 0, out, exit_code
+    local out, _, code = finish()
+    return code == 0, out, code
   end
 
-  if type(opts.stdin) == "string" then
-    handle.stdin:write(opts.stdin as string)
-    handle.stdin:close()
+  --- Run the process to completion and capture both output streams.
+  --- Feeds any stdin while draining stdout and stderr concurrently, then reaps.
+  --- @return string The captured stdout
+  --- @return string The captured stderr
+  --- @return number The exit code (-1 if the process did not exit normally)
+  --- @return string An error (signal death, or a pump I/O error), or nil
+  function handle:communicate(): string, string, number, string
+    return finish()
   end
 
   return handle

--- a/lib/cosmic/child_io.tl
+++ b/lib/cosmic/child_io.tl
@@ -1,0 +1,193 @@
+--- Low-level child-process I/O primitives.
+---
+--- Holds the pipe wrapper shared by cosmic.child and a poll-driven `pump`
+--- that concurrently feeds a child's stdin while draining its stdout and
+--- stderr. Doing all three in one poll loop is what keeps large I/O in any
+--- direction from deadlocking on a full pipe buffer.
+local unix = require("cosmo.unix")
+local poll = require("cosmic.poll")
+local errno = require("cosmic.errno")
+
+-- Writing to a pipe whose read end has already closed raises SIGPIPE, whose
+-- default action terminates the process. A library that writes to a child's
+-- stdin must never let the child's early exit kill its parent, so neutralize
+-- SIGPIPE process-wide; the write then fails with EPIPE, which pump handles.
+unix.sigaction(unix.SIGPIPE, unix.SIG_IGN)
+
+local CHUNK = 65536
+
+--- A pipe endpoint. `fd` is a plain field (not a method like io.Handle:fd()).
+local record Pipe
+  fd: number
+  write: function(self: Pipe, data: string): number, string
+  read: function(self: Pipe, size?: number): string, string
+  close: function(self: Pipe)
+end
+
+--- Wrap a raw pipe fd in a Pipe. Returns nil when fd is nil.
+--- read()/write() return `nil, err` on a real I/O error; read() returns ""
+--- only on genuine end-of-file, so an error is never mistaken for EOF.
+--- @param fd number Raw file descriptor, or nil
+--- @return Pipe wrapper, or nil when fd is nil
+local function make_pipe(fd: number): Pipe
+  if not fd then
+    return nil
+  end
+  local pipe: Pipe = {fd = fd}
+
+  function pipe:write(data: string): number, string
+    local n, err = unix.write(self.fd, data)
+    if n == nil then
+      return nil, errno.str(err, "write")
+    end
+    return n
+  end
+
+  function pipe:read(size?: number): string, string
+    if size then
+      local chunk, err = unix.read(self.fd, size)
+      if chunk == nil then
+        return nil, errno.str(err, "read")
+      end
+      return chunk
+    end
+    local chunks: {string} = {}
+    while true do
+      local chunk, err = unix.read(self.fd, CHUNK)
+      if chunk == nil then
+        return nil, errno.str(err, "read")
+      end
+      if chunk == "" then
+        break
+      end
+      table.insert(chunks, chunk)
+    end
+    return table.concat(chunks)
+  end
+
+  pipe.close = function(self: Pipe)
+    if self.fd then
+      local _ = unix.close(self.fd)
+      self.fd = nil
+    end
+  end
+
+  return pipe
+end
+
+-- Put a pipe write end into non-blocking mode so a stdin write in the pump
+-- can never block the loop that is simultaneously draining stdout/stderr.
+-- F_SETFL replaces the file-status flags, but a fresh pipe write end carries
+-- none worth preserving (F_SETFL ignores the access mode), so setting
+-- O_NONBLOCK outright is safe — and F_GETFL is not usable here anyway (the
+-- runtime returns a boolean for it rather than the flag bits).
+local function set_nonblocking(fd: number): boolean, string
+  local ok = unix.fcntl(fd, unix.F_SETFL, unix.O_NONBLOCK)
+  if not ok then
+    return false, "fcntl F_SETFL O_NONBLOCK failed"
+  end
+  return true
+end
+
+--- Concurrently write `stdin_data` to `stdin_fd` while draining `stdout_fd`
+--- and `stderr_fd` to end-of-file, all in one poll loop so no direction can
+--- deadlock on a full pipe buffer. `stdin_fd` is closed when the write
+--- finishes or the child hangs up (EPIPE); stdout/stderr fds are left open
+--- for the caller to close. A read/write error stops that stream and is
+--- reported; EPIPE on stdin (the child stopped reading) is not an error.
+--- @param stdout_fd number stdout read end, or nil
+--- @param stderr_fd number stderr read end, or nil
+--- @param stdin_fd number stdin write end, or nil
+--- @param stdin_data string bytes to send to stdin, or nil
+--- @return string collected stdout
+--- @return string collected stderr
+--- @return string? first I/O error, or nil when clean
+local function pump(stdout_fd: number, stderr_fd: number, stdin_fd: number, stdin_data: string): string, string, string
+  local out: {string} = {}
+  local err_out: {string} = {}
+  local io_err: string = nil
+  local p = poll.new()
+  if stdout_fd then p:add(stdout_fd, poll.POLLIN) end
+  if stderr_fd then p:add(stderr_fd, poll.POLLIN) end
+
+  local w_off = 0
+  if stdin_fd then
+    if stdin_data and #stdin_data > 0 then
+      local ok, serr = set_nonblocking(stdin_fd)
+      if not ok then io_err = io_err or serr end
+      p:add(stdin_fd, poll.POLLOUT)
+    else
+      unix.close(stdin_fd)
+      stdin_fd = nil
+    end
+  end
+
+  -- Read whatever is ready on fd into buf; drop it from the set on EOF, a
+  -- read error, or a hangup with no pending data. When both readable and
+  -- hangup are set, data still remains, so read rather than drop.
+  local function read_ready(fd: number, buf: {string})
+    local ev = p:events(fd)
+    if not ev then return end
+    if ev.readable then
+      local chunk, rerr = unix.read(fd, CHUNK)
+      if chunk == nil then
+        io_err = io_err or errno.str(rerr, "read")
+        p:remove(fd)
+      elseif chunk == "" then
+        p:remove(fd)
+      else
+        table.insert(buf, chunk)
+      end
+    elseif ev.hangup or ev.error or ev.invalid then
+      p:remove(fd)
+    end
+  end
+
+  while not p:empty() do
+    local ready, perr = p:poll(-1)
+    if ready == nil then
+      io_err = io_err or perr
+      break
+    end
+    if stdin_fd then
+      local ev = p:events(stdin_fd)
+      if ev and ev.writable then
+        local n, werr = unix.write(stdin_fd, stdin_data:sub(w_off + 1, w_off + CHUNK))
+        if n ~= nil then
+          w_off = w_off + (n as integer)
+          if w_off >= #stdin_data then
+            p:remove(stdin_fd); unix.close(stdin_fd); stdin_fd = nil
+          end
+        elseif errno.is(werr, "EAGAIN") then
+          -- Not actually writable yet; try again on the next poll.
+        elseif errno.is(werr, "EPIPE") then
+          -- The child stopped reading stdin; stop feeding it (not an error).
+          p:remove(stdin_fd); unix.close(stdin_fd); stdin_fd = nil
+        else
+          io_err = io_err or errno.str(werr, "write stdin")
+          p:remove(stdin_fd); unix.close(stdin_fd); stdin_fd = nil
+        end
+      elseif ev and (ev.error or ev.hangup or ev.invalid) then
+        p:remove(stdin_fd); unix.close(stdin_fd); stdin_fd = nil
+      end
+    end
+    if stdout_fd then read_ready(stdout_fd, out) end
+    if stderr_fd then read_ready(stderr_fd, err_out) end
+  end
+
+  if stdin_fd then unix.close(stdin_fd) end
+  return table.concat(out), table.concat(err_out), io_err
+end
+
+local record ChildIoModule
+  Pipe: Pipe
+  make_pipe: function(fd: number): Pipe
+  pump: function(stdout_fd: number, stderr_fd: number, stdin_fd: number, stdin_data: string): string, string, string
+end
+
+local M: ChildIoModule = {
+  make_pipe = make_pipe,
+  pump = pump,
+}
+
+return M

--- a/lib/cosmic/child_io_test.tl
+++ b/lib/cosmic/child_io_test.tl
@@ -1,0 +1,103 @@
+#!/usr/bin/env cosmic
+-- Regressions for the cosmic.child I/O layer (child_io.pump): stdin is fed
+-- concurrently with stdout/stderr draining so no direction deadlocks, a child
+-- that stops reading stdin cannot SIGPIPE-kill the parent, and communicate()
+-- captures both output streams plus the exit status.
+local child = require("cosmic.child")
+local fs = require("cosmic.fs")
+-- cosmo.unix is required directly only to monkey-patch unix.pipe for fault
+-- injection (test_spawn_pipe_failure_cleans_up), which must share the exact
+-- module table that child.tl uses, and to send a signal from a child payload.
+local unix = require("cosmo.unix")
+
+local lua_bin = fs.join(os.getenv("TEST_BIN"), "cosmic")
+
+local function test_large_stdin_no_deadlock()
+  -- 256KB of stdin far exceeds the pipe buffer, and the child echoes it back,
+  -- so both directions overflow at once. Before the pump fix, spawn() wrote
+  -- stdin synchronously and blocked once the buffer filled while nobody was
+  -- draining stdout -- deadlock.
+  local big = string.rep("z", 262144)
+  local handle = child.spawn({lua_bin, "-e", "io.write(io.read('*a'))"}, {stdin = big})
+  assert(handle ~= nil, "handle should not be nil")
+  local ok, out = handle:read()
+  assert(ok, "command should succeed")
+  assert(#out == #big, "expected " .. #big .. " bytes echoed, got " .. #out)
+  assert(out == big, "echoed stdin should match input")
+end
+test_large_stdin_no_deadlock()
+
+local function test_stdin_to_early_exiting_child_no_sigpipe()
+  -- The child exits immediately without reading stdin, closing its read end.
+  -- Feeding a large stdin then hits a broken pipe: before SIGPIPE was ignored
+  -- this SIGPIPE-killed the parent (this test process). It must instead
+  -- complete cleanly and report the child's exit code.
+  local big = string.rep("q", 262144)
+  local handle = child.spawn({lua_bin, "-e", "os.exit(3)"}, {stdin = big})
+  assert(handle ~= nil, "handle should not be nil")
+  local _, _, code = handle:communicate()
+  assert(code == 3, "expected exit code 3 from early-exiting child, got " .. tostring(code))
+end
+test_stdin_to_early_exiting_child_no_sigpipe()
+
+local function test_communicate_captures_both_streams()
+  local handle = child.spawn({lua_bin, "-e", [[
+    io.write("on stdout")
+    io.flush()
+    io.stderr:write("on stderr")
+    io.stderr:flush()
+    os.exit(7)
+  ]]})
+  assert(handle ~= nil, "handle should not be nil")
+  local out, err_out, code, err = handle:communicate()
+  assert(out == "on stdout", "expected stdout 'on stdout', got '" .. tostring(out) .. "'")
+  assert(err_out == "on stderr", "expected stderr 'on stderr', got '" .. tostring(err_out) .. "'")
+  assert(code == 7, "expected exit code 7, got " .. tostring(code))
+  assert(err == nil, "expected no error on a normal exit, got " .. tostring(err))
+end
+test_communicate_captures_both_streams()
+
+local function test_communicate_reports_signal_death()
+  -- SIGKILL the child; communicate() surfaces the signal as its error and a
+  -- -1 exit code rather than pretending the process exited normally.
+  local handle = child.spawn({lua_bin, "-e", [[
+    local unix = require("cosmo.unix")
+    unix.kill(unix.getpid(), unix.SIGKILL)
+  ]]})
+  assert(handle ~= nil, "handle should not be nil")
+  local _, _, code, err = handle:communicate()
+  assert(code == -1, "expected -1 exit code for signal death, got " .. tostring(code))
+  assert(err ~= nil and err:find("signal"), "expected a signal error, got " .. tostring(err))
+end
+test_communicate_reports_signal_death()
+
+local function test_large_stdin_with_output_no_deadlock()
+  -- Large stdin AND large stdout at the same time: the child reads all of
+  -- stdin and writes twice as much to stdout. The pump must interleave the
+  -- write and both reads.
+  local big = string.rep("m", 200000)
+  local handle = child.spawn({lua_bin, "-e", [[
+    local data = io.read("*a")
+    io.write(data)
+    io.write(data)
+  ]]}, {stdin = big})
+  assert(handle ~= nil, "handle should not be nil")
+  local out, err_out, code = handle:communicate()
+  assert(code == 0, "expected exit 0, got " .. tostring(code))
+  assert(#out == 2 * #big, "expected " .. (2 * #big) .. " bytes, got " .. #out)
+  assert(err_out == "", "expected empty stderr, got " .. #err_out .. " bytes")
+end
+test_large_stdin_with_output_no_deadlock()
+
+local function test_spawn_pipe_failure_cleans_up()
+  -- Monkey-patch unix.pipe to fail, as the fork-failure test does for fork.
+  -- spawn() must unwind cleanly and return an error, not leak fds or crash.
+  local real_pipe = rawget(unix, "pipe")
+  rawset(unix, "pipe", function(): number, number return nil, nil end)
+  local handle, err = child.spawn({lua_bin, "-e", "print('x')"})
+  rawset(unix, "pipe", real_pipe)
+  assert(handle == nil, "expected nil handle on pipe failure, got: " .. tostring(handle))
+  assert(type(err) == "string" and err:find("pipe", 1, true),
+    "expected a 'pipe' error, got: " .. tostring(err))
+end
+test_spawn_pipe_failure_cleans_up()

--- a/lib/cosmic/poll.tl
+++ b/lib/cosmic/poll.tl
@@ -1,6 +1,7 @@
 --- Typed interface for polling file descriptors.
 --- Provides an ergonomic wrapper around unix.poll().
 local unix = require("cosmo.unix")
+local errno = require("cosmic.errno")
 
 --- Poll event flags.
 --- Use these to specify which events to monitor.
@@ -41,6 +42,9 @@ local record Poller
   clear: function(Poller)
   --- Poll for events with optional timeout.
   --- Returns an iterator over (fd, events) pairs for ready descriptors.
+  --- EINTR is retried internally. A hard poll error yields an empty iterator
+  --- (indistinguishable from a timeout); callers that must detect errors
+  --- should use poll() directly, which returns them.
   --- @param timeoutms number Timeout in ms (-1 for infinite, 0 for non-blocking)
   --- @return function Iterator yielding (fd: number, events: Events)
   wait: function(Poller, number): function(): number, Events
@@ -120,9 +124,20 @@ local function new(): Poller
   end
 
   poller.poll = function(self: Poller, timeoutms: number): number, string
-    results = unix.poll(fds, timeoutms or -1)
+    -- Retry when a signal interrupts the wait: an unretried EINTR otherwise
+    -- surfaces as a poll failure, and a caller that loops on it (e.g. a drain
+    -- loop waiting on a child that raised SIGCHLD) spins at 100% CPU.
+    local res: {number: number}
+    local err: unix.Errno
+    while true do
+      res, err = unix.poll(fds, timeoutms or -1)
+      if res ~= nil or not errno.is(err, "EINTR") then
+        break
+      end
+    end
+    results = res
     if not results then
-      return nil, "poll failed"
+      return nil, errno.str(err, "poll")
     end
     local ready = 0
     for _ in pairs(results) do


### PR DESCRIPTION
## Summary

Executes **Phase 1 step 9** — the last item in the phase — from the [audit remediation plan](https://github.com/whilp/cosmic/pull/420): the `child.tl` / `poll.tl` process-I/O hazards (audit §2.2). Because `child.tl` was already at the 500-line limit, the pipe wrapper and a new poll-driven pump are extracted into `child_io.tl`.

The plan sequenced this last because it's the highest-complexity item and touches the most-used spawning API. API changes here are intentional (the owner OK'd breaking the API for safety/ergonomics).

## The hazards & fixes

**`poll.tl`**
- `Poller:poll()` now **retries `EINTR`** and returns the real errno on a hard error. An unretried `EINTR` (e.g. the `SIGCHLD` raised when a child exits) made a caller looping on `poll()` **spin at 100% CPU** — the child drain loop did exactly that.

**`child_io.tl` (new)**
- `pump()` feeds stdin **and** drains stdout+stderr in one poll loop, so large I/O in any direction **cannot deadlock**. stdin is written non-blocking.
- **SIGPIPE is set to `SIG_IGN`** at load. Writing to a child that stopped reading stdin previously **killed the parent process** — verified locally (process exited 141 = 128+SIGPIPE). It now fails with `EPIPE`, which the pump handles.
- `Pipe:read()` returns `nil, err` on a real I/O error and `""` **only** on genuine EOF, so a read error is no longer silently truncated into end-of-input.

**`child.tl`**
- `opts.stdin` strings are delivered **lazily through the pump** during `wait()`/`read()`/`communicate()` instead of a synchronous write in `spawn()` that deadlocked on `>`pipe-buffer input and SIGPIPE-killed the parent.
- `unix.pipe()` results are checked; a mid-way failure (fd exhaustion) **unwinds cleanly and releases the exec fd**, which previously leaked on that path.
- New **`handle:communicate()`** → `(stdout, stderr, exit_code, err)` — the first high-level way to capture **both** streams. `wait()`/`read()` are re-expressed over a shared `finish()`.

## API changes (intentional)

- `Pipe:read()`/`Pipe:write()` now return `(value, err)` rather than swallowing errors; the `Pipe` type moved to `cosmic.child_io` (re-referenced by `child.tl`).
- `opts.stdin` string delivery moved from `spawn()` to the completion methods (`wait`/`read`/`communicate`). A child that is spawned with an `opts.stdin` string must be waited on/read/communicated for the input to be sent — every existing call site already does.

## Test plan

- `bin/make teal` — 199/199
- `bin/make format` — 199/199
- `bin/make lint` — 257/257
- `bin/make test` — full suite green (95 checks); `bin/make example` green
- New regressions in `child_io_test.tl`: 256KB stdin round-trip (deadlock), large stdin + large stdout interleaved, stdin to an early-exiting child (SIGPIPE), `communicate()` capturing both streams, signal-death reporting, and `pipe()`-failure fd cleanup via fault injection.

This completes Phase 1 (steps 5–9). Next phases: 2 (portability/CI), 3 (tests/docs), 4 (batteries), 5 (perf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01E8bf2Y1P1XAEPKpgoEVnpR)_