### PR TITLE
net: delegate parseip/formatip to cosmo.ParseIp/FormatIp

### DIFF
--- a/lib/cosmic/net.tl
+++ b/lib/cosmic/net.tl
@@ -1,6 +1,7 @@
 --- Networking and socket utilities.
 --- Wraps cosmo.unix socket functions for TCP/UDP and Unix domain sockets.
 local unix = require("cosmo.unix")
+local cosmo = require("cosmo")
 
 local record NetSocket
   make_socket: function(fd: number): Socket
@@ -238,26 +239,18 @@ end
 --- @return number Numeric IP address
 --- @return string Error message on failure
 local function parseip(str: string): number, string
-  local a, b, c, d = str:match("^(%d+)%.(%d+)%.(%d+)%.(%d+)$")
-  if not a then
+  local ip = cosmo.ParseIp(str)
+  if ip == -1 then
     return nil, "invalid IP address format"
   end
-  local na, nb, nc, nd = tonumber(a), tonumber(b), tonumber(c), tonumber(d)
-  if na > 255 or nb > 255 or nc > 255 or nd > 255 then
-    return nil, "IP address octet out of range"
-  end
-  return (na << 24) | (nb << 16) | (nc << 8) | nd
+  return ip
 end
 
 --- Format a numeric IP address to string.
 --- @param ip number Numeric IP address
 --- @return string IP address in dotted notation
 local function formatip(ip: number): string
-  return string.format("%d.%d.%d.%d",
-    (ip >> 24) & 0xff,
-    (ip >> 16) & 0xff,
-    (ip >> 8) & 0xff,
-    ip & 0xff)
+  return cosmo.FormatIp(ip)
 end
 
 --- Network interface information.

--- a/lib/cosmic/time.tl
+++ b/lib/cosmic/time.tl
@@ -231,9 +231,7 @@ end
 --- @param timestamp number UNIX timestamp (seconds since epoch)
 --- @return string Date string (e.g., "2025-01-01")
 local function format_date(timestamp: number): string
-  local dt = gmtime(timestamp)
-  return string.format("%.4d-%.2d-%.2d",
-    dt.year as integer, dt.month as integer, dt.day as integer)
+  return cosmo.Strftime("%Y-%m-%d", timestamp)
 end
 
 --- Parse a YYYY-MM-DD date string into a UNIX timestamp (midnight UTC).

--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -422,6 +422,34 @@ code read suggests one.
     - result: `bin/make perf-compare` from a clean re-baseline, confirmed
       on a second re-measure: 23 scenarios, 0 regression, 1 faster, 22 ok.
 
+11. **time.format_date builds a full DateTime just to use 3 fields** —
+      done (2026-07-04)
+    - scenario: `time_format_date` (new): 745.9ns -> 263.8ns first pass
+      (-64.6%), 262.2ns on re-measure (-64.8%)
+    - evidence: `format_date` (lib/cosmic/time.tl) called `gmtime()` — a
+      full `unix.gmtime` C call returning 11 fields (year, month, day,
+      hour, min, sec, gmtoff, wday, yday, isdst, zone) plus a Lua table
+      build for all of them — then formatted only 3 of the 11 fields via
+      `string.format("%.4d-%.2d-%.2d", ...)`. `cosmo.Strftime` already
+      existed and was unused for this. Verified `cosmo.Strftime("%Y-%m-%d",
+      ts)` produces byte-identical output to the old code across epoch,
+      Y2K, a modern date, year 1, and year 9999 (confirming `%Y`
+      zero-pads to 4 digits the same way `%.4d` did).
+    - fix: replaced the `gmtime()` + `string.format` with a direct
+      `cosmo.Strftime("%Y-%m-%d", timestamp)` call. `gmtime()`/`localtime()`
+      themselves are untouched — other callers depend on the full
+      `DateTime` record per their documented contract; only the one
+      function that built a full record just to discard 8 of 11 fields
+      changed.
+    - added a new `lib/perf/bench/time_bench.tl` (no scenario existed for
+      any `time.*` function before this).
+    - result: `bin/make perf-compare` flagged `startup_run_lua`/
+      `startup_run_teal` as regressed on the first pass (+11.3%/+10.3%,
+      unrelated to this change); a clean re-run showed both back within
+      noise and confirmed `time_format_date` at -64.8% — 24 scenarios,
+      0 regression, 1 faster, 23 ok. Textbook case for the "re-measure
+      before trusting an inconsistent flag" rule.
+
 ## optimizing the cosmo/cosmopolitan layer end to end
 
 scenarios call `cosmic.*` wrappers, which call the `cosmo.*` C bindings

--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -400,6 +400,28 @@ code read suggests one.
    - result: `bin/make perf-compare` from a clean re-baseline, confirmed
      on a second re-measure: 22 scenarios, 0 regression, 1 faster, 21 ok.
 
