### PR TITLE
sys: translate host_os() XNU/METAL tokens to documented names

### DIFF
--- a/lib/cosmic/sys.tl
+++ b/lib/cosmic/sys.tl
@@ -20,11 +20,48 @@ local record Uname
   domainname: string
 end
 
+--- Operating system name as reported by `host_os`.
+--- These are the normalized cosmic names, not the raw cosmopolitan tokens:
+--- macOS reports as "macos" (the C layer returns "XNU"), and bare-metal as
+--- "metal".
+local enum HostOs
+  "linux"
+  "macos"
+  "windows"
+  "freebsd"
+  "openbsd"
+  "netbsd"
+  "metal"
+end
+
+-- Cosmopolitan's GetHostOs() returns tokens that do not all match the names
+-- cosmic documents ("XNU" vs "macos"). Translate in the wrapper so callers
+-- compare against a single, stable vocabulary across the six fat-binary OSes.
+local host_os_names: {string: HostOs} = {
+  linux = "linux",
+  xnu = "macos",
+  windows = "windows",
+  freebsd = "freebsd",
+  openbsd = "openbsd",
+  netbsd = "netbsd",
+  metal = "metal",
+}
+
+--- Normalize a raw cosmopolitan OS token (e.g. "XNU", "Linux") to a HostOs.
+--- Unknown tokens are passed through lowercased.
+--- @param raw string The raw OS token from cosmo.GetHostOs()
+--- @return HostOs The normalized operating system name
+local function normalize_host_os(raw: string): HostOs
+  local lowered = raw:lower()
+  return host_os_names[lowered] or (lowered as HostOs)
+end
+
 --- Get the operating system name.
---- Returns lowercase strings: "linux", "macos", "windows", "freebsd", "openbsd", "netbsd".
---- @return string The operating system name
-local function host_os(): string
-  return cosmo.GetHostOs():lower()
+--- Returns one of: "linux", "macos", "windows", "freebsd", "openbsd",
+--- "netbsd", "metal".
+--- @return HostOs The operating system name
+local function host_os(): HostOs
+  return normalize_host_os(cosmo.GetHostOs())
 end
 
 --- Get the CPU architecture (instruction set architecture).
@@ -100,7 +137,8 @@ local record SysModule
   SC_NPROCESSORS_CONF: number
   SC_NPROCESSORS_ONLN: number
 
-  host_os: function(): string
+  host_os: function(): HostOs
+  normalize_host_os: function(raw: string): HostOs
   host_isa: function(): string
   platform: function(): string
   sysconf: function(name: number): number, string
@@ -120,6 +158,7 @@ local M: SysModule = {
   SC_NPROCESSORS_ONLN = unix.SC_NPROCESSORS_ONLN,
 
   host_os = host_os,
+  normalize_host_os = normalize_host_os,
   host_isa = host_isa,
   platform = platform,
   sysconf = sysconf,

--- a/lib/cosmic/sys_test.tl
+++ b/lib/cosmic/sys_test.tl
@@ -11,7 +11,7 @@ end
 test_host_os_returns_string()
 
 local function test_host_os_is_lowercase()
-  local os_name = sys.host_os()
+  local os_name = sys.host_os() as string
   assert(os_name == os_name:lower(), "host_os should return lowercase, got " .. os_name)
 end
 test_host_os_is_lowercase()
@@ -20,9 +20,40 @@ local function test_host_os_is_known_value()
   local os_name = sys.host_os()
   local is_known = os_name == "linux" or os_name == "macos" or os_name == "windows"
   or os_name == "freebsd" or os_name == "openbsd" or os_name == "netbsd"
+  or os_name == "metal"
   assert(is_known, "host_os should return a known OS, got " .. os_name)
 end
 test_host_os_is_known_value()
+
+local function test_host_os_never_returns_raw_token()
+  -- The raw cosmopolitan token for macOS is "XNU"; host_os() must never
+  -- leak it (docs promise "macos"). Same for any lowercased raw form.
+  local os_name = sys.host_os() as string
+  assert(os_name ~= "xnu", "host_os must translate XNU to macos, got " .. os_name)
+end
+test_host_os_never_returns_raw_token()
+
+local function test_normalize_host_os_mapping()
+  -- Table-driven: the wrapper translates the raw cosmo.GetHostOs() tokens
+  -- to the documented names. XNU -> macos is the load-bearing case.
+  local cases: {{string, string}} = {
+    {"LINUX", "linux"},
+    {"XNU", "macos"},
+    {"Xnu", "macos"},
+    {"WINDOWS", "windows"},
+    {"FREEBSD", "freebsd"},
+    {"OPENBSD", "openbsd"},
+    {"NETBSD", "netbsd"},
+    {"METAL", "metal"},
+  }
+  for _, case in ipairs(cases) do
+    local raw, want = case[1], case[2]
+    local got = sys.normalize_host_os(raw) as string
+    assert(got == want,
+      "normalize_host_os(" .. raw .. ") should be " .. want .. ", got " .. tostring(got))
+  end
+end
+test_normalize_host_os_mapping()
 
 -- host_isa tests
 


### PR DESCRIPTION
## Problem

`sys.host_os()` documents that it returns `"linux"|"macos"|"windows"|"freebsd"|"openbsd"|"netbsd"`, but it returned `cosmo.GetHostOs():lower()` verbatim. The C layer returns `"XNU"` for macOS (and `"METAL"` for bare metal), so on macOS `host_os()` returned `"xnu"` and every `== "macos"` check silently failed — on one of the six OSes the fat binary targets.

## Change

- Add a `HostOs` enum (`linux`/`macos`/`windows`/`freebsd`/`openbsd`/`netbsd`/`metal`).
- Translate raw cosmopolitan tokens in the wrapper: `XNU → macos`, `METAL → metal`, everything else lowercased through.
- `host_os()` now returns `HostOs`.
- Expose `normalize_host_os(raw)` so the mapping is table-testable without a real macOS host.

## Tests (`sys_test.tl`)

- Membership assertion updated to include `metal`.
- `test_host_os_never_returns_raw_token` — asserts `host_os()` never yields `"xnu"`.
- `test_normalize_host_os_mapping` — table-driven over every raw token, pinning `XNU → macos`.

`bin/make teal`, `bin/make test only=sys`, `format`, and `lint` all pass.

This is one of five independent P0 fixes from whilp/cosmic#526 (item 3), shipped as its own non-stacking PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_016WqbGrYuTQ58Rcpu82pwZh)_