### PR TITLE
string: use indexed assignment instead of table.insert in split()

### DIFF
--- a/lib/cosmic/string.tl
+++ b/lib/cosmic/string.tl
@@ -62,9 +62,11 @@ end
 --- @return {string} Array of substrings
 local function split(s: string, sep: string): {string}
   local result: {string} = {}
+  local n = 0
   if sep == "" then
     for i = 1, #s do
-      table.insert(result, s:sub(i, i))
+      n = n + 1
+      result[n] = s:sub(i, i)
     end
     return result
   end
@@ -76,10 +78,12 @@ local function split(s: string, sep: string): {string}
   while true do
     local found = s:find(sep, pos, true)
     if not found then
-      table.insert(result, s:sub(pos))
+      n = n + 1
+      result[n] = s:sub(pos)
       break
     end
-    table.insert(result, s:sub(pos, found - 1))
+    n = n + 1
+    result[n] = s:sub(pos, found - 1)
     pos = found + sep_len
   end
   return result

--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -265,14 +265,19 @@ code read suggests one.
      verified against `lib/cosmic/fs_walk_test.tl`'s existing symlink-cycle
      tests for `collect_all()` and `files()`, which pass unchanged.
 
-6. **string.split micro-costs** — open, low priority
-   - scenario: `string_split_csv` (~50µs for 256 fields ≈ 190ns/field)
-   - evidence: implementation already uses plain `find`; remaining cost
-     is `table.insert` (a C call resolving `#result` each time) and one
+6. **string.split micro-costs** — done (2026-07-04)
+   - scenario: `string_split_csv`: 38.82µs -> 32.20µs (-17.0%, matching
+     the 10-20% hypothesis)
+   - evidence: implementation already used plain `find`; remaining cost
+     was `table.insert` (a C call resolving `#result` each time) and one
      `sub` per field.
-   - hypothesis: indexed assignment (`n = n + 1; result[n] = ...`) trims
-     10-20% of this scenario. real user impact is small — do it only as
-     a warm-up exercise for the loop, or skip.
+   - fix: replaced every `table.insert(result, ...)` with an explicit
+     `n = n + 1; result[n] = ...` counter, in both the empty-separator
+     (per-character) and normal-separator branches.
+   - result: `bin/make perf-compare`: 21 scenarios, 0 regression, 1
+     faster, 20 ok. real user impact is small (this was a warm-up-scale
+     item per the original hypothesis), but the win landed exactly where
+     predicted with zero risk.
 
 7. **json decode allocation pressure** — rejected for now (2026-07)
    - scenario: `json_decode_large` (~1.3ms/op, ~375KB allocated per op)


### PR DESCRIPTION
## Summary
- `table.insert` resolves `#result` (a C call) on every insertion; an explicit counter avoids that per-field.
- Replaced `table.insert(result, ...)` with `n = n + 1; result[n] = ...` in both the empty-separator (per-character) and normal-separator branches of `cosmic.string.split`.

## Result
`string_split_csv`: 38.82µs -> 32.20µs (-17.0%, matching the backlog's 10-20% hypothesis). `bin/make perf-compare`: 21 scenarios, 0 regression, 1 faster, 20 ok.

Works an entry of `lib/perf/OPTIMIZE.md`'s hypothesis backlog.

## Test plan
- [x] `bin/make ci`
- [x] `bin/make perf-compare` (clean re-baseline)


---
_Generated by [Claude Code](https://claude.ai/code/session_012uyf3CZ9nsm9Mv2KEwi6J9)_