### PR TITLE
embed: skip stat(2) for directories/symlinks via dirent d_type

### DIFF
--- a/lib/cosmic/embed.tl
+++ b/lib/cosmic/embed.tl
@@ -36,6 +36,7 @@ local cio = require("cosmic.io")
 local czip = require("cosmic.zip")
 local fs = require("cosmic.fs")
 local unix = require("cosmo.unix")
+local errstr = require("cosmic.errno").str
 
 --- Result returned from embed and extract operations.
 local record EmbedResult
@@ -71,6 +72,22 @@ local record ZipReader
   close: function(self: ZipReader)
 end
 
+--- Directory handle whose `read` exposes the dirent d_type (unix.DT_DIR /
+--- DT_REG / DT_LNK / ... / DT_UNKNOWN) where the filesystem supports it,
+--- letting collect_dir skip a stat(2) call for entries d_type already
+--- identifies as neither a directory nor a regular file.
+local record EmbedDirHandle
+  read: function(self): string, number
+  close: function(self)
+end
+
+-- One directory entry plus its d_type, sorted together for deterministic
+-- embed order without needing two parallel arrays.
+local record DirEntry
+  name: string
+  kind: number
+end
+
 -- Internal record for files staged for embedding.
 local record FileToEmbed
   path: string
@@ -88,51 +105,67 @@ local function collect_dir(dir: string): {FileToEmbed}, string
   local collected: {FileToEmbed} = {}
 
   local function do_walk(base_dir: string, rel_prefix: string): string
-    local handle, dir_err = fs.opendir(base_dir)
+    local raw, dir_err = unix.opendir(base_dir)
+    local handle = raw as EmbedDirHandle
     if not handle then
-      return "cannot open directory '" .. base_dir .. "': " .. (dir_err or "unknown error")
+      return "cannot open directory '" .. base_dir .. "': " .. errstr(dir_err, "opendir")
     end
 
-    local entries: {string} = {}
+    local entries: {DirEntry} = {}
     while true do
-      local entry = handle:read()
+      local entry, kind = handle:read()
       if not entry then break end
       if entry ~= "." and entry ~= ".." then
