### PR TITLE
sqlite: cache prepared statements for db:query too

### DIFF
--- a/lib/cosmic/hash.tl
+++ b/lib/cosmic/hash.tl
@@ -48,7 +48,9 @@ end
 --- @param data string The data to hash
 --- @return string The SHA-256 hash as a hex string
 local function sha256_hex(data: string): string
-  return codec.encode_hex(cosmo.Sha256(data)):lower()
+  -- cosmo.EncodeHex (which encode_hex delegates to) already emits
+  -- lowercase hex, so :lower() here was a dead full-string scan.
+  return codec.encode_hex(cosmo.Sha256(data))
 end
 
 --- Hash a password using Argon2.

--- a/lib/cosmic/main_handlers.tl
+++ b/lib/cosmic/main_handlers.tl
@@ -21,7 +21,6 @@ Quick start:
 
 Run 'cosmic --welcome' to see this again.
 ]]
-
 end
 
 --- Interactive REPL using cosmopolitan's linenoise-based REPL.
@@ -41,18 +40,21 @@ local function run_repl()
   require("cosmo.repl").start()
 end
 
---- Load a script file (.tl or .lua).
---- Compiles .tl files through Teal, loads .lua files directly.
+--- Load a script file (.tl or .lua): .tl through Teal (cached), .lua directly.
 local function load_script_file(script_path: string): function(...: any): any ..., string
   if script_path:match("%.tl$") then
-    -- add bundled .tl source path so teal compiler can find cosmic modules
-    package.path = package.path .. ";/zip/.tl/?.tl"
-    local teal = require("cosmic.teal")
-    local result = teal.compile(script_path)
-    if not result.ok then
-      return nil, teal.format_issues(result.errors)
+    package.path = package.path .. ";/zip/.tl/?.tl" -- so teal can find cosmic modules
+    local script_cache = require("cosmic.script_cache")
+    local code = script_cache.load(script_path)
+    if not code then
+      local teal = require("cosmic.teal")
+      local result = teal.compile(script_path)
+      if not result.ok then
+        return nil, teal.format_issues(result.errors)
+      end
+      code = result.code
+      script_cache.store(script_path, code)
     end
-    local code = result.code
     if code:sub(1, 2) == "#!" then
       local newline_pos = code:find("\n")
       if newline_pos then

--- a/lib/cosmic/script_cache.tl
+++ b/lib/cosmic/script_cache.tl
@@ -1,0 +1,69 @@
+--- Caches compiled Lua output for .tl scripts run directly (`cosmic
+--- script.tl`), keyed by path + content + cosmic build version, so a
+--- repeat run of an unchanged script skips Teal compilation entirely.
+--- Reading the source to hash it is cheap next to a full Teal compile,
+--- and (unlike an mtime-based key) can't produce a stale hit from
+--- coarse filesystem mtime granularity. Best-effort: any cache
+--- read/write failure (missing dir, no write permission, a race with
+--- another process, etc.) is treated as a cache miss/no-op, never a
+--- hard error — running the script must still work with no cache at all.
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
+local hash = require("cosmic.hash")
+
+--- @return string The cache directory (override with COSMIC_TL_CACHE_DIR)
+local function cache_dir(): string
+  return os.getenv("COSMIC_TL_CACHE_DIR") or
+  fs.join(os.getenv("TMPDIR") or "/tmp", "cosmic-tl-cache")
+end
+
+--- Build identifier included in the cache key, so a different cosmic
+--- binary (embedded Teal compiler may differ) never reuses another
+--- build's cached output. Falls back to a constant when unavailable
+--- (e.g. a dev build without the generated version module).
+--- @return string
+local function build_id(): string
+  local mod = "cosmic.version"
+  local ok, ver = pcall(require, mod)
+  if ok then
+    return tostring((ver as {string: string}).cosmic)
+  end
+  return "unknown"
+end
+
+--- @param script_path string Path to the .tl script
+--- @return string Cache file path, or nil if the script can't be read
+local function cache_file(script_path: string): string
+  local content = cio.slurp(script_path)
+  if not content then
+    return nil
+  end
+  local key = hash.sha256_hex(script_path .. "\0" .. content .. "\0" .. build_id())
+  return fs.join(cache_dir(), key .. ".lua")
+end
+
+--- Load cached compiled Lua code for a .tl script, if present and fresh.
+--- @param script_path string Path to the .tl script
+--- @return string? Cached Lua code, or nil on any cache miss
+local function load_cached(script_path: string): string
+  local path = cache_file(script_path)
+  if not path or not fs.isfile(path) then
+    return nil
+  end
+  return (cio.slurp(path))
+end
+
+--- Store compiled Lua code for a .tl script in the cache.
+--- @param script_path string Path to the .tl script
+--- @param code string Compiled Lua code to cache
+local function store(script_path: string, code: string)
+  local path = cache_file(script_path)
+  if not path then
+    return
+  end
+  if fs.makedirs(cache_dir()) then
+    cio.barf(path, code)
+  end
+end
+
+return {load = load_cached, store = store}

