### PR TITLE
cosmos: bump pin to 2026.07.06-2d00678fc for the shipped SSL roots

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "0dff1ea827204743b5ad44ab836b7b2af9d610daf76324e1d371ee5d44e19426"}},
+  platforms = {["*"] = {sha = "83aaf85c0ecb878ab487b3959f319c446f2aa856e80e1e229ce1034be84c0c6e"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.06-dfdf61ac4"
+  version = "2026.07.06-2d00678fc"
 }


### PR DESCRIPTION
Picks up whilp/cosmopolitan#168: `usertrust.pem` now actually ships in the embedded root store (it was compiled into a zip asset but never `__static_yoink`ed, so no released binary linked it), which means cosmic binaries can verify github.com's Sectigo chain with embedded-only trust (`SSL_USE_SYSTEM_CERTS` unset). The build's own fetches were already made independent of this in #546; this bump fixes it for cosmic's *users* calling `cosmic.fetch` against github URLs.

## Changes

- `3p/cosmos/version.lua`: `2026.07.06-dfdf61ac4` → `2026.07.06-2d00678fc` (cosmos.zip sha256 `83aaf85c…`, verified by downloading and hashing).

## Verification

- `bin/make regen-types` is **byte-identical** (no binding contract changes in #168 — gentype drift test green).
- Staged cosmos `lua` verified to embed all 14 roots including `usertrust.pem`.
- Full `bin/make ci`: 102 tests, teal 226, format 226, example 18, lint 292 — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJhKFGUr4h42ifchBdDnzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJhKFGUr4h42ifchBdDnzj)_