### PR TITLE
perf: research pass — seed backlog entries 22-27 and document the techniques

### DIFF
--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -119,6 +119,31 @@ work ONE scenario (or one closely related group) at a time.
 - benchmarks live under `lib/perf/bench/` and use `cosmic.*` modules only
   (never raw `cosmo.*`) — they measure what users experience.
 
+## running a research pass (re-seeding the backlog)
+
+when the open backlog runs thin, spend a session on research instead of
+optimization: gather evidence, write new `open` entries, change no
+product code. the workflow that has worked (entries 22-27 came out of
+one such pass):
+
+1. `bin/make perf` on current main; read every line of the report.
+2. rank suspects by the signal shapes in `optimize/finding.md`
+   (alloc-per-op sanity math, sibling mismatches, cpu/wall surprises).
+3. for each suspect, spend a few minutes reading the wrapper source —
+   most hypotheses die or crystallize within one code read.
+4. for startup/syscall suspects, use the tracing decomposition recipes
+   in `optimize/cosmopolitan.md` (cosmo `--strace` call counting,
+   kernel `strace -c`, raw-vs-wrapped binary timing).
+5. cheap probes are allowed and encouraged — rebuild a variant
+   artifact in a scratch directory and shell-time it (that's how the
+   store-vs-deflate slice in entry 24 got real numbers) — but label
+   probe numbers as scouting in the entry; accept/reject decisions
+   still require the real harness.
+6. one file per hypothesis in `lib/perf/backlog/`, each with the
+   evidence, the expected mechanism, the correctness constraints, and
+   a risk note. update related older entries in the same commit
+   (cross-reference rather than duplicate).
+
 ## the hypothesis backlog
 
 `lib/perf/backlog/` holds the log — one file per concrete,

--- a/lib/perf/backlog/004-startup-runtime-boot-floor.md
+++ b/lib/perf/backlog/004-startup-runtime-boot-floor.md
@@ -31,10 +31,33 @@
   Lua-require level entirely — the APE loader, zip filesystem init,
   or Lua runtime boot, all of which live in whilp/cosmopolitan. Work
   it with the loop in `lib/perf/optimize/cosmopolitan.md`.
-- suggested first step (decomposition, not yet an optimization): time
-  the pinned raw cosmos `lua` binary running `-e 'print("hello")'`
-  next to cosmic's `startup_run_lua`. The gap isolates what cosmic's
-  ~6MB zip payload adds to boot (zip central-directory scan, more
-  package path entries) from the APE+Lua floor itself; whichever side
-  is bigger tells you where to read C code first.
-- risk: unknown until a concrete C-side hypothesis is formed.
+- decomposition measured (2026-07-05, shell-loop scouting on the CI
+  container — re-measure with the real scenarios before optimizing):
+  - raw pinned cosmos `lua -e 'print("hi")'`: ~5.0ms/invocation.
+  - `cosmic -e 'print("hi")'`: ~7.8ms/invocation.
+  - so the APE+Lua floor (~5ms) is the bigger half, and cosmic's
+    payload/CLI boot adds ~2.8ms on top.
+  - cosmo `--strace` shows 279 userspace-traced calls for cosmic vs
+    47 for raw lua: cosmic's extra work is 16 `require()`s (14
+    cosmic modules, ~44KB of .lua source), 29 `inflate()` calls
+    (every module is deflate-compressed in the zip — entry 24 covers
+    eliminating these; a store-mode probe put that slice at
+    ~0.5ms), and zipos open/readv/fstat per module.
+  - kernel-level strace shows ~195 rt_sigprocmask and ~115 mmap
+    calls per trivial run — entry 27 covers that slice.
+  - also observed under `--strace`: failed openat probes for
+    `cosmic.dbg`/`cosmic.com.dbg` plus an `OpenSymbolTable()
+    ENOEXEC` and a second whole-binary (6.6MB) MAP_PRIVATE mmap at
+    every boot — likely ShowCrashReports() symbol-table eagerness
+    (third_party/lua/lua.main.c:394), but verify it happens in
+    plain (non---strace) runs before spending effort on it.
+- remaining in this entry once 24 and 27 are worked: the ~5ms raw
+  floor itself (APE loader, zipos central-directory init for a
+  300+-entry archive, Lua state construction) and the Lua-parse
+  cost of the ~44KB of boot modules (precompiling the payload to
+  Lua 5.4 bytecode is a candidate — same interpreter build on
+  every platform makes bytecode portable across the fat binary's
+  architectures, but verify aarch64/x86_64 chunk compatibility
+  before trusting that).
+- risk: unknown per sub-hypothesis; the decomposition above is the
+  map.