--- a/lib/cosmic/script_test.tl
+++ b/lib/cosmic/script_test.tl
@@ -167,4 +167,35 @@ print("shebang=" .. x)
 end
 test_teal_with_shebang()
 
+-- Test that running a .tl script twice reuses cosmic.script_cache's
+-- compiled output (a cache hit), and that changing the script's content
+-- (and so its mtime) invalidates the cache and picks up the new output.
+local function test_script_cache_reuse_and_invalidation()
+  local env = require("cosmic.env")
+  env.set("COSMIC_TL_CACHE_DIR", fs.join(test_subdir, "tl-cache"), true)
+
+  local script = write_temp("cached.tl", [[
+local x: number = 1
+print("value=" .. x)
+]])
+
+  for _ = 1, 2 do
+    local ok, out = spawn.spawn({cosmic, script}):read()
+    assert(ok, "cosmic should execute .tl file: " .. tostring(out))
+    assert((out as string):find("value=1"), "expected value=1, got: " .. tostring(out))
+  end
+
+  -- Overwrite with different content; the mtime change must invalidate
+  -- the cached compiled output from the runs above.
+  cio.barf(script, [[
+local x: number = 2
+print("value=" .. x)
+]])
+  local ok, out = spawn.spawn({cosmic, script}):read()
+  assert(ok, "cosmic should execute changed .tl file: " .. tostring(out))
+  assert((out as string):find("value=2"),
+    "expected value=2 after script change (stale cache?), got: " .. tostring(out))
+end
+test_script_cache_reuse_and_invalidation()
+
 print("All script tests passed!")

--- a/lib/cosmic/sqlite.tl
+++ b/lib/cosmic/sqlite.tl
@@ -99,7 +99,8 @@ local record Database
   close: function(self: Database)
 end
 
-local function make_statement(raw_stmt: RawStatement, raw_db: RawDatabase): Statement
+-- on_close, if given, replaces finalize on close (returns a cached statement to its pool).
+local function make_statement(raw_stmt: RawStatement, raw_db: RawDatabase, on_close?: function(RawStatement)): Statement
   local stmt: Statement = {}
   local closed = false
 
@@ -228,8 +229,11 @@ local function make_statement(raw_stmt: RawStatement, raw_db: RawDatabase): Stat
   end
 
   stmt.close = function(_: Statement)
-    if not closed then
-      closed = true
+    if closed then return end
+    closed = true
+    if on_close then
+      on_close(raw_stmt)
+    else
       local _ = raw_stmt:finalize()
     end
   end
@@ -281,18 +285,19 @@ local function make_database(raw_db: RawDatabase): Database
   end
 
   function db:query(sql: string, ...: any): Rows, string
-    local stmt, err = self:prepare(sql)
-    if not stmt then
+    if closed then
+      return nil, "query failed: database is closed"
+    end
+    local raw_stmt, on_close, err = stmt_cache:checkout(sql)
+    if not raw_stmt then
       return nil, "query failed: " .. (err or "unknown error")
     end
-
-    local n = select("#", ...) as integer
-    if n > 0 then
-      local ok, bind_err = stmt:bind(...)
-      if not ok then
-        stmt:close()
-        return nil, "bind failed: " .. (bind_err or "unknown error")
-      end
+    local stmt = make_statement(raw_stmt as RawStatement, raw_db, on_close as function(RawStatement))
+    -- bind() resets first (even with 0 args), clearing a reused statement.
+    local ok, bind_err = stmt:bind(...)
+    if not ok then
+      stmt:close()
+      return nil, "bind failed: " .. (bind_err or "unknown error")
     end
 
     return make_query_iter(stmt)

--- a/lib/cosmic/sqlite_advanced_test.tl
+++ b/lib/cosmic/sqlite_advanced_test.tl
@@ -306,4 +306,36 @@ local function test_query_named()
 end
 test_query_named()
 
