### PR TITLE
net: suppress SIGPIPE on Socket:send/sendto

### DIFF
--- a/lib/cosmic/net_socket.tl
+++ b/lib/cosmic/net_socket.tl
@@ -77,9 +77,13 @@ local function make_socket(fd: number): Socket
     return true
   end
 
+  -- Always suppress SIGPIPE on writes: a peer that disconnects mid-response
+  -- would otherwise kill the whole process (exit 141) instead of returning an
+  -- EPIPE error the caller can handle. cosmo maps MSG_NOSIGNAL to the native
+  -- per-OS flag, so ORing it in is portable.
   function sock:send(data: string, flags?: number): number, string
     if not self.fd then return nil, "socket closed" end
-    local n = unix.send(self.fd, data, flags or 0)
+    local n = unix.send(self.fd, data, (flags or 0) | unix.MSG_NOSIGNAL)
     if not n then
       return nil, "send failed"
     end
@@ -88,7 +92,7 @@ local function make_socket(fd: number): Socket
 
   function sock:sendto(data: string, ip: number, port: number, flags?: number): number, string
     if not self.fd then return nil, "socket closed" end
-    local n = unix.sendto(self.fd, data, ip, port, flags or 0)
+    local n = unix.sendto(self.fd, data, ip, port, (flags or 0) | unix.MSG_NOSIGNAL)
     if not n then
       return nil, "sendto failed"
     end

--- a/lib/cosmic/net_test.tl
+++ b/lib/cosmic/net_test.tl
@@ -33,6 +33,28 @@ local function test_socketpair()
 end
 test_socketpair()
 
+local function test_send_to_closed_peer_returns_error()
+  -- Regression: sending to a peer that has closed must return nil, err --
+  -- NOT kill the process with SIGPIPE (which surfaces as exit 141, an
+  -- unambiguous red before send() ORed in MSG_NOSIGNAL).
+  local a, b, err = net.socketpair()
+  assert(a ~= nil and b ~= nil, "socketpair failed: " .. tostring(err))
+  b:close()
+
+  -- Loop so a kernel that accepts the first write into the buffer before
+  -- reporting EPIPE still exercises the error path; without the fix the
+  -- first EPIPE-triggering write signals SIGPIPE and the test never returns.
+  local n, serr: number, string
+  for _ = 1, 1000 do
+    n, serr = a:send("data")
+    if n == nil then break end
+  end
+  assert(n == nil, "send to closed peer should return nil, got " .. tostring(n))
+  assert(serr ~= nil, "send to closed peer should return an error message")
+  a:close()
+end
+test_send_to_closed_peer_returns_error()
+
 local function test_bind_and_getsockname()
   local sock, err = net.socket()
   assert(sock ~= nil, "socket creation failed: " .. tostring(err))


### PR DESCRIPTION
## Problem

`Socket:send`/`sendto` passed `flags or 0` straight to `unix.send`/`sendto` with nothing to inhibit SIGPIPE. When a peer disconnected mid-response, the write raised SIGPIPE and killed the entire process (exit 141) instead of returning an error — so any server whose client dropped mid-response died.

## Change

`send`/`sendto` now OR `unix.MSG_NOSIGNAL` into the flags on every call. Cosmopolitan maps `MSG_NOSIGNAL` to the native per-OS flag, so the broken-pipe condition surfaces as `nil, "send failed"` (EPIPE) rather than a fatal signal.

**Note on macOS/`SO_NOSIGPIPE`:** the issue also suggested setting `SO_NOSIGPIPE` in `make_socket` for platforms where `MSG_NOSIGNAL` maps to 0. That constant isn't part of the `cosmo.unix` binding surface, so wiring it up would require a coordinated `definitions.lua` change + cosmos release on the cosmopolitan side — out of scope for a cosmic-only PR. `MSG_NOSIGNAL` is the portable mechanism here and fully covers the Linux CI reproducer.

## Test (`net_test.tl`)

`test_send_to_closed_peer_returns_error` — socketpair, close the peer, then assert `a:send("data")` returns `nil, err`. Before the fix this test process exited 141 (unambiguous red); it now returns cleanly. A bounded send loop makes the error path deterministic regardless of buffer timing.

`teal`, `test only=net`, `format`, and `lint` all pass.

One of five independent P0 fixes from whilp/cosmic#526 (item 1), shipped as its own non-stacking PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_016WqbGrYuTQ58Rcpu82pwZh)_