### PR TITLE
hash: remove dead :lower() call in sha256_hex

### DIFF
--- a/lib/cosmic/hash.tl
+++ b/lib/cosmic/hash.tl
@@ -48,7 +48,9 @@ end
 --- @param data string The data to hash
 --- @return string The SHA-256 hash as a hex string
 local function sha256_hex(data: string): string
-  return codec.encode_hex(cosmo.Sha256(data)):lower()
+  -- cosmo.EncodeHex (which encode_hex delegates to) already emits
+  -- lowercase hex, so :lower() here was a dead full-string scan.
+  return codec.encode_hex(cosmo.Sha256(data))
 end
 
 --- Hash a password using Argon2.

--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -332,6 +332,28 @@ code read suggests one.
      on a second re-measure: 21 scenarios, 0 regression, 1-2 faster
      (`sqlite_point_query`), 19-20 ok.
 
+9. **hash.sha256_hex dead `:lower()` call** — done (2026-07-04)
+   - scenario: `hash_sha256_small` (new scenario): 488.9ns -> 305.1ns
+     first pass (-37.6%), 300.8ns on re-measure (-38.5%)
+   - evidence: `sha256_hex` (lib/cosmic/hash.tl) was
+     `codec.encode_hex(cosmo.Sha256(data)):lower()`. Verified at runtime
+     that `cosmo.EncodeHex` (which `encode_hex` delegates to directly)
+     already emits lowercase hex, so `:lower()` was a dead full-string
+     scan + allocation on every call, on top of the digest — same
+     "wrapper redoes work the C binding already did" shape as the
+     hex-decode fix (entry 1), just smaller.
+   - fix: removed the `:lower()` call; existing tests already assert
+     lowercase output and a known digest value, so this is provably a
+     no-op removal, not a behavior change.
+   - added `hash_sha256_small` to `lib/perf/bench/micro_bench.tl`
+     (hashing `"abc"`, the NIST test vector) alongside the existing
+     `hash_sha256_1mb`: the 1MB scenario's SHA-256 compute swamps a
+     fixed-per-call wrapper cost like this one, so it needed a tiny-input
+     scenario to show up at all — `hash_sha256_1mb` itself was
+     unaffected (within noise), as expected.
+   - result: `bin/make perf-compare` from a clean re-baseline, confirmed
+     on a second re-measure: 22 scenarios, 0 regression, 1 faster, 21 ok.
+
 ## optimizing the cosmo/cosmopolitan layer end to end
 
 scenarios call `cosmic.*` wrappers, which call the `cosmo.*` C bindings

--- a/lib/perf/bench/micro_bench.tl
+++ b/lib/perf/bench/micro_bench.tl
@@ -13,6 +13,10 @@ local pt = require("perf.perf_types")
 local A_MILLION = string.rep("a", 1000000)
 local SHA_A_MILLION = "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0"
 
+-- NIST SHA-256 test vector: "abc".
+local ABC = "abc"
+local SHA_ABC = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+
 local CSV_FIELDS = 256
 
 --- Build a deterministic ~64KB blob with enough variety to be a fair
@@ -50,6 +54,21 @@ local function scenarios(): {pt.Scenario}, string
       end,
       check = function(_: any, res: any): boolean, string
         if res as string ~= SHA_A_MILLION then
+          return false, "digest mismatch: " .. tostring(res)
+        end
+        return true
+      end,
+    },
+    {
+      -- A tiny input, unlike hash_sha256_1mb: isolates fixed per-call
+      -- wrapper overhead (encode + any post-processing) from the SHA-256
+      -- compute itself, which is negligible here.
+      name = "hash_sha256_small",
+      fn = function(_: any): any
+        return hash.sha256_hex(ABC)
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res as string ~= SHA_ABC then
           return false, "digest mismatch: " .. tostring(res)
         end
         return true


### PR DESCRIPTION
## Summary
- Stacked on #443 — only the last commit on this branch is new.
- `cosmo.EncodeHex` (which `encode_hex` delegates to directly) already emits lowercase hex, so the trailing `:lower()` in `sha256_hex` was a dead full-string scan + allocation on every call. Existing tests already assert lowercase output and a known digest value, so this is a provable no-op removal.
- Added `hash_sha256_small` (hashing `"abc"`) to `micro_bench.tl` alongside the existing `hash_sha256_1mb`, since the 1MB scenario's SHA-256 compute swamps a fixed-per-call wrapper cost like this one.

## Result
`hash_sha256_small`: 488.9ns -> 305.1ns (-37.6%, confirmed -38.5% on re-measure). `bin/make perf-compare`: 22 scenarios, 0 regression, 1 faster, 21 ok.

## Test plan
- [x] `bin/make ci`
- [x] `bin/make perf-compare` (clean re-baseline)


---
_Generated by [Claude Code](https://claude.ai/code/session_012uyf3CZ9nsm9Mv2KEwi6J9)_