### PR TITLE
perf(embed): store embedded .lua uncompressed so produced apps skip boot inflate (backlog 028)

### DIFF
--- a/lib/cosmic/embed.tl
+++ b/lib/cosmic/embed.tl
@@ -270,10 +270,16 @@ local function run(paths: {string}, output?: string, exe_path?: string): EmbedRe
   end
   local appender = appender_result as ZipAppender
 
-  -- Remove existing entries that conflict, then add new ones
+  -- Remove existing entries that conflict, then add new ones.
+  -- Store .lua uncompressed; deflate everything else. The produced
+  -- executable loads its embedded Lua at boot, so a deflated .lua costs an
+  -- inflate() on every launch (the per-boot cost backlog 024 removed from
+  -- cosmic's own payload). Bulk assets, which the entry point does not
+  -- necessarily read at startup, stay compressed to hold the size down.
   for _, file_info in ipairs(files_to_embed) do
     appender:remove(file_info.stored_name)
-    local opts: AddOptions = {mode = file_info.mode, method = "deflate"}
+    local is_lua = file_info.stored_name:sub(-4) == ".lua"
+    local opts: AddOptions = {mode = file_info.mode, method = is_lua and "store" or "deflate"}
     local add_ok, add_err = appender:add(file_info.stored_name, file_info.content, opts)
     if not add_ok then
       appender:close()

--- a/lib/cosmic/embed_test.tl
+++ b/lib/cosmic/embed_test.tl
@@ -260,7 +260,7 @@ local function test_embed_directory_executable()
 end
 test_embed_directory_executable()
 
--- Test that embedded files use deflate compression (method=8)
+-- Test that embedded non-.lua files use deflate compression (method=8)
 local function test_embed_uses_deflate()
   -- Use compressible content (repeated pattern) to ensure deflate is applied
   local compressible = string.rep("abcdefghij", 100)
@@ -286,6 +286,38 @@ local function test_embed_uses_deflate()
   reader:close()
 end
 test_embed_uses_deflate()
+
+-- Test that embedded .lua files are stored uncompressed (method=0): the
+-- produced executable loads them at boot, so storing skips a per-launch
+-- inflate() (see lib/perf/backlog/024).
+local function test_embed_stores_lua()
+  -- Compressible content that deflate WOULD shrink, to prove the store is a
+  -- deliberate .lua policy and not just deflate declining to grow the file.
+  local compressible = "-- " .. string.rep("abcdefghij", 100) .. "\nreturn 1\n"
+  local input = write_temp("store_test.lua", compressible)
+  local output = fs.join(tmpdir, "cosmic-store")
+
+  local ok, out = spawn.spawn({cosmic, "--embed", input, "--output", output}):read()
+  assert(ok, "embed should succeed: " .. (out or ""))
+
+  local data = cio.slurp(output)
+  local reader_maybe = zip.from(data)
+  assert(reader_maybe, "failed to open zip from data")
+  local reader = reader_maybe as Reader
+
+  local name = input:gsub("^/+", "")
+  local st = reader:stat(name)
+  assert(st ~= nil, "stat should return metadata for embedded file")
+  local stat = st as Stat
+  assert(stat.method == 0,
+    "embedded .lua should be stored (method=0), got: " .. tostring(stat.method))
+  assert(stat.compressed_size == stat.size,
+    "stored .lua should not be compressed: " .. tostring(stat.compressed_size) .. " vs " .. tostring(stat.size))
+  -- Content must still round-trip identically.
+  assert(reader:read(name) == compressible, "stored .lua content should match")
+  reader:close()
+end
+test_embed_stores_lua()
 
 -- Zip-slip: extract() must reject any entry that would land outside the
 -- output directory. cosmic executables also extract on Windows, so the

--- a/lib/perf/backlog/024-store-lua-payload-uncompressed.md
+++ b/lib/perf/backlog/024-store-lua-payload-uncompressed.md
@@ -72,7 +72,8 @@
   appender walks every central-dir entry's local header, and all
   512 entries remain valid under the multi-pass store/deflate/exclude
   build; welcome_test.tl passes).
-- not pursued this round (left for a follow-up): `embed.run()`-built
-  executables still deflate their embedded payload, and the
-  release-artifact path was not separately re-checked (it builds via
-  the same cosmic_bin recipe, so it inherits the change).
+- follow-up: `embed.run()`-built executables had the same problem
+  (they force-deflated every embedded file, so the produced app
+  inflate()d its own .lua at each launch) — now fixed, see entry 028.
+  The release-artifact path was not separately re-checked (it builds
+  via the same cosmic_bin recipe, so it inherits the change).

