### PR TITLE
perf(startup): store boot-critical .lua payload uncompressed (backlog 024)

### DIFF
--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -19,6 +19,18 @@ cosmic_types := $(wildcard lib/types/*.tl) $(wildcard lib/types/*.d.tl) $(wildca
 
 cosmic_version_lua := $(o)/cosmic/version.lua
 
+# Pack the cosmic payload into the binary given as $(1). The boot-critical
+# Lua — .lua/cosmic/* modules, main.lua and .args — is inflate()d on EVERY
+# invocation (29 inflate() calls at boot; see lib/perf/backlog/024), so store
+# it uncompressed to skip the decompress. The rest (tl.lua, the type
+# declarations, docs, .tl source, skills) is either large or lazy-loaded and
+# not on the startup path, so keep it deflated to hold the size cost down.
+define pack-cosmic
+	@cd $(cosmic_built) && $(CURDIR)/$(cosmos_zip_bin) -qr0 $(CURDIR)/$(1) .lua/cosmic
+	@cd $(cosmic_built) && $(CURDIR)/$(cosmos_zip_bin) -qr $(CURDIR)/$(1) .lua .tl .docs sys skills -x '.lua/cosmic/*'
+	@$(cosmos_zip_bin) -qj0 $(1) $(cosmic_main) $(cosmic_args)
+endef
+
 $(cosmic_version_lua): .FORCE | $$(cosmos_staged)
 	@mkdir -p $(@D)
 	@echo "return { cosmic = \"$$(git describe --tags --always --dirty 2>/dev/null || echo unknown)\", cosmos = \"$$($(cosmos_lua_bin) -e "print(dofile('3p/cosmos/version.lua').version)")\" }" > $@.tmp
@@ -53,14 +65,12 @@ $(cosmic_bin): $$(cosmic_lua) $(cosmic_main) $(cosmic_args) $$(tl_staged) $$(tea
 	@$(cp) $(cosmic_skills) $(cosmic_built)/skills/cosmic/
 	@$(cp) $(cosmos_lua_bin) $@
 	@chmod +x $@
-	@cd $(cosmic_built) && $(CURDIR)/$(cosmos_zip_bin) -qr $(CURDIR)/$@ .lua .tl .docs sys skills
-	@$(cosmos_zip_bin) -qj $@ $(cosmic_main) $(cosmic_args)
+	$(call pack-cosmic,$@)
 
 $(cosmic_debug_bin): $(cosmic_bin)
 	@$(cp) $(cosmos_lua_debug_bin) $@
 	@chmod +x $@
-	@cd $(cosmic_built) && $(CURDIR)/$(cosmos_zip_bin) -qr $(CURDIR)/$@ .lua .tl .docs sys skills
-	@$(cosmos_zip_bin) -qj $@ $(cosmic_main) $(cosmic_args)
+	$(call pack-cosmic,$@)
 
 cosmic: $(cosmic_bin)
 

--- a/lib/perf/backlog/024-store-lua-payload-uncompressed.md
+++ b/lib/perf/backlog/024-store-lua-payload-uncompressed.md
@@ -1,6 +1,6 @@
 # 24. embedded .lua payload is deflated; every boot pays 29 inflate() calls
 
-- status: open
+- status: done (2026-07-05) — selective store (shape 2) landed
 - layer: cosmic (packaging — lib/cosmic/cook.mk zip flags)
 - scenario: startup_run_lua, startup_run_teal
 
@@ -34,3 +34,45 @@
 - risk: low for correctness; the real question is whether the size
   cost is acceptable — make the call with `perf-compare` numbers
   from the real harness (the probe above is shell-loop scouting).
+
+- outcome (2026-07-05): shipped shape 2 (selective store). A
+  `pack-cosmic` canned recipe in lib/cosmic/cook.mk stores the
+  boot-critical payload uncompressed — `.lua/cosmic/*` (via `-qr0`),
+  plus `main.lua` and `.args` (via `-qj0`) — and keeps everything
+  else deflated (`.lua .tl .docs sys skills -x '.lua/cosmic/*'`),
+  which leaves the big compressible masses compressed: tl.lua
+  (435KB, lazy-loaded since entry 3), .docs/index.lua (648KB), and
+  the .lua/types/*.d.tl declarations. lib/perf/cook.mk's `perf-bin`
+  uses the same recipe so local cosmopolitan-layer measurements
+  match the release packaging.
+- results:
+  - `--strace -e 'print(1)'` boot inflate() calls: 29 -> 0 (a strict
+    syscall reduction, deterministic — not a timing probe).
+  - binary size: 6,697,667 -> 6,960,395 bytes (+262KB, +3.9%) — far
+    cheaper than shape 1's +28% because tl.lua/.docs/types stay
+    deflated.
+  - controlled A/B, both binaries assimilated to native ELF, 1800
+    `-e 'print(1)'` runs each in alternating 150-run blocks (pstdev
+    0.03-0.06ms): 3.267ms -> 2.936ms, -10.1% median (-11.1% min).
+  - full `bin/make perf-compare` (default samples): 0 regressions,
+    32/32 ok; startup rows moved -2.2% (run_lua), -6.8% (run_teal),
+    -4.7% (compile_teal) but within their noise bars.
+- harness note: the `startup_*` scenarios cannot resolve this win.
+  They spawn the cosmic binary from inside cosmic, so cpu/wall sits
+  at ~0.07-0.20 — ~80-93% of the measured wall time is the parent's
+  fork/exec of a ~20MB process, not the child's boot CPU where the
+  inflate() work lives. The controlled A/B above uses a tiny parent
+  (python subprocess), which is why the child-boot delta is visible
+  there. A future harness finding: a startup scenario with a
+  minimal-footprint spawner would give the gate resolution on
+  boot-CPU wins like this one.
+- correctness verified: `bin/make ci` green; `unzip -t` reports no
+  errors; the self-modifying welcome marker still works (welcome.tl
+  appends `.cosmic/welcome-shown` via `czip.open(self,"a")` — the
+  appender walks every central-dir entry's local header, and all
+  512 entries remain valid under the multi-pass store/deflate/exclude
+  build; welcome_test.tl passes).
+- not pursued this round (left for a follow-up): `embed.run()`-built
+  executables still deflate their embedded payload, and the
+  release-artifact path was not separately re-checked (it builds via
+  the same cosmic_bin recipe, so it inherits the change).

--- a/lib/perf/cook.mk
+++ b/lib/perf/cook.mk
@@ -45,8 +45,7 @@ perf-bin: $(cosmic_bin)
 	@mkdir -p $(perf_sandbox)
 	@cp $(COSMO_LUA) $(cosmic_local_bin)
 	@chmod +x $(cosmic_local_bin)
-	@cd $(cosmic_built) && $(CURDIR)/$(cosmos_zip_bin) -qr $(CURDIR)/$(cosmic_local_bin) .lua .tl .docs sys skills
-	@$(cosmos_zip_bin) -qj $(cosmic_local_bin) $(cosmic_main) $(cosmic_args)
+	$(call pack-cosmic,$(cosmic_local_bin))
 	@echo "built $(cosmic_local_bin) from $(COSMO_LUA)"
 	@echo "measure it with: PERF_BIN=$(cosmic_local_bin) bin/make perf-compare"
 


### PR DESCRIPTION
## What

One optimization round from `lib/perf/optimize`, working backlog entry **024**: the embedded `.lua` boot payload was DEFLATE-compressed, so every cosmic invocation decompressed it — **29 `inflate()` calls at startup** (`--strace -e 'print(1)'`).

This stores the boot-critical payload uncompressed instead. A new `pack-cosmic` canned recipe in `lib/cosmic/cook.mk`:

- stores `.lua/cosmic/*` (`-qr0`) plus `main.lua` and `.args` (`-qj0`) — the entries zipos reads on every boot;
- keeps everything else deflated (`.lua .tl .docs sys skills -x '.lua/cosmic/*'`), so the big compressible, non-boot masses stay compressed: `tl.lua` (435KB, lazy-loaded since backlog 003), `.docs/index.lua` (648KB), and the `.d.tl` type declarations.

This is **shape 2 (selective)** from the backlog entry; shape 1 (store everything) cost +28% size for the same win. `lib/perf/cook.mk`'s `perf-bin` shares the recipe so local cosmopolitan-layer measurements match release packaging.

## Results

- boot `inflate()` calls: **29 → 0** (a strict, deterministic syscall reduction — not a timing probe)
- binary size: 6,697,667 → 6,960,395 bytes (**+262KB, +3.9%**)
- controlled A/B (both binaries assimilated to native ELF, 1800 `-e 'print(1)'` runs each in alternating 150-run blocks, pstdev 0.03–0.06ms): **3.267 → 2.936 ms, −10.1% median** (−11.1% min)
- `bin/make perf-compare` (default samples): **0 regressions, 32/32 ok**

```
startup_run_lua       6.05 ms ->   5.92 ms   -2.2%  (noise ±10.0%)  ok
startup_run_teal      7.34 ms ->   6.84 ms   -6.8%  (noise ±13.8%)  ok
startup_compile_teal 31.50 ms ->  30.02 ms   -4.7%  (noise ±12.7%)  ok
32 scenarios: 0 regression, 0 faster, 32 ok, 0 noise, 0 new, 0 missing, 0 error
```

### Why the harness rows read as noise

The `startup_*` scenarios spawn the cosmic binary *from inside cosmic*, so `cpu/wall` sits at ~0.07–0.20 — ~80–93% of the measured wall time is the parent's fork/exec of a ~20MB process, not the child's boot CPU where the `inflate()` work lives. The controlled A/B above uses a tiny parent (python subprocess), which is why the child-boot delta is visible there. The win is proven independently of any timing noise by the syscall count (29 → 0). Backlog 024 records this as a harness-resolution limitation worth a future finding (a minimal-footprint spawner scenario).

## Correctness

- `bin/make ci` green (format + type check + tests + examples)
- `unzip -t` on the built binary: no errors
- the self-modifying welcome marker still works: `welcome.tl` appends `.cosmic/welcome-shown` via `czip.open(self, "a")`; the appender walks every central-directory entry's local file header, and all 512 entries keep valid headers under the multi-pass store/deflate/exclude build. `welcome_test.tl` passes (verified across repeated runs and the make harness).

## Not pursued this round

`embed.run()`-built executables still deflate their embedded payload (left for a follow-up); the release-artifact path inherits this change since it builds via the same `cosmic_bin` recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McB68PkkDbFQsudVWduo9U

---
_Generated by [Claude Code](https://claude.ai/code/session_01McB68PkkDbFQsudVWduo9U)_