### PR TITLE
fs: dedup redundant getcwd() call in relpath; document rejected compress attempt

### DIFF
--- a/lib/cosmic/fs_path.tl
+++ b/lib/cosmic/fs_path.tl
@@ -134,13 +134,21 @@ end
 --- @param base string The base path (defaults to cwd)
 --- @return string The relative path
 local function relpath(p: string, base: string): string
-  -- Get absolute versions of both paths
-  local abs_p = abspath(p)
+  -- Get absolute versions of both paths. When both p and the implicit
+  -- base need cwd (relative p, no explicit base), fetch it once instead
+  -- of once per abspath() call.
+  local abs_p: string
   local abs_base: string
   if base then
+    abs_p = abspath(p)
     abs_base = abspath(base)
-  else
+  elseif p:sub(1, 1) == "/" then
+    abs_p = normalize(p)
     abs_base = unix.getcwd() or "."
+  else
+    local cwd = unix.getcwd() or "."
+    abs_p = normalize(cwd .. "/" .. p)
+    abs_base = cwd
   end
 
   -- Split into components

--- a/lib/perf/BACKLOG.md
+++ b/lib/perf/BACKLOG.md
@@ -406,3 +406,30 @@ cap — the split carries no other meaning.
       rule — it's a real, permanent addition to the suite even though
       this round's hypothesis on it didn't pan out.
     - risk: n/a, rejected on measurement grounds, not correctness.
