### PR TITLE
perf(codec): skip full-string scan in decode_hex happy path

### DIFF
--- a/lib/cosmic/codec.tl
+++ b/lib/cosmic/codec.tl
@@ -16,16 +16,20 @@ end
 --- @return string The decoded binary data, or nil on error
 --- @return string? Error message if decoding failed
 local function decode_hex(hex: string): string, string
-  -- Validate length is even
+  -- Validate length is even (O(1))
   if #hex % 2 ~= 0 then
     return nil, "hex string must have even length"
   end
-  -- Validate characters are valid hex
-  if hex:match("[^0-9a-fA-F]") then
+  -- Happy path is a single C call: with even length guaranteed above,
+  -- cosmo.DecodeHex raises only on an invalid hex character. Wrapping it
+  -- in pcall lets the valid case skip the full character-class scan of
+  -- the whole input; the scan's only remaining job (choosing the error
+  -- message) is unnecessary here since even length is already handled.
+  local ok, result = pcall(cosmo.DecodeHex, hex)
+  if not ok then
     return nil, "invalid hex character"
   end
-  -- Validation above guarantees cosmo.DecodeHex cannot raise
-  return cosmo.DecodeHex(hex), nil
+  return result as string, nil
 end
 
 --- Encode a Lua value as Lua source code.

--- a/lib/perf/backlog/022-hex-decode-happy-path-scan.md
+++ b/lib/perf/backlog/022-hex-decode-happy-path-scan.md
@@ -1,6 +1,6 @@
 # 22. codec.decode_hex scans the whole input for validity on every call
 
-- status: open
+- status: done (2026-07-05)
 - layer: cosmic
 - scenario: codec_hex_roundtrip_64k
 
@@ -29,3 +29,16 @@
   entry 1), so no invalid input can slip through the pcall path.
 - risk: low — same accept/reject set, same messages, evaluation order
   changes only on the failure path.
+- result: done. `decode_hex` now keeps the O(1) even-length check and
+  wraps `cosmo.DecodeHex` in `pcall` on the happy path, dropping the
+  128KB negated-character-class `hex:match` scan entirely; the failure
+  branch returns the documented "invalid hex character" message
+  (even length is already guaranteed, so a raise can only mean a
+  non-hex byte). Verified against `tool/net/lfuncs.c:718` `LuaDecodeHex`,
+  which raises via `luaL_argerror` on non-hex/odd input and never
+  returns nil — so the pcall path cannot leak a bad decode.
+  `perf-compare`: `codec_hex_roundtrip_64k` 2.14 ms/op -> 137.38 µs/op
+  (-93.6%), no regressions in the other 31 scenarios. The win landed
+  far above the predicted 10-30% because the full-string scan, not the
+  decode, dominated the workload. `bin/make ci` green (codec_test pins
+  the messages and roundtrip).


### PR DESCRIPTION
## What

One round of the `lib/perf/optimize` loop, closing backlog entry **022**.

`codec.decode_hex` ran `hex:match("[^0-9a-fA-F]")` — a full negated-character-class scan of the *entire* input — on every call before delegating to `cosmo.DecodeHex`. For the 64k roundtrip scenario that is a 128KB byte-by-byte scan, and it turned out to dominate the workload rather than the decode itself.

The fix keeps the O(1) even-length check, then wraps `cosmo.DecodeHex` in `pcall` on the happy path. With even length already guaranteed, `LuaDecodeHex` (`tool/net/lfuncs.c:718`) raises via `luaL_argerror` only on a non-hex byte and never returns nil, so a failed pcall maps unambiguously to the documented `"invalid hex character"` message. The full-string scan is gone from the success path.

## Contract

Same accept/reject set and same error messages (`"hex string must have even length"` / `"invalid hex character"`). `codec_test.tl` pins both messages and the roundtrip; empty-string input still returns `""`. Verified the C binding's raise behavior directly (raises on odd-length and non-hex, accepts upper/lowercase, never returns nil).

## Gates

- `bin/make ci` — green (format + teal + test + example + lint, 0 failures).
- `bin/make perf-compare` (A/B, same machine, same input):

```
codec_hex_roundtrip_64k   2.14 ms/op ->  137.38 µs/op   -93.6%  faster
32 scenarios: 0 regression, 1 faster, 31 ok, 0 new, 0 missing, 0 error
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3LLKk1LBKarc5bd2Q3LsC

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3LLKk1LBKarc5bd2Q3LsC)_