### PR TITLE
fs_walk: use dirent d_type to skip stat(2) in files()/collect_all()

### DIFF
--- a/lib/cosmic/fs_walk.tl
+++ b/lib/cosmic/fs_walk.tl
@@ -8,8 +8,11 @@ local WalkStat = types.WalkStat
 local FileInfo = types.FileInfo
 
 --- Handle for reading directory entries (internal).
+--- `read`'s second return is the dirent d_type (unix.DT_DIR / DT_REG /
+--- DT_LNK / ... / DT_UNKNOWN) where the filesystem supports it, letting
+--- callers that only need "is this a directory" skip a stat(2) call.
 local record WalkDirHandle
-  read: function(self): string
+  read: function(self): string, number
   close: function(self)
 end
 
@@ -111,21 +114,35 @@ local function collect_all(dir: string): {string: FileInfo}
     if not handle then return end
 
     while true do
-      local entry = handle:read()
+      local entry, kind = handle:read()
       if not entry then break end
       if entry ~= "." and entry ~= ".." then
         local full_path = cosmo_path.join(base_dir, entry)
         local rel_path = rel_base == "" and entry or cosmo_path.join(rel_base, entry)
-        -- Use AT_SYMLINK_NOFOLLOW to detect symlinked dirs as S_ISLNK, not S_ISDIR.
-        -- This prevents infinite recursion through symlink cycles.
-        local st = unix.stat(full_path, unix.AT_SYMLINK_NOFOLLOW) as WalkStat
 