+
+15. **fs_path.relpath calls getcwd(2) twice for the common case** — done
+      (2026-07-04)
+    - scenario: `fs_relpath_relative` (new, in `lib/perf/bench/fs_bench.tl`):
+      5.03µs baseline; three re-measures came back -8.3%, -10.4% (crossed
+      the noise bar, flagged `faster`), -5.9% — consistently faster,
+      never slower, across all three passes.
+    - evidence: `relpath(p, base)` with a relative `p` and no explicit
+      `base` (the common call shape — "make this path relative to cwd")
+      called `abspath(p)` first, which internally calls `unix.getcwd()`
+      to resolve `p`, and then called `unix.getcwd()` a second time to
+      resolve the implicit `base`. Two syscalls doing the same lookup.
+    - fix: in `lib/cosmic/fs_path.tl`, `relpath` now fetches `cwd` once
+      when `base` is nil, reusing it both to resolve `p` (via
+      `normalize(cwd .. "/" .. p)` when `p` isn't already absolute) and
+      directly as `abs_base`, instead of the previous unconditional
+      second `unix.getcwd()` call. The explicit-`base` path is
+      unchanged.
+    - correctness: `fs_path_test.tl`'s six `relpath` cases all pass
+      absolute paths for both `p` and `base`, so they pin the shared
+      path-math (common prefix / `..` counting) the fix doesn't touch,
+      without exercising the changed branch directly. Verified by hand
+      that the new branch produces identical results to the old code
+      for relative-`p`/no-`base` inputs — both reduce to
+      `normalize(cwd .. "/" .. p)` vs. `cwd` itself.
+    - risk: low — pure refactor of which syscall runs when, no change to
+      the string math or the public signature.

--- a/lib/perf/BACKLOG.md
+++ b/lib/perf/BACKLOG.md
@@ -377,3 +377,32 @@ cap — the split carries no other meaning.
       alongside `format_date`'s scenario.
     - result: `bin/make perf-compare` from a clean re-baseline, confirmed
       on a second re-measure: 26 scenarios, 0 regression, 1 faster, 25 ok.
+
+14. **compress.deflate/inflate size-prefix pack/unpack** — rejected
+      (2026-07-04)
+    - scenario: `compress_deflate_roundtrip_small` (new): 6.84µs baseline;
+      deflate-only fix measured +0.2% then +1.7% (no win); deflate+inflate
+      together measured +1.3% then -0.3% (still no win) across four
+      separate measurements
+    - evidence: `deflate` built a 4-byte little-endian length prefix via
+      `string.char(size % 256, math.floor(size/256) % 256, ...)`;
+      `inflate` unpacked it via `data:byte(1,4)` plus multiply-adds.
+      `string.pack("<I4", size)` / `string.unpack("<I4", data)` (Lua
+      5.4's own C-backed pack/unpack, not a `cosmo.*` binding, but the
+      same "let a C routine do it" idea) replace ~10 Lua ops with one
+      call each — objectively simpler code.
+    - fix attempted: replaced the manual byte-char loop with
+      `string.pack`/`string.unpack` in both functions (first deflate
+      alone, then both together, to see if the combined effect crossed
+      the noise bar either way — it didn't).
+    - why it was rejected despite being clean, simpler code: the
+      `cosmo.Deflate`/`cosmo.Inflate` zlib calls themselves have enough
+      fixed per-call overhead (state setup/teardown) that they swamp the
+      few nanoseconds saved on prefix packing even for a 3-byte input —
+      there's no input size where the Lua-side saving would be *more*
+      visible, since zlib's per-call floor doesn't shrink with smaller
+      inputs. Reverted both changes (`git checkout -- lib/cosmic/compress.tl`).
+      Kept the new benchmark scenario per the "never remove a scenario"
+      rule — it's a real, permanent addition to the suite even though
+      this round's hypothesis on it didn't pan out.
+    - risk: n/a, rejected on measurement grounds, not correctness.

--- a/lib/perf/bench/fs_bench.tl
+++ b/lib/perf/bench/fs_bench.tl
@@ -115,6 +115,21 @@ local function scenarios(): {pt.Scenario}, string
       end,
     },
     {
+      -- Relative path, no explicit base: the case where relpath() needs
+      -- cwd for both the target and the implicit base, isolating any
+      -- redundant getcwd(2) call from the pure-string path math.
+      name = "fs_relpath_relative",
+      fn = function(_: any): any
+        return fs.relpath("dir-1/file-1.txt")
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res as string ~= "dir-1/file-1.txt" then
+          return false, "wrong relpath: " .. tostring(res)
+        end
+        return true
+      end,
+    },
+    {
       -- Read-only metadata pass over the seeded tree. Write-churn
       -- scenarios (mkdir+rmrf) drift monotonically on overlay
       -- filesystems, which breaks baseline comparisons, so this

--- a/lib/perf/bench/micro_bench.tl
+++ b/lib/perf/bench/micro_bench.tl
@@ -115,6 +115,22 @@ local function scenarios(): {pt.Scenario}, string
       end,
     },
     {
+      -- A small input, unlike compress_roundtrip_64k: isolates the
+      -- deflate()/inflate() size-prefix pack/unpack overhead from the
+      -- zlib compute itself, which barely registers on this little data.
+      name = "compress_deflate_roundtrip_small",
+      fn = function(_: any): any
+        local packed = compress.deflate(ABC)
+        return (compress.inflate(packed))
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res as string ~= ABC then
+          return false, "deflate roundtrip corrupted data"
+        end
+        return true
+      end,
+    },
+    {
       name = "string_split_csv",
       fn = function(_: any): any
         return cstr.split(CSV, ",")


### PR DESCRIPTION
## Summary
Stacked on #449 — two commits are new on this branch:

**Rejected attempt (documented, no code kept):** added `compress_deflate_roundtrip_small` benchmark scenario (small input, isolates the `deflate()`/`inflate()` size-prefix pack/unpack overhead from the zlib compute itself). Tried replacing the manual `string.char`/`byte` prefix pack/unpack with `string.pack("<I4")`/`string.unpack("<I4")` in both `deflate` and `inflate`, alone and combined. Measured no improvement across four passes (+0.2%, +1.7% deflate-only; +1.3%, -0.3% combined) since zlib's fixed per-call overhead swamps the few nanoseconds saved on prefix packing even for tiny inputs. Reverted the code change, kept the benchmark scenario.

**Kept fix:** `relpath(p, base)` with a relative `p` and no explicit `base` called `unix.getcwd()` twice: once inside `abspath(p)` to resolve `p`, and again to resolve the implicit `base`. Fetch cwd once and reuse it for both when `base` is nil. Added `fs_relpath_relative` benchmark scenario covering this call shape.

## Result
`fs_relpath_relative` measured consistently faster across three re-measures (-8.3%, -10.4%, -5.9%).

## Test plan
- [x] `bin/make ci`
- [x] `bin/make perf-compare` (clean re-baseline, both attempts)


---
_Generated by [Claude Code](https://claude.ai/code/session_012uyf3CZ9nsm9Mv2KEwi6J9)_