### PR TITLE
sqlite: roll back db:transaction when the body signals failure

### DIFF
--- a/lib/cosmic/sqlite.tl
+++ b/lib/cosmic/sqlite.tl
@@ -424,18 +424,22 @@ local function make_database(raw_db: RawDatabase): Database
     return first
   end
 
-  --- Execute fn within a transaction. Calls BEGIN before fn, COMMIT after
-  --- fn returns, and ROLLBACK if fn raises an error.
-  --- Returns true on success, or false and an error message on failure.
+  --- Execute fn within a transaction. BEGIN before fn; COMMIT if fn returns
+  --- cleanly; ROLLBACK if fn raises OR signals failure the library way -- a
+  --- returned `false`, or `nil` plus an error (nothing returned still commits).
   function db:transaction(fn: function(Database)): boolean, string
     local ok, err = self:exec("BEGIN IMMEDIATE")
     if not ok then
       return false, err or "begin failed"
     end
-    local success, call_err = pcall(fn, self) as(boolean, string)
+    local success, result, result_err = pcall(fn, self) as(boolean, any, any)
     if not success then
       self:exec("ROLLBACK")
-      return false, call_err or "transaction failed"
+      return false, (result as string) or "transaction failed"
+    end
+    if result == false or (result == nil and result_err ~= nil) then
+      self:exec("ROLLBACK")
+      return false, (result_err as string) or "transaction rolled back"
     end
     return self:exec("COMMIT")
   end

--- a/lib/cosmic/sqlite_advanced_test.tl
+++ b/lib/cosmic/sqlite_advanced_test.tl
@@ -233,6 +233,71 @@ local function test_transaction_multiple_ops()
 end
 test_transaction_multiple_ops()
 
+local function test_transaction_rollback_on_false()
+  -- A body that returns `false, err` (the library's own failure convention)
+  -- must roll back. Before the fix, transaction() discarded the returned
+  -- error and COMMITted, leaving the row behind.
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+
+  local body: function(sqlite.Database): (boolean, string) = function(d: sqlite.Database): (boolean, string)
+    d:exec("INSERT INTO t (name) VALUES (?)", "doomed")
+    return false, "boom"
+  end
+  local ok, err = db:transaction(body)
+  assert(ok == false, "should report failure, got ok=" .. tostring(ok))
+  assert(err == "boom", "should surface the body error, got " .. tostring(err))
+
+  local count = 0
+  for _ in db:query("SELECT * FROM t") do
+    count = count + 1
+  end
+  assert(count == 0, "row must roll back when body returns false, got " .. tostring(count))
+  db:close()
+end
+test_transaction_rollback_on_false()
+
+local function test_transaction_rollback_on_nil_err()
+  -- `nil, err` is the same failure convention and must also roll back.
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+
+  local body: function(sqlite.Database): (boolean, string) = function(d: sqlite.Database): (boolean, string)
+    d:exec("INSERT INTO t (name) VALUES (?)", "doomed")
+    return nil, "nope"
+  end
+  local ok, err = db:transaction(body)
+  assert(ok == false, "should report failure, got ok=" .. tostring(ok))
+  assert(err == "nope", "should surface the body error, got " .. tostring(err))
+
+  local count = 0
+  for _ in db:query("SELECT * FROM t") do
+    count = count + 1
+  end
+  assert(count == 0, "row must roll back when body returns nil, err, got " .. tostring(count))
+  db:close()
+end
+test_transaction_rollback_on_nil_err()
+
+local function test_transaction_commits_on_no_return()
+  -- A body that returns nothing (the common case) still commits.
+  local db = sqlite.open(":memory:")
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+
+  local ok, err = db:transaction(function(d: sqlite.Database)
+      d:exec("INSERT INTO t (name) VALUES (?)", "kept")
+    end)
+  assert(ok, "should commit when body returns nothing: " .. tostring(err))
+
+  local count = 0
+  for _ in db:query("SELECT * FROM t") do
+    count = count + 1
+  end
+  assert(count == 1, "row must commit when body returns nothing, got " .. tostring(count))
+  db:close()
+end
+test_transaction_commits_on_no_return()
+
 -- Named parameters
 
 local function test_bind_named()


### PR DESCRIPTION
## Problem

`db:transaction` only rolled back when the body **threw**. A body that signaled failure the library way — `return false, "boom"` or `return nil, err` — had its return value discarded, and `transaction()` returned `true, nil` while the write was **COMMITted**. Verified: `d:exec("INSERT ...") return false, "boom"` left the row behind.

## Change

After `pcall(fn, self)`, inspect the body's return values:
- fn **raised** → ROLLBACK (unchanged).
- fn returned literal `false`, or `nil` with a second error value → ROLLBACK, surfacing that error.
- fn returned nothing (the common case) → COMMIT.

The `fn` parameter type stays `function(Database)` rather than the issue's `function(Database): boolean, string`: Teal enforces exact return arity, so a strict 2-return type would reject every zero-return body — including the `commits_on_no_return` case the issue itself requires. The returns are inspected at runtime instead; a value-returning body is passed via a typed local (a `function(D): (boolean, string)` value is assignable to the `function(D)` param).

## Tests (`sqlite_advanced_test.tl`)

- `test_transaction_rollback_on_false` — `false, "boom"` → returns `false, "boom"`, `count(*) == 0`.
- `test_transaction_rollback_on_nil_err` — `nil, "nope"` → rolls back.
- `test_transaction_commits_on_no_return` — body returning nothing still commits.

Placed in `sqlite_advanced_test.tl` (which already houses the transaction tests) because `sqlite_test.tl` is already at the hard 500-line cap.

`teal`, `test only=sqlite`, `format`, and `lint` all pass.

One of five independent P0 fixes from whilp/cosmic#526 (item 2), shipped as its own non-stacking PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_016WqbGrYuTQ58Rcpu82pwZh)_