### PR TITLE
fuzzy: gate find_similar on length difference before the DP (#511 P3)

### DIFF
--- a/lib/cosmic/fuzzy.tl
+++ b/lib/cosmic/fuzzy.tl
@@ -63,10 +63,16 @@ local function find_similar(query: string, candidates: {string}, max_distance?: 
     -- the same candidate (matching is already case-insensitive).
     local candidate_lower = candidate:lower()
     if not seen[candidate_lower] then
-      local dist = levenshtein(query_lower, candidate_lower)
-      if dist <= max_distance then
-        seen[candidate_lower] = true
-        table.insert(results, {candidate, dist})
+      -- Length-difference gate: the edit distance between two strings is at
+      -- least the difference in their lengths, so a candidate whose length
+      -- differs from the query by more than max_distance can never qualify.
+      -- Skipping it avoids the O(n*m) DP with no change to the result set.
+      if math.abs(#query_lower - #candidate_lower) <= max_distance then
+        local dist = levenshtein(query_lower, candidate_lower)
+        if dist <= max_distance then
+          seen[candidate_lower] = true
+          table.insert(results, {candidate, dist})
+        end
       end
     end
   end

--- a/lib/perf/bench/fuzzy_bench.tl
+++ b/lib/perf/bench/fuzzy_bench.tl
@@ -1,0 +1,62 @@
+--- Fuzzy-matching scenarios: cosmic.fuzzy.find_similar over a namespace.
+--- Models a "did you mean?" / autocomplete lookup: one short query matched
+--- against a large candidate set. The check pins the exact match set so a
+--- faster-but-wrong matcher (e.g. one that wrongly prunes candidates) fails
+--- instead of winning.
+
+local fuzzy = require("cosmic.fuzzy")
+local pt = require("perf.perf_types")
+
+local QUERY = "instal"
+
+--- Build a candidate namespace with one true match and a mix of non-matches.
+--- Half the non-matches share the query's length (6) so they run the full
+--- edit-distance DP; the other half are much longer, the case a
+--- length-difference gate can reject without the DP. None of the decoys are
+--- within edit distance 3 of the query, so the match set is exactly
+--- {"install"} regardless of any such gate.
+--- @return {string} The candidate list
+local function build_candidates(): {string}
+  local c: {string} = {"install"}
+  for i = 1, 128 do
+    -- length 6, same as the query, content-far: not gated, no match.
+    c[#c + 1] = string.format("qx%04d", i)
+    -- length 11, far from the query length: a length gate can skip these.
+    c[#c + 1] = string.format("symbol_%04d", i)
+  end
+  return c
+end
+
+local CANDIDATES = build_candidates()
+
+local function scenarios(): {pt.Scenario}, string
+  return {
+    {
+      name = "fuzzy_find_similar",
+      fn = function(_: any): any
+        return fuzzy.find_similar(QUERY, CANDIDATES)
+      end,
+      check = function(_: any, res: any): boolean, string
+        local names = res as {string}
+        if names == nil or #names ~= 1 then
+          return false, "expected exactly one match, got " ..
+          tostring(names and #names)
+        end
+        if names[1] ~= "install" then
+          return false, "wrong match: " .. tostring(names[1])
+        end
+        return true
+      end,
+    },
+  }
+end
+
+local function cleanup()
+end
+
+local M: pt.BenchModule = {
+  scenarios = scenarios,
+  cleanup = cleanup,
+}
+
+return M


### PR DESCRIPTION
## What

Fixes the **P3** item of #511: `fuzzy.find_similar` ran the full O(n·m) Levenshtein DP for every candidate.

Added a length-difference gate: edit distance is at least the difference in string lengths, so a candidate whose length differs from the query by more than `max_distance` can never qualify — skip the DP for it. The result set is unchanged (only provably-too-far candidates are skipped). `fuzzy_test` passes unchanged.

## Method

The path had no perf coverage, so per the harness guardrail I added a scenario first (own commit, no product change), baselined the unoptimized code, then applied the fix and compared. `fuzzy_find_similar` runs the matcher over a 257-entry namespace (a short query vs a mix of length-close and length-far decoys), with a `check()` pinning the exact match set.

## Result (`bin/make perf-compare`, A/B of two local builds)

```
fuzzy_find_similar   1.37 ms ->  558.21 µs   -59.1%   faster
```

No regression in any of the other 34 scenarios.

## Gates

- `bin/make ci` — pass (exit 0).
- `bin/make perf-compare` — 0 regressions; target scenario improved far beyond its noise bar.

Split out from #514 (was bundled with the unrelated fetch change, now #515).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxbnedBTuwTtWTEYa3zhHk)_