### PR TITLE
fetch: collapse has_forbidden_byte's three scans into one

### DIFF
--- a/lib/cosmic/fetch.tl
+++ b/lib/cosmic/fetch.tl
@@ -71,12 +71,10 @@ local function validate_url(url: string): string
   return nil
 end
 
--- True when s carries a CR, LF, or NUL. Plain-text search (find's 4th arg)
--- so the bytes are matched literally, not as pattern metacharacters.
+-- True when s carries a CR, LF, or NUL. One character-class scan instead
+-- of three separate plain-text searches over the same string.
 local function has_forbidden_byte(s: string): boolean
-  return s:find("\r", 1, true) ~= nil
-  or s:find("\n", 1, true) ~= nil
-  or s:find("\0", 1, true) ~= nil
+  return s:find("[\r\n\0]") ~= nil
 end
 
 --- Reject header names or values that carry a CR, LF, or NUL. HTTP headers

--- a/lib/perf/BACKLOG.md
+++ b/lib/perf/BACKLOG.md
@@ -342,3 +342,39 @@ other meaning.
     - risk: n/a, rejected on measurement grounds, not correctness (the
       manual loop was verified correct against all existing `decode()`
       tests before being measured and reverted).
+
+20. **fetch.has_forbidden_byte runs three plain-text scans where one
+      character-class scan would do** — done, modest win (2026-07-04)
+    - scenario: `http_fetch_get_with_headers` (new — the existing
+      `http_fetch_get` never passes headers, so `validate_headers`
+      short-circuits on `if not headers then return nil end` and never
+      calls `has_forbidden_byte` at all): 70.56µs baseline; three
+      re-measures came back -2.1%, -1.6%, -3.0% — small but consistently
+      faster, never a regression. `http_fetch_get` itself (no headers)
+      is unaffected, as expected, since it never touches this function.
+    - evidence: `has_forbidden_byte` (lib/cosmic/fetch.tl, called once
+      per header name and once per header value in `validate_headers`,
+      security-critical CRLF-injection guard, audit §2.3) ran three
+      separate `s:find(byte, 1, true)` calls — one each for CR, LF, NUL —
+      each a full scan of the string on the common (no-early-exit)
+      clean-header path.
+    - fix: replaced the three plain-text `find` calls with one
+      character-class pattern scan, `s:find("[\r\n\0]")` — still exactly
+      one `string.find` C call, just checking all three bytes per
+      position instead of one call per byte. Verified in a standalone
+      Lua 5.4 script that embedded NUL bytes inside a Lua pattern
+      character class match correctly (Lua 5.4 removed the old `%z`
+      class; a literal `\0` inside `[...]` works directly since Lua
+      strings carry an explicit length, not a NUL terminator).
+    - why this one worked where entry #19 (`url.decode`) didn't: this
+      fix reduces the call *count* on the happy path (3 C calls -> 1),
+      not just bytes touched by more calls — the exact distinction
+      entry #19's "lesson for future rounds" called out.
+    - correctness: ran the full `fetch_headers_test.tl` suite (CRLF in
+      value, LF-only, CR-only, CRLF in name, NUL in value, empty name,
+      clean headers, plus the `stream()` variants) and `fetch_test.tl` —
+      all pass unchanged, confirming identical accept/reject behavior
+      for every existing case.
+    - risk: low — same three forbidden bytes, same short-circuit
+      semantics (`find` still returns at the first match), only the
+      call shape changed.

--- a/lib/perf/BACKLOG.md
+++ b/lib/perf/BACKLOG.md
@@ -300,3 +300,45 @@ other meaning.
     - risk: low — same two validation conditions and error messages,
       only their evaluation order changed; no change to what cosmo.DecodeBase64
       is ultimately called with.
+
+19. **url.decode's gsub+match validation replaced with a manual %-scan
+      loop** — rejected (2026-07-04)
+    - scenario: `url_decode_query_value` (new): 45.04µs baseline;
+      manual-loop fix measured +53.2% then +56.1% on re-measure — a
+      confirmed regression, not noise (crossed the ±10% bar both times).
+    - evidence: `decode()` (lib/cosmic/url.tl) validated %XX
+      percent-encoding via `str:gsub("%%(%x%x)", "")` (remove every
+      valid escape) followed by `check:match("%%")` (anything left over
+      is invalid) — two full-string C calls, the first of which builds
+      and discards an entire copy of the string. Looked like the same
+      "redundant full-string scan" shape as entry #18
+      (`codec.decode_base64`).
+    - fix attempted: replaced the gsub+match pair with a manual loop —
+      `str:find("%", pos, true)` to locate each literal `%`, then
+      `str:match("^%x%x", pos + 1)` to check the two bytes after it —
+      so validation only touches `%` occurrences instead of the whole
+      string, with no intermediate copy.
+    - why it was rejected despite being the "obviously less work"
+      approach: unlike base64's grammar, arbitrary percent-encoded text
+      isn't expressible as a single anchored Lua pattern (the escape
+      sequences can appear anywhere, and Lua patterns can't repeat a
+      captured alternation), so the replacement needed a Lua-level loop
+      making one `find` and one `match` call *per* `%` character. Each
+      of those is a separate Lua-to-C round trip with its own call
+      overhead; `QUERY_ENCODED` (the benchmark's realistic value) has
+      enough `%XX` sequences that the sum of many small C calls lost to
+      two single large-string C calls (`gsub`/`match`, each one call
+      doing a tight internal C loop over the whole string). The "avoid
+      building an intermediate string" saving was real but smaller than
+      the added per-occurrence call overhead. Reverted
+      (`git checkout -- lib/cosmic/url.tl`). Kept the new benchmark
+      scenario per the "never remove a scenario" rule.
+    - lesson for future rounds: "fewer bytes touched" doesn't always
+      beat "fewer Lua-to-C calls" — a single C-implemented full-string
+      operation can outperform a Lua-level loop over a subset of the
+      same string once the subset isn't tiny relative to call overhead.
+      Entry #18 won because it was still exactly one full-string C call
+      on the happy path, not more calls of any kind.
+    - risk: n/a, rejected on measurement grounds, not correctness (the
+      manual loop was verified correct against all existing `decode()`
+      tests before being measured and reverted).

--- a/lib/perf/bench/http_bench.tl
+++ b/lib/perf/bench/http_bench.tl
@@ -96,6 +96,37 @@ local function scenarios(): {pt.Scenario}, string
       end,
     },
     {
+      -- Same request, but with headers set, so validate_headers/
+      -- has_forbidden_byte actually run (http_fetch_get passes no
+      -- headers, so that scenario never touches this code path at all).
+      name = "http_fetch_get_with_headers",
+      fn = function(_: any): any
+        return fetch.Fetch(url, {
+            proxy = proxy,
+            headers = {
+              ["Accept"] = "application/json",
+              ["X-Test"] = "a moderately realistic header value, not just a few bytes",
+            },
+          })
+      end,
+      check = function(_: any, res: any): boolean, string
+        local r = res as fetch.Result
+        if r == nil then
+          return false, "no result"
+        end
+        if not r.ok then
+          return false, "fetch failed: " .. tostring(r.error)
+        end
+        if r.status ~= 200 then
+          return false, "status " .. tostring(r.status)
+        end
+        if r.body ~= BODY then
+          return false, "wrong body"
+        end
+        return true
+      end,
+    },
+    {
       name = "http_tcp_roundtrip",
       fn = function(_: any): any
         local sock, cerr = net.connect_tcp(LOCALHOST, port)

--- a/lib/perf/bench/micro_bench.tl
+++ b/lib/perf/bench/micro_bench.tl
@@ -8,6 +8,7 @@ local codec = require("cosmic.codec")
 local compress = require("cosmic.compress")
 local cstr = require("cosmic.string")
 local net = require("cosmic.net")
+local url = require("cosmic.url")
 local pt = require("perf.perf_types")
 
 -- NIST SHA-256 test vector: one million repetitions of "a".
@@ -43,8 +44,22 @@ local function build_csv(): string
   return table.concat(fields, ",")
 end
 
+--- Build a deterministic query-value-like string with a realistic mix of
+--- safe characters and ones url.encode must percent-escape, so decode()
+--- has a real handful of %XX sequences to validate, not zero.
+--- @return string The value
+local function build_query_value(): string
+  local parts: {string} = {}
+  for i = 1, 64 do
+    parts[i] = string.format("field %d: a/b+c=d&e %04d", i, i * 37)
+  end
+  return table.concat(parts, " ")
+end
+
 local BLOB = build_blob()
 local CSV = build_csv()
+local QUERY_VALUE = build_query_value()
+local QUERY_ENCODED = url.encode(QUERY_VALUE)
 
 local function scenarios(): {pt.Scenario}, string
   return {
@@ -155,6 +170,21 @@ local function scenarios(): {pt.Scenario}, string
       check = function(_: any, res: any): boolean, string
         if res as string ~= "192.168.1.1" then
           return false, "ip roundtrip mismatch: " .. tostring(res)
+        end
+        return true
+      end,
+    },
+    {
+      -- A pre-encoded query value with a real handful of %XX sequences,
+      -- so decode()'s percent-encoding validation has actual work to do
+      -- rather than short-circuiting on a string with no '%' at all.
+      name = "url_decode_query_value",
+      fn = function(_: any): any
+        return (url.decode(QUERY_ENCODED))
+      end,
+      check = function(_: any, res: any): boolean, string
+        if res as string ~= QUERY_VALUE then
+          return false, "url decode roundtrip corrupted data"
         end
         return true
       end,


### PR DESCRIPTION
## Summary
Stacked on #453 — two commits are new on this branch:

**Rejected attempt (documented, no code kept):** added `url_decode_query_value` benchmark scenario (a realistic query value with a handful of `%XX` escapes, so `decode()`'s validation has real work to do). Tried replacing `url.decode`'s `gsub`+`match` validation with a manual find/match loop over just the `%` occurrences, expecting fewer bytes touched to win. Measured a confirmed regression instead (+53.2%, +56.1%): each `%` occurrence costs a separate Lua-to-C call, and enough of them add up to more overhead than the two single full-string C calls (`gsub`/`match`) they replaced. Reverted, kept the benchmark scenario.

**Kept fix:** `has_forbidden_byte` (the CRLF/NUL header-injection guard, audit §2.3) ran three separate plain-text `find()` calls — one each for CR, LF, and NUL — on every header name and value, even on the clean-header happy path where none of them match. Replaced with one character-class scan, `s:find("[\r\n\0]")`, cutting the call count from 3 to 1 without changing short-circuit semantics. Added `http_fetch_get_with_headers` benchmark scenario, since the existing `http_fetch_get` never passes headers and so never exercises `validate_headers`/`has_forbidden_byte` at all.

## Result
`http_fetch_get_with_headers` measured consistently faster across three re-measures (-2.1%, -1.6%, -3.0%), small but never a regression — unlike the rejected `url.decode` attempt above, this fix reduces the call count on the happy path rather than trading fewer bytes scanned for more calls.

Verified against the full `fetch_headers_test.tl` and `fetch_test.tl` suites, which pin the CRLF/LF/CR/NUL rejection behavior and error messages exactly.

## Test plan
- [x] `bin/make ci`
- [x] `bin/make perf-compare` (clean re-baseline, both attempts)


---
_Generated by [Claude Code](https://claude.ai/code/session_012uyf3CZ9nsm9Mv2KEwi6J9)_