### PR TITLE
child: stop mutating caller argv and make spawn pipes CLOEXEC

### DIFF
--- a/lib/cosmic/child.tl
+++ b/lib/cosmic/child.tl
@@ -154,8 +154,12 @@ end
 local function spawn(argv: {string}, opts?: Opts): Handle, string
   opts = opts or {}
 
-  -- Handle /zip/ paths: open zip fd for fexecve
+  -- Resolve the executable into a LOCAL, never by mutating the caller's
+  -- argv table: a PATH search wrote the resolved path back into argv[1],
+  -- corrupting the caller's own table. argv is passed to exec unchanged, so
+  -- argv[0] stays the name the caller gave.
   local exec_fd: number
+  local prog = argv[1]
   if is_zip_path(argv[1]) then
     local fd, err = prepare_zip_exec(argv[1])
     if not fd then
@@ -167,7 +171,7 @@ local function spawn(argv: {string}, opts?: Opts): Handle, string
     if not cmd then
       return nil, "command not found: " .. argv[1]
     end
-    argv[1] = cmd
+    prog = cmd
   end
 
   -- Track every fd we open so a mid-way pipe() failure (fd exhaustion) can be
@@ -179,8 +183,14 @@ local function spawn(argv: {string}, opts?: Opts): Handle, string
     if exec_fd then unix.close(exec_fd) end
     return nil, msg
   end
+  -- Create pipes CLOEXEC so their ends do not leak into an unrelated child
+  -- spawned while this handle is still open: otherwise child B inherits child
+  -- A's pipe ends and A never sees stdin EOF until B exits (communicate()
+  -- hangs on overlap). The child's own dup2 onto 0/1/2 clears CLOEXEC on the
+  -- ends it keeps; the ends that happen to already be fd 0/1/2 are cleared
+  -- explicitly below.
   local function new_pipe(): number, number
-    local r, w = unix.pipe()
+    local r, w = unix.pipe(unix.O_CLOEXEC)
     if r == nil or w == nil then
       return nil, nil
     end
@@ -229,7 +239,9 @@ local function spawn(argv: {string}, opts?: Opts): Handle, string
         unix.dup(stdin_r, 0)
         unix.close(stdin_r)
       else
-        -- stdin_r == 0: dup2(0, 0) is fine, just close the write end
+        -- stdin_r == 0: no dup2 to clear CLOEXEC, so clear it directly or
+        -- fd 0 would close on execve; then just close the write end.
+        unix.fcntl(0, unix.F_SETFD, 0)
         unix.close(stdin_w)
       end
     end
@@ -245,7 +257,8 @@ local function spawn(argv: {string}, opts?: Opts): Handle, string
         unix.dup(stdout_w, 1)
         unix.close(stdout_w)
       else
-        -- stdout_w == 1: dup2(1, 1) is fine, just close the read end
+        -- stdout_w == 1: no dup2 to clear CLOEXEC, so clear it directly.
+        unix.fcntl(1, unix.F_SETFD, 0)
         unix.close(stdout_r)
       end
     end
@@ -261,7 +274,8 @@ local function spawn(argv: {string}, opts?: Opts): Handle, string
         unix.dup(stderr_w, 2)
         unix.close(stderr_w)
       else
-        -- stderr_w == 2: dup2(2, 2) is fine, just close the read end
+        -- stderr_w == 2: no dup2 to clear CLOEXEC, so clear it directly.
+        unix.fcntl(2, unix.F_SETFD, 0)
         unix.close(stderr_r)
       end
     end
@@ -277,7 +291,7 @@ local function spawn(argv: {string}, opts?: Opts): Handle, string
     if exec_fd then
       unix.fexecve(exec_fd, argv, env)
     else
-      unix.execve(argv[1], argv, env)
+      unix.execve(prog, argv, env)
     end
     os.exit(127)
   end

--- a/lib/cosmic/child_test.tl
+++ b/lib/cosmic/child_test.tl
@@ -438,3 +438,46 @@ local function test_spawn_many_captures_correct()
   end
 end
 test_spawn_many_captures_correct()