-        entries[#entries + 1] = entry
+        entries[#entries + 1] = {name = entry, kind = kind}
       end
     end
     handle:close()
-    table.sort(entries)
+    table.sort(entries, function(a: DirEntry, b: DirEntry): boolean
+        return a.name < b.name
+      end)
 
-    for _, entry in ipairs(entries) do
+    for _, de in ipairs(entries) do
+      local entry = de.name
+      local kind = de.kind
       local full_path = fs.join(base_dir, entry)
-      -- Use lstat (follow_symlinks=false) so symlinked dirs appear as S_ISLNK,
-      -- not S_ISDIR.  This prevents infinite recursion through symlink cycles
-      -- and stops symlinks to paths outside the embed dir from being followed.
-      local st = fs.stat(full_path, false)
-      if st then
-        if fs.is_dir(st:mode()) then
-          -- Only recurse into real directories, never symlinked ones.
-          local rel = rel_prefix == "" and entry or (rel_prefix .. "/" .. entry)
-          local walk_err = do_walk(full_path, rel)
-          if walk_err then return walk_err end
-        elseif unix.S_ISREG(st:mode()) then
-          -- Only embed regular files; skip symlinks (S_ISLNK) entirely.
-          local stored_name = rel_prefix == "" and entry or (rel_prefix .. "/" .. entry)
-          local content, read_err = cio.slurp(full_path)
-          if not content then
-            return "cannot open file '" .. full_path .. "': " .. (read_err or "unknown error")
+      local rel = rel_prefix == "" and entry or (rel_prefix .. "/" .. entry)
+
+      if kind == unix.DT_DIR then
+        -- d_type never follows symlinks, so this is a real directory (a
+        -- symlinked dir reports DT_LNK), skipping a stat(2) call. This is
+        -- also what prevents infinite recursion through symlink cycles.
+        local walk_err = do_walk(full_path, rel)
+        if walk_err then return walk_err end
+      elseif kind ~= unix.DT_REG and kind ~= unix.DT_UNKNOWN then
+        -- Definitely neither a directory nor a regular file (symlink,
+        -- fifo, socket, ...): skip without paying for a stat(2) call.
+      else
+        -- kind is DT_REG (need the mode bits) or DT_UNKNOWN (filesystem
+        -- doesn't expose d_type; fall back to a real lstat so a symlinked
+        -- dir reports S_ISLNK, not S_ISDIR, preserving the same cycle
+        -- prevention as the d_type == DT_DIR branch above).
+        local st = fs.stat(full_path, false)
+        if st then
+          if fs.is_dir(st:mode()) then
+            local walk_err = do_walk(full_path, rel)
+            if walk_err then return walk_err end
+          elseif unix.S_ISREG(st:mode()) then
+            -- Only embed regular files; skip symlinks (S_ISLNK) entirely.
+            local content, read_err = cio.slurp(full_path)
+            if not content then
+              return "cannot open file '" .. full_path .. "': " .. (read_err or "unknown error")
+            end
+            -- Extract permission bits (lower 9 bits)
+            local file_mode = st:mode() & tonumber("777", 8)
+            collected[#collected + 1] = {
+              path = full_path,
+              content = content,
+              stored_name = rel,
+              mode = file_mode,
+            }
           end
-          -- Extract permission bits (lower 9 bits)
-          local file_mode = st:mode() & tonumber("777", 8)
-          collected[#collected + 1] = {
-            path = full_path,
-            content = content,
-            stored_name = stored_name,
-            mode = file_mode,
-          }
+          -- S_ISLNK entries are silently skipped (no recurse, no embed)
         end
-        -- S_ISLNK entries are silently skipped (no recurse, no embed)
       end
     end
     return nil

--- a/lib/perf/BACKLOG.md
+++ b/lib/perf/BACKLOG.md
@@ -433,3 +433,52 @@ cap — the split carries no other meaning.
       `normalize(cwd .. "/" .. p)` vs. `cwd` itself.
     - risk: low — pure refactor of which syscall runs when, no change to
       the string math or the public signature.
+
+16. **embed.collect_dir stats every directory entry, even directories and
+      symlinks it's about to skip** — done (2026-07-04)
+    - scenario: `embed_run_tree` (new, in `lib/perf/bench/embed_bench.tl`,
+      600 directories/1 file each so the syscall savings are big enough
+      to show over `embed.run()`'s dominant, roughly-fixed cost of
+      copying the ~6MB source executable into the output file): 41.98ms
+      baseline; four re-measures came back -8.6%, -10.6%, -10.1%, -6.5%
+      — consistently faster, never a regression, though the swing never
+      cleared the noise bar (±38.6%, driven by that fixed exe-copy floor
+      dominating the timing and only 5 samples fitting in the budget at
+      ~40ms/op). Also added `embed_extract_tree`, covering `extract()`
+      for round 8 — unaffected by this round's fix since it only times
+      `extract()`, not `collect_dir`.
+    - evidence: `collect_dir`'s `do_walk` called `fs.stat(full_path,
+      false)` (lstat) on literally every directory entry before deciding
+      what to do with it — including entries that turn out to be
+      directories (stat result only checked via `fs.is_dir`, no data
+      needed to recurse) or symlinks (silently skipped either way). The
+      exact same waste `fs_walk.tl`'s `collect_all`/`files` already fix
+      via dirent d_type.
+    - fix: switched `collect_dir` from `fs.opendir` (whose `Dir.read`
+      only exposes the entry name) to `unix.opendir` directly, cast to a
+      local `EmbedDirHandle` type declaring `read`'s second return (the
+      d_type), mirroring `fs_walk.tl`'s `WalkDirHandle` pattern exactly.
+      `do_walk` now recurses on `kind == unix.DT_DIR` without a stat
+      call (d_type never follows symlinks, so this can't be a symlinked
+      dir — same cycle-prevention property the old lstat-based check
+      had), skips entries that are definitely neither a dir nor a
+      regular file (symlink, fifo, socket, ...) without stating them
+      either, and only falls back to `fs.stat` for `DT_REG` (needs mode
+      bits) or `DT_UNKNOWN` (filesystem doesn't expose d_type). Sorting
+      entries for deterministic embed order now sorts an array of
+      `{name, kind}` records instead of a bare `{string}` array, since
+      the kind has to travel with the name through the sort.
+    - correctness: ran the full `embed_test.tl`/`embed_advanced_test.tl`/
+      `embed_env_test.tl` suite, including the two tests that exist
+      specifically to pin this function's symlink handling —
+      `test_embed_symlink_loop_terminates` (a self-referential symlink
+      inside the embed dir must not cause infinite recursion) and
+      `test_embed_symlink_to_outside_file_skipped` (a symlink pointing
+      outside the embed dir must not be embedded) — both pass unchanged,
+      since DT_LNK falls into the "skip without stat" branch exactly
+      like the old code's S_ISLNK check did.
+    - risk: low-medium — changes which C binding opens the directory
+      (`unix.opendir` instead of `fs.opendir`) and adds a new local
+      record type, but preserves every branch's existing behavior; the
+      existing symlink-cycle and outside-symlink tests are the ones most
+      likely to catch a regression here, and both still pass.

--- a/lib/perf/bench/embed_bench.tl
+++ b/lib/perf/bench/embed_bench.tl
@@ -1,0 +1,198 @@
+--- Embed/extract scenarios: exercises cosmic.embed's directory walk
+--- (collect_dir) and zip-to-disk unpack (extract) against a real tree of
+--- directories and files, using the cosmic binary under test as the
+--- source executable.
+
+local embed = require("cosmic.embed")
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
+local czip = require("cosmic.zip")
+local pt = require("perf.perf_types")
+
+-- Deliberately dir-heavy: embed.run()'s dominant, roughly-fixed cost is
+-- copying the whole source executable (megabytes) into the output file,
+-- which would swamp a d_type-vs-stat(2) difference measured over just a
+-- handful of directories. A large DIRS count makes the per-directory
+-- syscall savings big enough to show up over that fixed floor.
+local DIRS = 600
+local FILES_PER_DIR = 1
+
+-- Mirrors cosmic.embed's EmbedResult shape (not exported by that module).
+local record EmbedResult
+  ok: boolean
+  message: string
+  file_count: integer
+end
+
+local tmpdir: string
+local srcdir: string
+local packed_exe: string
+local extract_dir: string
+
+--- Base directory for scratch files.
+--- @return string An existing writable directory
+local function tmp_base(): string
+  return os.getenv("TEST_TMPDIR") or os.getenv("TMPDIR") or "/tmp"
+end
+
+--- Locate the cosmic binary to benchmark.
+--- PERF_BIN wins; then TEST_BIN/cosmic (set by the test harness); then
+--- the interpreter running this script (arg[-1], per cosmic.child docs).
+--- @return string Path to the binary, or nil if none was found
+local function find_bin(): string
+  local envbin = os.getenv("PERF_BIN")
+  if envbin and #envbin > 0 then
+    return envbin
+  end
+  local test_bin = os.getenv("TEST_BIN")
+  if test_bin and #test_bin > 0 then
+    local p = fs.join(test_bin, "cosmic")
+    if fs.isfile(p) then
+      return p
+    end
+  end
+  return rawget(arg, -1) as string
+end
+
+--- Create DIRS directories of FILES_PER_DIR small files under srcdir.
+--- @return string Error message, or nil on success
+local function init_tree(): string
+  for d = 1, DIRS do
+    local sub = fs.join(srcdir, "dir-" .. d)
+    local ok, merr = fs.makedirs(sub)
+    if not ok then
+      return "makedirs: " .. tostring(merr)
+    end
+    for f = 1, FILES_PER_DIR do
+      local wok, werr = cio.barf(
+        fs.join(sub, "file-" .. f .. ".txt"), "data-" .. d .. "-" .. f .. "\n")
+      if not wok then
+        return "barf: " .. tostring(werr)
+      end
+    end
+  end
+  return nil
+end
+
+--- Count non-directory entries in a packed executable's zip archive.
+--- extract()'s file_count covers the whole archive (the base binary's own
+--- embedded stdlib plus whatever was just embedded), not just the tree
+--- this bench module added, so the check needs the real total.
+--- @param exe_path string Path to the packed executable
+--- @return integer Number of non-directory zip entries, or nil on error
+--- @return string Error message, or nil on success
+local function count_zip_files(exe_path: string): integer, string
+  local data, rerr = cio.slurp(exe_path)
+  if not data then
+    return nil, "slurp: " .. tostring(rerr)
+  end
+  local reader, zerr = czip.from(data)
+  if not reader then
+    return nil, "zip.from: " .. tostring(zerr)
+  end
+  local count = 0
+  for _, name in ipairs(reader:list()) do
+    if name:sub(-1) ~= "/" then
+      count = count + 1
+    end
+  end
+  reader:close()
+  return count
+end
+
+local function scenarios(): {pt.Scenario}, string
+  local bin = find_bin()
+  if bin == nil or #bin == 0 then
+    return nil, "cannot locate cosmic binary (set PERF_BIN)"
+  end
+
+  local dir, derr = fs.mkdtemp(fs.join(tmp_base(), "perf-embed-XXXXXX"))
+  if dir == nil then
+    return nil, "mkdtemp: " .. tostring(derr)
+  end
+  tmpdir = dir
+  srcdir = fs.join(tmpdir, "src")
+  local mok, merr = fs.makedirs(srcdir)
+  if not mok then
+    return nil, "makedirs: " .. tostring(merr)
+  end
+  local ierr = init_tree()
+  if ierr then
+    return nil, ierr
+  end
+
+  packed_exe = fs.join(tmpdir, "packed")
+  extract_dir = fs.join(tmpdir, "extracted")
+  local total_files = DIRS * FILES_PER_DIR
+
+  return {
+    {
+      -- Many directories, few files each: isolates collect_dir's d_type
+      -- fast path (skip stat(2) on entries the dirent already identifies
+      -- as a directory or as neither dir nor regular file) from the
+      -- per-file slurp/embed cost.
+      name = "embed_run_tree",
+      fn = function(_: any): any
+        return embed.run({srcdir}, packed_exe, bin)
+      end,
+      check = function(_: any, res: any): boolean, string
+        local r = res as EmbedResult
+        if not r.ok then
+          return false, "embed.run failed"
+        end
+        if r.file_count ~= total_files then
+          return false, string.format("embedded %d files, want %d",
+            r.file_count, total_files)
+        end
+        return true
+      end,
+    },
+    {
+      -- Extracting this archive writes FILES_PER_DIR files per directory,
+      -- isolating extract()'s per-file makedirs(dir) call — repeated
+      -- FILES_PER_DIR times for the same already-created directory —
+      -- from the archive read/write cost.
+      name = "embed_extract_tree",
+      setup = function(): any, string
+        local result = embed.run({srcdir}, packed_exe, bin)
+        if not result.ok then
+          return nil, "embed.run: " .. tostring(result.message)
+        end
+        local expected, cerr = count_zip_files(packed_exe)
+        if not expected then
+          return nil, cerr
+        end
+        return expected
+      end,
+      fn = function(_: any): any
+        return embed.extract(extract_dir, packed_exe)
+      end,
+      check = function(ctx: any, res: any): boolean, string
+        local r = res as EmbedResult
+        local expected = ctx as integer
+        if not r.ok then
+          return false, "embed.extract failed"
+        end
+        if r.file_count ~= expected then
+          return false, string.format("extracted %d files, want %d",
+            r.file_count, expected)
+        end
+        return true
+      end,
+    },
+  }
+end
+
+local function cleanup()
+  if tmpdir then
+    fs.rmrf(tmpdir)
+    tmpdir = nil
+  end
+end
+
+local M: pt.BenchModule = {
+  scenarios = scenarios,
+  cleanup = cleanup,
+}
+
+return M


### PR DESCRIPTION
## Summary
- Stacked on #450 — only the last commit on this branch is new.
- `collect_dir`'s `do_walk` called `fs.stat` (lstat) on every directory entry before deciding what to do with it, including entries that turn out to be directories or symlinks that get skipped either way. Mirrors the d_type fast path `fs_walk.tl` already uses: recurse on `DT_DIR` without a stat call, skip definite non-dir/non-regular entries (symlink, fifo, socket) without one either, and only fall back to a real stat for `DT_REG` (need mode bits) or `DT_UNKNOWN` (no d_type support).
- Switched from `fs.opendir` (name only) to `unix.opendir` directly (exposes d_type as `read()`'s second return), cast to a local `EmbedDirHandle` type following the same pattern as `fs_walk.tl`'s `WalkDirHandle`.
- Added `embed_run_tree`/`embed_extract_tree` benchmark scenarios (also covers the next PR's `extract()` target). Sized the tree at 600 directories so the syscall savings show over `embed.run()`'s dominant, roughly-fixed cost of copying the ~6MB source executable.

## Result
`embed_run_tree` measured consistently faster across four re-measures (-8.6%, -10.6%, -10.1%, -6.5%), though the swing never crossed the noise bar given that fixed floor.

Verified against `embed_test.tl`/`embed_advanced_test.tl`/`embed_env_test.tl`, including the tests pinning symlink-loop termination and outside-symlink skipping — both still pass since `DT_LNK` falls into the skip-without-stat branch exactly like the old `S_ISLNK` check did.

## Test plan
- [x] `bin/make ci`
- [x] `bin/make perf-compare` (clean re-baseline)


---
_Generated by [Claude Code](https://claude.ai/code/session_012uyf3CZ9nsm9Mv2KEwi6J9)_