### PR TITLE
perf(harness): add perf-selfcheck A/A control for noise-floor triage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,6 +290,7 @@ checks, a JSON results format, and a noise-aware baseline comparison gate.
 bin/make perf                 # run scenarios, write o/perf/current.json
 bin/make perf-baseline        # snapshot baseline before optimizing
 bin/make perf-compare         # re-run and fail on regression vs baseline
+bin/make perf-selfcheck       # A/A control: same binary vs itself = noise floor
 bin/make perf-bin COSMO_LUA=… # wrap a local cosmopolitan lua for PERF_BIN
 ```
 

--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -28,8 +28,17 @@ FAILS the benchmark.
 bin/make perf                 # run all scenarios, write o/perf/current.json
 bin/make perf-baseline        # snapshot results to o/perf/baseline.json
 bin/make perf-compare         # re-run and fail on regression vs baseline
+bin/make perf-selfcheck       # A/A control: same binary vs itself = noise floor
 bin/make perf PERF_ONLY=json  # filter scenarios by Lua pattern
 ```
+
+`perf-selfcheck` is the fast way out of a false alarm: when `perf-compare`
+flags a scenario your change never touched (a fixed-overhead microbench
+like `hash_sha256_small` or `startup_run_*` swung by frequency scaling,
+a noisy neighbor, or code-layout shift), it measures the same binary
+twice and compares it to itself, so anything it flags is machine noise
+rather than your edit. `lib/perf/optimize/measurement.md` has the full
+playbook.
 
 knobs: `PERF_SAMPLES` (default 5), `PERF_MIN_SECS` (default 0.15),
 `PERF_THRESHOLD` (regression bar in percent, default 10), `PERF_BIN`
@@ -95,8 +104,14 @@ work ONE scenario (or one closely related group) at a time.
 6. **decide.**
    - target scenario improved beyond its noise bar and nothing else
      regressed → keep it.
