### PR TITLE
perf: end-to-end benchmark harness with functional-check and regression gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ lib/
     *_example.tl       runnable examples
   build/               build infrastructure (fetch, stage, reporter)
   docs/                doc publishing
+  perf/                performance benchmark harness (see lib/perf/OPTIMIZE.md)
   types/               cosmo.* type declarations (generated) + gentype generator
 3p/
   cosmos/              Cosmopolitan Lua binary + zip tool
@@ -278,6 +279,23 @@ test_something()
 ```
 
 each test gets its own temp directory via `TEST_TMPDIR`.
+
+## Performance
+
+`lib/perf` holds the benchmark harness: end-to-end scenarios (JSON, SQLite,
+HTTP, fs, crypto/codecs, binary startup) with per-scenario functional
+checks, a JSON results format, and a noise-aware baseline comparison gate.
+
+```bash
+bin/make perf                 # run scenarios, write o/perf/current.json
+bin/make perf-baseline        # snapshot baseline before optimizing
+bin/make perf-compare         # re-run and fail on regression vs baseline
+```
+
+all performance work follows the loop in `lib/perf/OPTIMIZE.md`: baseline →
+hypothesis → change → `bin/make ci` (correctness/style gate) →
+`bin/make perf-compare` (regression gate) → keep or revert. never weaken a
+scenario or its check to make numbers pass; never commit `o/perf/*.json`.
 
 ## CI
 

--- a/lib/build/make-help.tl
+++ b/lib/build/make-help.tl
@@ -116,15 +116,28 @@ end
 
 -- Main execution
 local function main(args: {string}): number, string
-  local makefile = args[1] or "Makefile"
-
-  local content, read_err = cio.slurp(makefile)
-  if not content then
-    return 1, "Failed to read " .. makefile .. ": " .. (read_err or "unknown error")
+  local makefiles: {string} = {}
+  for _, a in ipairs(args) do
+    table.insert(makefiles, a)
+  end
+  if #makefiles == 0 then
+    makefiles = {"Makefile"}
   end
 
-  local targets = parse_makefile(content)
-  print(format_help(targets))
+  -- Aggregate documented targets and options across every makefile given
+  -- (make passes $(MAKEFILE_LIST), so included cook.mk files count too).
+  local items: {Item} = {}
+  for _, makefile in ipairs(makefiles) do
+    local content, read_err = cio.slurp(makefile)
+    if not content then
+      return 1, "Failed to read " .. makefile .. ": " .. (read_err or "unknown error")
+    end
+    for _, item in ipairs(parse_makefile(content)) do
+      table.insert(items, item)
+    end
+  end
+
+  print(format_help(items))
   return 0
 end
 

--- a/lib/cook.mk
+++ b/lib/cook.mk
@@ -7,4 +7,5 @@ types_files := $(wildcard lib/types/*.d.tl lib/types/*/*.d.tl lib/types/*/*/*.d.
 include lib/build/cook.mk
 include lib/cosmic/cook.mk
 include lib/docs/cook.mk
+include lib/perf/cook.mk
 include lib/types/cook.mk

--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -1,0 +1,148 @@
+# Optimizing cosmic performance
+
+this document is the operating manual for performance work on cosmic. it
+defines a measurement-driven loop with hard gates, so optimization can be
+executed mechanically — including by an agent — without risking functional
+or style regressions. read it top to bottom once before changing anything.
+
+## the harness in one minute
+
+`lib/perf` benchmarks ~20 end-to-end scenarios (JSON, SQLite, HTTP client,
+filesystem, hashing/codecs/compression, binary startup, Teal compilation).
+every scenario validates its own output with a `check()` function, so a
+change that makes a workload faster but wrong FAILS the benchmark.
+
+```bash
+bin/make perf                 # run all scenarios, write o/perf/current.json
+bin/make perf-baseline        # snapshot results to o/perf/baseline.json
+bin/make perf-compare         # re-run and fail on regression vs baseline
+bin/make perf PERF_ONLY=json  # filter scenarios by Lua pattern
+```
+
+knobs: `PERF_SAMPLES` (default 5), `PERF_MIN_SECS` (default 0.15),
+`PERF_THRESHOLD` (regression bar in percent, default 10), `PERF_BIN`
+(which cosmic binary to measure).
+
+report columns, per scenario:
+
+```
+sqlite_point_query    4537 x   12.62 µs/op  ± 0.7%  cpu/wall 1.00  alloc 2.36 KB
+```
+
+- `N x` iterations per sample; `µs/op` is the median across samples.
+- `±%` spread across samples — treat deltas smaller than this as noise.
+- `cpu/wall` — near 1.0 means CPU-bound (optimize algorithms/allocations);
+  well below 1.0 means the time is in syscalls, I/O, or child processes.
+- `alloc` — Lua-side KB allocated per op; high values mean GC pressure.
+
+## the optimization loop
+
+work ONE scenario (or one closely related group) at a time.
+
+1. **baseline** on a quiet machine, from a clean tree:
+   `git status` must be clean, then `bin/make perf-baseline`.
+2. **pick a target** (see "finding opportunities" below). state a
+   hypothesis: *"X is slow because Y; changing Z should cut ns/op by W%."*
+3. **change the code.** smallest diff that tests the hypothesis. follow
+   every repo convention (AGENTS.md): Teal, 2-space indent, ≤500-line
+   files, `value, string` error returns, wrappers keep their documented
+   behavior and error messages.
+4. **gate 1 — correctness and style:** `bin/make ci` must pass
+   (format + type check + tests + examples). the perf smoke test
+   (`lib/perf/perf_test.tl`) runs every scenario end to end in CI, so a
+   broken scenario check fails here too.
+5. **gate 2 — performance:** `bin/make perf-compare`. it re-measures,
+   compares against your baseline with a noise-aware bar
+   (max of `PERF_THRESHOLD`, baseline spread, current spread), retries
+   once on failure to filter machine noise, and exits nonzero if any
+   scenario regressed, errored, or disappeared.
+6. **decide.**
+   - target scenario improved beyond its noise bar and nothing else
+     regressed → keep it.
+   - no measurable improvement, or anything else regressed → `git
+     checkout` the change and record the failed hypothesis.
+7. **commit**, quoting before/after numbers for the affected scenarios in
+   the commit message (copy the `perf-compare` lines).
+
+## hard rules (guardrails)
+
+- NEVER delete, rename, or weaken a scenario or its `check()` to make a
+  comparison pass. `perf-compare` treats missing scenarios as failures and
+  the smoke test rejects scenarios without checks — do not work around
+  either. renames belong in a separate, no-code-change commit that also
+  re-baselines.
+- NEVER commit `o/perf/*.json`. baselines are machine-specific and live
+  only in your working `o/` directory.
+- a wrapper's observable behavior (return values, error strings, edge
+  cases like empty input) is part of its contract. optimizations that
+  change behavior are rejected by `bin/make ci` / scenario checks — fix
+  the approach, not the test.
+- one hypothesis per commit. if `bin/make ci` fails, you are done with
+  that hypothesis until it passes; never trade correctness for speed.
+- benchmarks live under `lib/perf/bench/` and use `cosmic.*` modules only
+  (never raw `cosmo.*`) — they measure what users experience.
+
+## finding opportunities
+
+read `bin/make perf` output and look for:
+
+- **implementation mismatches between siblings.** example found during
+  harness bring-up: `codec_hex_roundtrip_64k` ran ~17.6ms while
+  `codec_base64_roundtrip_64k` ran ~2.1ms on the same input. cause:
+  `codec.decode_hex` is a pure-Lua `gsub` with a per-byte-pair callback
+  plus two validation scans, while a `cosmo.DecodeHex` C binding exists
+  (`lib/types/cosmo.d.tl`). preserving the documented error returns while
+  delegating the hot path is the archetypal cosmic-layer win.
+- **high `alloc` with high ns/op** — allocation-heavy Lua (string
+  concatenation in loops, per-item closures). e.g. `json_decode_large`
+  allocates ~375KB/op; how much is unavoidable C-side table building vs
+  wrapper overhead is a question worth answering.
+- **`cpu/wall ≈ 1.0` on I/O scenarios** — a workload you expected to be
+  I/O-bound but that burns CPU (e.g. rebuilding strings per chunk).
+- **pairs of scenarios that bracket a layer.** `http_fetch_get` vs
+  `http_tcp_roundtrip` isolates the fetch-wrapper overhead from raw
+  socket cost; `startup_run_teal` vs `startup_run_lua` isolates the Teal
+  loader (~13ms today) from runtime boot (~14.5ms).
+- **profile a single scenario** by bisection: `bin/make perf
+  PERF_ONLY=<name>` is cheap; temporarily splitting a scenario's fn into
+  narrower scenarios in a scratch bench file localizes the cost. delete
+  scratch scenarios before committing.
+
+if a workload you want to optimize has no scenario, add one FIRST (in a
+`lib/perf/bench/*_bench.tl` module, with a real `check()`), baseline it,
+then optimize.
+
+## optimizing the cosmo/cosmopolitan layer end to end
+
+scenarios call `cosmic.*` wrappers, which call the `cosmo.*` C bindings
+from the pinned cosmos binary, so C-layer changes show up in the same
+numbers. `startup_*` scenarios additionally cover the APE loader, zip
+filesystem, and Lua boot — the parts that only change when the
+cosmopolitan pin changes.
+
+to evaluate a cosmopolitan-side change (in whilp/cosmopolitan):
+
+1. baseline with the current pin: `bin/make perf-baseline`.
+2. build or fetch a cosmos release with the change and produce a cosmic
+   binary from it: bump `3p/cosmos/version.lua` (url + sha256), run
+   `bin/make regen-types && bin/make build` and fix any wrapper breakage
+   (see AGENTS.md "Type Generation").
+3. `bin/make perf-compare` now measures old pin vs new pin with identical
+   scenarios. `PERF_BIN=/path/to/other/cosmic bin/make perf` measures any
+   prebuilt binary without touching the pin; results record the binary in
+   `meta.bin`.
+
+## measurement discipline
+
+- machine noise is real: nothing else heavy runs during measurement;
+  baseline and comparison run on the same machine, same power state.
+- the compare bar auto-widens to each scenario's observed spread, and
+  `perf-compare` re-measures once before failing — but if results still
+  look inconsistent, re-run `perf-compare`; a genuine change reproduces
+  in the same direction every time.
+- prefer default `PERF_SAMPLES`/`PERF_MIN_SECS` for accept/reject
+  decisions; use lower values only for quick scouting.
+- scenarios must be stationary: an op must not get slower the more often
+  it runs (growing tables, leaking fds, write-churn on overlay
+  filesystems). the insert scenario deletes inside its transaction and
+  fs scenarios stick to stable operations for exactly this reason.

--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -84,7 +84,8 @@ work ONE scenario (or one closely related group) at a time.
 
 ## finding opportunities
 
-read `bin/make perf` output and look for:
+check the hypothesis backlog below first — it holds vetted, evidence-backed
+starting points. to find new ones, read `bin/make perf` output and look for:
 
 - **implementation mismatches between siblings.** example found during
   harness bring-up: `codec_hex_roundtrip_64k` ran ~17.6ms while
@@ -111,6 +112,106 @@ read `bin/make perf` output and look for:
 if a workload you want to optimize has no scenario, add one FIRST (in a
 `lib/perf/bench/*_bench.tl` module, with a real `check()`), baseline it,
 then optimize.
