### PR TITLE
time: delegate format_date to cosmo.Strftime

### DIFF
--- a/lib/cosmic/time.tl
+++ b/lib/cosmic/time.tl
@@ -231,9 +231,7 @@ end
 --- @param timestamp number UNIX timestamp (seconds since epoch)
 --- @return string Date string (e.g., "2025-01-01")
 local function format_date(timestamp: number): string
-  local dt = gmtime(timestamp)
-  return string.format("%.4d-%.2d-%.2d",
-    dt.year as integer, dt.month as integer, dt.day as integer)
+  return cosmo.Strftime("%Y-%m-%d", timestamp)
 end
 
 --- Parse a YYYY-MM-DD date string into a UNIX timestamp (midnight UTC).

--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -422,6 +422,34 @@ code read suggests one.
     - result: `bin/make perf-compare` from a clean re-baseline, confirmed
       on a second re-measure: 23 scenarios, 0 regression, 1 faster, 22 ok.
 
+11. **time.format_date builds a full DateTime just to use 3 fields** —
+      done (2026-07-04)
+    - scenario: `time_format_date` (new): 745.9ns -> 263.8ns first pass
+      (-64.6%), 262.2ns on re-measure (-64.8%)
+    - evidence: `format_date` (lib/cosmic/time.tl) called `gmtime()` — a
+      full `unix.gmtime` C call returning 11 fields (year, month, day,
+      hour, min, sec, gmtoff, wday, yday, isdst, zone) plus a Lua table
+      build for all of them — then formatted only 3 of the 11 fields via
+      `string.format("%.4d-%.2d-%.2d", ...)`. `cosmo.Strftime` already
+      existed and was unused for this. Verified `cosmo.Strftime("%Y-%m-%d",
+      ts)` produces byte-identical output to the old code across epoch,
+      Y2K, a modern date, year 1, and year 9999 (confirming `%Y`
+      zero-pads to 4 digits the same way `%.4d` did).
+    - fix: replaced the `gmtime()` + `string.format` with a direct
+      `cosmo.Strftime("%Y-%m-%d", timestamp)` call. `gmtime()`/`localtime()`
+      themselves are untouched — other callers depend on the full
+      `DateTime` record per their documented contract; only the one
+      function that built a full record just to discard 8 of 11 fields
+      changed.
+    - added a new `lib/perf/bench/time_bench.tl` (no scenario existed for
+      any `time.*` function before this).
+    - result: `bin/make perf-compare` flagged `startup_run_lua`/
+      `startup_run_teal` as regressed on the first pass (+11.3%/+10.3%,
+      unrelated to this change); a clean re-run showed both back within
+      noise and confirmed `time_format_date` at -64.8% — 24 scenarios,
+      0 regression, 1 faster, 23 ok. Textbook case for the "re-measure
+      before trusting an inconsistent flag" rule.
+
 ## optimizing the cosmo/cosmopolitan layer end to end
 
 scenarios call `cosmic.*` wrappers, which call the `cosmo.*` C bindings

--- a/lib/perf/bench/time_bench.tl
+++ b/lib/perf/bench/time_bench.tl
@@ -1,0 +1,36 @@
+--- Date/time formatting scenarios.
+--- Exercises cosmic.time's format_date/format_iso8601 against known
+--- timestamps to catch a faster-but-wrong implementation.
+
+local time = require("cosmic.time")
+local pt = require("perf.perf_types")
+
+-- 2025-01-02 (the time-of-day part is irrelevant to format_date)
+local TS = 1735786445
+
+local function scenarios(): {pt.Scenario}, string
+  return {
+    {
+      name = "time_format_date",
+      fn = function(_: any): any
+        return time.format_date(TS)
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res as string ~= "2025-01-02" then
+          return false, "wrong date: " .. tostring(res)
+        end
+        return true
+      end,
+    },
+  }
+end
+
+local function cleanup()
+end
+
+local M: pt.BenchModule = {
+  scenarios = scenarios,
+  cleanup = cleanup,
+}
+
+return M


### PR DESCRIPTION
## Summary
- Stacked on #446 — only the last commit on this branch is new.
- `format_date` called `gmtime()` — a full `unix.gmtime` C call returning 11 fields plus a Lua table build for all of them — then formatted only 3 of the 11 fields. `cosmo.Strftime` already existed and was unused for this. Verified byte-identical output to the old code across epoch, Y2K, a modern date, year 1, and year 9999.
- `gmtime()`/`localtime()` themselves are untouched — other callers depend on the full `DateTime` record per their documented contract; only the one function that built a full record just to discard most of it changed.
- Added `lib/perf/bench/time_bench.tl` (no `time.*` scenario existed before).

## Result
`time_format_date`: 745.9ns -> 263.8ns (-64.6%, confirmed -64.8% on re-measure). `bin/make perf-compare`: 24 scenarios, 0 regression, 1 faster, 23 ok (an initial run flagged unrelated `startup_run_lua`/`startup_run_teal` noise that didn't reproduce).

## Test plan
- [x] `bin/make ci`
- [x] `bin/make perf-compare` (clean re-baseline)


---
_Generated by [Claude Code](https://claude.ai/code/session_012uyf3CZ9nsm9Mv2KEwi6J9)_