+--- A nested query for the SAME SQL text as a still-open outer query must
+--- not corrupt either cursor: db:query's statement cache (see
+--- cosmic.sqlite_stmt_cache) only hands out its cached slot for a given
+--- SQL text once at a time, giving a nested query for that same text its
+--- own separate statement instead.
+local function test_same_sql_nested_query_reentrant()
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+  db:exec("INSERT INTO t (name) VALUES ('a'), ('b'), ('c')")
+
+  local pairs_seen: {string} = {}
+  for outer in db:query("SELECT * FROM t ORDER BY id") do
+    for inner in db:query("SELECT * FROM t ORDER BY id") do
+      table.insert(pairs_seen, (outer.name as string) .. (inner.name as string))
+    end
+  end
+
+  local expected = {"aa", "ab", "ac", "ba", "bb", "bc", "ca", "cb", "cc"}
+  assert(#pairs_seen == 9, "expected 9 pairs, got " .. tostring(#pairs_seen))
+  for i, pair in ipairs(expected) do
+    assert(pairs_seen[i] == pair,
+      "pair " .. i .. ": expected " .. pair .. ", got " .. tostring(pairs_seen[i]))
+  end
+
+  -- Once both iterators are drained, the cached slot for this SQL must be
+  -- available again, not left permanently "checked out".
+  local row, err = db:query_one("SELECT * FROM t WHERE id = 1")
+  assert(row ~= nil, "query after nested reentrant use should still work: " .. tostring(err))
+  db:close()
+end
+test_same_sql_nested_query_reentrant()
+
 print("All sqlite tests passed")

--- a/lib/cosmic/sqlite_stmt_cache.tl
+++ b/lib/cosmic/sqlite_stmt_cache.tl
@@ -15,82 +15,124 @@ local record RawDatabase
   errmsg: function(self: RawDatabase): string
 end
 
-local record StmtCache
-  exec: function(self: StmtCache, sql: string, args: {integer: any}, n: integer): boolean, string
-  close_all: function(self: StmtCache)
-end
+-- Named alias so a function-typed return value never appears as an inline
+-- literal in a multi-return signature: writing that out inline trips a
+-- bootstrap-compiler formatter bug (mis-indents everything after it).
+local type OnClose = function(RawStatement)
 
---- Create a statement cache bound to a raw database handle.
---- @param raw_db_any any The lsqlite3 database handle to prepare against
---- (typed `any` so callers don't need a nominally-identical RawDatabase type)
---- @param ok_code number lsqlite3.OK
---- @param done_code number lsqlite3.DONE
---- @param row_code number lsqlite3.ROW
---- @param schema_code number lsqlite3.SCHEMA
---- @return StmtCache
-local function new(raw_db_any: any, ok_code: number, done_code: number, row_code: number, schema_code: number): StmtCache
-  local raw_db = raw_db_any as RawDatabase
-  local cache: {string: RawStatement} = {}
-  local self: StmtCache = {}
-
-  local function get(sql: string): RawStatement, string
-    local cached = cache[sql]
-    if cached then
-      return cached
-    end
-    local raw_stmt, errcode, errmsg = raw_db:prepare(sql)
-    if not raw_stmt then
-      return nil, errmsg or ("error code " .. tostring(errcode))
-    end
-    cache[sql] = raw_stmt
-    return raw_stmt
+  local record StmtCache
+    exec: function(self: StmtCache, sql: string, args: {integer: any}, n: integer): boolean, string
+    checkout: function(self: StmtCache, sql: string): RawStatement, OnClose, string
+    close_all: function(self: StmtCache)
   end
 
-  local function bind_and_step(raw_stmt: RawStatement, args: {integer: any}, n: integer): number
-    raw_stmt:reset()
-    for i = 1, n do
-      local rc = raw_stmt:bind(i, args[i])
-      if rc ~= ok_code then
-        return rc
+  --- Create a statement cache bound to a raw database handle.
+  --- @param raw_db_any any The lsqlite3 database handle to prepare against
+  --- (typed `any` so callers don't need a nominally-identical RawDatabase type)
+  --- @param ok_code number lsqlite3.OK
+  --- @param done_code number lsqlite3.DONE
+  --- @param row_code number lsqlite3.ROW
+  --- @param schema_code number lsqlite3.SCHEMA
+  --- @return StmtCache
+  local function new(raw_db_any: any, ok_code: number, done_code: number, row_code: number, schema_code: number): StmtCache
+    local raw_db = raw_db_any as RawDatabase
+    local cache: {string: RawStatement} = {}
+    -- Separate from `cache`: a query's statement stays alive for the life
+    -- of its Rows iterator (unlike exec's synchronous prepare-bind-step),
+    -- so it needs its own pool plus a checked-out flag per SQL text.
+    local query_cache: {string: RawStatement} = {}
+    local checked_out: {string: boolean} = {}
+    local self: StmtCache = {}
+
+    local function get(sql: string): RawStatement, string
+      local cached = cache[sql]
+      if cached then
+        return cached
+      end
+      local raw_stmt, errcode, errmsg = raw_db:prepare(sql)
+      if not raw_stmt then
+        return nil, errmsg or ("error code " .. tostring(errcode))
+      end
+      cache[sql] = raw_stmt
+      return raw_stmt
+    end
+
+    local function bind_and_step(raw_stmt: RawStatement, args: {integer: any}, n: integer): number
+      raw_stmt:reset()
+      for i = 1, n do
+        local rc = raw_stmt:bind(i, args[i])
+        if rc ~= ok_code then
+          return rc
+        end
+      end
+      return raw_stmt:step()
+    end
+
+    --- Finalize every cached statement, e.g. when the owning database closes.
+    self.close_all = function(_: StmtCache)
+      for sql, raw_stmt in pairs(cache) do
+        local _ = raw_stmt:finalize()
+        cache[sql] = nil
+      end
+      for sql, raw_stmt in pairs(query_cache) do
+        local _ = raw_stmt:finalize()
+        query_cache[sql] = nil
       end
     end
-    return raw_stmt:step()
-  end
 
-  --- Finalize every cached statement, e.g. when the owning database closes.
-  self.close_all = function(_: StmtCache)
-    for sql, raw_stmt in pairs(cache) do
-      local _ = raw_stmt:finalize()
-      cache[sql] = nil
+    --- Check out a statement for db:query, preparing and caching one if this
+    --- SQL text hasn't been queried yet. Returns (statement, on_close):
+    --- on_close is non-nil when the statement is the shared cached one —
+    --- the caller must call it (instead of finalizing) when its Rows
+    --- iterator finishes, to return the slot. When the cached slot for
+    --- this SQL is already checked out by an unfinished query
+    --- (nested/interleaved queries for the same SQL text), a fresh
+    --- throwaway statement is prepared instead and on_close is nil — the
+    --- caller finalizes it itself, same as an uncached prepare.
+    function self:checkout(sql: string): RawStatement, OnClose, string
+      local cached = query_cache[sql]
+      if cached and not checked_out[sql] then
+        checked_out[sql] = true
+        return cached, function(_: RawStatement) checked_out[sql] = nil end
+      end
+      local raw_stmt, errcode, errmsg = raw_db:prepare(sql)
+      if not raw_stmt then
+        return nil, nil, errmsg or ("error code " .. tostring(errcode))
+      end
+      if not cached then
+        query_cache[sql] = raw_stmt
+        checked_out[sql] = true
+        return raw_stmt, function(_: RawStatement) checked_out[sql] = nil end
+      end
+      return raw_stmt, nil
     end
-  end
 
-  --- Execute a parameterized statement once, reusing (or preparing and
-  --- caching) the statement for `sql`. On SQLITE_SCHEMA, drops the stale
-  --- statement and retries once (sqlite3 already retries internally
-  --- before surfacing SCHEMA, so a second failure is a real error).
-  function self:exec(sql: string, args: {integer: any}, n: integer): boolean, string
-    local raw_stmt, err = get(sql)
-    if not raw_stmt then
-      return false, err
-    end
-    local rc = bind_and_step(raw_stmt, args, n)
-    if rc == schema_code then
-      cache[sql] = nil
-      local _ = raw_stmt:finalize()
-      raw_stmt, err = get(sql)
+    --- Execute a parameterized statement once, reusing (or preparing and
+    --- caching) the statement for `sql`. On SQLITE_SCHEMA, drops the stale
+    --- statement and retries once (sqlite3 already retries internally
+    --- before surfacing SCHEMA, so a second failure is a real error).
+    function self:exec(sql: string, args: {integer: any}, n: integer): boolean, string
+      local raw_stmt, err = get(sql)
       if not raw_stmt then
         return false, err
       end
-      rc = bind_and_step(raw_stmt, args, n)
+      local rc = bind_and_step(raw_stmt, args, n)
+      if rc == schema_code then
+        cache[sql] = nil
+        local _ = raw_stmt:finalize()
+        raw_stmt, err = get(sql)
+        if not raw_stmt then
+          return false, err
+        end
+        rc = bind_and_step(raw_stmt, args, n)
+      end
+      if rc ~= done_code and rc ~= row_code then
+        return false, raw_db:errmsg()
+      end
+      return true
     end
-    if rc ~= done_code and rc ~= row_code then
-      return false, raw_db:errmsg()
-    end
-    return true
+
+    return self
   end
 
-  return self
-end
-
-return {new = new}
+  return {new = new}

--- a/lib/cosmic/string.tl
+++ b/lib/cosmic/string.tl
@@ -62,9 +62,11 @@ end
 --- @return {string} Array of substrings
 local function split(s: string, sep: string): {string}
   local result: {string} = {}
+  local n = 0
   if sep == "" then
     for i = 1, #s do
-      table.insert(result, s:sub(i, i))
+      n = n + 1
+      result[n] = s:sub(i, i)
     end
     return result
   end
@@ -76,10 +78,12 @@ local function split(s: string, sep: string): {string}
   while true do
     local found = s:find(sep, pos, true)
     if not found then
-      table.insert(result, s:sub(pos))
+      n = n + 1
+      result[n] = s:sub(pos)
       break
     end
-    table.insert(result, s:sub(pos, found - 1))
+    n = n + 1
+    result[n] = s:sub(pos, found - 1)
     pos = found + sep_len
   end
   return result

--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -265,14 +265,19 @@ code read suggests one.
      verified against `lib/cosmic/fs_walk_test.tl`'s existing symlink-cycle
      tests for `collect_all()` and `files()`, which pass unchanged.
 
-6. **string.split micro-costs** — open, low priority
-   - scenario: `string_split_csv` (~50µs for 256 fields ≈ 190ns/field)
-   - evidence: implementation already uses plain `find`; remaining cost
-     is `table.insert` (a C call resolving `#result` each time) and one
+6. **string.split micro-costs** — done (2026-07-04)
+   - scenario: `string_split_csv`: 38.82µs -> 32.20µs (-17.0%, matching
+     the 10-20% hypothesis)
+   - evidence: implementation already used plain `find`; remaining cost
+     was `table.insert` (a C call resolving `#result` each time) and one
      `sub` per field.
-   - hypothesis: indexed assignment (`n = n + 1; result[n] = ...`) trims
-     10-20% of this scenario. real user impact is small — do it only as
-     a warm-up exercise for the loop, or skip.
+   - fix: replaced every `table.insert(result, ...)` with an explicit
+     `n = n + 1; result[n] = ...` counter, in both the empty-separator
+     (per-character) and normal-separator branches.
+   - result: `bin/make perf-compare`: 21 scenarios, 0 regression, 1
+     faster, 20 ok. real user impact is small (this was a warm-up-scale
+     item per the original hypothesis), but the win landed exactly where
+     predicted with zero risk.
 
 7. **json decode allocation pressure** — rejected for now (2026-07)
    - scenario: `json_decode_large` (~1.3ms/op, ~375KB allocated per op)

--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -173,7 +173,7 @@ code read suggests one.
    - result: `bin/make perf-compare` from a clean re-baseline: 20
      scenarios, 0 regression, 2 faster, 18 ok.
 
-3. **startup: Teal loader cost** — step (a) done (2026-07-04), step (b) open
+3. **startup: Teal loader cost** — step (a) and step (b) both done (2026-07-04)
    - scenario: `startup_run_lua`: 19.20ms -> 8.40ms..5.72ms across two
      re-measures (-56% to -70%). the whole `.lua`-vs-`.tl` gap this entry
      named turned out to be almost entirely step (a), not compilation
@@ -193,9 +193,6 @@ code read suggests one.
      and not at position 2) and manually: plain `.lua` scripts, `-e`, and
      requiring a `.tl`-only module (falling back through the lazy
      searcher) all still work.
-   - step (b) (compiled-output caching keyed by mtime/hash, so repeat runs
-     of an unchanged `.tl` script cost `.lua` startup) is unexplored;
-     `startup_run_teal`/`startup_compile_teal` remain open for it.
    - risk note for step (a) that mattered in practice: the return type of
      a `package.searchers` element is itself a function type
      (`function(string): (function(string?, any?): any, any)`); writing
@@ -206,11 +203,43 @@ code read suggests one.
      and destructuring the real searcher's result into typed locals
      before returning them, instead of returning the call expression
      directly.
-   - result: `bin/make perf-compare` from a clean re-baseline, confirmed
-     on a second re-measure: 20 scenarios, 0 regression, 1-2 faster
-     (`startup_run_lua`), 18-19 ok.
+   - result (step a): `bin/make perf-compare` from a clean re-baseline,
+     confirmed on a second re-measure: 20 scenarios, 0 regression, 1-2
+     faster (`startup_run_lua`), 18-19 ok.
+   - fix (step b): added `lib/cosmic/script_cache.tl`, a compiled-output
+     cache used only by `load_script_file` (`main_handlers.tl`) — i.e.
+     only `cosmic script.tl`, not `--compile`/`--check-types`/etc., which
+     call `cosmic.teal` directly and are unaffected. Keyed on
+     `script_path .. content .. build_id` (the running cosmic binary's
+     version string, so a different build — possibly a different
+     embedded Teal compiler — never reuses another build's cached
+     output), hashed with `cosmic.hash.sha256_hex`. **Deliberately
+     content-hashed, not mtime-based**: an mtime key (the original
+     hypothesis's wording) risks a false cache hit if a script is
+     rewritten within one filesystem mtime tick (coarse on some
+     filesystems) — reading the small source file to hash it is cheap
+     next to a full Teal compile, so there's no real reason to accept
+     that risk. A failed compile (type or syntax error) is never cached,
+     so error messages always reflect a fresh compile. Best-effort
+     throughout: any cache read/write failure (missing dir, no write
+     permission, a race with another process) is treated as a miss/no-op,
+     never a hard error.
+   - added `test_script_cache_reuse_and_invalidation` to
+     `lib/cosmic/script_test.tl`: runs a `.tl` script twice (same
+     content, expects a cache hit the second time — verified indirectly,
+     since correctness rather than hit/miss is what's asserted), then
+     overwrites it with different content and confirms the new output
+     wins (cache invalidation via content hash, not stale reuse).
+   - result (step b): `startup_run_teal` 27.91ms -> 6.55ms first pass
+     (-76.5%), 7.59ms on re-measure (-72.8%) — now close to
+     `startup_run_lua`'s own floor, as step (b)'s original hypothesis
+     predicted. `startup_compile_teal` unaffected (within noise) both
+     times, as expected since `--compile` bypasses the cache entirely.
+     `bin/make perf-compare` both times: 22 scenarios, 0 regression,
+     1 faster, 21 ok.
 
-4. **startup: runtime boot floor (cosmopolitan side)** — open, floor moved
+4. **startup: runtime boot floor (cosmopolitan side)** — import-deferral
+     step rejected (2026-07-04); cosmopolitan-side work still open
    - scenario: `startup_run_lua` was ~14.5-19ms for `print()`; after
      entry 3's step (a) fix it measured 5.7-8.4ms across two runs on a
      noisy machine (re-baseline before trusting an absolute number here).
@@ -219,13 +248,30 @@ code read suggests one.
      module loading in main.tl" generally; with it gone, remaining floor
      is the APE loader + zip filesystem + Lua init + cosmic's other
      top-level `require`s (getopt, args, help, main_handlers, etc.).
-   - hypothesis: deferring the remaining dispatch-only imports (e.g.
-     `help`, only used for `--help`) trims a small additional amount; the
-     rest is cosmos-side (zip central-directory scan, stdlib init) —
-     measure with the pinned raw cosmos `lua` binary as `PERF_BIN`
-     denominator before touching whilp/cosmopolitan.
-   - risk: low for any further import-deferral; cosmopolitan-side work
-     follows the "optimizing the cosmo/cosmopolitan layer" section.
+   - attempt: deferred `local help = require("cosmic.help")` in main.tl
+     to inside the `if opts.help then` branch (the only place it's
+     used), matching the exact "e.g. `help`" example this entry named.
+   - finding: `bin/make perf-compare` from a clean re-baseline showed
+     `startup_run_lua` +4.0% — noise (±10.0% bar), not a real
+     regression, but also not a measurable improvement. A quick manual
+     A/B first (alternating `COSMIC_NO_REQUIRE_HINTS=1` runs of a
+     trivial `.lua` script, ~30-50 iterations each way) had already shown
+     the same thing: differences bounced both directions across repeats,
+     never landing consistently on one side. `getopt`/`args`/
+     `main_handlers` can't be deferred the same way (needed on every
+     invocation to parse args and dispatch), so there wasn't a second
+     candidate to combine with `help` for a larger, clearer effect.
+     Reverted the change (`git checkout -- lib/cosmic/main.tl`) since it
+     had no measurable win to justify keeping.
+   - revised hypothesis: this entry's `startup_run_lua` floor (now
+     single-digit ms, cpu/wall ~0.2-0.3 per recent baselines — mostly
+     NOT CPU) is dominated by something below the Lua-require level
+     entirely: the APE loader, zip filesystem init, or Lua runtime boot.
+     Further wins here belong to the "optimizing the cosmo/cosmopolitan
+     layer" section below (measure against the pinned raw cosmos `lua`
+     binary via `PERF_BIN` first), not to more main.tl import shuffling.
+   - risk: n/a for the rejected step; cosmopolitan-side work follows the
+     "optimizing the cosmo/cosmopolitan layer" section.
 
 5. **fs.walk per-entry cost** — done for `files()`/`collect_all()`
      (2026-07-04); `walk()`/`collect()` unchanged (see below)

--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -332,6 +332,28 @@ code read suggests one.
      on a second re-measure: 21 scenarios, 0 regression, 1-2 faster
      (`sqlite_point_query`), 19-20 ok.
 
+9. **hash.sha256_hex dead `:lower()` call** — done (2026-07-04)
+   - scenario: `hash_sha256_small` (new scenario): 488.9ns -> 305.1ns
+     first pass (-37.6%), 300.8ns on re-measure (-38.5%)
+   - evidence: `sha256_hex` (lib/cosmic/hash.tl) was
+     `codec.encode_hex(cosmo.Sha256(data)):lower()`. Verified at runtime
+     that `cosmo.EncodeHex` (which `encode_hex` delegates to directly)
+     already emits lowercase hex, so `:lower()` was a dead full-string
+     scan + allocation on every call, on top of the digest — same
+     "wrapper redoes work the C binding already did" shape as the
+     hex-decode fix (entry 1), just smaller.
+   - fix: removed the `:lower()` call; existing tests already assert
+     lowercase output and a known digest value, so this is provably a
+     no-op removal, not a behavior change.
+   - added `hash_sha256_small` to `lib/perf/bench/micro_bench.tl`
+     (hashing `"abc"`, the NIST test vector) alongside the existing
+     `hash_sha256_1mb`: the 1MB scenario's SHA-256 compute swamps a
+     fixed-per-call wrapper cost like this one, so it needed a tiny-input
+     scenario to show up at all — `hash_sha256_1mb` itself was
+     unaffected (within noise), as expected.
+   - result: `bin/make perf-compare` from a clean re-baseline, confirmed
+     on a second re-measure: 22 scenarios, 0 regression, 1 faster, 21 ok.
+
 ## optimizing the cosmo/cosmopolitan layer end to end
 
 scenarios call `cosmic.*` wrappers, which call the `cosmo.*` C bindings

--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -288,6 +288,50 @@ code read suggests one.
      cosmopolitan-side arena would change object lifetimes. revisit only
      if a scenario shows GC pauses dominating a real workload.
 
+8. **sqlite `db:query`/`db:query_one` prepared-statement reuse** — done
+     (2026-07-04); extends entry 2, which scoped the original cache to
+     `db:exec` only
+   - scenario: `sqlite_point_query`: 8.87µs -> 6.32µs (-28.7% first
+     pass, -29.2% on re-measure)
+   - evidence: `db:query(sql, ...)` (lib/cosmic/sqlite.tl) called
+     `self:prepare(sql)` on every call — a fresh prepare/finalize per
+     query even for identical repeated SQL text. `sqlite_point_query`
+     and `sqlite_scan_aggregate` (via `db:query_one`) both hit this.
+   - fix: added `checkout`/an implicit checkin (a returned closure) to
+     `lib/cosmic/sqlite_stmt_cache.tl`, in a *separate* cache/table from
+     `db:exec`'s (so the two call kinds can never contend for the same
+     slot even if the same SQL text were somehow used for both). Unlike
+     `exec`, a query's statement stays alive for its `Rows` iterator's
+     whole lifetime, so a naive single-slot-by-SQL-text cache would
+     corrupt a nested/interleaved query for the *same* SQL text (e.g. a
+     self-join pattern querying the same table twice, one query per
+     loop level). `checkout()` hands out the shared cached statement
+     only when it isn't already checked out; otherwise it prepares a
+     throwaway statement for that call, exactly like the old
+     uncached behavior. `make_statement`'s `close()` takes an optional
+     `on_close` callback (checkin instead of finalize) so `db:query`
+     didn't need its own iterator-wrapping code — `make_query_iter`
+     already calls `stmt:close()` on completion, unchanged.
+   - added `test_same_sql_nested_query_reentrant` to
+     `lib/cosmic/sqlite_advanced_test.tl` (the existing
+     `test_nested_queries` only nests *different* SQL text, which never
+     touches the same cache slot) — queries the same table with the
+     same SQL in a nested loop, then confirms the cache slot still
+     works after both iterators drain.
+   - gotcha hit while implementing: writing a function type as one
+     return value in a multi-return signature — even as a named `local
+     type X = function(...)` alias rather than an inline literal — trips
+     the same bootstrap-compiler formatter bug found in the Teal-loader
+     round (mis-indents every line after the declaration). This turned
+     out to already be baked into the committed `lib/cosmic/init.tl`
+     (its `local type MainFn = function(...)` line has the identical
+     shift), so the fix was to accept the formatter's own output
+     verbatim as the file content, matching that existing precedent,
+     rather than fight it.
+   - result: `bin/make perf-compare` from a clean re-baseline, confirmed
+     on a second re-measure: 21 scenarios, 0 regression, 1-2 faster
+     (`sqlite_point_query`), 19-20 ok.
+
 ## optimizing the cosmo/cosmopolitan layer end to end
 
 scenarios call `cosmic.*` wrappers, which call the `cosmo.*` C bindings

--- a/lib/perf/bench/micro_bench.tl
+++ b/lib/perf/bench/micro_bench.tl
@@ -13,6 +13,10 @@ local pt = require("perf.perf_types")
 local A_MILLION = string.rep("a", 1000000)
 local SHA_A_MILLION = "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0"
 
+-- NIST SHA-256 test vector: "abc".
+local ABC = "abc"
+local SHA_ABC = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+
 local CSV_FIELDS = 256
 
 --- Build a deterministic ~64KB blob with enough variety to be a fair
@@ -50,6 +54,21 @@ local function scenarios(): {pt.Scenario}, string
       end,
       check = function(_: any, res: any): boolean, string
         if res as string ~= SHA_A_MILLION then
+          return false, "digest mismatch: " .. tostring(res)
+        end
+        return true
+      end,
+    },
+    {
+      -- A tiny input, unlike hash_sha256_1mb: isolates fixed per-call
+      -- wrapper overhead (encode + any post-processing) from the SHA-256
+      -- compute itself, which is negligible here.
+      name = "hash_sha256_small",
+      fn = function(_: any): any
+        return hash.sha256_hex(ABC)
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res as string ~= SHA_ABC then
           return false, "digest mismatch: " .. tostring(res)
         end
         return true


### PR DESCRIPTION
## Summary
- Stacked on #442 — only the last commit on this branch is new.
- `db:query(sql, ...)` prepared and finalized a fresh statement on every call, even for identical repeated SQL text — the same gap `db:exec` already closed. Unlike `exec`, a query's statement stays alive for its `Rows` iterator's whole lifetime, so this needed its own checkout mechanism (in a separate cache/table from `exec`'s) that hands out the shared cached statement only when it isn't already checked out; a nested/interleaved query for the same SQL text gets a throwaway statement instead, exactly like the old uncached behavior.
- `make_statement`'s `close()` now takes an optional `on_close` callback (checkin instead of finalize) so `db:query` didn't need its own iterator-wrapping code.
- Added `test_same_sql_nested_query_reentrant` to `sqlite_advanced_test.tl` to cover the one genuinely new failure mode (the existing `test_nested_queries` only nests *different* SQL text).

## Result
`sqlite_point_query`: 8.87µs -> 6.32µs (-28.7%, confirmed -29.2% on re-measure). `bin/make perf-compare`: 21 scenarios, 0 regression, 1-2 faster, rest ok.

Extends an earlier backlog entry that scoped the original statement cache to `db:exec` only.

## Test plan
- [x] `bin/make ci`
- [x] `bin/make perf-compare` (clean re-baseline)


---
_Generated by [Claude Code](https://claude.ai/code/session_012uyf3CZ9nsm9Mv2KEwi6J9)_