+
+## hypothesis backlog
+
+concrete, evidence-backed starting points, ordered by expected
+value-for-effort. numbers are from harness bring-up on the CI container
+(2026-07); re-baseline on your machine before trusting them.
+
+work the backlog like this: pick ONE entry, run the loop above, then
+update the entry in the same commit — `done` (commit hash + before/after
+numbers) or `rejected` (measured numbers + why the hypothesis was wrong).
+rejected entries stay in the file; they save the next agent from
+re-testing a dead end. add new entries as `open` when a report line or
+code read suggests one.
+
+1. **hex decode via the C binding** — open
+   - scenario: `codec_hex_roundtrip_64k` (~17.3ms; base64 does the same
+     64KB in ~2.1ms)
+   - evidence: `codec.decode_hex` (lib/cosmic/codec.tl) is a pure-Lua
+     `gsub("(%x%x)", callback)` — one closure call per byte pair, ~32k
+     for 64KB — plus two full-string validation scans. `cosmo.DecodeHex`
+     exists (lib/types/cosmo.d.tl:130) and is unused.
+   - hypothesis: delegating the hot path to `cosmo.DecodeHex` while
+     keeping the documented `value, string` error returns (even-length
+     and hex-character validation semantics must not change) cuts the
+     roundtrip by ~5-8x.
+   - risk: low. check how the C binding handles odd length, invalid
+     chars, uppercase, and empty string; keep Lua-side validation where
+     the binding's behavior differs.
+
+2. **sqlite prepared-statement reuse** — open
+   - scenarios: `sqlite_insert_delete_tx` (~680µs for 100 inserts + 1
+     delete ≈ 6.6µs/row), `sqlite_point_query` (~12.7µs)
+   - evidence: `db:exec(sql, ...)` and `db:query(sql, ...)`
+     (lib/cosmic/sqlite.tl) prepare, bind, and finalize a fresh statement
+     on every parameterized call; the insert scenario pays 100
+     prepares per transaction for the same SQL string.
+   - hypothesis: a small per-database cache of prepared statements keyed
+     by SQL text (reset + rebind on hit, finalize on close/eviction)
+     cuts parameterized exec/query by 20-50%.
+   - risk: medium. statement lifetime vs `db:close`, statements held
+     mid-iteration, cache invalidation on schema change (sqlite returns
+     SQLITE_SCHEMA; re-prepare on that error). start with exec-only.
+
+3. **startup: Teal loader cost** — open
+   - scenarios: `startup_run_teal` (~30ms) vs `startup_run_lua` (~16.5ms)
+   - evidence: running a one-line `.tl` script costs ~13ms more than the
+     identical `.lua` script, and `startup_compile_teal` (~32ms) shows
+     compile of a tiny module costs about the same as running it — the
+     overhead is dominated by loading the embedded Teal compiler and
+     type environment, not by compiling the script.
+   - hypothesis: (a) lazy-load the compiler strictly on the `.tl` path
+     (verify `.lua` scripts never pay it), and (b) cache compiled output
+     next to the script or under a cache dir keyed by mtime/hash, making
+     repeat runs of unchanged `.tl` scripts cost `.lua` startup.
+   - risk: medium. cache invalidation and write-permission fallbacks;
+     measure step (a) first with `instrument` spans in main.tl.
+
+4. **startup: runtime boot floor (cosmopolitan side)** — open
+   - scenario: `startup_run_lua` (~14.5-16.5ms for `print()`)
+   - evidence: this is the APE loader + zip filesystem + Lua init + the
+     eager `require`s in cosmic's main.lua, measured end to end.
+   - hypothesis: part of the floor is cosmic-side eager module loading in
+     main.tl (imports pulled in before the script path is even known);
+     deferring dispatch-only imports trims 1-3ms. the remainder is
+     cosmos-side (zip central-directory scan, stdlib init) — measure with
+     the pinned raw cosmos `lua` binary as `PERF_BIN` denominator before
+     touching whilp/cosmopolitan.
+   - risk: low for the import-deferral step; cosmopolitan-side work
+     follows the "optimizing the cosmo/cosmopolitan layer" section.
+
+5. **fs.walk per-entry cost** — open (evidence-gathering)
+   - scenario: `fs_walk_tree` (~390µs for 210 entries ≈ 1.9µs/entry,
+     ~200B allocated per entry)
+   - evidence: `fs_walk.tl` calls `unix.stat` on every entry (needed
+     today to detect directories) and allocates a joined path string +
+     stat userdata per entry.
+   - hypothesis: if the dirent from `handle:read()` can expose the entry
+     type (d_type is available on Linux; check the cosmo opendir
+     binding), directory detection skips one stat syscall per
+     non-directory entry — roughly halving syscalls for file-heavy trees.
+   - risk: needs a binding check first; d_type is DT_UNKNOWN on some
+     filesystems, so the stat fallback must remain.
+
+6. **string.split micro-costs** — open, low priority
+   - scenario: `string_split_csv` (~50µs for 256 fields ≈ 190ns/field)
+   - evidence: implementation already uses plain `find`; remaining cost
+     is `table.insert` (a C call resolving `#result` each time) and one
+     `sub` per field.
+   - hypothesis: indexed assignment (`n = n + 1; result[n] = ...`) trims
+     10-20% of this scenario. real user impact is small — do it only as
+     a warm-up exercise for the loop, or skip.
+
+7. **json decode allocation pressure** — rejected for now (2026-07)
+   - scenario: `json_decode_large` (~1.3ms/op, ~375KB allocated per op)
+   - finding: the wrapper (lib/cosmic/json.tl) is a two-line delegation
+     to `cosmo.DecodeJson`; the allocation is the decoded table graph
+     itself (1000 records × maps/arrays), which is the workload's
+     output, not overhead. no cosmic-layer fix exists; a
+     cosmopolitan-side arena would change object lifetimes. revisit only
+     if a scenario shows GC pauses dominating a real workload.
 
 ## optimizing the cosmo/cosmopolitan layer end to end
 

--- a/lib/perf/bench/fs_bench.tl
+++ b/lib/perf/bench/fs_bench.tl
@@ -1,0 +1,142 @@
+--- Filesystem scenarios: directory walking, whole-file I/O, tree churn.
+--- Exercises cosmic.fs and cosmic.io wrappers over the cosmo unix/path
+--- C bindings, against a real temp directory tree.
+
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
+local pt = require("perf.perf_types")
+
+local DIRS = 10
+local FILES_PER_DIR = 20
+local BLOB = string.rep("cosmic performance harness line\n", 2048)
+
+local tmpdir: string
+
+--- Base directory for scratch files.
+--- @return string An existing writable directory
+local function tmp_base(): string
+  return os.getenv("TEST_TMPDIR") or os.getenv("TMPDIR") or "/tmp"
+end
+
+--- Create the scratch tree: DIRS directories of FILES_PER_DIR small files.
+--- @return string Error message, or nil on success
+local function init_tree(): string
+  local dir, derr = fs.mkdtemp(fs.join(tmp_base(), "perf-fs-XXXXXX"))
+  if dir == nil then
+    return "mkdtemp: " .. tostring(derr)
+  end
+  tmpdir = dir
+  for d = 1, DIRS do
+    local sub = fs.join(dir, "dir-" .. d)
+    local ok, merr = fs.makedirs(sub)
+    if not ok then
+      return "makedirs: " .. tostring(merr)
+    end
+    for f = 1, FILES_PER_DIR do
+      local wok, werr = cio.barf(fs.join(sub, "file-" .. f .. ".txt"),
+        "data-" .. d .. "-" .. f .. "\n")
+      if not wok then
+        return "barf: " .. tostring(werr)
+      end
+    end
+  end
+  return nil
+end
+
+local function scenarios(): {pt.Scenario}, string
+  local ierr = init_tree()
+  if ierr then
+    return nil, ierr
+  end
+  local blob_path = fs.join(tmpdir, "blob.bin")
+  -- Entries visited under tmpdir: each subdirectory plus its files. The
+  -- blob and churn paths live at the top level and are counted separately.
+  local tree_entries = DIRS + DIRS * FILES_PER_DIR
+
+  return {
+    {
+      name = "fs_walk_tree",
+      fn = function(_: any): any
+        local count = 0
+        fs.walk(tmpdir, function(path: string, _name: string, _st: any, _ctx: any)
+            -- Only count the seeded tree so fs_barf_slurp's blob (created
+            -- by a sibling scenario) does not change the expected total.
+            if path:find("dir-", 1, true) then
+              count = count + 1
+            end
+          end)
+        return count
+      end,
+      check = function(_: any, res: any): boolean, string
+        local count = res as integer
+        if count ~= tree_entries then
+          return false, string.format("walked %s entries, want %d",
+            tostring(count), tree_entries)
+        end
+        return true
+      end,
+    },
+    {
+      name = "fs_barf_slurp_64k",
+      fn = function(_: any): any
+        local wok, werr = cio.barf(blob_path, BLOB)
+        assert(wok, werr)
+        local data, rerr = cio.slurp(blob_path)
+        assert(data, rerr)
+        return data
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res as string ~= BLOB then
+          return false, "read back different content"
+        end
+        return true
+      end,
+    },
+    {
+      -- Read-only metadata pass over the seeded tree. Write-churn
+      -- scenarios (mkdir+rmrf) drift monotonically on overlay
+      -- filesystems, which breaks baseline comparisons, so this
+      -- deliberately sticks to stat.
+      name = "fs_stat_tree",
+      fn = function(_: any): any
+        local size_total: number = 0
+        for d = 1, DIRS do
+          for f = 1, FILES_PER_DIR do
+            local st, serr = fs.stat(fs.join(tmpdir, "dir-" .. d, "file-" .. f .. ".txt"))
+            assert(st, serr)
+            size_total = size_total + st:size()
+          end
+        end
+        return size_total
+      end,
+      check = function(_: any, res: any): boolean, string
+        -- Each file holds "data-<d>-<f>\n"; sizes are deterministic.
+        local expected = 0
+        for d = 1, DIRS do
+          for f = 1, FILES_PER_DIR do
+            expected = expected + #("data-" .. d .. "-" .. f .. "\n")
+          end
+        end
+        if res as number ~= expected then
+          return false, string.format("stat size total %s, want %d",
+            tostring(res), expected)
+        end
+        return true
+      end,
+    },
+  }
+end
+
+local function cleanup()
+  if tmpdir then
+    fs.rmrf(tmpdir)
+    tmpdir = nil
+  end
+end
+
+local M: pt.BenchModule = {
+  scenarios = scenarios,
+  cleanup = cleanup,
+}
+
+return M

--- a/lib/perf/bench/http_bench.tl
+++ b/lib/perf/bench/http_bench.tl
@@ -1,0 +1,147 @@
+--- HTTP client scenarios against a loopback server.
+--- A forked child serves fixed HTTP/1.1 responses on 127.0.0.1; the
+--- scenarios time the full client path: cosmic.fetch (the cosmo Fetch
+--- C binding) and a raw cosmic.net TCP round trip for comparison.
+--- The gap between the two is the fetch-layer overhead.
+
+local net = require("cosmic.net")
+local fetch = require("cosmic.fetch")
+local child = require("cosmic.child")
+local signal = require("cosmic.signal")
+local pt = require("perf.perf_types")
+
+local LOCALHOST = 0x7f000001
+local BODY = "hello from the perf harness server"
+local RESPONSE = "HTTP/1.1 200 OK\r\n"
+.. "Content-Type: text/plain\r\n"
+.. "Content-Length: " .. #BODY .. "\r\n"
+.. "Connection: close\r\n\r\n"
+.. BODY
+
+local server_pid: number
+local listener: net.Socket
+
+--- Read from a connection until the end of the request headers.
+--- @param conn Socket The accepted connection
+--- @return boolean True when a full request head was read
+local function read_request(conn: net.Socket): boolean
+  local buf = ""
+  while not buf:find("\r\n\r\n", 1, true) do
+    local data = conn:recv(4096)
+    if data == nil or #data == 0 then
+      return false
+    end
+    buf = buf .. data
+  end
+  return true
+end
+
+--- Accept loop run inside the forked server child. Never returns.
+--- @param srv Socket The listening socket
+local function serve_loop(srv: net.Socket)
+  while true do
+    local conn = srv:accept()
+    if conn then
+      if read_request(conn) then
+        conn:send(RESPONSE)
+      end
+      conn:close()
+    end
+  end
+end
+
+local function scenarios(): {pt.Scenario}, string
+  local srv, port, lerr = net.listen_tcp(LOCALHOST, 0)
+  if srv == nil then
+    return nil, "listen_tcp: " .. tostring(lerr)
+  end
+  listener = srv
+  local pid = child.fork()
+  if pid == 0 then
+    serve_loop(srv)
+    os.exit(0)
+  end
+  if pid == nil or pid < 0 then
+    return nil, "fork failed"
+  end
+  server_pid = pid
+  -- cosmo.Fetch refuses direct connections to private IPs (SSRF
+  -- protection, no opt-out), but proxied requests skip that check.
+  -- Point the proxy at the loopback server; it answers every request
+  -- with the same fixed response, so the full fetch code path runs.
+  local proxy = "http://127.0.0.1:" .. port
+  local url = "http://bench.invalid/"
+
+  return {
+    {
+      name = "http_fetch_get",
+      fn = function(_: any): any
+        return fetch.Fetch(url, {proxy = proxy})
+      end,
+      check = function(_: any, res: any): boolean, string
+        local r = res as fetch.Result
+        if r == nil then
+          return false, "no result"
+        end
+        if not r.ok then
+          return false, "fetch failed: " .. tostring(r.error)
+        end
+        if r.status ~= 200 then
+          return false, "status " .. tostring(r.status)
+        end
+        if r.body ~= BODY then
+          return false, "wrong body"
+        end
+        return true
+      end,
+    },
+    {
+      name = "http_tcp_roundtrip",
+      fn = function(_: any): any
+        local sock, cerr = net.connect_tcp(LOCALHOST, port)
+        assert(sock, cerr)
+        local sent, serr = sock:send("GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n")
+        assert(sent, serr)
+        local buf = ""
+        while true do
+          local data = sock:recv(4096)
+          if data == nil or #data == 0 then
+            break
+          end
+          buf = buf .. data
+        end
+        sock:close()
+        return buf
+      end,
+      check = function(_: any, res: any): boolean, string
+        local s = res as string
+        if s == nil or not s:find("200 OK", 1, true) then
+          return false, "no 200 response"
+        end
+        if not s:find(BODY, 1, true) then
+          return false, "body missing from response"
+        end
+        return true
+      end,
+    },
+  }
+end
+
+local function cleanup()
+  if server_pid and server_pid > 0 then
+    child.kill(server_pid, signal.SIGKILL)
+    child.wait(server_pid)
+    server_pid = nil
+  end
+  if listener then
+    listener:close()
+    listener = nil
+  end
+end
+
+local M: pt.BenchModule = {
+  scenarios = scenarios,
+  cleanup = cleanup,
+}
+
+return M

