### PR TITLE
release: locate artifact binaries instead of trusting a hard-coded path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,22 @@ jobs:
           PRERELEASE_FLAG: ${{ (github.event.inputs.prerelease == 'true' || (github.event.inputs.prerelease == '' && env.PRERELEASE == 'true')) && '--prerelease' || '' }}
         run: |
           mkdir -p release
-          cp artifacts/cosmic-lua/cosmic release/cosmic-lua
-          cp artifacts/cosmic-lua/cosmic-debug release/cosmic-lua-debug
+          # upload-artifact >= v7 ships the artifact as a zip (archive: true
+          # by default) and download-artifact >= v8 does not extract it, while
+          # older versions delivered the files directly -- the v4 -> v7/v8
+          # bump silently broke every release after 2026-03-24. Handle both
+          # layouts and fail loudly (with a listing) if the binaries are
+          # missing, instead of trusting a hard-coded path.
+          find artifacts -type f -name '*.zip' -execdir unzip -o {} \;
+          cosmic_src=$(find artifacts -type f -name cosmic | head -1)
+          debug_src=$(find artifacts -type f -name cosmic-debug | head -1)
+          if [ -z "$cosmic_src" ] || [ -z "$debug_src" ]; then
+            echo "cosmic binaries not found in downloaded artifacts:" >&2
+            find artifacts >&2
+            exit 1
+          fi
+          cp "$cosmic_src" release/cosmic-lua
+          cp "$debug_src" release/cosmic-lua-debug
           chmod +x release/cosmic-lua release/cosmic-lua-debug
           tag="$(date -u +%Y-%m-%d)-${GITHUB_SHA::7}"
           (cd release && sha256sum cosmic-lua cosmic-lua-debug > SHA256SUMS && cat SHA256SUMS)


### PR DESCRIPTION
The release you dispatched ([run 28814253951](https://github.com/whilp/cosmic/actions/runs/28814253951)) failed at `create release` with `cp: cannot stat 'artifacts/cosmic-lua/cosmic'` — and digging in, **every daily release since 2026-03-25 has failed the same way** (latest published release is `2026-03-24-f2f562b`, which is why the bootstrap pin has been stuck on a March binary).

## Root cause

#405 (whilpbot, 2026-03-24) bumped `actions/upload-artifact` v4→v7 and `actions/download-artifact` v4→v8 for Node 24 compatibility. The new versions changed the artifact layout: upload-artifact ≥ v7 ships the artifact as a zip (`archive: true` is the default — the build log shows `Uploading artifact: cosmic-lua.zip`) and download-artifact ≥ v8 delivers it without extracting, so the release step's hard-coded `cp artifacts/cosmic-lua/cosmic` finds nothing. The build itself is fine — both binaries upload successfully.

## Fix

The `create release` step now extracts any downloaded artifact zips, locates `cosmic`/`cosmic-debug` wherever they landed (works with both the old extracted layout and the new zipped one), and fails with a full `find` listing of `artifacts/` when the binaries are missing — so the next layout change surfaces as one clear error instead of months of silent failures.

## Follow-up once this merges

Re-dispatch `release.yml` — a successful release from current main unblocks the bootstrap pin bump in `cook.mk` (currently `2026-03-08-ac3a5d5`), after which the transitional barf runtime shim in `lib/cosmic/io.tl` can be deleted. That's the last piece of the error-convention migration (#544).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJhKFGUr4h42ifchBdDnzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJhKFGUr4h42ifchBdDnzj)_