--- a/lib/perf/backlog/028-embed-store-lua.md
+++ b/lib/perf/backlog/028-embed-store-lua.md
@@ -1,0 +1,50 @@
+# 28. embed.run() force-deflates embedded .lua; produced apps inflate at boot
+
+- status: done (2026-07-05)
+- layer: cosmic (lib/cosmic/embed.tl)
+- scenario: embed_run_startup (new, lib/perf/bench/embed_startup_bench.tl)
+
+- evidence: entry 024 stored cosmic's own boot-critical .lua so it no
+  longer inflate()s the stdlib at startup. `embed.run()` — which
+  bundles a user app into a copy of the cosmic binary — did the
+  opposite: it added EVERY embedded file with `method = "deflate"`
+  (embed.tl:276), so the produced executable inflate()d its own .lua
+  on every launch. Measured on a 25-module app
+  (`packed --strace | grep -c inflate`): 26 boot inflate() calls,
+  all of them the app's embedded .lua (cosmic's stdlib is already
+  stored post-024). Forcing deflate also grew tiny .lua ABOVE their
+  source size (deflate overhead), so it cost both space and time.
+- fix: store .lua uncompressed, deflate everything else. One line in
+  run()'s add loop —
+  `method = (stored_name ends in ".lua") and "store" or "deflate"`.
+  The czip appender already supports `method="store"`; bulk assets
+  (data, images, binaries) stay deflated since the entry point does
+  not necessarily read them at startup.
+- new scenario: `embed_run_startup` builds a 10-module app, embeds it
+  once (the megabyte base-binary copy is fixed setup, not timed), and
+  measures the produced executable's cold start with a functional
+  check on its output.
+- results:
+  - boot inflate() calls (25-module app): 26 -> 0 (strict, deterministic).
+  - `bin/make perf-compare`: 0 regressions, 33/33 ok. `embed_run_startup`
+    read +0.6% (within its ±10% bar) — same harness-resolution limit as
+    entry 024: the scenario spawns the app from cosmic, so cpu/wall ~0.20
+    and parent fork/exec dominates the wall time, burying the child's
+    boot-CPU win.
+  - controlled A/B (two produced binaries differing only by embed's .lua
+    compression, both assimilated to native ELF, 1800 runs each in
+    alternating 150-run blocks, pstdev 0.04-0.06ms): 4.068 -> 3.770 ms,
+    -7.3% median (-7.0% min).
+  - size: +91KB (+1.3%) for a 108KB-source app — bounded to .lua code;
+    assets stay compressed.
+- correctness: `bin/make ci` green. embed_test.tl gains
+  `test_embed_stores_lua` (a .lua embeds as method=0, content
+  round-trips) alongside the existing `test_embed_uses_deflate` (a
+  .txt still embeds as method=8). The extract->embed roundtrip is
+  unaffected — extract rewrites files from decompressed content, so it
+  never depended on the stored method.
+- cross-reference: entry 024 fixed the same inflate-at-boot cost for
+  cosmic's own payload; this is its embed-produced-executable analog.
+- risk: low — behavior change is compression method only (zipos serves
+  stored and deflated identically); the .lua policy is the same one 024
+  validated for the base binary.

