### PR TITLE
sqlite: cache prepared statements for db:exec

### DIFF
--- a/lib/cosmic/sqlite.tl
+++ b/lib/cosmic/sqlite.tl
@@ -17,6 +17,7 @@
 ---     db:close()
 
 local lsqlite3 = require("cosmo.lsqlite3")
+local stmt_cache_mod = require("cosmic.sqlite_stmt_cache")
 
 -- Raw lsqlite3 types (0-indexed, requires manual cleanup)
 local record RawStatement
@@ -45,6 +46,7 @@ local record RawSqlite3
   OK: number
   ROW: number
   DONE: number
+  SCHEMA: number
   open: function(filename: string): RawDatabase, number, string
 end
 
@@ -264,6 +266,9 @@ local function make_database(raw_db: RawDatabase): Database
   local db: Database = {}
   local closed = false
 
+  -- Reuses prepared statements for db:exec (see cosmic.sqlite_stmt_cache).
+  local stmt_cache = stmt_cache_mod.new(raw_db as any, sqlite3.OK, sqlite3.DONE, sqlite3.ROW, sqlite3.SCHEMA)
+
   function db:prepare(sql: string): Statement, string
     if closed then
       return nil, "database is closed"
@@ -307,21 +312,12 @@ local function make_database(raw_db: RawDatabase): Database
       return true
     end
 
-    -- has params: prepare/bind/exec
-    local stmt, err = self:prepare(sql)
-    if not stmt then
-      return false, err or "prepare failed"
+    -- has params: reuse a cached prepared statement (see cosmic.sqlite_stmt_cache)
+    local args: {integer: any} = {}
+    for i = 1, n do
+      args[i] = select(i, ...)
     end
-
-    local ok, bind_err = stmt:bind(...)
-    if not ok then
-      stmt:close()
-      return false, bind_err or "bind failed"
-    end
-
-    local exec_ok, exec_err = stmt:exec()
-    stmt:close()
-    return exec_ok, exec_err
+    return stmt_cache:exec(sql, args, n)
   end
 
   --- Execute SQL with parameters from a list (table).
@@ -460,6 +456,7 @@ local function make_database(raw_db: RawDatabase): Database
   db.close = function(_: Database)
     if not closed then
       closed = true
+      stmt_cache:close_all()
       local _ = raw_db:close()
     end
   end

