### PR TITLE
quicksand: derive unveil capability instead of a destructive probe

### DIFF
--- a/lib/cosmic/quicksand/init.tl
+++ b/lib/cosmic/quicksand/init.tl
@@ -85,7 +85,9 @@ local cached: Capabilities = nil
 --- Repeated calls return the same table.
 local function capabilities(): Capabilities
   if cached then return cached end
-  local is_linux = cosmo.GetHostOs() == "LINUX"
+  local host = cosmo.GetHostOs()
+  local is_linux = host == "LINUX"
+  local has_landlock = is_linux and probe_landlock()
   cached = {
     linux = is_linux,
     user_ns = is_linux and unix.CLONE_NEWUSER ~= nil,
@@ -95,9 +97,13 @@ local function capabilities(): Capabilities
     pid_ns = is_linux and unix.CLONE_NEWPID ~= nil,
     pivot_root = is_linux and unix.pivot_root ~= nil,
     cap_net_admin = is_linux and unix.geteuid ~= nil and unix.geteuid() == 0,
-    landlock = is_linux and probe_landlock(),
+    landlock = has_landlock,
     pledge = probe(unix.pledge),
-    unveil = probe(unix.unveil),
+    -- unveil is DERIVED, never probed: for unveil, unix.unveil(nil, nil) is
+    -- the commit call -- probing it would lock this very process into a
+    -- deny-all sandbox. cosmo implements unveil via Landlock on Linux, so it
+    -- is available exactly when Landlock is; OpenBSD has it natively.
+    unveil = has_landlock or host == "OPENBSD",
     caps = is_linux and caps.supported(),
   }
   return cached

--- a/lib/cosmic/quicksand/init_test.tl
+++ b/lib/cosmic/quicksand/init_test.tl
@@ -108,6 +108,39 @@ local function test_real_pledge_unveil_probe()
 end
 test_real_pledge_unveil_probe()
 
+local function test_capabilities_does_not_self_brick()
+  -- Regression: capabilities() must never invoke the destructive
+  -- unix.unveil(nil, nil) commit, which locks the calling process into a
+  -- deny-all sandbox. Prove ordinary filesystem IO still works afterward by
+  -- reading back a file written before the probe.
+  local tmp = os.getenv("TEST_TMPDIR") as string
+  local path = tmp .. "/unveil_probe_check"
+  local w = io.open(path, "w")
+  assert(w, "should create probe check file")
+  w:write("ok")
+  w:close()
+
+  quicksand.capabilities()
+
+  local f = io.open(path, "r")
+  assert(f ~= nil, "capabilities() must not sandbox the calling process")
+  if f then f:close() end
+end
+test_capabilities_does_not_self_brick()
+
+local function test_unveil_matches_landlock_on_linux()
+  -- On Linux, cosmo implements unveil via Landlock, so the derived unveil
+  -- capability must equal the landlock one (no independent, destructive probe).
+  local c = quicksand.capabilities()
+  if not c.linux then
+    a.skip("unveil/landlock equivalence: non-Linux host")
+    return
+  end
+  a.eq(c.unveil, c.landlock,
+    "on Linux unveil is derived from landlock and must equal it")
+end
+test_unveil_matches_landlock_on_linux()
+
 local function test_box_reexported()
   local J = quicksand.Box as {string: any}
   assert(J, "Box should be re-exported from cosmic.quicksand")


### PR DESCRIPTION
## Problem

`quicksand.capabilities()` probed unveil the same way it probes pledge: `probe(unix.unveil)`, which calls `unix.unveil(nil, nil)`. But for unveil, `unveil(NULL, NULL)` **is the commit operation** — on any Landlock kernel it locks the *calling* process into a deny-all sandbox (plus seccomp). Because `Box:run → preflight → caps()`, every Box user self-bricked before the fork (surfacing as exit 126, tolerated as a skip). On Landlock-less Linux it silently succeeded and reported `unveil = true` next to `landlock = false`.

## Change

Derive `unveil` non-destructively instead of probing it:
- Linux: cosmo implements unveil via Landlock, so `unveil == landlock`.
- OpenBSD: native syscall, always `true`.
- Elsewhere: `false`.

No syscall, no side effect. The generic `probe()` (still used for pledge, and unit-tested against synthetic returns) is unchanged.

## Tests (`init_test.tl`)

- `test_capabilities_does_not_self_brick` — writes a temp file, calls `capabilities()`, then asserts the file is still readable (a deny-all unveil commit would block it).
- `test_unveil_matches_landlock_on_linux` — asserts `c.unveil == c.landlock` on Linux.

`teal`, `test only=quicksand` (13 checks), `format`, and `lint` all pass.

One of five independent P0 fixes from whilp/cosmic#526 (item 4), shipped as its own non-stacking PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_016WqbGrYuTQ58Rcpu82pwZh)_