### PR TITLE
perf(harness): auto-triage perf-compare regressions via A/A self-check

### DIFF
--- a/lib/perf/OPTIMIZE.md
+++ b/lib/perf/OPTIMIZE.md
@@ -32,13 +32,16 @@ bin/make perf-selfcheck       # A/A control: same binary vs itself = noise floor
 bin/make perf PERF_ONLY=json  # filter scenarios by Lua pattern
 ```
 
-`perf-selfcheck` is the fast way out of a false alarm: when `perf-compare`
-flags a scenario your change never touched (a fixed-overhead microbench
-like `hash_sha256_small` or `startup_run_*` swung by frequency scaling,
-a noisy neighbor, or code-layout shift), it measures the same binary
-twice and compares it to itself, so anything it flags is machine noise
-rather than your edit. `lib/perf/optimize/measurement.md` has the full
-playbook.
+`perf-compare` already handles the false alarm for you: when a
+regression survives its retry, it runs one more pass of the same binary
+and auto-triages against that A/A self-check — a fixed-overhead
+microbench (`hash_sha256_small`, `startup_run_*`, `net_ip_*`) that swung
+on frequency scaling, a noisy neighbor, or code-layout shift is reported
+as `noise` and does not fail the gate, while a regression the binary
+reproduces against itself still fails. `perf-selfcheck` runs that same
+A/A control standalone, for interactive use or to profile the machine's
+noise floor before you start. `lib/perf/optimize/measurement.md` has the
+full playbook.
 
 knobs: `PERF_SAMPLES` (default 5), `PERF_MIN_SECS` (default 0.15),
 `PERF_THRESHOLD` (regression bar in percent, default 10), `PERF_BIN`
@@ -100,18 +103,23 @@ work ONE scenario (or one closely related group) at a time.
    compares against your baseline with a noise-aware bar
    (max of `PERF_THRESHOLD`, baseline spread, current spread), retries
    once on failure to filter machine noise, and exits nonzero if any
-   scenario regressed, errored, or disappeared.
+   scenario regressed, errored, or disappeared. if a regression survives
+   the retry it runs one more pass of the same binary and auto-triages:
+   a scenario that also swings past the bar against itself is reported
+   as `noise` and does not fail the gate, so a green `perf-compare` means
+   "no regression the binary can reproduce against itself." trust the
+   verdict — the manual A/A hunt is now built in.
 6. **decide.**
-   - target scenario improved beyond its noise bar and nothing else
-     regressed → keep it.
-   - no measurable improvement, or a real regression elsewhere → `git
-     checkout` the change and record the failed hypothesis.
-   - a scenario your change cannot touch flagged as regressed → this is
-     usually machine noise, not a reason to revert. confirm with
-     `bin/make perf-selfcheck` (A/A control): if the same scenario
-     swings as much comparing the binary to itself, discount it. only a
-     regression that is both *explainable by your diff* and *reproducible
-     under the A/A control* counts. see `optimize/measurement.md`.
+   - target scenario improved beyond its noise bar and `perf-compare`
+     exited 0 (no real regression; any `noise` rows already discounted)
+     → keep it.
+   - no measurable improvement, or a surviving `regression` row → `git
+     checkout` the change and record the failed hypothesis. a surviving
+     regression already reproduced against the binary itself, so it is
+     real; do not re-litigate it as noise.
+   - want to see the machine's noise floor yourself → `bin/make
+     perf-selfcheck` runs the same A/A control on demand. see
+     `optimize/measurement.md`.
 7. **commit**, quoting before/after numbers for the affected scenarios in
    the commit message (copy the `perf-compare` lines), and update the
    backlog entry file in the same commit.

--- a/lib/perf/compare.tl
+++ b/lib/perf/compare.tl
@@ -93,6 +93,42 @@ local function diff(base: pt.Results, cur: pt.Results, threshold_pct?: number): 
   return deltas, failures
 end
 
+--- Reclassify baseline-vs-current regressions using an A/A self-check.
+--- A regression whose scenario ALSO moves past its noise bar when the
+--- current binary is compared against itself (two same-binary runs) is
+--- indistinguishable from run-to-run variance, so it is reclassified to
+--- the non-failing verdict "noise". A scenario that stays within the bar
+--- under the self-check keeps its "regression" verdict — so a real
+--- regression in a stable, low-variance scenario (json, sqlite, ...)
+--- still fails the gate. This makes the noise/real call deterministic
+--- instead of a manual judgement (see lib/perf/optimize/measurement.md).
+--- @param base Results Baseline results
+--- @param cur Results Current results
+--- @param noise_a Results First self-check pass (current binary)
+--- @param noise_b Results Second self-check pass (current binary)
+--- @param threshold_pct number? Noise bar in percent (default 10)
+--- @return {Delta} Deltas, with confirmed-noise regressions reclassified
+--- @return integer Number of real failures (regressions + errors + missing)
+local function triage(base: pt.Results, cur: pt.Results, noise_a: pt.Results, noise_b: pt.Results, threshold_pct?: number): {pt.Delta}, integer
+  local deltas, failures = diff(base, cur, threshold_pct)
+  local self_deltas = diff(noise_a, noise_b, threshold_pct)
+  local unstable: {string: boolean} = {}
+  for _, sd in ipairs(self_deltas) do
+    -- The same binary vs itself should read "ok"; a scenario that instead
+    -- clears the bar in either direction is too noisy to judge here.
+    if sd.verdict == "regression" or sd.verdict == "faster" then
+      unstable[sd.name] = true
+    end
+  end
+  for _, d in ipairs(deltas) do
+    if d.verdict == "regression" and unstable[d.name] then
+      d.verdict = "noise"
+      failures = failures - 1
+    end
+  end
+  return deltas, failures
+end
+
 --- Format one delta as a report line.
 --- @param d Delta The delta
 --- @return string A single aligned line
@@ -122,11 +158,12 @@ local function format(deltas: {pt.Delta}): string
     counts[d.verdict] = (counts[d.verdict] or 0) + 1
   end
   table.insert(lines, string.format(
-      "%d scenarios: %d regression, %d faster, %d ok, %d new, %d missing, %d error",
+      "%d scenarios: %d regression, %d faster, %d ok, %d noise, %d new, %d missing, %d error",
       #deltas,
       counts["regression"] or 0,
       counts["faster"] or 0,
       counts["ok"] or 0,
+      counts["noise"] or 0,
       counts["new"] or 0,
       counts["missing"] or 0,
       counts["error"] or 0))
@@ -137,6 +174,7 @@ local record compare
   DEFAULT_THRESHOLD_PCT: number
   load_results: function(path: string): pt.Results, string
   diff: function(base: pt.Results, cur: pt.Results, threshold_pct?: number): {pt.Delta}, integer
+  triage: function(base: pt.Results, cur: pt.Results, noise_a: pt.Results, noise_b: pt.Results, threshold_pct?: number): {pt.Delta}, integer
   format_delta: function(d: pt.Delta): string
   format: function(deltas: {pt.Delta}): string
 end
@@ -145,6 +183,7 @@ local M: compare = {
   DEFAULT_THRESHOLD_PCT = DEFAULT_THRESHOLD_PCT,
   load_results = load_results,
   diff = diff,
+  triage = triage,
   format_delta = format_delta,
   format = format,
 }

--- a/lib/perf/compare_test.tl
+++ b/lib/perf/compare_test.tl
@@ -131,4 +131,50 @@ local function test_load_results_rejects_garbage()
 end
 test_load_results_rejects_garbage()
 
+local function test_triage_keeps_stable_regression()
+  -- The regression reproduces: the A/A self-check is quiet for "a", so
+  -- the regression stands and still fails the gate.
+  local deltas, failures = compare.triage(
+    results({m("a", 1000, 2)}), results({m("a", 1300, 2)}),
+    results({m("a", 1300, 2)}), results({m("a", 1305, 2)}), 10)
+  assert(failures == 1, "stable regression must still fail, got " .. failures)
+  assert(find_delta(deltas, "a").verdict == "regression", "should stay regression")
+end
+test_triage_keeps_stable_regression()
+
+local function test_triage_reclassifies_noisy_regression()
+  -- Same +30% "regression", but the current binary swings ~-31% against
+  -- itself for "a": indistinguishable from noise, so reclassify.
+  local deltas, failures = compare.triage(
+    results({m("a", 1000, 2)}), results({m("a", 1300, 2)}),
+    results({m("a", 1300, 2)}), results({m("a", 900, 2)}), 10)
+  assert(failures == 0, "noisy regression must not fail, got " .. failures)
+  assert(find_delta(deltas, "a").verdict == "noise", "should reclassify to noise")
+end
+test_triage_reclassifies_noisy_regression()
+
+local function test_triage_only_touches_regressions()
+  -- "a" is a noisy regression -> noise; "b" is ok in the main diff even
+  -- though its A/A is unstable -> triage must leave it ok, not invent a
+  -- regression.
+  local deltas, failures = compare.triage(
+    results({m("a", 1000, 2), m("b", 1000, 2)}),
+    results({m("a", 1300, 2), m("b", 1005, 2)}),
+    results({m("a", 1300, 2), m("b", 1000, 2)}),
+    results({m("a", 900, 2), m("b", 1400, 2)}), 10)
+  assert(failures == 0, "a->noise, b ok: no failures, got " .. failures)
+  assert(find_delta(deltas, "a").verdict == "noise", "a -> noise")
+  assert(find_delta(deltas, "b").verdict == "ok", "b stays ok")
+end
+test_triage_only_touches_regressions()
+
+local function test_triage_format_counts_noise()
+  local deltas = compare.triage(
+    results({m("a", 1000, 2)}), results({m("a", 1300, 2)}),
+    results({m("a", 1300, 2)}), results({m("a", 900, 2)}), 10)
+  local text = compare.format(deltas)
+  assert(text:find("1 noise", 1, true), "summary should count noise:\n" .. text)
+end
+test_triage_format_counts_noise()
+
 print("OK compare_test")

--- a/lib/perf/cook.mk
+++ b/lib/perf/cook.mk
@@ -70,14 +70,29 @@ perf_compare_cmd = $(PERF_BIN) -- $(perf_run) --compare \
 	$(perf_sandbox)/baseline.json $(perf_sandbox)/current.json \
 	--threshold $(PERF_THRESHOLD)
 
+# Final stage: reclassify any surviving regression the current binary
+# cannot reproduce against itself (selfcheck-b vs the current run) as
+# "noise" rather than a failure — the A/A control, run automatically.
+perf_triage_cmd = $(PERF_BIN) -- $(perf_run) --compare \
+	$(perf_sandbox)/baseline.json $(perf_sandbox)/current.json \
+	--threshold $(PERF_THRESHOLD) \
+	--selfcheck-a $(perf_sandbox)/current.json \
+	--selfcheck-b $(perf_sandbox)/selfcheck-b.json
+
 ## Re-run scenarios and fail on any regression vs the saved baseline
-# A failed comparison retries once with fresh measurements so that
-# machine noise has to strike twice in the same direction to fail.
+# A failed comparison retries once with fresh measurements so machine
+# noise has to strike twice in the same direction. If a regression still
+# stands, one more pass of the same binary drives an automatic A/A
+# triage: scenarios that swing past the bar against themselves are
+# reclassified "noise" and the gate passes iff a real regression remains.
 perf-compare: perf
 	@$(perf_compare_cmd) || { \
 		echo "perf-compare: regression flagged; re-measuring once to filter noise"; \
 		$(perf_cmd) --out $(perf_sandbox)/current.json $(perf_bench_mods) \
-			&& $(perf_compare_cmd); }
+			&& $(perf_compare_cmd); } || { \
+		echo "perf-compare: regression persists; running A/A self-check to separate real regressions from machine noise"; \
+		$(perf_cmd) --out $(perf_sandbox)/selfcheck-b.json $(perf_bench_mods) \
+			&& $(perf_triage_cmd); }
 
 perf-selfcheck: .PLEDGE = stdio rpath wpath cpath proc exec
 perf-selfcheck: .UNVEIL = rx:$(o)/bootstrap r:lib r:3p rwcx:$(o) rwc:$(TMP) rx:/usr rx:/proc r:/etc r:/dev/null

--- a/lib/perf/optimize/measurement.md
+++ b/lib/perf/optimize/measurement.md
@@ -18,25 +18,30 @@ chapter of `lib/perf/OPTIMIZE.md` — read that first.
   microbenchmarks (`hash_sha256_small`, `startup_run_*`, `net_ip_*`)
   without touching their code. so the compare bar, derived from
   within-run spread, will flag these as "regressions" on pure noise.
-- **when `perf-compare` flags a scenario your change does not touch,
-  do not spend a round hand-rolling A/B runs — run the built-in A/A
-  control:** `bin/make perf-selfcheck` measures the SAME binary twice
-  and compares it against itself, so anything it flags is this machine's
-  noise floor, not your edit. `PERF_ONLY=<name> bin/make perf-selfcheck`
-  narrows it to just the flagged scenario for a fast answer. if
-  `perf-selfcheck` flags the same scenario at a similar magnitude, the
-  `perf-compare` "regression" there is noise; discount it and judge the
-  change by (a) your TARGET scenario moving well beyond its own noise
-  floor and (b) that movement reproducing every run. this is the entry
-  21 story: `json_decode_*` reproduced at ~-30% on every run while the
-  flagged `hash`/`startup_*` scenarios tripped the bar in an A/A control
-  of an unmodified binary against itself.
-- for a scenario perf-compare flagged, an alternative to `perf-selfcheck`
-  is to re-measure just it in isolation on both builds back to back:
-  `PERF_ONLY=<name> bin/make perf` on binary A, then on binary B. an
-  isolated run also removes the thermal/cache wake left by the 20-odd
-  scenarios that precede it in a full suite, which is itself a source of
-  drift for the cheap scenarios near the end.
+- **`perf-compare` triages this for you — trust its verdict, don't
+  hand-roll A/B runs.** after its re-measure retry, if a regression
+  still stands it runs one more pass of the SAME binary and compares it
+  against itself (an A/A self-check); any flagged scenario that also
+  swings past the bar against itself is reclassified `noise` and does
+  NOT fail the gate. so `perf-compare` exits 0 when every survivor is
+  machine noise and nonzero only on a regression the binary reproduces
+  against itself. read the final report: `regression` = real (a stable
+  scenario that moved), `noise` = discounted (a scenario too variable to
+  judge here). this is the entry 21 story made automatic:
+  `json_decode_*` reproduced at ~-30% while `hash`/`startup_*` tripped
+  the bar only on variance an A/A control also shows.
+- the reclassification is deliberately conservative: it only ever
+  downgrades a `regression`, and only when the current binary cannot
+  reproduce that scenario's timing against itself. a real regression in
+  a stable scenario (json, sqlite, codec) has a quiet A/A and stays
+  `regression` — the gate still catches it.
+- `bin/make perf-selfcheck` runs the same A/A control on demand, for
+  interactive use or to profile the machine's noise floor before you
+  start. `PERF_ONLY=<name> bin/make perf-selfcheck` narrows it to one
+  scenario. for a still-suspect scenario, re-measuring it in isolation
+  on both builds back to back (`PERF_ONLY=<name> bin/make perf` on A,
+  then on B) also removes the thermal/cache wake left by the ~20
+  scenarios that precede it in a full suite.
 - prefer default `PERF_SAMPLES`/`PERF_MIN_SECS` for accept/reject
   decisions; use lower values only for quick scouting.
 - scenarios must be stationary: an op must not get slower the more often

--- a/lib/perf/perf_types.tl
+++ b/lib/perf/perf_types.tl
@@ -64,9 +64,11 @@ local record perf_types
   end
 
   --- One row of a baseline-vs-current comparison.
-  --- verdict is one of: "ok", "faster", "regression", "new", "missing",
-  --- "error". noise_pct is the bar a delta must clear to count as real:
-  --- max(threshold, baseline spread, current spread).
+  --- verdict is one of: "ok", "faster", "regression", "noise", "new",
+  --- "missing", "error". "noise" is a regression that an A/A self-check
+  --- reclassified as run-to-run variance (see compare.triage); it does
+  --- not fail the gate. noise_pct is the bar a delta must clear to count
+  --- as real: max(threshold, baseline spread, current spread).
   record Delta
     name: string
     base_ns: number

--- a/lib/perf/run.tl
+++ b/lib/perf/run.tl
@@ -30,6 +30,8 @@ local record Args
   only: string
   compare_mode: boolean
   threshold: number
+  selfcheck_a: string
+  selfcheck_b: string
   help: boolean
   positional: {string}
   err: string
@@ -38,6 +40,7 @@ end
 local USAGE = [[
 usage: run.lua [--out FILE] [--samples N] [--min-secs S] [--only PAT] MODULE...
        run.lua --compare BASE.json CUR.json [--threshold PCT]
+         [--selfcheck-a AA.json --selfcheck-b AB.json]
 ]]
 
 --- Parse command-line arguments.
@@ -57,6 +60,8 @@ local function parse_args(argv: {string}): Args
       {name = "only", has_arg = "required"},
       {name = "compare", has_arg = "none"},
       {name = "threshold", has_arg = "required"},
+      {name = "selfcheck-a", has_arg = "required"},
+      {name = "selfcheck-b", has_arg = "required"},
       {name = "help", has_arg = "none", short = "h"},
     })
   while true do
@@ -91,6 +96,10 @@ local function parse_args(argv: {string}): Args
       else
         a.threshold = t
       end
+    elseif opt == "selfcheck-a" then
+      a.selfcheck_a = optarg
+    elseif opt == "selfcheck-b" then
+      a.selfcheck_b = optarg
     elseif opt == "h" then
       a.help = true
     end
@@ -224,7 +233,25 @@ local function run_compare(a: Args): integer
     io.stderr:write(cerr .. "\n")
     return 1
   end
-  local deltas, failures = compare.diff(base, cur, a.threshold)
+  local deltas: {pt.Delta}
+  local failures: integer
+  if a.selfcheck_a and a.selfcheck_b then
+    -- A/A triage: reclassify regressions the current binary can't
+    -- reproduce against itself as "noise" rather than failures.
+    local na, naerr = compare.load_results(a.selfcheck_a)
+    if na == nil then
+      io.stderr:write(naerr .. "\n")
+      return 1
+    end
+    local nb, nberr = compare.load_results(a.selfcheck_b)
+    if nb == nil then
+      io.stderr:write(nberr .. "\n")
+      return 1
+    end
+    deltas, failures = compare.triage(base, cur, na, nb, a.threshold)
+  else
+    deltas, failures = compare.diff(base, cur, a.threshold)
+  end
   print(compare.format(deltas))
   if failures > 0 then
     io.stderr:write("perf: " .. failures .. " scenario(s) regressed, errored, or went missing\n")


### PR DESCRIPTION
## Problem

`perf-selfcheck` (#461) gave a manual escape from noise-driven false alarms, but the agent/human still had to *notice* a flag, decide to run it, and interpret the result. That's exactly the multi-hour judgement detour the entry-21 (ljson) round hit. This makes the noise-vs-real call **deterministic and automatic**, so the loop needs no manual triage.

## Change

`perf-compare` gains a third stage. After its existing re-measure retry, if a regression still stands it runs **one more pass of the same binary** and compares it against itself (an A/A self-check). `compare.triage()` then reclassifies any regression the binary **cannot reproduce against itself** — a scenario that also swings past the bar comparing it to itself — as the non-failing verdict `noise`.

A stable scenario (json, sqlite, codec) has a quiet A/A and **keeps** its `regression` verdict, so a real regression still fails the gate. The reclassification only ever *downgrades* a regression — it never invents or hides one elsewhere.

Net: `bin/make perf-compare` exits 0 iff no regression the binary reproduces against itself remains. Read the verdict — `regression` = real, `noise` = discounted.

- `compare.tl`: `triage()` + `noise` in the summary line.
- `run.tl`: `--selfcheck-a` / `--selfcheck-b` feed the A/A pair into `--compare`.
- `cook.mk`: `perf-compare` runs the A/A pass + triage as its final stage.
- `perf_types.tl`: document the `noise` verdict.
- `compare_test.tl`: triage keeps stable regressions, reclassifies noisy ones, touches only regressions, counts noise.
- `OPTIMIZE.md` / `measurement.md`: describe the automatic triage; `perf-selfcheck` (from #461) stays as the on-demand/interactive control.

## Validation

- `bin/make ci` green (all tests, incl. new triage cases; docs lint clean).
- End-to-end at the `run.lua` CLI (the path `cook.mk` invokes):

```
# plain --compare: +30% regression fails
h   1.00 µs -> 1.30 µs  +30.0%  (noise ±10.0%)  regression   → exit 1

# same delta, unstable A/A pair: reclassified, gate passes
h   1.00 µs -> 1.30 µs  +30.0%  (noise ±10.0%)  noise         → exit 0
```

Builds on #461 (merged): that added the manual `perf-selfcheck` control; this wires the same A/A control into the gate automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3LLKk1LBKarc5bd2Q3LsC

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3LLKk1LBKarc5bd2Q3LsC)_