### PR TITLE
perf(fs): add already-normal fast path to fs_path.normalize

### DIFF
--- a/lib/cosmic/fs_path.tl
+++ b/lib/cosmic/fs_path.tl
@@ -75,34 +75,56 @@ local function normalize(p: string): string
     return "."
   end
 
+  -- Fast path: a path that is already normal — no redundant "//" or
+  -- trailing "/", and no "." or ".." components — normalizes to itself,
+  -- so return it without allocating the parts table and result string.
+  -- The predicate is a conservative subset of "output == input" built
+  -- from C-implemented full-string checks (no per-component Lua loop);
+  -- anything it doesn't match falls through to the authoritative loop
+  -- below, which stays the source of truth for correctness. Note a
+  -- component merely containing dots (e.g. "..." or "a.b") is normal and
+  -- correctly passes, since only exact "." / ".." segments are excluded.
+  if p:sub(-1) ~= "/"
+  and not p:find("//", 1, true)
+  and p ~= "." and p:sub(1, 2) ~= "./"
+  and p:sub(-2) ~= "/." and not p:find("/./", 1, true)
+  and p ~= ".." and p:sub(1, 3) ~= "../"
+  and p:sub(-3) ~= "/.." and not p:find("/../", 1, true) then
+    return p
+  end
+
   local is_absolute = p:sub(1, 1) == "/"
 
   -- Split into components, filtering empty strings (from // or trailing /)
   local parts: {string} = {}
+  local n = 0
   for part in p:gmatch("[^/]+") do
     if part == "." then
       -- skip current dir
     elseif part == ".." then
-      if #parts > 0 and parts[#parts] ~= ".." then
-        table.remove(parts)
+      if n > 0 and parts[n] ~= ".." then
+        parts[n] = nil
+        n = n - 1
       elseif not is_absolute then
         -- for relative paths, preserve leading ..
-        table.insert(parts, "..")
+        n = n + 1
+        parts[n] = ".."
       end
       -- for absolute paths starting with /.., just ignore the ..
     else
-      table.insert(parts, part)
+      n = n + 1
+      parts[n] = part
     end
   end
 
   if is_absolute then
-    if #parts == 0 then
+    if n == 0 then
       return "/"
     else
       return "/" .. table.concat(parts, "/")
     end
   else
-    if #parts == 0 then
+    if n == 0 then
       return "."
     else
       return table.concat(parts, "/")

--- a/lib/cosmic/fs_path_normalize_test.tl
+++ b/lib/cosmic/fs_path_normalize_test.tl
@@ -1,0 +1,41 @@
+#!/usr/bin/env cosmic
+-- Edge cases for normalize()'s already-normal fast path. The predicate
+-- that returns the input unchanged must be exactly "output == input":
+-- it must accept genuinely-normal paths and dot-adjacent-but-legal
+-- component names, and it must reject any input that the split/collapse
+-- loop would rewrite. These live in their own file so fs_path_test.tl
+-- stays under the 500-line cap.
+local fs = require("cosmic.fs")
+
+-- Already-normal inputs are returned unchanged (they take the fast path).
+local function test_fast_path_already_normal()
+  assert(fs.normalize("/usr/lib") == "/usr/lib", "normal absolute")
+  assert(fs.normalize("a/b/c") == "a/b/c", "normal relative")
+  assert(fs.normalize("/a") == "/a", "single absolute component")
+  assert(fs.normalize("a") == "a", "single relative component")
+end
+test_fast_path_already_normal()
+
+-- Components that merely contain dots are legal filenames, not "." / ".."
+-- segments, so the fast path must pass them through untouched.
+local function test_fast_path_dotty_components()
+  assert(fs.normalize("...") == "...", "triple-dot filename")
+  assert(fs.normalize("a/.../b") == "a/.../b", "triple-dot middle")
+  assert(fs.normalize("..a/b..") == "..a/b..", "leading/trailing dot names")
+  assert(fs.normalize("a.b/c.d") == "a.b/c.d", "dotted names")
+end
+test_fast_path_dotty_components()
+
+-- Near-miss non-normal paths must be REJECTED by the fast path and
+-- collapsed by the loop — the dangerous failure mode is over-acceptance.
+local function test_fast_path_rejects_nonnormal()
+  assert(fs.normalize("a/b/..") == "a", "trailing ..")
+  assert(fs.normalize("foo/.") == "foo", "trailing .")
+  assert(fs.normalize("./foo") == "foo", "leading .")
+  assert(fs.normalize("../foo") == "../foo", "leading .. (preserved)")
+  assert(fs.normalize("a//b") == "a/b", "double slash")
+  assert(fs.normalize("a/b/") == "a/b", "trailing slash")
+  assert(fs.normalize("a/./b") == "a/b", "interior .")
+  assert(fs.normalize("a/../b") == "b", "interior ..")
+end
+test_fast_path_rejects_nonnormal()

--- a/lib/perf/backlog/025-fs-normalize-fast-path.md
+++ b/lib/perf/backlog/025-fs-normalize-fast-path.md
@@ -1,6 +1,6 @@
 # 25. fs_path.normalize splits and rebuilds every path, even already-normal ones
 
-- status: open
+- status: done (2026-07-05)
 - layer: cosmic
 - scenario: fs_relpath_relative
 
@@ -32,3 +32,20 @@
   Lua loop, or the fast path eats its own win.
 - risk: medium-low — pure function with a thorough existing test
   table; the danger is a subtle predicate miss, which tests must pin.
+- result: done. `normalize()` gained a fast path that returns the input
+  unchanged when a handful of C-implemented full-string checks prove it
+  is already normal: no trailing `/`, no `//`, and no exact `.` / `..`
+  component (each tested as whole-string, leading `"./"`/`"../"`,
+  trailing `"/."`/`"/.."`, or interior `"/./"`/`"/../"`). The predicate
+  is a conservative subset of "output == input" — inputs it does not
+  match (e.g. a normal relative path with leading `..`) still fall
+  through to the authoritative loop, so it can never return a wrong
+  result, only miss a speedup. The slow path also swapped
+  `table.insert`/`table.remove` for an indexed counter (entry 6 shape).
+  Predicate edges pinned in a new `fs_path_normalize_test.tl`
+  (fs_path_test.tl was 498/500 lines, no room): dotty-but-legal names
+  (`"..."`, `"a/.../b"`, `"..a/b.."`) pass unchanged, near-miss
+  non-normal inputs (`"a/b/.."`, `"foo/."`, `"a//b"`, trailing slash)
+  still collapse. `perf-compare`: `fs_relpath_relative` 5.31 µs/op ->
+  4.08 µs/op (-23.1%), alloc 2.62 KB/op -> 1.77 KB/op, no regressions
+  in the other 31 scenarios. `bin/make ci` green.


### PR DESCRIPTION
## What

Next round of the `lib/perf/optimize` loop, closing backlog entry **025**.

`fs_path.normalize` unconditionally split every path into a parts array (`gmatch` + `table.insert`) and `table.concat`'d it back — allocating the table, every component substring, and the result string on every call. But most inputs are already normal (e.g. the `getcwd`-joined path `relpath` feeds it), so all that allocation just reproduces the input.

The fix adds a fast path that returns the input unchanged when a handful of C-implemented full-string checks prove it's already normal: no trailing `/`, no `//`, and no exact `.` / `..` component (checked as whole-string, leading `./`/`../`, trailing `/.`/`/..`, or interior `/./`/`/../`). The slow path also swaps `table.insert`/`table.remove` for an indexed counter.

## Correctness

The predicate is a deliberately **conservative subset** of "output == input" — anything it doesn't match (e.g. a normal relative path with a leading `..`) falls through to the authoritative loop, so it can only ever miss a speedup, never return a wrong result. Dot-adjacent-but-legal component names like `...` and `a/.../b` pass through unchanged.

Predicate edges are pinned in a new `fs_path_normalize_test.tl` (the existing `fs_path_test.tl` was already at 498/500 lines, so there was no room to extend it): dotty-but-legal names pass unchanged; near-miss non-normal inputs (`a/b/..`, `foo/.`, `a//b`, trailing slash, interior `./`/`../`) still collapse.

## Gates

- `bin/make ci` — green (format + teal + test + example + lint, 0 failures).
- `bin/make perf-compare` (A/B, same machine, baseline includes merged #457):

```
fs_relpath_relative   5.31 µs/op ->  4.08 µs/op   -23.1%  faster
alloc                 2.62 KB/op ->  1.77 KB/op
32 scenarios: 0 regression, 1 faster, 31 ok, 0 new, 0 missing, 0 error
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3LLKk1LBKarc5bd2Q3LsC

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3LLKk1LBKarc5bd2Q3LsC)_