--- a/lib/cosmic/sqlite_stmt_cache.tl
+++ b/lib/cosmic/sqlite_stmt_cache.tl
@@ -1,0 +1,96 @@
+--- Internal helper for cosmic.sqlite: caches prepared statements by SQL
+--- text so db:exec can reuse a statement across repeated calls with the
+--- same SQL (e.g. inside a loop in a transaction) instead of preparing
+--- and finalizing a fresh one every time.
+
+local record RawStatement
+  bind: function(self: RawStatement, n: number, value?: any): number
+  step: function(self: RawStatement): number
+  reset: function(self: RawStatement)
+  finalize: function(self: RawStatement): number
+end
+
+local record RawDatabase
+  prepare: function(self: RawDatabase, sql: string): RawStatement, number, string
+  errmsg: function(self: RawDatabase): string
+end
+
+local record StmtCache
+  exec: function(self: StmtCache, sql: string, args: {integer: any}, n: integer): boolean, string
+  close_all: function(self: StmtCache)
+end
+
+--- Create a statement cache bound to a raw database handle.
+--- @param raw_db_any any The lsqlite3 database handle to prepare against
+--- (typed `any` so callers don't need a nominally-identical RawDatabase type)
+--- @param ok_code number lsqlite3.OK
+--- @param done_code number lsqlite3.DONE
+--- @param row_code number lsqlite3.ROW
+--- @param schema_code number lsqlite3.SCHEMA
+--- @return StmtCache
+local function new(raw_db_any: any, ok_code: number, done_code: number, row_code: number, schema_code: number): StmtCache
+  local raw_db = raw_db_any as RawDatabase
+  local cache: {string: RawStatement} = {}
+  local self: StmtCache = {}
+
+  local function get(sql: string): RawStatement, string
+    local cached = cache[sql]
+    if cached then
+      return cached
+    end
+    local raw_stmt, errcode, errmsg = raw_db:prepare(sql)
+    if not raw_stmt then
+      return nil, errmsg or ("error code " .. tostring(errcode))
+    end
+    cache[sql] = raw_stmt
+    return raw_stmt
+  end
+
+  local function bind_and_step(raw_stmt: RawStatement, args: {integer: any}, n: integer): number
+    raw_stmt:reset()
+    for i = 1, n do
+      local rc = raw_stmt:bind(i, args[i])
+      if rc ~= ok_code then
+        return rc
+      end
+    end
+    return raw_stmt:step()
+  end
+
+  --- Finalize every cached statement, e.g. when the owning database closes.
+  self.close_all = function(_: StmtCache)
+    for sql, raw_stmt in pairs(cache) do
+      local _ = raw_stmt:finalize()
+      cache[sql] = nil
+    end
+  end
+
+  --- Execute a parameterized statement once, reusing (or preparing and
+  --- caching) the statement for `sql`. On SQLITE_SCHEMA, drops the stale
+  --- statement and retries once (sqlite3 already retries internally
+  --- before surfacing SCHEMA, so a second failure is a real error).
+  function self:exec(sql: string, args: {integer: any}, n: integer): boolean, string
+    local raw_stmt, err = get(sql)
+    if not raw_stmt then
+      return false, err
+    end
+    local rc = bind_and_step(raw_stmt, args, n)
+    if rc == schema_code then
+      cache[sql] = nil
+      local _ = raw_stmt:finalize()
+      raw_stmt, err = get(sql)
+      if not raw_stmt then
+        return false, err
+      end
+      rc = bind_and_step(raw_stmt, args, n)
+    end
+    if rc ~= done_code and rc ~= row_code then
+      return false, raw_db:errmsg()
+    end
+    return true
+  end
+
+  return self
+end
+
+return {new = new}

--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -144,19 +144,34 @@ code read suggests one.
      an initial run flagged an unrelated `startup_*` scenario that
      didn't reproduce and isn't touched by this change).
 
-2. **sqlite prepared-statement reuse** — open
-   - scenarios: `sqlite_insert_delete_tx` (~680µs for 100 inserts + 1
-     delete ≈ 6.6µs/row), `sqlite_point_query` (~12.7µs)
-   - evidence: `db:exec(sql, ...)` and `db:query(sql, ...)`
-     (lib/cosmic/sqlite.tl) prepare, bind, and finalize a fresh statement
-     on every parameterized call; the insert scenario pays 100
-     prepares per transaction for the same SQL string.
-   - hypothesis: a small per-database cache of prepared statements keyed
-     by SQL text (reset + rebind on hit, finalize on close/eviction)
-     cuts parameterized exec/query by 20-50%.
-   - risk: medium. statement lifetime vs `db:close`, statements held
-     mid-iteration, cache invalidation on schema change (sqlite returns
-     SQLITE_SCHEMA; re-prepare on that error). start with exec-only.
+2. **sqlite prepared-statement reuse** — done (2026-07-04)
+   - scenario: `sqlite_insert_delete_tx`: 679.87µs -> 234.32µs (-65.5%,
+     comfortably beating the 20-50% hypothesis). `sqlite_point_query`
+     also moved 13.34µs -> 11.98µs (-10.2%) though it goes through
+     `db:query`/`db:query_one`, not the cached `db:exec` path — likely
+     machine variance between the two runs rather than an effect of
+     this change, noted rather than claimed.
+   - evidence: `db:exec(sql, ...)` (lib/cosmic/sqlite.tl) prepared,
+     bound, and finalized a fresh statement on every parameterized call;
+     the insert scenario paid 100 prepares per transaction for the same
+     SQL string.
+   - fix: added `lib/cosmic/sqlite_stmt_cache.tl` (a new file, needed to
+     keep sqlite.tl under the 500-line cap), a per-database cache of
+     prepared statements keyed by SQL text used only by `db:exec`
+     (per the "start with exec-only" risk note; `db:query*` still
+     prepare/finalize per call). reset + rebind on a cache hit; on
+     SQLITE_SCHEMA the stale statement is dropped and re-prepared once;
+     all cached statements are finalized in `db:close`.
+   - gotcha hit while implementing: the bootstrap compiler's `--compile`
+     path (used to transpile .tl -> .lua, distinct from `--check-types`)
+     misreports a zero-return-value method defined with colon-method
+     sugar (`function self:m()`) inside a closure as returning 1 value.
+     The existing codebase already works around this for `db.close` /
+     `stmt.close` by assigning a plain function value
+     (`self.m = function(self: T) ... end`) instead of colon sugar for
+     zero-return methods; `close_all` here follows the same idiom.
+   - result: `bin/make perf-compare` from a clean re-baseline: 20
+     scenarios, 0 regression, 2 faster, 18 ok.
 
 3. **startup: Teal loader cost** — open
    - scenarios: `startup_run_teal` (~30ms) vs `startup_run_lua` (~16.5ms)


