### PR TITLE
bootstrap: bump to 2026-07-06-9b7f95b; drop the barf runtime shim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,16 @@ all_versioned := $(call filter-only,$(foreach m,$(modules),$(if $($(m)_version),
 all_fetched := $(patsubst %/.versioned,%/.fetched,$(all_versioned))
 ## Fetch all dependencies only
 fetched: $(all_fetched)
+# Downloads are integrity-checked against the sha256 pinned in each module's
+# version.lua, so TLS here is a transport safeguard, not the trust root. The
+# bootstrap cosmic trusts only its embedded CA set by default (upstream's
+# anti-MITM opt-in), which is too narrow for github.com's cert chain; trust
+# the host's CA store for these fetches so the build works on stock runners
+# and behind TLS-intercepting proxies alike. An operator-supplied
+# SSL_CERT_FILE bundle is unveiled so the sandboxed fetch can read it.
+$(o)/%/.fetched: export SSL_USE_SYSTEM_CERTS = 1
 $(o)/%/.fetched: .PLEDGE = stdio rpath wpath cpath inet dns
-$(o)/%/.fetched: .UNVEIL = rx:$(o)/bootstrap r:3p rwc:$(o) r:/etc/resolv.conf r:/etc/ssl
+$(o)/%/.fetched: .UNVEIL = rx:$(o)/bootstrap r:3p rwc:$(o) r:/etc/resolv.conf r:/etc/ssl $(if $(SSL_CERT_FILE),r:$(SSL_CERT_FILE))
 $(o)/%/.fetched: $(o)/%/.versioned $(build_files) | $(bootstrap_cosmic)
 	@$(bootstrap_cosmic) -- $(build_fetch) $$(readlink $<) $(platform) $@
 

--- a/cook.mk
+++ b/cook.mk
@@ -10,10 +10,10 @@ type_modules := cosmo unix path getopt lsqlite3 re argon2 zip repl
 modules += bootstrap
 bootstrap_cosmic := $(o)/bootstrap/cosmic
 bootstrap_files := $(bootstrap_cosmic)
-bootstrap_url := https://github.com/whilp/cosmic/releases/download/2026-03-08-ac3a5d5/cosmic-lua
+bootstrap_url := https://github.com/whilp/cosmic/releases/download/2026-07-06-9b7f95b/cosmic-lua
 # SHA-256 of the bootstrap cosmic binary. It compiles the entire project, so
 # verify it before executing. Update this when bumping bootstrap_url.
-bootstrap_sha256 := 4aee99daab172af2c662354e519170fa5c5793e5820e8a2bcd02f23f1d99e531
+bootstrap_sha256 := 2217687a73958110ebeae85a2d8b7af401472212bbdd168cd24a06fc37793173
 
 export PATH := $(o)/bootstrap:$(PATH)
 

--- a/lib/cosmic/io.tl
+++ b/lib/cosmic/io.tl
@@ -288,28 +288,11 @@ local function slurp(path: string): string | nil, string
   return data
 end
 
--- cosmo.Barf's third argument changed from a positional mode integer to an
--- options table in the 2026.07 error-convention release. The build's pinned
--- BOOTSTRAP cosmic (an older runtime) executes scripts from this tree with
--- the freshly compiled lib on package.path -- reaching this module through
--- the script cache -- so barf must work on both sides of the change until
--- the bootstrap pin advances past it, at which point this shim can go.
--- cosmo.Lz4Compress was purged in the same release train, so its absence
--- marks a runtime with the new Barf signature.
-local barf_takes_options = (cosmo as {string: any}).Lz4Compress == nil
-
 --- Write data to file, creating or overwriting it.
 local function barf(path: string, data: string, mode?: number): boolean, string
-  local ok: boolean
-  local err: any
-  if barf_takes_options then
-    ok, err = cosmo.Barf(path, data, {mode = mode})
-  else
-    local old_barf = cosmo.Barf as function(string, string, number): boolean, any
-    ok, err = old_barf(path, data, mode)
-  end
+  local ok, err = cosmo.Barf(path, data, {mode = mode})
   if not ok then
-    return false, tostring(err or ("failed to write file: " .. path))
+    return false, err or ("failed to write file: " .. path)
   end
   return true
 end


### PR DESCRIPTION
Final piece of the error-convention migration (#544, #545): the bootstrap cosmic moves off its March pin onto `2026-07-06-9b7f95b` — the first successful release since 2026-03-24 — whose runtime postdates the migration.

## Changes

- **`cook.mk`**: `bootstrap_url` → `2026-07-06-9b7f95b`, `bootstrap_sha256` → `2217687a…` (verified against the release's `SHA256SUMS` and by hashing the downloaded asset).
- **`lib/cosmic/io.tl`**: the transitional barf runtime shim is deleted — with the bootstrap speaking the options-table `cosmo.Barf` convention, `barf` is back to a plain thin wrapper.
- **`Makefile`** (added after the first CI round failed): the `.fetched` rule exports `SSL_USE_SYSTEM_CERTS=1` and unveils an operator-supplied `SSL_CERT_FILE` bundle.

## The CI failure this uncovered

The first push failed `build`/`enforce` on the runners with `badcert_not_trusted` fetching from github.com. Root cause is upstream: `usertrust.pem` was never linked into released cosmopolitan binaries (missing `__static_yoink` — fix + drift ratchet in whilp/cosmopolitan#168), so the new bootstrap's embedded CA set can't verify github.com's Sectigo chain, and unlike the March bootstrap it no longer consults the system store implicitly (upstream's anti-MITM opt-in from the TLS hardening).

Since every fetched artifact is integrity-checked against the sha256 pinned in its `version.lua`, TLS on these downloads is a transport safeguard rather than the trust root — so the fetch rule now opts into the host CA store, scoped to just that rule. This makes the build independent of the embedded set's completeness on stock runners *and* behind TLS-intercepting proxies (the `SSL_CERT_FILE` unveil lets the sandboxed fetch actually read an operator-pointed bundle).

## Verification

From-clean `bin/make ci` (cold `o/`, new bootstrap compiling the whole tree, shim-free barf through the script cache and fetch/stage): 102 tests, teal 226, format 226, example 18, lint 292 — all green. Run behind a TLS-intercepting proxy with no extra environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJhKFGUr4h42ifchBdDnzj