--- a/lib/perf/bench/json_bench.tl
+++ b/lib/perf/bench/json_bench.tl
@@ -1,0 +1,117 @@
+--- JSON scenarios: decode/encode of small and large payloads.
+--- Exercises cosmic.json wrappers and the cosmo DecodeJson/EncodeJson
+--- C bindings end to end.
+
+local json = require("cosmic.json")
+local pt = require("perf.perf_types")
+
+local SMALL = [[{"name":"cosmic","version":3,"tags":["lua","teal","cosmo"],"nested":{"a":1,"b":true,"c":null}}]]
+local LARGE_ITEMS = 1000
+
+--- Build a deterministic 1000-record payload.
+--- @return {any} The records
+local function build_large(): {any}
+  local items: {any} = {}
+  for i = 1, LARGE_ITEMS do
+    items[i] = {
+      id = i,
+      name = "item-" .. i,
+      active = i % 2 == 0,
+      score = i * 0.5,
+      tags = {"alpha", "beta", "gamma"},
+    }
+  end
+  return items
+end
+
+local large_table = build_large()
+local large_json = json.encode(large_table)
+
+local function scenarios(): {pt.Scenario}, string
+  return {
+    {
+      name = "json_decode_small",
+      fn = function(_: any): any
+        return (json.decode(SMALL))
+      end,
+      check = function(_: any, res: any): boolean, string
+        local t = res as {string: any}
+        if t == nil then
+          return false, "decode returned nil"
+        end
+        if t.name ~= "cosmic" then
+          return false, "bad name: " .. tostring(t.name)
+        end
+        local tags = t.tags as {any}
+        if tags == nil or #tags ~= 3 then
+          return false, "bad tags"
+        end
+        return true
+      end,
+    },
+    {
+      name = "json_decode_large",
+      fn = function(_: any): any
+        return (json.decode(large_json))
+      end,
+      check = function(_: any, res: any): boolean, string
+        local items = res as {{string: any}}
+        if items == nil or #items ~= LARGE_ITEMS then
+          return false, "bad item count"
+        end
+        if items[500].id ~= 500 or items[500].name ~= "item-500" then
+          return false, "bad item content"
+        end
+        return true
+      end,
+    },
+    {
+      name = "json_encode_large",
+      fn = function(_: any): any
+        return (json.encode(large_table))
+      end,
+      check = function(_: any, res: any): boolean, string
+        local s = res as string
+        if s == nil or #s == 0 then
+          return false, "encode returned nothing"
+        end
+        local items = json.decode(s) as {{string: any}}
+        if items == nil or #items ~= LARGE_ITEMS then
+          return false, "roundtrip lost items"
+        end
+        if items[LARGE_ITEMS].name ~= "item-" .. LARGE_ITEMS then
+          return false, "roundtrip corrupted content"
+        end
+        return true
+      end,
+    },
+    {
+      name = "json_roundtrip_small",
+      fn = function(_: any): any
+        local decoded = json.decode(SMALL)
+        return (json.encode(decoded))
+      end,
+      check = function(_: any, res: any): boolean, string
+        local s = res as string
+        if s == nil then
+          return false, "roundtrip returned nil"
+        end
+        local t = json.decode(s) as {string: any}
+        if t == nil or t.version ~= 3 then
+          return false, "roundtrip corrupted content"
+        end
+        return true
+      end,
+    },
+  }
+end
+
+local function cleanup()
+end
+
+local M: pt.BenchModule = {
+  scenarios = scenarios,
+  cleanup = cleanup,
+}
+
+return M

--- a/lib/perf/bench/micro_bench.tl
+++ b/lib/perf/bench/micro_bench.tl
@@ -1,0 +1,124 @@
+--- CPU-bound scenarios: hashing, encoding, compression, string handling.
+--- Exercises the cosmo crypto/codec C bindings and pure-Lua cosmic.string
+--- code. Checks use known-answer vectors and round-trip properties, so a
+--- faster-but-wrong implementation fails instead of winning.
+
+local hash = require("cosmic.hash")
+local codec = require("cosmic.codec")
+local compress = require("cosmic.compress")
+local cstr = require("cosmic.string")
+local pt = require("perf.perf_types")
+
+-- NIST SHA-256 test vector: one million repetitions of "a".
+local A_MILLION = string.rep("a", 1000000)
+local SHA_A_MILLION = "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0"
+
+local CSV_FIELDS = 256
+
+--- Build a deterministic ~64KB blob with enough variety to be a fair
+--- compression and encoding workload.
+--- @return string The blob
+local function build_blob(): string
+  local parts: {string} = {}
+  for i = 1, 1024 do
+    parts[i] = string.format(
+      "record %04d: the quick brown fox jumps over the lazy dog %d\n",
+      i, i * 37)
+  end
+  return table.concat(parts)
+end
+
+--- Build a deterministic CSV line of CSV_FIELDS fields.
+--- @return string The line
+local function build_csv(): string
+  local fields: {string} = {}
+  for i = 1, CSV_FIELDS do
+    fields[i] = "field-" .. i
+  end
+  return table.concat(fields, ",")
+end
+
+local BLOB = build_blob()
+local CSV = build_csv()
+
+local function scenarios(): {pt.Scenario}, string
+  return {
+    {
+      name = "hash_sha256_1mb",
+      fn = function(_: any): any
+        return hash.sha256_hex(A_MILLION)
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res as string ~= SHA_A_MILLION then
+          return false, "digest mismatch: " .. tostring(res)
+        end
+        return true
+      end,
+    },
+    {
+      name = "codec_hex_roundtrip_64k",
+      fn = function(_: any): any
+        local encoded = codec.encode_hex(BLOB)
+        return (codec.decode_hex(encoded))
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res as string ~= BLOB then
+          return false, "hex roundtrip corrupted data"
+        end
+        return true
+      end,
+    },
+    {
+      name = "codec_base64_roundtrip_64k",
+      fn = function(_: any): any
+        local encoded = codec.encode_base64(BLOB)
+        return (codec.decode_base64(encoded))
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res as string ~= BLOB then
+          return false, "base64 roundtrip corrupted data"
+        end
+        return true
+      end,
+    },
+    {
+      name = "compress_roundtrip_64k",
+      fn = function(_: any): any
+        local packed = compress.compress(BLOB)
+        return (compress.uncompress(packed))
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res as string ~= BLOB then
+          return false, "compression roundtrip corrupted data"
+        end
+        return true
+      end,
+    },
+    {
+      name = "string_split_csv",
+      fn = function(_: any): any
+        return cstr.split(CSV, ",")
+      end,
+      check = function(_: any, res: any): boolean, string
+        local fields = res as {string}
+        if fields == nil or #fields ~= CSV_FIELDS then
+          return false, "wrong field count"
+        end
+        if fields[1] ~= "field-1" or fields[CSV_FIELDS] ~= "field-" .. CSV_FIELDS then
+          return false, "wrong field content"
+        end
+        return true
+      end,
+    },
+  }
+end
+
+local function cleanup()
+end
+
+local M: pt.BenchModule = {
+  scenarios = scenarios,
+  cleanup = cleanup,
+}
+
+return M

--- a/lib/perf/bench/sqlite_bench.tl
+++ b/lib/perf/bench/sqlite_bench.tl
@@ -1,0 +1,166 @@
+--- SQLite scenarios: transactional writes, point queries, aggregate scans.
+--- Exercises the cosmic.sqlite ergonomic API and the bundled lsqlite3
+--- C binding end to end, against a real database file on disk.
+
+local sqlite = require("cosmic.sqlite")
+local fs = require("cosmic.fs")
+local pt = require("perf.perf_types")
+
+local ROWS = 2000
+local INSERT_BATCH = 100
+
+local tmpdir: string
+local db: sqlite.Database
+
+--- Base directory for scratch files.
+--- @return string An existing writable directory
+local function tmp_base(): string
+  return os.getenv("TEST_TMPDIR") or os.getenv("TMPDIR") or "/tmp"
+end
+
+--- Create the scratch database and seed deterministic rows.
+--- @return string Error message, or nil on success
+local function init_db(): string
+  local dir, derr = fs.mkdtemp(fs.join(tmp_base(), "perf-sqlite-XXXXXX"))
+  if dir == nil then
+    return "mkdtemp: " .. tostring(derr)
+  end
+  tmpdir = dir
+  local d, oerr = sqlite.open(fs.join(dir, "bench.db"))
+  if d == nil then
+    return "open: " .. tostring(oerr)
+  end
+  db = d
+  -- WAL with NORMAL sync keeps commit costs realistic while avoiding
+  -- fsync dominating every sample with filesystem-dependent noise.
+  local pragmas = "PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;"
+  local ok, err = db:exec(pragmas)
+  if not ok then
+    return "pragma: " .. tostring(err)
+  end
+  ok, err = db:exec([[
+    CREATE TABLE kv (id INTEGER PRIMARY KEY, name TEXT NOT NULL, score REAL NOT NULL);
+    CREATE TABLE scratch (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, score REAL NOT NULL);
+  ]])
+  if not ok then
+    return "create: " .. tostring(err)
+  end
+  local tok, terr = db:transaction(function(tx: sqlite.Database)
+      for i = 1, ROWS do
+        assert(tx:exec("INSERT INTO kv (id, name, score) VALUES (?, ?, ?)",
+            i, "row-" .. i, i * 0.25))
+      end
+    end)
+  if not tok then
+    return "seed: " .. tostring(terr)
+  end
+  return nil
+end
+
+local function scenarios(): {pt.Scenario}, string
+  local ierr = init_db()
+  if ierr then
+    return nil, ierr
+  end
+
+  local query_id = 0
+
+  return {
+    {
+      -- Insert a batch then delete it inside one transaction, so the
+      -- database stays the same size and samples remain comparable.
+      name = "sqlite_insert_delete_tx",
+      fn = function(_: any): any
+        local ok, err = db:transaction(function(tx: sqlite.Database)
+            for i = 1, INSERT_BATCH do
+              assert(tx:exec("INSERT INTO scratch (name, score) VALUES (?, ?)",
+                  "s-" .. i, i * 1.5))
+            end
+            assert(tx:exec("DELETE FROM scratch"))
+          end)
+        assert(ok, err)
+        return ok
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res ~= true then
+          return false, "transaction did not succeed"
+        end
+        local row, qerr = db:query_one("SELECT COUNT(*) AS n FROM scratch")
+        if row == nil then
+          return false, "count query failed: " .. tostring(qerr)
+        end
+        if row.n ~= 0 then
+          return false, "scratch table not empty: " .. tostring(row.n)
+        end
+        return true
+      end,
+    },
+    {
+      name = "sqlite_point_query",
+      fn = function(_: any): any
+        query_id = (query_id % ROWS) + 1
+        local row, err = db:query_one("SELECT id, name, score FROM kv WHERE id = ?", query_id)
+        assert(row, err)
+        return row
+      end,
+      -- Validated against the row's own id (the harness may run extra
+      -- probe iterations, so query_id has moved on by check time).
+      check = function(_: any, res: any): boolean, string
+        local row = res as {string: any}
+        if row == nil then
+          return false, "no row returned"
+        end
+        local id = row.id as number
+        if id == nil or row.name ~= "row-" .. math.floor(id) then
+          return false, "wrong row: " .. tostring(row.name)
+        end
+        if row.score as number ~= id * 0.25 then
+          return false, "wrong score: " .. tostring(row.score)
+        end
+        return true
+      end,
+    },
+    {
+      name = "sqlite_scan_aggregate",
+      fn = function(_: any): any
+        local row, err = db:query_one("SELECT COUNT(*) AS n, SUM(score) AS total FROM kv")
+        assert(row, err)
+        return row
+      end,
+      check = function(_: any, res: any): boolean, string
+        local row = res as {string: any}
+        if row == nil then
+          return false, "no row returned"
+        end
+        if row.n ~= ROWS then
+          return false, "wrong count: " .. tostring(row.n)
+        end
+        -- SUM(i * 0.25) for i in 1..ROWS
+        local expected = ROWS * (ROWS + 1) / 2 * 0.25
+        local total = row.total as number
+        if total == nil or math.abs(total - expected) > 0.001 then
+          return false, "wrong sum: " .. tostring(row.total)
+        end
+        return true
+      end,
+    },
+  }
+end
+
+local function cleanup()
+  if db then
+    db:close()
+    db = nil
+  end
+  if tmpdir then
+    fs.rmrf(tmpdir)
+    tmpdir = nil
+  end
+end
+
+local M: pt.BenchModule = {
+  scenarios = scenarios,
+  cleanup = cleanup,
+}
+
+return M