### PR DESCRIPTION
## Summary

Works the second entry of the `lib/perf/OPTIMIZE.md` hypothesis backlog: sqlite prepared-statement reuse.

- `db:exec(sql, ...)` (`lib/cosmic/sqlite.tl`) previously prepared, bound, and finalized a fresh statement on every parameterized call, so a loop executing the same SQL (e.g. 100 inserts inside one transaction) paid 100 prepares for a single statement.
- added `lib/cosmic/sqlite_stmt_cache.tl`, a per-database cache of prepared statements keyed by SQL text, used only by `db:exec` (scoped to exec-only per the backlog entry's risk note; `db:query`/`db:query_one`/etc. are unchanged).
  - cache hit: reset + rebind the existing statement instead of re-preparing.
  - `SQLITE_SCHEMA`: drop the stale statement, re-prepare once, retry (sqlite3 already retries internally before surfacing `SCHEMA`, so a second failure is a real error).
  - `db:close()` finalizes every cached statement.
- the cache lives in its own file because `lib/cosmic/sqlite.tl` was already at the repo's 500-line-per-file cap; adding this inline would have pushed it over.
- hit a real gotcha along the way: the bootstrap compiler's `--compile` path (used to transpile `.tl` → `.lua`, distinct from `--check-types`) misreports a zero-return-value method defined with colon-method sugar (`function self:m()`) inside a closure as returning 1 value. The existing codebase already works around this for `db.close`/`stmt.close` by assigning a plain function value instead of colon sugar for zero-return methods — `close_all` here follows the same idiom.
- updated the backlog entry in `lib/perf/OPTIMIZE.md` from `open` to `done` with before/after numbers and the gotcha, per the loop's documented procedure.

## Results

Followed the loop in `lib/perf/OPTIMIZE.md`: baseline → hypothesis → change → gate 1 → gate 2. Since the prior PR (#438, hex decode) had merged in the meantime, re-baselined from a clean tree on the current `main` before measuring this change.

- gate 1 (`bin/make ci`): format + type check + tests + examples all pass.
- gate 2 (`bin/make perf-compare`): `sqlite_insert_delete_tx` 679.87µs → 234.32µs (**-65.5%**, well past the 20-50% hypothesis). `sqlite_point_query` also moved -10.2%, though that scenario goes through `db:query`/`db:query_one` rather than the cached `db:exec` path — noted as likely machine variance rather than claimed as an effect of this change. 20 scenarios, 0 regression, 2 faster, 18 ok.

## Test plan

- [x] `bin/make ci` (format, teal type check, tests, examples) — all pass
- [x] `bin/make perf-baseline` from a clean tree on current `main`
- [x] `bin/make perf-compare` after the change — 0 regressions
- [x] existing `sqlite_test.tl`/`sqlite_advanced_test.tl` cases (exec with params, multiple params, no params, use-after-close, prepare/bind/exec, etc.) pass unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_012uyf3CZ9nsm9Mv2KEwi6J9)_