### PR TITLE
codec: decode_hex delegates to cosmo.DecodeHex for the hot path

### DIFF
--- a/lib/cosmic/codec.tl
+++ b/lib/cosmic/codec.tl
@@ -24,11 +24,8 @@ local function decode_hex(hex: string): string, string
   if hex:match("[^0-9a-fA-F]") then
     return nil, "invalid hex character"
   end
-  -- Decode pairs of hex digits
-  local result = hex:gsub("(%x%x)", function(pair: string): string
-      return string.char(tonumber(pair, 16) as integer)
-    end)
-  return result, nil
+  -- Validation above guarantees cosmo.DecodeHex cannot raise
+  return cosmo.DecodeHex(hex), nil
 end
 
 --- Encode a Lua value as Lua source code.

--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -126,20 +126,23 @@ rejected entries stay in the file; they save the next agent from
 re-testing a dead end. add new entries as `open` when a report line or
 code read suggests one.
 
-1. **hex decode via the C binding** — open
-   - scenario: `codec_hex_roundtrip_64k` (~17.3ms; base64 does the same
-     64KB in ~2.1ms)
-   - evidence: `codec.decode_hex` (lib/cosmic/codec.tl) is a pure-Lua
+1. **hex decode via the C binding** — done (2026-07-04)
+   - scenario: `codec_hex_roundtrip_64k`: 17.53ms -> 2.16ms (-87.7%
+     first pass, -88.0% on re-measure)
+   - evidence: `codec.decode_hex` (lib/cosmic/codec.tl) was a pure-Lua
      `gsub("(%x%x)", callback)` — one closure call per byte pair, ~32k
      for 64KB — plus two full-string validation scans. `cosmo.DecodeHex`
-     exists (lib/types/cosmo.d.tl:130) and is unused.
-   - hypothesis: delegating the hot path to `cosmo.DecodeHex` while
-     keeping the documented `value, string` error returns (even-length
-     and hex-character validation semantics must not change) cuts the
-     roundtrip by ~5-8x.
-   - risk: low. check how the C binding handles odd length, invalid
-     chars, uppercase, and empty string; keep Lua-side validation where
-     the binding's behavior differs.
+     exists (lib/types/cosmo.d.tl:130) and was unused.
+   - fix: kept the existing Lua-side even-length and hex-character
+     validation (so the documented `value, string` error returns and
+     messages are unchanged — `cosmo.DecodeHex` raises a Lua error on
+     odd length / non-hex input rather than returning nil+err, so
+     validation must run first), then delegated the actual byte
+     conversion to `cosmo.DecodeHex` instead of the gsub callback.
+   - result: no other scenario regressed (`bin/make perf-compare`: 20
+     scenarios, 0 regression, 1 faster, 19 ok after a clean re-measure;
+     an initial run flagged an unrelated `startup_*` scenario that
+     didn't reproduce and isn't touched by this change).
 
 2. **sqlite prepared-statement reuse** — open
    - scenarios: `sqlite_insert_delete_tx` (~680µs for 100 inserts + 1


### PR DESCRIPTION
## Summary

Works the first entry of the `lib/perf/OPTIMIZE.md` hypothesis backlog: hex decode via the C binding.

- `codec.decode_hex` (`lib/cosmic/codec.tl`) previously decoded via a pure-Lua `gsub("(%x%x)", callback)` — one closure call per byte pair (~32k for a 64KB input) — even though `cosmo.DecodeHex` (`lib/types/cosmo.d.tl:130`) already exists and was unused.
- kept the existing Lua-side even-length and hex-character validation in front of the C call, since `cosmo.DecodeHex` raises a Lua error on odd length / non-hex input rather than returning `nil, err` — this preserves the documented `value, string` error returns and messages exactly.
- replaced only the per-byte-pair gsub callback with a single `cosmo.DecodeHex` call for the (now pre-validated) hot path.
- updated the backlog entry in `lib/perf/OPTIMIZE.md` from `open` to `done` with before/after numbers, per the loop's documented procedure.

## Results

Followed the loop in `lib/perf/OPTIMIZE.md`: baseline → hypothesis → change → gate 1 → gate 2.

- gate 1 (`bin/make ci`): format + type check + tests + examples all pass.
- gate 2 (`bin/make perf-compare`): `codec_hex_roundtrip_64k` 17.53ms → 2.16ms (**-87.7%**, confirmed **-88.0%** on a clean re-measure). 20 scenarios, 0 regression, 1 faster, 19 ok. (An initial run flagged an unrelated `startup_*` scenario that didn't reproduce on re-measure and isn't touched by this change — noise, not a regression.)

## Test plan

- [x] `bin/make ci` (format, teal type check, tests, examples) — all pass
- [x] `bin/make perf-baseline` before the change
- [x] `bin/make perf-compare` after the change — re-measured to confirm no regression
- [x] existing `codec_test.tl` cases for `decode_hex` (basic, uppercase, empty, odd length, invalid char, roundtrip) pass unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_012uyf3CZ9nsm9Mv2KEwi6J9)_