### PR TITLE
time: delegate format_iso8601 to cosmo.Strftime

### DIFF
--- a/lib/cosmic/time.tl
+++ b/lib/cosmic/time.tl
@@ -252,10 +252,7 @@ end
 --- @param timestamp number UNIX timestamp (seconds since epoch)
 --- @return string ISO 8601 string (e.g., "2025-01-01T00:00:00Z")
 local function format_iso8601(timestamp: number): string
-  local dt = gmtime(timestamp)
-  return string.format("%.4d-%.2d-%.2dT%.2d:%.2d:%.2dZ",
-    dt.year as integer, dt.month as integer, dt.day as integer,
-    dt.hour as integer, dt.min as integer, dt.sec as integer)
+  return cosmo.Strftime("%Y-%m-%dT%H:%M:%SZ", timestamp)
 end
 
 --- Resolve an ISO 8601 timezone suffix into a signed offset in seconds.

--- a/lib/perf/BACKLOG.md
+++ b/lib/perf/BACKLOG.md
@@ -364,3 +364,16 @@ cap — the split carries no other meaning.
       always allocating 3 pipes when a caller doesn't need
       stdin/stderr capture is worth a fast path).
     - risk: unknown until a concrete hypothesis is found.
+
+13. **time.format_iso8601 builds a full DateTime just to use 6 fields** —
+      done (2026-07-04)
+    - scenario: `time_format_iso8601` (new): 1.01µs -> 393.4ns first pass
+      (-61.1%), 394.0ns on re-measure (-61.1%)
+    - evidence: same shape as entry 11 (`format_date`), just formatting 6
+      of `gmtime()`'s 11 fields instead of 3.
+    - fix: replaced `gmtime()` + `string.format` with a direct
+      `cosmo.Strftime("%Y-%m-%dT%H:%M:%SZ", timestamp)` call.
+    - added `time_format_iso8601` to `lib/perf/bench/time_bench.tl`
+      alongside `format_date`'s scenario.
+    - result: `bin/make perf-compare` from a clean re-baseline, confirmed
+      on a second re-measure: 26 scenarios, 0 regression, 1 faster, 25 ok.

--- a/lib/perf/bench/time_bench.tl
+++ b/lib/perf/bench/time_bench.tl
@@ -5,7 +5,7 @@
 local time = require("cosmic.time")
 local pt = require("perf.perf_types")
 
--- 2025-01-02 (the time-of-day part is irrelevant to format_date)
+-- 2025-01-02T02:54:05Z
 local TS = 1735786445
 
 local function scenarios(): {pt.Scenario}, string
@@ -18,6 +18,18 @@ local function scenarios(): {pt.Scenario}, string
       check = function(_: any, res: any): boolean, string
         if res as string ~= "2025-01-02" then
           return false, "wrong date: " .. tostring(res)
+        end
+        return true
+      end,
+    },
+    {
+      name = "time_format_iso8601",
+      fn = function(_: any): any
+        return time.format_iso8601(TS)
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res as string ~= "2025-01-02T02:54:05Z" then
+          return false, "wrong iso8601: " .. tostring(res)
         end
         return true
       end,


### PR DESCRIPTION
## Summary
- Stacked on #448 — only the last commit on this branch is new.
- Same shape as `format_date` (#447): `gmtime()` then format 6 of 11 fields. `cosmo.Strftime("%Y-%m-%dT%H:%M:%SZ", ts)` replaces it directly.
- Added `time_format_iso8601` to `time_bench.tl`.

## Result
`time_format_iso8601`: 1.01µs -> 393.4ns (-61.1%, confirmed -61.1% on re-measure). `bin/make perf-compare`: 26 scenarios, 0 regression, 1 faster, 25 ok.

## Test plan
- [x] `bin/make ci`
- [x] `bin/make perf-compare` (clean re-baseline)


---
_Generated by [Claude Code](https://claude.ai/code/session_012uyf3CZ9nsm9Mv2KEwi6J9)_