### PR TITLE
main: cache compiled .tl output; document rejected import-deferral attempt

### DIFF
--- a/lib/cosmic/hash.tl
+++ b/lib/cosmic/hash.tl
@@ -48,7 +48,9 @@ end
 --- @param data string The data to hash
 --- @return string The SHA-256 hash as a hex string
 local function sha256_hex(data: string): string
-  return codec.encode_hex(cosmo.Sha256(data)):lower()
+  -- cosmo.EncodeHex (which encode_hex delegates to) already emits
+  -- lowercase hex, so :lower() here was a dead full-string scan.
+  return codec.encode_hex(cosmo.Sha256(data))
 end
 
 --- Hash a password using Argon2.

--- a/lib/cosmic/main_handlers.tl
+++ b/lib/cosmic/main_handlers.tl
@@ -21,7 +21,6 @@ Quick start:
 
 Run 'cosmic --welcome' to see this again.
 ]]
-
 end
 
 --- Interactive REPL using cosmopolitan's linenoise-based REPL.
@@ -41,18 +40,21 @@ local function run_repl()
   require("cosmo.repl").start()
 end
 
---- Load a script file (.tl or .lua).
---- Compiles .tl files through Teal, loads .lua files directly.
+--- Load a script file (.tl or .lua): .tl through Teal (cached), .lua directly.
 local function load_script_file(script_path: string): function(...: any): any ..., string
   if script_path:match("%.tl$") then
-    -- add bundled .tl source path so teal compiler can find cosmic modules
-    package.path = package.path .. ";/zip/.tl/?.tl"
-    local teal = require("cosmic.teal")
-    local result = teal.compile(script_path)
-    if not result.ok then
-      return nil, teal.format_issues(result.errors)
+    package.path = package.path .. ";/zip/.tl/?.tl" -- so teal can find cosmic modules
+    local script_cache = require("cosmic.script_cache")
+    local code = script_cache.load(script_path)
+    if not code then
+      local teal = require("cosmic.teal")
+      local result = teal.compile(script_path)
+      if not result.ok then
+        return nil, teal.format_issues(result.errors)
+      end
+      code = result.code
+      script_cache.store(script_path, code)
     end
-    local code = result.code
     if code:sub(1, 2) == "#!" then
       local newline_pos = code:find("\n")
       if newline_pos then

--- a/lib/cosmic/script_cache.tl
+++ b/lib/cosmic/script_cache.tl
@@ -1,0 +1,69 @@
+--- Caches compiled Lua output for .tl scripts run directly (`cosmic
+--- script.tl`), keyed by path + content + cosmic build version, so a
+--- repeat run of an unchanged script skips Teal compilation entirely.
+--- Reading the source to hash it is cheap next to a full Teal compile,
+--- and (unlike an mtime-based key) can't produce a stale hit from
+--- coarse filesystem mtime granularity. Best-effort: any cache
+--- read/write failure (missing dir, no write permission, a race with
+--- another process, etc.) is treated as a cache miss/no-op, never a
+--- hard error — running the script must still work with no cache at all.
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
+local hash = require("cosmic.hash")
+
+--- @return string The cache directory (override with COSMIC_TL_CACHE_DIR)
+local function cache_dir(): string
+  return os.getenv("COSMIC_TL_CACHE_DIR") or
+  fs.join(os.getenv("TMPDIR") or "/tmp", "cosmic-tl-cache")
+end
+
+--- Build identifier included in the cache key, so a different cosmic
+--- binary (embedded Teal compiler may differ) never reuses another
+--- build's cached output. Falls back to a constant when unavailable
+--- (e.g. a dev build without the generated version module).
+--- @return string
+local function build_id(): string
+  local mod = "cosmic.version"
+  local ok, ver = pcall(require, mod)
+  if ok then
+    return tostring((ver as {string: string}).cosmic)
+  end
+  return "unknown"
+end
+
+--- @param script_path string Path to the .tl script
+--- @return string Cache file path, or nil if the script can't be read
+local function cache_file(script_path: string): string
+  local content = cio.slurp(script_path)
+  if not content then
+    return nil
+  end
+  local key = hash.sha256_hex(script_path .. "\0" .. content .. "\0" .. build_id())
+  return fs.join(cache_dir(), key .. ".lua")
+end
+
+--- Load cached compiled Lua code for a .tl script, if present and fresh.
+--- @param script_path string Path to the .tl script
+--- @return string? Cached Lua code, or nil on any cache miss
+local function load_cached(script_path: string): string
+  local path = cache_file(script_path)
+  if not path or not fs.isfile(path) then
+    return nil
+  end
+  return (cio.slurp(path))
+end
+
+--- Store compiled Lua code for a .tl script in the cache.
+--- @param script_path string Path to the .tl script
+--- @param code string Compiled Lua code to cache
+local function store(script_path: string, code: string)
+  local path = cache_file(script_path)
+  if not path then
+    return
+  end
+  if fs.makedirs(cache_dir()) then
+    cio.barf(path, code)
+  end
+end
+
+return {load = load_cached, store = store}