+
+-- FIX (#526 item 5): spawn must not mutate the caller's argv, and its pipes
+-- must be CLOEXEC so overlapping children don't inherit each other's ends.
+
+local function test_spawn_does_not_mutate_argv()
+  -- A PATH search wrote the resolved path back into argv[1], corrupting the
+  -- caller's own table. The resolution must go into a local instead.
+  local argv = {"echo", "x"}
+  local handle = child.spawn(argv)
+  assert(handle ~= nil, "spawn should succeed")
+  handle:wait()
+  assert(argv[1] == "echo",
+    "spawn must not mutate caller's argv[1], got '" .. tostring(argv[1]) .. "'")
+end
+test_spawn_does_not_mutate_argv()
+
+local function test_spawn_overlap_no_stdin_leak()
+  -- Non-CLOEXEC pipes let a later child inherit an earlier child's stdin
+  -- write end, so the earlier child never saw EOF until the later one exited
+  -- and communicate() hung on overlap. Spawn A (reads stdin to EOF), then a
+  -- long-lived B; with CLOEXEC pipes A gets EOF immediately once the parent
+  -- closes its write end, so it finishes without waiting on B.
+  local a = child.spawn({lua_bin, "-e", "io.write(io.read('*a') or '')"},
+    {stdin = "hello"})
+  assert(a ~= nil, "spawn A should succeed")
+  local b = child.spawn({lua_bin, "-e", "require('cosmic.time').sleep(10)"})
+  assert(b ~= nil, "spawn B should succeed")
+
+  local s0, n0 = time.monotonic()
+  local out, _, code = a:communicate()
+  local s1, n1 = time.monotonic()
+  local elapsed = (s1 - s0) + (n1 - n0) / 1e9
+
+  assert(code == 0, "A should exit 0, got " .. tostring(code))
+  assert(out == "hello", "A should echo its stdin, got '" .. tostring(out) .. "'")
+  assert(elapsed < 3,
+    "A must finish promptly, not block on B's lifetime (took "
+    .. tostring(elapsed) .. "s)")
+
+  child.kill(b.pid, child.SIGKILL)
+  b:wait()
+end
+test_spawn_overlap_no_stdin_leak()


### PR DESCRIPTION
## Problem

Two independent `child.spawn` hygiene bugs:

1. **argv mutation** — a PATH search did `argv[1] = cmd`, writing the resolved absolute path (e.g. `/usr/bin/echo`) back into the caller's own `argv` table. After `spawn({"echo","hi"})` the caller's `argv[1]` was silently changed to `/usr/bin/echo`.
2. **non-CLOEXEC pipes** — `new_pipe()` used `unix.pipe()` with no `O_CLOEXEC`. Spawning child B while a handle to child A was still open let B inherit A's pipe ends, so A never saw stdin EOF until B exited — `communicate()` hung whenever two children overlapped.

## Change

- Resolve the executable into a local `prog` and `execve(prog, argv, env)`; `argv` is passed through untouched, so `argv[0]` stays the name the caller gave.
- Create pipes with `unix.pipe(unix.O_CLOEXEC)`. The child's `dup2` onto fd 0/1/2 clears CLOEXEC on the ends it keeps; the rare branches where a pipe end already sits on fd 0/1/2 (no `dup2` to clear it) now clear CLOEXEC explicitly with `fcntl(fd, F_SETFD, 0)`, so those std fds still survive `execve`.

## Tests (`child_test.tl`)

- `test_spawn_does_not_mutate_argv` — `spawn({"echo","x"}):wait()`, then assert `argv[1] == "echo"`.
- `test_spawn_overlap_no_stdin_leak` — spawn A (reads stdin to EOF), then a long-lived B, then `a:communicate()` and assert it finishes in well under B's lifetime. Without CLOEXEC, A would block until B exits.

`teal`, `test only=child`, `format`, and `lint` all pass.

One of five independent P0 fixes from whilp/cosmic#526 (item 5), shipped as its own non-stacking PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_016WqbGrYuTQ58Rcpu82pwZh)_