--- a/lib/perf/bench/startup_bench.tl
+++ b/lib/perf/bench/startup_bench.tl
@@ -1,0 +1,158 @@
+--- End-to-end binary scenarios: process startup and Teal compilation.
+--- Spawns the cosmic binary itself, so these numbers cover the whole
+--- cosmopolitan stack: APE loader, zip filesystem, Lua runtime boot,
+--- and (for the compile scenario) the embedded Teal compiler.
+---
+--- These are the scenarios that move when whilp/cosmopolitan (the cosmos
+--- pin) changes. Set PERF_BIN to benchmark a different binary.
+
+local child = require("cosmic.child")
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
+local pt = require("perf.perf_types")
+
+local HELLO = "perf-hello"
+local COMPILE_SRC = [[
+local record Point
+  x: number
+  y: number
+end
+local function dist(p: Point, q: Point): number
+  local dx = p.x - q.x
+  local dy = p.y - q.y
+  return math.sqrt(dx * dx + dy * dy)
+end
+print(dist({x = 0, y = 0}, {x = 3, y = 4}))
+]]
+
+local tmpdir: string
+
+--- Base directory for scratch files.
+--- @return string An existing writable directory
+local function tmp_base(): string
+  return os.getenv("TEST_TMPDIR") or os.getenv("TMPDIR") or "/tmp"
+end
+
+--- Locate the cosmic binary to benchmark.
+--- PERF_BIN wins; then TEST_BIN/cosmic (set by the test harness); then
+--- the interpreter running this script (arg[-1], per cosmic.child docs).
+--- @return string Path to the binary, or nil if none was found
+local function find_bin(): string
+  local envbin = os.getenv("PERF_BIN")
+  if envbin and #envbin > 0 then
+    return envbin
+  end
+  local test_bin = os.getenv("TEST_BIN")
+  if test_bin and #test_bin > 0 then
+    local p = fs.join(test_bin, "cosmic")
+    if fs.isfile(p) then
+      return p
+    end
+  end
+  return rawget(arg, -1) as string
+end
+
+--- Spawn the binary with the given argv tail and return trimmed stdout.
+--- Raises on spawn failure or nonzero exit, which the harness reports.
+--- @param bin string Binary path
+--- @param argv_tail {string} Arguments after the binary path
+--- @return string Trimmed stdout
+local function spawn_capture(bin: string, argv_tail: {string}): string
+  local argv: {string} = {bin}
+  for _, a in ipairs(argv_tail) do
+    table.insert(argv, a)
+  end
+  local handle, serr = child.spawn(argv)
+  assert(handle, serr)
+  local ok, out, code = handle:read()
+  assert(ok, "exit code " .. tostring(code) .. ": " .. tostring(out))
+  return ((out as string):gsub("%s+$", ""))
+end
+
+local function scenarios(): {pt.Scenario}, string
+  local bin = find_bin()
+  if bin == nil or #bin == 0 then
+    return nil, "cannot locate cosmic binary (set PERF_BIN)"
+  end
+  local dir, derr = fs.mkdtemp(fs.join(tmp_base(), "perf-startup-XXXXXX"))
+  if dir == nil then
+    return nil, "mkdtemp: " .. tostring(derr)
+  end
+  tmpdir = dir
+  local hello_lua = fs.join(dir, "hello.lua")
+  local hello_tl = fs.join(dir, "hello.tl")
+  local compile_tl = fs.join(dir, "compile_target.tl")
+  local hello_src = "print(\"" .. HELLO .. "\")\n"
+  local wok, werr = cio.barf(hello_lua, hello_src)
+  if not wok then
+    return nil, "barf: " .. tostring(werr)
+  end
+  wok, werr = cio.barf(hello_tl, hello_src)
+  if not wok then
+    return nil, "barf: " .. tostring(werr)
+  end
+  wok, werr = cio.barf(compile_tl, COMPILE_SRC)
+  if not wok then
+    return nil, "barf: " .. tostring(werr)
+  end
+
+  return {
+    {
+      -- Boot + run a plain Lua script: APE load, zip fs, runtime init.
+      name = "startup_run_lua",
+      fn = function(_: any): any
+        return spawn_capture(bin, {hello_lua})
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res as string ~= HELLO then
+          return false, "wrong output: " .. tostring(res)
+        end
+        return true
+      end,
+    },
+    {
+      -- Same, but through the Teal loader: adds type check + compile.
+      name = "startup_run_teal",
+      fn = function(_: any): any
+        return spawn_capture(bin, {hello_tl})
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res as string ~= HELLO then
+          return false, "wrong output: " .. tostring(res)
+        end
+        return true
+      end,
+    },
+    {
+      -- Full compile of a small typed module via the embedded compiler.
+      name = "startup_compile_teal",
+      fn = function(_: any): any
+        return spawn_capture(bin, {"--compile", compile_tl})
+      end,
+      check = function(_: any, res: any): boolean, string
+        local out = res as string
+        if out == nil or not out:find("local function dist", 1, true) then
+          return false, "compile output missing function"
+        end
+        if out:find("record", 1, true) then
+          return false, "compile output still contains Teal syntax"
+        end
+        return true
+      end,
+    },
+  }
+end
+
+local function cleanup()
+  if tmpdir then
+    fs.rmrf(tmpdir)
+    tmpdir = nil
+  end
+end
+
+local M: pt.BenchModule = {
+  scenarios = scenarios,
+  cleanup = cleanup,
+}
+
+return M

--- a/lib/perf/compare.tl
+++ b/lib/perf/compare.tl
@@ -1,0 +1,152 @@
+--- Baseline-vs-current comparison gate for perf results.
+--- Loads two results files produced by perf.run, compares median wall ns
+--- per operation, and classifies each scenario. A delta only counts as a
+--- regression (or improvement) when it clears the noise bar:
+--- max(threshold, baseline spread, current spread).
+---
+--- Guardrails: scenarios that error, and scenarios present in the baseline
+--- but missing from the current run (deleting a benchmark cannot hide a
+--- regression), both count as failures.
+
+local cio = require("cosmic.io")
+local json = require("cosmic.json")
+local harness = require("perf.harness")
+local pt = require("perf.perf_types")
+
+local DEFAULT_THRESHOLD_PCT = 10.0
+
+--- Load a results JSON file written by perf.run.
+--- @param path string Path to the results file
+--- @return Results The decoded results, or nil on error
+--- @return string Error message on failure
+local function load_results(path: string): pt.Results, string
+  local data, rerr = cio.slurp(path)
+  if data == nil then
+    return nil, path .. ": " .. tostring(rerr)
+  end
+  local decoded, jerr = json.decode(data)
+  if decoded == nil then
+    return nil, path .. ": " .. tostring(jerr)
+  end
+  local results = decoded as pt.Results
+  if results.results == nil then
+    return nil, path .. ": not a perf results file (missing 'results')"
+  end
+  return results
+end
+
+--- Compare current results against a baseline.
+--- @param base Results The baseline results
+--- @param cur Results The current results
+--- @param threshold_pct number? Minimum noise bar in percent (default 10)
+--- @return {Delta} One delta per scenario, current order first
+--- @return integer Number of failures (regressions + errors + missing)
+local function diff(base: pt.Results, cur: pt.Results, threshold_pct?: number): {pt.Delta}, integer
+  local threshold = threshold_pct or DEFAULT_THRESHOLD_PCT
+  local by_name: {string: pt.Measurement} = {}
+  for _, b in ipairs(base.results) do
+    by_name[b.name] = b
+  end
+
+  local deltas: {pt.Delta} = {}
+  local failures = 0
+  local seen: {string: boolean} = {}
+  for _, c in ipairs(cur.results) do
+    seen[c.name] = true
+    local b = by_name[c.name]
+    local d: pt.Delta = {name = c.name}
+    if c.error then
+      d.verdict = "error"
+      failures = failures + 1
+    elseif b == nil or b.error ~= nil or b.wall_ns == nil then
+      d.cur_ns = c.wall_ns
+      d.verdict = "new"
+    else
+      d.base_ns = b.wall_ns
+      d.cur_ns = c.wall_ns
+      d.noise_pct = math.max(threshold, b.spread_pct or 0, c.spread_pct or 0)
+      if b.wall_ns > 0 then
+        d.delta_pct = (c.wall_ns - b.wall_ns) / b.wall_ns * 100.0
+      else
+        d.delta_pct = 0.0
+      end
+      if d.delta_pct > d.noise_pct then
+        d.verdict = "regression"
+        failures = failures + 1
+      elseif d.delta_pct < -d.noise_pct then
+        d.verdict = "faster"
+      else
+        d.verdict = "ok"
+      end
+    end
+    table.insert(deltas, d)
+  end
+
+  for _, b in ipairs(base.results) do
+    if not seen[b.name] and b.error == nil then
+      local d: pt.Delta = {name = b.name, base_ns = b.wall_ns, verdict = "missing"}
+      failures = failures + 1
+      table.insert(deltas, d)
+    end
+  end
+
+  return deltas, failures
+end
+
+--- Format one delta as a report line.
+--- @param d Delta The delta
+--- @return string A single aligned line
+local function format_delta(d: pt.Delta): string
+  local base_str = d.base_ns and harness.format_ns(d.base_ns) or "-"
+  local cur_str = d.cur_ns and harness.format_ns(d.cur_ns) or "-"
+  local delta_str = "-"
+  if d.delta_pct then
+    delta_str = string.format("%+.1f%%", d.delta_pct)
+  end
+  local noise_str = "-"
+  if d.noise_pct then
+    noise_str = string.format("±%.1f%%", d.noise_pct)
+  end
+  return string.format("%-28s %12s -> %12s  %8s  (noise %7s)  %s",
+    d.name, base_str, cur_str, delta_str, noise_str, d.verdict)
+end
+
+--- Format a full comparison report with a summary line.
+--- @param deltas {Delta} Deltas from diff()
+--- @return string The report text
+local function format(deltas: {pt.Delta}): string
+  local lines: {string} = {}
+  local counts: {string: integer} = {}
+  for _, d in ipairs(deltas) do
+    table.insert(lines, format_delta(d))
+    counts[d.verdict] = (counts[d.verdict] or 0) + 1
+  end
+  table.insert(lines, string.format(
+      "%d scenarios: %d regression, %d faster, %d ok, %d new, %d missing, %d error",
+      #deltas,
+      counts["regression"] or 0,
+      counts["faster"] or 0,
+      counts["ok"] or 0,
+      counts["new"] or 0,
+      counts["missing"] or 0,
+      counts["error"] or 0))
+  return table.concat(lines, "\n")
+end
+
+local record compare
+  DEFAULT_THRESHOLD_PCT: number
+  load_results: function(path: string): pt.Results, string
+  diff: function(base: pt.Results, cur: pt.Results, threshold_pct?: number): {pt.Delta}, integer
+  format_delta: function(d: pt.Delta): string
+  format: function(deltas: {pt.Delta}): string
+end
+
+local M: compare = {
+  DEFAULT_THRESHOLD_PCT = DEFAULT_THRESHOLD_PCT,
+  load_results = load_results,
+  diff = diff,
+  format_delta = format_delta,
+  format = format,
+}
+
+return M

