### PR TITLE
cosmos: bump pin to 2026.07.06-dfdf61ac4; migrate to string+errno errors

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "92e5c888bff5ab0322b46814da375fd60f461577c546abee32e83f3e41a9e55f"}},
+  platforms = {["*"] = {sha = "0dff1ea827204743b5ad44ab836b7b2af9d610daf76324e1d371ee5d44e19426"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.05-ebed15817"
+  version = "2026.07.06-dfdf61ac4"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,8 +132,10 @@ end
 - **Fallible effect**: `boolean, string` (returns `false, msg` on failure).
 - **Infallible**: bare value.
 
-Errors are strings from `errno.str`; `unix.Errno` never crosses the cosmic
-boundary. Because Teal (0.24.8) does not flow-narrow record or map unions, a
+Errors are strings: failed `cosmo.unix` calls return `nil, err, errno` (a
+formatted string plus the numeric errno), wrappers add context with
+`errno.str(err, prefix)`, and branch on the numeric errno via
+`errno.is(errno_value, "EINTR")`. Because Teal (0.24.8) does not flow-narrow record or map unions, a
 caller that has ruled out `nil` casts at the use site — `(x as Rec).field`,
 `(x as {K:V})[k]` — mirroring `lib/cosmic/embed.tl`. Scalars (`string | nil`)
 narrow, except method-call syntax: use `string.sub(x, …)` not `x:sub(…)` on a

--- a/lib/build/build-fetch.tl
+++ b/lib/build/build-fetch.tl
@@ -1,8 +1,8 @@
 #!/usr/bin/env lua
 -- ast-grep ignore: builds relative symlink paths
-local cio = require("cosmic.io")
 local fs = require("cosmic.fs")
 local hash = require("cosmic.hash")
+local portable = require("build.portable")
 local proc = require("cosmic.proc")
 local fetch = require("cosmic.fetch")
 
@@ -138,7 +138,7 @@ local function main(version_file: string, platform: string, output: string): boo
 
   fs.makedirs(archive_dir)
 
-  local barf_ok, barf_err = cio.barf(archive_path, body, tonumber("644", 8))
+  local barf_ok, barf_err = portable.write_file(archive_path, body, tonumber("644", 8))
   if not barf_ok then
     return nil, "failed to write " .. archive_path .. ": " .. (barf_err or "unknown error")
   end

--- a/lib/build/build-stage.tl
+++ b/lib/build/build-stage.tl
@@ -5,6 +5,7 @@
 local cio = require("cosmic.io")
 local fs = require("cosmic.fs")
 local fs_types = require("cosmic.fs_types")
+local portable = require("build.portable")
 local proc = require("cosmic.proc")
 local spawn = require("cosmic.child")
 
@@ -36,6 +37,10 @@ local function move_contents(source_dir: string, dest_dir: string): boolean, str
     if name ~= "." and name ~= ".." then
       local src = fs.join(source_dir, name)
       local dst = fs.join(dest_dir, name)
+      -- rename() cannot replace a non-empty directory, so a restage over a
+      -- stale destination (e.g. after the build tooling itself changed and
+      -- invalidated .staged) must clear the old entry first.
+      fs.rmrf(dst)
       local ok, err = fs.rename(src, dst)
       if not ok then
         return nil, "failed to move " .. src .. " to " .. dst .. ": " .. (err or "unknown error")
@@ -114,7 +119,7 @@ local function copy_binary(archive: string, dest_dir: string, module_name: strin
   if not content then
     return nil, "failed to open " .. archive .. ": " .. (read_err or "unknown error")
   end
-  local ok, write_err = cio.barf(dest, content, tonumber("755", 8))
+  local ok, write_err = portable.write_file(dest, content, tonumber("755", 8))
   if not ok then
     return nil, "failed to create " .. dest .. ": " .. (write_err or "unknown error")
   end
@@ -130,7 +135,7 @@ local function extract_gz(archive: string, dest_dir: string, module_name: string
   if not exit_code then
     return nil, "gunzip failed: " .. tostring(content)
   end
-  local ok, write_err = cio.barf(dest, content, tonumber("755", 8))
+  local ok, write_err = portable.write_file(dest, content, tonumber("755", 8))
   if not ok then
     return nil, "failed to create " .. dest .. ": " .. (write_err or "unknown error")
   end

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -2,10 +2,11 @@ modules += build
 build_lua_dirs := $(o)/lib/build
 build_fetch := $(o)/lib/build/build-fetch.lua
 build_stage := $(o)/lib/build/build-stage.lua
+build_portable := $(o)/lib/build/portable.lua
 build_reporter := $(o)/lib/build/reporter.lua
 build_help := $(o)/lib/build/make-help.lua
 build_lint := $(o)/lib/build/lint.lua
-build_files := $(build_fetch) $(build_stage) $(build_reporter) $(build_help) $(build_lint)
+build_files := $(build_fetch) $(build_stage) $(build_portable) $(build_reporter) $(build_help) $(build_lint)
 build_tests := $(wildcard lib/build/*_test.tl)
 
 reporter := $(bootstrap_cosmic) -- $(build_reporter)

--- a/lib/build/portable.tl
+++ b/lib/build/portable.tl
@@ -1,0 +1,43 @@
+--- Bootstrap-portable file writing for the build tooling.
+---
+--- lib/build's fetch/stage pipeline runs under the pinned BOOTSTRAP cosmic
+--- binary (an older runtime) while the modules it requires are compiled
+--- from the current tree, which targets the current cosmos pin. Anything
+--- on this path must therefore survive BOTH runtimes. `cosmo.Barf`'s third
+--- argument changed from a positional mode to an options table across the
+--- 2026.07 error-convention release, which made `cosmic.io.barf` crash the
+--- fetch step under the old bootstrap; writing through signature-stable
+--- `cosmo.unix` primitives instead keeps the pipeline working no matter
+--- which side of a binding change the hosting binary is on. Errors are
+--- stringified with tostring, which renders both the old `unix.Errno`
+--- userdata and the new error strings.
+local unix = require("cosmo.unix")
+
+--- Write data to a file (create or truncate), bootstrap-portably.
+--- @param path string destination path
+--- @param data string bytes to write
+--- @param mode integer? file mode for a newly created file (default 0644)
+--- @return boolean success
+--- @return string? error
+local function write_file(path: string, data: string, mode?: integer): boolean, string
+  local fd, oerr = unix.open(path, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC,
+    mode or tonumber("644", 8))
+  if not fd then
+    return false, "open " .. path .. ": " .. tostring(oerr)
+  end
+  local off: integer = 1
+  while off <= #data do
+    local n, werr = unix.write(fd, string.sub(data, off))
+    if not n or n <= 0 then
+      unix.close(fd)
+      return false, "write " .. path .. ": " .. tostring(werr)
+    end
+    off = off + math.tointeger(n)
+  end
+  unix.close(fd)
+  return true
+end
+
+return {
+  write_file = write_file,
+}

--- a/lib/build/portable_test.tl
+++ b/lib/build/portable_test.tl
@@ -1,0 +1,50 @@
+local portable = require("build.portable")
+local fs = require("cosmic.fs")
+local fs_types = require("cosmic.fs_types")
+local cio = require("cosmic.io")
+
+local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
+
+local function test_write_file_roundtrip()
+  local path = fs.join(tmpdir, "portable-roundtrip.txt")
+  local data = "hello\0binary\nworld"
+  local ok, err = portable.write_file(path, data)
+  assert(ok, "write failed: " .. tostring(err))
+  local got = cio.slurp(path)
+  assert(got == data, "content mismatch: " .. tostring(got))
+end
+test_write_file_roundtrip()
+
+local function test_write_file_truncates()
+  local path = fs.join(tmpdir, "portable-trunc.txt")
+  assert(portable.write_file(path, "a longer first write"))
+  assert(portable.write_file(path, "short"))
+  local got = cio.slurp(path)
+  assert(got == "short", "expected truncation, got: " .. tostring(got))
+end
+test_write_file_truncates()
+
+local function test_write_file_mode()
+  local path = fs.join(tmpdir, "portable-mode.bin")
+  assert(portable.write_file(path, "#!x", tonumber("755", 8)))
+  local st = fs.stat(path)
+  assert(st, "stat failed")
+  local perms = (st as fs_types.Stat):mode() & 511
+  assert(perms == tonumber("755", 8), "expected 0755, got " .. tostring(perms))
+end
+test_write_file_mode()
+
+local function test_write_file_empty()
+  local path = fs.join(tmpdir, "portable-empty.txt")
+  assert(portable.write_file(path, ""))
+  local got = cio.slurp(path)
+  assert(got == "", "expected empty file, got: " .. tostring(got))
+end
+test_write_file_empty()
+
+local function test_write_file_bad_path()
+  local ok, err = portable.write_file(fs.join(tmpdir, "no/such/dir/f"), "x")
+  assert(not ok, "expected failure for missing directory")
+  assert(err and err:find("open ", 1, true), "expected open error, got: " .. tostring(err))
+end
+test_write_file_bad_path()

--- a/lib/cosmic/child_io.tl
+++ b/lib/cosmic/child_io.tl
@@ -153,15 +153,15 @@ local function pump(stdout_fd: number, stderr_fd: number, stdin_fd: number, stdi
     if stdin_fd then
       local ev = p:events(stdin_fd) as {string: boolean}
       if ev and ev.writable then
-        local n, werr = unix.write(stdin_fd, stdin_data:sub(w_off + 1, w_off + CHUNK))
+        local n, werr, weno = unix.write(stdin_fd, stdin_data:sub(w_off + 1, w_off + CHUNK))
         if n ~= nil then
           w_off = w_off + (n as integer)
           if w_off >= #stdin_data then
             p:remove(stdin_fd); unix.close(stdin_fd); stdin_fd = nil
           end
-        elseif errno.is(werr, "EAGAIN") then
+        elseif errno.is(weno, "EAGAIN") then
           -- Not actually writable yet; try again on the next poll.
-        elseif errno.is(werr, "EPIPE") then
+        elseif errno.is(weno, "EPIPE") then
           -- The child stopped reading stdin; stop feeding it (not an error).
           p:remove(stdin_fd); unix.close(stdin_fd); stdin_fd = nil
         else

--- a/lib/cosmic/codec.tl
+++ b/lib/cosmic/codec.tl
@@ -16,20 +16,13 @@ end
 --- @return string | nil The decoded binary data, or nil on error
 --- @return string? Error message if decoding failed
 local function decode_hex(hex: string): string | nil, string
-  -- Validate length is even (O(1))
-  if #hex % 2 ~= 0 then
-    return nil, "hex string must have even length"
+  -- The binding validates the input (odd length, non-hex characters)
+  -- and reports bad data as nil, err; forward its error verbatim.
+  local result, err = cosmo.DecodeHex(hex)
+  if not result then
+    return nil, err as string
   end
-  -- Happy path is a single C call: with even length guaranteed above,
-  -- cosmo.DecodeHex raises only on an invalid hex character. Wrapping it
-  -- in pcall lets the valid case skip the full character-class scan of
-  -- the whole input; the scan's only remaining job (choosing the error
-  -- message) is unnecessary here since even length is already handled.
-  local ok, result = pcall(cosmo.DecodeHex, hex)
-  if not ok then
-    return nil, "invalid hex character"
-  end
-  return result as string, nil
+  return result
 end
 
 --- Encode a Lua value as Lua source code.
@@ -38,7 +31,7 @@ end
 --- @param opts {string:any}? Optional encoding options
 --- @return string The Lua source code representation
 local function encode_lua(value: any, opts?: {string: any}): string
-  return (cosmo.EncodeLua(value, opts))
+  return (cosmo.EncodeLua(value, opts as cosmo.EncoderOptions))
 end
 
 --- Decode Lua source code to a value with a restricted environment.
@@ -97,7 +90,9 @@ end
 --- @param data string The binary data to encode
 --- @return string The base32 encoded string
 local function encode_base32(data: string): string
-  return cosmo.EncodeBase32(data)
+  -- The binding is fallible only when a custom alphabet of invalid
+  -- length is supplied; with the default alphabet it cannot fail.
+  return (cosmo.EncodeBase32(data))
 end
 
 --- Decode a base32 string to binary data.
@@ -107,10 +102,18 @@ end
 --- @return string? Error message if decoding failed
 local function decode_base32(str: string): string | nil, string
   -- cosmo base32 alphabet: 0123456789abcdefghjkmnpqrstvwxyz (32 chars, no i,l,o,u)
+  -- The binding decodes permissively (it stops at the first character
+  -- outside the alphabet), so this strict validation is load-bearing.
   if str:match("[^0-9a-hj-km-np-tv-z]") then
     return nil, "invalid base32 character"
   end
-  return cosmo.DecodeBase32(str)
+  -- The binding is fallible only for custom alphabets of invalid
+  -- length; forward its error anyway rather than swallowing it.
+  local result, err = cosmo.DecodeBase32(str)
+  if not result then
+    return nil, err as string
+  end
+  return result
 end
 
 --- Encode a UTF-8 string as Latin-1 (ISO-8859-1).
@@ -119,6 +122,8 @@ end
 --- @return string | nil The Latin-1 encoded bytes, or nil on error
 --- @return string? Error message if encoding failed
 local function encode_latin1(str: string): string | nil, string
+  -- cosmo.EncodeLatin1 still raises on input it cannot re-encode
+  -- (its declared signature is a bare string), so the pcall stays.
   local ok, result = pcall(cosmo.EncodeLatin1, str)
   if not ok then
     return nil, "cannot encode to Latin-1: character out of range"

--- a/lib/cosmic/codec_test.tl
+++ b/lib/cosmic/codec_test.tl
@@ -48,7 +48,7 @@ local function test_decode_hex_odd_length()
   local result, err = codec.decode_hex("abc")
   assert(result == nil, "expected nil for odd length")
   assert(err ~= nil, "expected error message")
-  assert(err:match("even length"), "error should mention even length")
+  assert(err:match("uneven"), "error should mention uneven length, got: " .. err)
 end
 test_decode_hex_odd_length()
 
@@ -56,7 +56,7 @@ local function test_decode_hex_invalid_char()
   local result, err = codec.decode_hex("ghij")
   assert(result == nil, "expected nil for invalid hex")
   assert(err ~= nil, "expected error message")
-  assert(err:match("invalid"), "error should mention invalid")
+  assert(err:match("non%-hex"), "error should mention non-hex character, got: " .. err)
 end
 test_decode_hex_invalid_char()
 

--- a/lib/cosmic/compress.tl
+++ b/lib/cosmic/compress.tl
@@ -16,9 +16,10 @@ end
 --- @return string | nil The decompressed data, or nil on error
 --- @return string? Error message if decompression failed
 local function uncompress(data: string): string | nil, string
-  local ok, result = pcall(cosmo.Uncompress, data)
-  if not ok then
-    return nil, "decompression failed: " .. tostring(result)
+  -- The binding reports truncated or corrupt input as nil, err.
+  local result, err = cosmo.Uncompress(data)
+  if not result then
+    return nil, err as string
   end
   return result
 end
@@ -45,7 +46,11 @@ local function deflate(data: string): string | nil, string
     math.floor(size / 65536) % 256,
     math.floor(size / 16777216) % 256
   )
-  return prefix .. cosmo.Deflate(data)
+  local compressed, err = cosmo.Deflate(data)
+  if not compressed then
+    return nil, err as string
+  end
+  return prefix .. compressed
 end
 
 --- Decompress raw deflate data.
@@ -63,12 +68,10 @@ local function inflate(data: string): string | nil, string
   local b1, b2, b3, b4 = data:byte(1, 4)
   local size = b1 + b2 * 256 + b3 * 65536 + b4 * 16777216
   local compressed = data:sub(5)
-  local ok, result = pcall(cosmo.Inflate, compressed, size)
-  if not ok then
-    return nil, "decompression failed: " .. tostring(result)
-  end
-  if result == nil then
-    return nil, "decompression failed: invalid data"
+  -- The binding reports invalid input as nil, err.
+  local result, err = cosmo.Inflate(compressed, size)
+  if not result then
+    return nil, err as string
   end
   return result
 end

--- a/lib/cosmic/errno.tl
+++ b/lib/cosmic/errno.tl
@@ -1,35 +1,27 @@
 --- Error information from system calls.
 ---
---- Provides the `Errno` error type plus a canonical formatter (`str`)
---- and helpers for programmatic errno handling (`is`, `code`). Most
---- `cosmic.*` wrappers surface a failed `unix.*` call's error through
---- `str`, so error messages share one shape across the stdlib:
+--- Failed `cosmo.unix` calls return `nil, err, errno`: a formatted string
+--- (`"open: ENOENT: No such file or directory"`) plus the numeric errno.
+--- This module provides the canonical formatter (`str`) that most
+--- `cosmic.*` wrappers use to add operation context, and helpers for
+--- programmatic errno handling (`is`, `code`), so error messages share
+--- one shape across the stdlib:
 ---
 ---     local ok, err = unix.mkdir(path, mode)
 ---     if not ok then return false, errno.str(err, "mkdir: " .. path) end
 ---     -- -> "mkdir: /x: EACCES: Permission denied"
 local unix = require("cosmo.unix")
 
---- A system-call error object, returned in the second slot of a failed
---- `unix.*` call. Structurally matches the generated `unix.Errno`,
---- including its `__tostring` metamethod (which the previous local
---- declaration dropped).
-local record Errno
-  errno: function(self: Errno): number
-  winerr: function(self: Errno): number
-  name: function(self: Errno): string
-  call: function(self: Errno): string
-  doc: function(self: Errno): string
-  __tostring: function(self: Errno): string
-end
-
 --- Format an error as one canonical string, optionally prefixed with the
---- failing operation or context. A `unix.Errno` renders as
---- `"NAME: description"` (e.g. `"EACCES: Permission denied"`); any other
---- value falls back to `tostring`; `nil` becomes `"unknown error"`. With
---- a prefix the result is `"<prefix>: NAME: description"`.
+--- failing operation or context. Binding error strings already name the
+--- failing call (`"mkdir: EACCES: Permission denied"`); when a prefix is
+--- supplied, that lowercase `call: ` head is dropped so the operation is
+--- not stated twice (`"mkdir: /x: EACCES: Permission denied"`, not
+--- `"mkdir: /x: mkdir: EACCES: ..."`). Errno names are uppercase, so
+--- they are never mistaken for a call head. Any non-string value falls
+--- back to `tostring`; `nil` becomes `"unknown error"`.
 ---
---- @param err any the error value (a `unix.Errno`, a string, or nil)
+--- @param err any the error value (a string, or nil)
 --- @param prefix? string operation/context to prepend
 --- @return string canonical error string
 local function str(err: any, prefix?: string): string
@@ -37,20 +29,13 @@ local function str(err: any, prefix?: string): string
   if err == nil then
     msg = "unknown error"
   else
-    local e = err as Errno
-    if e.doc then
-      msg = e:doc()
-      if e.name then
-        local n = e:name()
-        if n and n ~= "" then
-          msg = n .. ": " .. msg
-        end
-      end
-    else
-      msg = tostring(err)
-    end
+    msg = tostring(err)
   end
   if prefix and prefix ~= "" then
+    local stripped = string.match(msg, "^[%l_][%w_]*: (.+)$")
+    if stripped then
+      msg = stripped
+    end
     return prefix .. ": " .. msg
   end
   return msg
@@ -65,24 +50,24 @@ local function code(name: string): integer
   return (unix as {string: any})[name] as integer
 end
 
---- True when `err` is a `unix.Errno` whose number matches the named errno
---- constant. Enables programmatic handling without string-matching:
---- `if errno.is(err, "EAGAIN") then retry() end`.
+--- True when a failed call's numeric errno (the third return value of a
+--- failed `unix.*` call) matches the named constant. Enables programmatic
+--- handling without string-matching:
 ---
---- @param err any the error value
+---     local n, err, eno = unix.poll(fds, timeout)
+---     if errno.is(eno, "EINTR") then retry() end
+---
+--- @param eno any the numeric errno from a failed call
 --- @param name string errno constant name (e.g. "ENOENT")
 --- @return boolean
-local function is(err: any, name: string): boolean
-  if err == nil then return false end
-  local e = err as Errno
-  if not e.errno then return false end
+local function is(eno: any, name: string): boolean
+  if not (eno is number) then return false end
   local want = code(name)
   if want == nil then return false end
-  return e:errno() == want
+  return eno == want
 end
 
 return {
-  Errno = Errno,
   str = str,
   code = code,
   is = is,

--- a/lib/cosmic/errno_test.tl
+++ b/lib/cosmic/errno_test.tl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cosmic
 local errno = require("cosmic.errno")
 
--- str: nil, string, and prefix handling (no Errno object needed).
+-- str: nil and plain strings, with and without prefix.
 local function test_str_fallbacks()
   assert(errno.str(nil) == "unknown error")
   assert(errno.str(nil, "op") == "op: unknown error")
@@ -11,46 +11,52 @@ local function test_str_fallbacks()
 end
 test_str_fallbacks()
 
--- str: an Errno-shaped object renders "NAME: doc", with optional prefix.
-local function test_str_errno()
-  local e: any = {
-    errno = function(_: any): integer return errno.code("ENOENT") end,
-    name = function(_: any): string return "ENOENT" end,
-    doc = function(_: any): string return "No such file or directory" end,
-  }
-  assert(errno.str(e) == "ENOENT: No such file or directory",
-    "got: " .. errno.str(e))
-  assert(errno.str(e, "open: /x") == "open: /x: ENOENT: No such file or directory",
-    "got: " .. errno.str(e, "open: /x"))
+-- str: a prefix replaces a lowercase `call: ` head so the failing
+-- operation is not stated twice.
+local function test_str_prefix_strips_call_head()
+  local got = errno.str("mkdir: EACCES: Permission denied", "mkdir: /x")
+  assert(got == "mkdir: /x: EACCES: Permission denied", "got: " .. got)
 end
-test_str_errno()
+test_str_prefix_strips_call_head()
 
--- str: an Errno with no name() still renders its doc.
-local function test_str_errno_no_name()
-  local e: any = {
-    doc = function(_: any): string return "Permission denied" end,
-  }
-  assert(errno.str(e) == "Permission denied", "got: " .. errno.str(e))
+-- str: without a prefix, the message is passed through untouched.
+local function test_str_no_prefix_keeps_call_head()
+  local got = errno.str("mkdir: EACCES: Permission denied")
+  assert(got == "mkdir: EACCES: Permission denied", "got: " .. got)
 end
-test_str_errno_no_name()
+test_str_no_prefix_keeps_call_head()
+
+-- str: uppercase errno names are never mistaken for a call head.
+local function test_str_prefix_keeps_errno_head()
+  local got = errno.str("ENOENT: No such file or directory", "open: /x")
+  assert(got == "open: /x: ENOENT: No such file or directory", "got: " .. got)
+end
+test_str_prefix_keeps_errno_head()
+
+-- str: non-string values fall back to tostring.
+local function test_str_non_string()
+  assert(errno.str(42) == "42")
+  assert(errno.str(42, "op") == "op: 42")
+end
+test_str_non_string()
 
 -- code: known constants resolve to numbers; unknown ones are nil.
 local function test_code()
-  assert(type(errno.code("ENOENT")) == "number", "ENOENT should resolve")
+  local n = errno.code("ENOENT")
+  assert(type(n) == "number", "ENOENT should resolve to a number")
   assert(errno.code("E_NOT_A_REAL_ERRNO") == nil, "unknown errno is nil")
 end
 test_code()
 
--- is: matches by errno number; false for nil, wrong name, and non-Errno.
+-- is: matches by numeric errno; false for nil, non-numbers, wrong or
+-- unknown names.
 local function test_is()
-  local e: any = {
-    errno = function(_: any): integer return errno.code("ENOENT") end,
-  }
-  assert(errno.is(e, "ENOENT"), "should match ENOENT")
-  assert(not errno.is(e, "EACCES"), "should not match EACCES")
-  assert(not errno.is(nil, "ENOENT"), "nil err is never a match")
-  assert(not errno.is("a string", "ENOENT"), "non-Errno is never a match")
-  assert(not errno.is(e, "E_NOT_A_REAL_ERRNO"), "unknown name is never a match")
+  local enoent = errno.code("ENOENT")
+  assert(errno.is(enoent, "ENOENT"), "should match ENOENT")
+  assert(not errno.is(enoent, "EACCES"), "should not match EACCES")
+  assert(not errno.is(nil, "ENOENT"), "nil is never a match")
+  assert(not errno.is("a string", "ENOENT"), "non-number is never a match")
+  assert(not errno.is(enoent, "E_NOT_A_REAL_ERRNO"), "unknown name is never a match")
 end
 test_is()
 

--- a/lib/cosmic/fetch.tl
+++ b/lib/cosmic/fetch.tl
@@ -102,6 +102,24 @@ local function validate_headers(headers: {string: string}): string
   return nil
 end
 
+--- Project the transport-relevant Opts fields onto a typed cosmo.FetchOptions.
+--- Retry-loop fields (max_attempts, max_delay, should_retry) stay wrapper-side.
+--- @param opts Opts? wrapper options, or nil
+--- @return cosmo.FetchOptions? options for cosmo.Fetch/FetchStream, or nil
+local function to_fetch_options(opts?: Opts): cosmo.FetchOptions
+  if not opts then
+    return nil
+  end
+  return {
+    method = opts.method,
+    body = opts.body,
+    headers = opts.headers,
+    proxy = opts.proxy,
+    maxresponse = opts.maxresponse,
+    timeout = opts.timeout,
+  }
+end
+
 local function do_fetch(url: string, opts?: Opts): Result
   local verr = validate_url(url)
   if verr then
@@ -116,7 +134,7 @@ local function do_fetch(url: string, opts?: Opts): Result
   local headers_or_err: {string: string} | string
   local body: string
 
-  status, headers_or_err, body = cosmo.Fetch(url, opts as {string: any})
+  status, headers_or_err, body = cosmo.Fetch(url, to_fetch_options(opts))
 
   if not status then
     return {ok = false, error = tostring(headers_or_err or "unknown error")}
@@ -266,7 +284,7 @@ local function stream(url: string, opts?: Opts): StreamResult
   local headers_or_err: {string: string} | string
   local raw_reader: cosmo.StreamReader
 
-  status, headers_or_err, raw_reader = cosmo.FetchStream(url, opts as {string: any})
+  status, headers_or_err, raw_reader = cosmo.FetchStream(url, to_fetch_options(opts))
 
   if not status then
     return {ok = false, error = tostring(headers_or_err or "unknown error")}

--- a/lib/cosmic/hash.tl
+++ b/lib/cosmic/hash.tl
@@ -11,7 +11,6 @@
 local cosmo = require("cosmo")
 local argon2 = require("cosmo.argon2")
 local codec = require("cosmic.codec")
-local rand = require("cosmic.rand")
 
 --- Options for password hashing with Argon2.
 --- All fields are optional and have sensible defaults.
@@ -28,11 +27,13 @@ local record HashOptions
   variant: string
 end
 
--- Map variant string names to argon2 variant constants
-local variant_map: {string: argon2.Variant} = {
-  argon2id = argon2.variants.argon2_id,
-  argon2i = argon2.variants.argon2_i,
-  argon2d = argon2.variants.argon2_d,
+-- Variant names accepted by the argon2 binding. An unknown variant
+-- string makes the binding raise (programmer error), so the wrapper
+-- validates here and returns nil, err instead.
+local valid_variants: {string: boolean} = {
+  argon2id = true,
+  argon2i = true,
+  argon2d = true,
 }
 
 --- Compute SHA-256 hash of data.
@@ -60,9 +61,6 @@ end
 --- @return string? The encoded hash string, or nil on error
 --- @return string? Error message if hashing failed
 local function password(pwd: string, options?: HashOptions): string | nil, string
-  -- Generate a random salt (16 bytes is recommended)
-  local salt = rand.bytes(16)
-
   -- Build config from options
   -- Default m_cost to 19456 KiB (19 MiB) per OWASP minimum recommendation.
   local config: argon2.Config = {m_cost = 19456}
@@ -72,18 +70,18 @@ local function password(pwd: string, options?: HashOptions): string | nil, strin
     if options.parallelism then config.parallelism = options.parallelism end
     if options.hash_len then config.hash_len = options.hash_len end
     if options.variant then
-      local v = variant_map[options.variant]
-      if v then
-        config.variant = v
+      if valid_variants[options.variant] then
+        config.variant = options.variant
       else
         return nil, "invalid variant: " .. options.variant .. " (expected argon2id, argon2i, or argon2d)"
       end
     end
   end
 
-  local encoded, err = argon2.hash_encoded(pwd, salt, config) as(string, any)
+  -- salt = nil: the binding generates 16 random bytes with a CSPRNG.
+  local encoded, err = argon2.hash_encoded(pwd, nil, config)
   if not encoded then
-    return nil, tostring(err or "failed to hash password")
+    return nil, err as string
   end
   return encoded
 end
@@ -97,16 +95,12 @@ end
 --- @return boolean True if the password matches, false otherwise
 --- @return string? Error message if the hash is malformed or another error occurred
 local function verify_password(encoded: string, pwd: string): boolean, string
-  local ok, err = (argon2.verify as function(string, string): boolean, any)(encoded, pwd)
-  if ok == true then
-    return true
+  local ok, err = argon2.verify(encoded, pwd)
+  if err then
+    -- Malformed encoded string or another binding error.
+    return false, err
   end
-  if ok == false then
-    -- Clean mismatch: wrong password, no error.
-    return false
-  end
-  -- ok is nil: the binding reported an error (e.g. malformed hash).
-  return false, tostring(err or "argon2 verify failed")
+  return ok
 end
 
 local record HashModule

--- a/lib/cosmic/io.tl
+++ b/lib/cosmic/io.tl
@@ -288,11 +288,28 @@ local function slurp(path: string): string | nil, string
   return data
 end
 
+-- cosmo.Barf's third argument changed from a positional mode integer to an
+-- options table in the 2026.07 error-convention release. The build's pinned
+-- BOOTSTRAP cosmic (an older runtime) executes scripts from this tree with
+-- the freshly compiled lib on package.path -- reaching this module through
+-- the script cache -- so barf must work on both sides of the change until
+-- the bootstrap pin advances past it, at which point this shim can go.
+-- cosmo.Lz4Compress was purged in the same release train, so its absence
+-- marks a runtime with the new Barf signature.
+local barf_takes_options = (cosmo as {string: any}).Lz4Compress == nil
+
 --- Write data to file, creating or overwriting it.
 local function barf(path: string, data: string, mode?: number): boolean, string
-  local ok, err = cosmo.Barf(path, data, {mode = mode})
+  local ok: boolean
+  local err: any
+  if barf_takes_options then
+    ok, err = cosmo.Barf(path, data, {mode = mode})
+  else
+    local old_barf = cosmo.Barf as function(string, string, number): boolean, any
+    ok, err = old_barf(path, data, mode)
+  end
   if not ok then
-    return false, err or ("failed to write file: " .. path)
+    return false, tostring(err or ("failed to write file: " .. path))
   end
   return true
 end

--- a/lib/cosmic/io.tl
+++ b/lib/cosmic/io.tl
@@ -26,7 +26,7 @@ local record UnixIO
   truncate: function(path: string, length?: number): boolean, any
   ftruncate: function(fd: number, length?: number): boolean, any
   dup: function(oldfd: number, newfd?: number, flags?: number, lowest?: number): number, any
-  pipe: function(flags?: number): number, number | any
+  pipe: function(flags?: number): number, number, any
   fcntl: function(fd: number, cmd: number, arg?: number): number, any
   sync: function()
   fsync: function(fd: number): boolean, any
@@ -257,11 +257,11 @@ end
 
 --- Create a pipe. flags: O_CLOEXEC, O_NONBLOCK.
 local function pipe(flags?: number): Pipe | nil, string
-  local reader_fd, writer_fd = unix.pipe(flags)
+  local reader_fd, writer_fd, err = unix.pipe(flags)
   if not reader_fd then
-    return nil, tostring(writer_fd)
+    return nil, tostring(err)
   end
-  return make_pipe(make_handle(reader_fd), make_handle(writer_fd as number))
+  return make_pipe(make_handle(reader_fd), make_handle(writer_fd))
 end
 
 --- Truncate a file by path.
@@ -280,18 +280,19 @@ end
 
 --- Read entire file contents.
 local function slurp(path: string): string | nil, string
-  local data = cosmo.Slurp(path)
+  local data, err = cosmo.Slurp(path)
   if not data then
-    return nil, "failed to read file: " .. path
+    -- The binding error already names the path (e.g. "open: /x: ENOENT: ...").
+    return nil, err or ("failed to read file: " .. path)
   end
   return data
 end
 
 --- Write data to file, creating or overwriting it.
 local function barf(path: string, data: string, mode?: number): boolean, string
-  local ok = cosmo.Barf(path, data, mode)
+  local ok, err = cosmo.Barf(path, data, {mode = mode})
   if not ok then
-    return false, "failed to write file: " .. path
+    return false, err or ("failed to write file: " .. path)
   end
   return true
 end

--- a/lib/cosmic/ip.tl
+++ b/lib/cosmic/ip.tl
@@ -76,11 +76,16 @@ local function addr(n: number): Addr
 end
 
 --- Parse an IP address string to its integer representation.
---- Returns -1 for invalid or unsupported addresses (including IPv6).
+--- Invalid or unsupported addresses (including IPv6) are errors.
 --- @param str string The IP address string (e.g., "192.168.1.1")
---- @return integer The IP address as an integer, or -1 on error
-local function parse(str: string): number
-  return cosmo.ParseIp(str)
+--- @return integer | nil The IP address as an integer, or nil on error
+--- @return string Error message if parsing failed
+local function parse(str: string): integer | nil, string
+  local n, err = cosmo.ParseIp(str)
+  if not n then
+    return nil, err as string
+  end
+  return n as integer
 end
 
 --- Format an integer IP address as a string.
@@ -122,10 +127,14 @@ end
 
 --- Resolve a hostname to an IP address.
 --- @param hostname string The hostname to resolve
---- @return integer The IP address as an integer, or -1 on error
-local function resolve(hostname: string): number
-  local ip = cosmo.ResolveIp(hostname)
-  return ip or -1
+--- @return integer | nil The IP address as an integer, or nil on error
+--- @return string Error message if resolution failed
+local function resolve(hostname: string): integer | nil, string
+  local ip, err = cosmo.ResolveIp(hostname)
+  if not ip then
+    return nil, err as string
+  end
+  return ip as integer
 end
 
 --- Look up a hostname and return a typed Addr.
@@ -134,9 +143,9 @@ end
 --- @return Addr? The resolved IP address, or nil on error
 --- @return string? Error message on failure
 local function lookup(hostname: string): Addr | nil, string
-  local ip = cosmo.ResolveIp(hostname)
-  if not ip or ip == -1 then
-    return nil, "dns: lookup failed for " .. hostname
+  local ip, err = cosmo.ResolveIp(hostname)
+  if not ip then
+    return nil, "dns: lookup failed for " .. hostname .. ": " .. tostring(err)
   end
   return make_addr(ip)
 end
@@ -144,13 +153,13 @@ end
 local record IpModule
   Addr: Addr
   addr: function(n: number): Addr
-  parse: function(str: string): number
+  parse: function(str: string): integer | nil, string
   format: function(ip: number): string
   categorize: function(ip: number): string
   is_loopback: function(ip: number): boolean
   is_private: function(ip: number): boolean
   is_public: function(ip: number): boolean
-  resolve: function(hostname: string): number
+  resolve: function(hostname: string): integer | nil, string
   lookup: function(hostname: string): Addr | nil, string
 end
 

--- a/lib/cosmic/ip_test.tl
+++ b/lib/cosmic/ip_test.tl
@@ -1,6 +1,13 @@
 #!/usr/bin/env cosmic
 local ip = require("cosmic.ip")
 
+--- Parse an address the test knows is valid, asserting success.
+local function p(s: string): integer
+  local n, err = ip.parse(s)
+  assert(n ~= nil, "parse failed for " .. s .. ": " .. tostring(err))
+  return n as integer
+end
+
 -- parse tests
 
 local function test_parse_ipv4_basic()
@@ -15,15 +22,17 @@ local function test_parse_localhost()
 end
 test_parse_localhost()
 
-local function test_parse_invalid_returns_negative()
-  local result = ip.parse("invalid")
-  assert(result == -1, "expected -1 for invalid IP, got " .. tostring(result))
+local function test_parse_invalid_returns_nil()
+  local result, err = ip.parse("invalid")
+  assert(result == nil, "expected nil for invalid IP, got " .. tostring(result))
+  assert(type(err) == "string", "expected error message, got " .. tostring(err))
 end
-test_parse_invalid_returns_negative()
+test_parse_invalid_returns_nil()
 
 local function test_parse_out_of_range()
-  local result = ip.parse("256.1.1.1")
-  assert(result == -1, "expected -1 for out-of-range IP, got " .. tostring(result))
+  local result, err = ip.parse("256.1.1.1")
+  assert(result == nil, "expected nil for out-of-range IP, got " .. tostring(result))
+  assert(type(err) == "string", "expected error message, got " .. tostring(err))
 end
 test_parse_out_of_range()
 
@@ -43,7 +52,7 @@ test_format_localhost()
 
 local function test_format_roundtrip()
   local original = "10.0.0.1"
-  local parsed = ip.parse(original)
+  local parsed = p(original)
   local formatted = ip.format(parsed)
   assert(formatted == original, "expected roundtrip to preserve '" .. original .. "', got '" .. formatted .. "'")
 end
@@ -52,25 +61,25 @@ test_format_roundtrip()
 -- categorize tests
 
 local function test_categorize_loopback()
-  local result = ip.categorize(ip.parse("127.0.0.1"))
+  local result = ip.categorize(p("127.0.0.1"))
   assert(result == "LOOPBACK", "expected 'LOOPBACK', got '" .. result .. "'")
 end
 test_categorize_loopback()
 
 local function test_categorize_private_192()
-  local result = ip.categorize(ip.parse("192.168.1.1"))
+  local result = ip.categorize(p("192.168.1.1"))
   assert(result == "PRIVATE", "expected 'PRIVATE', got '" .. result .. "'")
 end
 test_categorize_private_192()
 
 local function test_categorize_private_10()
-  local result = ip.categorize(ip.parse("10.0.0.1"))
+  local result = ip.categorize(p("10.0.0.1"))
   assert(result == "PRIVATE", "expected 'PRIVATE', got '" .. result .. "'")
 end
 test_categorize_private_10()
 
 local function test_categorize_public()
-  local result = ip.categorize(ip.parse("8.8.8.8"))
+  local result = ip.categorize(p("8.8.8.8"))
   -- Public IPs return RIR name like "ARIN"
   assert(result ~= "LOOPBACK" and result ~= "PRIVATE", "expected public category, got '" .. result .. "'")
 end
@@ -79,19 +88,19 @@ test_categorize_public()
 -- is_loopback tests
 
 local function test_is_loopback_true()
-  local result = ip.is_loopback(ip.parse("127.0.0.1"))
+  local result = ip.is_loopback(p("127.0.0.1"))
   assert(result == true, "expected true for loopback")
 end
 test_is_loopback_true()
 
 local function test_is_loopback_127_255()
-  local result = ip.is_loopback(ip.parse("127.255.255.255"))
+  local result = ip.is_loopback(p("127.255.255.255"))
   assert(result == true, "expected true for 127.255.255.255")
 end
 test_is_loopback_127_255()
 
 local function test_is_loopback_false()
-  local result = ip.is_loopback(ip.parse("192.168.1.1"))
+  local result = ip.is_loopback(p("192.168.1.1"))
   assert(result == false, "expected false for non-loopback")
 end
 test_is_loopback_false()
@@ -99,25 +108,25 @@ test_is_loopback_false()
 -- is_private tests
 
 local function test_is_private_192_168()
-  local result = ip.is_private(ip.parse("192.168.1.1"))
+  local result = ip.is_private(p("192.168.1.1"))
   assert(result == true, "expected true for 192.168.x.x")
 end
 test_is_private_192_168()
 
 local function test_is_private_10()
-  local result = ip.is_private(ip.parse("10.0.0.1"))
+  local result = ip.is_private(p("10.0.0.1"))
   assert(result == true, "expected true for 10.x.x.x")
 end
 test_is_private_10()
 
 local function test_is_private_172_16()
-  local result = ip.is_private(ip.parse("172.16.0.1"))
+  local result = ip.is_private(p("172.16.0.1"))
   assert(result == true, "expected true for 172.16.x.x")
 end
 test_is_private_172_16()
 
 local function test_is_private_false()
-  local result = ip.is_private(ip.parse("8.8.8.8"))
+  local result = ip.is_private(p("8.8.8.8"))
   assert(result == false, "expected false for public IP")
 end
 test_is_private_false()
@@ -125,25 +134,25 @@ test_is_private_false()
 -- is_public tests
 
 local function test_is_public_true()
-  local result = ip.is_public(ip.parse("8.8.8.8"))
+  local result = ip.is_public(p("8.8.8.8"))
   assert(result == true, "expected true for public IP")
 end
 test_is_public_true()
 
 local function test_is_public_cloudflare()
-  local result = ip.is_public(ip.parse("1.1.1.1"))
+  local result = ip.is_public(p("1.1.1.1"))
   assert(result == true, "expected true for Cloudflare DNS")
 end
 test_is_public_cloudflare()
 
 local function test_is_public_false_private()
-  local result = ip.is_public(ip.parse("192.168.1.1"))
+  local result = ip.is_public(p("192.168.1.1"))
   assert(result == false, "expected false for private IP")
 end
 test_is_public_false_private()
 
 local function test_is_public_false_loopback()
-  local result = ip.is_public(ip.parse("127.0.0.1"))
+  local result = ip.is_public(p("127.0.0.1"))
   assert(result == false, "expected false for loopback")
 end
 test_is_public_false_loopback()
@@ -155,6 +164,13 @@ local function test_resolve_localhost()
   assert(result == 2130706433, "expected 127.0.0.1 for localhost, got " .. tostring(result))
 end
 test_resolve_localhost()
+
+local function test_resolve_invalid_returns_nil()
+  local result, err = ip.resolve("this.host.does.not.exist.invalid")
+  assert(result == nil, "expected nil for unresolvable hostname, got " .. tostring(result))
+  assert(type(err) == "string", "expected error message, got " .. tostring(err))
+end
+test_resolve_invalid_returns_nil()
 
 -- lookup tests
 
@@ -184,43 +200,43 @@ end
 test_addr_int()
 
 local function test_addr_format()
-  local a = ip.addr(ip.parse("192.168.1.1"))
+  local a = ip.addr(p("192.168.1.1"))
   assert(a:format() == "192.168.1.1", "expected '192.168.1.1', got '" .. a:format() .. "'")
 end
 test_addr_format()
 
 local function test_addr_tostring()
-  local a = ip.addr(ip.parse("10.0.0.1"))
+  local a = ip.addr(p("10.0.0.1"))
   assert(tostring(a) == "10.0.0.1", "expected '10.0.0.1', got '" .. tostring(a) .. "'")
 end
 test_addr_tostring()
 
 local function test_addr_categorize()
-  local a = ip.addr(ip.parse("127.0.0.1"))
+  local a = ip.addr(p("127.0.0.1"))
   assert(a:categorize() == "LOOPBACK", "expected 'LOOPBACK', got '" .. a:categorize() .. "'")
 end
 test_addr_categorize()
 
 local function test_addr_is_loopback()
-  local a = ip.addr(ip.parse("127.0.0.1"))
+  local a = ip.addr(p("127.0.0.1"))
   assert(a:is_loopback() == true, "expected true for loopback")
-  local b = ip.addr(ip.parse("8.8.8.8"))
+  local b = ip.addr(p("8.8.8.8"))
   assert(b:is_loopback() == false, "expected false for non-loopback")
 end
 test_addr_is_loopback()
 
 local function test_addr_is_private()
-  local a = ip.addr(ip.parse("192.168.1.1"))
+  local a = ip.addr(p("192.168.1.1"))
   assert(a:is_private() == true, "expected true for private")
-  local b = ip.addr(ip.parse("8.8.8.8"))
+  local b = ip.addr(p("8.8.8.8"))
   assert(b:is_private() == false, "expected false for public")
 end
 test_addr_is_private()
 
 local function test_addr_is_public()
-  local a = ip.addr(ip.parse("8.8.8.8"))
+  local a = ip.addr(p("8.8.8.8"))
   assert(a:is_public() == true, "expected true for public")
-  local b = ip.addr(ip.parse("10.0.0.1"))
+  local b = ip.addr(p("10.0.0.1"))
   assert(b:is_public() == false, "expected false for private")
 end
 test_addr_is_public()

--- a/lib/cosmic/net.tl
+++ b/lib/cosmic/net.tl
@@ -243,9 +243,9 @@ end
 --- @return number | nil Numeric IP address
 --- @return string Error message on failure
 local function parseip(str: string): number | nil, string
-  local ip = cosmo.ParseIp(str)
-  if ip == -1 then
-    return nil, "invalid IP address format"
+  local ip, err = cosmo.ParseIp(str)
+  if not ip then
+    return nil, err or "invalid IP address format"
   end
   return ip
 end

--- a/lib/cosmic/poll.tl
+++ b/lib/cosmic/poll.tl
@@ -128,10 +128,11 @@ local function new(): Poller
     -- surfaces as a poll failure, and a caller that loops on it (e.g. a drain
     -- loop waiting on a child that raised SIGCHLD) spins at 100% CPU.
     local res: {number: number}
-    local err: unix.Errno
+    local err: string
+    local eno: number
     while true do
-      res, err = unix.poll(fds, timeoutms or -1)
-      if res ~= nil or not errno.is(err, "EINTR") then
+      res, err, eno = unix.poll(fds, timeoutms or -1)
+      if res ~= nil or not errno.is(eno, "EINTR") then
         break
       end
     end

--- a/lib/cosmic/proc.tl
+++ b/lib/cosmic/proc.tl
@@ -34,9 +34,6 @@ local record Rusage
   nivcsw: function(self: Rusage): number
 end
 
---- Error information from system calls.
---- Provides detailed error codes and human-readable descriptions.
-local Errno = require("cosmic.errno").Errno
 local errstr = require("cosmic.errno").str
 
 -- Identity --
@@ -74,7 +71,7 @@ end
 --- @param pid number The process id to query
 --- @return number The process group id
 local function getpgid(pid: number): number
-  return unix.getpgid(pid)
+  return (unix.getpgid(pid))
 end
 
 --- Sets process group id (same as setpgid(0, 0)).
@@ -136,10 +133,10 @@ end
 --- @param prog string Absolute path to the executable
 --- @param args {string} Argument vector passed to the program
 --- @param env {string} Environment variables (KEY=value format)
---- @return nil, Errno Only returns on error
-local function execve(prog: string, args: {string}, env: {string}): nil, Errno
+--- @return nil, string Only returns on error
+local function execve(prog: string, args: {string}, env: {string}): nil, string
   local _, err = unix.execve(prog, args, env)
-  return nil, err as Errno
+  return nil, err
 end
 
 --- Executes program with PATH search.
@@ -147,10 +144,10 @@ end
 --- This function never returns on success.
 --- @param prog string The program name to execute
 --- @param argv {string}? Argument vector. Defaults to {prog}
---- @return nil, Errno Only returns on error
-local function execvp(prog: string, argv?: {string}): nil, Errno
+--- @return nil, string Only returns on error
+local function execvp(prog: string, argv?: {string}): nil, string
   local _, err = unix.execvp(prog, argv)
-  return nil, err as Errno
+  return nil, err
 end
 
 --- Executes program with PATH search and custom environment.
@@ -159,10 +156,10 @@ end
 --- @param prog string The program name to execute
 --- @param argv {string} Argument vector passed to the program
 --- @param envp {string}? Environment variables. Inherits if not specified
---- @return nil, Errno Only returns on error
-local function execvpe(prog: string, argv: {string}, envp?: {string}): nil, Errno
+--- @return nil, string Only returns on error
+local function execvpe(prog: string, argv: {string}, envp?: {string}): nil, string
   local _, err = unix.execvpe(prog, argv, envp)
-  return nil, err as Errno
+  return nil, err
 end
 
 --- Executes program from file descriptor.
@@ -171,10 +168,10 @@ end
 --- @param fd number Open file descriptor pointing to an executable
 --- @param argv {string} Argument vector passed to the program
 --- @param envp {string}? Environment variables. Inherits if not specified
---- @return nil, Errno Only returns on error
-local function fexecve(fd: number, argv: {string}, envp?: {string}): nil, Errno
+--- @return nil, string Only returns on error
+local function fexecve(fd: number, argv: {string}, envp?: {string}): nil, string
   local _, err = unix.fexecve(fd, argv, envp)
-  return nil, err as Errno
+  return nil, err
 end
 
 -- Resource Usage --
@@ -294,10 +291,10 @@ local record ProcModule
 
   -- Exec
   commandv: function(prog: string): string
-  execve: function(prog: string, args: {string}, env: {string}): nil, Errno
-  execvp: function(prog: string, argv?: {string}): nil, Errno
-  execvpe: function(prog: string, argv: {string}, envp?: {string}): nil, Errno
-  fexecve: function(fd: number, argv: {string}, envp?: {string}): nil, Errno
+  execve: function(prog: string, args: {string}, env: {string}): nil, string
+  execvp: function(prog: string, argv?: {string}): nil, string
+  execvpe: function(prog: string, argv: {string}, envp?: {string}): nil, string
+  fexecve: function(fd: number, argv: {string}, envp?: {string}): nil, string
 
   -- Resource usage
   getrusage: function(who?: number): Rusage

--- a/lib/cosmic/quicksand/caps.tl
+++ b/lib/cosmic/quicksand/caps.tl
@@ -19,23 +19,7 @@
 --- constants) the constants are nil; drop_bounding() is then a
 --- successful no-op and supported() returns false.
 local unix = require("cosmo.unix")
-local Errno = require("cosmic.errno").Errno
-
---- Turn a unix.Errno-shaped error into a human string, or `fallback`.
-local function wrap_err(err: any, fallback: string): string
-  if not err then return fallback end
-  local e = err as Errno
-  if e.doc then return e:doc() end
-  return tostring(err)
-end
-
---- Extract the errno number from a unix.Errno-shaped error, or nil.
-local function errno_of(err: any): integer
-  if err == nil then return nil end
-  local e = err as Errno
-  if e.errno == nil then return nil end
-  return e:errno() as integer
-end
+local errno = require("cosmic.errno")
 
 --- The Linux capability names, matching unix.CAP_*. CAP_LAST_CAP is the
 --- highest valid capability *number* (a bound, not a capability) and is
@@ -119,7 +103,7 @@ local function bounding_read(cap: string): boolean | nil, string
   if n == nil then return nil, nerr end
   local r, err = unix.prctl(unix.PR_CAPBSET_READ, n)
   if r == nil then
-    return nil, wrap_err(err, "PR_CAPBSET_READ " .. cap .. " failed")
+    return nil, errno.str(err, "PR_CAPBSET_READ " .. cap)
   end
   return r == 1
 end
@@ -136,7 +120,7 @@ local function bounding_drop(cap: string): boolean, string
   if n == nil then return false, nerr end
   local rc, err = unix.prctl(unix.PR_CAPBSET_DROP, n)
   if rc == nil then
-    return false, wrap_err(err, "PR_CAPBSET_DROP " .. cap .. " failed")
+    return false, errno.str(err, "PR_CAPBSET_DROP " .. cap)
   end
   return true
 end
@@ -173,17 +157,16 @@ local function drop_bounding(opts?: DropOpts): boolean, string
   end
   for c = 0, last do
     if not keep[c] then
-      local rc, err = unix.prctl(unix.PR_CAPBSET_DROP, c)
+      local rc, err, eno = unix.prctl(unix.PR_CAPBSET_DROP, c)
       if rc == nil then
-        local en = errno_of(err)
-        if en == unix.EINVAL then
+        if errno.is(eno, "EINVAL") then
           -- Capability number unknown to this kernel; skip it.
-        elseif en == unix.ENOSYS then
+        elseif errno.is(eno, "ENOSYS") then
           -- Capabilities unsupported on this host; done.
           return true
         else
-          return false, wrap_err(err,
-            "PR_CAPBSET_DROP " .. tostring(c) .. " failed")
+          return false, errno.str(err,
+            "PR_CAPBSET_DROP " .. tostring(c))
         end
       end
     end

--- a/lib/cosmic/quicksand/init.tl
+++ b/lib/cosmic/quicksand/init.tl
@@ -19,7 +19,7 @@ local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
 local box = require("cosmic.quicksand.box")
 local caps = require("cosmic.quicksand.caps")
-local Errno = require("cosmic.errno").Errno
+local errno = require("cosmic.errno")
 
 --- Fine-grained feature availability on the current host.
 --- Every field is a boolean. Higher-level helpers use these to fail
@@ -52,20 +52,23 @@ end
 --- (a policy error still proves the syscall is wired up). A nil binding
 --- (not exported on this host) reports unavailable.
 ---
---- This classification is only correct because a failed `unix.*` call now
---- returns a real `Errno` in its second slot (the Phase 0 annotation fix):
---- before it, the error was swallowed and every probe reported available
---- (fail-open, audit §2.3). Exported so the classifier is unit-testable
---- against synthetic ENOSYS / policy-error / success returns.
+--- This classification is only correct because a failed `unix.*` call
+--- reports its error (the Phase 0 annotation fix gave it an error slot;
+--- the binding now returns `nil, err (string), errno (number)`): before
+--- that fix the error was swallowed and every probe reported available
+--- (fail-open, audit §2.3). The numeric errno in the third return slot
+--- is what classifies ENOSYS. Exported so the classifier is
+--- unit-testable against synthetic ENOSYS / policy-error / success
+--- returns.
 ---
 --- @param fn any the binding to probe (e.g. `unix.pledge`), or nil
 --- @return boolean true when the syscall is wired up on this host
 local function probe(fn: any): boolean
   if not fn then return false end
-  local call = fn as function(any, any): any, Errno
-  local ok, err = call(nil, nil)
+  local call = fn as function(any, any): any, string, integer
+  local ok, _, eno = call(nil, nil)
   if ok then return true end
-  if err and err.errno and err:errno() == unix.ENOSYS then return false end
+  if errno.is(eno, "ENOSYS") then return false end
   return true
 end
 

--- a/lib/cosmic/quicksand/init_test.tl
+++ b/lib/cosmic/quicksand/init_test.tl
@@ -47,19 +47,23 @@ local function test_is_supported_matches_capabilities()
 end
 test_is_supported_matches_capabilities()
 
--- Build a synthetic Errno-shaped value carrying a fixed errno number, so
--- the probe's ENOSYS classification can be exercised without a host that
+-- Build a synthetic failed binding returning the new failure triple —
+-- `nil, err (string), errno (number)` — with a fixed errno number, so the
+-- probe's ENOSYS classification can be exercised without a host that
 -- actually lacks the syscall.
-local function mk_err(n: integer): any
-  return {errno = function(_: any): integer return n end}
+local function mk_fail(msg: string, n: integer): any
+  return function(): any, string, integer
+    return nil, msg, n
+  end
 end
 
 -- The probe reports a binding available when a no-op call succeeds or
 -- fails with anything other than ENOSYS, and unavailable when the binding
--- is absent (nil) or the call returns ENOSYS. This is the classification
--- that was fail-open before the Phase 0 Errno-return fix (audit §2.3): the
--- error used to be swallowed, so the ENOSYS branch was dead and every
--- probe reported available. These cases fail if that regresses.
+-- is absent (nil) or the call fails with a numeric ENOSYS in its third
+-- return slot. This is the classification that was fail-open before the
+-- Phase 0 errno-return fix (audit §2.3): the error used to be swallowed,
+-- so the ENOSYS branch was dead and every probe reported available. These
+-- cases fail if that regresses.
 local function test_probe_nil_binding_is_unavailable()
   a.eq(quicksand.probe(nil), false, "a nil binding must probe as unavailable")
 end
@@ -74,7 +78,8 @@ test_probe_success_is_available()
 local function test_probe_enosys_is_unavailable()
   local enosys = errno.code("ENOSYS")
   assert(enosys, "ENOSYS must be defined on this host")
-  a.eq(quicksand.probe(function(): any, any return nil, mk_err(enosys) end), false,
+  a.eq(quicksand.probe(
+      mk_fail("prctl: ENOSYS: Function not implemented", enosys)), false,
     "ENOSYS means the syscall is absent -> unavailable (the branch that was dead pre-fix)")
 end
 test_probe_enosys_is_unavailable()
@@ -82,10 +87,22 @@ test_probe_enosys_is_unavailable()
 local function test_probe_policy_error_is_available()
   local eperm = errno.code("EPERM")
   assert(eperm, "EPERM must be defined on this host")
-  a.eq(quicksand.probe(function(): any, any return nil, mk_err(eperm) end), true,
+  a.eq(quicksand.probe(
+      mk_fail("prctl: EPERM: Operation not permitted", eperm)), true,
     "a policy error (EPERM) still proves the syscall is wired up")
 end
 test_probe_policy_error_is_available()
+
+local function test_probe_string_only_failure_is_available()
+  -- A failure that carries no numeric errno (third slot nil) cannot be
+  -- classified as ENOSYS; the error string alone must never match, so
+  -- the probe reports the syscall wired up.
+  a.eq(quicksand.probe(function(): any, string, integer
+        return nil, "prctl: ENOSYS: Function not implemented", nil
+      end), true,
+    "an error string without a numeric errno is never classified as ENOSYS")
+end
+test_probe_string_only_failure_is_available()
 
 -- Re-verify against the real host: on Linux both pledge (seccomp) and,
 -- when the kernel advertises landlock, unveil are genuinely present, so the

--- a/lib/cosmic/quicksand/netns.tl
+++ b/lib/cosmic/quicksand/netns.tl
@@ -18,17 +18,10 @@
 ---     assert(ns.enter(fd))
 ---     ns.close(fd)
 local unix = require("cosmo.unix")
-local Errno = require("cosmic.errno").Errno
+local errno = require("cosmic.errno")
 
 local IFREQ_UNION_SIZE < const > = 24
 local IFNAMSIZ < const > = 16 -- mirrors unix.IFNAMSIZ; kernel ABI constant
-
-local function wrap_err(err: any, fallback: string): string
-  if not err then return fallback end
-  local e = err as Errno
-  if e.doc then return e:doc() end
-  return tostring(err)
-end
 
 --- Build a `struct ifreq` for SIOCGIFFLAGS/SIOCSIFFLAGS: char
 --- ifr_name[IFNAMSIZ] at offset 0, int16 ifr_flags at offset IFNAMSIZ,
@@ -54,7 +47,7 @@ end
 local function control_socket(): integer, string
   local sk, err = unix.socket(
     unix.AF_INET, unix.SOCK_DGRAM | unix.SOCK_CLOEXEC, 0)
-  if not sk then return nil, wrap_err(err, "socket failed") end
+  if not sk then return nil, errno.str(err, "socket") end
   return sk as integer
 end
 
@@ -69,7 +62,7 @@ local function get_flags(name: string): integer | nil, string
   if not sk then return nil, err end
   local result, ioerr = unix.ioctl(sk, unix.SIOCGIFFLAGS, build_ifreq(name, 0))
   unix.close(sk)
-  if not result then return nil, wrap_err(ioerr, "SIOCGIFFLAGS failed") end
+  if not result then return nil, errno.str(ioerr, "SIOCGIFFLAGS") end
   return parse_ifreq_flags(result as string)
 end
 
@@ -85,7 +78,7 @@ local function set_flags(name: string, flags: integer): boolean, string
   if not sk then return false, err end
   local ok, ioerr = unix.ioctl(sk, unix.SIOCSIFFLAGS, build_ifreq(name, flags))
   unix.close(sk)
-  if not ok then return false, wrap_err(ioerr, "SIOCSIFFLAGS failed") end
+  if not ok then return false, errno.str(ioerr, "SIOCSIFFLAGS") end
   return true
 end
 
@@ -104,7 +97,7 @@ local function open(pid: integer): integer | nil, string
   local tag = pid and tostring(pid) or "self"
   local fd, err = unix.open("/proc/" .. tag .. "/ns/net",
     unix.O_RDONLY | unix.O_CLOEXEC)
-  if not fd then return nil, wrap_err(err, "netns.open failed") end
+  if not fd then return nil, errno.str(err, "netns.open") end
   return fd as integer
 end
 
@@ -117,7 +110,7 @@ end
 --- @return string? error message on failure
 local function enter(fd: integer): boolean, string
   local ok, err = unix.setns(fd, unix.CLONE_NEWNET)
-  if not ok then return false, wrap_err(err, "setns failed") end
+  if not ok then return false, errno.str(err, "setns") end
   return true
 end
 
@@ -131,7 +124,7 @@ end
 --- @return string? error message on failure
 local function unshare_user(): boolean, string
   local ok, err = unix.unshare(unix.CLONE_NEWUSER)
-  if not ok then return false, wrap_err(err, "unshare_user failed") end
+  if not ok then return false, errno.str(err, "unshare_user") end
   return true
 end
 
@@ -143,7 +136,7 @@ end
 --- @return string? error message on failure
 local function unshare(): boolean, string
   local ok, err = unix.unshare(unix.CLONE_NEWNET)
-  if not ok then return false, wrap_err(err, "unshare failed") end
+  if not ok then return false, errno.str(err, "unshare") end
   return true
 end
 
@@ -156,7 +149,7 @@ end
 local function bring_up(name: string): boolean, string
   local flags, err = get_flags(name)
   if not flags then
-    return false, wrap_err(err, "bring_up " .. name .. " failed")
+    return false, errno.str(err, "bring_up " .. name)
   end
   return set_flags(name, flags | (unix.IFF_UP as integer))
 end
@@ -169,7 +162,7 @@ end
 local function bring_down(name: string): boolean, string
   local flags, err = get_flags(name)
   if not flags then
-    return false, wrap_err(err, "bring_down " .. name .. " failed")
+    return false, errno.str(err, "bring_down " .. name)
   end
   return set_flags(name, flags & ~ (unix.IFF_UP as integer))
 end
@@ -181,7 +174,7 @@ end
 --- @return string? error message on failure
 local function close(fd: integer): boolean, string
   local ok, err = unix.close(fd)
-  if not ok then return false, wrap_err(err, "close failed") end
+  if not ok then return false, errno.str(err, "close") end
   return true
 end
 

--- a/lib/cosmic/quicksand/proc.tl
+++ b/lib/cosmic/quicksand/proc.tl
@@ -13,22 +13,7 @@
 --- become_init: run a PID-1 loop that forwards signals, reaps zombies,
 ---   and coordinates main-process / sidecar lifecycles.
 local unix = require("cosmo.unix")
-local Errno = require("cosmic.errno").Errno
-
-local function wrap_err(err: any, fallback: string): string
-  if not err then return fallback end
-  local e = err as Errno
-  if e.doc then return e:doc() end
-  return tostring(err)
-end
-
---- Extract the errno number from a unix.Errno-shaped error, or nil.
-local function errno_of(err: any): integer
-  if err == nil then return nil end
-  local e = err as Errno
-  if e.errno == nil then return nil end
-  return e:errno() as integer
-end
+local errno = require("cosmic.errno")
 
 --- One-shot pipe-backed barrier for cross-process fork+unshare
 --- synchronization.
@@ -58,7 +43,7 @@ local DEFAULT_SIGNALS: {string} = {"SIGINT", "SIGTERM", "SIGHUP"}
 --- @return string? error message on failure
 local function no_new_privs(): boolean, string
   local ok, err = unix.prctl(unix.PR_SET_NO_NEW_PRIVS, 1)
-  if not ok then return false, wrap_err(err, "no_new_privs failed") end
+  if not ok then return false, errno.str(err, "no_new_privs") end
   return true
 end
 
@@ -82,27 +67,29 @@ local function drop_privs(uid: integer, gid: integer): boolean, string
   if gid == nil then gid = uid end
   if uid ~= 0 then
     local kok, kerr = unix.prctl(unix.PR_SET_KEEPCAPS, 1)
-    if not kok then return false, wrap_err(kerr, "PR_SET_KEEPCAPS failed") end
+    if not kok then return false, errno.str(kerr, "PR_SET_KEEPCAPS") end
     local gok, gerr = unix.setresgid(gid, gid, gid)
-    if not gok then return false, wrap_err(gerr, "setresgid failed") end
+    if not gok then return false, errno.str(gerr, "setresgid") end
     local uok, uerr = unix.setresuid(uid, uid, uid)
-    if not uok then return false, wrap_err(uerr, "setresuid failed") end
+    if not uok then return false, errno.str(uerr, "setresuid") end
   end
-  local cok, cerr = unix.capset(0, 0, 0)
+  local cok, cerr, ceno = unix.capset(0, 0, 0)
   if not cok then
-    if errno_of(cerr) == unix.ENOSYS then return true end
-    return false, wrap_err(cerr, "capset failed")
+    if errno.is(ceno, "ENOSYS") then return true end
+    return false, errno.str(cerr, "capset")
   end
   return true
 end
 
---- Open `path` write-only and write `data` in one shot.
-local function write_file(path: string, data: string): boolean, any
-  local fd, oerr = unix.open(path, unix.O_WRONLY)
-  if not fd then return false, oerr end
-  local n, werr = unix.write(fd, data)
+--- Open `path` write-only and write `data` in one shot. On failure
+--- returns false plus the binding's error string and numeric errno,
+--- so callers can classify the failure (e.g. a benign ENOENT).
+local function write_file(path: string, data: string): boolean, string, integer
+  local fd, oerr, oeno = unix.open(path, unix.O_WRONLY)
+  if not fd then return false, oerr, oeno as integer end
+  local n, werr, weno = unix.write(fd, data)
   unix.close(fd)
-  if not n then return false, werr end
+  if not n then return false, werr, weno as integer end
   return true
 end
 
@@ -130,14 +117,14 @@ local function setup_userns_maps(uid: integer, gid: integer): boolean, string
   if gid == nil then gid = unix.getegid() as integer end
   local ok, err = write_file("/proc/self/uid_map",
     "0 " .. tostring(uid) .. " 1\n")
-  if not ok then return false, wrap_err(err, "uid_map write failed") end
-  local sg, sgerr = write_file("/proc/self/setgroups", "deny")
-  if not sg and errno_of(sgerr) ~= unix.ENOENT then
-    return false, wrap_err(sgerr, "setgroups write failed")
+  if not ok then return false, errno.str(err, "uid_map write") end
+  local sg, sgerr, sgeno = write_file("/proc/self/setgroups", "deny")
+  if not sg and not errno.is(sgeno, "ENOENT") then
+    return false, errno.str(sgerr, "setgroups write")
   end
   local gok, gerr = write_file("/proc/self/gid_map",
     "0 " .. tostring(gid) .. " 1\n")
-  if not gok then return false, wrap_err(gerr, "gid_map write failed") end
+  if not gok then return false, errno.str(gerr, "gid_map write") end
   return true
 end
 
@@ -163,8 +150,10 @@ end
 --- @return Barrier? barrier object on success
 --- @return string? error message on failure
 local function barrier(): Barrier | nil, string
+  -- On failure pipe returns nil, err (string), errno; the error string
+  -- lands in the second slot where the write fd would have been.
   local r, w = unix.pipe()
-  if not r then return nil, wrap_err(w, "pipe failed") end
+  if not r then return nil, errno.str(w, "pipe") end
   local rfd: integer = r as integer
   local wfd: integer = w as integer
   local b: Barrier = {}
@@ -214,10 +203,10 @@ end
 local function fork_pidns(): integer | nil, string
   local ok, uerr = unix.unshare(unix.CLONE_NEWPID)
   if not ok then
-    return nil, wrap_err(uerr, "unshare(CLONE_NEWPID) failed")
+    return nil, errno.str(uerr, "unshare(CLONE_NEWPID)")
   end
   local pid, ferr = unix.fork()
-  if not pid then return nil, wrap_err(ferr, "fork failed") end
+  if not pid then return nil, errno.str(ferr, "fork") end
   return pid as integer
 end
 
@@ -259,11 +248,13 @@ local function become_init(main_pid: integer, opts: InitOpts): integer
   end
 
   while true do
-    local pid, ws = unix.wait()
+    -- On success: pid, wait status, rusage. On failure: nil, err
+    -- (string), errno — so `weno` is the numeric errno exactly when
+    -- pid is nil.
+    local pid, ws, weno = unix.wait()
     if not pid then
-      -- ws holds a unix.Errno on failure. EINTR = a forwarded signal
-      -- arrived mid-wait; loop and reap.
-      if errno_of(ws) ~= unix.EINTR then
+      -- EINTR = a forwarded signal arrived mid-wait; loop and reap.
+      if not errno.is(weno, "EINTR") then
         return 1
       end
     elseif pid == main_pid then

--- a/lib/cosmic/quicksand/proxy.tl
+++ b/lib/cosmic/quicksand/proxy.tl
@@ -40,16 +40,9 @@
 local unix = require("cosmo.unix")
 local rules = require("cosmic.quicksand.proxy.rules")
 local serve = require("cosmic.quicksand.proxy.serve")
-local Errno = require("cosmic.errno").Errno
+local errno = require("cosmic.errno")
 
 local type ProxyOptions = serve.ProxyOptions
-
-local function wrap_err(err: any, fallback: string): string
-  if not err then return fallback end
-  local e = err as Errno
-  if e.doc then return e:doc() end
-  return tostring(err)
-end
 
 --- Returned by start(). `stop()` sends SIGTERM and reaps the
 --- listener, escalating to SIGKILL after `timeout_ms` (default 5000).
@@ -123,14 +116,14 @@ local function start(opts: ProxyOptions): ProxyHandle | nil, string
   local vok, verr = rules.validate((opts.allowed_hosts or {}) as {string: any})
   if not vok then return nil, verr end
   local r, w = unix.pipe()
-  if not r then return nil, wrap_err(w, "pipe failed") end
+  if not r then return nil, errno.str(w, "pipe") end
   local rfd = r as integer
   local wfd = w as integer
   local pid, ferr = unix.fork()
   if not pid then
     unix.close(rfd)
     unix.close(wfd)
-    return nil, wrap_err(ferr, "fork failed")
+    return nil, errno.str(ferr, "fork")
   end
   if pid == 0 then
     -- Child: listen, report the bound port to the parent, then serve.

--- a/lib/cosmic/quicksand/proxy/dial.tl
+++ b/lib/cosmic/quicksand/proxy/dial.tl
@@ -9,14 +9,7 @@
 --- other connections.
 local unix = require("cosmo.unix")
 local cosmo = require("cosmo")
-local Errno = require("cosmic.errno").Errno
-
-local function wrap_err(err: any, fallback: string): string
-  if not err then return fallback end
-  local e = err as Errno
-  if e.doc then return e:doc() end
-  return tostring(err)
-end
+local errno = require("cosmic.errno")
 
 --- Resolve `host` to an IPv4 integer. Literal IPs parse immediately;
 --- otherwise the lookup goes through `resolver` (default
@@ -44,18 +37,18 @@ local function resolve(host: string, timeout_ms: integer,
   end
   if not timeout_ms then
     local resolved, rerr = resolver(host)
-    if not resolved then return nil, wrap_err(rerr, "resolve failed") end
+    if not resolved then return nil, errno.str(rerr, "resolve") end
     return resolved
   end
   local r, w = unix.pipe()
-  if not r then return nil, wrap_err(w, "pipe failed") end
+  if not r then return nil, errno.str(w, "pipe") end
   local rfd = r as integer
   local wfd = w as integer
   local pid, ferr = unix.fork()
   if not pid then
     unix.close(rfd)
     unix.close(wfd)
-    return nil, wrap_err(ferr, "fork failed")
+    return nil, errno.str(ferr, "fork")
   end
   if pid == 0 then
     unix.close(rfd)
@@ -116,7 +109,7 @@ local function dial(host: string, port: integer, upstream_ns_fd: integer,
     resolve_timeout_ms: integer): integer | nil, string
   if upstream_ns_fd then
     local ok, err = unix.setns(upstream_ns_fd, unix.CLONE_NEWNET)
-    if not ok then return nil, wrap_err(err, "setns failed") end
+    if not ok then return nil, errno.str(err, "setns") end
   end
   local ip, rerr = resolve(host, resolve_timeout_ms, nil)
   if not ip then return nil, rerr end
@@ -125,12 +118,12 @@ local function dial(host: string, port: integer, upstream_ns_fd: integer,
   end
   local sk, serr = unix.socket(unix.AF_INET,
     (unix.SOCK_STREAM as integer) | (unix.SOCK_CLOEXEC as integer), 0)
-  if not sk then return nil, wrap_err(serr, "socket failed") end
+  if not sk then return nil, errno.str(serr, "socket") end
   local skfd = sk as integer
   local ok, cerr = unix.connect(skfd, ip, port)
   if not ok then
     unix.close(skfd)
-    return nil, wrap_err(cerr, "connect failed")
+    return nil, errno.str(cerr, "connect")
   end
   return skfd
 end

--- a/lib/cosmic/quicksand/proxy/serve.tl
+++ b/lib/cosmic/quicksand/proxy/serve.tl
@@ -12,22 +12,7 @@ local cosmo = require("cosmo")
 local rules = require("cosmic.quicksand.proxy.rules")
 local http = require("cosmic.quicksand.proxy.http")
 local updial = require("cosmic.quicksand.proxy.dial")
-local Errno = require("cosmic.errno").Errno
-
-local function wrap_err(err: any, fallback: string): string
-  if not err then return fallback end
-  local e = err as Errno
-  if e.doc then return e:doc() end
-  return tostring(err)
-end
-
---- Extract the errno number from a unix.Errno-shaped error, or nil.
-local function errno_of(err: any): integer
-  if err == nil then return nil end
-  local e = err as Errno
-  if e.errno == nil then return nil end
-  return e:errno() as integer
-end
+local errno = require("cosmic.errno")
 
 --- Leveled event logger. Each method takes an event name and a flat
 --- field table.
@@ -323,18 +308,18 @@ local function new(opts: ServeModule.ProxyOptions): Server | nil, string
     -- close it.
     local fd, serr = unix.socket(unix.AF_INET,
       (unix.SOCK_STREAM as integer) | (unix.SOCK_CLOEXEC as integer), 0)
-    if not fd then return nil, wrap_err(serr, "socket failed") end
+    if not fd then return nil, errno.str(serr, "socket") end
     local lfd = fd as integer
     unix.setsockopt(lfd, unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
     local bok, berr = unix.bind(lfd, bind_ip, bind_port)
     if not bok then
       unix.close(lfd)
-      return nil, wrap_err(berr, "bind failed")
+      return nil, errno.str(berr, "bind")
     end
     local lok, lerr2 = unix.listen(lfd, backlog)
     if not lok then
       unix.close(lfd)
-      return nil, wrap_err(lerr2, "listen failed")
+      return nil, errno.str(lerr2, "listen")
     end
     -- Refresh bind_port if the caller asked for an ephemeral port.
     local _, got_port = unix.getsockname(lfd)
@@ -347,7 +332,7 @@ local function new(opts: ServeModule.ProxyOptions): Server | nil, string
 
   local function accept(): integer | nil, string
     local cli, aerr = unix.accept(listen_fd)
-    if not cli then return nil, wrap_err(aerr, "accept failed") end
+    if not cli then return nil, errno.str(aerr, "accept") end
     return cli as integer
   end
 
@@ -363,12 +348,13 @@ local function new(opts: ServeModule.ProxyOptions): Server | nil, string
       end
     end
     while true do
-      local cli, aerr = unix.accept(listen_fd)
+      -- On failure accept returns nil, err (string), errno; the error
+      -- string and numeric errno land in the ip/port success slots.
+      local cli, aerr, aeno = unix.accept(listen_fd)
       if not cli then
-        local errno = errno_of(aerr)
-        if errno == unix.EINTR then
+        if errno.is(aeno, "EINTR") then
           reap()
-        elseif errno == unix.EBADF or errno == unix.EINVAL then
+        elseif errno.is(aeno, "EBADF") or errno.is(aeno, "EINVAL") then
           logger.warn("accept_fatal", {err = tostring(aerr)})
           return
         else

--- a/lib/cosmic/rand.tl
+++ b/lib/cosmic/rand.tl
@@ -1,19 +1,23 @@
 --- Random number generation.
 --- Wraps cosmo.GetRandomBytes for cryptographically secure randomness, and
---- cosmo.Rand64/Lemur64/Rdrand/Rdseed for fast non-cryptographic use cases.
+--- cosmo.Rand64 for fast non-cryptographic use cases.
 ---
 --- Example usage:
 ---   local rand = require("cosmic.rand")
----   local key = rand.bytes(32)          -- cryptographically secure
+---   local key, err = rand.bytes(32)     -- cryptographically secure
 ---   local n = rand.rand64()             -- fast pseudo-random (not secure)
----   local n, err = rand.rdrand()        -- hardware random (may be unavailable)
 local cosmo = require("cosmo")
 
 --- Generate cryptographically secure random bytes.
---- @param n number The number of random bytes to generate
---- @return string Random bytes
-local function bytes(n: number): string
-  return cosmo.GetRandomBytes(n)
+--- @param n number The number of random bytes to generate (1..4194304)
+--- @return string | nil Random bytes, or nil on failure
+--- @return string? Error message on failure
+local function bytes(n: number): string | nil, string
+  local data, err = cosmo.GetRandomBytes(n)
+  if not data then
+    return nil, err or "GetRandomBytes failed"
+  end
+  return data
 end
 
 --- Generate a fast 64-bit pseudo-random integer (non-cryptographic).
@@ -23,51 +27,14 @@ local function rand64(): number
   return cosmo.Rand64()
 end
 
---- Generate a fast 64-bit pseudo-random integer using Lemire's PRNG (non-cryptographic).
---- Note: result is a signed 64-bit Lua integer; may appear negative if high bit is set.
---- @return integer Random 64-bit integer
-local function lemur64(): number
-  return cosmo.Lemur64()
-end
-
---- Generate a hardware random integer using Intel RDRAND instruction.
---- Returns nil and an error message on CPUs that do not support RDRAND.
---- @return integer | nil, string Random integer, or nil and error message if unavailable
-local function rdrand(): number | nil, string
-  return cosmo.Rdrand()
-end
-
---- Generate a hardware random seed using Intel RDSEED instruction.
---- Returns nil and an error message on CPUs that do not support RDSEED.
---- @return integer | nil, string Random seed integer, or nil and error message if unavailable
-local function rdseed(): number | nil, string
-  return cosmo.Rdseed()
-end
-
---- Report whether the CPU provides a hardware random number generator.
---- Probes the RDRAND instruction; rdrand/rdseed return nil, err when this is false.
---- @return boolean true if hardware randomness (rdrand/rdseed) is usable
-local function has_hwrng(): boolean
-  local n = cosmo.Rdrand()
-  return n ~= nil
-end
-
 local record RandModule
-  bytes: function(n: number): string
+  bytes: function(n: number): string | nil, string
   rand64: function(): number
-  lemur64: function(): number
-  rdrand: function(): number | nil, string
-  rdseed: function(): number | nil, string
-  has_hwrng: function(): boolean
 end
 
 local M: RandModule = {
   bytes = bytes,
   rand64 = rand64,
-  lemur64 = lemur64,
-  rdrand = rdrand,
-  rdseed = rdseed,
-  has_hwrng = has_hwrng,
 }
 
 return M

--- a/lib/cosmic/rand_test.tl
+++ b/lib/cosmic/rand_test.tl
@@ -2,21 +2,23 @@
 local rand = require("cosmic.rand")
 
 local function test_bytes_returns_requested_length()
-  local b = rand.bytes(16)
+  local b, err = rand.bytes(16)
+  assert(b, "bytes(16) failed: " .. tostring(err))
   assert(#b == 16, "bytes(16) should return 16 bytes, got " .. #b)
 end
 test_bytes_returns_requested_length()
 
 local function test_bytes_different_each_call()
-  local b1 = rand.bytes(32)
-  local b2 = rand.bytes(32)
+  local b1 = assert(rand.bytes(32))
+  local b2 = assert(rand.bytes(32))
   assert(b1 ~= b2, "bytes should return different values each call")
 end
 test_bytes_different_each_call()
 
 local function test_bytes_various_sizes()
   for _, size in ipairs({1, 8, 16, 32, 64, 128}) do
-    local b = rand.bytes(size)
+    local b, err = rand.bytes(size)
+    assert(b, "bytes(" .. size .. ") failed: " .. tostring(err))
     assert(#b == size, "bytes(" .. size .. ") should return " .. size .. " bytes, got " .. #b)
   end
 end
@@ -32,40 +34,3 @@ local function test_rand64()
   assert(n ~= n2, "rand64 should return different values each call")
 end
 test_rand64()
-
-local function test_lemur64()
-  local n = rand.lemur64()
-  assert(math.type(n) == "integer", "lemur64 should return integer, got " .. type(n))
-  local n2 = rand.lemur64()
-  assert(n ~= n2, "lemur64 should return different values each call")
-end
-test_lemur64()
-
--- Hardware RNG tests: skip gracefully when the CPU lacks RDRAND/RDSEED.
-
-local function test_rdrand()
-  if not rand.has_hwrng() then
-    io.stderr:write("SKIP: rdrand (hardware RNG not available)\n")
-    return
-  end
-  local n, err = rand.rdrand()
-  assert(n ~= nil, "rdrand should return a value when hardware RNG is available: " .. tostring(err))
-  assert(math.type(n) == "integer", "rdrand should return integer, got " .. type(n))
-end
-test_rdrand()
-
-local function test_rdseed()
-  if not rand.has_hwrng() then
-    io.stderr:write("SKIP: rdseed (hardware RNG not available)\n")
-    return
-  end
-  local n, err = rand.rdseed()
-  if n == nil then
-    -- RDSEED can transiently fail even when present; require an error message.
-    assert(type(err) == "string" and #err > 0, "rdseed should return error string on transient failure")
-    io.stderr:write("SKIP: rdseed (transient hardware failure: " .. err .. ")\n")
-    return
-  end
-  assert(math.type(n) == "integer", "rdseed should return integer, got " .. type(n))
-end
-test_rdseed()

--- a/lib/cosmic/re.tl
+++ b/lib/cosmic/re.tl
@@ -9,11 +9,17 @@ local re = require("cosmo.re")
 --- Use compile() to create, then call :search() for O(n) matching.
 local record Regex
   --- Search for pattern match in text.
-  --- Returns the matched substring, or nil if no match.
+  --- On a match, returns the matched substring plus a table of the
+  --- parenthesized capture groups (an empty table when the pattern has
+  --- no groups, "" for groups that did not participate). A no-match is
+  --- not an error: it returns a single bare nil. A genuine engine
+  --- failure (e.g. out of memory) returns nil, err — the error string
+  --- arrives in the second position, mirroring the cosmo.re binding.
   --- @param text string The text to search
   --- @param flags number? Optional flags: NOTBOL, NOTEOL
-  --- @return string? The matched substring, or nil if no match
-  search: function(self: Regex, text: string, flags?: number): string | nil
+  --- @return string The matched substring, or nil if no match
+  --- @return {string} Capture groups on match (error string on engine failure)
+  search: function(self: Regex, text: string, flags?: number): string, {string}, string | nil
 end
 
 --- Compile a regular expression pattern.
@@ -26,8 +32,7 @@ end
 local function compile(pattern: string, flags?: number): Regex | nil, string
   local result, err = re.compile(pattern, flags)
   if not result then
-    -- err is an Errno userdata with __tostring metamethod
-    return nil, tostring(err)
+    return nil, err as string
   end
   return result as Regex
 end
@@ -35,20 +40,33 @@ end
 --- Search for pattern match in text (convenience function).
 --- Compiles pattern on each call - use compile() for repeated searches.
 --- Uses POSIX extended syntax by default.
+--- On a match, returns the matched substring plus a table of the
+--- parenthesized capture groups (an empty table when the pattern has no
+--- groups, "" for groups that did not participate). A no-match returns
+--- nil with no error; a bad pattern or an engine failure returns
+--- nil, nil, err.
 --- @param pattern string The regex pattern to search for
 --- @param text string The text to search in
 --- @param flags number? Optional compile flags: BASIC, ICASE, NEWLINE, NOSUB
---- @return string? The matched substring, or nil if no match
---- @return string? Error message if pattern compilation failed
-local function search(pattern: string, text: string, flags?: number): string | nil, string
-  local regex, err = compile(pattern, flags)
+--- @return string | nil The matched substring, or nil on no match or error
+--- @return {string} | nil Capture groups on match
+--- @return string | nil Error message if compilation or the engine failed
+local function search(pattern: string, text: string, flags?: number): string | nil, {string} | nil, string | nil
+  local regex, cerr = compile(pattern, flags)
   if not regex then
-    return nil, err
+    return nil, nil, cerr
   end
-  -- Note: regex:search returns nil for no match, not an error condition
   -- Search flags (NOTBOL/NOTEOL) are not passed here; use compile() + :search() for those
-  local result = (regex as Regex):search(text)
-  return result
+  local m, caps = (regex as Regex):search(text)
+  if not m then
+    if caps then
+      -- Engine failure: the binding reports nil, err.
+      return nil, nil, tostring(caps)
+    end
+    -- No match is not an error.
+    return nil
+  end
+  return m, caps
 end
 
 --- Check if pattern matches anywhere in text.
@@ -57,13 +75,13 @@ end
 --- @param text string The text to search in
 --- @param flags number? Optional compile flags: BASIC, ICASE, NEWLINE, NOSUB
 --- @return boolean True if pattern matches, false otherwise
---- @return string? Error message if pattern compilation failed
+--- @return string? Error message if compilation or the engine failed
 local function match(pattern: string, text: string, flags?: number): boolean, string
-  local result, err = search(pattern, text, flags)
+  local m, _, err = search(pattern, text, flags)
   if err then
     return false, err
   end
-  return result ~= nil
+  return m ~= nil
 end
 
 local record ReModule
@@ -72,7 +90,7 @@ local record ReModule
 
   -- Functions
   compile: function(pattern: string, flags?: number): Regex | nil, string
-  search: function(pattern: string, text: string, flags?: number): string | nil, string
+  search: function(pattern: string, text: string, flags?: number): string | nil, {string} | nil, string | nil
   match: function(pattern: string, text: string, flags?: number): boolean, string
 
   -- Compile flags

--- a/lib/cosmic/re_test.tl
+++ b/lib/cosmic/re_test.tl
@@ -82,28 +82,78 @@ local function test_regex_search_alternation()
 end
 test_regex_search_alternation()
 
+local function test_regex_search_captures()
+  local regex = re.compile("([a-z]+)([0-9]+)")
+  assert(regex, "compile failed")
+  local result, caps = (regex as re.Regex):search("abc123")
+  assert(result == "abc123", "expected 'abc123', got '" .. tostring(result) .. "'")
+  assert(caps ~= nil, "expected captures table on match")
+  assert(#caps == 2, "expected 2 captures, got " .. tostring(#caps))
+  assert(caps[1] == "abc", "expected first capture 'abc', got '" .. tostring(caps[1]) .. "'")
+  assert(caps[2] == "123", "expected second capture '123', got '" .. tostring(caps[2]) .. "'")
+end
+test_regex_search_captures()
+
+local function test_regex_search_no_match_no_error()
+  -- A no-match from a compiled regex is a single bare nil, not an error.
+  local regex = re.compile("cat")
+  assert(regex, "compile failed")
+  local result, caps = (regex as re.Regex):search("dog only")
+  assert(result == nil, "expected nil for no match")
+  assert(caps == nil, "expected no second value for no match")
+end
+test_regex_search_no_match_no_error()
+
 -- search convenience function tests
 
 local function test_search_simple()
-  local result, err = re.search("world", "hello world")
+  local result, caps, err = re.search("world", "hello world")
   assert(err == nil, "expected no error, got: " .. tostring(err))
   assert(result == "world", "expected 'world', got '" .. tostring(result) .. "'")
+  local c = caps as {string}
+  assert(c ~= nil and #c == 0, "expected empty captures table for pattern without groups")
 end
 test_search_simple()
 
 local function test_search_no_match()
-  local result, err = re.search("xyz", "hello world")
-  assert(err == nil, "expected no error")
+  -- No match is not an error: a bare nil, no captures, no error message.
+  local result, caps, err = re.search("xyz", "hello world")
   assert(result == nil, "expected nil for no match")
+  assert(caps == nil, "expected nil captures for no match")
+  assert(err == nil, "expected no error for no match")
 end
 test_search_no_match()
 
 local function test_search_invalid_pattern()
-  local result, err = re.search("[invalid", "hello world")
+  local result, caps, err = re.search("[invalid", "hello world")
   assert(result == nil, "expected nil for invalid pattern")
+  assert(caps == nil, "expected nil captures for invalid pattern")
   assert(err ~= nil, "expected error message")
+  assert(type(err) == "string", "error should be a string")
 end
 test_search_invalid_pattern()
+
+local function test_search_captures()
+  local result, caps, err = re.search("([0-9]+)-([a-z]+)", "id 42-abc!")
+  assert(err == nil, "expected no error, got: " .. tostring(err))
+  assert(result == "42-abc", "expected '42-abc', got '" .. tostring(result) .. "'")
+  local c = caps as {string}
+  assert(c ~= nil, "expected captures table")
+  assert(#c == 2, "expected 2 captures, got " .. tostring(#c))
+  assert(c[1] == "42", "expected first capture '42', got '" .. tostring(c[1]) .. "'")
+  assert(c[2] == "abc", "expected second capture 'abc', got '" .. tostring(c[2]) .. "'")
+end
+test_search_captures()
+
+local function test_search_nonparticipating_group()
+  local result, caps = re.search("(aa)|(bb)", "xxaaxx")
+  assert(result == "aa", "expected 'aa', got '" .. tostring(result) .. "'")
+  local c = caps as {string}
+  assert(#c == 2, "expected 2 capture slots, got " .. tostring(#c))
+  assert(c[1] == "aa", "expected first capture 'aa', got '" .. tostring(c[1]) .. "'")
+  assert(c[2] == "", "non-participating group should be empty string, got '" .. tostring(c[2]) .. "'")
+end
+test_search_nonparticipating_group()
 
 local function test_search_regex_metacharacters()
   local result = re.search("h.llo", "hello")

--- a/lib/cosmic/signal.tl
+++ b/lib/cosmic/signal.tl
@@ -1,7 +1,6 @@
 --- Signal handling utilities.
 --- Wraps cosmo.unix signal functions for process signaling, handlers, and timers.
 local unix = require("cosmo.unix")
-local Errno = require("cosmic.errno").Errno
 local errstr = require("cosmic.errno").str
 
 --- Options for setitimer: specifies which timer, initial fire time, and repeat interval.
@@ -107,7 +106,7 @@ local record SignalModule
 
   --- Suspend the process until a signal is delivered.
   --- Temporarily replaces the signal mask with the provided mask.
-  sigsuspend: function(mask: Sigset): boolean, Errno
+  sigsuspend: function(mask: Sigset): boolean, string
 
   --- Schedule SIGALRM signals at intervals.
   --- Accepts a SetitimerOpts record with named fields for clarity.
@@ -199,7 +198,7 @@ local M = {} as SignalModule
 M.Sigset = unix.Sigset as function(...: number): Sigset
 M.sigaction = unix.sigaction as function(sig: number, handler?: function | number, flags?: number, mask?: Sigset): (function | number, number, Sigset)
 M.sigprocmask = unix.sigprocmask as function(how: number, set: Sigset): Sigset
-M.sigsuspend = unix.sigsuspend as function(mask: Sigset): (boolean, Errno)
+M.sigsuspend = unix.sigsuspend as function(mask: Sigset): (boolean, string)
 M.setitimer = setitimer
 
 -- Delivery functions

--- a/lib/cosmic/time.tl
+++ b/lib/cosmic/time.tl
@@ -229,9 +229,14 @@ end
 
 --- Format a UNIX timestamp as a date string in UTC.
 --- @param timestamp number UNIX timestamp (seconds since epoch)
---- @return string Date string (e.g., "2025-01-01")
-local function format_date(timestamp: number): string
-  return cosmo.Strftime("%Y-%m-%d", timestamp)
+--- @return string | nil Date string (e.g., "2025-01-01"), or nil on error
+--- @return string Error message if formatting failed
+local function format_date(timestamp: number): string | nil, string
+  local s, err = cosmo.Strftime("%Y-%m-%d", timestamp)
+  if not s then
+    return nil, err as string
+  end
+  return s
 end
 
 --- Parse a YYYY-MM-DD date string into a UNIX timestamp (midnight UTC).
@@ -250,9 +255,14 @@ end
 
 --- Format a UNIX timestamp as an ISO 8601 string in UTC.
 --- @param timestamp number UNIX timestamp (seconds since epoch)
---- @return string ISO 8601 string (e.g., "2025-01-01T00:00:00Z")
-local function format_iso8601(timestamp: number): string
-  return cosmo.Strftime("%Y-%m-%dT%H:%M:%SZ", timestamp)
+--- @return string | nil ISO 8601 string (e.g., "2025-01-01T00:00:00Z"), or nil on error
+--- @return string Error message if formatting failed
+local function format_iso8601(timestamp: number): string | nil, string
+  local s, err = cosmo.Strftime("%Y-%m-%dT%H:%M:%SZ", timestamp)
+  if not s then
+    return nil, err as string
+  end
+  return s
 end
 
 --- Resolve an ISO 8601 timezone suffix into a signed offset in seconds.
@@ -340,9 +350,9 @@ local record TimeModule
   localtime: function(unixts: number): DateTime
   format_http: function(timestamp: number): string
   parse_http: function(str: string): number | nil, string
-  format_date: function(timestamp: number): string
+  format_date: function(timestamp: number): string | nil, string
   parse_date: function(str: string): number | nil, string
-  format_iso8601: function(timestamp: number): string
+  format_iso8601: function(timestamp: number): string | nil, string
   parse_iso8601: function(str: string): number | nil, string
   timegm: function(year: number, month: number, day: number, hour: number, min: number, sec: number): number | nil, string
 end

--- a/lib/cosmic/time_parse_test.tl
+++ b/lib/cosmic/time_parse_test.tl
@@ -95,8 +95,8 @@ test_format_date_known()
 
 local function test_format_date_format()
   local secs, _ = time.now()
-  local s = time.format_date(secs)
-  assert(s:match("^%d%d%d%d%-%d%d%-%d%d$"),
+  local s = assert(time.format_date(secs))
+  assert(string.match(s, "^%d%d%d%d%-%d%d%-%d%d$"),
     "expected YYYY-MM-DD format, got " .. s)
 end
 test_format_date_format()
@@ -174,8 +174,8 @@ test_format_iso8601_known()
 
 local function test_format_iso8601_format()
   local secs, _ = time.now()
-  local s = time.format_iso8601(secs)
-  assert(s:match("^%d%d%d%d%-%d%d%-%d%dT%d%d:%d%d:%d%dZ$"),
+  local s = assert(time.format_iso8601(secs))
+  assert(string.match(s, "^%d%d%d%d%-%d%d%-%d%dT%d%d:%d%d:%d%dZ$"),
     "expected ISO 8601 format, got " .. s)
 end
 test_format_iso8601_format()

--- a/lib/cosmic/tty.tl
+++ b/lib/cosmic/tty.tl
@@ -12,13 +12,13 @@ local record Termios
   ospeed: number
 end
 
-local Errno = require("cosmic.errno").Errno
+local errstr = require("cosmic.errno").str
 
 local record UnixTty
   isatty: function(fd: number): boolean
   tiocgwinsz: function(fd: number): number, number
-  tcgetattr: function(fd: number): Termios, Errno
-  tcsetattr: function(fd: number, action: number, termios: Termios): boolean, Errno
+  tcgetattr: function(fd: number): Termios, string
+  tcsetattr: function(fd: number, action: number, termios: Termios): boolean, string
   TCSANOW: number
   TCSADRAIN: number
   TCSAFLUSH: number
@@ -109,10 +109,7 @@ end
 local function getattr(fd: number): Termios | nil, string
   local termios, err = unix.tcgetattr(fd)
   if not termios then
-    if err and err.doc then
-      return nil, err:doc()
-    end
-    return nil, "tcgetattr failed"
+    return nil, errstr(err, "tcgetattr")
   end
   return termios
 end
@@ -126,10 +123,7 @@ end
 local function setattr(fd: number, action: number, termios: Termios): boolean, string
   local ok, err = unix.tcsetattr(fd, action, termios)
   if not ok then
-    if err and err.doc then
-      return false, err:doc()
-    end
-    return false, "tcsetattr failed"
+    return false, errstr(err, "tcsetattr")
   end
   return true
 end

--- a/lib/perf/bench/time_bench.tl
+++ b/lib/perf/bench/time_bench.tl
@@ -13,7 +13,7 @@ local function scenarios(): {pt.Scenario}, string
     {
       name = "time_format_date",
       fn = function(_: any): any
-        return time.format_date(TS)
+        return (time.format_date(TS))
       end,
       check = function(_: any, res: any): boolean, string
         if res as string ~= "2025-01-02" then
@@ -25,7 +25,7 @@ local function scenarios(): {pt.Scenario}, string
     {
       name = "time_format_iso8601",
       fn = function(_: any): any
-        return time.format_iso8601(TS)
+        return (time.format_iso8601(TS))
       end,
       check = function(_: any, res: any): boolean, string
         if res as string ~= "2025-01-02T02:54:05Z" then

--- a/lib/types/cosmo.d.tl
+++ b/lib/types/cosmo.d.tl
@@ -2,8 +2,6 @@
 -- GENERATED from cosmopolitan's definitions.lua by lib/types/gentype.tl.
 -- Do not edit by hand. Regenerate with: bin/make regen-types
 
-local unix = require("cosmo.unix")
-
 --- represented as the data structure `{{"a", "b"}, {"c"}, ...}`
 local record Url
   --- e.g. `"http"`
@@ -37,6 +35,38 @@ local record EncoderOptions
   maxdepth: number
 end
 
+local record FetchOptions
+  --- request headers to send.
+  headers: {string: string}
+  --- HTTP method, e.g. `"GET"` (default) or `"POST"`.
+  method: string
+  --- request payload.
+  body: string
+  --- maximum number of redirects to follow.
+  maxredirects: number
+  --- whether to follow redirects. Defaults to `true`.
+  followredirect: boolean
+  --- whether to keep the connection alive.
+  keepalive: boolean
+  --- proxy URL to route the request through.
+  proxy: string
+  --- limit on response (or per-read buffer) size.
+  maxresponse: number
+  --- request timeout in seconds. `0` or absent keeps the 60-second default; there is no "infinite" option.
+  timeout: number
+  --- whether to reset TLS session state before the request.
+  resettls: boolean
+end
+
+local record BarfOptions
+  --- file mode for a newly created file, defaults to 0644
+  mode: number
+  --- append to the file instead of truncating it (default false)
+  append: boolean
+  --- 1-indexed byte offset for overwriting a slice of the file; incompatible with `append`
+  offset: number
+end
+
 --- Streaming reader for an HTTP response body, returned by
 --- `cosmo.FetchStream`. The reader owns the underlying connection. It is
 --- closed automatically on garbage collection, but calling `close`
@@ -59,24 +89,20 @@ end
 local record cosmo
   type Url = Url
   type EncoderOptions = EncoderOptions
+  type FetchOptions = FetchOptions
+  type BarfOptions = BarfOptions
   type StreamReader = StreamReader
 
   --- Writes all data to file the easy way.
-  --- This function writes to the local file system.
+  --- This function writes to the local file system. By default it truncates
+  --- (or creates) the file. Pass `append = true` to append instead, or an
+  --- `offset` to overwrite a slice in place. On failure it returns nil plus
+  --- an error string that names the path.
   --- For example:
   ---     assert(Barf('x.txt', 'abc123'))
-  ---     assert(Barf('x.txt', 'XX', 0, 0, 3))
+  ---     assert(Barf('x.txt', 'XX', {offset = 3}))
   ---     assert(assert(Slurp('x.txt', 1, 6)) == 'abXX23')
-  Barf: function(filename: string, data: string, mode?: number, flags?: number, offset?: number): boolean | nil, unix.Errno
-  --- Formats string as binary integer literal string. If the provided value is zero,
-  --- the result will be `"0"`. Otherwise the resulting value will be the
-  --- "0b"-prefixed binary str. The result is currently modulo 2^64. Negative numbers
-  --- are converted to unsigned.
-  bin: function(int: number): string
-  --- Passing `0` will raise an error. Same as the Intel x86 instruction BSF.
-  Bsf: function(x: number): number
-  --- Passing `0` will raise an error. Same as the Intel x86 instruction BSR.
-  Bsr: function(x: number): number
+  Barf: function(filename: string, data: string, options?: BarfOptions): boolean, string | nil, number | nil
   CategorizeIp: function(ip: number): string
   --- Compresses data using zlib DEFLATE with a small framing header.
   --- By default the result starts with a header that stores the
@@ -92,42 +118,23 @@ local record cosmo
   Crc32: function(initial: number, data: string): number
   --- Computes 32-bit Castagnoli Cyclic Redundancy Check.
   Crc32c: function(initial: number, data: string): number
-  --- Computes the Curve25519 elliptic-curve scalar multiplication used
-  --- for Diffie-Hellman key agreement.
-  --- The second argument can be either a public key or a basepoint. Use
-  --- the magic basepoint `"\9"` to derive a public key from a 32-byte
-  --- secret, then multiply your secret against the other party's public
-  --- key to derive a shared key, e.g.
-  ---     >: secret1 = GetRandomBytes(32)
-  ---     >: public1 = Curve25519(secret1, "\9")
-  ---     >: secret2 = GetRandomBytes(32)
-  ---     >: public2 = Curve25519(secret2, "\9")
-  ---     >: Curve25519(secret1, public2) == Curve25519(secret2, public1)
-  ---     true
-  --- Arguments are zero-padded or truncated to 32 bytes.
-  Curve25519: function(secret: string, public_or_basepoint: string): string
-  --- Shrinks byte buffer in half using John Costella's magic kernel. This downscales
-  --- data 2x using an eight-tap convolution, e.g.
-  ---     >: Decimate('\xff\xff\x00\x00\xff\xff\x00\x00\xff\xff\x00\x00')
-  ---     "\xff\x00\xff\x00\xff\x00"
-  --- This is very fast if SSSE3 is available (Intel 2004+ / AMD 2011+).
-  Decimate: function(data: string): string
   --- Turns ASCII into binary using the provided alphabet. The default
   --- decoding uses Crockford's base32 alphabet in a permissive way that
   --- ignores whitespace and dash (`-`) and stops at the first character
   --- outside of the alphabet. Any alphabet that has a power of 2 length
   --- (up to 128) may be supplied, which allows alternative base32
-  --- encodings to be decoded. Raises an error if the alphabet length is
+  --- encodings to be decoded. Returns nil, err if the alphabet length is
   --- not a power of 2 in the range 2..128.
-  DecodeBase32: function(ascii: string, alphabet?: string): string
+  DecodeBase32: function(ascii: string, alphabet?: string): string, string | nil
   --- Decodes binary data encoded as base64.
   --- This turns ASCII into binary, in a permissive way that ignores
   --- characters outside the base64 alphabet, such as whitespace. See
   --- `decodebase64.c`.
   DecodeBase64: function(ascii: string): string
   --- Turns ASCII base-16 hexadecimal byte string into binary string,
-  --- case-insensitively. Non-hex characters may not appear in string.
-  DecodeHex: function(ascii: string): string
+  --- case-insensitively. Returns nil, err if the string has an odd length
+  --- or contains a non-hex character.
+  DecodeHex: function(ascii: string): string, string | nil
   --- Turns JSON string into a Lua data structure.
   --- This is a generally permissive parser, in the sense that like
   --- v8, it permits scalars as top-level values. Therefore we must
@@ -156,7 +163,7 @@ local record cosmo
   --- `EncodeJson()` and may not round-trip with original intent.
   --- This parser has perfect conformance with JSONTestSuite.
   --- This parser validates utf-8 and utf-16.
-  DecodeJson: function(input: string): any | nil, string
+  DecodeJson: function(input: string): any, string | nil
   --- Turns ISO-8859-1 string into UTF-8.
   DecodeLatin1: function(iso_8859_1: string): string
   --- Compresses data.
@@ -169,13 +176,13 @@ local record cosmo
   --- `Crc32()` checksum in addition to the original uncompressed size.
   --- Lower numbers go faster (4 for instance is a sweet spot) and higher numbers go
   --- slower but have better compression.
-  Deflate: function(uncompressed: string, level?: number): string | nil, string
+  Deflate: function(uncompressed: string, level?: number): string, string | nil
   --- Turns binary into ASCII using the provided alphabet (Crockford's
   --- base32 alphabet by default). Any alphabet that has a power of 2
   --- length (up to 128) may be supplied for encoding and decoding, which
-  --- allows alternative base32 encodings to be produced. Raises an error
+  --- allows alternative base32 encodings to be produced. Returns nil, err
   --- if the alphabet length is not a power of 2 in the range 2..128.
-  EncodeBase32: function(binary: string, alphabet?: string): string
+  EncodeBase32: function(binary: string, alphabet?: string): string, string | nil
   --- Turns binary into ASCII. This can be used to create HTML data:
   --- URIs that do things like embed a PNG file in a web page. See
   --- encodebase64.c.
@@ -252,7 +259,7 @@ local record cosmo
   --- encodings in your input strings will be canonicalized rather than validated.
   --- NaNs are serialized as `null` and Infinities are `null` which is consistent
   --- with the v8 behavior.
-  EncodeJson: function(value: any, options?: any): string | nil, string
+  EncodeJson: function(value: any, options?: EncoderOptions): string, string | nil
   --- Turns UTF-8 into ISO-8859-1 string.
   EncodeLatin1: function(utf8: string, flags?: number): string
   --- Turns Lua data structure into Lua code string.
@@ -322,7 +329,7 @@ local record cosmo
   ---     >: -9223372036854775807 - 1
   ---     -9223372036854775807 - 1
   --- The only failure return condition currently implemented is when C runs out of heap memory.
-  EncodeLua: function(value: any, options?: any): string | nil, string
+  EncodeLua: function(value: any, options?: EncoderOptions): string, string | nil
   --- This function is the inverse of ParseUrl. The output will always be correctly
   --- formatted. The exception is if illegal characters are supplied in the scheme
   --- field, since there's no way of escaping those. Opaque parts are escaped as
@@ -423,7 +430,7 @@ local record cosmo
   --- is set to GET and the body is removed before the redirect is followed. Note
   --- that if these (method/body) values are provided as table fields, they will be
   --- modified in place.
-  Fetch: function(url: string, body?: string | any): number | nil, {string: string}, string, string
+  Fetch: function(url: string, body?: string | FetchOptions): number, {string: string}, string, string | nil
   --- Sends an HTTP/HTTPS request and returns a streaming reader for the response body.
   --- Useful for Server-Sent Events (SSE), large downloads, or processing data incrementally.
   --- Accepts the same options table as `Fetch()`, including `timeout`, `maxresponse`,
@@ -431,17 +438,14 @@ local record cosmo
   --- Note: `timeout=0` (or absent) retains the 60-second default; there is no
   --- "infinite" option.  `maxresponse` limits per-read buffer growth; negative
   --- values are rejected.
-  FetchStream: function(url: string, options?: any): number | nil, {string: string}, StreamReader, string
+  FetchStream: function(url: string, options?: FetchOptions): number, {string: string}, StreamReader, string | nil
   --- Converts UNIX timestamp to an RFC1123 string that looks like this:
   --- `Mon, 29 Mar 2021 15:37:13 GMT`. See `formathttpdatetime.c`.
   FormatHttpDateTime: function(seconds: number): string
   --- Turns integer like `0x01020304` into a string like `"1.2.3.4"`. See also
   --- `ParseIp` for the inverse operation.
   FormatIp: function(uint32: number): string
-  GetCpuCore: function(): number
-  GetCpuCount: function(): number
-  GetCpuNode: function(): number
-  GetCryptoHash: function(name: string, payload: string, key?: string): string
+  GetCryptoHash: function(name: string, payload: string, key?: string): string, string | nil
   --- Returns string describing host instruction set architecture.
   --- This can return:
   --- - `"X86_64"` for Intel and AMD systems
@@ -455,8 +459,7 @@ local record cosmo
   --- characters, which are discounted, as well as control codes and ANSI escape
   --- sequences.
   GetMonospaceWidth: function(str: string | number): number
-  GetRandomBytes: function(length?: number): string
-  GetTime: function(): number
+  GetRandomBytes: function(length?: number): string, string | nil
   --- Returns `true` if the string contains forbidden control codes.
   --- `flags` selects which characters are considered forbidden and may be
   --- any combination of:
@@ -470,26 +473,13 @@ local record cosmo
   --- and this function returns `false`. Raises an error if `flags` has
   --- bits outside the values above.
   HasControlCodes: function(str: string, flags?: number): boolean
-  --- Formats string as hexadecimal integer literal string. If the provided value is
-  --- zero, the result will be `"0"`. Otherwise the resulting value will be the
-  --- "0x"-prefixed hex string. The result is currently modulo 2^64. Negative numbers
-  --- are converted to unsigned.
-  hex: function(int: number): string
-  --- Computes 64-bit Google HighwayHash of a string.
-  --- HighwayHash is a fast keyed pseudorandom function. The four optional
-  --- 64-bit key words default to zero. A zero key isn't a secret key;
-  --- pass four random 64-bit integers if keyed hashing is desired.
-  HighwayHash64: function(str: string, k1?: number, k2?: number, k3?: number, k4?: number): number
-  --- Adds spaces to beginnings of multiline string. If the int parameter is not
-  --- supplied then 1 space will be added.
-  IndentLines: function(str: string, int?: number): string
   --- Decompresses data.
   --- This function performs the inverse of Deflate(). It's recommended that you
   --- perform a `Crc32()` check on the output string after this function succeeds.
   --- However, it is permissable (although not advised) to specify some large number
   --- in which case (on success) the byte length of the output string may be less
   --- than `maxoutsize`.
-  Inflate: function(compressed: string, maxoutsize: number): string | nil, string
+  Inflate: function(compressed: string, maxoutsize: number): string, string | nil
   --- Check if the calling script is being run directly (not require'd).
   --- This function provides a Python-like `if __name__ == "__main__"` idiom
   --- for Lua scripts. It returns true when the script is executed directly
@@ -519,45 +509,11 @@ local record cosmo
   --- and numbers greater than 65535 are rejected. See
   --- `isacceptableport.c`.
   IsAcceptablePort: function(str: string): boolean
-  --- Returns `true` if the given HTTP header name is a standard header
-  --- that the RFCs define as storing comma-separated values and may
-  --- therefore appear multiple times in a message, e.g.
-  --- `Accept-Encoding`. Returns `false` for non-repeatable and
-  --- unrecognized headers. See `khttprepeatable.c`.
-  IsHeaderRepeatable: function(name: string): boolean
   IsLoopbackIp: function(uint32: number): boolean
   IsPrivateIp: function(uint32: number): boolean
   --- Note: we intentionally regard TEST-NET IPs as public.
   IsPublicIp: function(uint32: number): boolean
   IsReasonablePath: function(str: string): boolean
-  --- Returns `true` if the string is a valid HTTP token, i.e. a nonempty
-  --- ASCII string without separators or control codes, as defined by
-  --- RFC7230. Tokens are used for things like HTTP methods and header
-  --- names. See `isvalidhttptoken.c`.
-  IsValidHttpToken: function(str: string): boolean
-  --- This linear congruential generator passes practrand and bigcrush.
-  Lemur64: function(): number
-  --- Compresses data using LZ4.
-  --- LZ4 is an extremely fast compression algorithm, trading compression ratio
-  --- for speed. It's particularly well-suited for real-time compression scenarios.
-  --- The compressed output is not compatible with other compression formats (use
-  --- Deflate/Inflate for standard zlib compatibility).
-  --- produce faster compression but with worse compression ratio. Range is 1-65537.
-  Lz4Compress: function(data: string, acceleration?: number): string | nil, string
-  --- Decompresses LZ4-compressed data.
-  --- You must know the maximum size of the decompressed output beforehand.
-  --- This is a limitation of the LZ4 format which doesn't store the original size.
-  Lz4Decompress: function(compressed: string, maxoutsize: number): string | nil, string
-  --- Computes MD5 checksum, returning 16 bytes of binary.
-  Md5: function(str: string): string
-  --- This gives you an idea of the density of information. Cryptographic random
-  --- should be in the ballpark of `7.9` whereas plaintext will be more like `4.5`.
-  MeasureEntropy: function(data: string): number
-  --- Formats string as octal integer literal string. If the provided value is zero,
-  --- the result will be `"0"`. Otherwise the resulting value will be the
-  --- zero-prefixed octal string. The result is currently modulo 2^64. Negative
-  --- numbers are converted to unsigned.
-  oct: function(int: number): string
   --- Parses a `host[:port]` string, e.g. `"example.com:8080"`.
   --- Please note a longstanding quirk inherited from redbean: only the
   --- port component is currently returned. This function yields the port
@@ -566,12 +522,11 @@ local record cosmo
   --- nil-propagating: passing `nil` returns `nil`. Raises an error if the
   --- system runs out of memory.
   ParseHost: function(str: string): string | nil
-  --- Converts RFC1123 string that looks like this: Mon, 29 Mar 2021 15:37:13 GMT to
-  --- a UNIX timestamp. See `parsehttpdatetime.c`.
-  ParseHttpDateTime: function(rfc1123: string): number
-  --- Converts IPv4 address string to integer, e.g. "1.2.3.4" → 0x01020304, or
-  --- returns -1 for invalid inputs. See also `FormatIp` for the inverse operation.
-  ParseIp: function(ip: string): number
+  --- Converts IPv4 address string to integer, e.g. "1.2.3.4" → 0x01020304.
+  --- Returns nil, err for invalid inputs (previously it returned the -1
+  --- sentinel, which `FormatIp` rendered as the broadcast address). See also
+  --- `FormatIp` for the inverse operation.
+  ParseIp: function(ip: string): number, string | nil
   --- Parses `application/x-www-form-urlencoded` key/value parameters,
   --- e.g. `"a=b&c"` becomes `{{"a", "b"}, {"c"}}`. This returns the same
   --- data structure as the `params` field of the `Url` object returned by
@@ -613,17 +568,9 @@ local record cosmo
   --- URIs like data:opaque, better in fact than most things which
   --- claim to be URI parsers.
   ParseUrl: function(url: string, flags?: number): Url
-  --- Returns number of bits set in integer.
-  Popcnt: function(x: number): number
   --- This linear congruential generator passes practrand and bigcrush. This
   --- generator is safe across `fork()`, threads, and signal handlers.
   Rand64: function(): number
-  --- read raw hardware RDRAND; it returns output from the OS CSPRNG (arc4random64), which is
-  --- seeded from hardware entropy but is safer (no RNG fault exposure).
-  Rdrand: function(): number
-  --- read raw hardware RDSEED; it returns output from the OS CSPRNG (arc4random64), which is
-  --- seeded from hardware entropy but is safer (no RNG fault exposure).
-  Rdseed: function(): number
   --- Gets IP address associated with hostname.
   --- This function first checks if hostname is already an IP address, in which case
   --- it returns the result of `ParseIp`. Otherwise, it checks HOSTS.TXT on the local
@@ -637,20 +584,9 @@ local record cosmo
   --- If no IP address could be found, then `nil` is returned alongside a string of
   --- unspecified format describing the error. Calls to this function may be wrapped
   --- in `assert()` if an exception is desired.
-  ResolveIp: function(hostname: string): number | nil, string
-  --- Computes SHA1 checksum, returning 20 bytes of binary.
-  Sha1: function(str: string): string
-  --- Computes SHA224 checksum, returning 28 bytes of binary.
-  Sha224: function(str: string): string
+  ResolveIp: function(hostname: string): number, string | nil
   --- Computes SHA256 checksum, returning 32 bytes of binary.
   Sha256: function(str: string): string
-  --- Computes SHA384 checksum, returning 48 bytes of binary.
-  Sha384: function(str: string): string
-  --- Computes SHA512 checksum, returning 64 bytes of binary.
-  Sha512: function(str: string): string
-  --- Sleeps the specified number of seconds (can be fractional).
-  --- The smallest interval is a microsecond.
-  Sleep: function(seconds: number)
   --- Reads all data from file the easy way.
   --- This function reads file data from local file system. Zip file assets can be
   --- accessed using the `/zip/...` prefix.
@@ -661,7 +597,7 @@ local record cosmo
   --- This function is uninterruptible so `unix.EINTR` errors will be ignored. This
   --- should only be a concern if you've installed signal handlers. Use the UNIX API
   --- if you need to react to it.
-  Slurp: function(filename: string, i?: number, j?: number): string | nil, unix.Errno
+  Slurp: function(filename: string, i?: number, j?: number): string, string | nil, number | nil
   --- Formats a timestamp using strftime(3) format specifiers.
   --- Common format specifiers:
   --- - `%Y` four-digit year
@@ -679,28 +615,15 @@ local record cosmo
   ---     Strftime("%F %T", os.time())            -- "2024-12-29 15:30:00"
   ---     Strftime("%a, %d %b %Y", 0)             -- "Thu, 01 Jan 1970"
   ---     Strftime("%F %T", os.time(), true)      -- local time instead of UTC
-  Strftime: function(format: string, timestamp?: number, localtime?: boolean): string | nil
-  --- Parses a datetime string using strptime(3) format specifiers.
-  --- Returns a table with parsed components and any unparsed remainder.
-  --- Uses the same format specifiers as `Strftime`.
-  --- Example:
-  ---     local t = Strptime("2024-12-29", "%Y-%m-%d")
-  ---     -- t = {year=2024, month=12, day=29, hour=0, min=0, sec=0, ...}
-  ---     local t = Strptime("2024-12-29 15:30", "%Y-%m-%d %H:%M")
-  ---     -- t.rest = "" (nothing unparsed)
-  ---     local t = Strptime("2024-12-29 extra", "%Y-%m-%d")
-  ---     -- t.rest = " extra"
-  Strptime: function(str: string, format: string): table | nil, string | nil
+  Strftime: function(format: string, timestamp?: number, localtime?: boolean): string, string | nil
   --- Decompresses data produced by `Compress`.
   --- If `maxoutsize` is absent, the input is expected to begin with the
   --- header that `Compress` writes by default; the embedded length and
   --- `Crc32` checksum are verified. If `maxoutsize` is given, the input
   --- must be a raw zlib stream that decompresses to exactly `maxoutsize`
   --- bytes.
-  --- This function raises an error if the input is truncated or corrupt.
-  Uncompress: function(compressed: string, maxoutsize?: number): string
-  --- Canonicalizes overlong encodings.
-  Underlong: function(str: string): string
+  --- This function returns nil, err if the input is truncated or corrupt.
+  Uncompress: function(compressed: string, maxoutsize?: number): string, string | nil
   --- Unescapes URL parameter name or value. Decodes `%XX` hex sequences and
   --- converts `+` to space (common in application/x-www-form-urlencoded).
   --- This is the inverse of EscapeParam.
@@ -709,10 +632,6 @@ local record cosmo
   UuidV4: function(): string
   --- Generate a uuid_v7
   UuidV7: function(): string
-  --- Replaces C0 control codes and trojan source characters with descriptive
-  --- UNICODE pictorial representation. This function also canonicalizes overlong
-  --- encodings. C1 control codes are replaced with a JavaScript-like escape sequence.
-  VisualizeControlCodes: function(str: string): string
 end
 
 return cosmo

--- a/lib/types/cosmo/argon2.d.tl
+++ b/lib/types/cosmo/argon2.d.tl
@@ -2,20 +2,6 @@
 -- GENERATED from cosmopolitan's definitions.lua by lib/types/gentype.tl.
 -- Do not edit by hand. Regenerate with: bin/make regen-types
 
---- An opaque handle identifying an Argon2 hashing variant. The available
---- variants live in the `argon2.variants` table.
-local record Variant
-end
-
-local record Variants
-  --- blend of other two methods [default]
-  argon2_id: Variant
-  --- maximize resistance to side-channel attacks
-  argon2_i: Variant
-  --- maximize resistance to gpu cracking attacks
-  argon2_d: Variant
-end
-
 local record Config
   --- the memory hardness in kibibytes, which defaults to 4096 (4 mibibytes). It's recommended that this be tuned upwards.
   m_cost: number
@@ -25,27 +11,22 @@ local record Config
   parallelism: number
   --- the number of desired bytes in hash output, which defaults to 32.
   hash_len: number
-  --- may be `argon2.variants.argon2_id` blend of other two methods [default], `argon2.variants.argon2_i` maximize resistance to side-channel attacks, or `argon2.variants.argon2_d` maximize resistance to gpu cracking attacks
-  variant: Variant
+  --- the Argon2 variant: `"argon2id"` blend of other two methods [default], `"argon2i"` maximize resistance to side-channel attacks, or `"argon2d"` maximize resistance to gpu cracking attacks
+  variant: string
 end
 
 local record argon2
-  type Variant = Variant
-  type Variants = Variants
   type Config = Config
-
-  --- Argon2 hashing variants. The fields are opaque read-only userdata
-  --- values that can be fed to `config.variant` or `argon2.variant`.
-  variants: Variants
 
   --- Hashes password.
   --- This is consistent with the README of the reference implementation:
   ---     >: assert(argon2.hash_encoded("password", "somesalt", {
-  ---         variant = argon2.variants.argon2_i,
+  ---         variant = "argon2i",
   ---         hash_len = 24,
   ---         t_cost = 2,
   ---     }))
-  --- `salt` is a nonce value used to hash the string.
+  --- `salt` is a nonce value used to hash the string. It is optional: when it is
+  --- `nil` or omitted, 16 random bytes are generated with a CSPRNG.
   --- `config.m_cost` is the memory hardness in kibibytes, which defaults
   --- to 4096 (4 mibibytes). It's recommended that this be tuned upwards.
   --- `config.t_cost` is the number of iterations, which defaults to 3.
@@ -53,36 +34,17 @@ local record argon2
   --- `config.hash_len` is the number of desired bytes in hash output,
   --- which defaults to 32.
   --- `config.variant` may be:
-  --- - `argon2.variants.argon2_id` blend of other two methods [default]
-  --- - `argon2.variants.argon2_i` maximize resistance to side-channel attacks
-  --- - `argon2.variants.argon2_d` maximize resistance to gpu cracking attacks
-  hash_encoded: function(pass: string, salt: string, config: Config): string | nil, string
-  --- Verifies password, e.g.
-  ---     >: argon2.verify(
-  ---         "p=4$c29tZXNhbHQ$RdescudvJCsgt3ub+b+dWRWJTmaaJObG",
+  --- - `"argon2id"` blend of other two methods [default]
+  --- - `"argon2i"` maximize resistance to side-channel attacks
+  --- - `"argon2d"` maximize resistance to gpu cracking attacks
+  hash_encoded: function(pass: string, salt?: string, config?: Config): string, string | nil
+  --- Verifies a password against an encoded hash, e.g.
+  ---     >: argon2.verify(encoded, "password")
   ---     true
-  verify: function(encoded: string, pass: string): boolean | nil, string
-  --- Gets or sets the default memory hardness in kibibytes used by
-  --- `argon2.hash_encoded` when its config omits `m_cost`. Called with no
-  --- argument (or `nil`), it returns the current default (initially 4096).
-  m_cost: function(m_cost?: number): number
-  --- Gets or sets the default number of iterations used by
-  --- `argon2.hash_encoded` when its config omits `t_cost`. Called with no
-  --- argument (or `nil`), it returns the current default (initially 3).
-  t_cost: function(t_cost?: number): number
-  --- Gets or sets the default parallelism factor used by
-  --- `argon2.hash_encoded` when its config omits `parallelism`. Called with
-  --- no argument (or `nil`), it returns the current default (initially 1).
-  parallelism: function(parallelism?: number): number
-  --- Gets or sets the default hash output length in bytes used by
-  --- `argon2.hash_encoded` when its config omits `hash_len`. Called with no
-  --- argument (or `nil`), it returns the current default (initially 32).
-  hash_len: function(hash_len?: number): number
-  --- Sets the default variant used by `argon2.hash_encoded` when its config
-  --- omits `variant`, e.g. `argon2.variant(argon2.variants.argon2_id)`.
-  --- Unlike the other configuration functions, the argument is required.
-  --- The default is `argon2.variants.argon2_id`.
-  variant: function(variant: Variant): Variant
+  --- Returns `true` when the password matches. A plain mismatch returns
+  --- `false` (with no error). A malformed `encoded` string returns
+  --- `false, err`.
+  verify: function(encoded: string, pass: string): boolean, string | nil
 end
 
 return argon2

--- a/lib/types/cosmo/getopt.d.tl
+++ b/lib/types/cosmo/getopt.d.tl
@@ -70,7 +70,7 @@ local record getopt
   ---       end
   ---     end
   ---     -- Now excludes contains all -e values: {"foo", "bar", "spam"}
-  parse: function(args: {string}, optstring: string, longopts?: {table}): Result | nil, string
+  parse: function(args: {string}, optstring: string, longopts?: {table}): Result, string | nil
 end
 
 return getopt

--- a/lib/types/cosmo/lsqlite3.d.tl
+++ b/lib/types/cosmo/lsqlite3.d.tl
@@ -37,7 +37,6 @@ end
 --- the returned database object should be used for all further method calls in
 --- connection with that database.
 local record Database
-  apply_changeset: function(self: Database, changeset: string, conflict_cb: function, filter_cb: function, udata?: any, rebaser?: Rebaser, flags?: number): boolean | nil, number
   --- Sets or removes a busy handler for a database.
   --- The handler function is called with two parameters: `udata` and the number
   --- of (re-)tries for a pending transaction. It should return `nil`, `false` or
@@ -65,8 +64,6 @@ local record Database
   --- otherwise the COMMIT is converted to a ROLLBACK.
   --- See: `db:rollback_hook` and `db:update_hook`
   commit_hook: function(self: Database, func: function(udata: any), udata: any)
-  --- Concatenate a list of changesets.
-  concat_changeset: function(self: Database, changesets: {string}): string
   --- It should accept a function context (see Methods for callback contexts) plus
   --- the same number of parameters as given in `nargs`.
   --- It receives one argument, the function context.
@@ -130,59 +127,19 @@ local record Database
   ---       util.printf('%2i+%2i+%2i=%2i\n',col1,col2,col3,sum)
   ---     end
   create_function: function(self: Database, name: string, nargs: number, func: function(ctx: Context, ...: any), userdata?: any): boolean
-  create_rebaser: function(self: Database): Rebaser | nil, number
-  create_session: function(self: Database, name?: string): Session | nil, number
   --- If there is no attached database name on the database connection, then no value is
   --- returned; if database name is a temporary or in-memory database, then an
   --- empty string is returned.
   db_filename: function(self: Database, name: string): string | nil
   --- Deserializes data from a string which was created by `db:serialize`.
   deserialize: function(self: Database, s: string)
-  --- See https://lua.sqlite.org/home/doc/tip/doc/lsqlite3.wiki#numerical_error_and_result_codes for details.
-  error_code: function(self: Database): number
-  --- Alias for `lsqlite3.Database:error_code()`.
   errcode: function(self: Database): number
-  error_message: function(self: Database): string
-  --- Alias for `lsqlite3.Database:error_message()`.
   errmsg: function(self: Database): string
-  --- Compiles and executes the SQL statement(s) given in string sql. The statements
-  --- are simply executed one after the other and not stored. The function returns
-  --- `lsqlite3.OK` on success or else a numerical error code.
-  --- If one or more of the SQL statements are queries, then the callback function
-  --- specified in func is invoked once for each row of the query result (if func is
-  --- `nil`, no callback is invoked).
-  --- The callback receives four arguments:
-  --- -  `udata (the third parameter of the db:exec() call),
-  --- - the number of columns in the row
-  --- - a table with the column values
-  --- - another table with the column names.
-  --- The callback function should return `0`. If the callback returns a non-zero
-  --- value then the query is aborted, all subsequent SQL statements are skipped
-  --- and `db:exec()` returns `lsqlite3.ABORT`. Here is a simple example:
-  ---     sql=[=[
-  ---         CREATE TABLE numbers(num1,num2,str);
-  ---         INSERT INTO numbers VALUES(1,11,"ABC");
-  ---         INSERT INTO numbers VALUES(2,22,"DEF");
-  ---         INSERT INTO numbers VALUES(3,33,"UVW");
-  ---         INSERT INTO numbers VALUES(4,44,"XYZ");
-  ---         SELECT * FROM numbers;
-  ---     ]=]
-  ---     function showrow(udata,cols,values,names)
-  ---         assert(udata=='test_udata')
-  ---         print('exec:')
-  ---         for i=1,cols do print('',names[i],values[i]) end
-  ---         return 0
-  ---     end
-  ---     db:exec(sql,showrow,'test_udata')
-  execute: function(self: Database, sql: string, func?: (function(udata: any, cols: number, values: {string}, names: {string}): number), udata?: any)
-  --- Alias for `lsqlite3.Database:execute()`.
   exec: function(self: Database, sql: string, func?: (function(udata: any, cols: number, values: {string}, names: {string}): number), udata?: any)
   --- This function causes any pending database operation to abort and return at
   --- the next opportunity.
   interrupt: function(self: Database)
-  invert_changeset: function(self: Database, changeset: string): string
   isopen: function(self: Database): boolean
-  iterate_changeset: function(self: Database, name: string, flags?: number): Iterator | nil, number
   --- Each row in an SQLite table has a unique 64-bit signed integer key called
   --- the rowid. This id is always available as an undeclared column named ROWID,
   --- OID, or _ROWID_. If the table has a column of type INTEGER PRIMARY KEY then
@@ -219,7 +176,7 @@ local record Database
   --- Returns `true` if the database `name` of connection `db` is read-only,
   --- `false` if it is read/write. Returns `nil` plus an error message if
   --- `name` is not the name of a database on connection `db`.
-  readonly: function(self: Database, name?: string): boolean | nil, string
+  readonly: function(self: Database, name?: string): boolean, string | nil
   --- This function installs a rollback_hook callback handler.
   --- See: `db:commit_hook` and `db:update_hook`
   rollback_hook: function(self: Database, func: function(udata: any), udata: any)
@@ -276,39 +233,8 @@ local record Database
   ---     2       22
   ---     3       33
   urows: function(self: Database, sql: string): function, VM
-  wal_checkpoint: function(self: Database, mode?: number, name?: string): number | nil, number, number
+  wal_checkpoint: function(self: Database, mode?: number, name?: string): number, number, number | nil
   wal_hook: function(self: Database, func?: (function(udata: any, db: Database, name: string, page_count: number): number), udata?: any)
-end
-
---- Returned by `db:iterate_changeset`
-local record Iterator
-  conflict: function(self: Iterator): {string | number | boolean} | nil, number
-  fk_conflicts: function(self: Iterator): number | nil, number
-  finalize: function(self: Iterator): boolean | nil, number
-  next: function(self: Iterator): number | nil, number
-  new: function(self: Iterator): {string | number | boolean | nil}, number
-  old: function(self: Iterator): {string | number | boolean | nil}, number
-  op: function(self: Iterator): string | nil, number, boolean, number
-  pk: function(self: Iterator): {boolean} | nil, number
-end
-
---- Returned by `db:create_rebaser`.
-local record Rebaser
-  delete: function(self: Rebaser)
-  rebase: function(self: Rebaser, changeset: string): string | nil, number
-end
-
---- Returned by `db:create_session`.
-local record Session
-  attach: function(self: Session, filter_cb?: function(udata: any), udata?: any): boolean | nil, number
-  changeset: function(self: Session): string
-  --- Closes the session. Further method calls on the session will throw errors.
-  delete: function(self: Session)
-  diff: function(self: Session, s1: string, s2: string): boolean
-  enable: function(self: Session): boolean
-  indirect: function(self: Session): boolean
-  isempty: function(self: Session): boolean
-  patchset: function(self: Session): string
 end
 
 --- After creating a prepared statement with `db:prepare()` the returned statement
@@ -453,9 +379,6 @@ end
 local record lsqlite3
   type Context = Context
   type Database = Database
-  type Iterator = Iterator
-  type Rebaser = Rebaser
-  type Session = Session
   type Statement = Statement
   type VM = VM
 
@@ -756,28 +679,6 @@ local record lsqlite3
   CHECKPOINT_RESTART: number
   --- truncates the log file before returning. See `db:wal_checkpoint`.
   CHECKPOINT_TRUNCATE: number
-  --- changeset while iterating it.
-  CHANGESETSTART_INVERT: number
-  --- SAVEPOINT that is otherwise used to rollback partially applied changes.
-  CHANGESETAPPLY_NOSAVEPOINT: number
-  --- before applying it.
-  CHANGESETAPPLY_INVERT: number
-  --- "before" values. See `db:apply_changeset`.
-  CHANGESET_DATA: number
-  --- database. See `db:apply_changeset`.
-  CHANGESET_NOTFOUND: number
-  --- See `db:apply_changeset`.
-  CHANGESET_CONFLICT: number
-  --- constraint. See `db:apply_changeset`.
-  CHANGESET_CONSTRAINT: number
-  --- after all changes were applied. See `db:apply_changeset`.
-  CHANGESET_FOREIGN_KEY: number
-  --- change. See `db:apply_changeset`.
-  CHANGESET_OMIT: number
-  --- row with the change. See `db:apply_changeset`.
-  CHANGESET_REPLACE: number
-  --- changeset. See `db:apply_changeset`.
-  CHANGESET_ABORT: number
 
   --- Opens (or creates if it does not exist) an SQLite database with name filename
   --- and returns its handle as userdata (the returned object should be used for all
@@ -790,11 +691,11 @@ local record lsqlite3
   --- Since `0.9.4`, there is a second optional `flags` argument to `lsqlite3.open`.
   --- See https://www.sqlite.org/c3ref/open.html for an explanation of these flags and options.
   ---     local db = lsqlite3.open('foo.db', lsqlite3.OPEN_READWRITE + lsqlite3.OPEN_CREATE + lsqlite3.OPEN_SHAREDCACHE)
-  open: function(filename: string, flags?: number): Database | nil, number
+  open: function(filename: string, flags?: number): Database, number | nil, string | nil
   --- Opens an SQLite database in memory and returns its handle as userdata. In case
   --- of an error, the function returns `nil`, an error code and an error message.
   --- (In-memory databases are volatile as they are never stored on disk.)
-  open_memory: function(): Database | nil, number
+  open_memory: function(): Database, number | nil, string | nil
   lversion: function(): string
   version: function(): string
   --- Sets global SQLite3 library configuration options.
@@ -808,7 +709,7 @@ local record lsqlite3
   ---   removes the current callback when `func` is `nil`. Returns
   ---   `lsqlite3.OK` followed by the previously installed callback and its
   ---   user data.
-  config: function(option: number, func?: function, udata?: any): number | nil, function | nil, any, number
+  config: function(option: number, func?: function, udata?: any): number, function | nil, any, number | nil
 end
 
 return lsqlite3

--- a/lib/types/cosmo/re.d.tl
+++ b/lib/types/cosmo/re.d.tl
@@ -2,40 +2,22 @@
 -- GENERATED from cosmopolitan's definitions.lua by lib/types/gentype.tl.
 -- Do not edit by hand. Regenerate with: bin/make regen-types
 
-local record Errno
-  --- - `unix.NOMATCH` No match
-  --- - `unix.BADPAT` Invalid regex
-  --- - `unix.ECOLLATE` Unknown collating element
-  --- - `unix.ECTYPE` Unknown character class name
-  --- - `unix.EESCAPE` Trailing backslash
-  --- - `unix.ESUBREG` Invalid back reference
-  --- - `unix.EBRACK` Missing `]`
-  --- - `unix.EPAREN` Missing `)`
-  --- - `unix.EBRACE` Missing `}`
-  --- - `unix.BADBR` Invalid contents of `{}`
-  --- - `unix.ERANGE` Invalid character range.
-  --- - `unix.ESPACE` Out of memory
-  --- - `unix.BADRPT` Repetition not preceded by valid expression
-  errno: function(self: Errno): number
-  doc: function(self: Errno): string
-  --- Delegates to `re.Errno:doc()`.
-  __tostring: function(self: Errno): string
-end
-
 local record Regex
   --- Executes precompiled regular expression.
-  --- Returns nothing (`nil`) if the pattern doesn't match anything. Otherwise it
-  --- pushes the matched substring and any parenthesis-captured values too. Flags may
-  --- contain `re.NOTBOL` or `re.NOTEOL` to indicate whether or not text should be
-  --- considered at the start and/or end of a line.
+  --- On a match, returns the whole matched substring plus a table of the
+  --- parenthesized capture groups (an empty table when the pattern has no groups).
+  --- A no-match is not an error: it returns a single bare `nil`, so the idiomatic
+  --- `if match then` works. Only a genuine regex engine failure (e.g. running out
+  --- of memory) returns `nil, err`. Flags may contain `re.NOTBOL` or `re.NOTEOL`
+  --- to indicate whether or not text should be considered at the start and/or end
+  --- of a line.
   --- - `re.NOTBOL`
   --- - `re.NOTEOL`
   --- This has an O(𝑛) cost.
-  search: function(self: Regex, str: string, flags?: number): string | nil, string...
+  search: function(self: Regex, str: string, flags?: number): string, {string}, string | nil
 end
 
 local record re
-  type Errno = Errno
   type Regex = Regex
 
   --- No match
@@ -96,8 +78,11 @@ local record re
 
   --- Searches for regular expression match in text.
   --- This is a shorthand notation roughly equivalent to:
-  ---     preg = re.compile(regex)
-  ---     patt = preg:search(re, text)
+  ---     local preg = assert(re.compile(regex))
+  ---     local match, captures = preg:search(text)
+  --- On a match, returns the whole matched substring plus a table of the
+  --- parenthesized capture groups. A no-match returns a bare `nil`. A bad pattern
+  --- (compile failure) or a regex engine failure returns `nil, err`.
   --- - `re.BASIC`
   --- - `re.ICASE`
   --- - `re.NEWLINE`
@@ -106,7 +91,7 @@ local record re
   --- - `re.NOTEOL`
   --- This has exponential complexity. Please use `re.compile()` to compile your regular expressions once from `/.init.lua`. This API exists for convenience. This isn't recommended for prod.
   --- This uses POSIX extended syntax by default.
-  search: function(regex: string, text: string, flags?: number): string | nil, string...
+  search: function(regex: string, text: string, flags?: number): string, {string}, string | nil
   --- Compiles regular expression.
   --- - `re.BASIC`
   --- - `re.ICASE`
@@ -117,7 +102,7 @@ local record re
   --- If regex is an untrusted user value, then `unix.setrlimit` should be
   --- used to impose cpu and memory quotas for security.
   --- This uses POSIX extended syntax by default.
-  compile: function(regex: string, flags?: number): Regex | nil, Errno
+  compile: function(regex: string, flags?: number): Regex, string | nil
 end
 
 return re

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -129,7 +129,7 @@ local record Memory
   --- `EAGAIN` is raised if, upon entry, the word at `word_index` had a
   --- different value than what's specified at `expect`.
   --- `ETIMEDOUT` is raised when the absolute deadline expires.
-  wait: function(self: Memory, word_index: number, expect: number, abs_deadline?: number, nanos?: number): number | nil, Errno
+  wait: function(self: Memory, word_index: number, expect: number, abs_deadline?: number, nanos?: number): number, string | nil, number | nil
   --- Wakes other processes waiting on word.
   --- This method may be used to signal or broadcast to waiters. The
   --- `count` specifies the number of processes that should be woken,
@@ -145,7 +145,7 @@ local record Dir
   --- Closes directory stream object and associated its file descriptor.
   --- This is called automatically by the garbage collector.
   --- This may be called multiple times.
-  close: function(self: Dir): boolean | nil, Errno
+  close: function(self: Dir): boolean, string | nil, number | nil
   --- Reads entry from directory stream.
   --- Returns `nil` if there are no more entries.
   --- On error, `nil` will be returned and `errno` will be non-nil.
@@ -162,8 +162,8 @@ local record Dir
   --- `unix.Dir` objects may be used as a for loop iterator.
   read: function(self: Dir): string, number, number, number
   --- Returns `EOPNOTSUPP` if using a `/zip/...` path or if using Windows NT.
-  fd: function(self: Dir): number | nil, Errno
-  tell: function(self: Dir): number | nil, Errno
+  fd: function(self: Dir): number, string | nil, number | nil
+  tell: function(self: Dir): number, string | nil, number | nil
   --- Resets stream back to beginning.
   rewind: function(self: Dir)
 end
@@ -354,38 +354,6 @@ local record Sigset
   __tostring: function(self: Sigset): string
 end
 
---- Error information from system calls.
---- Provides detailed error codes and human-readable descriptions.
---- This object is returned by system calls that fail. We prefer returning
---- an object because for many system calls, an error is part of their normal
---- operation. For example, it's often desirable to use the `errno()` method
---- when performing a `read()` to check for EINTR.
-local record Errno
-  --- The error number is always different for different platforms. On
-  --- UNIX systems, error numbers occupy the range [1,127] in practice.
-  --- The System V ABI reserves numbers as high as 4095. On Windows NT,
-  --- error numbers can go up to 65535.
-  errno: function(self: Errno): number
-  --- On UNIX systems this is always 0. On Windows NT this will normally
-  --- be the same as `errno(). Because Windows defines so many error codes,
-  --- there's oftentimes a multimapping between its error codes and System
-  --- Five. In those cases, this value reflects the `GetLastError()` result
-  --- at the time the error occurred.
-  winerr: function(self: Errno): number
-  --- For example, this might return `"EINTR"`.
-  name: function(self: Errno): string
-  --- For example, this might return `"read"` if `read()` was what failed.
-  call: function(self: Errno): string
-  --- For example, this might return `"Interrupted system call"`.
-  doc: function(self: Errno): string
-  --- Different information components are delimited by slash.
-  --- For example, this might return `"EINTR/4/Interrupted system call"`.
-  --- On Windows NT this will include additional information about the
-  --- Windows error (including FormatMessage() output) if the WIN32 error
-  --- differs from the System Five error code.
-  __tostring: function(self: Errno): string
-end
-
 local record unix
   type Termios = Termios
   type Memory = Memory
@@ -393,7 +361,6 @@ local record unix
   type Rusage = Rusage
   type Stat = Stat
   type Statfs = Statfs
-  type Errno = Errno
 
   --- @type integer
   AF_INET: number
@@ -1471,7 +1438,7 @@ local record unix
   --- Returns `ENOTDIR` if `path` contained a directory component that
   --- wasn't a directory
   --- .
-  open: function(path: string, flags: number, mode?: number, dirfd?: number): number | nil, Errno
+  open: function(path: string, flags: number, mode?: number, dirfd?: number): number, string | nil, number | nil
   --- Closes file descriptor.
   --- This function should never be called twice for the same file
   --- descriptor, regardless of whether or not an error happened. The file
@@ -1487,14 +1454,14 @@ local record unix
   --- Returns `EBADF` if `fd` wasn't valid.
   --- Returns `EINTR` possibly maybe.
   --- Returns `EIO` if an i/o error occurred.
-  close: function(fd: number): boolean | nil, Errno
+  close: function(fd: number): boolean, string | nil, number | nil
   --- Reads from file descriptor.
   --- This function returns empty string on end of file. The exception is
   --- if `bufsiz` is zero, in which case an empty returned string means
   --- the file descriptor works.
-  read: function(fd: number, bufsiz?: number, offset?: number): string | nil, Errno
+  read: function(fd: number, bufsiz?: number, offset?: number): string, string | nil, number | nil
   --- Writes to file descriptor.
-  write: function(fd: number, data: string, offset?: number): number | nil, Errno
+  write: function(fd: number, data: string, offset?: number): number, string | nil, number | nil
   --- Invokes `_Exit(exitcode)` on the process. This will immediately
   --- halt the current process. Memory will be freed. File descriptors
   --- will be closed. Any open connections it owns will be reset. This
@@ -1517,19 +1484,19 @@ local record unix
   --- Sets environment variable.
   --- This wraps the C `setenv()` function to allow Lua scripts to set
   --- environment variables.
-  setenv: function(name: string, value: string, overwrite?: boolean): boolean | nil, Errno
+  setenv: function(name: string, value: string, overwrite?: boolean): boolean, string | nil, number | nil
   --- Unsets environment variable.
   --- This wraps the C `unsetenv()` function to allow Lua scripts to remove
   --- environment variables.
-  unsetenv: function(name: string): boolean | nil, Errno
+  unsetenv: function(name: string): boolean, string | nil, number | nil
   --- Clears all environment variables.
   --- This wraps the C `clearenv()` function to allow Lua scripts to remove
   --- all environment variables at once.
-  clearenv: function(): boolean | nil, Errno
+  clearenv: function(): boolean, string | nil, number | nil
   --- Gets login name of current user.
   --- This wraps the C `getlogin()` function to retrieve the login name
   --- associated with the current session.
-  getlogin: function(): string | nil, Errno
+  getlogin: function(): string, string | nil, number | nil
   --- Creates a new process mitosis style.
   --- This system call returns twice. The parent process gets the nonzero
   --- pid. The child gets zero.
@@ -1585,7 +1552,7 @@ local record unix
   --- Hence it should come as no surprise that `fork()` would go slower on
   --- operating systems that have more security features. So depending on
   --- your use case, you can choose the operating system that suits you.
-  fork: function(): number | nil, Errno
+  fork: function(): number, string | nil, number | nil
   --- Performs `$PATH` lookup of executable.
   ---     unix = require 'unix'
   ---     prog = assert(unix.commandv('ls'))
@@ -1598,7 +1565,7 @@ local record unix
   --- they can be discovered like they would on UNIX. If you want to find
   --- a program like notepad on the $PATH using this function, then you
   --- need to specify "notepad.exe" so it includes the extension.
-  commandv: function(prog: string): string | nil, Errno
+  commandv: function(prog: string): string, string | nil, number | nil
   --- Exits current process, replacing it with a new instance of the
   --- specified program. `prog` needs to be an absolute path, see
   --- commandv(). `env` defaults to to the current `environ`. Here's
@@ -1622,20 +1589,20 @@ local record unix
   --- This function never returns on success.
   --- `EAGAIN` is returned if you've enforced a max number of
   --- processes using `setrlimit(RLIMIT_NPROC)`.
-  execve: function(prog: string, args: {string}, env: {string}): nil, Errno
+  execve: function(prog: string, args: {string}, env: {string}): nil, string | nil, number | nil
   --- Executes program with PATH search.
   --- Unlike `execve()`, this function searches for `prog` in the
   --- directories listed in the `PATH` environment variable.
   --- If `argv` is not provided, it defaults to `{prog}`.
   --- This function never returns on success.
-  execvp: function(prog: string, argv?: {string}): nil, Errno
+  execvp: function(prog: string, argv?: {string}): nil, string | nil, number | nil
   --- Executes program with PATH search and custom environment.
   --- Like `execvp()` but also allows specifying a custom environment.
   --- `envp` is a string list table where each string is typically
   --- in the form `"KEY=value"`. If not specified, inherits the
   --- current environment.
   --- This function never returns on success.
-  execvpe: function(prog: string, argv: {string}, envp?: {string}): nil, Errno
+  execvpe: function(prog: string, argv: {string}, envp?: {string}): nil, string | nil, number | nil
   --- Executes program from file descriptor.
   --- This allows executing a program that has already been opened,
   --- which can be useful for executing programs that have been
@@ -1646,7 +1613,7 @@ local record unix
   --- `envp` is the environment. If not specified, inherits the
   --- current environment.
   --- This function never returns on success.
-  fexecve: function(fd: number, argv: {string}, envp?: {string}): nil, Errno
+  fexecve: function(fd: number, argv: {string}, envp?: {string}): nil, string | nil, number | nil
   --- Spawns a new process.
   --- Unlike `fork()` + `execve()`, this uses `posix_spawn()` which
   --- can be more efficient on some platforms.
@@ -1655,12 +1622,12 @@ local record unix
   --- `envp` is the environment. If not specified, inherits the
   --- current environment.
   --- Returns the child process id on success.
-  spawn: function(prog: string, argv: {string}, envp?: {string}): number | nil, Errno
+  spawn: function(prog: string, argv: {string}, envp?: {string}): number, string | nil, number | nil
   --- Spawns a new process with PATH search.
   --- Like `spawn()` but searches for `prog` in the directories
   --- listed in the `PATH` environment variable.
   --- Returns the child process id on success.
-  spawnp: function(prog: string, argv: {string}, envp?: {string}): number | nil, Errno
+  spawnp: function(prog: string, argv: {string}, envp?: {string}): number, string | nil, number | nil
   --- Duplicates file descriptor.
   --- `newfd` may be specified to choose a specific number for the new
   --- file descriptor. If it's already open, then the preexisting one will
@@ -1675,7 +1642,7 @@ local record unix
   --- Will ensure that, in the rare event standard output or standard
   --- error are closed, you won't accidentally duplicate standard input to
   --- those numbers.
-  dup: function(oldfd: number, newfd?: number, flags?: number, lowest?: number): number | nil, Errno
+  dup: function(oldfd: number, newfd?: number, flags?: number, lowest?: number): number, string | nil, number | nil
   --- Creates fifo which enables communication between processes.
   --- - `O_CLOEXEC`: Automatically close file descriptor upon execve()
   --- - `O_NONBLOCK`: Request `EAGAIN` be raised rather than blocking
@@ -1699,22 +1666,22 @@ local record unix
   ---        unix.close(writer)
   ---        SetHeader('Content-Type', 'text/plain')
   ---        while true do
-  ---           data, err = unix.read(reader)
+  ---           data, err, errno = unix.read(reader)
   ---           if data then
   ---              if data ~= "" then
   ---                 Write(data)
   ---              else
   ---                 break
   ---              end
-  ---           elseif err:errno() ~= EINTR then
-  ---              Log(kLogWarn, tostring(err))
+  ---           elseif errno ~= EINTR then
+  ---              Log(kLogWarn, err)
   ---              break
   ---           end
   ---        end
   ---        assert(unix.close(reader))
   ---        assert(unix.wait())
   ---     end
-  pipe: function(flags?: number): number | nil, number, Errno
+  pipe: function(flags?: number): number, number, string | nil, number | nil
   --- Waits for subprocess to terminate.
   --- `pid` defaults to `-1` which means any child process. Setting
   --- `pid` to `0` is equivalent to `-getpid()`. If `pid < -1` then
@@ -1731,7 +1698,7 @@ local record unix
   ---     -- wait for zombies
   ---     -- traditional technique for SIGCHLD handlers
   ---     while true do
-  ---        pid, status = unix.wait(-1, unix.WNOHANG)
+  ---        pid, status, errno = unix.wait(-1, unix.WNOHANG)
   ---        if pid then
   ---           if unix.WIFEXITED(status) then
   ---              print('child', pid, 'exited with',
@@ -1740,15 +1707,15 @@ local record unix
   ---              print('child', pid, 'crashed with',
   ---                    unix.strsignal(unix.WTERMSIG(status)))
   ---           end
-  ---        elseif status:errno() == unix.ECHILD then
+  ---        elseif errno == unix.ECHILD then
   ---           Log(kLogDebug, 'no more zombies')
   ---           break
   ---        else
-  ---           Log(kLogWarn, tostring(err))
+  ---           Log(kLogWarn, status)
   ---           break
   ---        end
   ---     end
-  wait: function(pid?: number, options?: number): number | nil, number, Rusage, Errno
+  wait: function(pid?: number, options?: number): number, number, Rusage, string | nil, number | nil
   --- Returns `true` if process exited cleanly.
   WIFEXITED: function(wstatus: number): boolean
   --- Returns code passed to exit() assuming `WIFEXITED(wstatus)` is true.
@@ -1782,20 +1749,20 @@ local record unix
   --- standard, which are `SIGINT` and `SIGQUIT`. All other signals on the
   --- Windows platform that are sent to another process via kill() will be
   --- treated like `SIGKILL`.
-  kill: function(pid: number, sig: number): boolean | nil, Errno
+  kill: function(pid: number, sig: number): boolean, string | nil, number | nil
   --- Sends signal to process group.
   --- This is similar to `kill()` but sends the signal to all processes
   --- in the specified process group.
   --- `pgrp` is the process group id. If 0, sends to the calling process's
   --- process group.
   --- `sig` can be any signal value (e.g., `SIGTERM`, `SIGKILL`, etc.).
-  killpg: function(pgrp: number, sig: number): boolean | nil, Errno
+  killpg: function(pgrp: number, sig: number): boolean, string | nil, number | nil
   --- Triggers signal in current process.
   --- This is pretty much the same as `kill(getpid(), sig)`.
-  raise: function(sig: number): number | nil, Errno
+  raise: function(sig: number): number, string | nil, number | nil
   --- Checks if effective user of current process has permission to access file.
   --- - `AT_SYMLINK_NOFOLLOW`: do not follow symbolic links.
-  access: function(path: string, how: number, flags?: number, dirfd?: number): boolean | nil, Errno
+  access: function(path: string, how: number, flags?: number, dirfd?: number): boolean, string | nil, number | nil
   --- Makes directory.
   --- `path` is the path of the directory you wish to create.
   --- `mode` is octal permission bits, e.g. `0755`.
@@ -1809,14 +1776,14 @@ local record unix
   --- Fails with `EACCES` if the parent directory doesn't grant write
   --- permission to the current user.
   --- Fails with `ENAMETOOLONG` if the path is too long.
-  mkdir: function(path: string, mode?: number, dirfd?: number): boolean | nil, Errno
+  mkdir: function(path: string, mode?: number, dirfd?: number): boolean, string | nil, number | nil
   --- Unlike mkdir() this convenience wrapper will automatically create
   --- parent parent directories as needed. If the directory already exists
   --- then, unlike mkdir() which returns EEXIST, the makedirs() function
   --- will return success.
   --- `path` is the path of the directory you wish to create.
   --- `mode` is octal permission bits, e.g. `0755`.
-  makedirs: function(path: string, mode?: number): boolean | nil, Errno
+  makedirs: function(path: string, mode?: number): boolean, string | nil, number | nil
   --- Creates a temporary directory with a unique name.
   --- `template` must end with "XXXXXX" which will be replaced with random
   --- characters to create a unique directory name.
@@ -1824,7 +1791,7 @@ local record unix
   --- Example:
   ---     local tmpdir = unix.mkdtemp("/tmp/myapp_XXXXXX")
   ---     -- tmpdir is now something like "/tmp/myapp_a3b2c1"
-  mkdtemp: function(template: string): string | nil, Errno
+  mkdtemp: function(template: string): string, string | nil, number | nil
   --- Creates a temporary file with a unique name.
   --- `template` must end with "XXXXXX" which will be replaced with random
   --- characters to create a unique filename.
@@ -1835,26 +1802,26 @@ local record unix
   ---     unix.write(fd, "hello")
   ---     unix.close(fd)
   ---     unix.unlink(path)
-  mkstemp: function(template: string): number | nil, string, Errno
+  mkstemp: function(template: string): number, string, string | nil, number | nil
   --- Changes current directory to `path`.
-  chdir: function(path: string): boolean | nil, Errno
+  chdir: function(path: string): boolean, string | nil, number | nil
   --- Removes file at `path`.
   --- If `path` refers to a symbolic link, the link is removed.
   --- Returns `EISDIR` if `path` refers to a directory. See `rmdir()`.
-  unlink: function(path: string, dirfd?: number): boolean | nil, Errno
+  unlink: function(path: string, dirfd?: number): boolean, string | nil, number | nil
   --- Removes empty directory at `path`.
   --- Returns `ENOTDIR` if `path` isn't a directory, or a path component
   --- in `path` exists yet wasn't a directory.
-  rmdir: function(path: string, dirfd?: number): boolean | nil, Errno
+  rmdir: function(path: string, dirfd?: number): boolean, string | nil, number | nil
   --- Renames file or directory.
-  rename: function(oldpath: string, newpath: string, olddirfd: number, newdirfd: number): boolean | nil, Errno
+  rename: function(oldpath: string, newpath: string, olddirfd: number, newdirfd: number): boolean, string | nil, number | nil
   --- Creates hard link, so your underlying inode has two names.
-  link: function(existingpath: string, newpath: string, flags: number, olddirfd: number, newdirfd: number): boolean | nil, Errno
+  link: function(existingpath: string, newpath: string, flags: number, olddirfd: number, newdirfd: number): boolean, string | nil, number | nil
   --- Creates symbolic link.
   --- On Windows NT a symbolic link is called a "reparse point" and can
   --- only be created from an administrator account. Your redbean will
   --- automatically request the appropriate permissions.
-  symlink: function(target: string, linkpath: string, newdirfd?: number): boolean | nil, Errno
+  symlink: function(target: string, linkpath: string, newdirfd?: number): boolean, string | nil, number | nil
   --- Reads contents of symbolic link.
   --- Note that broken links are supported on all platforms. A symbolic
   --- link can contain just about anything. It's important to not assume
@@ -1863,10 +1830,10 @@ local record unix
   --- furthermore prefixes `//?/` to WIN32 DOS-style absolute paths,
   --- thereby assisting with simple absolute filename checks in addition
   --- to enabling one to exceed the traditional 260 character limit.
-  readlink: function(path: string, dirfd?: number): string | nil, Errno
+  readlink: function(path: string, dirfd?: number): string, string | nil, number | nil
   --- Returns absolute path of filename, with `.` and `..` components
   --- removed, and symlinks will be resolved.
-  realpath: function(path: string): string | nil, Errno
+  realpath: function(path: string): string, string | nil, number | nil
   --- Changes access and/or modified timestamps on file.
   --- `path` is a string with the name of the file.
   --- The `asecs` and `ananos` parameters set the access time. If they're
@@ -1888,7 +1855,7 @@ local record unix
   --- - `AT_SYMLINK_NOFOLLOW`: Do not follow symbolic links. This makes it
   --- possible to edit the timestamps on the symbolic link itself,
   --- rather than the file it points to.
-  utimensat: function(path: string, asecs: number, ananos: number, msecs: number, mnanos: number, dirfd?: number, flags?: number): number | nil, Errno
+  utimensat: function(path: string, asecs: number, ananos: number, msecs: number, mnanos: number, dirfd?: number, flags?: number): number, string | nil, number | nil
   --- Changes access and/or modified timestamps on file descriptor.
   --- `fd` is the file descriptor of a file opened with `unix.open`.
   --- The `asecs` and `ananos` parameters set the access time. If they're
@@ -1904,25 +1871,25 @@ local record unix
   --- - `unix.UTIME_OMIT`: Do not alter this timestamp.
   --- This system call is currently not available on very old versions of
   --- Linux, e.g. RHEL5.
-  futimens: function(fd: number, asecs: number, ananos: number, msecs: number, mnanos: number): number | nil, Errno
+  futimens: function(fd: number, asecs: number, ananos: number, msecs: number, mnanos: number): number, string | nil, number | nil
   --- Changes user and group on file.
   --- Returns `ENOSYS` on Windows NT.
-  chown: function(path: string, uid: number, gid: number, flags?: number, dirfd?: number): boolean | nil, Errno
+  chown: function(path: string, uid: number, gid: number, flags?: number, dirfd?: number): boolean, string | nil, number | nil
   --- Changes mode bits on file.
   --- On Windows NT the chmod system call only changes the read-only
   --- status of a file.
-  chmod: function(path: string, mode: number, flags?: number, dirfd?: number): boolean | nil, Errno
+  chmod: function(path: string, mode: number, flags?: number, dirfd?: number): boolean, string | nil, number | nil
   --- Returns current working directory.
   --- On Windows NT, this function transliterates `\` to `/` and
   --- furthermore prefixes `//?/` to WIN32 DOS-style absolute paths,
   --- thereby assisting with simple absolute filename checks in addition
   --- to enabling one to exceed the traditional 260 character limit.
-  getcwd: function(): string | nil, Errno
+  getcwd: function(): string, string | nil, number | nil
   --- Recursively removes filesystem path.
   --- Like `unix.makedirs()` this function isn't actually a system call but
   --- rather is a Libc convenience wrapper. It's intended to be equivalent
   --- to using the UNIX shell's `rm -rf path` command.
-  rmrf: function(path: string): boolean | nil, Errno
+  rmrf: function(path: string): boolean, string | nil, number | nil
   --- Manipulates file descriptor.
   --- `cmd` may be one of:
   --- - `unix.F_GETFD` Returns file descriptor flags.
@@ -1934,21 +1901,21 @@ local record unix
   --- - `unix.F_GETLK` Acquires information about lock.
   --- unix.fcntl(fd:int, unix.F_GETFD)
   ---     ├─→ flags:int
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   ---   Returns file descriptor flags.
   ---   The returned `flags` may include any of:
   ---   - `unix.FD_CLOEXEC` if `fd` was opened with `unix.O_CLOEXEC`.
   ---   Returns `EBADF` if `fd` isn't open.
   --- unix.fcntl(fd:int, unix.F_SETFD, flags:int)
   ---     ├─→ true
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   ---   Sets file descriptor flags.
   ---   `flags` may include any of:
   ---   - `unix.FD_CLOEXEC` to re-open `fd` with `unix.O_CLOEXEC`.
   ---   Returns `EBADF` if `fd` isn't open.
   --- unix.fcntl(fd:int, unix.F_GETFL)
   ---     ├─→ flags:int
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   ---   Returns file descriptor status flags.
   ---   `flags & unix.O_ACCMODE` includes one of:
   ---   - `O_RDONLY`
@@ -1968,7 +1935,7 @@ local record unix
   ---   Returns `EBADF` if `fd` isn't open.
   --- unix.fcntl(fd:int, unix.F_SETFL, flags:int)
   ---     ├─→ true
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   ---   Changes file descriptor status flags.
   ---   Examples of values `flags` may include:
   ---   - `O_NONBLOCK`
@@ -1984,7 +1951,7 @@ local record unix
   --- unix.fcntl(fd:int, unix.F_SETLK[, type[, start[, len[, whence]]]])
   --- unix.fcntl(fd:int, unix.F_SETLKW[, type[, start[, len[, whence]]]])
   ---     ├─→ true
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   ---   Acquires lock on file interval.
   ---   POSIX Advisory Locks allow multiple processes to leave voluntary
   ---   hints to each other about which portions of a file they're using.
@@ -2010,7 +1977,7 @@ local record unix
   --- unix.fcntl(fd:int, unix.F_GETLK[, type[, start[, len[, whence]]]])
   ---     ├─→ unix.F_UNLCK
   ---     ├─→ type, start, len, whence, pid
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   ---   Acquires information about POSIX advisory lock on file.
   ---   This function accepts the same parameters as fcntl(F_SETLK) and
   ---   tells you if the lock acquisition would be successful for a given
@@ -2021,21 +1988,21 @@ local record unix
   ---   Returned `pid` is the process id of the current lock owner.
   ---   This function is currently not supported on Windows.
   ---   Returns `EBADF` if `fd` wasn't open.
-  fcntl: function(fd: number, cmd: number, ...: any): any...
+  fcntl: function(fd: number, cmd: number, ...: any): any, string | nil, number | nil
   --- Gets session id.
-  getsid: function(pid: number): number | nil, Errno
+  getsid: function(pid: number): number, string | nil, number | nil
   --- Gets process group id.
-  getpgrp: function(): number | nil, Errno
+  getpgrp: function(): number, string | nil, number | nil
   --- Sets process group id. This is the same as `setpgid(0,0)`.
-  setpgrp: function(): number | nil, Errno
+  setpgrp: function(): number, string | nil, number | nil
   --- Sets process group id the modern way.
-  setpgid: function(pid: number, pgid: number): boolean | nil, Errno
+  setpgid: function(pid: number, pgid: number): boolean, string | nil, number | nil
   --- Gets process group id the modern way.
-  getpgid: function(pid: number)
+  getpgid: function(pid: number): number, string | nil, number | nil
   --- Sets session id.
   --- This function can be used to create daemons.
   --- Fails with `ENOSYS` on Windows NT.
-  setsid: function(): number | nil, Errno
+  setsid: function(): number, string | nil, number | nil
   --- Daemonizes the current process.
   --- This function performs the standard Unix daemonization steps:
   --- forks, creates a new session, and optionally changes directory
@@ -2046,7 +2013,7 @@ local record unix
   --- `/dev/null`. Defaults to false (will redirect to `/dev/null`).
   --- This is a convenience wrapper that combines `fork()`, `setsid()`,
   --- and related operations.
-  daemon: function(nochdir?: boolean, noclose?: boolean): boolean | nil, Errno
+  daemon: function(nochdir?: boolean, noclose?: boolean): boolean, string | nil, number | nil
   --- Gets real user id.
   --- On Windows this system call is polyfilled by running `GetUserNameW()`
   --- through Knuth's multiplicative hash.
@@ -2069,7 +2036,7 @@ local record unix
   getegid: function(): number
   --- Changes root directory.
   --- Returns `ENOSYS` on Windows NT.
-  chroot: function(path: string): boolean | nil, Errno
+  chroot: function(path: string): boolean, string | nil, number | nil
   --- Sets user id.
   --- One use case for this function is dropping root privileges. Should
   --- you ever choose to run redbean as root and decide not to use the
@@ -2089,24 +2056,24 @@ local record unix
   --- system manual about the subtleties of changing user id in a way that
   --- isn't restorable.
   --- Returns `ENOSYS` on Windows NT if `uid` isn't `getuid()`.
-  setuid: function(uid: number): boolean | nil, Errno
+  setuid: function(uid: number): boolean, string | nil, number | nil
   --- Sets user id for file system ops.
-  setfsuid: function(uid: number): boolean | nil, Errno
+  setfsuid: function(uid: number): boolean, string | nil, number | nil
   --- Sets group id for file system ops.
-  setfsgid: function(gid: number): boolean | nil, Errno
+  setfsgid: function(gid: number): boolean, string | nil, number | nil
   --- Sets group id.
   --- Returns `ENOSYS` on Windows NT if `gid` isn't `getgid()`.
-  setgid: function(gid: number): boolean | nil, Errno
+  setgid: function(gid: number): boolean, string | nil, number | nil
   --- Sets real, effective, and saved user ids.
   --- If any of the above parameters are -1, then it's a no-op.
   --- Returns `ENOSYS` on Windows NT.
   --- Returns `ENOSYS` on Macintosh and NetBSD if `saved` isn't -1.
-  setresuid: function(real: number, effective: number, saved: number): boolean | nil, Errno
+  setresuid: function(real: number, effective: number, saved: number): boolean, string | nil, number | nil
   --- Sets real, effective, and saved group ids.
   --- If any of the above parameters are -1, then it's a no-op.
   --- Returns `ENOSYS` on Windows NT.
   --- Returns `ENOSYS` on Macintosh and NetBSD if `saved` isn't -1.
-  setresgid: function(real: number, effective: number, saved: number): boolean | nil, Errno
+  setresgid: function(real: number, effective: number, saved: number): boolean, string | nil, number | nil
   --- Sets file permission mask and returns the old one.
   --- This is used to remove bits from the `mode` parameter of functions
   --- like open() and mkdir(). The masks typically used are 027 and 022.
@@ -2125,12 +2092,12 @@ local record unix
   ---     unix.sysconf(unix.SC_PAGESIZE)          -- mmap() page size
   ---     unix.sysconf(unix.SC_CLK_TCK)           -- clock ticks per second
   --- Returns `nil` with an `EINVAL` errno when `name` isn't recognized.
-  sysconf: function(name: number): number | nil, Errno
+  sysconf: function(name: number): number, string | nil, number | nil
   --- Returns identity of the current operating system.
   --- Example:
   ---     local u = assert(unix.uname())
   ---     print(u.sysname, u.release, u.machine)
-  uname: function(): any | nil, Errno
+  uname: function(): any, string | nil, number | nil
   --- Generates a log message, which will be distributed by syslogd.
   --- `priority` is a bitmask containing the facility value and the level
   --- value. If no facility value is ORed into priority, then the default
@@ -2209,32 +2176,32 @@ local record unix
   --- Returns `EINVAL` if clock isn't supported on platform.
   --- This function only fails if `clock` is invalid.
   --- This function goes fastest on Linux and Windows.
-  clock_gettime: function(clock?: number): number | nil, number, Errno
+  clock_gettime: function(clock?: number): number, number, string | nil, number | nil
   --- Sleeps with nanosecond precision.
   --- Returns `EINTR` if a signal was received while waiting.
-  nanosleep: function(seconds: number, nanos?: number): number | nil, number, Errno
+  nanosleep: function(seconds: number, nanos?: number): number, number, string | nil, number | nil
   --- These functions are used to make programs slower by asking the
   --- operating system to flush data to the physical medium.
   sync: function()
   --- These functions are used to make programs slower by asking the
   --- operating system to flush data to the physical medium.
-  fsync: function(fd: number): boolean | nil, Errno
+  fsync: function(fd: number): boolean, string | nil, number | nil
   --- These functions are used to make programs slower by asking the
   --- operating system to flush data to the physical medium.
-  fdatasync: function(fd: number): boolean | nil, Errno
+  fdatasync: function(fd: number): boolean, string | nil, number | nil
   --- Seeks to file position.
   --- `whence` can be one of:
   --- - `SEEK_SET`: Sets the file position to `offset` [default]
   --- - `SEEK_CUR`: Sets the file position to `position + offset`
   --- - `SEEK_END`: Sets the file position to `filesize + offset`
   --- Returns the new position relative to the start of the file.
-  lseek: function(fd: number, offset: number, whence?: number): number | nil, Errno
+  lseek: function(fd: number, offset: number, whence?: number): number, string | nil, number | nil
   --- Reduces or extends underlying physical medium of file.
   --- If file was originally larger, content >length is lost.
-  truncate: function(path: string, length?: number): boolean | nil, Errno
+  truncate: function(path: string, length?: number): boolean, string | nil, number | nil
   --- Reduces or extends underlying physical medium of open file.
   --- If file was originally larger, content >length is lost.
-  ftruncate: function(fd: number, length?: number): boolean | nil, Errno
+  ftruncate: function(fd: number, length?: number): boolean, string | nil, number | nil
   --- - `AF_INET`: Creates Internet Protocol Version 4 (IPv4) socket.
   --- - `AF_UNIX`: Creates local UNIX domain socket. On the New Technology
   --- this requires Windows 10 and only works with `SOCK_STREAM`.
@@ -2252,7 +2219,7 @@ local record unix
   --- - `IPPROTO_RAW`
   --- - `IPPROTO_IP`
   --- - `IPPROTO_ICMP`
-  socket: function(family?: number, type?: number, protocol?: number): number | nil, Errno
+  socket: function(family?: number, type?: number, protocol?: number): number, string | nil, number | nil
   --- Creates bidirectional pipe.
   --- - `SOCK_STREAM`
   --- - `SOCK_DGRAM`
@@ -2260,7 +2227,7 @@ local record unix
   --- You may bitwise OR any of the following into `type`:
   --- - `SOCK_CLOEXEC`
   --- - `SOCK_NONBLOCK`
-  socketpair: function(family?: number, type?: number, protocol?: number): number | nil, number, Errno
+  socketpair: function(family?: number, type?: number, protocol?: number): number, number, string | nil, number | nil
   ---  Binds socket.
   ---  `ip` and `port` are in host endian order. For example, if you
   ---  wanted to listen on `1.2.3.4:31337` you could do any of these
@@ -2282,9 +2249,9 @@ local record unix
   ---      end
   ---  Further note that calling `unix.bind(sock)` is equivalent to not
   ---  calling bind() at all, since the above behavior is the default.
-  bind: function(fd: number, ip?: number, port?: number): boolean | nil, Errno
+  bind: function(fd: number, ip?: number, port?: number): boolean, string | nil, number | nil
   --- Returns list of network adapter addresses.
-  siocgifconf: function(): any | nil, Errno
+  siocgifconf: function(): any, string | nil, number | nil
   --- Tunes networking parameters.
   --- `level` and `optname` may be one of the following pairs. The ellipses
   --- type signature above changes depending on which options are used.
@@ -2297,10 +2264,10 @@ local record unix
   --- Raises `EBADF` if `fd` isn't valid.
   --- unix.getsockopt(fd:int, level:int, optname:int)
   ---     ├─→ value:int
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- unix.setsockopt(fd:int, level:int, optname:int, value:bool)
   ---     ├─→ true
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- - `SOL_SOCKET`, `SO_TYPE`
   --- - `SOL_SOCKET`, `SO_DEBUG`
   --- - `SOL_SOCKET`, `SO_ACCEPTCONN`
@@ -2317,10 +2284,10 @@ local record unix
   --- - `SOL_IP`, `IP_HDRINCL`
   --- unix.getsockopt(fd:int, level:int, optname:int)
   ---     ├─→ value:int
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- unix.setsockopt(fd:int, level:int, optname:int, value:int)
   ---     ├─→ true
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- - `SOL_SOCKET`, `SO_SNDBUF`
   --- - `SOL_SOCKET`, `SO_RCVBUF`
   --- - `SOL_SOCKET`, `SO_RCVLOWAT`
@@ -2338,10 +2305,10 @@ local record unix
   --- - `SOL_IP`, `IP_TTL`
   --- unix.getsockopt(fd:int, level:int, optname:int)
   ---     ├─→ secs:int, nsecs:int
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- unix.setsockopt(fd:int, level:int, optname:int, secs:int[, nanos:int])
   ---     ├─→ true
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- - `SOL_SOCKET`, `SO_RCVTIMEO`: If this option is specified then
   ---   your stream socket will have a read() / recv() timeout. If the
   ---   specified interval elapses without receiving data, then EAGAIN
@@ -2352,27 +2319,27 @@ local record unix
   ---   but it applies to the write() / send() functions.
   --- unix.getsockopt(fd:int, unix.SOL_SOCKET, unix.SO_LINGER)
   ---     ├─→ seconds:int, enabled:bool
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- unix.setsockopt(fd:int, unix.SOL_SOCKET, unix.SO_LINGER, secs:int, enabled:bool)
   ---     ├─→ true
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- This `SO_LINGER` parameter can be used to make close() a blocking
   --- call. Normally when the kernel returns immediately when it receives
   --- close(). Sometimes it's desirable to have extra assurance on errors
   --- happened, even if it comes at the cost of performance.
   --- unix.setsockopt(serverfd:int, unix.SOL_TCP, unix.TCP_SAVE_SYN, enabled:int)
   ---     ├─→ true
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- unix.getsockopt(clientfd:int, unix.SOL_TCP, unix.TCP_SAVED_SYN)
   ---     ├─→ syn_packet_bytes:str
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- This `TCP_SAVED_SYN` option may be used to retrieve the bytes of the
   --- TCP SYN packet that the client sent when the connection for `fd` was
   --- opened. In order for this to work, `TCP_SAVE_SYN` must have been set
   --- earlier on the listening socket. This is Linux-only. You can use the
   --- `OnServerListen` hook to enable SYN saving in your Redbean. When the
   --- `TCP_SAVE_SYN` option isn't used, this may return empty string.
-  getsockopt: function(fd: number, level: number, optname: number): number | nil, Errno
+  getsockopt: function(fd: number, level: number, optname: number): number, string | nil, number | nil
   --- Tunes networking parameters.
   --- `level` and `optname` may be one of the following pairs. The ellipses
   --- type signature above changes depending on which options are used.
@@ -2385,10 +2352,10 @@ local record unix
   --- Raises `EBADF` if `fd` isn't valid.
   --- unix.getsockopt(fd:int, level:int, optname:int)
   ---     ├─→ value:int
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- unix.setsockopt(fd:int, level:int, optname:int, value:bool)
   ---     ├─→ true
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- - `SOL_SOCKET`, `SO_TYPE`
   --- - `SOL_SOCKET`, `SO_DEBUG`
   --- - `SOL_SOCKET`, `SO_ACCEPTCONN`
@@ -2405,10 +2372,10 @@ local record unix
   --- - `SOL_IP`, `IP_HDRINCL`
   --- unix.getsockopt(fd:int, level:int, optname:int)
   ---     ├─→ value:int
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- unix.setsockopt(fd:int, level:int, optname:int, value:int)
   ---     ├─→ true
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- - `SOL_SOCKET`, `SO_SNDBUF`
   --- - `SOL_SOCKET`, `SO_RCVBUF`
   --- - `SOL_SOCKET`, `SO_RCVLOWAT`
@@ -2426,10 +2393,10 @@ local record unix
   --- - `SOL_IP`, `IP_TTL`
   --- unix.getsockopt(fd:int, level:int, optname:int)
   ---     ├─→ secs:int, nsecs:int
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- unix.setsockopt(fd:int, level:int, optname:int, secs:int[, nanos:int])
   ---     ├─→ true
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- - `SOL_SOCKET`, `SO_RCVTIMEO`: If this option is specified then
   ---   your stream socket will have a read() / recv() timeout. If the
   ---   specified interval elapses without receiving data, then EAGAIN
@@ -2440,27 +2407,27 @@ local record unix
   ---   but it applies to the write() / send() functions.
   --- unix.getsockopt(fd:int, unix.SOL_SOCKET, unix.SO_LINGER)
   ---     ├─→ seconds:int, enabled:bool
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- unix.setsockopt(fd:int, unix.SOL_SOCKET, unix.SO_LINGER, secs:int, enabled:bool)
   ---     ├─→ true
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- This `SO_LINGER` parameter can be used to make close() a blocking
   --- call. Normally when the kernel returns immediately when it receives
   --- close(). Sometimes it's desirable to have extra assurance on errors
   --- happened, even if it comes at the cost of performance.
   --- unix.setsockopt(serverfd:int, unix.SOL_TCP, unix.TCP_SAVE_SYN, enabled:int)
   ---     ├─→ true
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- unix.getsockopt(clientfd:int, unix.SOL_TCP, unix.TCP_SAVED_SYN)
   ---     ├─→ syn_packet_bytes:str
-  ---     └─→ nil, unix.Errno
+  ---     └─→ nil, string, integer
   --- This `TCP_SAVED_SYN` option may be used to retrieve the bytes of the
   --- TCP SYN packet that the client sent when the connection for `fd` was
   --- opened. In order for this to work, `TCP_SAVE_SYN` must have been set
   --- earlier on the listening socket. This is Linux-only. You can use the
   --- `OnServerListen` hook to enable SYN saving in your Redbean. When the
   --- `TCP_SAVE_SYN` option isn't used, this may return empty string.
-  setsockopt: function(fd: number, level: number, optname: number, value: boolean | number): boolean | nil, Errno
+  setsockopt: function(fd: number, level: number, optname: number, value: boolean | number): boolean, string | nil, number | nil
   --- Checks for events on a set of file descriptors.
   --- The table of file descriptors to poll uses sparse integer keys. Any
   --- pairs with non-integer keys will be ignored. Pairs with negative
@@ -2482,61 +2449,61 @@ local record unix
   --- - `POLLNVAL` (revents): Invalid request.
   --- If this is set to -1 then that means block as long as it takes until there's an
   --- event or an interrupt. If the timeout expires, an empty table is returned.
-  poll: function(fds: {number: number}, timeoutms?: number): {number: number} | nil, Errno
+  poll: function(fds: {number: number}, timeoutms?: number): {number: number}, string | nil, number | nil
   --- Returns hostname of system.
-  gethostname: function(): string | nil, Errno
+  gethostname: function(): string, string | nil, number | nil
   --- Sets hostname of system.
   --- Requires CAP_SYS_ADMIN on Linux (or root on BSDs); returns `EPERM`
   --- otherwise. Not supported on Windows, where it returns `ENOSYS`.
-  sethostname: function(name: string): boolean | nil, Errno
+  sethostname: function(name: string): boolean, string | nil, number | nil
   --- Begins listening for incoming connections on a socket.
-  listen: function(fd: number, backlog?: number): boolean | nil, Errno
+  listen: function(fd: number, backlog?: number): boolean, string | nil, number | nil
   --- Accepts new client socket descriptor for a listening tcp socket.
   --- `flags` may have any combination (using bitwise OR) of:
   --- - `SOCK_CLOEXEC`
   --- - `SOCK_NONBLOCK`
-  accept: function(serverfd: number, flags?: number): number | nil, number, number, Errno
+  accept: function(serverfd: number, flags?: number): number, number, number, string | nil, number | nil
   ---  Connects a TCP socket to a remote host.
   ---  With TCP this is a blocking operation. For a UDP socket it simply
   ---  remembers the intended address so that `send()` or `write()` may be used
   ---  rather than `sendto()`.
-  connect: function(fd: number, ip: number, port: number): boolean | nil, Errno
+  connect: function(fd: number, ip: number, port: number): boolean, string | nil, number | nil
   --- Retrieves the local address of a socket.
-  getsockname: function(fd: number): number | nil, number, Errno
+  getsockname: function(fd: number): number, number, string | nil, number | nil
   --- Retrieves the remote address of a socket.
   --- This operation will either fail on `AF_UNIX` sockets or return an
   --- empty string.
-  getpeername: function(fd: number): number | nil, number, Errno
+  getpeername: function(fd: number): number, number, string | nil, number | nil
   --- - `MSG_WAITALL`
   --- - `MSG_DONTROUTE`
   --- - `MSG_PEEK`
   --- - `MSG_OOB`
-  recv: function(fd: number, bufsiz?: number, flags?: number): string | nil, Errno
+  recv: function(fd: number, bufsiz?: number, flags?: number): string, string | nil, number | nil
   --- - `MSG_WAITALL`
   --- - `MSG_DONTROUTE`
   --- - `MSG_PEEK`
   --- - `MSG_OOB`
-  recvfrom: function(fd: number, bufsiz?: number, flags?: number): string | nil, number, number, Errno
+  recvfrom: function(fd: number, bufsiz?: number, flags?: number): string, number, number, string | nil, number | nil
   --- This is the same as `write` except it has a `flags` argument
   --- that's intended for sockets.
   --- - `MSG_NOSIGNAL`: Don't SIGPIPE on EOF
   --- - `MSG_OOB`: Send stream data through out of bound channel
   --- - `MSG_DONTROUTE`: Don't go through gateway (for diagnostics)
   --- - `MSG_MORE`: Manual corking to belay nodelay (0 on non-Linux)
-  send: function(fd: number, data: string, flags?: number, offset?: number): number | nil, Errno
+  send: function(fd: number, data: string, flags?: number, offset?: number): number, string | nil, number | nil
   --- This is useful for sending messages over UDP sockets to specific
   --- addresses.
   --- - `MSG_OOB`
   --- - `MSG_DONTROUTE`
   --- - `MSG_NOSIGNAL`
-  sendto: function(fd: number, data: string, ip: number, port: number, flags?: number): number | nil, Errno
+  sendto: function(fd: number, data: string, ip: number, port: number, flags?: number): number, string | nil, number | nil
   --- Partially closes socket.
   --- - `SHUT_RD`: sends a tcp half close for reading
   --- - `SHUT_WR`: sends a tcp half close for writing
   --- - `SHUT_RDWR`
   --- This system call currently has issues on Macintosh, so portable code
   --- should log rather than assert failures reported by `shutdown()`.
-  shutdown: function(fd: number, how: number): boolean | nil, Errno
+  shutdown: function(fd: number, how: number): boolean, string | nil, number | nil
   --- Manipulates bitset of signals blocked by process.
   --- - `SIG_BLOCK`: applies `mask` to set of blocked signals using bitwise OR
   --- - `SIG_UNBLOCK`: removes bits in `mask` from set of blocked signals
@@ -2548,7 +2515,7 @@ local record unix
   ---   oldmask = assert(unix.sigprocmask(unix.SIG_BLOCK, newmask))
   ---   -- do something...
   ---   assert(unix.sigprocmask(unix.SIG_SETMASK, oldmask))
-  sigprocmask: function(how: number, newmask: Sigset): Sigset | nil, Errno
+  sigprocmask: function(how: number, newmask: Sigset): Sigset, string | nil, number | nil
   --- - `unix.SIGINT`
   --- - `unix.SIGQUIT`
   --- - `unix.SIGTERM`
@@ -2598,9 +2565,9 @@ local record unix
   ---     assert(unix.sigaction(unix.SIGUSR1, OnSigUsr1))
   ---     assert(unix.raise(unix.SIGUSR1))
   ---     assert(not gotsigusr1)
-  ---     ok, err = unix.sigsuspend(oldmask)
+  ---     ok, err, errno = unix.sigsuspend(oldmask)
   ---     assert(not ok)
-  ---     assert(err:errno() == unix.EINTR)
+  ---     assert(errno == unix.EINTR)
   ---     assert(gotsigusr1)
   ---     assert(unix.sigprocmask(unix.SIG_SETMASK, oldmask))
   --- When `handler` is a Lua function, it is dispatched *deferred* rather than
@@ -2615,13 +2582,13 @@ local record unix
   --- handlers (e.g. `unix.SIG_IGN`, `unix.SIG_DFL`, or a raw function pointer)
   --- are installed directly and are not deferred.
   --- It's a good idea to not do too much work in a signal handler.
-  sigaction: function(sig: number, handler?: function | number, flags?: number, mask?: Sigset): function | number | nil, number, Sigset, Errno
+  sigaction: function(sig: number, handler?: function | number, flags?: number, mask?: Sigset): function | number, number, Sigset, string | nil, number | nil
   --- Waits for signal to be delivered.
   --- The signal mask is temporarily replaced with `mask` during this system call.
-  sigsuspend: function(mask?: Sigset): nil, Errno
+  sigsuspend: function(mask?: Sigset): nil, string | nil, number | nil
   --- Returns the set of signals pending delivery to the calling process
   --- that are currently blocked.
-  sigpending: function(): Sigset | nil, Errno
+  sigpending: function(): Sigset, string | nil, number | nil
   --- Causes `SIGALRM` signals to be generated at some point(s) in the
   --- future. The `which` parameter should be `ITIMER_REAL`.
   --- Here's an example of how to create a 400 ms interval timer:
@@ -2637,7 +2604,7 @@ local record unix
   --- Here's how you'd do a single-shot timeout in 1 second:
   ---     unix.sigaction(unix.SIGALRM, MyOnSigAlrm, unix.SA_RESETHAND)
   ---     unix.setitimer(unix.ITIMER_REAL, 0, 0, 1, 0)
-  setitimer: function(which: number, intervalsec: number, intervalns: number, valuesec: number, valuens: number): number | nil, number, number, number, Errno
+  setitimer: function(which: number, intervalsec: number, intervalns: number, valuesec: number, valuens: number): number, number, number, number, string | nil, number | nil
   --- Turns platform-specific `sig` code into its symbolic name.
   --- For example:
   ---     >: unix.strsignal(9)
@@ -2667,9 +2634,9 @@ local record unix
   --- If a limit isn't supported by the host platform, it'll be set to
   --- 127. On most platforms these limits are enforced by the kernel and
   --- as such are inherited by subprocesses.
-  setrlimit: function(resource: number, soft: number, hard?: number): boolean | nil, Errno
+  setrlimit: function(resource: number, soft: number, hard?: number): boolean, string | nil, number | nil
   --- Returns information about resource limits for current process.
-  getrlimit: function(resource: number): number | nil, number, Errno
+  getrlimit: function(resource: number): number, number, string | nil, number | nil
   --- Adjusts the nice value (scheduling priority) of the calling process.
   --- The nice value ranges from -20 (highest priority) to 19 (lowest priority).
   --- Only privileged processes can lower the nice value (increase priority).
@@ -2677,7 +2644,7 @@ local record unix
   --- priority, negative values increase it.
   --- Returns the new nice value on success. Note that -1 is a valid return
   --- value, so errors must be detected by checking the second return value.
-  nice: function(inc: number): number | nil, Errno
+  nice: function(inc: number): number, string | nil, number | nil
   --- Lowers the calling process to the lowest scheduling priority.
   --- On Linux this additionally requests the idle scheduling policy and a
   --- best-effort idle i/o priority. This function does not fail.
@@ -2690,7 +2657,7 @@ local record unix
   --- Returns the priority value (nice value) which ranges from -20 to 19.
   --- Note that -1 is a valid return value, so errors must be detected by
   --- checking the second return value.
-  getpriority: function(which: number, who: number): number | nil, Errno
+  getpriority: function(which: number, who: number): number, string | nil, number | nil
   --- Sets the scheduling priority of a process, process group, or user.
   --- `which` specifies what `who` refers to:
   --- - `PRIO_PROCESS`: `who` is a process id (0 = calling process)
@@ -2699,7 +2666,7 @@ local record unix
   --- `prio` is the new priority value (nice value), ranging from -20
   --- (highest priority) to 19 (lowest priority). Only privileged processes
   --- can set negative priority values.
-  setpriority: function(which: number, who: number, prio: number): boolean | nil, Errno
+  setpriority: function(which: number, who: number, prio: number): boolean, string | nil, number | nil
   --- Returns information about resource usage for current process, e.g.
   ---     >: unix.getrusage()
   ---     {utime={0, 53644000}, maxrss=44896, minflt=545, oublock=24, nvcsw=9}
@@ -2707,7 +2674,7 @@ local record unix
   --- - `RUSAGE_THREAD`: current thread
   --- - `RUSAGE_CHILDREN`: not supported on Windows NT
   --- - `RUSAGE_BOTH`: not supported on non-Linux
-  getrusage: function(who?: number): Rusage | nil, Errno
+  getrusage: function(who?: number): Rusage, string | nil, number | nil
   --- Restrict system operations.
   --- This can be used to sandbox your redbean workers. It allows finer
   --- customization compared to the `-S` flag.
@@ -2830,7 +2797,7 @@ local record unix
   ---   means that the `unix.WTERMSIG()` on your killed processes will
   ---   always be `unix.SIGABRT` on both Linux and OpenBSD. Otherwise,
   ---   Linux prefers to raise `unix.SIGSYS`.
-  pledge: function(promises?: string, execpromises?: string, mode?: number): boolean | nil, Errno
+  pledge: function(promises?: string, execpromises?: string, mode?: number): boolean, string | nil, number | nil
   --- Restricts filesystem operations, e.g.
   ---    unix.unveil(".", "r");     -- current dir + children visible
   ---    unix.unveil("/etc", "r");  -- make /etc readable too
@@ -2873,9 +2840,9 @@ local record unix
   ---   corresponding to the pledge promises "exec" and "execnative".
   --- - `c` allows `path` to be created and removed, corresponding to
   ---   the pledge promise "cpath".
-  unveil: function(path: string, permissions: string): boolean | nil, Errno
+  unveil: function(path: string, permissions: string): boolean, string | nil, number | nil
   --- Breaks down UNIX timestamp into Zulu Time numbers.
-  gmtime: function(unixts: number): number | nil, number, number, number, number, number, number, number, number, number, string, Errno
+  gmtime: function(unixts: number): number, number, number, number, number, number, number, number, number, number, string, string | nil, number | nil
   --- Breaks down UNIX timestamp into local time numbers, e.g.
   ---     >: unix.localtime(unix.clock_gettime())
   ---     2022    4       28      2       14      22      -25200  4       117     1       "PDT"
@@ -2901,10 +2868,10 @@ local record unix
   --- can simply copy it inside your redbean. The same is also the case
   --- for future updates to the database, which can be swapped out when
   --- needed, without having to recompile.
-  localtime: function(unixts: number): number | nil, number, number, number, number, number, number, number, number, number, string, Errno
+  localtime: function(unixts: number): number, number, number, number, number, number, number, number, number, number, string, string | nil, number | nil
   --- Gets information about file or directory.
   --- - `AT_SYMLINK_NOFOLLOW`: do not follow symbolic links.
-  stat: function(path: string, flags?: number, dirfd?: number): Stat | nil, Errno
+  stat: function(path: string, flags?: number, dirfd?: number): Stat, string | nil, number | nil
   --- Tests if file mode represents a directory.
   S_ISDIR: function(mode: number): boolean
   --- Tests if file mode represents a regular file.
@@ -2929,7 +2896,7 @@ local record unix
   ---     st = assert(unix.fstat(fd))
   ---     Log(kLogInfo, 'hello.txt is %d bytes in size' % {st:size()})
   ---     unix.close(fd)
-  fstat: function(fd: number): Stat | nil, Errno
+  fstat: function(fd: number): Stat, string | nil, number | nil
   --- Opens directory for listing its contents.
   --- For example, to print a simple directory listing:
   ---     Write('<ul>\r\n')
@@ -2939,19 +2906,19 @@ local record unix
   ---         end
   ---     end
   ---     Write('</ul>\r\n')
-  opendir: function(path: string): Dir | nil, Errno
+  opendir: function(path: string): Dir, string | nil, number | nil
   --- Opens directory for listing its contents, via an fd.
   --- The returned `unix.Dir` takes ownership of the file descriptor
   --- and will close it automatically when garbage collected.
-  fdopendir: function(fd: number): Dir | nil, Errno
+  fdopendir: function(fd: number): Dir, string | nil, number | nil
   --- Returns true if file descriptor is a teletypewriter. Otherwise nil
   --- with an Errno object holding one of the following values:
   --- - `ENOTTY` if `fd` is valid but not a teletypewriter
   --- - `EBADF` if `fd` isn't a valid file descriptor.
   --- - `EPERM` if pledge() is used without `tty` in lenient mode
   --- No other error numbers are possible.
-  isatty: function(fd: number): boolean | nil, Errno
-  tiocgwinsz: function(fd: number): number | nil, number, Errno
+  isatty: function(fd: number): boolean, string | nil, number | nil
+  tiocgwinsz: function(fd: number): number, number, string | nil, number | nil
   --- Gets terminal attributes.
   --- Returns a termios table containing the terminal I/O settings for the
   --- specified file descriptor. The table contains these fields:
@@ -2970,7 +2937,7 @@ local record unix
   ---     local password = io.read()
   ---     tio.lflag = old_lflag
   ---     unix.tcsetattr(0, unix.TCSANOW, tio)
-  tcgetattr: function(fd: number): Termios | nil, Errno
+  tcgetattr: function(fd: number): Termios, string | nil, number | nil
   --- Sets terminal attributes.
   --- Modifies the terminal I/O settings for the specified file descriptor
   --- using the provided termios table. The `action` parameter controls when
@@ -2981,7 +2948,7 @@ local record unix
   ---   input is discarded
   --- The termios table should contain the same fields as returned by
   --- `unix.tcgetattr()`. Missing fields default to zero.
-  tcsetattr: function(fd: number, action: number, termios: Termios): boolean | nil, Errno
+  tcsetattr: function(fd: number, action: number, termios: Termios): boolean, string | nil, number | nil
   --- Returns file descriptor of open anonymous file.
   --- This creates a secure temporary file inside `$TMPDIR`. If it isn't
   --- defined, then `/tmp` is used on UNIX and GetTempPath() is used on
@@ -2992,59 +2959,59 @@ local record unix
   --- On the New Technology, temporary files created by this function
   --- should have better performance, because `kNtFileAttributeTemporary`
   --- asks the kernel to more aggressively cache and reduce i/o ops.
-  tmpfd: function(): number | nil, Errno
+  tmpfd: function(): number, string | nil, number | nil
   --- Relinquishes scheduled quantum.
   sched_yield: function()
   --- Disassociates parts of the caller's execution context, placing it
   --- into fresh namespace(s) specified by `flags` (bitwise OR of
   --- `unix.CLONE_NEW*` constants). Linux-only; returns ENOSYS elsewhere.
-  unshare: function(flags: number): boolean | nil, Errno
+  unshare: function(flags: number): boolean, string | nil, number | nil
   --- Reassociates the calling thread with the namespace referenced by
   --- `fd` (typically from `/proc/<pid>/ns/*`). `nstype`, if nonzero,
   --- must match a `unix.CLONE_NEW*` constant and asserts the kind of
   --- namespace. Linux-only; returns ENOSYS elsewhere.
-  setns: function(fd: number, nstype?: number): boolean | nil, Errno
+  setns: function(fd: number, nstype?: number): boolean, string | nil, number | nil
   --- Mounts a filesystem. `flags` is a bitwise OR of `unix.MS_*`
   --- constants; `data` is a filesystem-specific options string.
-  mount: function(source?: string, target?: string, fstype?: string, flags?: number, data?: string): boolean | nil, Errno
+  mount: function(source?: string, target?: string, fstype?: string, flags?: number, data?: string): boolean, string | nil, number | nil
   --- Unmounts a filesystem. On Linux this is the `umount2` syscall.
   --- `flags` may include `unix.MNT_FORCE`, `unix.MNT_DETACH`,
   --- `unix.MNT_EXPIRE`, `unix.UMOUNT_NOFOLLOW`.
-  unmount: function(target: string, flags?: number): boolean | nil, Errno
+  unmount: function(target: string, flags?: number): boolean, string | nil, number | nil
   --- Moves the root filesystem of the current mount namespace to
   --- `put_old` and makes `new_root` the new root. Usually paired with
   --- `chdir("/")` in the child. Requires a private mount namespace.
-  pivot_root: function(new_root: string, put_old: string): boolean | nil, Errno
+  pivot_root: function(new_root: string, put_old: string): boolean, string | nil, number | nil
   --- Performs an operation on the calling process. `option` is one of
   --- the `unix.PR_*` constants; remaining arguments are option-specific.
   --- Returns the integer result (0 for most setters).
-  prctl: function(option: number, arg2?: number, arg3?: number, arg4?: number, arg5?: number): number | nil, Errno
+  prctl: function(option: number, arg2?: number, arg3?: number, arg4?: number, arg5?: number): number, string | nil, number | nil
   --- Returns the calling thread's (or `pid`'s) capability sets as
   --- 64-bit bitmasks. Each bit position N corresponds to `unix.CAP_*`
   --- constant N. Linux-only.
-  capget: function(pid?: number): number | nil, number, number, Errno
+  capget: function(pid?: number): number, number, number, string | nil, number | nil
   --- Sets the calling thread's (or `pid`'s) capability sets. Each
   --- argument is a 64-bit bitmask of `1 << unix.CAP_*` bits. Linux-only.
-  capset: function(effective: number, permitted: number, inheritable: number, pid?: number): boolean | nil, Errno
+  capset: function(effective: number, permitted: number, inheritable: number, pid?: number): boolean, string | nil, number | nil
   --- Generic device control. When `arg` is nil or absent, the ioctl is
   --- invoked with a null pointer. When `arg` is an integer, it's passed
   --- by value. When `arg` is a string, a mutable copy of the same size
   --- is passed to the kernel and the (possibly-modified) buffer of the
   --- same length is returned.
-  ioctl: function(fd: number, request: number, arg?: number | string): boolean | string | nil, Errno
+  ioctl: function(fd: number, request: number, arg?: number | string): boolean | string, string | nil, number | nil
   --- Landlock: create ruleset. With no args, returns the kernel's
   --- supported ABI version. With `handled_access_fs`, creates a new
   --- ruleset file descriptor that handles the given access categories
   --- (bitwise OR of `unix.LANDLOCK_ACCESS_FS_*`). Linux 5.13+.
-  landlock_create_ruleset: function(handled_access_fs?: number, flags?: number): number | nil, Errno
+  landlock_create_ruleset: function(handled_access_fs?: number, flags?: number): number, string | nil, number | nil
   --- Landlock: add a PATH_BENEATH rule granting `allowed` access to the
   --- subtree rooted at `parent_fd` (opened with `unix.O_PATH`). `allowed`
   --- must be a subset of the ruleset's handled set.
-  landlock_add_rule: function(ruleset_fd: number, parent_fd: number, allowed: number, flags?: number): boolean | nil, Errno
+  landlock_add_rule: function(ruleset_fd: number, parent_fd: number, allowed: number, flags?: number): boolean, string | nil, number | nil
   --- Landlock: apply the ruleset to the current thread (and its future
   --- children). Caller must set `PR_SET_NO_NEW_PRIVS` first or hold
   --- `CAP_SYS_ADMIN`. The restriction is irrevocable.
-  landlock_restrict_self: function(ruleset_fd: number, flags?: number): boolean | nil, Errno
+  landlock_restrict_self: function(ruleset_fd: number, flags?: number): boolean, string | nil, number | nil
   --- Creates interprocess shared memory mapping.
   --- This function allocates special memory that'll be inherited across
   --- fork in a shared way. By default all memory in Redbean is "private"
@@ -3103,9 +3070,9 @@ local record unix
   --- Extracts the minor device number from a device id such as `Stat:rdev()`.
   minor: function(rdev: number): number
   --- Gets filesystem statistics for the filesystem that contains `path`.
-  statfs: function(path: string): Statfs | nil, Errno
+  statfs: function(path: string): Statfs, string | nil, number | nil
   --- Gets filesystem statistics via an open file descriptor.
-  fstatfs: function(fd: number): Statfs | nil, Errno
+  fstatfs: function(fd: number): Statfs, string | nil, number | nil
   --- Signal set for blocking, unblocking, and waiting on signals.
   --- Used with `unix.sigprocmask()`, `unix.sigaction()`, and `unix.sigsuspend()`.
   --- The unix.Sigset class defines a mutable bitset that may currently

--- a/lib/types/gentype.tl
+++ b/lib/types/gentype.tl
@@ -4,6 +4,7 @@
 
 local cosmo = require("cosmo")
 local cosmic = require("cosmic")
+local tl = require("tl")
 local gt = require("types.gentype_types")
 local Param = gt.Param
 local Return = gt.Return
@@ -22,6 +23,7 @@ local render = require("types.gentype_render") as GentypeRender
 
 local record GentypeParse
   parse_annotations: function(raw_lines: {string}): {string}, {Param}, {Return}, boolean, string, {Field}, boolean, string
+  valid_type: function(t: string): boolean
 end
 local parse = require("types.gentype_parse") as GentypeParse
 local parse_annotations = parse.parse_annotations
@@ -295,6 +297,99 @@ local record Result
   error: string
 end
 
+local UPSTREAM_HINT = "; fix the annotation upstream in whilp/cosmopolitan"
+  .. " tool/net/definitions.lua (its test_definitions_coverage.lua check 9"
+  .. " validates the same type grammar)"
+
+--- Validate every parsed type expression in a module against the type
+--- grammar, so a malformed upstream annotation fails generation loudly with
+--- a pointer at the offending definitions.lua entry instead of rendering
+--- invalid Teal. Returns an error message, or nil when everything is valid.
+local function validate_module(module: ModuleDecl): string
+  local function bad(decl: string, what: string, text: string): string
+    return "invalid type annotation in definitions.lua module '" .. module.name
+      .. "': " .. decl .. " " .. what .. " has malformed type '"
+      .. tostring(text) .. "'" .. UPSTREAM_HINT
+  end
+  local function check_func(decl: string, f: FuncDecl): string
+    for _, p in ipairs(f.params) do
+      if not parse.valid_type(p.param_type) then
+        return bad(decl, "param '" .. p.name .. "'", p.param_type)
+      end
+    end
+    for idx, r in ipairs(f.returns) do
+      if r.description ~= "type" and not parse.valid_type(r.return_type) then
+        return bad(decl, "return #" .. idx, r.return_type)
+      end
+    end
+    if f.fallible and f.error_type and not parse.valid_type(f.error_type) then
+      return bad(decl, "error type", f.error_type)
+    end
+    return nil
+  end
+  for _, f in ipairs(module.functions) do
+    local err = check_func(module.name .. "." .. f.name, f)
+    if err then return err end
+  end
+  for _, cls in ipairs(module.classes) do
+    for _, field in ipairs(cls.fields) do
+      if not parse.valid_type(field.field_type) then
+        return bad(module.name .. "." .. cls.name .. "." .. field.name,
+          "field", field.field_type)
+      end
+    end
+    for _, m in ipairs(cls.methods) do
+      local err = check_func(module.name .. "." .. cls.name .. ":" .. m.name, m)
+      if err then return err end
+    end
+  end
+  for _, c in ipairs(module.constants) do
+    if not parse.valid_type(c.const_type) then
+      return bad(module.name .. "." .. c.name, "constant", c.const_type)
+    end
+  end
+  return nil
+end
+
+--- Belt and suspenders: the rendered output must at least parse as Teal.
+--- Full cross-module type resolution is not available at generation time,
+--- so only syntax errors are consulted. Returns an error message or nil.
+local function syntax_check(output: string, module_name: string): string
+  local name = "cosmo/" .. module_name .. ".d.tl"
+  local env = tl.init_env(true)
+  local ok, res = pcall(tl.process_string, output, false, env, name)
+  if not ok then
+    return "generated " .. name .. " failed to parse: " .. tostring(res)
+      .. "; this usually means a malformed type annotation in definitions.lua"
+      .. UPSTREAM_HINT
+  end
+  local result = res as tl.Result
+  if result and result.syntax_errors and #result.syntax_errors > 0 then
+    local msgs: {string} = {}
+    for idx, e in ipairs(result.syntax_errors) do
+      if idx > 3 then break end
+      table.insert(msgs, tostring(e.y or 0) .. ":" .. tostring(e.x or 0)
+        .. ": " .. (e.msg or ""))
+    end
+    return "generated " .. name .. " is not valid Teal ("
+      .. table.concat(msgs, "; ")
+      .. "); this usually means a malformed type annotation in definitions.lua"
+      .. UPSTREAM_HINT
+  end
+  return nil
+end
+
+--- Validate a parsed module and render it, syntax-checking the result.
+--- Returns the rendered output, or nil and an error message.
+local function render_module(module: ModuleDecl): string, string
+  local verr = validate_module(module)
+  if verr then return nil, verr end
+  local output = render.generate_dtl(module)
+  local serr = syntax_check(output, module.name)
+  if serr then return nil, serr end
+  return output
+end
+
 --- Run the generator for a specific module or all modules.
 local function run(module_name: string): Result
   local source = cosmo.Slurp(defs_path())
@@ -314,14 +409,22 @@ local function run(module_name: string): Result
     if not module then
       return {success = false, error = "Failed to parse module: " .. module_name}
     end
-    return {success = true, output = render.generate_dtl(module)}
+    local output, err = render_module(module)
+    if not output then
+      return {success = false, error = err}
+    end
+    return {success = true, output = output}
   else
     local outputs: {string} = {}
     for _, m in ipairs(MODULES) do
       local module = parse_module(source, m)
       if module then
+        local output, err = render_module(module)
+        if not output then
+          return {success = false, error = err}
+        end
         table.insert(outputs, "-- === " .. m .. " ===")
-        table.insert(outputs, render.generate_dtl(module))
+        table.insert(outputs, output)
       end
     end
     return {success = true, output = table.concat(outputs, "\n")}
@@ -335,6 +438,7 @@ end
 local record GenTypeModule
   run: function(module_name?: string): Result
   parse_module: function(source: string, module_name: string): ModuleDecl
+  render_module: function(module: ModuleDecl): string, string
   generate_dtl: function(module: ModuleDecl): string
   convert_type: function(t: string): string
   get_modules: function(): {string}
@@ -344,6 +448,7 @@ end
 local M: GenTypeModule = {
   run = run,
   parse_module = parse_module,
+  render_module = render_module,
   generate_dtl = render.generate_dtl,
   convert_type = render.convert_type,
   get_modules = get_modules,

--- a/lib/types/gentype_parse.tl
+++ b/lib/types/gentype_parse.tl
@@ -69,6 +69,168 @@ local function split_type_desc(rest: string): string, string
   return scan_token(rest)
 end
 
+--- Validate a type expression against the LuaLS type grammar gentype
+--- understands (upstream's test_definitions_coverage.lua check 9 enforces
+--- the same grammar on definitions.lua):
+---   union   := postfix ('|' postfix)*
+---   postfix := atom ('?' | '[]')*
+---   atom    := 'fun' '(' balanced ')' (':' return-list)?
+---            | '{' balanced '}' | '(' union ')'
+---            | quoted string literal | integer literal
+---            | dotted identifier ('<' type-list '>')?
+--- plus the generator-synthesized trailing `...` variadic suffix
+--- (`string...`). A parse that consumes the whole string = valid; anything
+--- else (e.g. the malformed `nil,|nil` that once rendered invalid Teal and
+--- surfaced as baffling downstream type errors) is rejected.
+local function valid_type(t: string): boolean
+  if not t then return false end
+  local src = t:match("^%s*(.-)%s*$")
+  if src == "" then return false end
+  local pos = 1
+  local n = #src
+
+  local function skip_ws()
+    while pos <= n and src:sub(pos, pos):match("%s") do pos = pos + 1 end
+  end
+
+  -- Consume from the opening bracket at `pos` to its balanced close. The
+  -- contents are not deep-validated (inline table and fun-arg types carry
+  -- their own labeled grammar); balance is the invariant that keeps the
+  -- rendered Teal parseable.
+  local function skip_balanced(open: string, close: string): boolean
+    if src:sub(pos, pos) ~= open then return false end
+    local depth = 0
+    while pos <= n do
+      local c = src:sub(pos, pos)
+      if c == open then
+        depth = depth + 1
+      elseif c == close then
+        depth = depth - 1
+        if depth == 0 then
+          pos = pos + 1
+          return true
+        end
+      end
+      pos = pos + 1
+    end
+    return false
+  end
+
+  local parse_union: function(): boolean
+
+  -- Return list after `fun(...):` — one or more comma-separated entries,
+  -- each a union or a typed vararg (`...`, `...: string|nil`) as folded by
+  -- split_type_desc.
+  local function parse_fun_returns(): boolean
+    while true do
+      skip_ws()
+      if src:sub(pos, pos + 2) == "..." then
+        pos = pos + 3
+        skip_ws()
+        if src:sub(pos, pos) == ":" then
+          pos = pos + 1
+          if not parse_union() then return false end
+        end
+      elseif not parse_union() then
+        return false
+      end
+      skip_ws()
+      if src:sub(pos, pos) ~= "," then return true end
+      pos = pos + 1
+    end
+  end
+
+  local function parse_atom(): boolean
+    skip_ws()
+    if pos > n then return false end
+    local c = src:sub(pos, pos)
+    if src:match("^fun%(", pos) then
+      pos = pos + 3
+      if not skip_balanced("(", ")") then return false end
+      local save = pos
+      skip_ws()
+      if src:sub(pos, pos) == ":" then
+        pos = pos + 1
+        return parse_fun_returns()
+      end
+      pos = save
+      return true
+    elseif c == "{" then
+      return skip_balanced("{", "}")
+    elseif c == "(" then
+      pos = pos + 1
+      if not parse_union() then return false end
+      skip_ws()
+      if src:sub(pos, pos) ~= ")" then return false end
+      pos = pos + 1
+      return true
+    elseif c == "\"" or c == "'" then
+      local close = src:find(c, pos + 1, true)
+      if not close then return false end
+      pos = close + 1
+      return true
+    elseif src:match("^%-?%d", pos) then
+      pos = pos + #src:match("^%-?%d+", pos)
+      return true
+    end
+    local ident = src:match("^[%a_][%w_]*", pos)
+    if not ident then return false end
+    pos = pos + #ident
+    while true do
+      local seg = src:match("^%.[%a_][%w_]*", pos)
+      if not seg then break end
+      pos = pos + #seg
+    end
+    if src:sub(pos, pos) == "<" then
+      pos = pos + 1
+      while true do
+        if not parse_union() then return false end
+        skip_ws()
+        if src:sub(pos, pos) ~= "," then break end
+        pos = pos + 1
+      end
+      if src:sub(pos, pos) ~= ">" then return false end
+      pos = pos + 1
+    end
+    return true
+  end
+
+  local function parse_postfix(): boolean
+    if not parse_atom() then return false end
+    while true do
+      if src:sub(pos, pos) == "?" then
+        pos = pos + 1
+      elseif src:sub(pos, pos + 1) == "[]" then
+        pos = pos + 2
+      else
+        break
+      end
+    end
+    return true
+  end
+
+  parse_union = function(): boolean
+    if not parse_postfix() then return false end
+    while true do
+      local save = pos
+      skip_ws()
+      if src:sub(pos, pos) ~= "|" then
+        pos = save
+        return true
+      end
+      pos = pos + 1
+      if not parse_postfix() then return false end
+    end
+  end
+
+  if not parse_union() then return false end
+  if src:sub(pos, pos + 2) == "..." then
+    pos = pos + 3
+  end
+  skip_ws()
+  return pos > n
+end
+
 --- Parse annotations from a block of text before a declaration.
 local function parse_annotations(raw_lines: {string}): {string}, {Param}, {Return}, boolean, string, {Field}, boolean, string
   local desc: {string} = {}
@@ -269,11 +431,13 @@ end
 local record GentypeParseModule
   split_type_desc: function(rest: string): string, string
   parse_annotations: function(raw_lines: {string}): {string}, {Param}, {Return}, boolean, string, {Field}, boolean, string
+  valid_type: function(t: string): boolean
 end
 
 local M: GentypeParseModule = {
   split_type_desc = split_type_desc,
   parse_annotations = parse_annotations,
+  valid_type = valid_type,
 }
 
 return M

--- a/lib/types/gentype_render.tl
+++ b/lib/types/gentype_render.tl
@@ -16,7 +16,7 @@ local ModuleDecl = gt.ModuleDecl
 local current_module: string = nil
 
 -- Type conversion from LuaLS to Teal
-local TYPE_ALIASES = {
+local TYPE_ALIASES: {string: string} = {
   ["integer"] = "number",
   ["number"] = "number",
   ["string"] = "string",

--- a/lib/types/gentype_test.tl
+++ b/lib/types/gentype_test.tl
@@ -309,6 +309,69 @@ function lsqlite3.open(filename) end
   print("test_qualified_class_methods: PASS")
 end
 
+-- A malformed upstream annotation (the real-world `---@return nil,|nil ...`
+-- left by a definitions.lua rewrite) must fail loudly at generation time,
+-- naming the offending declaration and pointing upstream, instead of
+-- rendering invalid Teal that surfaces as baffling downstream type errors.
+local function test_malformed_annotation_fails_loudly()
+  local source = [==[
+unix = {}
+
+--- Replaces current process with program.
+---@param prog string
+---@param args string[]
+---@param env string[]
+---@return nil,|nil string, integer error
+---@return string? error
+---@return integer? errno
+function unix.execve(prog, args, env) end
+]==]
+  local module = gentype.parse_module(source, "unix")
+  local output, err = gentype.render_module(module)
+  assert(not output, "malformed annotation must not render, got:\n" .. tostring(output))
+  assert(err, "expected an error message")
+  assert(err:find("unix.execve", 1, true),
+    "error must name the offending declaration: " .. err)
+  assert(err:find("nil,|nil", 1, true),
+    "error must quote the offending type text: " .. err)
+  assert(err:find("tool/net/definitions.lua", 1, true),
+    "error must point at the upstream fix location: " .. err)
+  print("test_malformed_annotation_fails_loudly: PASS")
+end
+
+-- Valid annotations of every supported grammar shape (unions, optionals,
+-- arrays, fun types, table types, inline maps, grouped unions, literals,
+-- varargs, generic instantiation) must pass validation and render.
+local function test_valid_types_pass_validation()
+  local source = [==[
+unix = {}
+--- Exercises the whole type grammar.
+---@param a string
+---@param b integer|string?
+---@param c fun(x: integer, ...): string?
+---@param d table<string, any>
+---@param e string[][]
+---@param f { [string]: integer }
+---@param g (true | string)
+---@param h "MD5"|'SHA256'
+---@param i unix.Sigset?
+---@return string? value
+---@return string? error
+---@return integer? errno
+function unix.frob(a, b, c, d, e, f, g, h, i) end
+
+--- Variadic return.
+---@param fd integer
+---@return string match, string ... captures
+function unix.grab(fd) end
+]==]
+  local module = gentype.parse_module(source, "unix")
+  local output, err = gentype.render_module(module)
+  assert(output, "valid annotations must render, got error: " .. tostring(err))
+  assert(output:match("frob: function%("), "frob should render:\n" .. output)
+  print("test_valid_types_pass_validation: PASS")
+end
+
 -- Drift: generator output must match the committed .d.tl byte-for-byte for
 -- every module. Fails after a cosmos bump or generator change until
 -- `bin/make regen-types` is run and the result committed.
@@ -417,6 +480,8 @@ local function run_tests()
   test_constant_docs_and_comment_braces()
   test_data_class_and_type_export()
   test_qualified_class_methods()
+  test_malformed_annotation_fails_loudly()
+  test_valid_types_pass_validation()
   test_module_list_completeness()
   test_drift_all_modules()
   test_generated_valid_teal()

--- a/skills/cosmic/checking.md
+++ b/skills/cosmic/checking.md
@@ -55,7 +55,6 @@ use `as` to cast between types when you know more than the type checker:
 
 ```teal
 local result = json.decode(input) as {string: any}
-local errno = err as Errno
 local count = value as integer
 ```
 


### PR DESCRIPTION
Adopts the cosmopolitan error-convention overhaul (whilp/cosmopolitan#151, PRs #159–#167): every fallible `cosmo` binding now returns `nil, err:string, errno:integer?` instead of the five old dialects (`unix.Errno` userdata, `re.Errno`, throwers, `-1`/`0` sentinels, argon2 tri-state). Pin bumped to `2026.07.06-dfdf61ac4` — the first release containing the definitions.lua syntax fixes from whilp/cosmopolitan#167, which this bump surfaced.

## Wrapper migration

- **errno** — the linchpin: `Errno` userdata type deleted; `str()` prefixes and strips the binding's duplicate lowercase `call:` head (so `"mkdir: /x: EACCES: Permission denied"` keeps its shape); `is()` now compares the numeric errno (third return) instead of poking userdata methods.
- **poll / child_io / quicksand** — EINTR/EAGAIN/EPIPE/ENOSYS/EPERM control flow branches on the numeric errno. These were the dangerous silent breaks: `errno.is(err_string, …)` always returned false, which would have quietly disabled poll's EINTR retry and quicksand's sandbox fail-open classification.
- **re** — `search` exposes capture groups (`{string}`) and finally distinguishes no-match (`nil`) from engine error (`nil, nil, err`).
- **hash** — argon2 string variants validated in the wrapper (binding raises on unknown strings), salt delegated to the binding's CSPRNG, `verify` simplified to `(boolean, err?)`.
- **codec / compress** — `DecodeHex`/`Uncompress`/`Inflate`/base32 stop pcalling; the bindings return `nil, err` instead of throwing. `deflate` also stops concatenating a possibly-nil binding result.
- **ip / net** — `ParseIp`/`ResolveIp` `-1` sentinels replaced by honest `nil, err` (net.tl had its own copy of the sentinel check).
- **io** — `Barf` options table (`{mode=…}`) replaces the positional-flags footgun; `slurp` forwards the binding's path-qualified error; `pipe` reads the error from its new position.
- **rand** — purged `Lemur64`/`Rdrand`/`Rdseed`/`has_hwrng` removed; `bytes()` is honestly fallible (`string | nil, string`).
- **time** — `format_date`/`format_iso8601` forward `Strftime`'s error.
- **proc / signal / tty / user / env / fs / sys / pledge / unveil** — `Errno` type annotations become `string`.

## Toolchain robustness

This bump broke the update tooling twice; both failure classes are now closed:

1. **gentype emitted unparseable Teal from malformed annotations.** The upstream dialect rewrite left `---@return nil,|nil string, integer error` on the exec family; gentype silently rendered `function(...): nil,, number, …`, which surfaced later as a baffling `variable 'unix' of type boolean`. gentype now validates every parsed type expression against the LuaLS type grammar and syntax-checks its rendered output with the embedded Teal parser — regen-types aborts with an error naming the offending definitions.lua declaration. Upstream, whilp/cosmopolitan#167 adds the mirror-image ratchet (check 9) so malformed types can't ship in the first place.
2. **The bootstrap chicken-and-egg.** lib/build's fetch/stage pipeline runs under the pinned bootstrap cosmic (old runtime) but requires modules compiled from the current tree (new binding contract) — `cosmo.Barf`'s signature change crashed the fetch step. New `lib/build/portable.tl` writes files through signature-stable `unix.open/write/close`, keeping the pipeline working on either side of any binding change. `build-stage` also clears stale destination entries before `rename()`, making restage idempotent.

## Types

Regenerated from the pinned release (`bin/make regen-types`); the gentype drift test is green, confirming committed `.d.tl` files are byte-identical to generator output from the embedded definitions.lua.

## Testing

`bin/make ci` fully green: 102 tests, teal 226, format 226, example 18, lint 290. New coverage: gentype fail-loud validation (fed the real-world malformed annotation), re captures/no-match/non-participating groups, errno prefix-strip semantics, portable writer roundtrip/truncate/mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJhKFGUr4h42ifchBdDnzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJhKFGUr4h42ifchBdDnzj)_