### PR TITLE
codec: run decode_base64's structural regex before the char-class scan

### DIFF
--- a/lib/cosmic/codec.tl
+++ b/lib/cosmic/codec.tl
@@ -71,13 +71,15 @@ end
 --- @return string The decoded binary data, or nil on error
 --- @return string? Error message if decoding failed
 local function decode_base64(str: string): string, string
-  -- Validate: base64 uses A-Z, a-z, 0-9, +, /, and = for padding
-  if str:match("[^A-Za-z0-9+/=]") then
-    return nil, "invalid base64 character"
-  end
-  -- Validate: = can only appear at the end, max 2
+  -- Validate structure (content chars, then = padding, then end) in one
+  -- pass. On the happy path this is the only scan needed; a mismatch
+  -- means either an invalid character anywhere or padding not confined
+  -- to the end, so a second, cheaper scan runs only then to tell which.
   local content, padding = str:match("^([A-Za-z0-9+/]*)(%=*)$")
   if not content then
+    if str:match("[^A-Za-z0-9+/=]") then
+      return nil, "invalid base64 character"
+    end
     return nil, "invalid base64: padding in middle"
   end
   if #padding > 2 then

--- a/lib/perf/BACKLOG.md
+++ b/lib/perf/BACKLOG.md
@@ -265,3 +265,38 @@ other meaning.
     - risk: low — the fix can only reduce the number of `makedirs` calls
       for paths already proven created within the same run; it never
       skips the first call for a given directory.
+
+18. **codec.decode_base64 scans the input twice on the happy path** — done
+      (2026-07-04)
+    - scenario: `codec_base64_roundtrip_64k`: 1.88ms baseline; two
+      re-measures came back -71.8% and -70.8% — large and consistent.
+    - evidence: `decode_base64` ran a negated-character-class scan
+      (`str:match("[^A-Za-z0-9+/=]")`, to give a specific "invalid
+      character" error) unconditionally, THEN an anchored
+      content/padding-capturing scan (`^([A-Za-z0-9+/]*)(%=*)$"`) to
+      validate structure — two full passes over the input on every
+      call, valid or not, even though the anchored pattern alone already
+      proves the input is well-formed when it matches.
+    - fix: run the anchored content/padding match first. On the happy
+      path (matches — i.e. every valid base64 string) that's the only
+      scan; the character-class scan now only runs to disambiguate the
+      error message in the failure branch (invalid character vs. padding
+      before the end), which is the rare path. Same two error messages,
+      same conditions, just reordered so the common case pays for one
+      scan instead of two.
+    - why the win is bigger than "cut one of two equal-cost scans in
+      half": the removed scan was the *negated* character class
+      (`[^A-Za-z0-9+/=]`, 4 ranges + a literal, excluded), which Lua's
+      pattern matcher evidently checks per byte less efficiently than
+      the anchored match's two positive classes — so removing it from
+      the happy path saved more than 50% of the matching-related work,
+      not describable as an cache/allocation change.
+    - correctness: verified against all four existing `decode_base64`
+      tests (`test_decode_base64_basic`, `_no_padding`, `_empty`,
+      `_invalid_char`, `_invalid_padding`, `_padding_in_middle`) by hand
+      — traced each through both branches to confirm identical error
+      messages and identical accept/reject decisions, then ran
+      `bin/make test only=codec_test`, which passed.
+    - risk: low — same two validation conditions and error messages,
+      only their evaluation order changed; no change to what cosmo.DecodeBase64
+      is ultimately called with.


### PR DESCRIPTION
## Summary
- Stacked on #452 — only the last commit on this branch is new.
- `decode_base64` ran a negated-character-class scan for a specific "invalid character" error message unconditionally, then a separate anchored content/padding match to validate structure — two full passes over the input on every call, even though the anchored match alone already proves the input well-formed when it succeeds.
- Reordered so the anchored match runs first: on the happy path (any valid base64 string) that's the only scan, and the character-class scan now only runs in the failure branch to disambiguate which error message applies. Same two error messages, same conditions, just reordered.

## Result
`codec_base64_roundtrip_64k` measured -71.8% and -70.8% across two re-measures — larger than a simple "cut one of two scans" would suggest, apparently because Lua's negated character class checks per byte less efficiently than the anchored match's positive classes.

Verified by hand against all six existing `decode_base64` test cases (basic, no-padding, empty, invalid-char, invalid-padding, padding-in-middle) and confirmed `bin/make test only=codec_test` passes.

## Test plan
- [x] `bin/make ci`
- [x] `bin/make perf-compare` (clean re-baseline)


---
_Generated by [Claude Code](https://claude.ai/code/session_012uyf3CZ9nsm9Mv2KEwi6J9)_