+10. **net.parseip/formatip pure-Lua reimplementation** — done (2026-07-04)
+    - scenario: `net_ip_roundtrip` (new): 864.0ns -> 115.3ns first pass
+      (-86.3%), 118.5ns on re-measure (-86.7%)
+    - evidence: `net.parseip` (lib/cosmic/net.tl) did a `string.match`
+      4-octet pattern, four `tonumber()` calls, and manual range checks;
+      `net.formatip` did 4 bit-shifts plus `string.format`. Meanwhile
+      `cosmo.ParseIp`/`cosmo.FormatIp` already existed and were already
+      correctly used for the exact same job by the sibling module
+      `lib/cosmic/ip.tl` — the same "unused sibling C binding" shape as
+      the original `codec.decode_hex` fix, just in a different module.
+    - fix: delegated both functions directly. `cosmo.ParseIp` returns
+      `-1` for invalid input (verified at runtime, matching its doc
+      comment) rather than `nil, err`; `net_test.tl`'s
+      `test_parseip_formatip` only asserts `ip == nil` for invalid/
+      out-of-range input (never asserts specific error text), so mapping
+      `-1` to the existing `"invalid IP address format"` message
+      preserves every asserted behavior exactly.
+    - added `net_ip_roundtrip` to `lib/perf/bench/micro_bench.tl` (no
+      scenario existed for `net.*` functions before this).
+    - result: `bin/make perf-compare` from a clean re-baseline, confirmed
+      on a second re-measure: 23 scenarios, 0 regression, 1 faster, 22 ok.
+
 ## optimizing the cosmo/cosmopolitan layer end to end
 
 scenarios call `cosmic.*` wrappers, which call the `cosmo.*` C bindings

--- a/lib/perf/bench/micro_bench.tl
+++ b/lib/perf/bench/micro_bench.tl
@@ -7,6 +7,7 @@ local hash = require("cosmic.hash")
 local codec = require("cosmic.codec")
 local compress = require("cosmic.compress")
 local cstr = require("cosmic.string")
+local net = require("cosmic.net")
 local pt = require("perf.perf_types")
 
 -- NIST SHA-256 test vector: one million repetitions of "a".
@@ -125,6 +126,19 @@ local function scenarios(): {pt.Scenario}, string
         end
         if fields[1] ~= "field-1" or fields[CSV_FIELDS] ~= "field-" .. CSV_FIELDS then
           return false, "wrong field content"
+        end
+        return true
+      end,
+    },
+    {
+      name = "net_ip_roundtrip",
+      fn = function(_: any): any
+        local n = net.parseip("192.168.1.1")
+        return net.formatip(n)
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res as string ~= "192.168.1.1" then
+          return false, "ip roundtrip mismatch: " .. tostring(res)
         end
         return true
       end,

--- a/lib/perf/bench/time_bench.tl
+++ b/lib/perf/bench/time_bench.tl
@@ -1,0 +1,36 @@
+--- Date/time formatting scenarios.
+--- Exercises cosmic.time's format_date/format_iso8601 against known
+--- timestamps to catch a faster-but-wrong implementation.
+
+local time = require("cosmic.time")
+local pt = require("perf.perf_types")
+
+-- 2025-01-02 (the time-of-day part is irrelevant to format_date)
+local TS = 1735786445
+
+local function scenarios(): {pt.Scenario}, string
+  return {
+    {
+      name = "time_format_date",
+      fn = function(_: any): any
+        return time.format_date(TS)
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res as string ~= "2025-01-02" then
+          return false, "wrong date: " .. tostring(res)
+        end
+        return true
+      end,
+    },
+  }
+end
+
+local function cleanup()
+end
+
+local M: pt.BenchModule = {
+  scenarios = scenarios,
+  cleanup = cleanup,
+}
+
+return M


### PR DESCRIPTION
## Summary
- Stacked on #445 — only the last commit on this branch is new.
- `net.parseip` did a `string.match` 4-octet pattern, four `tonumber()` calls, and manual range checks in pure Lua; `net.formatip` did 4 bit-shifts plus `string.format`. `cosmo.ParseIp`/`cosmo.FormatIp` already existed and were already used correctly for the same job by the sibling module `ip.tl` — the same "unused sibling C binding" shape as an earlier `codec.decode_hex` fix.
- `cosmo.ParseIp` returns `-1` for invalid input rather than `nil, err`; `net_test.tl`'s `test_parseip_formatip` only asserts `ip == nil` for invalid/out-of-range input (never asserts specific error text), so mapping `-1` to the existing error message preserves every asserted behavior.
- Added `net_ip_roundtrip` to `micro_bench.tl` (no `net.*` scenario existed before this).

## Result
`net_ip_roundtrip`: 864.0ns -> 115.3ns (-86.3%, confirmed -86.7% on re-measure). `bin/make perf-compare`: 23 scenarios, 0 regression, 1 faster, 22 ok.

## Test plan
- [x] `bin/make ci`
- [x] `bin/make perf-compare` (clean re-baseline)


---
_Generated by [Claude Code](https://claude.ai/code/session_012uyf3CZ9nsm9Mv2KEwi6J9)_