### PR TITLE
benchmark: measure wall time via CLOCK_MONOTONIC, not os.clock

### DIFF
--- a/lib/cosmic/benchmark.tl
+++ b/lib/cosmic/benchmark.tl
@@ -2,7 +2,18 @@
 --- Parses Benchmark_* functions from Teal files, runs them, and reports timing.
 --- Similar to Go's testing.B but simplified: functions are called N times automatically.
 
-local os_clock = os.clock
+local time = require("cosmic.time")
+
+--- Read the monotonic wall clock in nanoseconds.
+--- Uses CLOCK_MONOTONIC so IO-bound benchmarks (which block rather than
+--- burn CPU) are measured by elapsed wall time, not CPU time. Measuring
+--- CPU time via os.clock() would leave `elapsed` near zero on such
+--- benchmarks and make the calibration loop grow iterations without bound.
+--- @return number Monotonic time in nanoseconds
+local function monotonic_ns(): number
+  local secs, nanos = time.monotonic()
+  return secs * 1e9 + nanos
+end
 
 --- A parsed benchmark function.
 local record Benchmark
@@ -206,7 +217,7 @@ end
 
   while elapsed < MIN_DURATION do
     -- Warm up / calibrate
-    local start = os_clock()
+    local start = monotonic_ns()
     for _ = 1, n do
       local run_ok, run_err: boolean, any = pcall(bench_fn as function())
       if not run_ok then
@@ -222,7 +233,7 @@ end
         return result
       end
     end
-    elapsed = os_clock() - start
+    elapsed = (monotonic_ns() - start) / 1e9
 
     if elapsed < MIN_DURATION then
       -- Estimate iterations needed to reach MIN_DURATION


### PR DESCRIPTION
## What

Fixes the **P2** item of #511: `cosmic.benchmark` measured elapsed time with `os.clock()` (CPU time) instead of wall time.

## Why

The auto-calibration loop grows the iteration count until `elapsed` reaches `MIN_DURATION` (1s). `os.clock()` reports **CPU** time, so an IO-bound benchmark that blocks (sleep, network, disk) burns almost no CPU — `elapsed` stays near zero and the loop multiplies iterations without bound (runaway calibration), and any per-op number it eventually prints is CPU time, not the wall time the benchmark actually took.

## Change

Read the monotonic wall clock (`CLOCK_MONOTONIC`) via `cosmic.time.monotonic()` for both the start and end of each calibration round. A small `monotonic_ns()` helper converts the `(secs, nanos)` pair to nanoseconds; `elapsed` stays in seconds so the rest of the calibration math is unchanged.

## Verification

- `bin/make test only=benchmark` — passes (13 existing cases).
- `bin/make teal` / `bin/make format` — 223/223 pass.
- Behavioral check with an IO-bound benchmark (`time.sleep_ms(50)`):

  ```
  Benchmark_sleep        20    50.16 ms/op
  PASS
  real  0m1.572s   user 0m0.015s
  ```

  It now converges in ~20 iterations / ~1.5s and reports true wall time (~50ms/op). The 0.015s of `user` CPU is exactly what the old `os.clock()` path would have measured — which is why it ran away before.

Scope: only the P2 clock fix. The P1 (`fetch.lines` O(n²)) and P3 (`fuzzy` length gate) items of #511 remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxbnedBTuwTtWTEYa3zhHk)_