--- a/lib/perf/compare_test.tl
+++ b/lib/perf/compare_test.tl
@@ -1,0 +1,134 @@
+local compare = require("perf.compare")
+local pt = require("perf.perf_types")
+
+local function results(measurements: {pt.Measurement}): pt.Results
+  return {meta = {}, results = measurements}
+end
+
+local function m(name: string, wall_ns: number, spread_pct: number): pt.Measurement
+  return {
+    name = name,
+    wall_ns = wall_ns,
+    spread_pct = spread_pct,
+    samples_ns = {},
+    iterations = 1,
+  }
+end
+
+local function find_delta(deltas: {pt.Delta}, name: string): pt.Delta
+  for _, d in ipairs(deltas) do
+    if d.name == name then
+      return d
+    end
+  end
+  return nil
+end
+
+local function test_unchanged_is_ok()
+  local deltas, failures = compare.diff(
+    results({m("a", 1000, 2)}),
+    results({m("a", 1010, 2)}), 10)
+  assert(failures == 0, "no failures expected")
+  assert(find_delta(deltas, "a").verdict == "ok", "1% delta should be ok")
+end
+test_unchanged_is_ok()
+
+local function test_regression_beyond_noise_fails()
+  local deltas, failures = compare.diff(
+    results({m("a", 1000, 2)}),
+    results({m("a", 1300, 2)}), 10)
+  assert(failures == 1, "expected 1 failure, got " .. failures)
+  local d = find_delta(deltas, "a")
+  assert(d.verdict == "regression", "30% slower should regress, got " .. d.verdict)
+  assert(math.abs(d.delta_pct - 30.0) < 0.01, "delta_pct wrong: " .. d.delta_pct)
+end
+test_regression_beyond_noise_fails()
+
+local function test_noisy_scenario_needs_bigger_delta()
+  -- 30% slower but 40% spread in the baseline: not a confident regression.
+  local deltas, failures = compare.diff(
+    results({m("a", 1000, 40)}),
+    results({m("a", 1300, 2)}), 10)
+  assert(failures == 0, "noisy delta must not fail")
+  local d = find_delta(deltas, "a")
+  assert(d.verdict == "ok", "expected ok, got " .. d.verdict)
+  assert(math.abs(d.noise_pct - 40.0) < 0.01, "noise bar wrong: " .. d.noise_pct)
+end
+test_noisy_scenario_needs_bigger_delta()
+
+local function test_improvement_beyond_noise_is_faster()
+  local deltas, failures = compare.diff(
+    results({m("a", 1000, 2)}),
+    results({m("a", 700, 2)}), 10)
+  assert(failures == 0, "improvements are not failures")
+  assert(find_delta(deltas, "a").verdict == "faster", "30% faster should be faster")
+end
+test_improvement_beyond_noise_is_faster()
+
+local function test_new_scenario_is_not_failure()
+  local deltas, failures = compare.diff(
+    results({}),
+    results({m("fresh", 500, 1)}), 10)
+  assert(failures == 0, "new scenarios are informational")
+  assert(find_delta(deltas, "fresh").verdict == "new", "expected new")
+end
+test_new_scenario_is_not_failure()
+
+local function test_missing_scenario_fails()
+  -- Deleting a benchmark must not be a way to hide a regression.
+  local deltas, failures = compare.diff(
+    results({m("gone", 500, 1)}),
+    results({}), 10)
+  assert(failures == 1, "missing scenario must fail")
+  assert(find_delta(deltas, "gone").verdict == "missing", "expected missing")
+end
+test_missing_scenario_fails()
+
+local function test_errored_scenario_fails()
+  local bad: pt.Measurement = {name = "broken", samples_ns = {}, error = "boom"}
+  local deltas, failures = compare.diff(
+    results({m("broken", 500, 1)}),
+    results({bad}), 10)
+  assert(failures == 1, "errored scenario must fail")
+  assert(find_delta(deltas, "broken").verdict == "error", "expected error verdict")
+end
+test_errored_scenario_fails()
+
+local function test_errored_baseline_treated_as_new()
+  local bad: pt.Measurement = {name = "flaky", samples_ns = {}, error = "boom"}
+  local deltas, failures = compare.diff(
+    results({bad}),
+    results({m("flaky", 500, 1)}), 10)
+  assert(failures == 0, "recovered scenario is not a failure")
+  assert(find_delta(deltas, "flaky").verdict == "new", "expected new")
+end
+test_errored_baseline_treated_as_new()
+
+local function test_format_summarizes()
+  local deltas = compare.diff(
+    results({m("a", 1000, 2), m("b", 1000, 2)}),
+    results({m("a", 2000, 2), m("b", 990, 2)}), 10)
+  local text = compare.format(deltas)
+  assert(text:find("regression", 1, true), "report missing regression")
+  assert(text:find("2 scenarios: 1 regression", 1, true),
+    "summary line wrong:\n" .. text)
+end
+test_format_summarizes()
+
+local function test_load_results_rejects_garbage()
+  local r, err = compare.load_results("/nonexistent/path.json")
+  assert(r == nil and err ~= nil, "missing file should error")
+
+  local tmp = (os.getenv("TEST_TMPDIR") or os.getenv("TMPDIR") or "/tmp") .. "/not-results.json"
+  local f = io.open(tmp, "w")
+  assert(f ~= nil, "cannot create temp file")
+  f:write("{\"unrelated\": true}")
+  f:close()
+  local r2, err2 = compare.load_results(tmp)
+  assert(r2 == nil and err2 ~= nil and err2:find("results", 1, true),
+    "wrong-shape file should be rejected: " .. tostring(err2))
+  os.remove(tmp)
+end
+test_load_results_rejects_garbage()
+
+print("OK compare_test")