--- a/lib/perf/backlog/012-child-spawn-overhead.md
+++ b/lib/perf/backlog/012-child-spawn-overhead.md
@@ -25,10 +25,8 @@
   - cosmic layer: `spawn()` always allocates 3 pipes even when a
     caller doesn't need stdin/stderr capture — is a fast path worth
     it?
-  - cosmopolitan layer: where does the non-CPU 86% actually go?
-    cosmopolitan's `fork()` does userspace work beyond the raw
-    syscall (e.g. reconstituting runtime state for portability);
-    whether any of it is avoidable on the Linux hot path is a
-    C-side question — work it with
-    `lib/perf/optimize/cosmopolitan.md`.
+  - cosmopolitan layer: the non-CPU 86% is dominated by fork() of a
+    large process; cosmopolitan's own vfork-backed `posix_spawn()`
+    exists precisely to avoid that and has no Lua binding — this
+    became entry 26, the concrete C-side successor to this entry.
 - risk: unknown until a concrete hypothesis is found.

--- a/lib/perf/backlog/022-hex-decode-happy-path-scan.md
+++ b/lib/perf/backlog/022-hex-decode-happy-path-scan.md
@@ -1,0 +1,31 @@
+# 22. codec.decode_hex scans the whole input for validity on every call
+
+- status: open
+- layer: cosmic
+- scenario: codec_hex_roundtrip_64k
+
+- evidence: `codec_hex_roundtrip_64k` runs 2.09ms/op with 188KB/op
+  alloc, vs `codec_base64_roundtrip_64k` at 558µs/op on the same 64KB
+  input. Part of the gap is inherent (hex text is 128KB vs ~87KB for
+  base64), but `decode_hex` (lib/cosmic/codec.tl:18-29) still runs
+  `hex:match("[^0-9a-fA-F]")` — a full negated-character-class scan of
+  the 128KB string — on every call before delegating to
+  `cosmo.DecodeHex`. That is exactly the scan shape entry 18 removed
+  from the base64 happy path, and Lua's pattern matcher handles
+  negated classes per byte relatively slowly (entry 18's "why the win
+  is bigger" note).
+- hypothesis: keep the O(1) even-length check, wrap the delegation in
+  `pcall(cosmo.DecodeHex, hex)` — on the happy path that is still
+  exactly one C call (entry 19's lesson: don't add per-occurrence Lua
+  calls, and this doesn't) — and only run the character-class scan in
+  the failure branch to pick between the two documented error
+  messages. Expected: the decode half stops paying a full extra scan;
+  scenario delta likely 10-30% given encode+decode split.
+- correctness constraints: the documented `value, string` returns and
+  the exact messages "hex string must have even length" / "invalid
+  hex character" must be preserved; `codec_test.tl` pins them.
+  Verify `cosmo.DecodeHex`'s raise conditions cover every input the
+  scan currently rejects (it raises on non-hex and odd length per
+  entry 1), so no invalid input can slip through the pcall path.
+- risk: low — same accept/reject set, same messages, evaluation order
+  changes only on the failure path.

--- a/lib/perf/backlog/023-sqlite-query-iter-alloc.md
+++ b/lib/perf/backlog/023-sqlite-query-iter-alloc.md
@@ -1,0 +1,36 @@
+# 23. sqlite db:query rebuilds iterator machinery on every call
+
+- status: open
+- layer: cosmic
+- scenario: sqlite_point_query
+
+- evidence: `sqlite_point_query` allocates 2.41KB/op for a single-row
+  point query even though entries 2 and 8 already cache the prepared
+  statement. Reading `stmt:rows()` (lib/cosmic/sqlite.tl:149-183):
+  every `db:query` call builds, per call — a fresh iterator table, a
+  fresh metatable, two fresh closures (`__call` and `err`), and a
+  fresh `col_names` table populated by `get_name()` C calls on the
+  first row. Only the row table itself is per-row payload; the rest
+  is per-call overhead that is identical for every reuse of the same
+  cached statement. `stmt:values()` (lines 185-209) has the same
+  shape.
+- hypothesis: cache the column-name array on the statement object
+  (column names are a property of the prepared statement; invalidate
+  alongside the SQLITE_SCHEMA re-prepare in the statement cache), and
+  restructure so the iterator machinery isn't rebuilt per call —
+  e.g. hoist the metatable to module level and carry per-iteration
+  state (step_err, first_call) in the iterator table instead of
+  closure upvalues. Expected: meaningful cut of the 2.41KB/op alloc
+  and a few percent of the 7.98µs/op; `sqlite_scan_aggregate`
+  (many rows per call) should show the col_names win too.
+- correctness constraints: the reentrancy semantics from entry 8 must
+  survive — a checked-out cached statement falls back to a throwaway
+  statement, which must still get working (fresh or shared-static)
+  iterator machinery; nested same-SQL queries are pinned by
+  `test_same_sql_nested_query_reentrant`. The `iter.err` contract
+  (returns the step error after the iterator drains) and the
+  `stmt:close()`-on-completion behavior are pinned by existing
+  tests.
+- risk: medium — touches the query hot path and the iterator
+  lifecycle; the existing sqlite test suite is thorough
+  (sqlite_test, sqlite_advanced_test), which is the main safety net.

--- a/lib/perf/backlog/024-store-lua-payload-uncompressed.md
+++ b/lib/perf/backlog/024-store-lua-payload-uncompressed.md
@@ -1,0 +1,36 @@
+# 24. embedded .lua payload is deflated; every boot pays 29 inflate() calls
+
+- status: open
+- layer: cosmic (packaging — lib/cosmic/cook.mk zip flags)
+- scenario: startup_run_lua, startup_run_teal
+
+- evidence: `o/bin/cosmic --strace -e 'print("hi")'` shows 29
+  `inflate()` calls at boot — every embedded `.lua` module the CLI
+  loads (14 modules, ~44KB source total, plus /zip/main.lua and
+  .args) is DEFLATE-compressed in the zip payload, so zipos
+  decompresses it on every single invocation. The `$(cosmos_zip_bin)
+  -qr` calls in lib/cosmic/cook.mk use the default compression.
+- probe already measured (2026-07-05, shell-loop timing, treat as
+  scouting not accept/reject): rebuilt the identical payload with
+  `-0` (store) into a copy of the cosmos lua binary — inflate count
+  drops to 0, boot went ~7.6ms -> ~7.0ms per invocation over 30 runs
+  (~7%), binary size 6.6MB -> 8.4MB (+28%).
+- hypothesis: store (don't deflate) the boot-critical payload. Two
+  shapes to evaluate with the real scenarios:
+  1. store everything (`-0`): simplest, +1.8MB binary.
+  2. selective: store `.lua/` (what boot actually reads) and keep
+     `.docs`/`skills`/`.tl` deflated — most of the win, a fraction
+     of the size cost (the big compressible mass is tl.lua at
+     ~700KB source, which is lazy-loaded since entry 3 — decide
+     with data whether it stays deflated).
+- also worth checking in the same round: `zipcopy`/release artifacts
+  (cosmic-lua release builds embed the same way), and whether
+  `embed.run()`-produced executables should follow suit for their
+  own startup.
+- correctness constraints: none behavioral — zipos serves stored and
+  deflated entries identically; `bin/make ci` plus the startup
+  scenarios' checks cover it. The tradeoff is purely size vs boot
+  time, so quote both in the decision.
+- risk: low for correctness; the real question is whether the size
+  cost is acceptable — make the call with `perf-compare` numbers
+  from the real harness (the probe above is shell-loop scouting).

--- a/lib/perf/backlog/025-fs-normalize-fast-path.md
+++ b/lib/perf/backlog/025-fs-normalize-fast-path.md
@@ -1,0 +1,34 @@
+# 25. fs_path.normalize splits and rebuilds every path, even already-normal ones
+
+- status: open
+- layer: cosmic
+- scenario: fs_relpath_relative
+
+- evidence: `fs_relpath_relative` runs 5.78µs/op with 2.62KB/op alloc
+  — high for pure string math on short paths. `normalize()`
+  (lib/cosmic/fs_path.tl:73-103) unconditionally splits the path into
+  a parts array via `gmatch("[^/]+")` + `table.insert`, then
+  `table.concat`s it back — allocating the table, every component
+  substring, and the result string on every call. `relpath` with a
+  relative input calls it at least once (entry 15 already removed the
+  duplicate getcwd; the remaining cost is this). Most real inputs are
+  already normalized: no `//`, no `.` or `..` components, no trailing
+  slash.
+- hypothesis: add a fast path that detects already-normal input with
+  one or two cheap scans (e.g. no `"//"` plain-find, no `"/./"` /
+  `"/../"` / leading-or-trailing dot component, no trailing `/`) and
+  returns the input string unchanged, falling through to the split
+  loop otherwise. Also applicable micro-fix in the slow path: replace
+  `table.insert(parts, ...)` with an indexed counter (entry 6's
+  shape). Expected: large cut of the 2.62KB/op alloc and a
+  double-digit percent of ns/op for normal inputs.
+- watch out: the fast-path predicate must be *exactly* "output would
+  equal input" — e.g. `""` -> `"."`, `"/"` stays `"/"`, a lone `"."`
+  -> `"."`, `"a/"` -> `"a"` — enumerate fs_path_test.tl's normalize
+  cases and add ones for every predicate edge (a path ending in
+  `"/.."`, a component named `"..."` which is a legal filename, etc.)
+  before trusting it. entry 19's lesson applies: keep the detection
+  to one or two C-implemented full-string calls, not a per-component
+  Lua loop, or the fast path eats its own win.
+- risk: medium-low — pure function with a thorough existing test
+  table; the danger is a subtle predicate miss, which tests must pin.

--- a/lib/perf/backlog/026-posix-spawn-binding.md
+++ b/lib/perf/backlog/026-posix-spawn-binding.md
@@ -1,0 +1,39 @@
+# 26. child.spawn pays full fork(); vfork-backed posix_spawn is unexposed
+
+- status: open
+- layer: cosmopolitan (new binding) + cosmic (wrapper fast path)
+- scenario: child_spawn_true
+
+- evidence: `child_spawn_true` costs 1.71ms/op at cpu/wall 0.14 —
+  almost all kernel time — to spawn `/bin/true` from the ~20MB cosmic
+  process. `cosmic.child.spawn` (lib/cosmic/child.tl) uses
+  `unix.fork()` + dup2 + `unix.execve()`; fork of a large process
+  pays page-table copy proportional to the parent's memory.
+  Meanwhile cosmopolitan's `posix_spawn()`
+  (libc/proc/posix_spawn.c) explicitly uses vfork on the hot path —
+  its own doc comment: "Cosmopolitan Libc's posix_spawn() uses
+  vfork() under the hood ... because vfork() creates a child process
+  without needing to copy [the parent's page tables], which is
+  awesome for large processes" — with file-actions support for the
+  dup2/pipe plumbing spawn needs. There is NO Lua binding for it:
+  `grep posix_spawn tool/lua/lcosmo.c tool/net/lfuncs.c` comes back
+  empty (checked 2026-07-05).
+- hypothesis: expose posix_spawn (+ file actions for the
+  stdin/stdout/stderr pipe setup) as a `unix.*` binding upstream,
+  then give `child.spawn` a fast path that uses it when the caller's
+  options map onto file actions (the common capture-stdout shape
+  does). Given fork dominates the 1.71ms, expect a large cut — this
+  also feeds every `startup_*` scenario, which spawn the cosmic
+  binary via `child.spawn`.
+- how to work it: this is a binding-surface addition, so it follows
+  the contract rules in `lib/perf/optimize/cosmopolitan.md` — new
+  annotations in tool/net/definitions.lua, upstream tests
+  (tool/lua/test_unix_proc.lua is the precedent), a cosmic
+  `regen-types` + wrapper change landed together with the pin bump.
+  Measure locally first via `perf-bin` with a modified checkout.
+- cross-reference: entry 12 gathered the original evidence and found
+  no cosmic-layer fix; this entry is its concrete C-side successor.
+- risk: medium-high — new C binding surface (vfork semantics are
+  subtle; posix_spawn encapsulates them, which is exactly why it's
+  the right vehicle), plus a two-repo landing. The win size justifies
+  it.

--- a/lib/perf/backlog/027-startup-sigprocmask-storm.md
+++ b/lib/perf/backlog/027-startup-sigprocmask-storm.md
@@ -1,0 +1,36 @@
+# 27. startup issues ~195 rt_sigprocmask and ~115 mmap kernel calls
+
+- status: open
+- layer: cosmopolitan
+- scenario: startup_run_lua (and every startup_*/child_* scenario)
+
+- evidence: a real-kernel trace (`strace -c -f sh -c 'o/bin/cosmic -e
+  "print(1)"'`, 2026-07-05 — cosmo's own `--strace` shows the
+  userspace view; this is the kernel view) counts 572 syscalls for a
+  trivial run, dominated by:
+  - 195 rt_sigprocmask (~11% of traced syscall time)
+  - 115 mmap + 33 munmap
+  - 38 fcntl, 52 close
+  (numbers include a `sh -c` wrapper's own footprint — re-measure
+  bare via binfmt or subtract a `sh -c true` baseline when working
+  this; the sigprocmask count is far beyond what a shell adds.)
+- hypothesis: the sigprocmask storm is cosmopolitan libc wrapping
+  hot operations in block/unblock-signals pairs (allocator, zipos,
+  or stdio critical sections — find the exact callers first, e.g.
+  by breakpointing rt_sigprocmask in gdb on lua.dbg or reading
+  BLOCK_SIGNALS users under libc/). Batching or eliding redundant
+  mask flips on paths that run dozens of times per boot, and
+  consolidating the mmap churn (115 maps for a hello-world), would
+  shave fixed startup cost that no cosmic-side change can reach.
+- how to work it: `lib/perf/optimize/cosmopolitan.md` loop; this is
+  pure C-internals (no binding contract involved), so gates are
+  upstream tests + the startup scenarios. `perf record -g` on
+  `o//tool/lua/lua.dbg` and `--strace` before/after are the right
+  instruments.
+- relation to entry 4: entry 4 tracks the startup floor as a whole
+  and its decomposition; this entry is one concrete, measured slice
+  of it (syscall overhead), workable independently of the zipos/
+  payload questions (entry 24 covers the inflate slice).
+- risk: medium — signal-mask correctness around fork/threads is
+  easy to get wrong; lean on upstream's test suite and keep diffs
+  surgical per the fork-hygiene guardrail.

--- a/lib/perf/optimize/cosmopolitan.md
+++ b/lib/perf/optimize/cosmopolitan.md
@@ -119,6 +119,27 @@ two-repo dance — but only AFTER the local loop already proved the win:
   redundant syscalls. for CPU profiles, `$COSMO/o/tool/lua/lua.dbg`
   is a plain ELF with symbols, so Linux `perf record -g` /
   `perf report` work on it directly.
+- **count call shapes from `--strace`.** pipe the trace through
+  `grep -o '[a-z_]*(' | sort | uniq -c | sort -rn` to turn thousands
+  of lines into a histogram; anomalies jump out (29 `inflate()` calls
+  per cosmic boot became entry 24). grepping the trace for a
+  filename or call name then answers "who and why".
+- **compare cosmo's `--strace` with kernel `strace -c`.** they see
+  different worlds: `--strace` logs cosmopolitan's userspace view
+  (including zipos file ops that never hit the kernel), while
+  `strace -c` counts real syscalls. the diff localizes cost — cosmic
+  boot shows 35 zipos openats userspace-side but only ~10 kernel
+  openats (zipos serves from the mapped binary: CPU, not I/O), and
+  kernel-side revealed ~195 rt_sigprocmask calls invisible in the
+  userspace trace (entry 27). when strace can't exec an APE
+  directly, wrap it: `strace -c -f sh -c '<cmd>'` and subtract the
+  shell's own footprint.
+- **look for the fast path that already exists in libc.** before
+  designing a C optimization, search cosmopolitan for one already
+  implemented but unreachable from Lua — the posix_spawn/vfork case
+  (entry 26) was found by reading `libc/proc/` after `child_spawn`'s
+  cpu/wall said "kernel time". the C library's own doc comments
+  often name the exact problem you're measuring.
 - **allocation-heavy bindings** — a scenario with high `alloc` whose
   wrapper is thin is allocating inside the binding; look for
   `lua_newtable` where `lua_createtable(L, narr, nrec)` fits (entry

--- a/lib/perf/optimize/finding.md
+++ b/lib/perf/optimize/finding.md
@@ -38,6 +38,19 @@ vetted, evidence-backed starting points. to find new ones, read
   PERF_ONLY=<name>` is cheap; temporarily splitting a scenario's fn into
   narrower scenarios in a scratch bench file localizes the cost. delete
   scratch scenarios before committing.
+- **alloc-per-op sanity math.** for each scenario ask "what does one op
+  *have* to allocate?" and compare to the `alloc` column — the gap is
+  machinery. a single-row sqlite point query has to allocate roughly
+  one row table, yet measured 2.41KB/op; reading the code found a
+  fresh iterator table, metatable, two closures, and a col_names
+  rebuild per call (entry 23). a relpath on short strings measured
+  2.62KB/op; that was normalize's split-into-parts table (entry 25).
+- **audit hot wrappers for validation scans.** grep `lib/cosmic` for
+  `match("[^`, `gsub(` used only for validation, and pre-checks ahead
+  of a delegated C call — a full-string scan that only exists to pick
+  an error message can usually move to the failure branch (entries 18,
+  22), as long as the happy path stays a single C call (entry 19's
+  counter-lesson).
 
 ## when the wrapper is already thin
 


### PR DESCRIPTION
A research-only pass (no product code changes): ran the full perf suite on current main, dug into the standouts with code reads, tracing, and scratch probes, and seeded six new evidence-backed hypotheses across both layers. Then recorded the techniques that produced them in the OPTIMIZE docs so the next research pass is mechanical.

## New open entries

**Cosmic (Teal/Lua/packaging)**
- **022** `codec.decode_hex` still runs a full negated-char-class scan on every call — the shape entry 18 killed for base64. Fix shape: keep the O(1) length check, `pcall` the C binding, scan only in the failure branch. Evidence: 2.09ms/op vs base64's 558µs on the same input.
- **023** `db:query` rebuilds the iterator table, metatable, two closures, and `col_names` on every call despite the statement cache — 2.41KB alloc per single-row point query.
- **024** the embedded `.lua` payload is deflate-compressed, so every boot pays 29 `inflate()` calls. A store-mode probe measured 0 inflates, ~7.6→7.0ms boot, +1.8MB binary; selective store of `.lua/` only is the likely landing shape.
- **025** `fs_path.normalize` splits and rebuilds every path — 2.62KB/op on `relpath`; fast-path already-normalized inputs (with the predicate-edge caveats spelled out).

**Cosmopolitan (C)**
- **026** expose vfork-backed `posix_spawn()` as a `unix.*` binding: `child.spawn`'s `fork()` of a ~20MB process dominates `child_spawn_true`'s 1.71ms (cpu/wall 0.14), and cosmopolitan's own posix_spawn doc comment names exactly this problem. No Lua binding exists today.
- **027** kernel `strace -c` of a trivial run counts ~195 `rt_sigprocmask` and ~115 `mmap` calls — fixed syscall overhead no cosmic-side change can reach.

Also folded the measured startup decomposition into entry 4 (raw lua floor ~5.0ms vs cosmic ~7.8ms; 47 vs 279 traced calls; the inflate and syscall slices split out to 24/27, plus a bytecode-precompile candidate for the parse slice) and pointed entry 12 at its C-side successor 26.

## Technique notes added to the docs

- `OPTIMIZE.md`: a "running a research pass" section — the re-seeding workflow end to end.
- `optimize/finding.md`: alloc-per-op sanity math; auditing hot wrappers for validation scans.
- `optimize/cosmopolitan.md`: `--strace` call-shape histograms; diffing cosmo's userspace trace against kernel `strace -c` (zipos ops never hit the kernel — the diff localizes cost); "look for the fast path that already exists in libc".

## Verification

- `bin/make lint` passes (313 files). Docs/backlog only — no product code, no scenarios changed.
- All quoted numbers were measured this session on current main (perf suite output, `--strace`/`strace -c` traces, and the store-mode probe rebuilt from the real payload); probe numbers are labeled as scouting in the entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xx8xfBj9fhf3HcuZYzAJzt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xx8xfBj9fhf3HcuZYzAJzt)_