--- a/lib/cosmic/script_test.tl
+++ b/lib/cosmic/script_test.tl
@@ -167,4 +167,35 @@ print("shebang=" .. x)
 end
 test_teal_with_shebang()
 
+-- Test that running a .tl script twice reuses cosmic.script_cache's
+-- compiled output (a cache hit), and that changing the script's content
+-- (and so its mtime) invalidates the cache and picks up the new output.
+local function test_script_cache_reuse_and_invalidation()
+  local env = require("cosmic.env")
+  env.set("COSMIC_TL_CACHE_DIR", fs.join(test_subdir, "tl-cache"), true)
+
+  local script = write_temp("cached.tl", [[
+local x: number = 1
+print("value=" .. x)
+]])
+
+  for _ = 1, 2 do
+    local ok, out = spawn.spawn({cosmic, script}):read()
+    assert(ok, "cosmic should execute .tl file: " .. tostring(out))
+    assert((out as string):find("value=1"), "expected value=1, got: " .. tostring(out))
+  end
+
+  -- Overwrite with different content; the mtime change must invalidate
+  -- the cached compiled output from the runs above.
+  cio.barf(script, [[
+local x: number = 2
+print("value=" .. x)
+]])
+  local ok, out = spawn.spawn({cosmic, script}):read()
+  assert(ok, "cosmic should execute changed .tl file: " .. tostring(out))
+  assert((out as string):find("value=2"),
+    "expected value=2 after script change (stale cache?), got: " .. tostring(out))
+end
+test_script_cache_reuse_and_invalidation()
+
 print("All script tests passed!")

--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -173,7 +173,7 @@ code read suggests one.
    - result: `bin/make perf-compare` from a clean re-baseline: 20
      scenarios, 0 regression, 2 faster, 18 ok.
 
-3. **startup: Teal loader cost** — step (a) done (2026-07-04), step (b) open
+3. **startup: Teal loader cost** — step (a) and step (b) both done (2026-07-04)
    - scenario: `startup_run_lua`: 19.20ms -> 8.40ms..5.72ms across two
      re-measures (-56% to -70%). the whole `.lua`-vs-`.tl` gap this entry
      named turned out to be almost entirely step (a), not compilation
@@ -193,9 +193,6 @@ code read suggests one.
      and not at position 2) and manually: plain `.lua` scripts, `-e`, and
      requiring a `.tl`-only module (falling back through the lazy
      searcher) all still work.
-   - step (b) (compiled-output caching keyed by mtime/hash, so repeat runs
-     of an unchanged `.tl` script cost `.lua` startup) is unexplored;
-     `startup_run_teal`/`startup_compile_teal` remain open for it.
    - risk note for step (a) that mattered in practice: the return type of
      a `package.searchers` element is itself a function type
      (`function(string): (function(string?, any?): any, any)`); writing
@@ -206,9 +203,40 @@ code read suggests one.
      and destructuring the real searcher's result into typed locals
      before returning them, instead of returning the call expression
      directly.