-   - no measurable improvement, or anything else regressed → `git
+   - no measurable improvement, or a real regression elsewhere → `git
      checkout` the change and record the failed hypothesis.
+   - a scenario your change cannot touch flagged as regressed → this is
+     usually machine noise, not a reason to revert. confirm with
+     `bin/make perf-selfcheck` (A/A control): if the same scenario
+     swings as much comparing the binary to itself, discount it. only a
+     regression that is both *explainable by your diff* and *reproducible
+     under the A/A control* counts. see `optimize/measurement.md`.
 7. **commit**, quoting before/after numbers for the affected scenarios in
    the commit message (copy the `perf-compare` lines), and update the
    backlog entry file in the same commit.

--- a/lib/perf/cook.mk
+++ b/lib/perf/cook.mk
@@ -32,7 +32,7 @@ perf_cmd = PERF_BIN=$(PERF_BIN) $(PERF_BIN) -- $(perf_run) \
 perf_sandbox := $(o)/perf
 cosmic_local_bin := $(perf_sandbox)/cosmic-local
 
-.PHONY: perf perf-baseline perf-compare perf-bin
+.PHONY: perf perf-baseline perf-compare perf-bin perf-selfcheck
 
 perf-bin: .PLEDGE = stdio rpath wpath cpath proc exec
 perf-bin: .UNVEIL = rx:$(o)/bootstrap r:lib r:3p rwcx:$(o) rwc:$(TMP) rx:/usr rx:/proc r:/etc r:/dev/null $(if $(COSMO_LUA),r:$(COSMO_LUA))
@@ -78,3 +78,25 @@ perf-compare: perf
 		echo "perf-compare: regression flagged; re-measuring once to filter noise"; \
 		$(perf_cmd) --out $(perf_sandbox)/current.json $(perf_bench_mods) \
 			&& $(perf_compare_cmd); }
+
+perf-selfcheck: .PLEDGE = stdio rpath wpath cpath proc exec
+perf-selfcheck: .UNVEIL = rx:$(o)/bootstrap r:lib r:3p rwcx:$(o) rwc:$(TMP) rx:/usr rx:/proc r:/etc r:/dev/null
+
+perf_selfcheck_cmd = $(PERF_BIN) -- $(perf_run) --compare \
+	$(perf_sandbox)/selfcheck-a.json $(perf_sandbox)/selfcheck-b.json \
+	--threshold $(PERF_THRESHOLD)
+
+## A/A control: measure this machine's noise floor by comparing the SAME
+## binary against itself. Anything flagged here moves more than the bar on
+## nothing but run-to-run variance, so a like-named "regression" in
+## perf-compare is noise, not your change. Use it when perf-compare flags a
+## scenario unrelated to your edit (see lib/perf/optimize/measurement.md).
+# PERF_ONLY narrows it (e.g. PERF_ONLY=hash bin/make perf-selfcheck) for a
+# fast focused check on just the scenario perf-compare flagged.
+perf-selfcheck: $$(perf_lua) $(cosmic_bin)
+	@mkdir -p $(perf_sandbox)
+	@$(perf_cmd) --out $(perf_sandbox)/selfcheck-a.json $(perf_bench_mods)
+	@$(perf_cmd) --out $(perf_sandbox)/selfcheck-b.json $(perf_bench_mods)
+	@$(perf_selfcheck_cmd) && \
+		echo "perf-selfcheck: nothing exceeded the bar — the machine is quiet at this threshold" || \
+		echo "perf-selfcheck: the scenarios flagged above vary by more than the bar on noise alone; discount same-named perf-compare regressions"

--- a/lib/perf/optimize/cosmopolitan.md
+++ b/lib/perf/optimize/cosmopolitan.md
@@ -80,7 +80,16 @@ COSMO=~/cosmopolitan   # your checkout
 6. **decide** with the same rules as the main loop: target scenario
    improved beyond its noise bar and nothing else regressed → keep;
    otherwise revert and record the failed hypothesis in the backlog
-   entry.
+   entry. NOTE: a C edit relinks the whole binary, so function addresses
+   shift and unrelated fixed-overhead microbenchmarks
+   (`hash_sha256_small`, `startup_run_*`, `net_ip_*`) routinely trip the
+   regression bar on layout noise alone — this is the single most common
+   false alarm at this layer. Do NOT revert a real JSON/sqlite/etc. win
+   over it. Confirm with `PERF_BIN=o/perf/cosmic-local bin/make
+   perf-selfcheck` (A/A control): if the flagged scenario swings as much
+   comparing the modified binary to itself, it is noise, not your change
+   (entry 21 hit exactly this). `optimize/measurement.md` has the
+   playbook.
 
 7. **land it** (see below) and update the backlog entry in the same
    cosmic-side commit.

--- a/lib/perf/optimize/measurement.md
+++ b/lib/perf/optimize/measurement.md
@@ -10,6 +10,33 @@ chapter of `lib/perf/OPTIMIZE.md` — read that first.
   in the same direction every time. backlog entry 11 is a worked
   example: an unrelated `startup_*` regression flagged on the first
   pass vanished on a clean re-run while the real win reproduced.
+- **the `±%` in the report is WITHIN-run spread; it understates
+  cross-run variance.** a scenario can read ±2% across the 5 samples of
+  one invocation yet swing 10-15% between two separate invocations —
+  frequency scaling, a noisy neighbor on a shared runner, or code-layout
+  shift from relinking (C-layer builds) all move fixed-overhead
+  microbenchmarks (`hash_sha256_small`, `startup_run_*`, `net_ip_*`)
+  without touching their code. so the compare bar, derived from
+  within-run spread, will flag these as "regressions" on pure noise.
+- **when `perf-compare` flags a scenario your change does not touch,
+  do not spend a round hand-rolling A/B runs — run the built-in A/A
+  control:** `bin/make perf-selfcheck` measures the SAME binary twice
+  and compares it against itself, so anything it flags is this machine's
+  noise floor, not your edit. `PERF_ONLY=<name> bin/make perf-selfcheck`
+  narrows it to just the flagged scenario for a fast answer. if
+  `perf-selfcheck` flags the same scenario at a similar magnitude, the
+  `perf-compare` "regression" there is noise; discount it and judge the
+  change by (a) your TARGET scenario moving well beyond its own noise
+  floor and (b) that movement reproducing every run. this is the entry
+  21 story: `json_decode_*` reproduced at ~-30% on every run while the
+  flagged `hash`/`startup_*` scenarios tripped the bar in an A/A control
+  of an unmodified binary against itself.
+- for a scenario perf-compare flagged, an alternative to `perf-selfcheck`
+  is to re-measure just it in isolation on both builds back to back:
+  `PERF_ONLY=<name> bin/make perf` on binary A, then on binary B. an
+  isolated run also removes the thermal/cache wake left by the 20-odd
+  scenarios that precede it in a full suite, which is itself a source of
+  drift for the cheap scenarios near the end.
 - prefer default `PERF_SAMPLES`/`PERF_MIN_SECS` for accept/reject
   decisions; use lower values only for quick scouting.
 - scenarios must be stationary: an op must not get slower the more often


### PR DESCRIPTION
## Problem

`perf-compare`'s regression bar is derived from **within-run** sample spread (the `±%` in the report), which understates **cross-run** variance. Fixed-overhead microbenchmarks (`hash_sha256_small`, `startup_run_*`, `net_ip_*`) swing 10–20% between separate invocations on a shared runner — frequency scaling, noisy neighbors, or code-layout shift from relinking at the C layer — so `perf-compare` flags them as "regressions" on pure noise, even for a change that provably cannot touch them.

The entry-21 (ljson) round hit exactly this: a clean −30% JSON decode win came with `hash_sha256_small` / `startup_run_*` "regressions" that took a multi-hour detour of hand-rolled A/B and A/A runs to falsify. This PR turns that ad-hoc diagnosis into a one-command step so the next round doesn't repeat it.

## Change

**Harness** — new `bin/make perf-selfcheck` target (`lib/perf/cook.mk`): measures the **same binary twice** and compares it against itself. Anything it flags is this machine's noise floor, not your edit. `PERF_ONLY=<name> bin/make perf-selfcheck` narrows it to just the scenario `perf-compare` flagged, for a fast answer. It's a diagnostic (always reports, never a build gate).

**Docs** — route to it instead of improvised investigation:
- `OPTIMIZE.md`: lists the target; the **decide** step now says a regression in a scenario your change can't touch is usually noise — confirm with the A/A control before reverting; only a regression that is *both explainable by your diff and reproducible under A/A* counts.
- `measurement.md`: the within-run-vs-cross-run variance note + the full triage playbook (`perf-selfcheck`, or isolated `PERF_ONLY` re-measure back-to-back on both builds).
- `cosmopolitan.md`: flags layout-shift noise as the most common C-layer false alarm and points at `perf-selfcheck`.
- `AGENTS.md`: adds the target to the perf command list.

## Validation

- `bin/make ci` green (all four docs lint clean, no test/format/example breakage).
- `PERF_ONLY=hash bin/make perf-selfcheck` runs end to end: two passes, A-vs-B compare, and the interpretive verdict line.

```
hash_sha256_small   511.7 ns -> 500.5 ns   -2.2%  (noise ±10.0%)  ok
perf-selfcheck: nothing exceeded the bar — the machine is quiet at this threshold
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3LLKk1LBKarc5bd2Q3LsC

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3LLKk1LBKarc5bd2Q3LsC)_