--- a/lib/perf/cook.mk
+++ b/lib/perf/cook.mk
@@ -1,0 +1,60 @@
+modules += perf
+perf_srcs := $(wildcard lib/perf/*.tl) $(wildcard lib/perf/bench/*.tl)
+perf_tests := $(filter %_test.tl,$(perf_srcs))
+perf_tl := $(filter-out $(perf_tests),$(perf_srcs))
+# compiled perf modules are require()d as perf.* via LUA_PATH
+perf_lua_dirs := $(o)/lib
+perf_deps := cosmic
+
+perf_bench_srcs := $(wildcard lib/perf/bench/*_bench.tl)
+perf_bench_mods := $(subst /,.,$(patsubst lib/%.tl,%,$(perf_bench_srcs)))
+perf_run := $(o)/lib/perf/run.lua
+
+## PERF_BIN: cosmic binary to benchmark (default: freshly built o/bin/cosmic).
+## Point it at another build to measure cosmos/cosmopolitan changes end to end.
+PERF_BIN ?= $(cosmic_bin)
+## PERF_SAMPLES: timed samples per scenario (default 5)
+PERF_SAMPLES ?= 5
+## PERF_MIN_SECS: minimum seconds per sample (default 0.15)
+PERF_MIN_SECS ?= 0.15
+## PERF_ONLY: Lua pattern to filter scenario names (e.g. PERF_ONLY=sqlite)
+PERF_ONLY ?=
+## PERF_THRESHOLD: minimum regression percent for perf-compare to fail (default 10)
+PERF_THRESHOLD ?= 10
+
+perf_only_flag = $(if $(PERF_ONLY),--only $(PERF_ONLY))
+perf_cmd = PERF_BIN=$(PERF_BIN) $(PERF_BIN) -- $(perf_run) \
+	--samples $(PERF_SAMPLES) --min-secs $(PERF_MIN_SECS) $(perf_only_flag)
+
+perf_sandbox := $(o)/perf
+
+.PHONY: perf perf-baseline perf-compare
+
+perf perf-baseline: .PLEDGE = stdio rpath wpath cpath proc exec
+perf perf-baseline: .UNVEIL = rx:$(o)/bootstrap r:lib r:3p rwcx:$(o) rwc:$(TMP) rx:/usr rx:/proc r:/etc r:/dev/null
+
+## Run perf scenarios and write o/perf/current.json
+perf: $$(perf_lua) $(cosmic_bin)
+	@mkdir -p $(perf_sandbox)
+	@$(perf_cmd) --out $(perf_sandbox)/current.json $(perf_bench_mods)
+
+## Run perf scenarios and save the baseline (o/perf/baseline.json)
+perf-baseline: $$(perf_lua) $(cosmic_bin)
+	@mkdir -p $(perf_sandbox)
+	@$(perf_cmd) --out $(perf_sandbox)/baseline.json $(perf_bench_mods)
+
+perf-compare: .PLEDGE = stdio rpath wpath cpath proc exec
+perf-compare: .UNVEIL = rx:$(o)/bootstrap r:lib r:3p rwcx:$(o) rwc:$(TMP) rx:/usr rx:/proc r:/etc r:/dev/null
+
+perf_compare_cmd = $(PERF_BIN) -- $(perf_run) --compare \
+	$(perf_sandbox)/baseline.json $(perf_sandbox)/current.json \
+	--threshold $(PERF_THRESHOLD)
+
+## Re-run scenarios and fail on any regression vs the saved baseline
+# A failed comparison retries once with fresh measurements so that
+# machine noise has to strike twice in the same direction to fail.
+perf-compare: perf
+	@$(perf_compare_cmd) || { \
+		echo "perf-compare: regression flagged; re-measuring once to filter noise"; \
+		$(perf_cmd) --out $(perf_sandbox)/current.json $(perf_bench_mods) \
+			&& $(perf_compare_cmd); }

--- a/lib/perf/harness.tl
+++ b/lib/perf/harness.tl
@@ -1,0 +1,283 @@
+--- Scenario benchmark harness: wall-clock timing with functional checks.
+--- Runs Scenario specs (setup/fn/check/teardown): calibrates an iteration
+--- count so each sample lasts at least min_sample_secs, takes several timed
+--- samples, and reports per-operation statistics (median wall ns, CPU ns,
+--- spread, best-effort allocation).
+---
+--- Guardrails built into every run:
+--- - check() is executed before and after timing; a workload whose output
+---   is wrong fails the benchmark instead of reporting a bogus win.
+--- - setup/fn/check/teardown crashes are captured into Measurement.error
+---   so one broken scenario never aborts the whole run.
+---
+--- Unlike cosmic.benchmark (Go-style Benchmark_* micro runner using CPU
+--- time), this harness times wall clock, which is what end-to-end scenarios
+--- (HTTP, SQLite, process startup) actually cost.
+
+local stats = require("perf.stats")
+local time = require("cosmic.time")
+local pt = require("perf.perf_types")
+
+local DEFAULT_SAMPLES = 5
+local DEFAULT_MIN_SAMPLE_SECS = 0.15
+local MAX_ITERATIONS = 1000000000
+local ALLOC_PROBE_CAP = 1000
+
+--- Current monotonic clock reading in nanoseconds.
+--- @return number Monotonic nanoseconds
+local function monotonic_ns(): number
+  local secs, nanos = time.monotonic()
+  return secs * 1e9 + nanos
+end
+
+--- Run fn n times, timing wall clock and CPU time.
+--- @param fn function The per-operation function
+--- @param ctx any Context from setup, passed to fn
+--- @param n integer Number of iterations
+--- @return number Total wall nanoseconds
+--- @return number Total CPU nanoseconds
+--- @return any The last value returned by fn
+local function run_ops(fn: function(any): any, ctx: any, n: integer): number, number, any
+  local last: any
+  local cpu0 = os.clock()
+  local wall0 = monotonic_ns()
+  for _ = 1, n do
+    last = fn(ctx)
+  end
+  local wall1 = monotonic_ns()
+  local cpu1 = os.clock()
+  return wall1 - wall0, (cpu1 - cpu0) * 1e9, last
+end
+
+--- Find an iteration count whose sample lasts at least min_secs.
+--- @param fn function The per-operation function
+--- @param ctx any Context from setup
+--- @param min_secs number Minimum sample duration in seconds
+--- @return integer The calibrated iteration count
+local function calibrate(fn: function(any): any, ctx: any, min_secs: number): integer
+  local n: integer = 1
+  local target_ns = min_secs * 1e9
+  while n < MAX_ITERATIONS do
+    local wall = run_ops(fn, ctx, n)
+    if wall >= target_ns then
+      return n
+    end
+    local grown: integer
+    if wall <= 0 then
+      grown = n * 10
+    else
+      -- Overshoot by 20% so the next probe usually lands past the target,
+      -- but never grow more than 10x at once.
+      local estimate = math.ceil((n * target_ns * 1.2) / wall)
+      grown = math.min(estimate, n * 10)
+    end
+    if grown <= n then
+      grown = n + 1
+    end
+    n = grown
+  end
+  return MAX_ITERATIONS
+end
+
+--- Estimate Lua-side allocation per operation in KB (best-effort).
+--- Runs with the collector stopped so the count delta approximates
+--- allocation rather than live-set growth.
+--- @param fn function The per-operation function
+--- @param ctx any Context from setup
+--- @param n integer Calibrated iteration count (capped for the probe)
+--- @return number Allocated KB per operation
+local function alloc_probe(fn: function(any): any, ctx: any, n: integer): number
+  local iters = math.min(n, ALLOC_PROBE_CAP)
+  collectgarbage("collect")
+  collectgarbage("stop")
+  local before = collectgarbage("count")
+  for _ = 1, iters do
+    fn(ctx)
+  end
+  local after = collectgarbage("count")
+  collectgarbage("restart")
+  collectgarbage("collect")
+  return (after - before) / iters
+end
+
+--- Run a scenario's check hook against a result, if one is defined.
+--- @param scenario Scenario The scenario
+--- @param ctx any Context from setup
+--- @param result any The value returned by fn
+--- @return string An error message, or nil if the check passed
+local function run_check(scenario: pt.Scenario, ctx: any, result: any): string
+  if not scenario.check then
+    return nil
+  end
+  local ok, passed, cerr = pcall(scenario.check, ctx, result)
+  if not ok then
+    return "check crashed: " .. tostring(passed)
+  end
+  if not passed then
+    return "check failed: " .. tostring(cerr or "no reason given")
+  end
+  return nil
+end
+
+--- Mark a measurement as failed.
+--- @param m Measurement The measurement to fail
+--- @param msg string The error message
+--- @return Measurement The same measurement, for tail returns
+local function fail(m: pt.Measurement, msg: string): pt.Measurement
+  m.error = msg
+  return m
+end
+
+--- Run one scenario: setup, verify, calibrate, sample, re-verify, teardown.
+--- Never throws; failures are reported via Measurement.error.
+--- @param scenario Scenario The scenario to run
+--- @param opts Options? Harness options (defaults: 5 samples, 0.15s each)
+--- @return Measurement Timing statistics or an error
+local function run_scenario(scenario: pt.Scenario, opts?: pt.Options): pt.Measurement
+  local samples = DEFAULT_SAMPLES
+  local min_secs = DEFAULT_MIN_SAMPLE_SECS
+  if opts then
+    samples = opts.samples or samples
+    min_secs = opts.min_sample_secs or min_secs
+  end
+
+  local m: pt.Measurement = {
+    name = scenario.name,
+    iterations = 0,
+    samples_ns = {},
+  }
+
+  local ctx: any
+  if scenario.setup then
+    local sok, sctx, serr = pcall(scenario.setup)
+    if not sok then
+      return fail(m, "setup crashed: " .. tostring(sctx))
+    end
+    if sctx == nil and serr ~= nil then
+      return fail(m, "setup failed: " .. tostring(serr))
+    end
+    ctx = sctx
+  end
+
+  local function teardown()
+    if scenario.teardown then
+      pcall(scenario.teardown, ctx)
+    end
+  end
+
+  -- Warm up once and verify the workload before timing anything.
+  local wok, wres = pcall(scenario.fn, ctx)
+  if not wok then
+    teardown()
+    return fail(m, "fn crashed: " .. tostring(wres))
+  end
+  local cerr = run_check(scenario, ctx, wres)
+  if cerr then
+    teardown()
+    return fail(m, cerr)
+  end
+
+  local last: any
+  local function measure(): boolean
+    local n = calibrate(scenario.fn, ctx, min_secs)
+    m.iterations = n
+    local cpu_total = 0.0
+    for i = 1, samples do
+      local wall, cpu, res = run_ops(scenario.fn, ctx, n)
+      m.samples_ns[i] = wall / n
+      cpu_total = cpu_total + cpu
+      last = res
+    end
+    m.cpu_ns = cpu_total / (samples * n)
+    m.alloc_kb = alloc_probe(scenario.fn, ctx, n)
+    return true
+  end
+  local rok, rerr = pcall(measure)
+  if not rok then
+    teardown()
+    return fail(m, "run crashed: " .. tostring(rerr))
+  end
+
+  -- Re-verify after timing: catches workloads that only work once.
+  cerr = run_check(scenario, ctx, last)
+  if cerr then
+    teardown()
+    return fail(m, cerr)
+  end
+  teardown()
+
+  m.wall_ns = stats.median(m.samples_ns)
+  m.min_ns = stats.min(m.samples_ns)
+  m.max_ns = stats.max(m.samples_ns)
+  m.spread_pct = stats.spread_pct(m.samples_ns)
+  return m
+end
+
+--- Run a list of scenarios in order.
+--- @param scenarios {Scenario} The scenarios to run
+--- @param opts Options? Harness options applied to every scenario
+--- @param on_result function? Called with each Measurement as it completes
+--- @return {Measurement} All measurements, in scenario order
+local function run_all(scenarios: {pt.Scenario}, opts?: pt.Options, on_result?: function(pt.Measurement)): {pt.Measurement}
+  local out: {pt.Measurement} = {}
+  for _, s in ipairs(scenarios) do
+    local m = run_scenario(s, opts)
+    table.insert(out, m)
+    if on_result then
+      on_result(m)
+    end
+  end
+  return out
+end
+
+--- Format nanoseconds with a readable unit.
+--- @param ns number Nanoseconds
+--- @return string For example "1.25 µs"
+local function format_ns(ns: number): string
+  if ns == nil then
+    return "?"
+  end
+  if ns < 1000 then
+    return string.format("%.1f ns", ns)
+  elseif ns < 1000000 then
+    return string.format("%.2f µs", ns / 1000)
+  elseif ns < 1000000000 then
+    return string.format("%.2f ms", ns / 1000000)
+  end
+  return string.format("%.2f s", ns / 1000000000)
+end
+
+--- Format one measurement as a human-readable report line.
+--- @param m Measurement The measurement
+--- @return string A single line: name, iterations, ns/op, spread, cpu/wall, alloc
+local function format_line(m: pt.Measurement): string
+  if m.error then
+    return string.format("%-28s FAIL: %s", m.name, m.error)
+  end
+  local ratio = 0.0
+  if m.cpu_ns and m.wall_ns and m.wall_ns > 0 then
+    ratio = m.cpu_ns / m.wall_ns
+  end
+  return string.format("%-28s %10d x %12s/op  ±%5.1f%%  cpu/wall %4.2f  alloc %8.2f KB",
+    m.name, m.iterations, format_ns(m.wall_ns), m.spread_pct, ratio, m.alloc_kb or 0)
+end
+
+local record harness
+  DEFAULT_SAMPLES: integer
+  DEFAULT_MIN_SAMPLE_SECS: number
+  run_scenario: function(scenario: pt.Scenario, opts?: pt.Options): pt.Measurement
+  run_all: function(scenarios: {pt.Scenario}, opts?: pt.Options, on_result?: function(pt.Measurement)): {pt.Measurement}
+  format_ns: function(ns: number): string
+  format_line: function(m: pt.Measurement): string
+end
+
+local M: harness = {
+  DEFAULT_SAMPLES = DEFAULT_SAMPLES,
+  DEFAULT_MIN_SAMPLE_SECS = DEFAULT_MIN_SAMPLE_SECS,
+  run_scenario = run_scenario,
+  run_all = run_all,
+  format_ns = format_ns,
+  format_line = format_line,
+}
+
+return M

--- a/lib/perf/harness_test.tl
+++ b/lib/perf/harness_test.tl
@@ -1,0 +1,144 @@
+local harness = require("perf.harness")
+local pt = require("perf.perf_types")
+
+-- Tiny options so tests stay fast.
+local FAST: pt.Options = {samples = 2, min_sample_secs = 0.001}
+
+local function test_run_scenario_measures_and_checks()
+  local calls = 0
+  local m = harness.run_scenario({
+      name = "counting",
+      fn = function(_: any): any
+        calls = calls + 1
+        return "value"
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res as string ~= "value" then
+          return false, "unexpected result"
+        end
+        return true
+      end,
+    }, FAST)
+  assert(m.error == nil, "unexpected error: " .. tostring(m.error))
+  assert(m.name == "counting", "name wrong")
+  assert(calls > 0, "fn never ran")
+  assert(m.iterations >= 1, "iterations missing")
+  assert(#m.samples_ns == 2, "expected 2 samples, got " .. #m.samples_ns)
+  assert(m.wall_ns ~= nil and m.wall_ns >= 0, "wall_ns missing")
+  assert(m.min_ns <= m.wall_ns and m.wall_ns <= m.max_ns, "stats out of order")
+end
+test_run_scenario_measures_and_checks()
+
+local function test_setup_result_reaches_fn_and_teardown()
+  local torn_down: any = nil
+  local m = harness.run_scenario({
+      name = "ctx",
+      setup = function(): any, string
+        return {token = "abc"}
+      end,
+      fn = function(ctx: any): any
+        return (ctx as {string: string}).token
+      end,
+      check = function(_: any, res: any): boolean, string
+        return res as string == "abc", "token did not flow through"
+      end,
+      teardown = function(ctx: any)
+        torn_down = ctx
+      end,
+    }, FAST)
+  assert(m.error == nil, "unexpected error: " .. tostring(m.error))
+  assert(torn_down ~= nil, "teardown never ran")
+end
+test_setup_result_reaches_fn_and_teardown()
+
+local function test_failing_check_fails_measurement()
+  local m = harness.run_scenario({
+      name = "bad_check",
+      fn = function(_: any): any
+        return 42
+      end,
+      check = function(_: any, _res: any): boolean, string
+        return false, "wrong answer"
+      end,
+    }, FAST)
+  assert(m.error ~= nil, "expected check failure")
+  assert(m.error:find("wrong answer", 1, true), "reason lost: " .. m.error)
+end
+test_failing_check_fails_measurement()
+
+local function test_crashing_fn_fails_measurement()
+  local torn_down = false
+  local m = harness.run_scenario({
+      name = "crash",
+      fn = function(_: any): any
+        error("boom")
+      end,
+      check = function(_: any, _res: any): boolean, string
+        return true
+      end,
+      teardown = function(_: any)
+        torn_down = true
+      end,
+    }, FAST)
+  assert(m.error ~= nil, "expected crash to be captured")
+  assert(m.error:find("boom", 1, true), "crash message lost: " .. m.error)
+  assert(torn_down, "teardown must run even on crash")
+end
+test_crashing_fn_fails_measurement()
+
+local function test_failing_setup_fails_measurement()
+  local m = harness.run_scenario({
+      name = "bad_setup",
+      setup = function(): any, string
+        return nil, "no resources"
+      end,
+      fn = function(_: any): any
+        return 1
+      end,
+      check = function(_: any, _res: any): boolean, string
+        return true
+      end,
+    }, FAST)
+  assert(m.error ~= nil, "expected setup failure")
+  assert(m.error:find("no resources", 1, true), "setup reason lost: " .. m.error)
+end
+test_failing_setup_fails_measurement()
+
+local function test_run_all_reports_each_scenario()
+  local seen: {string} = {}
+  local results = harness.run_all({
+      {
+        name = "one",
+        fn = function(_: any): any return 1 end,
+        check = function(_: any, _r: any): boolean, string return true end,
+      },
+      {
+        name = "two",
+        fn = function(_: any): any return 2 end,
+        check = function(_: any, _r: any): boolean, string return true end,
+      },
+    }, FAST, function(m: pt.Measurement)
+      table.insert(seen, m.name)
+    end)
+  assert(#results == 2, "expected 2 results")
+  assert(seen[1] == "one" and seen[2] == "two", "callback order wrong")
+end
+test_run_all_reports_each_scenario()
+
+local function test_format_helpers()
+  assert(harness.format_ns(12) == "12.0 ns", "ns format wrong")
+  assert(harness.format_ns(1500) == "1.50 µs", "µs format wrong")
+  assert(harness.format_ns(2500000) == "2.50 ms", "ms format wrong")
+  assert(harness.format_ns(3.2e9) == "3.20 s", "s format wrong")
+  local line = harness.format_line({
+      name = "x", iterations = 10, samples_ns = {},
+      wall_ns = 100, cpu_ns = 50, spread_pct = 1.5, alloc_kb = 0.5,
+    })
+  assert(line:find("x", 1, true) and line:find("100.0 ns", 1, true), "line missing fields: " .. line)
+  local fail_line = harness.format_line({name = "y", samples_ns = {}, error = "broke"})
+  assert(fail_line:find("FAIL", 1, true) and fail_line:find("broke", 1, true),
+    "fail line wrong: " .. fail_line)
+end
+test_format_helpers()
+
+print("OK harness_test")

--- a/lib/perf/perf_test.tl
+++ b/lib/perf/perf_test.tl
@@ -1,0 +1,51 @@
+-- Smoke test for the perf harness: every bench module must load, every
+-- scenario must define a functional check, carry a unique name, and pass
+-- end to end with tiny settings. This keeps the scenarios from bit-rotting
+-- and enforces the no-check-no-benchmark guardrail in CI.
+
+local harness = require("perf.harness")
+local pt = require("perf.perf_types")
+
+local MODULES = {
+  "perf.bench.json_bench",
+  "perf.bench.sqlite_bench",
+  "perf.bench.http_bench",
+  "perf.bench.fs_bench",
+  "perf.bench.micro_bench",
+  "perf.bench.startup_bench",
+}
+
+local SMOKE: pt.Options = {samples = 2, min_sample_secs = 0.001}
+
+local function test_all_scenarios_pass()
+  local seen: {string: boolean} = {}
+  for _, name in ipairs(MODULES) do
+    local ok, mod = pcall(require, name)
+    assert(ok, name .. ": " .. tostring(mod))
+    local bench = mod as pt.BenchModule
+    assert(bench.scenarios ~= nil, name .. ": missing scenarios()")
+    assert(bench.cleanup ~= nil, name .. ": missing cleanup()")
+
+    local scenarios, serr = bench.scenarios()
+    assert(scenarios ~= nil, name .. ": scenarios: " .. tostring(serr))
+    assert(#scenarios > 0, name .. ": no scenarios returned")
+
+    for _, s in ipairs(scenarios) do
+      assert(s.name ~= nil and #s.name > 0, name .. ": scenario without a name")
+      assert(not seen[s.name], name .. ": duplicate scenario name " .. s.name)
+      seen[s.name] = true
+      assert(s.check ~= nil, name .. "/" .. s.name
+        .. ": scenario has no check(); every scenario must validate its output")
+      assert(s.fn ~= nil, name .. "/" .. s.name .. ": scenario has no fn()")
+
+      local m = harness.run_scenario(s, SMOKE)
+      assert(m.error == nil, name .. "/" .. s.name .. ": " .. tostring(m.error))
+      assert(m.wall_ns ~= nil and m.wall_ns > 0, name .. "/" .. s.name .. ": no timing")
+      assert(m.iterations >= 1, name .. "/" .. s.name .. ": no iterations")
+    end
+    bench.cleanup()
+  end
+end
+test_all_scenarios_pass()
+
+print("OK perf_test")

--- a/lib/perf/perf_types.tl
+++ b/lib/perf/perf_types.tl
@@ -1,0 +1,88 @@
+--- Shared type definitions for the perf harness (lib/perf).
+--- The harness measures end-to-end scenarios (JSON, SQLite, HTTP, fs,
+--- process startup) so that changes in cosmic wrappers or the underlying
+--- cosmo/cosmopolitan runtime show up in the same numbers.
+
+local record perf_types
+
+  --- One benchmark scenario.
+  --- setup runs once before timing and its return value is passed to every
+  --- fn/check/teardown call. fn performs exactly one operation per call.
+  --- check validates the workload output before and after timing — an
+  --- "optimization" that changes behavior fails the benchmark instead of
+  --- producing a bogus win. Every scenario must define check.
+  record Scenario
+    name: string
+    setup: function(): any, string
+    fn: function(any): any
+    check: function(any, any): boolean, string
+    teardown: function(any)
+  end
+
+  --- Harness knobs. samples is the number of timed samples per scenario;
+  --- min_sample_secs is the minimum wall-clock duration of one sample.
+  record Options
+    samples: integer
+    min_sample_secs: number
+  end
+
+  --- Timing result for one scenario.
+  --- wall_ns is the median wall-clock ns per operation across samples;
+  --- cpu_ns is the mean CPU ns per operation (cpu/wall ratio well below 1
+  --- means the scenario is I/O- or syscall-bound). alloc_kb is a
+  --- best-effort estimate of Lua-side allocation per operation.
+  record Measurement
+    name: string
+    iterations: integer
+    samples_ns: {number}
+    wall_ns: number
+    cpu_ns: number
+    min_ns: number
+    max_ns: number
+    spread_pct: number
+    alloc_kb: number
+    error: string
+  end
+
+  --- Environment metadata recorded alongside each results file.
+  record Meta
+    timestamp: number
+    bin: string
+    cosmic_version: string
+    cosmos_version: string
+    os: string
+    isa: string
+    nproc: number
+    samples: integer
+    min_sample_secs: number
+  end
+
+  --- The on-disk results format (JSON).
+  record Results
+    meta: Meta
+    results: {Measurement}
+  end
+
+  --- One row of a baseline-vs-current comparison.
+  --- verdict is one of: "ok", "faster", "regression", "new", "missing",
+  --- "error". noise_pct is the bar a delta must clear to count as real:
+  --- max(threshold, baseline spread, current spread).
+  record Delta
+    name: string
+    base_ns: number
+    cur_ns: number
+    delta_pct: number
+    noise_pct: number
+    verdict: string
+  end
+
+  --- Interface every lib/perf/bench/*_bench.tl module returns.
+  --- scenarios() may allocate shared resources (temp dirs, databases,
+  --- server processes) held in module upvalues; cleanup() releases them.
+  record BenchModule
+    scenarios: function(): {Scenario}, string
+    cleanup: function()
+  end
+end
+
+return perf_types

--- a/lib/perf/run.tl
+++ b/lib/perf/run.tl
@@ -1,0 +1,273 @@
+#!/usr/bin/env cosmic
+--- Perf harness CLI: run scenario benchmarks or compare two results files.
+---
+--- Run mode (writes JSON results and prints one line per scenario):
+---   cosmic -- o/lib/perf/run.lua [--out FILE] [--samples N] [--min-secs S]
+---     [--only PATTERN] MODULE...
+--- where MODULE is a bench module name such as perf.bench.json_bench
+--- (resolved via LUA_PATH; `bin/make perf` sets this up).
+---
+--- Compare mode (exits nonzero on regression/error/missing):
+---   cosmic -- o/lib/perf/run.lua --compare BASE.json CUR.json
+---     [--threshold PCT]
+---
+--- Exit codes: 0 all scenarios ok / no regressions; 1 failure.
+
+local getopt = require("cosmic.getopt")
+local json = require("cosmic.json")
+local cio = require("cosmic.io")
+local csys = require("cosmic.sys")
+local time = require("cosmic.time")
+local proc = require("cosmic.proc")
+local harness = require("perf.harness")
+local compare = require("perf.compare")
+local pt = require("perf.perf_types")
+
+local record Args
+  out: string
+  samples: integer
+  min_secs: number
+  only: string
+  compare_mode: boolean
+  threshold: number
+  help: boolean
+  positional: {string}
+  err: string
+end
+
+local USAGE = [[
+usage: run.lua [--out FILE] [--samples N] [--min-secs S] [--only PAT] MODULE...
+       run.lua --compare BASE.json CUR.json [--threshold PCT]
+]]
+
+--- Parse command-line arguments.
+--- @param argv {string} Raw arguments
+--- @return Args Parsed arguments; Args.err is set on parse failure
+local function parse_args(argv: {string}): Args
+  local a: Args = {
+    samples = harness.DEFAULT_SAMPLES,
+    min_secs = harness.DEFAULT_MIN_SAMPLE_SECS,
+    threshold = compare.DEFAULT_THRESHOLD_PCT,
+    positional = {},
+  }
+  local parser = getopt.new(argv, "h", {
+      {name = "out", has_arg = "required"},
+      {name = "samples", has_arg = "required"},
+      {name = "min-secs", has_arg = "required"},
+      {name = "only", has_arg = "required"},
+      {name = "compare", has_arg = "none"},
+      {name = "threshold", has_arg = "required"},
+      {name = "help", has_arg = "none", short = "h"},
+    })
+  while true do
+    local opt, optarg = parser:next()
+    if opt == nil then
+      break
+    end
+    if opt == "out" then
+      a.out = optarg
+    elseif opt == "samples" then
+      local n = math.tointeger(tonumber(optarg))
+      if n == nil or n < 1 then
+        a.err = "--samples requires a positive integer, got: " .. tostring(optarg)
+      else
+        a.samples = n
+      end
+    elseif opt == "min-secs" then
+      local s = tonumber(optarg)
+      if s == nil or s <= 0 then
+        a.err = "--min-secs requires a positive number, got: " .. tostring(optarg)
+      else
+        a.min_secs = s
+      end
+    elseif opt == "only" then
+      a.only = optarg
+    elseif opt == "compare" then
+      a.compare_mode = true
+    elseif opt == "threshold" then
+      local t = tonumber(optarg)
+      if t == nil or t < 0 then
+        a.err = "--threshold requires a non-negative number, got: " .. tostring(optarg)
+      else
+        a.threshold = t
+      end
+    elseif opt == "h" then
+      a.help = true
+    end
+  end
+  for _, u in ipairs(parser:unknown()) do
+    a.err = "unknown option: " .. u
+  end
+  for _, p in ipairs(parser:remaining()) do
+    table.insert(a.positional, p)
+  end
+  return a
+end
+
+--- Collect environment metadata for a results file.
+--- @param samples integer Samples per scenario used for this run
+--- @param min_secs number Minimum sample duration used for this run
+--- @return Meta The metadata record
+local function collect_meta(samples: integer, min_secs: number): pt.Meta
+  local meta: pt.Meta = {
+    timestamp = time.now(),
+    samples = samples,
+    min_sample_secs = min_secs,
+    os = csys.host_os(),
+    isa = csys.host_isa(),
+    nproc = csys.nproc(),
+  }
+  meta.bin = os.getenv("PERF_BIN") or rawget(arg, -1) as string or "unknown"
+  -- Resolved dynamically: cosmic.version only exists inside a built binary.
+  local version_module = "cosmic.version"
+  local vok, version = pcall(require, version_module)
+  if vok then
+    local v = version as {string: string}
+    meta.cosmic_version = v.cosmic
+    meta.cosmos_version = v.cosmos
+  end
+  return meta
+end
+
+--- Load a bench module by name and validate its interface.
+--- @param name string Module name, e.g. "perf.bench.json_bench"
+--- @return BenchModule The module, or nil on error
+--- @return string Error message on failure
+local function load_module(name: string): pt.BenchModule, string
+  local ok, mod = pcall(require, name)
+  if not ok then
+    return nil, "require " .. name .. ": " .. tostring(mod)
+  end
+  local bm = mod as pt.BenchModule
+  if bm == nil or bm.scenarios == nil then
+    return nil, name .. ": not a bench module (missing scenarios())"
+  end
+  return bm
+end
+
+--- Run all scenarios from the named bench modules.
+--- @param a Args Parsed arguments (positional = module names)
+--- @return integer Exit code: 0 on success, 1 on any failure
+local function run_benches(a: Args): integer
+  if #a.positional == 0 then
+    io.stderr:write("no bench modules given\n" .. USAGE)
+    return 1
+  end
+  local opts: pt.Options = {samples = a.samples, min_sample_secs = a.min_secs}
+  local all: {pt.Measurement} = {}
+  local failed = false
+  for _, name in ipairs(a.positional) do
+    local mod, merr = load_module(name)
+    if mod == nil then
+      io.stderr:write(merr .. "\n")
+      return 1
+    end
+    local scenarios, serr = mod.scenarios()
+    if scenarios == nil then
+      io.stderr:write(name .. ": scenarios: " .. tostring(serr) .. "\n")
+      failed = true
+    else
+      for _, s in ipairs(scenarios) do
+        if a.only == nil or s.name:find(a.only) then
+          local m = harness.run_scenario(s, opts)
+          print(harness.format_line(m))
+          table.insert(all, m)
+          if m.error then
+            failed = true
+          end
+        end
+      end
+    end
+    if mod.cleanup then
+      pcall(mod.cleanup)
+    end
+  end
+  if a.out then
+    local payload: pt.Results = {
+      meta = collect_meta(a.samples, a.min_secs),
+      results = all,
+    }
+    local encoded, eerr = json.encode(payload)
+    if encoded == nil then
+      io.stderr:write("encode results: " .. tostring(eerr) .. "\n")
+      return 1
+    end
+    local wok, werr = cio.barf(a.out, encoded)
+    if not wok then
+      io.stderr:write("write " .. a.out .. ": " .. tostring(werr) .. "\n")
+      return 1
+    end
+    print("wrote " .. a.out)
+  end
+  if failed then
+    io.stderr:write("perf: one or more scenarios failed\n")
+    return 1
+  end
+  return 0
+end
+
+--- Compare two results files and report.
+--- @param a Args Parsed arguments (positional = baseline path, current path)
+--- @return integer Exit code: 0 when clean, 1 on regression/error/missing
+local function run_compare(a: Args): integer
+  if #a.positional ~= 2 then
+    io.stderr:write("--compare needs exactly two results files\n" .. USAGE)
+    return 1
+  end
+  local base, berr = compare.load_results(a.positional[1])
+  if base == nil then
+    io.stderr:write(berr .. "\n")
+    return 1
+  end
+  local cur, cerr = compare.load_results(a.positional[2])
+  if cur == nil then
+    io.stderr:write(cerr .. "\n")
+    return 1
+  end
+  local deltas, failures = compare.diff(base, cur, a.threshold)
+  print(compare.format(deltas))
+  if failures > 0 then
+    io.stderr:write("perf: " .. failures .. " scenario(s) regressed, errored, or went missing\n")
+    return 1
+  end
+  return 0
+end
+
+--- CLI entry point.
+--- @param ... string Command-line arguments
+--- @return integer Exit code
+local function main(...: string): integer
+  local a = parse_args({...})
+  if a.help then
+    print(USAGE)
+    return 0
+  end
+  if a.err then
+    io.stderr:write(a.err .. "\n" .. USAGE)
+    return 1
+  end
+  if a.compare_mode then
+    return run_compare(a)
+  end
+  return run_benches(a)
+end
+
+if proc.is_main() then
+  os.exit(main(...))
+end
+
+local record run
+  main: function(...: string): integer
+  parse_args: function(argv: {string}): Args
+  collect_meta: function(samples: integer, min_secs: number): pt.Meta
+  load_module: function(name: string): pt.BenchModule, string
+end
+
+local M: run = {
+  main = main,
+  parse_args = parse_args,
+  collect_meta = collect_meta,
+  load_module = load_module,
+}
+
+return M

--- a/lib/perf/run_test.tl
+++ b/lib/perf/run_test.tl
@@ -1,0 +1,68 @@
+local run = require("perf.run")
+
+local function test_parse_defaults()
+  local a = run.parse_args({"perf.bench.json_bench"})
+  assert(a.err == nil, "unexpected parse error: " .. tostring(a.err))
+  assert(a.samples == 5, "default samples wrong: " .. tostring(a.samples))
+  assert(a.min_secs > 0, "default min_secs missing")
+  assert(not a.compare_mode, "compare mode should default off")
+  assert(#a.positional == 1 and a.positional[1] == "perf.bench.json_bench",
+    "positional args wrong")
+end
+test_parse_defaults()
+
+local function test_parse_run_flags()
+  local a = run.parse_args({
+      "--out", "results.json",
+      "--samples", "3",
+      "--min-secs", "0.05",
+      "--only", "json",
+      "perf.bench.json_bench",
+    })
+  assert(a.err == nil, "unexpected parse error: " .. tostring(a.err))
+  assert(a.out == "results.json", "out wrong")
+  assert(a.samples == 3, "samples wrong")
+  assert(math.abs(a.min_secs - 0.05) < 1e-9, "min_secs wrong")
+  assert(a.only == "json", "only wrong")
+end
+test_parse_run_flags()
+
+local function test_parse_compare_flags()
+  local a = run.parse_args({"--compare", "--threshold", "5", "base.json", "cur.json"})
+  assert(a.err == nil, "unexpected parse error: " .. tostring(a.err))
+  assert(a.compare_mode, "compare mode not set")
+  assert(math.abs(a.threshold - 5.0) < 1e-9, "threshold wrong")
+  assert(#a.positional == 2, "positional count wrong")
+end
+test_parse_compare_flags()
+
+local function test_parse_rejects_bad_values()
+  assert(run.parse_args({"--samples", "zero"}).err ~= nil, "bad samples accepted")
+  assert(run.parse_args({"--samples", "0"}).err ~= nil, "zero samples accepted")
+  assert(run.parse_args({"--min-secs", "-1"}).err ~= nil, "negative min-secs accepted")
+  assert(run.parse_args({"--threshold", "nope"}).err ~= nil, "bad threshold accepted")
+end
+test_parse_rejects_bad_values()
+
+local function test_collect_meta()
+  local meta = run.collect_meta(3, 0.05)
+  assert(meta.samples == 3, "meta samples wrong")
+  assert(math.abs(meta.min_sample_secs - 0.05) < 1e-9, "meta min_secs wrong")
+  assert(meta.timestamp ~= nil and meta.timestamp > 0, "meta timestamp missing")
+  assert(meta.os ~= nil and #meta.os > 0, "meta os missing")
+  assert(meta.bin ~= nil and #meta.bin > 0, "meta bin missing")
+end
+test_collect_meta()
+
+local function test_load_module_validates()
+  local mod, err = run.load_module("perf.bench.json_bench")
+  assert(mod ~= nil, "bench module should load: " .. tostring(err))
+  local bad, berr = run.load_module("perf.stats")
+  assert(bad == nil and berr ~= nil and berr:find("scenarios", 1, true),
+    "non-bench module should be rejected: " .. tostring(berr))
+  local missing, merr = run.load_module("perf.no_such_module")
+  assert(missing == nil and merr ~= nil, "missing module should error")
+end
+test_load_module_validates()
+
+print("OK run_test")

--- a/lib/perf/stats.tl
+++ b/lib/perf/stats.tl
@@ -1,0 +1,127 @@
+--- Basic statistics over benchmark samples.
+--- All functions return 0 for an empty input list.
+
+--- Return a sorted copy of the input list.
+--- @param values {number} The values to sort
+--- @return {number} A new, ascending-sorted list
+local function sorted(values: {number}): {number}
+  local copy: {number} = {}
+  for i, v in ipairs(values) do
+    copy[i] = v
+  end
+  table.sort(copy)
+  return copy
+end
+
+--- Smallest value in the list.
+--- @param values {number} The values
+--- @return number The minimum, or 0 if empty
+local function min(values: {number}): number
+  if #values == 0 then
+    return 0
+  end
+  local m = values[1]
+  for _, v in ipairs(values) do
+    if v < m then
+      m = v
+    end
+  end
+  return m
+end
+
+--- Largest value in the list.
+--- @param values {number} The values
+--- @return number The maximum, or 0 if empty
+local function max(values: {number}): number
+  if #values == 0 then
+    return 0
+  end
+  local m = values[1]
+  for _, v in ipairs(values) do
+    if v > m then
+      m = v
+    end
+  end
+  return m
+end
+
+--- Arithmetic mean of the list.
+--- @param values {number} The values
+--- @return number The mean, or 0 if empty
+local function mean(values: {number}): number
+  if #values == 0 then
+    return 0
+  end
+  local total = 0.0
+  for _, v in ipairs(values) do
+    total = total + v
+  end
+  return total / #values
+end
+
+--- Median of the list (midpoint of the two middle values for even counts).
+--- @param values {number} The values
+--- @return number The median, or 0 if empty
+local function median(values: {number}): number
+  local n = #values
+  if n == 0 then
+    return 0
+  end
+  local s = sorted(values)
+  local mid = n // 2
+  if n % 2 == 1 then
+    return s[mid + 1]
+  end
+  return (s[mid] + s[mid + 1]) / 2
+end
+
+--- Sample standard deviation of the list.
+--- @param values {number} The values
+--- @return number The standard deviation, or 0 for fewer than two values
+local function stddev(values: {number}): number
+  local n = #values
+  if n < 2 then
+    return 0
+  end
+  local m = mean(values)
+  local sum_sq = 0.0
+  for _, v in ipairs(values) do
+    local d = v - m
+    sum_sq = sum_sq + d * d
+  end
+  return math.sqrt(sum_sq / (n - 1))
+end
+
+--- Spread of the samples as a percentage of the median:
+--- (max - min) / median * 100. Used as the noise bar when comparing runs.
+--- @param values {number} The values
+--- @return number The spread percentage, or 0 if empty or median is 0
+local function spread_pct(values: {number}): number
+  local med = median(values)
+  if med == 0 then
+    return 0
+  end
+  return (max(values) - min(values)) / med * 100.0
+end
+
+local record stats
+  sorted: function(values: {number}): {number}
+  min: function(values: {number}): number
+  max: function(values: {number}): number
+  mean: function(values: {number}): number
+  median: function(values: {number}): number
+  stddev: function(values: {number}): number
+  spread_pct: function(values: {number}): number
+end
+
+local M: stats = {
+  sorted = sorted,
+  min = min,
+  max = max,
+  mean = mean,
+  median = median,
+  stddev = stddev,
+  spread_pct = spread_pct,
+}
+
+return M

--- a/lib/perf/stats_test.tl
+++ b/lib/perf/stats_test.tl
@@ -1,0 +1,56 @@
+local stats = require("perf.stats")
+
+local function close_enough(a: number, b: number): boolean
+  return math.abs(a - b) < 1e-9
+end
+
+local function test_empty_lists_return_zero()
+  assert(stats.min({}) == 0, "min of empty should be 0")
+  assert(stats.max({}) == 0, "max of empty should be 0")
+  assert(stats.mean({}) == 0, "mean of empty should be 0")
+  assert(stats.median({}) == 0, "median of empty should be 0")
+  assert(stats.stddev({}) == 0, "stddev of empty should be 0")
+  assert(stats.spread_pct({}) == 0, "spread of empty should be 0")
+end
+test_empty_lists_return_zero()
+
+local function test_sorted_returns_copy()
+  local input = {3, 1, 2}
+  local s = stats.sorted(input)
+  assert(s[1] == 1 and s[2] == 2 and s[3] == 3, "sorted order wrong")
+  assert(input[1] == 3, "input list must not be mutated")
+end
+test_sorted_returns_copy()
+
+local function test_min_max_mean()
+  local values = {4, 1, 7, 2}
+  assert(stats.min(values) == 1, "min wrong")
+  assert(stats.max(values) == 7, "max wrong")
+  assert(close_enough(stats.mean(values), 3.5), "mean wrong: " .. stats.mean(values))
+end
+test_min_max_mean()
+
+local function test_median_odd_and_even()
+  assert(stats.median({5}) == 5, "single-value median wrong")
+  assert(stats.median({3, 1, 2}) == 2, "odd median wrong")
+  assert(close_enough(stats.median({4, 1, 3, 2}), 2.5), "even median wrong")
+end
+test_median_odd_and_even()
+
+local function test_stddev()
+  assert(stats.stddev({5}) == 0, "single-value stddev should be 0")
+  -- sample stddev of {2, 4, 4, 4, 5, 5, 7, 9} is ~2.138
+  local sd = stats.stddev({2, 4, 4, 4, 5, 5, 7, 9})
+  assert(math.abs(sd - 2.138089935299395) < 1e-9, "stddev wrong: " .. sd)
+end
+test_stddev()
+
+local function test_spread_pct()
+  -- median 10, max-min = 2 -> 20%
+  assert(close_enough(stats.spread_pct({9, 10, 11}), 20.0),
+    "spread wrong: " .. stats.spread_pct({9, 10, 11}))
+  assert(stats.spread_pct({0, 0, 0}) == 0, "zero-median spread should be 0")
+end
+test_spread_pct()
+
+print("OK stats_test")


### PR DESCRIPTION
# perf harness: the mechanism for optimizing cosmic safely

This adds `lib/perf`, a benchmark harness that defines *how* performance work happens on cosmic — measurement, functional guardrails, and a regression gate — so the brute optimization loop can be handed to a lower-power model/agent. The operating manual is `lib/perf/OPTIMIZE.md`.

## What's in the box

**Harness** (`harness.tl`, `stats.tl`, `perf_types.tl`)
- Scenario spec: `setup / fn / check / teardown`. Wall-clock timing (monotonic), auto-calibrated iteration counts, multiple samples, median ns/op + spread + cpu/wall ratio + best-effort alloc KB/op.
- **Functional guardrail**: every scenario's `check()` validates the workload output before *and* after timing. A faster-but-wrong change fails the benchmark instead of reporting a win. `perf_test.tl` (runs in normal CI) smoke-runs all scenarios and rejects any scenario without a check.

**Regression gate** (`compare.tl`, `run.tl`)
- `bin/make perf-baseline` → snapshot; `bin/make perf-compare` → re-measure and fail on regression.
- Noise-aware bar: `max(PERF_THRESHOLD, baseline spread, current spread)`; a failed compare re-measures once, so machine noise must reproduce in the same direction to fail.
- Errored and **missing** scenarios count as failures — deleting a benchmark can't hide a regression.
- Results are JSON with environment metadata (binary path, cosmic/cosmos versions, os/isa/nproc).

**20 scenarios across 6 benches** (`lib/perf/bench/`)
- `json`: small/large decode, encode, roundtrip
- `sqlite`: transactional insert+delete (stationary), point query, aggregate scan — real DB file, WAL
- `http`: fetch GET and raw TCP roundtrip against a forked loopback server; the pair brackets the fetch-layer overhead (fetch goes through its proxy option because cosmo.Fetch hard-blocks private IPs — SSRF protection with no opt-out)
- `fs`: tree walk, 64KB barf/slurp, stat sweep (write-churn scenarios deliberately avoided: they drift monotonically on overlay filesystems)
- `micro`: SHA-256 with the NIST million-`a` vector, hex/base64/compress roundtrips, string split
- `startup`: spawn the cosmic binary to run Lua, run Teal, and `--compile` — this is the **cosmo/cosmopolitan end-to-end path** (APE loader + zip fs + Lua boot + Teal compiler). `PERF_BIN=/path/to/other/cosmic` measures any alternate binary, e.g. a new cosmos pin.

**Docs**: `lib/perf/OPTIMIZE.md` (the agent-executable loop: baseline → hypothesis → change → `bin/make ci` → `bin/make perf-compare` → keep or revert, plus hard rules and how to read the report), AGENTS.md Performance section.

**Bonus fix**: `make-help` only parsed the first makefile argument; it now aggregates `$(MAKEFILE_LIST)`, so module targets (including the new perf ones) show up in `bin/make help`.

## Gates proven end-to-end

- Planted `for _ = 1, 200000 do end` in `json.decode` → `perf-compare` failed on exactly the decode scenarios (+52% … +47,644%) while `json_encode_large` stayed ok, and make rebuilt the binary automatically.
- Planted a wrong-output change in `json.decode` → scenario `check()`s failed (`FAIL: check failed: bad item count`), nonzero exit.
- Clean tree: `bin/make ci` green (format 212, teal 212, test 98, example 18, lint 274); default-settings `perf-baseline` + `perf-compare`: 20 scenarios, 0 regressions.

## Opportunities the harness already surfaced

- `codec.decode_hex` is a pure-Lua `gsub` with a per-byte-pair callback: hex roundtrip of 64KB runs ~17.6ms vs ~2.1ms for base64 on the same input, while an unused `cosmo.DecodeHex` C binding exists. Archetypal first assignment for the optimization loop.
- `json_decode_large` allocates ~375KB/op; `startup_run_teal` vs `startup_run_lua` isolates ~13ms of Teal loader cost from ~14.5ms of runtime boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGYUQZ7Cur4zubkuYBFcVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGYUQZ7Cur4zubkuYBFcVB)_