-   - result: `bin/make perf-compare` from a clean re-baseline, confirmed
-     on a second re-measure: 20 scenarios, 0 regression, 1-2 faster
-     (`startup_run_lua`), 18-19 ok.
+   - result (step a): `bin/make perf-compare` from a clean re-baseline,
+     confirmed on a second re-measure: 20 scenarios, 0 regression, 1-2
+     faster (`startup_run_lua`), 18-19 ok.
+   - fix (step b): added `lib/cosmic/script_cache.tl`, a compiled-output
+     cache used only by `load_script_file` (`main_handlers.tl`) — i.e.
+     only `cosmic script.tl`, not `--compile`/`--check-types`/etc., which
+     call `cosmic.teal` directly and are unaffected. Keyed on
+     `script_path .. content .. build_id` (the running cosmic binary's
+     version string, so a different build — possibly a different
+     embedded Teal compiler — never reuses another build's cached
+     output), hashed with `cosmic.hash.sha256_hex`. **Deliberately
+     content-hashed, not mtime-based**: an mtime key (the original
+     hypothesis's wording) risks a false cache hit if a script is
+     rewritten within one filesystem mtime tick (coarse on some
+     filesystems) — reading the small source file to hash it is cheap
+     next to a full Teal compile, so there's no real reason to accept
+     that risk. A failed compile (type or syntax error) is never cached,
+     so error messages always reflect a fresh compile. Best-effort
+     throughout: any cache read/write failure (missing dir, no write
+     permission, a race with another process) is treated as a miss/no-op,
+     never a hard error.
+   - added `test_script_cache_reuse_and_invalidation` to
+     `lib/cosmic/script_test.tl`: runs a `.tl` script twice (same
+     content, expects a cache hit the second time — verified indirectly,
+     since correctness rather than hit/miss is what's asserted), then
+     overwrites it with different content and confirms the new output
+     wins (cache invalidation via content hash, not stale reuse).
+   - result (step b): `startup_run_teal` 27.91ms -> 6.55ms first pass
+     (-76.5%), 7.59ms on re-measure (-72.8%) — now close to
+     `startup_run_lua`'s own floor, as step (b)'s original hypothesis
+     predicted. `startup_compile_teal` unaffected (within noise) both
+     times, as expected since `--compile` bypasses the cache entirely.
+     `bin/make perf-compare` both times: 22 scenarios, 0 regression,
+     1 faster, 21 ok.
 
 4. **startup: runtime boot floor (cosmopolitan side)** — import-deferral
      step rejected (2026-07-04); cosmopolitan-side work still open

--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -332,6 +332,28 @@ code read suggests one.
      on a second re-measure: 21 scenarios, 0 regression, 1-2 faster
      (`sqlite_point_query`), 19-20 ok.
 
+9. **hash.sha256_hex dead `:lower()` call** — done (2026-07-04)
+   - scenario: `hash_sha256_small` (new scenario): 488.9ns -> 305.1ns
+     first pass (-37.6%), 300.8ns on re-measure (-38.5%)
+   - evidence: `sha256_hex` (lib/cosmic/hash.tl) was
+     `codec.encode_hex(cosmo.Sha256(data)):lower()`. Verified at runtime
+     that `cosmo.EncodeHex` (which `encode_hex` delegates to directly)
+     already emits lowercase hex, so `:lower()` was a dead full-string
+     scan + allocation on every call, on top of the digest — same
+     "wrapper redoes work the C binding already did" shape as the
+     hex-decode fix (entry 1), just smaller.
+   - fix: removed the `:lower()` call; existing tests already assert
+     lowercase output and a known digest value, so this is provably a
+     no-op removal, not a behavior change.
+   - added `hash_sha256_small` to `lib/perf/bench/micro_bench.tl`
+     (hashing `"abc"`, the NIST test vector) alongside the existing
+     `hash_sha256_1mb`: the 1MB scenario's SHA-256 compute swamps a
+     fixed-per-call wrapper cost like this one, so it needed a tiny-input
+     scenario to show up at all — `hash_sha256_1mb` itself was
+     unaffected (within noise), as expected.
+   - result: `bin/make perf-compare` from a clean re-baseline, confirmed
+     on a second re-measure: 22 scenarios, 0 regression, 1 faster, 21 ok.
+
 ## optimizing the cosmo/cosmopolitan layer end to end
 
 scenarios call `cosmic.*` wrappers, which call the `cosmo.*` C bindings

--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -210,7 +210,8 @@ code read suggests one.
      on a second re-measure: 20 scenarios, 0 regression, 1-2 faster
      (`startup_run_lua`), 18-19 ok.
 
-4. **startup: runtime boot floor (cosmopolitan side)** — open, floor moved
+4. **startup: runtime boot floor (cosmopolitan side)** — import-deferral
+     step rejected (2026-07-04); cosmopolitan-side work still open
    - scenario: `startup_run_lua` was ~14.5-19ms for `print()`; after
      entry 3's step (a) fix it measured 5.7-8.4ms across two runs on a
      noisy machine (re-baseline before trusting an absolute number here).
@@ -219,13 +220,30 @@ code read suggests one.
      module loading in main.tl" generally; with it gone, remaining floor
      is the APE loader + zip filesystem + Lua init + cosmic's other
      top-level `require`s (getopt, args, help, main_handlers, etc.).
-   - hypothesis: deferring the remaining dispatch-only imports (e.g.
-     `help`, only used for `--help`) trims a small additional amount; the
-     rest is cosmos-side (zip central-directory scan, stdlib init) —
-     measure with the pinned raw cosmos `lua` binary as `PERF_BIN`
-     denominator before touching whilp/cosmopolitan.
-   - risk: low for any further import-deferral; cosmopolitan-side work
-     follows the "optimizing the cosmo/cosmopolitan layer" section.
+   - attempt: deferred `local help = require("cosmic.help")` in main.tl
+     to inside the `if opts.help then` branch (the only place it's
+     used), matching the exact "e.g. `help`" example this entry named.
+   - finding: `bin/make perf-compare` from a clean re-baseline showed
+     `startup_run_lua` +4.0% — noise (±10.0% bar), not a real
+     regression, but also not a measurable improvement. A quick manual
+     A/B first (alternating `COSMIC_NO_REQUIRE_HINTS=1` runs of a
+     trivial `.lua` script, ~30-50 iterations each way) had already shown
+     the same thing: differences bounced both directions across repeats,
+     never landing consistently on one side. `getopt`/`args`/
+     `main_handlers` can't be deferred the same way (needed on every
+     invocation to parse args and dispatch), so there wasn't a second
+     candidate to combine with `help` for a larger, clearer effect.
+     Reverted the change (`git checkout -- lib/cosmic/main.tl`) since it
+     had no measurable win to justify keeping.
+   - revised hypothesis: this entry's `startup_run_lua` floor (now
+     single-digit ms, cpu/wall ~0.2-0.3 per recent baselines — mostly
+     NOT CPU) is dominated by something below the Lua-require level
+     entirely: the APE loader, zip filesystem init, or Lua runtime boot.
+     Further wins here belong to the "optimizing the cosmo/cosmopolitan
+     layer" section below (measure against the pinned raw cosmos `lua`
+     binary via `PERF_BIN` first), not to more main.tl import shuffling.
+   - risk: n/a for the rejected step; cosmopolitan-side work follows the
+     "optimizing the cosmo/cosmopolitan layer" section.
 
 5. **fs.walk per-entry cost** — done for `files()`/`collect_all()`
      (2026-07-04); `walk()`/`collect()` unchanged (see below)

