### PR TITLE
perf: linear Reader:lines() and length-gated fuzzy.find_similar (#511 P1/P3)

### DIFF
--- a/lib/cosmic/fetch.tl
+++ b/lib/cosmic/fetch.tl
@@ -196,31 +196,49 @@ local function make_reader(raw_reader: cosmo.StreamReader): Reader
   --- Buffers partial lines across chunks until a newline is received.
   --- @return function iterator yielding lines without trailing newline
   function reader:lines(): function(): string
+    -- Scan-position index into buffer: `pos` is the first unread byte.
+    -- Advancing it instead of slicing off each returned line, and dropping
+    -- the consumed prefix only when we must read more, keeps the whole loop
+    -- linear in the byte count. The previous buffer:sub()-per-line and
+    -- buffer..chunk-per-chunk both re-copied the entire buffer, making line
+    -- iteration O(n²) in the body size (audit §7.2 P1).
     local buffer = ""
+    local pos = 1
     local done = false
 
     return function(): string
-      while not done do
-        local newline_pos = buffer:find("\n")
+      while true do
+        local newline_pos = buffer:find("\n", pos, true)
         if newline_pos then
-          local line = buffer:sub(1, newline_pos - 1)
-          buffer = buffer:sub(newline_pos + 1)
+          local line = buffer:sub(pos, newline_pos - 1)
+          pos = newline_pos + 1
           return line
         end
 
-        local chunk = self:read()
-        if not chunk then
-          done = true
-          if #buffer > 0 then
-            local remaining = buffer
-            buffer = ""
+        if done then
+          -- EOF with a final unterminated line still buffered: yield it once.
+          if pos <= #buffer then
+            local remaining = buffer:sub(pos)
+            pos = #buffer + 1
             return remaining
           end
           return nil
         end
-        buffer = buffer .. chunk
+
+        -- No newline in the unread region; we need more data. Compact away
+        -- the already-returned prefix first so the buffer stays bounded and
+        -- the concat below copies only the unread tail, not the whole buffer.
+        if pos > 1 then
+          buffer = buffer:sub(pos)
+          pos = 1
+        end
+        local chunk = self:read()
+        if not chunk then
+          done = true
+        else
+          buffer = buffer .. chunk
+        end
       end
-      return nil
     end
   end
 

--- a/lib/cosmic/fuzzy.tl
+++ b/lib/cosmic/fuzzy.tl
@@ -63,10 +63,16 @@ local function find_similar(query: string, candidates: {string}, max_distance?: 
     -- the same candidate (matching is already case-insensitive).
     local candidate_lower = candidate:lower()
     if not seen[candidate_lower] then
-      local dist = levenshtein(query_lower, candidate_lower)
-      if dist <= max_distance then
-        seen[candidate_lower] = true
-        table.insert(results, {candidate, dist})
+      -- Length-difference gate: the edit distance between two strings is at
+      -- least the difference in their lengths, so a candidate whose length
+      -- differs from the query by more than max_distance can never qualify.
+      -- Skipping it avoids the O(n*m) DP with no change to the result set.
+      if math.abs(#query_lower - #candidate_lower) <= max_distance then
+        local dist = levenshtein(query_lower, candidate_lower)
+        if dist <= max_distance then
+          seen[candidate_lower] = true
+          table.insert(results, {candidate, dist})
+        end
       end
     end
   end

--- a/lib/perf/bench/fuzzy_bench.tl
+++ b/lib/perf/bench/fuzzy_bench.tl
@@ -1,0 +1,62 @@
+--- Fuzzy-matching scenarios: cosmic.fuzzy.find_similar over a namespace.
+--- Models a "did you mean?" / autocomplete lookup: one short query matched
+--- against a large candidate set. The check pins the exact match set so a
+--- faster-but-wrong matcher (e.g. one that wrongly prunes candidates) fails
+--- instead of winning.
+
+local fuzzy = require("cosmic.fuzzy")
+local pt = require("perf.perf_types")
+
+local QUERY = "instal"
+
+--- Build a candidate namespace with one true match and a mix of non-matches.
+--- Half the non-matches share the query's length (6) so they run the full
+--- edit-distance DP; the other half are much longer, the case a
+--- length-difference gate can reject without the DP. None of the decoys are
+--- within edit distance 3 of the query, so the match set is exactly
+--- {"install"} regardless of any such gate.
+--- @return {string} The candidate list
+local function build_candidates(): {string}
+  local c: {string} = {"install"}
+  for i = 1, 128 do
+    -- length 6, same as the query, content-far: not gated, no match.
+    c[#c + 1] = string.format("qx%04d", i)
+    -- length 11, far from the query length: a length gate can skip these.
+    c[#c + 1] = string.format("symbol_%04d", i)
+  end
+  return c
+end
+
+local CANDIDATES = build_candidates()
+
+local function scenarios(): {pt.Scenario}, string
+  return {
+    {
+      name = "fuzzy_find_similar",
+      fn = function(_: any): any
+        return fuzzy.find_similar(QUERY, CANDIDATES)
+      end,
+      check = function(_: any, res: any): boolean, string
+        local names = res as {string}
+        if names == nil or #names ~= 1 then
+          return false, "expected exactly one match, got " ..
+          tostring(names and #names)
+        end
+        if names[1] ~= "install" then
+          return false, "wrong match: " .. tostring(names[1])
+        end
+        return true
+      end,
+    },
+  }
+end
+
+local function cleanup()
+end
+
+local M: pt.BenchModule = {
+  scenarios = scenarios,
+  cleanup = cleanup,
+}
+
+return M

--- a/lib/perf/bench/stream_bench.tl
+++ b/lib/perf/bench/stream_bench.tl
@@ -1,0 +1,172 @@
+--- Streaming HTTP line-iteration against a loopback server.
+--- A forked child serves one large multi-line HTTP/1.1 body; the scenario
+--- times fetch.stream() + Reader:lines() consuming every line — the path SSE
+--- clients drive. The body is big enough that the reader's line-buffering
+--- cost (not the loopback transfer) dominates. The check pins the line count
+--- and the last line's content, so a buffering bug that drops or corrupts
+--- lines fails instead of winning.
+
+local net = require("cosmic.net")
+local fetch = require("cosmic.fetch")
+local child = require("cosmic.child")
+local signal = require("cosmic.signal")
+local pt = require("perf.perf_types")
+
+local LOCALHOST = 0x7f000001
+local NUM_LINES = 4000
+
+--- Build a deterministic multi-line body, each line newline-terminated.
+--- @return string The body
+local function build_body(): string
+  local lines: {string} = {}
+  for i = 1, NUM_LINES do
+    lines[i] = string.format(
+      "line %05d: the quick brown fox jumps over the lazy dog", i)
+  end
+  return table.concat(lines, "\n") .. "\n"
+end
+
+local BODY = build_body()
+local LAST_LINE = string.format(
+  "line %05d: the quick brown fox jumps over the lazy dog", NUM_LINES)
+local RESPONSE = "HTTP/1.1 200 OK\r\n"
+.. "Content-Type: text/plain\r\n"
+.. "Content-Length: " .. #BODY .. "\r\n"
+.. "Connection: close\r\n\r\n"
+.. BODY
+
+local server_pid: number
+local listener: net.Socket
+
+--- A single line-iteration outcome, checked after timing.
+local record LineStats
+  count: integer
+  last: string
+end
+
+--- Send every byte of data on conn, looping over short writes.
+--- @param conn Socket The connection
+--- @param data string The bytes to send
+--- @return boolean True when all bytes were sent
+local function send_all(conn: net.Socket, data: string): boolean
+  local off = 1
+  local total = #data
+  while off <= total do
+    local n, _ = conn:send(data:sub(off))
+    if n == nil then
+      return false
+    end
+    off = off + (n as integer)
+  end
+  return true
+end
+
+--- Read from a connection until the end of the request headers.
+--- @param conn Socket The accepted connection
+--- @return boolean True when a full request head was read
+local function read_request(conn: net.Socket): boolean
+  local buf = ""
+  while not buf:find("\r\n\r\n", 1, true) do
+    local data = conn:recv(4096)
+    if data == nil or #data == 0 then
+      return false
+    end
+    buf = buf .. data
+  end
+  return true
+end
+
+--- Accept loop run inside the forked server child. Never returns.
+--- @param srv Socket The listening socket
+local function serve_loop(srv: net.Socket)
+  while true do
+    local conn = srv:accept()
+    if conn then
+      if read_request(conn) then
+        send_all(conn, RESPONSE)
+      end
+      conn:close()
+    end
+  end
+end
+
+local function scenarios(): {pt.Scenario}, string
+  if not fetch.has_stream() then
+    -- Streaming primitive absent in this build; nothing to measure.
+    return {}
+  end
+  local srv, port, lerr = net.listen_tcp(LOCALHOST, 0)
+  if srv == nil then
+    return nil, "listen_tcp: " .. tostring(lerr)
+  end
+  listener = srv
+  local pid = child.fork()
+  if pid == 0 then
+    serve_loop(srv)
+    os.exit(0)
+  end
+  if pid == nil or pid < 0 then
+    return nil, "fork failed"
+  end
+  server_pid = pid
+  -- cosmo.Fetch/FetchStream refuse direct connections to private IPs
+  -- (SSRF protection); proxied requests skip that check. Point the proxy
+  -- at the loopback server so the full streaming path runs.
+  local proxy = "http://127.0.0.1:" .. port
+  local url = "http://bench.invalid/"
+
+  return {
+    {
+      name = "stream_lines_iterate",
+      fn = function(_: any): any
+        local res = fetch.stream(url, {proxy = proxy})
+        if not res.ok then
+          return {count = -1, last = tostring(res.error)}
+        end
+        local reader = res.reader
+        local count = 0
+        local last: string = nil
+        for line in reader:lines() do
+          count = count + 1
+          last = line
+        end
+        reader:close()
+        local stats: LineStats = {count = count, last = last}
+        return stats
+      end,
+      check = function(_: any, result: any): boolean, string
+        local s = result as LineStats
+        if s == nil then
+          return false, "no result"
+        end
+        if s.count ~= NUM_LINES then
+          return false, "line count " .. tostring(s.count) ..
+          " != " .. tostring(NUM_LINES)
+        end
+        if s.last ~= LAST_LINE then
+          return false, "wrong last line: " .. tostring(s.last)
+        end
+        return true
+      end,
+    },
+  }
+end
+
+local function cleanup()
+  if server_pid and server_pid > 0 then
+    child.kill(server_pid, signal.SIGKILL)
+    child.wait(server_pid)
+    server_pid = nil
+  end
+  if listener then
+    listener:close()
+    listener = nil
+  end
+end
+
+local M: pt.BenchModule = {
+  scenarios = scenarios,
+  cleanup = cleanup,
+}
+
+return M


### PR DESCRIPTION
## What

Optimization rounds (per `lib/perf/OPTIMIZE.md`) for the two remaining items of #511:

- **P1 — `fetch.Reader:lines()` was O(n²).** The line iterator rebuilt its buffer on every line (`buffer = buffer:sub(newline_pos+1)`) and every chunk (`buffer = buffer .. chunk`), each re-copying the whole buffer. Now it tracks a scan-position index, advancing per line and dropping the consumed prefix only when it must read more — linear in body size. This is the path SSE clients drive.
- **P3 — `fuzzy.find_similar` ran the full DP for every candidate.** Added a length-difference gate: edit distance is at least the difference in string lengths, so a candidate whose length differs from the query by more than `max_distance` can never qualify and its O(n·m) Levenshtein DP is skipped.

Both are behavior-preserving: they only skip work that provably can't change the output. Existing `fetch_test` / `fuzzy_test` pass unchanged.

## Method

Neither path had a perf scenario, so per the harness guardrail I added scenarios first (own commit, no product change), baselined the unoptimized code, then applied each fix and re-compared. Each scenario has a functional `check()` pinning exact output, so a faster-but-wrong change fails the benchmark.

## Results (`bin/make perf-compare`, same machine, A/B of two local builds)

```
fuzzy_find_similar     1.37 ms ->  558.21 µs   -59.1%   faster
stream_lines_iterate  10.18 ms ->  824.71 µs   -91.9%   faster
  (alloc/op          31889 KB  ->     735 KB   ~43x less churn)

35 scenarios: 0 regression, 2 faster, 33 ok, 0 noise, 0 new, 0 missing, 0 error
```

`stream_lines_iterate` also shifts from cpu/wall 1.00 → 0.86: the O(n²) CPU cost is gone and the scenario is now transfer-bound rather than buffering-bound.

## Gates

- `bin/make ci` — format + teal + test + example, all pass (exit 0).
- `bin/make perf-compare` — no regression; both target scenarios improved well beyond their noise bars.

## Commits

1. `perf: add fuzzy match and streaming-lines scenarios` (no product code)
2. `fuzzy: gate find_similar on length difference before the DP`
3. `fetch: make Reader:lines() linear instead of O(n²)`

Addresses the P1 and P3 items of #511 (P2 landed in #512).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxbnedBTuwTtWTEYa3zhHk)_