-        if st then
-          if unix.S_ISDIR(st:mode()) then
-            do_walk(full_path, rel_path)
-          elseif unix.S_ISREG(st:mode()) then
-            local mode = st:mode() & 0x1ff
-            files[rel_path] = {mode = mode}
+        if kind == unix.DT_DIR then
+          -- d_type never follows symlinks, so a real directory (as opposed
+          -- to a symlink to one) is enough to recurse without a stat(2)
+          -- call. This is what prevents infinite recursion through
+          -- symlink cycles below too: a symlinked dir reports DT_LNK.
+          do_walk(full_path, rel_path)
+        elseif kind ~= unix.DT_REG and kind ~= unix.DT_UNKNOWN then
+          -- Definitely neither a directory nor a regular file (symlink,
+          -- fifo, socket, ...): matches neither branch below, so skip
+          -- without paying for a stat(2) call.
+        else
+          -- kind is DT_REG (need the mode bits) or DT_UNKNOWN (filesystem
+          -- doesn't expose d_type; fall back to a real stat). Use
+          -- AT_SYMLINK_NOFOLLOW so a symlinked dir reports S_ISLNK, not
+          -- S_ISDIR, preserving the same cycle prevention as above.
+          local st = unix.stat(full_path, unix.AT_SYMLINK_NOFOLLOW) as WalkStat
+          if st then
+            if unix.S_ISDIR(st:mode()) then
+              do_walk(full_path, rel_path)
+            elseif unix.S_ISREG(st:mode()) then
+              local mode = st:mode() & 0x1ff
+              files[rel_path] = {mode = mode}
+            end
           end
         end
       end
@@ -167,24 +184,39 @@ local function files(dir: string, pattern?: string): function(): string
       local current_dir = current[1]
       local current_handle = current[2]
 
-      local entry = current_handle:read()
+      local entry, kind = current_handle:read()
       if not entry then
         current_handle:close()
         table.remove(stack)
       elseif entry ~= "." and entry ~= ".." then
         local full_path = cosmo_path.join(current_dir, entry)
-        -- Use AT_SYMLINK_NOFOLLOW to detect symlinked dirs as S_ISLNK, not S_ISDIR.
-        -- This prevents infinite recursion through symlink cycles.
-        local st = unix.stat(full_path, unix.AT_SYMLINK_NOFOLLOW) as WalkStat
-        if st then
-          if unix.S_ISDIR(st:mode()) then
-            -- Push subdirectory onto stack
-            local subhandle = unix.opendir(full_path) as WalkDirHandle
-            if subhandle then
-              table.insert(stack, {full_path, subhandle})
-            end
-          elseif entry:match(lua_pattern) then
+        if kind == unix.DT_DIR then
+          -- d_type never follows symlinks, so this is a real directory
+          -- (a symlinked dir reports DT_LNK), and skips a stat(2) call.
+          local subhandle = unix.opendir(full_path) as WalkDirHandle
+          if subhandle then
+            table.insert(stack, {full_path, subhandle})
+          end
+        elseif kind ~= unix.DT_UNKNOWN then
+          -- Definitely not a directory: files() never needs stat data,
+          -- only the path, so just check the pattern without stat(2).
+          if entry:match(lua_pattern) then
             return full_path
+          end
+        else
+          -- Filesystem doesn't expose d_type; fall back to a real stat,
+          -- using AT_SYMLINK_NOFOLLOW so a symlinked dir reports
+          -- S_ISLNK, not S_ISDIR, preserving the same cycle prevention.
+          local st = unix.stat(full_path, unix.AT_SYMLINK_NOFOLLOW) as WalkStat
+          if st then
+            if unix.S_ISDIR(st:mode()) then
+              local subhandle = unix.opendir(full_path) as WalkDirHandle
+              if subhandle then
+                table.insert(stack, {full_path, subhandle})
+              end
+            elseif entry:match(lua_pattern) then
+              return full_path
+            end
           end
         end
       end

--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -227,18 +227,43 @@ code read suggests one.
    - risk: low for any further import-deferral; cosmopolitan-side work
      follows the "optimizing the cosmo/cosmopolitan layer" section.
 
-5. **fs.walk per-entry cost** — open (evidence-gathering)
-   - scenario: `fs_walk_tree` (~390µs for 210 entries ≈ 1.9µs/entry,
-     ~200B allocated per entry)
-   - evidence: `fs_walk.tl` calls `unix.stat` on every entry (needed
-     today to detect directories) and allocates a joined path string +
-     stat userdata per entry.
-   - hypothesis: if the dirent from `handle:read()` can expose the entry
-     type (d_type is available on Linux; check the cosmo opendir
-     binding), directory detection skips one stat syscall per
-     non-directory entry — roughly halving syscalls for file-heavy trees.
-   - risk: needs a binding check first; d_type is DT_UNKNOWN on some
-     filesystems, so the stat fallback must remain.
+5. **fs.walk per-entry cost** — done for `files()`/`collect_all()`
+     (2026-07-04); `walk()`/`collect()` unchanged (see below)
+   - binding check: `unix.Dir:read()` (`lib/types/cosmo/unix.d.tl:157`)
+     already returns `string, number, number, number` — name, `kind`
+     (d_type: `DT_DIR`/`DT_REG`/`DT_LNK`/.../`DT_UNKNOWN`), ino, off —
+     but `fs_walk.tl`'s internal `WalkDirHandle` record only declared a
+     single `string` return, discarding `kind`.
+   - key finding that narrowed the hypothesis: `walk()` (and `collect()`,
+     which is implemented on top of `walk()`) hands every visitor a full
+     `WalkStat`, per its documented contract — so those two can NOT skip
+     the stat(2) call without changing observable behavior. Only
+     `collect_all()` and `files()` have their own private traversal loops
+     that never expose `st` to a caller, so only those two got the d_type
+     fast path. `walk()`/`collect()` are unchanged; a future pass could
+     revisit them with an explicitly lazy-stat visitor API, but that's a
+     bigger, contract-changing effort out of scope here.
+   - fix: `WalkDirHandle.read` now returns the `kind` too. In
+     `collect_all()`/`files()`, `kind == DT_DIR` recurses (or pushes)
+     without stat (d_type never follows symlinks, so this still can't
+     recurse into a symlinked dir — a symlink reports `DT_LNK`, the same
+     cycle prevention `AT_SYMLINK_NOFOLLOW` stat gave before); any other
+     definite (non-`DT_UNKNOWN`) kind skips stat too, since `files()`
+     never needed stat data beyond "not a directory" and `collect_all()`
+     only stores `DT_REG` entries (for which stat is still needed, for
+     the mode bits); `DT_UNKNOWN` falls back to the original stat-based
+     check unchanged, for filesystems that don't expose d_type.
+   - added a new scenario, `fs_files_tree` (iterates `fs.files()` over
+     the existing seeded tree matching `*.txt`), since `files()` and
+     `collect_all()` had no benchmark coverage before this — `files()`
+     is the one where a file-heavy tree pays for zero stat(2) calls
+     instead of one per entry, so it shows the win most clearly.
+   - result: `fs_files_tree` 415.81µs -> 187.31µs (-55.0%, confirmed
+     -56.7% on re-measure). `bin/make perf-compare` both times: 21
+     scenarios, 0 regression, 1 faster, 20 ok. `fs_walk_tree`/`fs_stat_tree`
+     unaffected (within noise), as expected since `walk()` didn't change.
+     verified against `lib/cosmic/fs_walk_test.tl`'s existing symlink-cycle
+     tests for `collect_all()` and `files()`, which pass unchanged.
 
 6. **string.split micro-costs** — open, low priority
    - scenario: `string_split_csv` (~50µs for 256 fields ≈ 190ns/field)

--- a/lib/perf/bench/fs_bench.tl
+++ b/lib/perf/bench/fs_bench.tl
@@ -77,6 +77,28 @@ local function scenarios(): {pt.Scenario}, string
       end,
     },
     {
+      -- Iterate matching files without ever needing stat data (fs.files()
+      -- only returns paths), so this is the scenario a d_type fast path
+      -- (skip stat(2) when the dirent already says "not a directory")
+      -- should show up in most clearly.
+      name = "fs_files_tree",
+      fn = function(_: any): any
+        local count = 0
+        for _ in fs.files(tmpdir, "*.txt") do
+          count = count + 1
+        end
+        return count
+      end,
+      check = function(_: any, res: any): boolean, string
+        local count = res as integer
+        if count ~= DIRS * FILES_PER_DIR then
+          return false, string.format("found %s *.txt files, want %d",
+            tostring(count), DIRS * FILES_PER_DIR)
+        end
+        return true
+      end,
+    },
+    {
       name = "fs_barf_slurp_64k",
       fn = function(_: any): any
         local wok, werr = cio.barf(blob_path, BLOB)


### PR DESCRIPTION
## Summary

Works the fifth entry of the `lib/perf/OPTIMIZE.md` hypothesis backlog: fs.walk per-entry cost, scoped down after investigation (see below).

- binding check: `unix.Dir:read()` (`lib/types/cosmo/unix.d.tl:157`) already returns `string, number, number, number` — name, `kind` (dirent d_type: `DT_DIR`/`DT_REG`/`DT_LNK`/.../`DT_UNKNOWN`), ino, off — but `fs_walk.tl`'s internal `WalkDirHandle` record only declared a single `string` return, so `kind` was discarded on every call.
- **key finding that narrowed the hypothesis**: `walk()` (and `collect()`, which is implemented on top of `walk()`) hand every visitor a full `WalkStat`, per their documented contract — so those two can't skip the `stat(2)` call without changing observable behavior. Only `collect_all()` and `files()` have their own private traversal loops that never expose `st` to a caller, so only those two got the d_type fast path. `walk()`/`collect()` are left unchanged; revisiting them would need a contract change (e.g. a lazy-stat visitor API) that's out of scope here.
- fix: `WalkDirHandle.read` now returns `kind` too. In `collect_all()`/`files()`, `kind == DT_DIR` recurses/pushes without a stat call (d_type never follows symlinks, so a symlinked directory still correctly reports `DT_LNK`, preserving the existing cycle-prevention that `AT_SYMLINK_NOFOLLOW` stat gave before); any other definite (non-`DT_UNKNOWN`) kind resolves from d_type alone without stat (`files()` never needed stat data beyond "not a directory"; `collect_all()` only stores `DT_REG` entries, for which stat is still needed for the mode bits). `DT_UNKNOWN` falls back to the original stat-based check unchanged, for filesystems that don't expose d_type.
- added a new `fs_files_tree` benchmark scenario (iterates `fs.files()` over the existing seeded tree matching `*.txt`), since `files()`/`collect_all()` had no benchmark coverage before this change — `files()` is where a file-heavy tree goes from one `stat(2)` call per entry to zero, so it shows the win most clearly.

## Results

Followed the loop in `lib/perf/OPTIMIZE.md`: baseline → hypothesis → change → gate 1 → gate 2. To get a fair before/after for the new scenario, baselined with the new scenario present but the old (unoptimized) `fs_walk.tl`, then compared against the optimized version.

- gate 1 (`bin/make ci`): format + type check + tests + examples all pass, including the existing symlink-cycle-termination tests in `lib/cosmic/fs_walk_test.tl` for `collect_all()` and `files()`.
- gate 2 (`bin/make perf-compare`): `fs_files_tree` 415.81µs → 187.31µs (**-55.0%**, confirmed **-56.7%** on re-measure). `fs_walk_tree`/`fs_stat_tree` unaffected (within noise), as expected since `walk()` didn't change. 21 scenarios, 0 regression, 1 faster, 20 ok — both runs.

## Test plan

- [x] `bin/make ci` (format, teal type check, tests, examples) — all pass
- [x] `bin/make perf-baseline` with the new scenario present but unoptimized `fs_walk.tl`
- [x] `bin/make perf-compare` after the change, run twice — 0 regressions both times
- [x] existing `lib/cosmic/fs_walk_test.tl` symlink-cycle-termination tests for `walk()`, `collect_all()`, and `files()` pass unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_012uyf3CZ9nsm9Mv2KEwi6J9)_