--- a/lib/perf/bench/micro_bench.tl
+++ b/lib/perf/bench/micro_bench.tl
@@ -13,6 +13,10 @@ local pt = require("perf.perf_types")
 local A_MILLION = string.rep("a", 1000000)
 local SHA_A_MILLION = "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0"
 
+-- NIST SHA-256 test vector: "abc".
+local ABC = "abc"
+local SHA_ABC = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+
 local CSV_FIELDS = 256
 
 --- Build a deterministic ~64KB blob with enough variety to be a fair
@@ -50,6 +54,21 @@ local function scenarios(): {pt.Scenario}, string
       end,
       check = function(_: any, res: any): boolean, string
         if res as string ~= SHA_A_MILLION then
+          return false, "digest mismatch: " .. tostring(res)
+        end
+        return true
+      end,
+    },
+    {
+      -- A tiny input, unlike hash_sha256_1mb: isolates fixed per-call
+      -- wrapper overhead (encode + any post-processing) from the SHA-256
+      -- compute itself, which is negligible here.
+      name = "hash_sha256_small",
+      fn = function(_: any): any
+        return hash.sha256_hex(ABC)
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res as string ~= SHA_ABC then
           return false, "digest mismatch: " .. tostring(res)
         end
         return true


### PR DESCRIPTION
## Summary
Stacked on #444 — two commits are new on this branch:

**Rejected attempt (documented, no code kept):** tried deferring `main.tl`'s `require("cosmic.help")` (only used by `--help`) to inside its one call site. `bin/make perf-compare` from a clean re-baseline showed `startup_run_lua` +4.0%, inside the noise bar — no measurable win. A manual A/B using the existing `COSMIC_NO_REQUIRE_HINTS` toggle showed the same thing (differences bounced both directions across repeats). Reverted; no other top-level require in `main.tl` can be deferred the same way since `getopt`/`args`/`main_handlers` are needed on every invocation. Recorded as rejected with a revised hypothesis: the remaining `startup_run_lua` floor (cpu/wall ~0.2-0.3, mostly not CPU) is dominated by something below the Lua-require level — APE loader, zip filesystem init, or Lua runtime boot.

**Kept fix:** `load_script_file` (`main_handlers.tl`) re-ran the full Teal compiler on every invocation of a `.tl` script, even when the script and the cosmic binary compiling it were both unchanged since the last run.
- Added `lib/cosmic/script_cache.tl`: a cache used only by `load_script_file` (running `cosmic script.tl`), not `--compile`/`--check-types`/etc, which call `cosmic.teal` directly and are unaffected. Keyed on script path + content + the running binary's build version (so a different build never reuses another build's output) — deliberately content-hashed rather than mtime-based, since an mtime key risks a false cache hit if a script is rewritten within one coarse filesystem mtime tick. A failed compile is never cached, so error messages always reflect a fresh compile. Best-effort throughout: any read/write failure is a miss/no-op, never a hard error.
- Added `test_script_cache_reuse_and_invalidation` to `script_test.tl`, covering both a same-content repeat run and a content change picking up the new output.

## Result
`startup_run_teal`: 27.91ms -> 6.55ms (-76.5%, confirmed -72.8% on re-measure) — now close to `startup_run_lua`'s own floor. `startup_compile_teal` unaffected both times, as expected. `bin/make perf-compare`: 22 scenarios, 0 regression, 1 faster, 21 ok.

## Test plan
- [x] `bin/make ci`
- [x] `bin/make perf-compare` (clean re-baseline)


---
_Generated by [Claude Code](https://claude.ai/code/session_012uyf3CZ9nsm9Mv2KEwi6J9)_