--- a/lib/perf/bench/embed_startup_bench.tl
+++ b/lib/perf/bench/embed_startup_bench.tl
@@ -1,0 +1,168 @@
+--- Startup of an embed.run()-produced executable.
+---
+--- embed.run() bundles a user app into a copy of the cosmic binary; the
+--- produced executable boots into the embedded main.lua, which loads the
+--- app's other embedded .lua modules. Whatever compression those modules
+--- carry is paid back as inflate() calls on every launch of the app — the
+--- same per-boot cost backlog 024 removed from cosmic's own payload, but
+--- for the executables embed produces. This scenario builds one such
+--- executable once (the ~megabyte base-binary copy is fixed overhead we
+--- keep out of the timed op) and measures its cold start.
+
+local child = require("cosmic.child")
+local embed = require("cosmic.embed")
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
+local pt = require("perf.perf_types")
+
+-- A code-heavy app: MODULES modules the entry point loads at boot, each
+-- padded to a few KB of real Lua so the store-vs-deflate difference is a
+-- measurable amount of inflate() work rather than rounding noise.
+local MODULES = 10
+local SENTINEL = "EMBED_STARTUP"
+
+local tmpdir: string
+local packed_exe: string
+local expected_sum: integer
+
+--- Base directory for scratch files.
+--- @return string An existing writable directory
+local function tmp_base(): string
+  return os.getenv("TEST_TMPDIR") or os.getenv("TMPDIR") or "/tmp"
+end
+
+--- Locate the cosmic binary to benchmark.
+--- PERF_BIN wins; then TEST_BIN/cosmic (set by the test harness); then
+--- the interpreter running this script (arg[-1], per cosmic.child docs).
+--- @return string Path to the binary, or nil if none was found
+local function find_bin(): string
+  local envbin = os.getenv("PERF_BIN")
+  if envbin and #envbin > 0 then
+    return envbin
+  end
+  local test_bin = os.getenv("TEST_BIN")
+  if test_bin and #test_bin > 0 then
+    local p = fs.join(test_bin, "cosmic")
+    if fs.isfile(p) then
+      return p
+    end
+  end
+  return rawget(arg, -1) as string
+end
+
+--- Source text for module i: returns the integer i after defining a padded
+--- block of trivial Lua, so each embedded module carries a few KB of
+--- compressible source (deflate has something to inflate at boot).
+--- @param i integer Module index
+--- @return string Lua source
+local function module_src(i: integer): string
+  local parts: {string} = {}
+  parts[#parts + 1] = "local t = {}"
+  for k = 1, 40 do
+    parts[#parts + 1] = string.format(
+      "t[%d] = function() return %d * %d + %d end", k, i, k, k)
+  end
+  parts[#parts + 1] = "return " .. tostring(i)
+  return table.concat(parts, "\n") .. "\n"
+end
+
+--- Write the app tree (main.lua + MODULES modules) under dir.
+--- main.lua loadfile()s each embedded module from /zip and prints the sum,
+--- so every module is genuinely loaded (and inflated, if deflated) at boot.
+--- @param dir string Application source directory
+--- @return string Error message, or nil on success
+local function init_app(dir: string): string
+  expected_sum = 0
+  for i = 1, MODULES do
+    expected_sum = expected_sum + i
+    local wok, werr = cio.barf(fs.join(dir, "mod_" .. i .. ".lua"), module_src(i))
+    if not wok then
+      return "barf mod_" .. i .. ": " .. tostring(werr)
+    end
+  end
+  local main: {string} = {"local sum = 0"}
+  for i = 1, MODULES do
+    main[#main + 1] = string.format(
+      'sum = sum + assert(loadfile("/zip/mod_%d.lua"))()', i)
+  end
+  main[#main + 1] = 'print("' .. SENTINEL .. ':" .. sum)'
+  local mok, merr = cio.barf(fs.join(dir, "main.lua"), table.concat(main, "\n") .. "\n")
+  if not mok then
+    return "barf main.lua: " .. tostring(merr)
+  end
+  return nil
+end
+
+--- Spawn the binary and return trimmed stdout.
+--- Raises on spawn failure or nonzero exit, which the harness reports.
+--- @param bin string Binary path
+--- @return string Trimmed stdout
+local function spawn_capture(bin: string): string
+  local handle, serr = child.spawn({bin})
+  assert(handle, serr)
+  local ok, out, code = handle:read()
+  assert(ok, "exit code " .. tostring(code) .. ": " .. tostring(out))
+  return ((out as string):gsub("%s+$", ""))
+end
+
+local function scenarios(): {pt.Scenario}, string
+  local bin = find_bin()
+  if bin == nil or #bin == 0 then
+    return nil, "cannot locate cosmic binary (set PERF_BIN)"
+  end
+  local dir, derr = fs.mkdtemp(fs.join(tmp_base(), "perf-embed-startup-XXXXXX"))
+  if dir == nil then
+    return nil, "mkdtemp: " .. tostring(derr)
+  end
+  tmpdir = dir
+  local appdir = fs.join(tmpdir, "app")
+  local mok, merr = fs.makedirs(appdir)
+  if not mok then
+    return nil, "makedirs: " .. tostring(merr)
+  end
+  local aerr = init_app(appdir)
+  if aerr then
+    return nil, aerr
+  end
+
+  -- Build the embedded executable once: the per-op cost is its startup,
+  -- not the (fixed, megabyte-scale) embed operation.
+  packed_exe = fs.join(tmpdir, "packed")
+  local res = embed.run({appdir}, packed_exe, bin)
+  if not res.ok then
+    return nil, "embed.run: " .. tostring(res.message)
+  end
+
+  local want = SENTINEL .. ":" .. tostring(expected_sum)
+  return {
+    {
+      -- Cold start of the produced executable: APE load, zip fs, Lua boot,
+      -- then loadfile() of every embedded module (the inflate() path that
+      -- storing boot .lua eliminates).
+      name = "embed_run_startup",
+      fn = function(_: any): any
+        return spawn_capture(packed_exe)
+      end,
+      check = function(_: any, res2: any): boolean, string
+        if res2 as string ~= want then
+          return false, "wrong output: " .. tostring(res2) .. " want " .. want
+        end
+        return true
+      end,
+    },
+  }
+end
+
+local function cleanup()
+  if tmpdir then
+    fs.rmrf(tmpdir)
+    tmpdir = nil
+  end
+end
+
+local M: pt.BenchModule = {
+  scenarios = scenarios,
+  cleanup = cleanup,
+}
+
+return M


### PR DESCRIPTION
## What

Follow-up to #463 (backlog 024), which stored cosmic's own boot-critical `.lua` so startup no longer inflate()s the stdlib. `embed.run()` — which bundles a user app into a copy of the cosmic binary — did the opposite: it added **every** embedded file with `method = "deflate"` (`embed.tl:276`), so an embed-produced executable inflate()d its own `.lua` on every launch.

On a 25-module app the produced binary made **26 boot `inflate()` calls**, all of them the app's embedded `.lua` (cosmic's stdlib is already stored post-#463). Forcing deflate even grew tiny `.lua` *above* their source size (deflate overhead) — costing both space and time.

## Change

Store `.lua` uncompressed, deflate everything else — one line in `run()`'s add loop:

```teal
local is_lua = file_info.stored_name:sub(-4) == ".lua"
local opts: AddOptions = {mode = file_info.mode, method = is_lua and "store" or "deflate"}
```

Bulk assets (data, images, binaries) stay compressed since the entry point doesn't necessarily read them at startup. The `czip` appender already supports `method = "store"`.

Adds an `embed_run_startup` scenario (`lib/perf/bench/embed_startup_bench.tl`) that embeds a 10-module app once (the megabyte base-binary copy is fixed setup, kept out of the timed op) and measures the produced executable's cold start with a functional check on its output.

## Results

- boot `inflate()` calls (25-module app): **26 → 0** (strict, deterministic)
- controlled A/B (two produced binaries differing only by embed's `.lua` compression, both assimilated to native ELF, 1800 `./app` runs each in alternating 150-run blocks, pstdev 0.04–0.06ms): **4.068 → 3.770 ms, −7.3% median** (−7.0% min)
- size: **+91KB (+1.3%)** for a 108KB-source app — bounded to `.lua` code; assets stay compressed
- `bin/make perf-compare`: **0 regressions, 33/33 ok**

```
embed_run_startup    2.93 ms ->   2.95 ms   +0.6%  (noise ±10.0%)  ok
startup_run_lua      6.12 ms ->   5.58 ms   -8.8%  (noise ±10.0%)  ok
startup_run_teal     7.37 ms ->   6.52 ms  -11.6%  (noise ±12.3%)  ok
33 scenarios: 0 regression, 0 faster, 33 ok, 0 noise, 0 new, 0 missing, 0 error
```

### Why `embed_run_startup` reads as noise

Same harness-resolution limit noted in #463: the scenario spawns the produced app *from cosmic*, so `cpu/wall` sits at ~0.20 — parent fork/exec dominates the wall time and buries the child's boot-CPU win. The controlled A/B (tiny python parent) and the deterministic inflate count isolate it. The scenario still earns its place: it functionally gates that embed-produced binaries boot and output correctly after the packaging change.

## Correctness

- `bin/make ci` green
- `embed_test.tl` gains `test_embed_stores_lua` (a `.lua` embeds as `method=0` and round-trips) alongside the existing `test_embed_uses_deflate` (a `.txt` still embeds as `method=8`)
- the `--extract` → `--embed` roundtrip is unaffected: extract rewrites files from decompressed content, so it never depended on the stored method

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McB68PkkDbFQsudVWduo9U

---
_Generated by [Claude Code](https://claude.ai/code/session_01McB68PkkDbFQsudVWduo9U)_