### PR TITLE
perf(sqlite): collapse db:query iterator machinery into one object

### DIFF
--- a/lib/cosmic/sqlite.tl
+++ b/lib/cosmic/sqlite.tl
@@ -18,6 +18,7 @@
 
 local lsqlite3 = require("cosmo.lsqlite3")
 local stmt_cache_mod = require("cosmic.sqlite_stmt_cache")
+local row_iter = require("cosmic.sqlite_row_iter")
 
 -- Raw lsqlite3 types (0-indexed, requires manual cleanup)
 local record RawStatement
@@ -99,8 +100,7 @@ local record Database
   close: function(self: Database)
 end
 
--- on_close, if given, replaces finalize on close (returns a cached statement to its pool).
-local function make_statement(raw_stmt: RawStatement, raw_db: RawDatabase, on_close?: function(RawStatement)): Statement
+local function make_statement(raw_stmt: RawStatement, raw_db: RawDatabase): Statement
   local stmt: Statement = {}
   local closed = false
 
@@ -231,11 +231,7 @@ local function make_statement(raw_stmt: RawStatement, raw_db: RawDatabase, on_cl
   stmt.close = function(_: Statement)
     if closed then return end
     closed = true
-    if on_close then
-      on_close(raw_stmt)
-    else
-      local _ = raw_stmt:finalize()
-    end
+    local _ = raw_stmt:finalize()
   end
 
   return setmetatable(stmt, {
@@ -292,15 +288,15 @@ local function make_database(raw_db: RawDatabase): Database
     if not raw_stmt then
       return nil, "query failed: " .. (err or "unknown error")
     end
-    local stmt = make_statement(raw_stmt as RawStatement, raw_db, on_close as function(RawStatement))
-    -- bind() resets first (even with 0 args), clearing a reused statement.
-    local ok, bind_err = stmt:bind(...)
-    if not ok then
-      stmt:close()
-      return nil, "bind failed: " .. (bind_err or "unknown error")
+    -- Hot path: skip the full Statement object and its per-call closures;
+    -- bind and iterate the raw statement directly (see cosmic.sqlite_row_iter).
+    local iter, bind_err = row_iter.query(
+      raw_stmt as any, raw_db as any, on_close as any,
+      sqlite3.OK, sqlite3.ROW, sqlite3.DONE, ...)
+    if not iter then
+      return nil, bind_err
     end
-
-    return make_query_iter(stmt)
+    return iter as Rows
   end
 
   function db:exec(sql: string, ...: any): boolean, string

--- a/lib/cosmic/sqlite_row_iter.tl
+++ b/lib/cosmic/sqlite_row_iter.tl
@@ -1,0 +1,123 @@
+--- Internal helper for cosmic.sqlite: the row iterator for db:query's hot
+--- path. Collapses what used to be a full Statement object (~10 method
+--- closures) + Statement:rows() + a close-on-drain wrapper into a single
+--- iterator that steps the raw statement directly, resolves column names
+--- once on the first row, and releases the statement when iteration drains.
+--- Lives in its own file so cosmic/sqlite.tl stays under the 500-line cap.
+
+local record RawStatement
+  bind: function(self: RawStatement, n: number, value?: any): number
+  step: function(self: RawStatement): number
+  reset: function(self: RawStatement)
+  finalize: function(self: RawStatement): number
+  get_value: function(self: RawStatement, n: number): any
+  columns: function(self: RawStatement): number
+  get_name: function(self: RawStatement, n: number): string
+end
+
+local record RawDatabase
+  errmsg: function(self: RawDatabase): string
+end
+
+-- Callable row iterator: `for row in iter do ... end`, then `iter:err()`
+-- surfaces a post-drain step error. Same shape as cosmic.sqlite's Rows.
+local record Rows
+  metamethod __call: function(self: Rows): {string: any}
+  err: function(self: Rows): string
+end
+
+-- on_close mirrors stmt_cache:checkout — non-nil returns the shared cached
+-- slot when iteration ends; nil means a throwaway statement to finalize.
+local type OnClose = function(RawStatement)
+
+  --- Build the row iterator over an already-reset+bound raw statement.
+  --- Raw handles are typed `any` so callers don't need nominally-identical
+  --- record types (same convention as sqlite_stmt_cache).
+  --- @param raw_stmt_any any The prepared, bound statement to step
+  --- @param raw_db_any any The owning database (for errmsg)
+  --- @param on_close_any any Release callback, or nil to finalize
+  --- @param row_code number sqlite3.ROW
+  --- @param done_code number sqlite3.DONE
+  --- @return Rows The callable row iterator
+  local function make(raw_stmt_any: any, raw_db_any: any, on_close_any: any, row_code: number, done_code: number): Rows
+    local raw_stmt = raw_stmt_any as RawStatement
+    local raw_db = raw_db_any as RawDatabase
+    local on_close = on_close_any as OnClose
+    local step_err: string
+    local col_count = raw_stmt:columns()
+    local col_names: {integer: string}
+    local first_call = true
+    local done = false
+
+    local iter = setmetatable({} as Rows, {
+        __call = function(_: Rows): {string: any}
+          if done then
+            return nil
+          end
+          local rc = raw_stmt:step()
+          if rc == row_code then
+            -- Column names require step to have run first; resolve once.
+            if first_call then
+              first_call = false
+              col_names = {}
+              for idx = 0, col_count - 1 do
+                col_names[(idx + 1) as integer] = raw_stmt:get_name(idx)
+              end
+            end
+            local row: {string: any} = {}
+            for idx = 0, col_count - 1 do
+              row[col_names[(idx + 1) as integer]] = raw_stmt:get_value(idx)
+            end
+            return row
+          end
+          -- Anything but a clean SQLITE_DONE is a real error to surface.
+          done = true
+          if rc ~= done_code then
+            step_err = raw_db:errmsg()
+          end
+          if on_close then
+            on_close(raw_stmt)
+          else
+            local _ = raw_stmt:finalize()
+          end
+          return nil
+        end,
+      })
+    iter.err = function(_: Rows): string return step_err end
+    return iter
+  end
+
+  --- Reset + positional-bind a raw statement, then return its row iterator.
+  --- Resets first (even with no args) so a reused cached statement is cleared.
+  --- On a bind failure the statement is released and (nil, message) returned.
+  --- @param raw_stmt_any any The checked-out statement
+  --- @param raw_db_any any The owning database (for errmsg)
+  --- @param on_close_any any Release callback, or nil to finalize
+  --- @param ok_code number sqlite3.OK
+  --- @param row_code number sqlite3.ROW
+  --- @param done_code number sqlite3.DONE
+  --- @param ... any Positional bind parameters
+  --- @return Rows The row iterator, or nil on bind failure
+  --- @return string Error message when binding failed
+  local function query(raw_stmt_any: any, raw_db_any: any, on_close_any: any, ok_code: number, row_code: number, done_code: number, ...: any): Rows, string
+    local raw_stmt = raw_stmt_any as RawStatement
+    local raw_db = raw_db_any as RawDatabase
+    local on_close = on_close_any as OnClose
+    raw_stmt:reset()
+    local n = select("#", ...) as integer
+    for i = 1, n do
+      local rc = raw_stmt:bind(i, (select(i, ...)))
+      if rc ~= ok_code then
+        local bind_err = raw_db:errmsg()
+        if on_close then
+          on_close(raw_stmt)
+        else
+          local _ = raw_stmt:finalize()
+        end
+        return nil, "bind failed: " .. (bind_err or "unknown error")
+      end
+    end
+    return make(raw_stmt, raw_db, on_close, row_code, done_code)
+  end
+
+  return {make = make, query = query}

--- a/lib/perf/backlog/023-sqlite-query-iter-alloc.md
+++ b/lib/perf/backlog/023-sqlite-query-iter-alloc.md
@@ -1,6 +1,6 @@
 # 23. sqlite db:query rebuilds iterator machinery on every call
 
-- status: open
+- status: done (2026-07-05)
 - layer: cosmic
 - scenario: sqlite_point_query
 
@@ -34,3 +34,27 @@
 - risk: medium — touches the query hot path and the iterator
   lifecycle; the existing sqlite test suite is thorough
   (sqlite_test, sqlite_advanced_test), which is the main safety net.
+- result: done. The bigger cost than the iterator turned out to be
+  `make_statement` itself: `db:query` built a full Statement object
+  (~10 method closures + metatable) plus `Statement:rows()` plus the
+  `make_query_iter` close-on-drain wrapper — three allocated layers —
+  on every call, just to grab and drain one row. Collapsed all three
+  into a single module-level iterator in a new
+  `lib/cosmic/sqlite_row_iter.tl` (`make`/`query`): it resets, binds,
+  steps the raw cached statement directly, resolves column names once
+  on the first row, and releases the statement (via the cache's
+  on_close, or finalize for a reentrant throwaway) when it drains.
+  `db:query` now bypasses `make_statement` entirely; the public
+  Statement API (`db:prepare`, `query_list`, `query_named`) is
+  untouched, and since `db:query` was the only caller passing
+  `on_close` to `make_statement`, that now-dead parameter was dropped.
+  The `col_names`-per-call cost is paid once per iterator rather than
+  cached across calls — measured alloc made the extra caching machinery
+  unnecessary. sqlite.tl was at 500/500 lines, hence the helper module.
+  Reentrancy (`test_same_sql_nested_query_reentrant`), the `iter:err()`
+  post-drain contract, and close-on-completion all still pass.
+  `perf-compare`:
+    sqlite_point_query    7.44 µs/op ->  5.52 µs/op   -25.8%
+      alloc               2.41 KB/op ->  1.08 KB/op   (-55%)
+    sqlite_scan_aggregate alloc 2.30 KB/op -> 0.97 KB/op (col_names win)
+  no regressions in the other 31 scenarios. `bin/make ci` green.


### PR DESCRIPTION
## What

Next round of the `lib/perf/optimize` loop, closing backlog entry **023**.

`db:query` built **three allocated layers** on every call to step a cached prepared statement: a full `Statement` object (~10 method closures + a metatable) via `make_statement`, then `Statement:rows()`, then the `make_query_iter` close-on-drain wrapper. The dominant cost turned out to be `make_statement`'s closures, not the iterator the backlog entry originally fingered.

The fix collapses all three into a single module-level iterator in a new `lib/cosmic/sqlite_row_iter.tl` (`make`/`query`): it resets, binds, and steps the raw cached statement directly, resolves column names once on the first row, and releases the statement (via the statement cache's `on_close`, or `finalize` for a reentrant throwaway) when iteration drains. `db:query` now bypasses `make_statement` entirely.

## Scope / correctness

- The public `Statement` API (`db:prepare`, `query_list`, `query_named`) is **untouched** — those still use `make_statement` + `make_query_iter`.
- `db:query` was the only caller passing `on_close` to `make_statement`, so that now-dead parameter is dropped.
- The helper lives in its own file because `sqlite.tl` was already at the 500-line cap.
- Reentrancy (`test_same_sql_nested_query_reentrant`), the `iter:err()` post-drain contract, and close-on-completion are all still pinned by the existing `sqlite_test` / `sqlite_advanced_test` suites.

## Gates

- `bin/make ci` — green (format + teal + test + example + lint, 0 failures).
- `bin/make perf-compare` (A/B, same machine):

```
sqlite_point_query    7.44 µs/op ->  5.52 µs/op   -25.8%  faster
  alloc               2.41 KB/op ->  1.08 KB/op   (-55%)
sqlite_scan_aggregate alloc 2.30 KB/op -> 0.97 KB/op   (col_names win)
32 scenarios: 0 regression, 1 faster, 31 ok, 0 new, 0 missing, 0 error
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3LLKk1LBKarc5bd2Q3LsC

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3LLKk1LBKarc5bd2Q3LsC)_