### PR TITLE
child: redesign Handle/Result API — kill, timeout, idempotent wait, no zombies (#527)

### DIFF
--- a/3p/cosmos/cosmos_test.tl
+++ b/3p/cosmos/cosmos_test.tl
@@ -9,7 +9,8 @@ local function test_lua()
   local bin = fs.join(TEST_DIR, "lua")
   local handle, err = spawn.spawn({bin, "-v"})
   assert(handle, "lua spawn failed: " .. tostring(err))
-  local ok, got = (handle as spawn.Handle):read()
+  local __r1 = (handle as spawn.Handle):wait() as spawn.Result
+  local ok, got = __r1.ok, __r1.stdout
   assert(ok, "lua -v failed")
   local want = "Lua"
   assert((got as string):find(want, 1, true), "expected '" .. want .. "' in output, got: " .. (got as string))
@@ -20,7 +21,8 @@ local function test_zip()
   local bin = fs.join(TEST_DIR, "zip")
   local handle, err = spawn.spawn({bin, "--version"})
   assert(handle, "zip spawn failed: " .. tostring(err))
-  local ok, got = (handle as spawn.Handle):read()
+  local __r2 = (handle as spawn.Handle):wait() as spawn.Result
+  local ok, got = __r2.ok, __r2.stdout
   assert(ok, "zip --version failed")
   local want = "Zip"
   assert((got as string):find(want, 1, true), "expected '" .. want .. "' in output, got: " .. (got as string))

--- a/lib/build/build-stage.tl
+++ b/lib/build/build-stage.tl
@@ -87,11 +87,11 @@ end
 
 local function extract_zip(archive: string, dest_dir: string, strip: number): boolean, string
   local temp_dir = fs.mkdtemp(fs.join(fs.dirname(dest_dir), ".stage_XXXXXX"))
-  local handle = spawn.spawn({"/usr/bin/unzip", "-o", "-q", "-d", temp_dir, archive})
-  local exit_code = (handle as spawn.Handle):wait()
-  if exit_code ~= 0 then
+  local result = spawn.run({"/usr/bin/unzip", "-o", "-q", "-d", temp_dir, archive})
+  local r = result as spawn.Result
+  if not r or not r.ok then
     fs.rmrf(temp_dir)
-    return nil, "unzip failed with exit code " .. exit_code
+    return nil, "unzip failed with exit code " .. tostring(r and r.code)
   end
   local ok, err = strip_components(temp_dir, dest_dir, strip)
   fs.rmrf(temp_dir)
@@ -100,11 +100,11 @@ end
 
 local function extract_targz(archive: string, dest_dir: string, strip: number): boolean, string
   local temp_dir = fs.mkdtemp(fs.join(fs.dirname(dest_dir), ".stage_XXXXXX"))
-  local handle = spawn.spawn({"tar", "-xzf", archive, "-C", temp_dir})
-  local exit_code = (handle as spawn.Handle):wait()
-  if exit_code ~= 0 then
+  local result = spawn.run({"tar", "-xzf", archive, "-C", temp_dir})
+  local r = result as spawn.Result
+  if not r or not r.ok then
     fs.rmrf(temp_dir)
-    return nil, "tar failed with exit code " .. exit_code
+    return nil, "tar failed with exit code " .. tostring(r and r.code)
   end
   local ok, err = strip_components(temp_dir, dest_dir, strip)
   fs.rmrf(temp_dir)
@@ -130,11 +130,15 @@ local function extract_gz(archive: string, dest_dir: string, module_name: string
   local bin_dir = fs.join(dest_dir, "bin")
   fs.makedirs(bin_dir)
   local dest = fs.join(bin_dir, module_name)
-  local handle = spawn.spawn({"gunzip", "-c", archive})
-  local exit_code, content = (handle as spawn.Handle):read()
-  if not exit_code then
-    return nil, "gunzip failed: " .. tostring(content)
+  local result, serr = spawn.run({"gunzip", "-c", archive})
+  if not result then
+    return nil, "gunzip failed: " .. tostring(serr)
   end
+  local r = result as spawn.Result
+  if not r.ok then
+    return nil, "gunzip failed (exit " .. tostring(r.code) .. "): " .. r.stderr
+  end
+  local content = r.stdout
   local ok, write_err = portable.write_file(dest, content, tonumber("755", 8))
   if not ok then
     return nil, "failed to create " .. dest .. ": " .. (write_err or "unknown error")

--- a/lib/build/reporter_test.tl
+++ b/lib/build/reporter_test.tl
@@ -16,16 +16,11 @@ local function write_test_result(base: string, exit_code: integer, stdout: strin
   cio.barf(base .. ".err", stderr or "")
 end
 
-local record SpawnHandle
-  stderr: FILE
-  read: function(self: SpawnHandle): boolean, string, integer
-end
-
 local function run_reporter(...: string): integer, string, string
   local test_bin = os.getenv("TEST_BIN") or ""
   local test_o = os.getenv("TEST_O") or "o"
   local reporter = fs.join(test_o, "lib/build/reporter.lua")
-  local spawn = require("cosmic.child").spawn
+  local child = require("cosmic.child")
   local args: {string} = {fs.join(test_bin, "cosmic"), "--", reporter}
   local varargs: {string} = {...}
   for _, a in ipairs(varargs) do
@@ -36,10 +31,18 @@ local function run_reporter(...: string): integer, string, string
   local new_lua_path = "o/lib/?.lua;o/lib/?/init.lua;;" .. lua_path
   env.set("LUA_PATH", new_lua_path)
 
-  local handle = spawn(args) as SpawnHandle
-  local stderr_content = handle.stderr and handle.stderr:read() or ""
-  local _ok, stdout, exit_code = handle:read()
-  return exit_code, stdout or "", stderr_content
+  local result, serr = child.run(args)
+  if not result then
+    return 1, "", tostring(serr)
+  end
+  local r = result as child.Result
+  local exit_code: integer = 1
+  if r.code ~= nil then
+    exit_code = r.code
+  elseif r.signal ~= nil then
+    exit_code = (128 + r.signal) as integer
+  end
+  return exit_code, r.stdout, r.stderr
 end
 
 -- test single checker mode (test)

--- a/lib/cosmic/args_test.tl
+++ b/lib/cosmic/args_test.tl
@@ -20,7 +20,8 @@ end
 ]])
 
   local h1 = spawn.spawn({cosmic, script, "foo", "bar", "baz"})
-  local ok, out = (h1 as spawn.Handle):read()
+  local __r1 = (h1 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   assert(ok, "cosmic should succeed")
   assert((out as string):find("varargs_count=3"), "should have 3 varargs")
   assert((out as string):find("vararg%[1%]=foo"), "vararg[1] should be foo")
@@ -41,7 +42,8 @@ end
 ]])
 
   local h2 = spawn.spawn({cosmic, script, "alpha", "beta"})
-  local ok, out = (h2 as spawn.Handle):read()
+  local __r2 = (h2 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r2.ok, __r2.stdout
   assert(ok, "cosmic should succeed")
   assert((out as string):find("arg_count=2"), "should have 2 args")
   assert((out as string):find("arg%[0%]=" .. script:gsub("[%-%.]", "%%%1")), "arg[0] should be script path")
@@ -64,7 +66,8 @@ end
 ]])
 
   local h3 = spawn.spawn({cosmic, script, "x", "y", "z"})
-  local ok, out = (h3 as spawn.Handle):read()
+  local __r3 = (h3 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r3.ok, __r3.stdout
   assert(ok, "cosmic should succeed")
   assert((out as string):find("varargs_count=3"), "varargs should have 3 elements")
   assert((out as string):find("arg_count=3"), "arg should have 3 elements")
@@ -92,7 +95,8 @@ os.exit(main(...))
 ]])
 
   local h4 = spawn.spawn({cosmic, script, "one", "two"})
-  local ok, out = (h4 as spawn.Handle):read()
+  local __r4 = (h4 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r4.ok, __r4.stdout
   assert(ok, "cosmic should succeed")
   assert((out as string):find("main_varargs_count=2"), "main should receive 2 varargs")
   assert((out as string):find("main_arg%[1%]=one"), "main_arg[1] should be one")
@@ -115,13 +119,15 @@ os.exit(main(...))
 
   -- Test with argument
   local h5 = spawn.spawn({cosmic, script, "custom"})
-  local ok, out = (h5 as spawn.Handle):read()
+  local __r5 = (h5 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r5.ok, __r5.stdout
   assert(ok, "cosmic should succeed")
   assert((out as string):find("param=custom"), "param should be custom")
 
   -- Test with no argument (should use default)
   local h6 = spawn.spawn({cosmic, script})
-  ok, out = (h6 as spawn.Handle):read()
+  local __r6 = (h6 as spawn.Handle):wait() as spawn.Result
+  ok, out = __r6.ok, __r6.stdout
   assert(ok, "cosmic should succeed")
   assert((out as string):find("param=default"), "param should be default")
 end
@@ -138,7 +144,8 @@ print("arg[0]=" .. tostring(arg[0]))
 ]])
 
   local h7 = spawn.spawn({cosmic, script})
-  local ok, out = (h7 as spawn.Handle):read()
+  local __r7 = (h7 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r7.ok, __r7.stdout
   assert(ok, "cosmic should succeed")
   assert((out as string):find("varargs_count=0"), "varargs should be empty")
   assert((out as string):find("arg_count=0"), "arg should be empty")
@@ -157,7 +164,8 @@ end
 ]])
 
   local h8 = spawn.spawn({cosmic, script, "hello world", "foo bar"})
-  local ok, out = (h8 as spawn.Handle):read()
+  local __r8 = (h8 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r8.ok, __r8.stdout
   assert(ok, "cosmic should succeed")
   assert((out as string):find("arg%[1%]=hello world"), "should preserve spaces in arg[1]")
   assert((out as string):find("arg%[2%]=foo bar"), "should preserve spaces in arg[2]")
@@ -175,7 +183,8 @@ end
 ]])
 
   local h9 = spawn.spawn({cosmic, script, "--", "--flag", "-x", "value=123"})
-  local ok, out = (h9 as spawn.Handle):read()
+  local __r9 = (h9 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r9.ok, __r9.stdout
   assert(ok, "cosmic should succeed")
   assert((out as string):find("arg%[1%]=%-%-flag"), "should handle --flag")
   assert((out as string):find("arg%[2%]=%-x"), "should handle -x")
@@ -202,7 +211,8 @@ end
 ]])
 
   local h10 = spawn.spawn({cosmic, script, "test1", "test2"})
-  local ok, out = (h10 as spawn.Handle):read()
+  local __r10 = (h10 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r10.ok, __r10.stdout
   assert(ok, "cosmic should succeed")
   assert((out as string):find("main_called=true"), "main should be called")
   assert((out as string):find("args_count=2"), "main should receive 2 args")
@@ -221,7 +231,8 @@ end
 ]])
 
   local h11 = spawn.spawn({cosmic, script, "--version"})
-  local ok, out = (h11 as spawn.Handle):read()
+  local __r11 = (h11 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r11.ok, __r11.stdout
   assert(ok, "cosmic should succeed")
   assert((out as string):find("args_count=1"), "should have 1 arg")
   assert((out as string):find("arg%[1%]=%-%-version"), "arg[1] should be --version")
@@ -240,7 +251,8 @@ end
 ]])
 
   local h12 = spawn.spawn({cosmic, script, "--help"})
-  local ok, out = (h12 as spawn.Handle):read()
+  local __r12 = (h12 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r12.ok, __r12.stdout
   assert(ok, "cosmic should succeed")
   assert((out as string):find("args_count=1"), "should have 1 arg")
   assert((out as string):find("arg%[1%]=%-%-help"), "arg[1] should be --help")
@@ -259,7 +271,8 @@ end
 ]])
 
   local h13 = spawn.spawn({cosmic, script, "-v"})
-  local ok, out = (h13 as spawn.Handle):read()
+  local __r13 = (h13 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r13.ok, __r13.stdout
   assert(ok, "cosmic should succeed")
   assert((out as string):find("args_count=1"), "should have 1 arg")
   assert((out as string):find("arg%[1%]=%-v"), "arg[1] should be -v")
@@ -279,7 +292,8 @@ end
 
   -- cosmic -e before script, then script gets --version
   local h14 = spawn.spawn({cosmic, "-e", "print('cosmic executed')", script, "--version", "arg2"})
-  local ok, out = (h14 as spawn.Handle):read()
+  local __r14 = (h14 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r14.ok, __r14.stdout
   assert(ok, "cosmic should succeed")
   assert((out as string):find("cosmic executed"), "cosmic -e should execute")
   assert((out as string):find("args_count=2"), "script should have 2 args")
@@ -300,7 +314,8 @@ end
 ]])
 
   local h15 = spawn.spawn({cosmic, script, "--version", "--help", "-v", "-i", "--unknown"})
-  local ok, out = (h15 as spawn.Handle):read()
+  local __r15 = (h15 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r15.ok, __r15.stdout
   assert(ok, "cosmic should succeed")
   assert((out as string):find("args_count=5"), "should have 5 args")
   assert((out as string):find("arg%[1%]=%-%-version"), "arg[1] should be --version")
@@ -323,7 +338,8 @@ end
 ]])
 
   local h16 = spawn.spawn({cosmic, script, "--", "arg1", "arg2"})
-  local ok, out = (h16 as spawn.Handle):read()
+  local __r16 = (h16 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r16.ok, __r16.stdout
   assert(ok, "cosmic should succeed")
   assert((out as string):find("args_count=2"), "should have 2 args")
   assert((out as string):find("arg%[1%]=arg1"), "arg[1] should be arg1")
@@ -348,7 +364,8 @@ print("No --version flag found")
 ]])
 
   local h17 = spawn.spawn({cosmic, script, "--version"})
-  local ok, out = (h17 as spawn.Handle):read()
+  local __r17 = (h17 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r17.ok, __r17.stdout
   assert(ok, "cosmic should succeed")
   assert((out as string):find("NVIM v0%.12%.0%-dev"), "script should handle --version")
   assert(not (out as string):find("No %-%-version flag found"), "should not print fallback message")
@@ -361,7 +378,8 @@ local function test_help_includes_all_options()
 
   -- Run cosmic --help and capture output
   local h18 = spawn.spawn({cosmic, "--help"})
-  local ok, out = (h18 as spawn.Handle):read()
+  local __r18 = (h18 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r18.ok, __r18.stdout
   assert(ok, "cosmic --help should succeed")
   local help_text = out as string
 

--- a/lib/cosmic/benchmark_test.tl
+++ b/lib/cosmic/benchmark_test.tl
@@ -92,7 +92,8 @@ local function Benchmark_cmd()
 end
 ]])
   local h1 = spawn.spawn({cosmic, "--benchmark", input})
-  local ok, out = (h1 as spawn.Handle):read()
+  local __r1 = (h1 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   assert(ok, "cosmic --benchmark should succeed")
   assert((out as string):find("Benchmark_cmd"), "output should contain benchmark name")
   assert((out as string):find("ns/op") or (out as string):find("µs/op") or (out as string):find("ms/op"), "output should show timing")
@@ -104,13 +105,9 @@ local function test_cosmic_benchmark_skip()
   local input = write_temp("cmd_bench_skip.tl", [[
 local x = 1
 ]])
-  local h0 = spawn.spawn({cosmic, "--benchmark", input})
-  local h = h0 as spawn.Handle
-  h.stdin:close()
-  local out = h.stdout:read()
-  local code = h:wait()
-  assert(code == 2, "should return skip code 2")
-  assert((out as string):find("SKIP"), "output should show SKIP")
+  local r = spawn.run({cosmic, "--benchmark", input}) as spawn.Result
+  assert(r.code == 2, "should return skip code 2")
+  assert(r.stdout:find("SKIP"), "output should show SKIP")
 end
 test_cosmic_benchmark_skip()
 
@@ -207,7 +204,8 @@ local function Benchmark_beta()
 end
 ]])
   local h2 = spawn.spawn({cosmic, "--benchmark", input .. ":alpha"})
-  local ok, out = (h2 as spawn.Handle):read()
+  local __r2 = (h2 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r2.ok, __r2.stdout
   assert(ok, "cosmic --benchmark with filter should succeed")
   assert((out as string):find("Benchmark_alpha"), "output should contain matching benchmark")
   assert(not (out as string):find("Benchmark_beta"), "output should not contain non-matching benchmark")

--- a/lib/cosmic/binary_test.tl
+++ b/lib/cosmic/binary_test.tl
@@ -21,7 +21,8 @@ end
 
 local function test_cosmic_child()
   local h1 = spawn.spawn({cosmic, "-e", "local c = require('cosmic.child'); print(c and 'ok' or 'fail')"}, {env = clean_env()})
-  local ok, out = (h1 as spawn.Handle):read()
+  local __r1 = (h1 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   assert(ok, "cosmic exited with error")
   assert((out as string):find("ok", 1, true), "expected output to contain 'ok'")
 end
@@ -29,7 +30,8 @@ test_cosmic_child()
 
 local function test_cosmic_walk()
   local h2 = spawn.spawn({cosmic, "-e", "local fs = require('cosmic.fs'); print(fs.walk and 'ok' or 'fail')"}, {env = clean_env()})
-  local ok, out = (h2 as spawn.Handle):read()
+  local __r2 = (h2 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r2.ok, __r2.stdout
   assert(ok, "cosmic exited with error")
   assert((out as string):find("ok", 1, true), "expected output to contain 'ok'")
 end
@@ -37,7 +39,8 @@ test_cosmic_walk()
 
 local function test_cosmic_help()
   local h3 = spawn.spawn({cosmic, "--help"}, {env = clean_env()})
-  local ok, out = (h3 as spawn.Handle):read()
+  local __r3 = (h3 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r3.ok, __r3.stdout
   assert(ok, "cosmic --help exited with error")
   assert((out as string):find("cosmic", 1, true), "expected output to contain 'cosmic'")
   assert((out as string):find("%-%-help", 1, false), "expected output to contain '--help'")
@@ -49,7 +52,8 @@ local function test_warnings_flag()
   -- -W should convert warnings to errors
   -- stderr = 1 merges stderr into stdout so we can capture the warning message
   local h4 = spawn.spawn({cosmic, "-W", "-e", "warn('test warning')"}, {env = clean_env(), stderr = 1})
-  local ok, out, code = (h4 as spawn.Handle):read()
+  local __r4 = (h4 as spawn.Handle):wait() as spawn.Result
+  local ok, out, code = __r4.ok, __r4.stdout, __r4.code
   assert(not ok, "cosmic should fail with -W when warning is issued")
   assert((out as string):find("warning: test warning", 1, true), "expected output to contain 'warning: test warning'")
   assert(code == 1, "expected exit code 1, got " .. tostring(code))
@@ -59,7 +63,8 @@ test_warnings_flag()
 local function test_warnings_without_flag()
   -- without -W, warnings should not cause errors
   local h5 = spawn.spawn({cosmic, "-e", "warn('test warning'); print('ok')"}, {env = clean_env()})
-  local ok, out = (h5 as spawn.Handle):read()
+  local __r5 = (h5 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r5.ok, __r5.stdout
   assert(ok, "cosmic should succeed without -W")
   assert((out as string):find("ok", 1, true), "expected output to contain 'ok'")
 end
@@ -68,7 +73,8 @@ test_warnings_without_flag()
 local function test_interactive_mode()
   -- -i should enter interactive mode (REPL)
   local proc = spawn.spawn({cosmic, "-i"}, {env = clean_env(), stdin = "print('hello')\nos.exit(0)\n"})
-  local ok, out = (proc as spawn.Handle):read()
+  local __r6 = (proc as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r6.ok, __r6.stdout
   assert(ok, "cosmic -i should succeed")
   assert((out as string):find("Lua 5.4", 1, true), "expected output to contain 'Lua 5.4'")
   assert((out as string):find("hello", 1, true), "expected output to contain 'hello'")
@@ -78,7 +84,8 @@ test_interactive_mode()
 local function test_repl_no_args()
   -- no args should enter REPL
   local proc = spawn.spawn({cosmic}, {env = clean_env(), stdin = "print('repl test')\nos.exit(0)\n"})
-  local ok, out = (proc as spawn.Handle):read()
+  local __r7 = (proc as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r7.ok, __r7.stdout
   assert(ok, "cosmic with no args should enter REPL")
   assert((out as string):find("Lua 5.4", 1, true), "expected output to contain 'Lua 5.4'")
   assert((out as string):find("repl test", 1, true), "expected output to contain 'repl test'")

--- a/lib/cosmic/check_test.tl
+++ b/lib/cosmic/check_test.tl
@@ -13,7 +13,8 @@ local tmpdir = os.getenv("TEST_TMPDIR")
 -- record union, so wrap the spawn+read in one helper that casts the handle.
 local function check_run(argv: {string}, opts?: spawn.Opts): boolean | string, string
   local h = spawn.spawn(argv, opts)
-  local ok, out = (h as spawn.Handle):read()
+  local __r1 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   return ok, out
 end
 

--- a/lib/cosmic/child.tl
+++ b/lib/cosmic/child.tl
@@ -1,115 +1,68 @@
 --- Child process management.
---- Spawn and manage child processes with I/O control.
+---
+--- The high-level spawn API. `spawn` starts a process and hands back a
+--- `Handle` you can `kill`, `wait` on (with an optional timeout), poll with
+--- `try_wait`, or stream from with `read`. `run` is the one-shot form that
+--- spawns, waits, and returns a structured `Result`. Low-level syscall
+--- passthroughs (fork/wait/kill/posix_spawn, the W* status helpers) live in
+--- `cosmic.proc`; this module builds the ergonomic layer on top.
+---
+--- A Handle owns the child: `wait`/`run` reap it and cache the `Result`, so a
+--- second `wait` returns the same value instead of failing. An abandoned
+--- handle is not leaked — its `__gc`/`__close` metamethods SIGKILL and reap an
+--- un-waited child and close its pipes, so `local h <close> = spawn{...}` (or
+--- simply dropping the handle) never leaves a zombie.
 local unix = require("cosmo.unix")
 local childio = require("cosmic.child_io")
+local errno = require("cosmic.errno")
 
---- Process resource usage statistics.
-local record Rusage
-  utime: function(self: Rusage): number, number
-  stime: function(self: Rusage): number, number
-  maxrss: function(self: Rusage): number
-  idrss: function(self: Rusage): number
-  ixrss: function(self: Rusage): number
-  isrss: function(self: Rusage): number
-  minflt: function(self: Rusage): number
-  majflt: function(self: Rusage): number
-  nswap: function(self: Rusage): number
-  inblock: function(self: Rusage): number
-  oublock: function(self: Rusage): number
-  msgsnd: function(self: Rusage): number
-  msgrcv: function(self: Rusage): number
-  nsignals: function(self: Rusage): number
-  nvcsw: function(self: Rusage): number
-  nivcsw: function(self: Rusage): number
+--- Structured outcome of a finished child.
+--- Exactly one of `code`/`signal` is set: `code` when the child exited,
+--- `signal` when a signal killed it. `ok` is true only on a zero exit.
+local record Result
+  code: integer -- exit status; nil if signaled
+  signal: integer -- terminating signal; nil if exited
+  ok: boolean -- code == 0
+  stdout: string
+  stderr: string
 end
 
 --- Handle for a spawned process.
---- stdin/stdout/stderr are cosmic.child_io Pipe wrappers (or nil when the
---- corresponding stream was redirected to a raw fd via Opts).
+--- Fields prefixed `_` are internal bookkeeping; use the methods.
 local record Handle
-  pid: number
-  stdin: childio.Pipe
-  stdout: childio.Pipe
-  stderr: childio.Pipe
-  wait: function(self: Handle): number | nil, string
-  read: function(self: Handle, size?: number): boolean | string | nil, string, number
-  communicate: function(self: Handle): string, string, number, string
+  pid: integer
+
+  -- internal state (do not touch)
+  _st: childio.PumpState
+  _result: Result
+  _closed: boolean
+
+  --- Sends `sig` (default SIGTERM) to the child. Fails once the child has
+  --- been reaped, since its pid may have been recycled.
+  kill: function(self: Handle, sig?: number): boolean, string
+  --- Non-blocking reap: the cached/final Result if the child has finished,
+  --- `nil, nil` while it is still running, or `nil, err` on a wait error.
+  try_wait: function(self: Handle): Result | nil, string
+  --- Runs the child to completion (feeding stdin, draining stdout+stderr) and
+  --- returns its Result. With `timeout_ms`, returns `nil, "timeout"` if the
+  --- child has not finished in time; the handle stays usable (wait again, or
+  --- kill it). Idempotent: repeat calls return the same cached Result.
+  wait: function(self: Handle, timeout_ms?: integer): Result | nil, string
+  --- Streaming read of up to `size` bytes from the child's stdout. Returns
+  --- "" at end of file. `size` is required; for whole-output capture use
+  --- `wait`/`run`, which also collect stderr and cannot deadlock.
+  read: function(self: Handle, size: integer): string | nil, string
 end
 
 --- Options for spawning a process.
---- stdout/stderr: raw fd dup2'd onto fd 1/2; handle fields nil.
---- Close write end before reading. See Example_spawn_pipe.
+--- stdout/stderr as numbers are raw fds dup2'd onto the child's fd 1/2 (the
+--- corresponding Result field is then ""). See Example_spawn_pipe.
 local record Opts
   stdin: string | number -- string piped to stdin, or raw fd dup2'd onto fd 0
-  stdout: number -- raw fd -> fd 1; handle.stdout becomes nil
-  stderr: number -- raw fd -> fd 2; handle.stderr becomes nil
+  stdout: number -- raw fd -> fd 1
+  stderr: number -- raw fd -> fd 2
   env: {string}
   cwd: string
-end
-
---- Creates a new process (fork).
---- @return number The child process id in parent, 0 in child
-local function fork(): number
-  return (unix.fork())
-end
-
---- Spawns a new process using posix_spawn (low-level).
---- @param prog string Absolute path to the executable
---- @param argv {string} Argument vector passed to the program
---- @param envp {string}? Environment variables (KEY=value format)
---- @return number The child process id on success
-local function posix_spawn(prog: string, argv: {string}, envp?: {string}): number
-  return (unix.spawn(prog, argv, envp))
-end
-
---- Spawns a new process with PATH search (low-level).
---- @param prog string The program name to execute
---- @param argv {string} Argument vector passed to the program
---- @param envp {string}? Environment variables
---- @return number The child process id on success
-local function posix_spawnp(prog: string, argv: {string}, envp?: {string}): number
-  return (unix.spawnp(prog, argv, envp))
-end
-
---- Waits for child process to terminate.
---- @param pid number? Process id to wait for (-1 for any child)
---- @param options number? Wait options (e.g., WNOHANG)
---- @return number The child process id that terminated
---- @return number Status code (use WIFEXITED, WEXITSTATUS to interpret)
---- @return Rusage Resource usage statistics
-local function wait(pid?: number, options?: number): number, number, Rusage
-  local wpid, status, rusage = unix.wait(pid, options)
-  return wpid, status, rusage as Rusage
-end
-
---- Sends signal to child process.
---- @param pid number Process id to signal
---- @param sig number Signal number (e.g., SIGTERM, SIGKILL)
---- @return boolean True on success
-local function kill(pid: number, sig: number): boolean
-  return (unix.kill(pid, sig))
-end
-
--- Status helpers --
-
---- Returns true if process exited normally.
-local function WIFEXITED(wstatus: number): boolean
-  return unix.WIFEXITED(wstatus)
-end
-
---- Returns the exit code (valid if WIFEXITED is true).
-local function WEXITSTATUS(wstatus: number): number
-  return unix.WEXITSTATUS(wstatus)
-end
-
---- Returns true if process was terminated by a signal.
-local function WIFSIGNALED(wstatus: number): boolean
-  return unix.WIFSIGNALED(wstatus)
-end
-
---- Returns the terminating signal number (valid if WIFSIGNALED is true).
-local function WTERMSIG(wstatus: number): number
-  return unix.WTERMSIG(wstatus)
 end
 
 --- Normalize an env table to a list of "KEY=VALUE" strings.
@@ -129,8 +82,7 @@ local function is_zip_path(p: string): boolean
   return p:sub(1, 5) == "/zip/"
 end
 
---- Prepares an executable fd from a /zip/ path.
---- Opens the path to get a zip fd suitable for fexecve.
+--- Prepares an executable fd from a /zip/ path for fexecve.
 --- @param zip_path string Path starting with /zip/
 --- @return number | nil The file descriptor ready for fexecve
 --- @return string Error message on failure
@@ -142,11 +94,121 @@ local function prepare_zip_exec(zip_path: string): number | nil, string
   return fd
 end
 
--- High-level spawn API --
+-- Close the child's stdin/stdout/stderr fds still held in the pump state,
+-- once. Safe to call repeatedly.
+local function close_fds(self: Handle)
+  local st = self._st
+  if st.stdin_fd then unix.close(st.stdin_fd); st.stdin_fd = nil end
+  if st.stdout_fd then unix.close(st.stdout_fd); st.stdout_fd = nil end
+  if st.stderr_fd then unix.close(st.stderr_fd); st.stderr_fd = nil end
+end
+
+-- Build and cache the Result from a reaped status word, then release fds.
+local function finish(self: Handle, status: number): Result
+  local r: Result = {
+    stdout = table.concat(self._st.out),
+    stderr = table.concat(self._st.err_out),
+  }
+  if unix.WIFEXITED(status) then
+    r.code = unix.WEXITSTATUS(status) as integer
+    r.ok = r.code == 0
+  elseif unix.WIFSIGNALED(status) then
+    r.signal = unix.WTERMSIG(status) as integer
+    r.ok = false
+  else
+    r.ok = false
+  end
+  self._result = r
+  close_fds(self)
+  return r
+end
+
+-- Kill (SIGKILL) and reap an un-waited child, then close its fds. Runs from
+-- __gc/__close so an abandoned handle never leaks a zombie or descriptors.
+local function cleanup(self: Handle)
+  if self._closed then return end
+  self._closed = true
+  if not self._result then
+    unix.kill(self.pid, unix.SIGKILL)
+    unix.wait(self.pid)
+  end
+  close_fds(self)
+end
+
+local handle_mt: metatable < Handle > = {
+  __close = function(self: Handle) cleanup(self) end,
+  __gc = function(self: Handle) cleanup(self) end,
+}
+
+-- Attach the Handle methods and finalizers to a freshly forked child.
+local function make_handle(pid: number, st: childio.PumpState): Handle
+  local handle: Handle = {pid = pid as integer, _st = st}
+
+  function handle:kill(sig?: number): boolean, string
+    if self._result then
+      return false, "kill: process already reaped"
+    end
+    local ok, err = unix.kill(self.pid, sig or unix.SIGTERM)
+    if not ok then
+      return false, errno.str(err, "kill")
+    end
+    return true
+  end
+
+  function handle:wait(timeout_ms?: integer): Result | nil, string
+    if self._result then
+      return self._result
+    end
+    local deadline: number = nil
+    if timeout_ms then
+      deadline = childio.now_ms() + timeout_ms
+    end
+    local timed_out = childio.pump(self._st, deadline)
+    if timed_out then
+      return nil, "timeout"
+    end
+    local _, status = unix.wait(self.pid)
+    if type(status) ~= "number" then
+      return nil, "wait failed: " .. tostring(status)
+    end
+    return finish(self, status as number)
+  end
+
+  function handle:try_wait(): Result | nil, string
+    if self._result then
+      return self._result
+    end
+    local wpid, status = unix.wait(self.pid, unix.WNOHANG)
+    if wpid == nil then
+      return nil, "wait failed: " .. tostring(status)
+    end
+    if wpid == 0 then
+      return nil -- still running
+    end
+    -- Reaped: the child is gone, so draining hits EOF promptly.
+    childio.pump(self._st, nil)
+    return finish(self, status as number)
+  end
+
+  function handle:read(size: integer): string | nil, string
+    local fd = self._st.stdout_fd
+    if not fd then
+      return nil, "stdout not captured"
+    end
+    local chunk, err = unix.read(fd, size)
+    if chunk == nil then
+      return nil, errno.str(err, "read")
+    end
+    return chunk
+  end
+
+  return setmetatable(handle, handle_mt)
+end
 
 --- Spawns a child process with I/O control. Uses fexecve for /zip/ paths.
---- When Opts.stdout/stderr are fds they are dup2'd into child (handle fields
---- nil); MUST close the write end before reading. See Example_spawn_pipe.
+--- Returns a Handle on success. If the program cannot be executed, spawn
+--- itself fails with `nil, "exec failed: ENOENT: ..."` — the error surfaces
+--- here, not as a bogus exit code from a later wait().
 --- To spawn cosmic itself, use `rawget(arg, -1)` — NOT arg[0] (gotchas #7).
 --- @param argv {string} Command and arguments
 --- @param opts Opts? Spawn options
@@ -154,10 +216,8 @@ end
 local function spawn(argv: {string}, opts?: Opts): Handle | nil, string
   opts = opts or {}
 
-  -- Resolve the executable into a LOCAL, never by mutating the caller's
-  -- argv table: a PATH search wrote the resolved path back into argv[1],
-  -- corrupting the caller's own table. argv is passed to exec unchanged, so
-  -- argv[0] stays the name the caller gave.
+  -- Resolve the executable into a LOCAL, never by mutating the caller's argv:
+  -- a PATH search that wrote back into argv[1] corrupts the caller's table.
   local exec_fd: number
   local prog = argv[1]
   if is_zip_path(argv[1]) then
@@ -175,20 +235,17 @@ local function spawn(argv: {string}, opts?: Opts): Handle | nil, string
   end
 
   -- Track every fd we open so a mid-way pipe() failure (fd exhaustion) can be
-  -- unwound cleanly instead of leaking descriptors — including any exec fd,
-  -- which would otherwise leak on this early-return path.
+  -- unwound cleanly, including the exec fd on the early-return path.
   local opened: {number} = {}
   local function fail(msg: string): Handle, string
     for _, fd in ipairs(opened) do unix.close(fd) end
     if exec_fd then unix.close(exec_fd) end
     return nil, msg
   end
-  -- Create pipes CLOEXEC so their ends do not leak into an unrelated child
-  -- spawned while this handle is still open: otherwise child B inherits child
-  -- A's pipe ends and A never sees stdin EOF until B exits (communicate()
-  -- hangs on overlap). The child's own dup2 onto 0/1/2 clears CLOEXEC on the
-  -- ends it keeps; the ends that happen to already be fd 0/1/2 are cleared
-  -- explicitly below.
+  -- Pipes are CLOEXEC so their ends do not leak into an unrelated child
+  -- spawned while this handle is still open (which would keep an earlier
+  -- child from seeing stdin EOF). The child's own dup2 onto 0/1/2 clears
+  -- CLOEXEC on the ends it keeps.
   local function new_pipe(): number, number
     local r, w = unix.pipe(unix.O_CLOEXEC)
     if r == nil or w == nil then
@@ -223,24 +280,27 @@ local function spawn(argv: {string}, opts?: Opts): Handle | nil, string
     if not stderr_w then return fail("pipe failed (stderr)") end
   end
 
+  -- Exec-status pipe: CLOEXEC, so a successful execve closes the write end and
+  -- the parent's read EOFs instantly. On exec failure the child writes the
+  -- errno string here before _exit, making the failure visible to the parent.
+  local exec_r, exec_w = new_pipe()
+  if not exec_w then return fail("pipe failed (exec)") end
+
   local pid = unix.fork()
   if pid == 0 then
+    unix.close(exec_r)
+
     -- stdin (fd 0)
     if stdin_is_fd then
       if opts.stdin ~= 0 then
         unix.dup(opts.stdin as number, 0)
       end
     else
-      -- Close the write end first, then dup2 the read end onto fd 0.
-      -- If stdin_r already IS fd 0, dup2 is a no-op (same fd), so skip
-      -- the close to avoid closing the fd we are about to use.
       if stdin_r ~= 0 then
         unix.close(stdin_w)
         unix.dup(stdin_r, 0)
         unix.close(stdin_r)
       else
-        -- stdin_r == 0: no dup2 to clear CLOEXEC, so clear it directly or
-        -- fd 0 would close on execve; then just close the write end.
         unix.fcntl(0, unix.F_SETFD, 0)
         unix.close(stdin_w)
       end
@@ -257,7 +317,6 @@ local function spawn(argv: {string}, opts?: Opts): Handle | nil, string
         unix.dup(stdout_w, 1)
         unix.close(stdout_w)
       else
-        -- stdout_w == 1: no dup2 to clear CLOEXEC, so clear it directly.
         unix.fcntl(1, unix.F_SETFD, 0)
         unix.close(stdout_r)
       end
@@ -274,25 +333,30 @@ local function spawn(argv: {string}, opts?: Opts): Handle | nil, string
         unix.dup(stderr_w, 2)
         unix.close(stderr_w)
       else
-        -- stderr_w == 2: no dup2 to clear CLOEXEC, so clear it directly.
         unix.fcntl(2, unix.F_SETFD, 0)
         unix.close(stderr_r)
       end
     end
 
-    -- change working directory if specified
     if opts.cwd then
       if not unix.chdir(opts.cwd) then
-        os.exit(126)
+        local _ = unix.write(exec_w, "chdir failed: " .. tostring(opts.cwd))
+        os.exit(127)
       end
     end
 
     local env = opts.env and normalize_env(opts.env) or unix.environ()
+    local eerr: string
     if exec_fd then
-      unix.fexecve(exec_fd, argv, env)
+      local _, e = unix.fexecve(exec_fd, argv, env)
+      eerr = e as string
     else
-      unix.execve(prog, argv, env)
+      local _, e = unix.execve(prog, argv, env)
+      eerr = e as string
     end
+    -- Only reached when exec failed. Report the errno through the pipe so the
+    -- parent's spawn() can return it, then exit distinctly.
+    local _ = unix.write(exec_w, tostring(eerr))
     os.exit(127)
   end
 
@@ -301,191 +365,80 @@ local function spawn(argv: {string}, opts?: Opts): Handle | nil, string
   end
 
   if pid == nil then
-    if not stdin_is_fd then
-      unix.close(stdin_r)
-      unix.close(stdin_w)
-    end
-    if not stdout_is_fd then
-      unix.close(stdout_r)
-      unix.close(stdout_w)
-    end
-    if not stderr_is_fd then
-      unix.close(stderr_r)
-      unix.close(stderr_w)
-    end
+    for _, fd in ipairs(opened) do unix.close(fd) end
     return nil, "fork failed"
   end
 
-  if not stdin_is_fd then
-    unix.close(stdin_r)
-  end
-  if not stdout_is_fd then
-    unix.close(stdout_w)
-  end
-  if not stderr_is_fd then
-    unix.close(stderr_w)
+  -- Parent: close the ends the child owns, then wait on the exec handshake.
+  if not stdin_is_fd then unix.close(stdin_r) end
+  if not stdout_is_fd then unix.close(stdout_w) end
+  if not stderr_is_fd then unix.close(stderr_w) end
+  unix.close(exec_w)
+
+  -- A non-empty read means exec failed inside the child: reap it and surface
+  -- the error from spawn itself. EOF (empty read) means exec succeeded.
+  local exec_msg = unix.read(exec_r, 4096)
+  unix.close(exec_r)
+  if exec_msg ~= nil and exec_msg ~= "" then
+    unix.wait(pid)
+    if not stdin_is_fd then unix.close(stdin_w) end
+    if not stdout_is_fd then unix.close(stdout_r) end
+    if not stderr_is_fd then unix.close(stderr_r) end
+    return nil, errno.str(exec_msg, "exec failed")
   end
 
-  -- An opts.stdin string is delivered lazily by wait()/read()/communicate()
-  -- via the pump, NOT written synchronously here: a >pipe-buffer write before
-  -- anyone drains stdout/stderr would deadlock, and a child that exits early
-  -- would SIGPIPE-kill this process. The pump feeds stdin and drains both
-  -- output streams in one poll loop, so neither can happen.
+  -- An opts.stdin string is delivered lazily by the pump (in wait/run), not
+  -- written synchronously here: a >pipe-buffer write before anyone drains
+  -- stdout/stderr would deadlock. The pump feeds stdin and drains both output
+  -- streams in one poll loop, so neither can happen.
   local stdin_data: string = nil
   if type(opts.stdin) == "string" then
     stdin_data = opts.stdin as string
   end
 
-  local handle: Handle = {
-    pid = pid,
-    stdin = childio.make_pipe(stdin_w),
-    stdout = childio.make_pipe(stdout_r),
-    stderr = childio.make_pipe(stderr_r),
+  local st: childio.PumpState = {
+    stdout_fd = stdout_is_fd and nil or stdout_r,
+    stderr_fd = stderr_is_fd and nil or stderr_r,
+    stdin_fd = stdin_is_fd and nil or stdin_w,
+    stdin_data = stdin_data,
+    stdin_off = 0,
+    out = {},
+    err_out = {},
   }
 
-  -- Run the process to completion: pump stdin in / stdout+stderr out without
-  -- deadlock, then reap. Returns stdout, stderr, exit code (-1 if the process
-  -- did not exit normally), and an error string (signal/abnormal exit, or a
-  -- pump I/O error) that is nil on a clean normal exit.
-  local function finish(): string, string, number, string
-    local sfd = handle.stdin and handle.stdin.fd or nil
-    handle.stdin = nil
-    local out_fd = handle.stdout and handle.stdout.fd or nil
-    local err_fd = handle.stderr and handle.stderr.fd or nil
-    local out, err_out, io_err = childio.pump(out_fd, err_fd, sfd, stdin_data)
-    if handle.stdout then handle.stdout:close(); handle.stdout = nil end
-    if handle.stderr then handle.stderr:close(); handle.stderr = nil end
-    local _, status = unix.wait(handle.pid)
-    local code: number = -1
-    local err: string = nil
-    if type(status) ~= "number" then
-      err = "wait failed: " .. tostring(status)
-    elseif unix.WIFEXITED(status) then
-      code = unix.WEXITSTATUS(status)
-    elseif unix.WIFSIGNALED(status) then
-      err = "killed by signal " .. tostring(unix.WTERMSIG(status))
-    else
-      err = "process terminated abnormally"
-    end
-    return out, err_out, code, err or io_err
-  end
+  return make_handle(pid, st)
+end
 
-  --- Wait for the process to exit and return its exit code.
-  --- Feeds any stdin and drains stdout/stderr first so it cannot deadlock.
-  --- @return number | nil The exit code if the process exited normally
-  --- @return string Error message if the process terminated abnormally
-  function handle:wait(): number | nil, string
-    local _, _, code, err = finish()
-    if err then
-      return nil, err
-    end
-    return code
+--- One-shot spawn: run to completion and return the Result.
+--- @param argv {string} Command and arguments
+--- @param opts Opts? Spawn options
+--- @return Result | nil, string? The Result, or nil + error
+local function run(argv: {string}, opts?: Opts): Result | nil, string
+  local h, err = spawn(argv, opts)
+  if not h then
+    return nil, err
   end
-
-  --- Read output from the process.
-  --- With a size, reads that many bytes from stdout and returns them (or
-  --- nil, err). Without a size, runs the process to completion (feeding stdin,
-  --- draining stdout+stderr) and returns success, stdout, and the exit code.
-  --- To also capture stderr, use communicate().
-  --- @param size number Optional number of bytes to read from stdout
-  --- @return boolean|string|nil Success (exit code 0) or, with size, the data read
-  --- @return string The stdout output, or the error when size read fails
-  --- @return number The exit code of the process
-  function handle:read(size?: number): boolean | string | nil, string, number
-    if not self.stdout then
-      return nil, "stdout not captured"
-    end
-    if size then
-      if self.stdin then self.stdin:close(); self.stdin = nil end
-      return self.stdout:read(size)
-    end
-    local out, _, code = finish()
-    return code == 0, out, code
-  end
-
-  --- Run the process to completion and capture both output streams.
-  --- Feeds any stdin while draining stdout and stderr concurrently, then reaps.
-  --- @return string The captured stdout
-  --- @return string The captured stderr
-  --- @return number The exit code (-1 if the process did not exit normally)
-  --- @return string An error (signal death, or a pump I/O error), or nil
-  function handle:communicate(): string, string, number, string
-    return finish()
-  end
-
-  return handle
+  return (h as Handle):wait()
 end
 
 local record ChildModule
-  -- Exported types so callers can name/cast the fallible spawn result.
+  -- Exported types so callers can name/cast the fallible results.
   type Handle = Handle
   type Opts = Opts
+  type Result = Result
 
   -- High-level spawn API
   spawn: function(argv: {string}, opts?: Opts): Handle | nil, string
+  run: function(argv: {string}, opts?: Opts): Result | nil, string
 
-  -- Zip binary helpers
+  -- Zip binary helper
   prepare_zip_exec: function(zip_path: string): number | nil, string
-
-  -- Low-level primitives
-  fork: function(): number
-  posix_spawn: function(prog: string, argv: {string}, envp?: {string}): number
-  posix_spawnp: function(prog: string, argv: {string}, envp?: {string}): number
-  wait: function(pid?: number, options?: number): number, number, Rusage
-  kill: function(pid: number, sig: number): boolean
-
-  -- Status helpers
-  WIFEXITED: function(wstatus: number): boolean
-  WEXITSTATUS: function(wstatus: number): number
-  WIFSIGNALED: function(wstatus: number): boolean
-  WTERMSIG: function(wstatus: number): number
-
-  -- Wait options
-  WNOHANG: number
-  WUNTRACED: number
-  WCONTINUED: number
-
-  -- Common signals for child management
-  SIGTERM: number
-  SIGKILL: number
-  SIGINT: number
-  SIGCHLD: number
-  SIGSTOP: number
-  SIGCONT: number
 end
 
 local M: ChildModule = {
-  -- High-level spawn API
   spawn = spawn,
-
-  -- Zip binary helpers
+  run = run,
   prepare_zip_exec = prepare_zip_exec,
-
-  -- Low-level primitives
-  fork = fork,
-  posix_spawn = posix_spawn,
-  posix_spawnp = posix_spawnp,
-  wait = wait,
-  kill = kill,
-
-  -- Status helpers
-  WIFEXITED = WIFEXITED,
-  WEXITSTATUS = WEXITSTATUS,
-  WIFSIGNALED = WIFSIGNALED,
-  WTERMSIG = WTERMSIG,
-
-  -- Wait options
-  WNOHANG = unix.WNOHANG,
-  WUNTRACED = unix.WUNTRACED,
-  WCONTINUED = unix.WCONTINUED,
-
-  -- Common signals for child management
-  SIGTERM = unix.SIGTERM,
-  SIGKILL = unix.SIGKILL,
-  SIGINT = unix.SIGINT,
-  SIGCHLD = unix.SIGCHLD,
-  SIGSTOP = unix.SIGSTOP,
-  SIGCONT = unix.SIGCONT,
 }
 
 return M

--- a/lib/cosmic/child_example.tl
+++ b/lib/cosmic/child_example.tl
@@ -1,39 +1,64 @@
 --- Examples for the cosmic.child module.
---- Demonstrates process spawning, stdin handling, and exit codes.
+--- Demonstrates process spawning, stdin handling, structured results,
+--- timeouts, and killing a running child.
 
--- Example_spawn demonstrates basic process spawning
-local function Example_spawn()
-  local spawn = require("cosmic.child")
-  local h = spawn.spawn({"echo", "hello world"})
-  local ok, out = (h as spawn.Handle):read()
-  print(out)
+-- Example_run demonstrates the one-shot run(): spawn, wait, and capture the
+-- structured Result (stdout, stderr, code/signal, ok) in a single call.
+local function Example_run()
+  local child = require("cosmic.child")
+  local r = child.run({"echo", "hello world"}) as child.Result
+  io.write(r.stdout)
   -- Output:
   -- hello world
 end
 
--- Example_spawn_stdin demonstrates passing stdin to a process
-local function Example_spawn_stdin()
-  local spawn = require("cosmic.child")
-  local h = spawn.spawn({"cat"}, {stdin = "hello from stdin"})
-  local ok, out = (h as spawn.Handle):read()
-  print(out)
+-- Example_run_stdin demonstrates feeding stdin to a process.
+local function Example_run_stdin()
+  local child = require("cosmic.child")
+  local r = child.run({"cat"}, {stdin = "hello from stdin"}) as child.Result
+  io.write(r.stdout)
   -- Output:
   -- hello from stdin
 end
 
--- Example_spawn_exit_code demonstrates checking exit codes
-local function Example_spawn_exit_code()
-  local spawn = require("cosmic.child")
-  local h = spawn.spawn({"sh", "-c", "exit 0"})
-  local code = (h as spawn.Handle):wait()
-  print("exit code:", code)
+-- Example_run_exit_code demonstrates inspecting the exit code.
+local function Example_run_exit_code()
+  local child = require("cosmic.child")
+  local r = child.run({"sh", "-c", "exit 0"}) as child.Result
+  print("exit code:", r.code)
   -- Output:
   -- exit code:	0
 end
 
--- Example_spawn_pipe demonstrates capturing output through an explicit pipe.
--- This pattern is needed when you want to interleave reads with the child's
--- execution rather than waiting for it to finish.
+-- Example_kill demonstrates killing a running child. kill() defaults to
+-- SIGTERM (signal 15); wait() then reports the terminating signal.
+local function Example_kill()
+  local child = require("cosmic.child")
+  local h = child.spawn({"sleep", "10"}) as child.Handle
+  h:kill()
+  local r = h:wait() as child.Result
+  print("signal:", r.signal)
+  -- Output:
+  -- signal:	15
+end
+
+-- Example_wait_timeout demonstrates a bounded wait. wait(timeout_ms) returns
+-- nil, "timeout" if the child has not finished in time; the handle stays
+-- usable, so we kill and reap it afterwards.
+local function Example_wait_timeout()
+  local child = require("cosmic.child")
+  local h = child.spawn({"sleep", "10"}) as child.Handle
+  local r, err = h:wait(50)
+  print(r, err)
+  h:kill()
+  h:wait()
+  -- Output:
+  -- nil	timeout
+end
+
+-- Example_run_pipe demonstrates capturing output through an explicit pipe.
+-- This pattern is needed when you want to redirect a child's stdout into a
+-- file descriptor you own rather than letting run()/wait() capture it.
 --
 -- Key steps:
 --   1. Create a pipe with cosmic.io.pipe().
@@ -42,7 +67,7 @@ end
 --      reader will block forever waiting for EOF.
 --   4. Read from the read end until EOF.
 --   5. Wait for the child.
-local function Example_spawn_pipe()
+local function Example_run_pipe()
   local child = require("cosmic.child")
   local cio = require("cosmic.io")
 
@@ -63,11 +88,10 @@ local function Example_spawn_pipe()
   pp.reader:close()
 
   -- Wait for the child to exit.
-  local code = (h as child.Handle):wait()
+  local r = (h as child.Handle):wait() as child.Result
 
-  -- echo adds a trailing newline; strip it before printing
   io.write(out)
-  print("exit:", code)
+  print("exit:", r.code)
   -- Output:
   -- from pipe
   -- exit:	0

--- a/lib/cosmic/child_io.tl
+++ b/lib/cosmic/child_io.tl
@@ -1,12 +1,15 @@
 --- Low-level child-process I/O primitives.
 ---
---- Holds the pipe wrapper shared by cosmic.child and a poll-driven `pump`
---- that concurrently feeds a child's stdin while draining its stdout and
---- stderr. Doing all three in one poll loop is what keeps large I/O in any
---- direction from deadlocking on a full pipe buffer.
+--- Holds the poll-driven `pump` that concurrently feeds a child's stdin while
+--- draining its stdout and stderr. Doing all three in one poll loop is what
+--- keeps large I/O in any direction from deadlocking on a full pipe buffer.
+--- The pump is deadline-aware and resumable: `cosmic.child` drives it through
+--- a shared PumpState so a `wait(timeout_ms)` that expires can be resumed by a
+--- later call, and the partial output collected so far is never lost.
 local unix = require("cosmo.unix")
 local poll = require("cosmic.poll")
 local errno = require("cosmic.errno")
+local time = require("cosmic.time")
 
 -- Writing to a pipe whose read end has already closed raises SIGPIPE, whose
 -- default action terminates the process. A library that writes to a child's
@@ -16,71 +19,33 @@ unix.sigaction(unix.SIGPIPE, unix.SIG_IGN)
 
 local CHUNK = 65536
 
---- A pipe endpoint. `fd` is a plain field (not a method like io.Handle:fd()).
-local record Pipe
-  fd: number
-  write: function(self: Pipe, data: string): number | nil, string
-  read: function(self: Pipe, size?: number): string | nil, string
-  close: function(self: Pipe)
+--- Mutable state threaded through `pump`. `cosmic.child` owns one per handle.
+--- Each fd field is nilled (and the fd closed) as that stream finishes, so a
+--- resumed pump only watches what is still live. `out`/`err_out` accumulate
+--- across calls; `stdin_off` records progress feeding `stdin_data`.
+local record PumpState
+  stdout_fd: number
+  stderr_fd: number
+  stdin_fd: number
+  stdin_data: string
+  stdin_off: integer
+  out: {string}
+  err_out: {string}
+  io_err: string
 end
 
---- Wrap a raw pipe fd in a Pipe. Returns nil when fd is nil.
---- read()/write() return `nil, err` on a real I/O error; read() returns ""
---- only on genuine end-of-file, so an error is never mistaken for EOF.
---- @param fd number Raw file descriptor, or nil
---- @return Pipe wrapper, or nil when fd is nil
-local function make_pipe(fd: number): Pipe
-  if not fd then
-    return nil
-  end
-  local pipe: Pipe = {fd = fd}
-
-  function pipe:write(data: string): number | nil, string
-    local n, err = unix.write(self.fd, data)
-    if n == nil then
-      return nil, errno.str(err, "write")
-    end
-    return n
-  end
-
-  function pipe:read(size?: number): string | nil, string
-    if size then
-      local chunk, err = unix.read(self.fd, size)
-      if chunk == nil then
-        return nil, errno.str(err, "read")
-      end
-      return chunk
-    end
-    local chunks: {string} = {}
-    while true do
-      local chunk, err = unix.read(self.fd, CHUNK)
-      if chunk == nil then
-        return nil, errno.str(err, "read")
-      end
-      if chunk == "" then
-        break
-      end
-      table.insert(chunks, chunk)
-    end
-    return table.concat(chunks)
-  end
-
-  pipe.close = function(self: Pipe)
-    if self.fd then
-      local _ = unix.close(self.fd)
-      self.fd = nil
-    end
-  end
-
-  return pipe
+-- Current monotonic time in milliseconds. Used only for relative deadline
+-- arithmetic, so the arbitrary epoch does not matter.
+local function now_ms(): number
+  local secs, nanos = time.monotonic()
+  return secs * 1000 + nanos / 1000000
 end
 
 -- Put a pipe write end into non-blocking mode so a stdin write in the pump
 -- can never block the loop that is simultaneously draining stdout/stderr.
 -- F_SETFL replaces the file-status flags, but a fresh pipe write end carries
 -- none worth preserving (F_SETFL ignores the access mode), so setting
--- O_NONBLOCK outright is safe — and F_GETFL is not usable here anyway (the
--- runtime returns a boolean for it rather than the flag bits).
+-- O_NONBLOCK outright is safe.
 local function set_nonblocking(fd: number): boolean, string
   local ok = unix.fcntl(fd, unix.F_SETFL, unix.O_NONBLOCK)
   if not ok then
@@ -89,106 +54,116 @@ local function set_nonblocking(fd: number): boolean, string
   return true
 end
 
---- Concurrently write `stdin_data` to `stdin_fd` while draining `stdout_fd`
---- and `stderr_fd` to end-of-file, all in one poll loop so no direction can
---- deadlock on a full pipe buffer. `stdin_fd` is closed when the write
---- finishes or the child hangs up (EPIPE); stdout/stderr fds are left open
---- for the caller to close. A read/write error stops that stream and is
---- reported; EPIPE on stdin (the child stopped reading) is not an error.
---- @param stdout_fd number stdout read end, or nil
---- @param stderr_fd number stderr read end, or nil
---- @param stdin_fd number stdin write end, or nil
---- @param stdin_data string bytes to send to stdin, or nil
---- @return string collected stdout
---- @return string collected stderr
---- @return string? first I/O error, or nil when clean
-local function pump(stdout_fd: number, stderr_fd: number, stdin_fd: number, stdin_data: string): string, string, string
-  local out: {string} = {}
-  local err_out: {string} = {}
-  local io_err: string = nil
+--- Drive `state` forward: feed stdin while draining stdout/stderr, all in one
+--- poll loop so no direction can deadlock on a full pipe buffer. Returns
+--- `true` if `deadline_ms` (an absolute `now_ms()` value, or nil for no limit)
+--- elapsed before every stream finished — the child may still be running and
+--- the caller can resume by calling `pump` again with the same state. Returns
+--- `false` once stdin is fully sent and stdout/stderr have both hit EOF; each
+--- fd is closed and nilled in `state` as it completes.
+--- @param state PumpState shared, mutable I/O state
+--- @param deadline_ms number? absolute monotonic-ms deadline, or nil
+--- @return boolean timed_out
+local function pump(state: PumpState, deadline_ms: number): boolean
   local p = poll.new()
-  if stdout_fd then p:add(stdout_fd, poll.POLLIN) end
-  if stderr_fd then p:add(stderr_fd, poll.POLLIN) end
+  if state.stdout_fd then p:add(state.stdout_fd, poll.POLLIN) end
+  if state.stderr_fd then p:add(state.stderr_fd, poll.POLLIN) end
 
-  local w_off = 0
-  if stdin_fd then
-    if stdin_data and #stdin_data > 0 then
-      local ok, serr = set_nonblocking(stdin_fd)
-      if not ok then io_err = io_err or serr end
-      p:add(stdin_fd, poll.POLLOUT)
+  -- stdin: watch for writability only while bytes remain; otherwise close it
+  -- now so the child sees EOF immediately.
+  if state.stdin_fd then
+    if state.stdin_data and state.stdin_off < #state.stdin_data then
+      local ok, serr = set_nonblocking(state.stdin_fd)
+      if not ok then state.io_err = state.io_err or serr end
+      p:add(state.stdin_fd, poll.POLLOUT)
     else
-      unix.close(stdin_fd)
-      stdin_fd = nil
+      unix.close(state.stdin_fd)
+      state.stdin_fd = nil
     end
   end
 
-  -- Read whatever is ready on fd into buf; drop it from the set on EOF, a
-  -- read error, or a hangup with no pending data. When both readable and
-  -- hangup are set, data still remains, so read rather than drop.
-  local function read_ready(fd: number, buf: {string})
+  -- Read whatever is ready on fd into buf; on EOF, a read error, or a hangup
+  -- with no pending data, drop it from the set and close/nil it in `state`.
+  -- When both readable and hangup are set, data still remains, so read.
+  local function read_ready(fd: number, buf: {string}, which: string)
     local ev0 = p:events(fd)
     if not ev0 then return end
     local ev = ev0 as {string: boolean}
     if ev.readable then
       local chunk, rerr = unix.read(fd, CHUNK)
       if chunk == nil then
-        io_err = io_err or errno.str(rerr, "read")
-        p:remove(fd)
+        state.io_err = state.io_err or errno.str(rerr, "read")
+        p:remove(fd); unix.close(fd)
+        if which == "out" then state.stdout_fd = nil else state.stderr_fd = nil end
       elseif chunk == "" then
-        p:remove(fd)
+        p:remove(fd); unix.close(fd)
+        if which == "out" then state.stdout_fd = nil else state.stderr_fd = nil end
       else
         table.insert(buf, chunk)
       end
     elseif ev.hangup or ev.error or ev.invalid then
-      p:remove(fd)
+      p:remove(fd); unix.close(fd)
+      if which == "out" then state.stdout_fd = nil else state.stderr_fd = nil end
     end
   end
 
   while not p:empty() do
-    local ready, perr = p:poll(-1)
+    local timeout: integer = -1
+    if deadline_ms then
+      local rem = deadline_ms - now_ms()
+      if rem <= 0 then return true end
+      -- poll wants an integer millisecond count; floor the remaining time
+      -- (any sub-millisecond remainder is caught by the next deadline check).
+      timeout = math.floor(rem) as integer
+    end
+    local ready, perr = p:poll(timeout)
     if ready == nil then
-      io_err = io_err or perr
+      state.io_err = state.io_err or perr
       break
     end
-    if stdin_fd then
-      local ev = p:events(stdin_fd) as {string: boolean}
+    if ready == 0 then
+      -- poll timed out with nothing ready: the deadline expired.
+      return true
+    end
+    if state.stdin_fd then
+      local ev = p:events(state.stdin_fd) as {string: boolean}
       if ev and ev.writable then
-        local n, werr, weno = unix.write(stdin_fd, stdin_data:sub(w_off + 1, w_off + CHUNK))
+        local slice = state.stdin_data:sub(state.stdin_off + 1, state.stdin_off + CHUNK)
+        local n, werr, weno = unix.write(state.stdin_fd, slice)
         if n ~= nil then
-          w_off = w_off + (n as integer)
-          if w_off >= #stdin_data then
-            p:remove(stdin_fd); unix.close(stdin_fd); stdin_fd = nil
+          state.stdin_off = state.stdin_off + (n as integer)
+          if state.stdin_off >= #state.stdin_data then
+            p:remove(state.stdin_fd); unix.close(state.stdin_fd); state.stdin_fd = nil
           end
         elseif errno.is(weno, "EAGAIN") then
           -- Not actually writable yet; try again on the next poll.
         elseif errno.is(weno, "EPIPE") then
           -- The child stopped reading stdin; stop feeding it (not an error).
-          p:remove(stdin_fd); unix.close(stdin_fd); stdin_fd = nil
+          p:remove(state.stdin_fd); unix.close(state.stdin_fd); state.stdin_fd = nil
         else
-          io_err = io_err or errno.str(werr, "write stdin")
-          p:remove(stdin_fd); unix.close(stdin_fd); stdin_fd = nil
+          state.io_err = state.io_err or errno.str(werr, "write stdin")
+          p:remove(state.stdin_fd); unix.close(state.stdin_fd); state.stdin_fd = nil
         end
       elseif ev and (ev.error or ev.hangup or ev.invalid) then
-        p:remove(stdin_fd); unix.close(stdin_fd); stdin_fd = nil
+        p:remove(state.stdin_fd); unix.close(state.stdin_fd); state.stdin_fd = nil
       end
     end
-    if stdout_fd then read_ready(stdout_fd, out) end
-    if stderr_fd then read_ready(stderr_fd, err_out) end
+    if state.stdout_fd then read_ready(state.stdout_fd, state.out, "out") end
+    if state.stderr_fd then read_ready(state.stderr_fd, state.err_out, "err") end
   end
 
-  if stdin_fd then unix.close(stdin_fd) end
-  return table.concat(out), table.concat(err_out), io_err
+  return false
 end
 
 local record ChildIoModule
-  Pipe: Pipe
-  make_pipe: function(fd: number): Pipe
-  pump: function(stdout_fd: number, stderr_fd: number, stdin_fd: number, stdin_data: string): string, string, string
+  PumpState: PumpState
+  pump: function(state: PumpState, deadline_ms: number): boolean
+  now_ms: function(): number
 end
 
 local M: ChildIoModule = {
-  make_pipe = make_pipe,
   pump = pump,
+  now_ms = now_ms,
 }
 
 return M

--- a/lib/cosmic/child_io_test.tl
+++ b/lib/cosmic/child_io_test.tl
@@ -1,91 +1,85 @@
 #!/usr/bin/env cosmic
 -- Regressions for the cosmic.child I/O layer (child_io.pump): stdin is fed
 -- concurrently with stdout/stderr draining so no direction deadlocks, a child
--- that stops reading stdin cannot SIGPIPE-kill the parent, and communicate()
--- captures both output streams plus the exit status.
+-- that stops reading stdin cannot SIGPIPE-kill the parent, and run()/wait()
+-- capture both output streams plus the exit status.
 local child = require("cosmic.child")
 local fs = require("cosmic.fs")
+local signal = require("cosmic.signal")
 -- cosmo.unix is required directly only to monkey-patch unix.pipe for fault
 -- injection (test_spawn_pipe_failure_cleans_up), which must share the exact
--- module table that child.tl uses, and to send a signal from a child payload.
+-- module table that child.tl uses.
 local unix = require("cosmo.unix")
 
 local lua_bin = fs.join(os.getenv("TEST_BIN"), "cosmic")
 
 local function test_large_stdin_no_deadlock()
   -- 256KB of stdin far exceeds the pipe buffer, and the child echoes it back,
-  -- so both directions overflow at once. Before the pump fix, spawn() wrote
-  -- stdin synchronously and blocked once the buffer filled while nobody was
-  -- draining stdout -- deadlock.
+  -- so both directions overflow at once. The pump interleaves the write with
+  -- draining stdout, so neither side blocks.
   local big = string.rep("z", 262144)
-  local handle = child.spawn({lua_bin, "-e", "io.write(io.read('*a'))"}, {stdin = big})
-  assert(handle ~= nil, "handle should not be nil")
-  local ok, out = (handle as child.Handle):read()
-  assert(ok, "command should succeed")
-  assert(#out == #big, "expected " .. #big .. " bytes echoed, got " .. #out)
-  assert(out == big, "echoed stdin should match input")
+  local r = child.run({lua_bin, "-e", "io.write(io.read('*a'))"}, {stdin = big}) as child.Result
+  assert(r ~= nil, "run should succeed")
+  assert(r.ok, "command should succeed")
+  assert(#r.stdout == #big, "expected " .. #big .. " bytes echoed, got " .. #r.stdout)
+  assert(r.stdout == big, "echoed stdin should match input")
 end
 test_large_stdin_no_deadlock()
 
 local function test_stdin_to_early_exiting_child_no_sigpipe()
   -- The child exits immediately without reading stdin, closing its read end.
-  -- Feeding a large stdin then hits a broken pipe: before SIGPIPE was ignored
-  -- this SIGPIPE-killed the parent (this test process). It must instead
-  -- complete cleanly and report the child's exit code.
+  -- Feeding a large stdin then hits a broken pipe: SIGPIPE is ignored, so the
+  -- write fails with EPIPE and the run completes with the child's exit code.
   local big = string.rep("q", 262144)
-  local handle = child.spawn({lua_bin, "-e", "os.exit(3)"}, {stdin = big})
-  assert(handle ~= nil, "handle should not be nil")
-  local _, _, code = (handle as child.Handle):communicate()
-  assert(code == 3, "expected exit code 3 from early-exiting child, got " .. tostring(code))
+  local r = child.run({lua_bin, "-e", "os.exit(3)"}, {stdin = big}) as child.Result
+  assert(r ~= nil, "run should succeed")
+  assert(r.code == 3, "expected exit code 3 from early-exiting child, got " .. tostring(r.code))
 end
 test_stdin_to_early_exiting_child_no_sigpipe()
 
-local function test_communicate_captures_both_streams()
-  local handle = child.spawn({lua_bin, "-e", [[
+local function test_run_captures_both_streams()
+  local r = child.run({lua_bin, "-e", [[
     io.write("on stdout")
     io.flush()
     io.stderr:write("on stderr")
     io.stderr:flush()
     os.exit(7)
-  ]]})
-  assert(handle ~= nil, "handle should not be nil")
-  local out, err_out, code, err = (handle as child.Handle):communicate()
-  assert(out == "on stdout", "expected stdout 'on stdout', got '" .. tostring(out) .. "'")
-  assert(err_out == "on stderr", "expected stderr 'on stderr', got '" .. tostring(err_out) .. "'")
-  assert(code == 7, "expected exit code 7, got " .. tostring(code))
-  assert(err == nil, "expected no error on a normal exit, got " .. tostring(err))
+  ]]}) as child.Result
+  assert(r ~= nil, "run should succeed")
+  assert(r.stdout == "on stdout", "expected stdout 'on stdout', got '" .. tostring(r.stdout) .. "'")
+  assert(r.stderr == "on stderr", "expected stderr 'on stderr', got '" .. tostring(r.stderr) .. "'")
+  assert(r.code == 7, "expected exit code 7, got " .. tostring(r.code))
+  assert(r.signal == nil, "a normal exit has no signal")
 end
-test_communicate_captures_both_streams()
+test_run_captures_both_streams()
 
-local function test_communicate_reports_signal_death()
-  -- SIGKILL the child; communicate() surfaces the signal as its error and a
-  -- -1 exit code rather than pretending the process exited normally.
-  local handle = child.spawn({lua_bin, "-e", [[
+local function test_run_reports_signal_death()
+  -- The child SIGKILLs itself; the Result reports the signal (not a fake exit)
+  -- and leaves `code` nil.
+  local r = child.run({lua_bin, "-e", [[
     local unix = require("cosmo.unix")
     unix.kill(unix.getpid(), unix.SIGKILL)
-  ]]})
-  assert(handle ~= nil, "handle should not be nil")
-  local _, _, code, err = (handle as child.Handle):communicate()
-  assert(code == -1, "expected -1 exit code for signal death, got " .. tostring(code))
-  assert(err ~= nil and err:find("signal"), "expected a signal error, got " .. tostring(err))
+  ]]}) as child.Result
+  assert(r ~= nil, "run should succeed")
+  assert(r.code == nil, "signal death has no exit code, got " .. tostring(r.code))
+  assert(r.signal == signal.SIGKILL, "expected SIGKILL, got " .. tostring(r.signal))
+  assert(r.ok == false, "signal death is not ok")
 end
-test_communicate_reports_signal_death()
+test_run_reports_signal_death()
 
 local function test_large_stdin_with_output_no_deadlock()
-  -- Large stdin AND large stdout at the same time: the child reads all of
-  -- stdin and writes twice as much to stdout. The pump must interleave the
-  -- write and both reads.
+  -- Large stdin AND large stdout at once: the child reads all of stdin and
+  -- writes twice as much to stdout. The pump must interleave write and reads.
   local big = string.rep("m", 200000)
-  local handle = child.spawn({lua_bin, "-e", [[
+  local r = child.run({lua_bin, "-e", [[
     local data = io.read("*a")
     io.write(data)
     io.write(data)
-  ]]}, {stdin = big})
-  assert(handle ~= nil, "handle should not be nil")
-  local out, err_out, code = (handle as child.Handle):communicate()
-  assert(code == 0, "expected exit 0, got " .. tostring(code))
-  assert(#out == 2 * #big, "expected " .. (2 * #big) .. " bytes, got " .. #out)
-  assert(err_out == "", "expected empty stderr, got " .. #err_out .. " bytes")
+  ]]}, {stdin = big}) as child.Result
+  assert(r ~= nil, "run should succeed")
+  assert(r.code == 0, "expected exit 0, got " .. tostring(r.code))
+  assert(#r.stdout == 2 * #big, "expected " .. (2 * #big) .. " bytes, got " .. #r.stdout)
+  assert(r.stderr == "", "expected empty stderr, got " .. #r.stderr .. " bytes")
 end
 test_large_stdin_with_output_no_deadlock()
 

--- a/lib/cosmic/child_test.tl
+++ b/lib/cosmic/child_test.tl
@@ -4,6 +4,7 @@ local fs = require("cosmic.fs")
 local proc = require("cosmic.proc")
 local env = require("cosmic.env")
 local time = require("cosmic.time")
+local signal = require("cosmic.signal")
 -- cosmo.unix is required directly only for raw fd ops (unix.close) and to
 -- monkey-patch unix.fork for fault injection (test_spawn_fork_failure), which
 -- must share the exact module table that child.tl uses.
@@ -12,270 +13,207 @@ local unix = require("cosmo.unix")
 local lua_bin = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
 
--- High-level spawn tests --
+-- === Issue #527 TDD cases (a)-(e) ===
 
-local function test_simple_command()
-  local handle = child.spawn({lua_bin, "-e", "print('hello')"})
-  assert(handle ~= nil, "handle should not be nil")
-  local ok, out = (handle as child.Handle):read()
-  assert(ok, "command should succeed")
-  assert(out == "hello\n", "expected 'hello\\n', got '" .. tostring(out) .. "'")
+-- (a) kill a long-running child; wait() reports the terminating signal.
+local function test_kill_reports_signal()
+  local h = child.spawn({"sleep", "10"}) as child.Handle
+  assert(h ~= nil, "spawn should succeed")
+  assert(h:kill(), "kill (default SIGTERM) should succeed")
+  local r = h:wait() as child.Result
+  assert(r ~= nil, "wait should return a Result")
+  assert(r.signal == signal.SIGTERM,
+    "expected SIGTERM, got signal=" .. tostring(r.signal) .. " code=" .. tostring(r.code))
+  assert(r.signal == 15, "SIGTERM should be 15, got " .. tostring(r.signal))
+  assert(r.code == nil, "a signaled child has no exit code")
+  assert(r.ok == false, "a signaled child is not ok")
 end
-test_simple_command()
+test_kill_reports_signal()
+
+-- (b) wait() is idempotent: the reaped Result is cached and returned again.
+local function test_wait_idempotent()
+  local h = child.spawn({lua_bin, "-e", "os.exit(3)"}) as child.Handle
+  assert(h ~= nil, "spawn should succeed")
+  local r1 = h:wait() as child.Result
+  local r2 = h:wait() as child.Result
+  assert(r1 == r2, "second wait() must return the same cached Result")
+  assert(r1.code == 3, "expected code 3, got " .. tostring(r1.code))
+end
+test_wait_idempotent()
+
+-- (c) wait(timeout_ms) returns nil, "timeout" for a child that has not exited;
+-- the handle stays usable so we can then kill and reap it.
+local function test_wait_timeout()
+  local h = child.spawn({"sleep", "10"}) as child.Handle
+  assert(h ~= nil, "spawn should succeed")
+  local r, err = h:wait(100)
+  assert(r == nil, "expected nil Result on timeout")
+  assert(err == "timeout", "expected 'timeout', got " .. tostring(err))
+  h:kill(signal.SIGKILL)
+  local r2 = h:wait() as child.Result
+  assert(r2.signal == signal.SIGKILL, "expected SIGKILL after timeout+kill")
+end
+test_wait_timeout()
+
+-- (d) a missing executable makes spawn() itself fail with a visible ENOENT,
+-- not a bogus exit code from a later wait().
+local function test_exec_failure_visible()
+  local h, err = child.spawn({"/no/such/bin"})
+  assert(h == nil, "spawn should fail for a missing executable")
+  assert(err ~= nil and err:match("ENOENT"),
+    "expected ENOENT in error, got " .. tostring(err))
+end
+test_exec_failure_visible()
+
+-- (e) run() captures stdout and stderr independently along with the exit code.
+local function test_run_captures_streams_and_code()
+  local r = child.run({"sh", "-c", "echo o; echo e >&2; exit 3"}) as child.Result
+  assert(r ~= nil, "run should succeed")
+  assert(r.stdout == "o\n", "expected stdout 'o\\n', got '" .. tostring(r.stdout) .. "'")
+  assert(r.stderr == "e\n", "expected stderr 'e\\n', got '" .. tostring(r.stderr) .. "'")
+  assert(r.code == 3, "expected code 3, got " .. tostring(r.code))
+  assert(r.ok == false, "exit 3 is not ok")
+end
+test_run_captures_streams_and_code()
+
+-- === High-level run/spawn behavior ===
+
+local function test_run_simple()
+  local r = child.run({lua_bin, "-e", "print('hello')"}) as child.Result
+  assert(r ~= nil, "run should succeed")
+  assert(r.ok, "command should succeed")
+  assert(r.stdout == "hello\n", "expected 'hello\\n', got '" .. tostring(r.stdout) .. "'")
+end
+test_run_simple()
 
 local function test_command_not_found()
-  local handle, err = child.spawn({"nonexistent_command_12345"})
-  assert(handle == nil, "handle should be nil for nonexistent command")
+  local h, err = child.spawn({"nonexistent_command_12345"})
+  assert(h == nil, "handle should be nil for nonexistent command")
   assert(err:find("command not found", 1, true), "expected 'command not found' in error: " .. tostring(err))
 end
 test_command_not_found()
 
-local function test_wait_returns_exit_code()
-  local handle = child.spawn({lua_bin, "-e", "os.exit(0)"})
-  assert(handle ~= nil, "handle should not be nil")
-  local exit_code = (handle as child.Handle):wait()
-  assert(exit_code == 0, "expected exit code 0, got " .. tostring(exit_code))
+local function test_run_exit_code()
+  local r = child.run({lua_bin, "-e", "os.exit(0)"}) as child.Result
+  assert(r.code == 0, "expected exit code 0, got " .. tostring(r.code))
+  assert(r.ok, "exit 0 should be ok")
 
-  handle = child.spawn({lua_bin, "-e", "os.exit(1)"})
-  assert(handle ~= nil, "handle should not be nil")
-  exit_code = (handle as child.Handle):wait()
-  assert(exit_code == 1, "expected exit code 1, got " .. tostring(exit_code))
+  r = child.run({lua_bin, "-e", "os.exit(1)"}) as child.Result
+  assert(r.code == 1, "expected exit code 1, got " .. tostring(r.code))
+  assert(not r.ok, "exit 1 should not be ok")
 end
-test_wait_returns_exit_code()
+test_run_exit_code()
 
-local function test_stdin_string()
-  local handle = child.spawn({lua_bin, "-e", "io.write(io.read('*a'))"}, {stdin = "hello from stdin"})
-  assert(handle ~= nil, "handle should not be nil")
-  local ok, out = (handle as child.Handle):read()
-  assert(ok, "command should succeed")
-  assert(out == "hello from stdin", "expected 'hello from stdin', got '" .. tostring(out) .. "'")
+local function test_run_stdin_string()
+  local r = child.run({lua_bin, "-e", "io.write(io.read('*a'))"}, {stdin = "hello from stdin"}) as child.Result
+  assert(r.ok, "command should succeed")
+  assert(r.stdout == "hello from stdin", "expected 'hello from stdin', got '" .. tostring(r.stdout) .. "'")
 end
-test_stdin_string()
+test_run_stdin_string()
 
-local function test_read_captures_output()
-  local handle = child.spawn({lua_bin, "-e", [[io.write("line1\nline2\n")]]})
-  assert(handle ~= nil, "handle should not be nil")
-  local ok, out = (handle as child.Handle):read()
-  assert(ok, "command should succeed")
-  assert(out == "line1\nline2\n", "expected 'line1\\nline2\\n', got '" .. tostring(out) .. "'")
+local function test_run_cwd_option()
+  local r = child.run({"pwd"}, {cwd = TEST_TMPDIR}) as child.Result
+  assert(r.ok, "pwd should succeed, code: " .. tostring(r.code) .. " stderr: " .. tostring(r.stderr))
+  local pwd_output = r.stdout:gsub("\n$", "")
+  assert(pwd_output == TEST_TMPDIR, "expected pwd '" .. TEST_TMPDIR .. "', got '" .. tostring(pwd_output) .. "'")
 end
-test_read_captures_output()
+test_run_cwd_option()
 
-local function test_cwd_option()
-  local handle = child.spawn({"pwd"}, {cwd = TEST_TMPDIR})
-  assert(handle ~= nil, "handle should not be nil")
-  local ok, out, exit_code = (handle as child.Handle):read()
-  assert(ok, "command should succeed, exit code: " .. tostring(exit_code) .. ", output: '" .. tostring(out) .. "'")
-  local pwd_output = out:gsub("\n$", "")
-  assert(pwd_output == TEST_TMPDIR, "expected pwd to be '" .. TEST_TMPDIR .. "', got '" .. tostring(pwd_output) .. "'")
-end
-test_cwd_option()
+-- === Handle-level methods: try_wait, read, kill-after-reap ===
 
--- fork and wait tests --
-
-local function test_fork_and_wait()
-  local pid = child.fork()
-  if pid == 0 then
-    proc.exit(42)
-  else
-    assert(pid > 0, "expected positive child pid in parent, got " .. tostring(pid))
-    local waited_pid, status = child.wait(pid)
-    assert(waited_pid == pid, "expected to wait for child " .. tostring(pid) .. ", got " .. tostring(waited_pid))
-    assert(child.WIFEXITED(status), "expected child to exit normally")
-    local exit_code = child.WEXITSTATUS(status)
-    assert(exit_code == 42, "expected exit code 42, got " .. tostring(exit_code))
+local function test_try_wait()
+  local h = child.spawn({"sleep", "10"}) as child.Handle
+  assert(h:try_wait() == nil, "try_wait on a running child returns nil")
+  h:kill(signal.SIGKILL)
+  local res: child.Result = nil
+  for _ = 1, 200 do
+    res = h:try_wait() as child.Result
+    if res ~= nil then break end
+    time.sleep(0, 10000000) -- 10ms
   end
+  assert(res ~= nil, "try_wait should eventually reap the killed child")
+  assert(res.signal == signal.SIGKILL, "expected SIGKILL, got signal=" .. tostring(res.signal))
 end
-test_fork_and_wait()
+test_try_wait()
 
-local function test_fork_child_has_different_pid()
-  local parent_pid = proc.getpid()
-  local marker_file = fs.join(TEST_TMPDIR, "fork_test_" .. tostring(parent_pid))
+local function test_read_streaming()
+  local h = child.spawn({lua_bin, "-e", "io.write('abcdef'); io.flush()"}) as child.Handle
+  local chunk = h:read(3) as string
+  assert(chunk ~= nil and #chunk >= 1, "streaming read should return bytes, got " .. tostring(chunk))
+  local r = h:wait() as child.Result
+  assert(chunk .. r.stdout == "abcdef",
+    "streamed + pumped output should reassemble, got '" .. chunk .. "' + '" .. r.stdout .. "'")
+end
+test_read_streaming()
 
-  local pid = child.fork()
-  if pid == 0 then
-    local child_pid = proc.getpid()
-    local f = io.open(marker_file, "w")
-    if f then
-      f:write(tostring(child_pid))
-      f:close()
-    end
-    proc.exit(0)
-  else
-    child.wait(pid)
-    local f = io.open(marker_file, "r")
-    assert(f ~= nil, "expected marker file to exist")
-    local child_pid_str = f:read("*a")
-    f:close()
-    os.remove(marker_file)
-    local child_pid = tonumber(child_pid_str)
-    assert(child_pid ~= parent_pid, "expected child to have different pid")
-    assert(child_pid == pid, "expected child pid " .. tostring(pid) .. ", got " .. tostring(child_pid))
+local function test_abandoned_handle_reaped()
+  -- Dropping an un-waited handle must not leak a zombie: the __gc finalizer
+  -- SIGKILLs and reaps the child. Lua 5.4 runs finalizers synchronously in
+  -- collectgarbage(), and the reap is a blocking wait, so by the time gc
+  -- returns the pid is gone (kill(pid, 0) fails with ESRCH).
+  local pid: integer = 0
+  do
+    local h = child.spawn({"sleep", "30"}) as child.Handle
+    pid = h.pid
   end
+  collectgarbage("collect")
+  collectgarbage("collect")
+  time.sleep(0, 100000000) -- 100ms for the kernel to finish teardown
+  assert(not proc.kill(pid, 0), "abandoned child should be killed and reaped, not left alive/zombie")
 end
-test_fork_child_has_different_pid()
+test_abandoned_handle_reaped()
 
--- WIFEXITED / WEXITSTATUS tests --
-
-local function test_wifexited_normal_exit()
-  local pid = child.fork()
-  if pid == 0 then
-    proc.exit(0)
-  else
-    local _, status = child.wait(pid)
-    assert(child.WIFEXITED(status), "expected WIFEXITED to be true")
-  end
+local function test_kill_after_reap_fails()
+  local h = child.spawn({lua_bin, "-e", "os.exit(0)"}) as child.Handle
+  h:wait()
+  local ok, err = h:kill()
+  assert(not ok, "kill after reap should fail")
+  assert(err ~= nil, "kill after reap should report an error")
 end
-test_wifexited_normal_exit()
+test_kill_after_reap_fails()
 
-local function test_wexitstatus_values()
-  for _, expected_code in ipairs({0, 1, 42, 127, 255}) do
-    local pid = child.fork()
-    if pid == 0 then
-      proc.exit(expected_code)
-    else
-      local _, status = child.wait(pid)
-      assert(child.WIFEXITED(status), "expected WIFEXITED to be true for code " .. tostring(expected_code))
-      local actual_code = child.WEXITSTATUS(status)
-      assert(actual_code == expected_code, "expected exit code " .. tostring(expected_code) .. ", got " .. tostring(actual_code))
-    end
-  end
-end
-test_wexitstatus_values()
-
--- WIFSIGNALED / WTERMSIG tests --
-
-local function test_wifsignaled_on_kill()
-  local pid = child.fork()
-  if pid == 0 then
-    while true do end
-  else
-    local killed = child.kill(pid, child.SIGKILL)
-    assert(killed, "expected kill to succeed")
-    local _, status = child.wait(pid)
-    assert(child.WIFSIGNALED(status), "expected WIFSIGNALED to be true")
-    local sig = child.WTERMSIG(status)
-    assert(sig == child.SIGKILL, "expected SIGKILL (" .. tostring(child.SIGKILL) .. "), got " .. tostring(sig))
-  end
-end
-test_wifsignaled_on_kill()
-
--- WNOHANG test --
-
-local function test_wnohang_returns_zero_for_running_process()
-  local pid = child.fork()
-  if pid == 0 then
-    time.sleep(0, 100000000) -- 100ms
-    proc.exit(0)
-  else
-    local waited_pid = child.wait(pid, child.WNOHANG)
-    assert(waited_pid == 0 or waited_pid == pid, "expected 0 or pid, got " .. tostring(waited_pid))
-    if waited_pid == 0 then
-      child.wait(pid)
-    end
-  end
-end
-test_wnohang_returns_zero_for_running_process()
-
--- posix_spawn tests --
-
-local function test_posix_spawn_returns_pid()
-  local ls_path = proc.commandv("ls")
-  if ls_path then
-    local pid = child.posix_spawn(ls_path, {"ls"})
-    assert(pid > 0, "expected positive pid, got " .. tostring(pid))
-    child.wait(pid)
-  end
-end
-test_posix_spawn_returns_pid()
-
-local function test_posix_spawnp_with_path_search()
-  local pid = child.posix_spawnp("ls", {"ls"})
-  assert(pid > 0, "expected positive pid, got " .. tostring(pid))
-  local waited_pid, status = child.wait(pid)
-  assert(waited_pid == pid, "expected to wait for spawned process")
-  assert(child.WIFEXITED(status), "expected normal exit")
-  assert(child.WEXITSTATUS(status) == 0, "expected exit code 0")
-end
-test_posix_spawnp_with_path_search()
-
--- Environment inheritance test --
+-- === Environment ===
 
 local function test_spawn_inherits_env()
-  -- child.spawn should pass the parent's environment to the child unchanged.
-  -- regression: environ() returns {string} ("KEY=VALUE" entries) but spawn()
-  -- iterated it as {string:string} producing "1=KEY=VALUE" garbage.
   local sentinel = "cosmic_test_inherit_" .. tostring(proc.getpid())
   env.set("COSMIC_TEST_SENTINEL", sentinel)
-  local handle = child.spawn({lua_bin, "-e", [[
+  local r = child.run({lua_bin, "-e", [[
     io.write(os.getenv("COSMIC_TEST_SENTINEL") or "")
-  ]]})
-  assert(handle ~= nil, "handle should not be nil")
-  local ok, out, code = (handle as child.Handle):read()
-  assert(ok, "child should exit 0, got code " .. tostring(code))
-  assert(out == sentinel, "expected '" .. sentinel .. "', got '" .. tostring(out) .. "'")
+  ]]}) as child.Result
+  assert(r.ok, "child should exit 0, got code " .. tostring(r.code))
+  assert(r.stdout == sentinel, "expected '" .. sentinel .. "', got '" .. tostring(r.stdout) .. "'")
 end
 test_spawn_inherits_env()
 
 local function test_spawn_with_env_map()
-  -- child.spawn should accept {string:string} map from env.all()
-  local env = require("cosmic.env")
   local sentinel = "cosmic_test_map_" .. tostring(proc.getpid())
   env.set("COSMIC_TEST_MAP", sentinel)
   local vars = env.all()
-  local handle = child.spawn({lua_bin, "-e", [[
+  local r = child.run({lua_bin, "-e", [[
     io.write(os.getenv("COSMIC_TEST_MAP") or "")
-  ]]}, {env = vars as {string}})
-  assert(handle ~= nil, "handle should not be nil")
-  local ok, out, code = (handle as child.Handle):read()
-  assert(ok, "child should exit 0, got code " .. tostring(code))
-  assert(out == sentinel, "expected '" .. sentinel .. "', got '" .. tostring(out) .. "'")
+  ]]}, {env = vars as {string}}) as child.Result
+  assert(r.ok, "child should exit 0, got code " .. tostring(r.code))
+  assert(r.stdout == sentinel, "expected '" .. sentinel .. "', got '" .. tostring(r.stdout) .. "'")
 end
 test_spawn_with_env_map()
 
 local function test_spawn_with_env_list()
-  -- child.spawn should still accept {string} list format
-  local env_mod = require("cosmic.env")
   local sentinel = "cosmic_test_list_" .. tostring(proc.getpid())
   env.set("COSMIC_TEST_LIST", sentinel)
-  local vars = env_mod.list()
-  local handle = child.spawn({lua_bin, "-e", [[
+  local vars = env.list()
+  local r = child.run({lua_bin, "-e", [[
     io.write(os.getenv("COSMIC_TEST_LIST") or "")
-  ]]}, {env = vars})
-  assert(handle ~= nil, "handle should not be nil")
-  local ok, out, code = (handle as child.Handle):read()
-  assert(ok, "child should exit 0, got code " .. tostring(code))
-  assert(out == sentinel, "expected '" .. sentinel .. "', got '" .. tostring(out) .. "'")
+  ]]}, {env = vars}) as child.Result
+  assert(r.ok, "child should exit 0, got code " .. tostring(r.code))
+  assert(r.stdout == sentinel, "expected '" .. sentinel .. "', got '" .. tostring(r.stdout) .. "'")
 end
 test_spawn_with_env_list()
 
--- Constants tests --
-
-local function test_signal_constants_defined()
-  assert(type(child.SIGTERM) == "number", "SIGTERM should be a number")
-  assert(type(child.SIGKILL) == "number", "SIGKILL should be a number")
-  assert(type(child.SIGINT) == "number", "SIGINT should be a number")
-  assert(type(child.SIGCHLD) == "number", "SIGCHLD should be a number")
-  assert(type(child.SIGSTOP) == "number", "SIGSTOP should be a number")
-  assert(type(child.SIGCONT) == "number", "SIGCONT should be a number")
-end
-test_signal_constants_defined()
-
-local function test_wait_option_constants_defined()
-  assert(type(child.WNOHANG) == "number", "WNOHANG should be a number")
-  assert(type(child.WUNTRACED) == "number", "WUNTRACED should be a number")
-  assert(child.WCONTINUED == nil or type(child.WCONTINUED) == "number",
-    "WCONTINUED should be a number or nil")
-end
-test_wait_option_constants_defined()
-
--- fork-failure fd-cleanup test --
+-- === fork-failure fd-cleanup ===
 
 local function test_spawn_fork_failure()
-  -- Monkey-patch unix.fork to simulate a fork failure.
-  -- child.tl requires "cosmo.unix" and calls unix.fork() via the shared
-  -- module table, so replacing it here affects child.spawn() as well.
-  -- Use rawget/rawset to bypass Teal's type checker.
+  -- Monkey-patch unix.fork to simulate a fork failure; child.tl calls
+  -- unix.fork() via the shared module table, so this affects child.spawn.
   local real_fork = rawget(unix, "fork")
   rawset(unix, "fork", function(): number return nil end)
   local handle, err = child.spawn({lua_bin, "-e", "print('x')"})
@@ -286,50 +224,28 @@ local function test_spawn_fork_failure()
 end
 test_spawn_fork_failure()
 
--- deadlock regression: large stderr output --
+-- === deadlock regression: large stderr output ===
 
-local function test_wait_no_deadlock_large_stderr()
-  -- Write 128KB to stderr and a small amount to stdout.
-  -- Before the fix, wait() would block reading stdout while the child
-  -- blocked writing stderr (pipe buffer full) -- deadlock.
-  local handle = child.spawn({lua_bin, "-e", [[
+local function test_run_no_deadlock_large_stderr()
+  local r = child.run({lua_bin, "-e", [[
     io.write("stdout ok\n")
     io.flush()
     local big = string.rep("x", 131072)
     io.stderr:write(big)
     io.stderr:flush()
     os.exit(0)
-  ]]})
-  assert(handle ~= nil, "handle should not be nil")
-  local exit_code = (handle as child.Handle):wait()
-  assert(exit_code == 0, "expected exit code 0, got " .. tostring(exit_code))
+  ]]}) as child.Result
+  assert(r.code == 0, "expected exit code 0, got " .. tostring(r.code))
+  assert(r.stdout == "stdout ok\n", "expected 'stdout ok\\n', got '" .. tostring(r.stdout) .. "'")
+  assert(#r.stderr == 131072, "expected 128KB stderr, got " .. #r.stderr)
 end
-test_wait_no_deadlock_large_stderr()
+test_run_no_deadlock_large_stderr()
 
-local function test_read_no_deadlock_large_stderr()
-  -- Same scenario but using (handle as child.Handle):read() instead of (handle as child.Handle):wait().
-  local handle = child.spawn({lua_bin, "-e", [[
-    io.write("stdout ok\n")
-    io.flush()
-    local big = string.rep("y", 131072)
-    io.stderr:write(big)
-    io.stderr:flush()
-    os.exit(0)
-  ]]})
-  assert(handle ~= nil, "handle should not be nil")
-  local ok, out, code = (handle as child.Handle):read()
-  assert(ok, "expected success, got code " .. tostring(code))
-  assert(out == "stdout ok\n", "expected 'stdout ok\\n', got '" .. tostring(out) .. "'")
-end
-test_read_no_deadlock_large_stderr()
-
--- /zip/ binary execution via fexecve --
+-- === /zip/ binary execution via fexecve ===
 
 local function test_prepare_zip_exec()
   local prepare_zip_exec = child.prepare_zip_exec
   assert(prepare_zip_exec, "prepare_zip_exec should be exported")
-
-  -- open a known /zip/ path (main.lua exists in every cosmic binary)
   local fd, err = prepare_zip_exec("/zip/main.lua")
   assert(fd, "should open zip fd: " .. tostring(err))
   assert(fd > 0, "fd should be positive: " .. tostring(fd))
@@ -355,22 +271,20 @@ end
 test_spawn_zip_nonexistent_path()
 
 local function test_spawn_zip_non_executable()
-  -- /zip/main.lua exists but is not an ELF binary, so fexecve fails
+  -- /zip/main.lua exists but is not an ELF binary, so fexecve fails. With the
+  -- exec-status pipe, that failure surfaces from spawn itself, not a fake 127.
   local handle, err = child.spawn({"/zip/main.lua"})
-  assert(handle ~= nil, "spawn should succeed (fork works): " .. tostring(err))
-  local exit_code = (handle as child.Handle):wait()
-  assert(exit_code == 127,
-    "expected exit 127 for non-executable, got " .. tostring(exit_code))
+  assert(handle == nil, "spawn should fail: fexecve of a non-binary is an exec error")
+  assert(err ~= nil and err:find("exec failed", 1, true),
+    "expected an 'exec failed' error, got: " .. tostring(err))
 end
 test_spawn_zip_non_executable()
 
 local function test_spawn_zip_embedded_binary()
   -- embed /bin/echo into a copy of cosmic, then spawn it from /zip/
-  local fs = require("cosmic.fs")
   local io_mod = require("cosmic.io")
   local tmpdir = os.getenv("TEST_TMPDIR") as string
 
-  -- set up embed directory with .bin/echo
   local bin_dir = fs.join(tmpdir, "embed", ".bin")
   fs.makedirs(bin_dir)
   local echo_data = io_mod.slurp("/bin/echo")
@@ -378,107 +292,87 @@ local function test_spawn_zip_embedded_binary()
   io_mod.barf(fs.join(bin_dir, "echo"), echo_data)
   fs.chmod(fs.join(bin_dir, "echo"), 493) -- 0755
 
-  -- create embedded cosmic binary
   local out_bin = fs.join(tmpdir, "cosmic-with-echo")
-  local build = child.spawn(
-    {lua_bin, "--embed", fs.join(tmpdir, "embed"), "--output", out_bin})
-  assert(build, "embed spawn should succeed")
-  assert((build as child.Handle):wait() == 0, "embed should exit 0")
+  local build = child.run(
+    {lua_bin, "--embed", fs.join(tmpdir, "embed"), "--output", out_bin}) as child.Result
+  assert(build ~= nil, "embed run should succeed")
+  assert(build.ok, "embed should exit 0, got " .. tostring(build.code) .. ": " .. build.stderr)
 
   -- run the embedded binary: spawn /zip/.bin/echo via fexecve
-  local handle = child.spawn({out_bin, "-e", [[
+  local r = child.run({out_bin, "-e", [[
     local child = require("cosmic.child")
-    local h = child.spawn({"/zip/.bin/echo", "hello-from-zip"})
-    assert(h, "spawn /zip/.bin/echo failed")
-    local ok, out = h:read()
-    io.write(out)
-  ]]})
-  assert(handle, "should spawn embedded binary")
-  local ok, out = (handle as child.Handle):read()
-  assert(ok, "embedded binary should succeed")
-  assert(out == "hello-from-zip\n",
-    "expected 'hello-from-zip\\n', got '" .. tostring(out) .. "'")
+    local r = child.run({"/zip/.bin/echo", "hello-from-zip"})
+    assert(r, "spawn /zip/.bin/echo failed")
+    io.write(r.stdout)
+  ]]}) as child.Result
+  assert(r ~= nil, "should run embedded binary")
+  assert(r.ok, "embedded binary should succeed: " .. tostring(r.stderr))
+  assert(r.stdout == "hello-from-zip\n",
+    "expected 'hello-from-zip\\n', got '" .. tostring(r.stdout) .. "'")
 end
 test_spawn_zip_embedded_binary()
 
--- FIX 4: fd redirection correctness using dup2-style unix.dup(src, dst).
--- Verify that stdout and stderr are independently redirected so that output
--- written to each stream appears on the correct pipe.
+-- === fd redirection correctness ===
+
 local function test_spawn_stdout_stderr_separate()
-  -- Child writes distinct text to stdout and stderr.
-  local handle = child.spawn({lua_bin, "-e", [[
+  local r = child.run({lua_bin, "-e", [[
     io.stdout:write("to-stdout\n")
     io.stdout:flush()
     io.stderr:write("to-stderr\n")
     io.stderr:flush()
-  ]]})
-  assert(handle ~= nil, "handle should not be nil")
-  local ok, out, code = (handle as child.Handle):read()
-  assert(ok, "command should succeed, exit=" .. tostring(code))
-  assert(out == "to-stdout\n",
-    "expected 'to-stdout\\n' on stdout, got '" .. tostring(out) .. "'")
+  ]]}) as child.Result
+  assert(r.ok, "command should succeed, exit=" .. tostring(r.code))
+  assert(r.stdout == "to-stdout\n",
+    "expected 'to-stdout\\n' on stdout, got '" .. tostring(r.stdout) .. "'")
+  assert(r.stderr == "to-stderr\n",
+    "expected 'to-stderr\\n' on stderr, got '" .. tostring(r.stderr) .. "'")
 end
 test_spawn_stdout_stderr_separate()
 
--- FIX 4: when stdin pipe fd happens to already be fd 0 in child, we must not
--- double-close it.  A pathological but valid scenario where spawning many
--- children leaves fd slots at low numbers.  The existing simple redirection
--- test covers the common case; this test exercises correct behavior when a
--- pipe end lands on the target fd.
 local function test_spawn_many_captures_correct()
-  -- Spawn several children in quick succession to exercise fd reuse.
   for i = 1, 5 do
-    local handle = child.spawn({lua_bin, "-e",
-        "io.write('iter" .. tostring(i) .. "\\n')"})
-    assert(handle ~= nil, "handle should not be nil on iteration " .. i)
-    local ok, out = (handle as child.Handle):read()
-    assert(ok, "iteration " .. i .. " should succeed")
-    assert(out == "iter" .. tostring(i) .. "\n",
-      "expected 'iter" .. i .. "\\n', got '" .. tostring(out) .. "'")
+    local r = child.run({lua_bin, "-e",
+        "io.write('iter" .. tostring(i) .. "\\n')"}) as child.Result
+    assert(r.ok, "iteration " .. i .. " should succeed")
+    assert(r.stdout == "iter" .. tostring(i) .. "\n",
+      "expected 'iter" .. i .. "\\n', got '" .. tostring(r.stdout) .. "'")
   end
 end
 test_spawn_many_captures_correct()
 
--- FIX (#526 item 5): spawn must not mutate the caller's argv, and its pipes
--- must be CLOEXEC so overlapping children don't inherit each other's ends.
+-- === spawn hygiene (#526 item 5 / #539) ===
 
 local function test_spawn_does_not_mutate_argv()
-  -- A PATH search wrote the resolved path back into argv[1], corrupting the
-  -- caller's own table. The resolution must go into a local instead.
   local argv = {"echo", "x"}
-  local handle = child.spawn(argv)
-  assert(handle ~= nil, "spawn should succeed");
-  (handle as child.Handle):wait()
+  local h = child.spawn(argv) as child.Handle
+  assert(h ~= nil, "spawn should succeed")
+  h:wait()
   assert(argv[1] == "echo",
     "spawn must not mutate caller's argv[1], got '" .. tostring(argv[1]) .. "'")
 end
 test_spawn_does_not_mutate_argv()
 
 local function test_spawn_overlap_no_stdin_leak()
-  -- Non-CLOEXEC pipes let a later child inherit an earlier child's stdin
-  -- write end, so the earlier child never saw EOF until the later one exited
-  -- and communicate() hung on overlap. Spawn A (reads stdin to EOF), then a
-  -- long-lived B; with CLOEXEC pipes A gets EOF immediately once the parent
-  -- closes its write end, so it finishes without waiting on B.
+  -- CLOEXEC pipes stop a later child from inheriting an earlier child's stdin
+  -- write end. Spawn A (reads stdin to EOF), then a long-lived B; A must see
+  -- EOF once the parent closes its write end and finish without waiting on B.
   local a = child.spawn({lua_bin, "-e", "io.write(io.read('*a') or '')"},
-    {stdin = "hello"})
+    {stdin = "hello"}) as child.Handle
   assert(a ~= nil, "spawn A should succeed")
-  local b = child.spawn({lua_bin, "-e", "require('cosmic.time').sleep(10)"})
+  local b = child.spawn({lua_bin, "-e", "require('cosmic.time').sleep(10)"}) as child.Handle
   assert(b ~= nil, "spawn B should succeed")
 
   local s0, n0 = time.monotonic()
-  local out, _, code = (a as child.Handle):communicate()
+  local r = a:wait() as child.Result
   local s1, n1 = time.monotonic()
   local elapsed = (s1 - s0) + (n1 - n0) / 1e9
 
-  assert(code == 0, "A should exit 0, got " .. tostring(code))
-  assert(out == "hello", "A should echo its stdin, got '" .. tostring(out) .. "'")
+  assert(r.code == 0, "A should exit 0, got " .. tostring(r.code))
+  assert(r.stdout == "hello", "A should echo its stdin, got '" .. tostring(r.stdout) .. "'")
   assert(elapsed < 3,
-    "A must finish promptly, not block on B's lifetime (took "
-    .. tostring(elapsed) .. "s)")
+    "A must finish promptly, not block on B's lifetime (took " .. tostring(elapsed) .. "s)")
 
-  local bh = b as child.Handle
-  child.kill(bh.pid, child.SIGKILL)
-  bh:wait()
+  b:kill(signal.SIGKILL)
+  b:wait()
 end
 test_spawn_overlap_no_stdin_leak()

--- a/lib/cosmic/compile_test.tl
+++ b/lib/cosmic/compile_test.tl
@@ -22,7 +22,8 @@ print(x)
 ]])
 
   local h1 = spawn.spawn({cosmic, "--compile", input})
-  local ok, out = (h1 as spawn.Handle):read()
+  local __r1 = (h1 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   assert(ok, "cosmic --compile should succeed")
   assert(not (out as string):find(": number"), "output should not contain type annotations")
   assert((out as string):find("local x = 42"), "output should contain compiled Lua")
@@ -36,7 +37,8 @@ if if if
 ]])
 
   local h2 = spawn.spawn({cosmic, "--compile", input})
-  local ok, out = (h2 as spawn.Handle):read()
+  local __r2 = (h2 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r2.ok, __r2.stdout
   assert(not ok, "cosmic --compile should fail on syntax error")
 end
 test_compile_syntax_error()
@@ -48,7 +50,8 @@ local x: number = "wrong type"
 ]])
 
   local h3 = spawn.spawn({cosmic, "--compile", input})
-  local ok, out = (h3 as spawn.Handle):read()
+  local __r3 = (h3 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r3.ok, __r3.stdout
   assert(not ok, "cosmic --compile should fail on type error")
 end
 test_compile_type_error()
@@ -66,7 +69,8 @@ print(p.x, p.y)
 ]])
 
   local h4 = spawn.spawn({cosmic, "--compile", input})
-  local ok, out = (h4 as spawn.Handle):read()
+  local __r4 = (h4 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r4.ok, __r4.stdout
   assert(ok, "cosmic --compile should succeed with records")
   assert((out as string):find("local p = {"), "should compile record to table")
 end
@@ -82,7 +86,8 @@ print(identity(42))
 ]])
 
   local h5 = spawn.spawn({cosmic, "--compile", input})
-  local ok, out = (h5 as spawn.Handle):read()
+  local __r5 = (h5 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r5.ok, __r5.stdout
   assert(ok, "cosmic --compile should succeed with generics")
   assert((out as string):find("local function identity%(x%)"), "generics should be erased")
 end
@@ -91,7 +96,8 @@ test_compile_generics()
 -- Test missing input file
 local function test_compile_missing_file()
   local h6 = spawn.spawn({cosmic, "--compile", "/nonexistent/file.tl"})
-  local ok, out = (h6 as spawn.Handle):read()
+  local __r6 = (h6 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r6.ok, __r6.stdout
   assert(not ok, "cosmic --compile should fail on missing file")
 end
 test_compile_missing_file()
@@ -107,13 +113,15 @@ print("result=" .. add(2, 3))
   local output = fs.join(tmpdir, "runnable.lua")
 
   local h7 = spawn.spawn({cosmic, "--compile", input})
-  local ok, lua_code = (h7 as spawn.Handle):read()
+  local __r7 = (h7 as spawn.Handle):wait() as spawn.Result
+  local ok, lua_code = __r7.ok, __r7.stdout
   assert(ok, "compilation should succeed")
 
   cio.barf(output, lua_code as string)
 
   local h8 = spawn.spawn({cosmic, output})
-  local run_ok, run_out = (h8 as spawn.Handle):read()
+  local __r8 = (h8 as spawn.Handle):wait() as spawn.Result
+  local run_ok, run_out = __r8.ok, __r8.stdout
   assert(run_ok, "compiled output should run")
   assert((run_out as string):find("result=5"), "compiled code should produce correct output")
 end
@@ -128,7 +136,8 @@ print("read " .. #data .. " bytes")
 ]])
 
   local h9 = spawn.spawn({cosmic, "--compile", input})
-  local ok, out = (h9 as spawn.Handle):read()
+  local __r9 = (h9 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r9.ok, __r9.stdout
   assert(ok, "compile with cosmic types should succeed")
 end
 test_compile_with_cosmic_types()
@@ -141,7 +150,8 @@ print(x)
 ]])
 
   local h10 = spawn.spawn({cosmic, "--compile", input})
-  local ok, out = (h10 as spawn.Handle):read()
+  local __r10 = (h10 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r10.ok, __r10.stdout
   assert(ok, "cosmic --compile should succeed")
   assert((out as string):sub(1, 21) == "#!/usr/bin/env cosmic", "shebang should be preserved at start of output")
   assert((out as string):find("\nlocal x = 42"), "compiled Lua should follow shebang")
@@ -155,7 +165,8 @@ print(x)
 ]])
 
   local h11 = spawn.spawn({cosmic, "--compile", input})
-  local ok, out = (h11 as spawn.Handle):read()
+  local __r11 = (h11 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r11.ok, __r11.stdout
   assert(ok, "cosmic --compile should succeed")
   assert((out as string):sub(1, 2) ~= "#!", "output should not have shebang if source didn't")
   assert((out as string):find("local x = 42"), "output should contain compiled Lua")
@@ -171,7 +182,8 @@ end
 ]])
 
   local h12 = spawn.spawn({cosmic, "--compile", input})
-  local ok, out = (h12 as spawn.Handle):read()
+  local __r12 = (h12 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r12.ok, __r12.stdout
   assert(ok, "compile should succeed in lax mode with unknown variables")
   assert((out as string):find("unknown_global_var"), "output should contain the unknown variable")
 end
@@ -187,7 +199,8 @@ print(x)
 
   -- First run: file does not exist, should be created
   local h13 = spawn.spawn({cosmic, "--write-if-changed", "--output", output, "--compile", input})
-  local ok1, _ = (h13 as spawn.Handle):read()
+  local __r13 = (h13 as spawn.Handle):wait() as spawn.Result
+  local ok1, _ = __r13.ok, __r13.stdout
   assert(ok1, "first compile --write-if-changed should succeed")
 
   local f1 = io.open(output, "r")
@@ -198,7 +211,8 @@ print(x)
 
   -- Record modification time
   local h14 = spawn.spawn({"stat", "-c", "%Y", output})
-  local mtime1_ok, mtime1 = (h14 as spawn.Handle):read()
+  local __r14 = (h14 as spawn.Handle):wait() as spawn.Result
+  local mtime1_ok, mtime1 = __r14.ok, __r14.stdout
   assert(mtime1_ok, "stat should succeed")
 
   -- Small delay to ensure mtime would differ if file were rewritten
@@ -206,11 +220,13 @@ print(x)
 
   -- Second run: identical content, file should NOT be rewritten
   local h15 = spawn.spawn({cosmic, "--write-if-changed", "--output", output, "--compile", input})
-  local ok2, _ = (h15 as spawn.Handle):read()
+  local __r15 = (h15 as spawn.Handle):wait() as spawn.Result
+  local ok2, _ = __r15.ok, __r15.stdout
   assert(ok2, "second compile --write-if-changed should succeed")
 
   local h16 = spawn.spawn({"stat", "-c", "%Y", output})
-  local mtime2_ok, mtime2 = (h16 as spawn.Handle):read()
+  local __r16 = (h16 as spawn.Handle):wait() as spawn.Result
+  local mtime2_ok, mtime2 = __r16.ok, __r16.stdout
   assert(mtime2_ok, "stat should succeed after second run")
   assert(mtime1 == mtime2, "file mtime should be unchanged when content identical: " .. tostring(mtime1) .. " vs " .. tostring(mtime2))
 end
@@ -223,7 +239,8 @@ local function test_format_write_if_changed()
 
   -- First run: output file does not exist, should be created
   local h17 = spawn.spawn({cosmic, "--write-if-changed", "--output", output, "--format", input})
-  local ok1, _ = (h17 as spawn.Handle):read()
+  local __r17 = (h17 as spawn.Handle):wait() as spawn.Result
+  local ok1, _ = __r17.ok, __r17.stdout
   assert(ok1, "first format --write-if-changed should succeed")
 
   local f1 = io.open(output, "r")
@@ -234,7 +251,8 @@ local function test_format_write_if_changed()
 
   -- Record modification time
   local h18 = spawn.spawn({"stat", "-c", "%Y", output})
-  local mtime1_ok, mtime1 = (h18 as spawn.Handle):read()
+  local __r18 = (h18 as spawn.Handle):wait() as spawn.Result
+  local mtime1_ok, mtime1 = __r18.ok, __r18.stdout
   assert(mtime1_ok, "stat should succeed")
 
   -- Small delay to ensure mtime would differ if file were rewritten
@@ -242,11 +260,13 @@ local function test_format_write_if_changed()
 
   -- Second run: identical content, file should NOT be rewritten
   local h19 = spawn.spawn({cosmic, "--write-if-changed", "--output", output, "--format", input})
-  local ok2, _ = (h19 as spawn.Handle):read()
+  local __r19 = (h19 as spawn.Handle):wait() as spawn.Result
+  local ok2, _ = __r19.ok, __r19.stdout
   assert(ok2, "second format --write-if-changed should succeed")
 
   local h20 = spawn.spawn({"stat", "-c", "%Y", output})
-  local mtime2_ok, mtime2 = (h20 as spawn.Handle):read()
+  local __r20 = (h20 as spawn.Handle):wait() as spawn.Result
+  local mtime2_ok, mtime2 = __r20.ok, __r20.stdout
   assert(mtime2_ok, "stat should succeed after second format run")
   assert(mtime1 == mtime2, "file mtime should be unchanged when format output identical: " .. tostring(mtime1) .. " vs " .. tostring(mtime2))
 end

--- a/lib/cosmic/cosmic_debug_test.tl
+++ b/lib/cosmic/cosmic_debug_test.tl
@@ -9,7 +9,8 @@ global TEST_BIN: string
 local function test_cosmic_debug_version()
   local bin = fs.join(TEST_BIN, "cosmic-debug")
   local h = spawn.spawn({bin, "-v"})
-  local ok, got = (h as spawn.Handle):read()
+  local __r1 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, got = __r1.ok, __r1.stdout
   assert(ok, "cosmic-debug -v failed: " .. tostring(got))
   local want = "Lua"
   assert((got as string):find(want, 1, true), "expected '" .. want .. "' in output, got: " .. (got as string))
@@ -19,7 +20,8 @@ test_cosmic_debug_version()
 local function test_cosmic_debug_runs_lua()
   local bin = fs.join(TEST_BIN, "cosmic-debug")
   local h = spawn.spawn({bin, "-e", "print('hello from debug')"})
-  local ok, got = (h as spawn.Handle):read()
+  local __r2 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, got = __r2.ok, __r2.stdout
   assert(ok, "cosmic-debug -e failed: " .. tostring(got))
   local want = "hello from debug"
   assert((got as string):find(want, 1, true), "expected '" .. want .. "' in output, got: " .. (got as string))
@@ -29,7 +31,8 @@ test_cosmic_debug_runs_lua()
 local function test_cosmic_debug_help()
   local bin = fs.join(TEST_BIN, "cosmic-debug")
   local h = spawn.spawn({bin, "--help"})
-  local ok, got = (h as spawn.Handle):read()
+  local __r3 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, got = __r3.ok, __r3.stdout
   assert(ok, "cosmic-debug --help failed: " .. tostring(got))
   local want = "cosmic"
   assert((got as string):lower():find(want, 1, true), "expected '" .. want .. "' in help output, got: " .. (got as string))

--- a/lib/cosmic/deploy_example.tl
+++ b/lib/cosmic/deploy_example.tl
@@ -25,11 +25,10 @@ local function Example_shebang()
   cio.barf(script, '#!/usr/bin/env cosmic\nlocal name: string = "world"\nprint("hello " .. name)\n')
 
   -- Run it via cosmic (portable across all platforms)
-  local h = spawn.spawn({cosmic, script}) as spawn.Handle
-  local ok, out = h:read()
+  local r = spawn.run({cosmic, script}) as spawn.Result
   fs.rmrf(tmpdir)
-  assert(ok, out)
-  print(out)
+  assert(r.ok, r.stderr)
+  print(r.stdout)
   -- Output:
   -- hello world
 end
@@ -53,17 +52,15 @@ print("hello " .. name)
 ]])
 
   -- Run with an argument
-  local h = spawn.spawn({cosmic, script, "alice"}) as spawn.Handle
-  local ok, out = h:read()
-  assert(ok, out)
-  io.write(out)
+  local r = spawn.run({cosmic, script, "alice"}) as spawn.Result
+  assert(r.ok, r.stderr)
+  io.write(r.stdout)
 
   -- Run without arguments to use the default
-  h = spawn.spawn({cosmic, script}) as spawn.Handle
-  ok, out = h:read()
+  r = spawn.run({cosmic, script}) as spawn.Result
   fs.rmrf(tmpdir)
-  assert(ok, out)
-  io.write(out)
+  assert(r.ok, r.stderr)
+  io.write(r.stdout)
   -- Output:
   -- hello alice
   -- hello world
@@ -90,11 +87,10 @@ local function Example_install_to_path()
   fs.chmod(script, 0x1ED) -- 0755
 
   -- Run it via cosmic (simulating PATH lookup)
-  local h = spawn.spawn({cosmic, script}) as spawn.Handle
-  local ok, out = h:read()
+  local r = spawn.run({cosmic, script}) as spawn.Result
   fs.rmrf(tmpdir)
-  assert(ok, out)
-  print(out)
+  assert(r.ok, r.stderr)
+  print(r.stdout)
   -- Output:
   -- mytool v1.0
 end
@@ -115,9 +111,9 @@ local function Example_portable_executable()
   cio.barf(tl_file, 'local msg: string = "portable app"\nprint(msg)\n')
 
   -- Compile .tl to .lua (--embed requires plain Lua)
-  local h = spawn.spawn({cosmic, "--compile", tl_file}) as spawn.Handle
-  local ok, lua_source = h:read()
-  assert(ok, lua_source)
+  local r = spawn.run({cosmic, "--compile", tl_file}) as spawn.Result
+  assert(r.ok, r.stderr)
+  local lua_source = r.stdout
 
   -- Create app directory with compiled entry point
   local appdir = fs.join(tmpdir, "pkg")
@@ -126,16 +122,14 @@ local function Example_portable_executable()
 
   -- Build a standalone executable
   local output = fs.join(tmpdir, "myapp")
-  h = spawn.spawn({cosmic, "--embed", appdir, "--output", output}) as spawn.Handle
-  ok, lua_source = h:read()
-  assert(ok, lua_source)
+  r = spawn.run({cosmic, "--embed", appdir, "--output", output}) as spawn.Result
+  assert(r.ok, r.stderr)
 
   -- Run the standalone binary — no cosmic needed on the target machine
-  h = spawn.spawn({output}) as spawn.Handle
-  ok, lua_source = h:read()
+  r = spawn.run({output}) as spawn.Result
   fs.rmrf(tmpdir)
-  assert(ok, lua_source)
-  print(lua_source)
+  assert(r.ok, r.stderr)
+  print(r.stdout)
   -- Output:
   -- portable app
 end

--- a/lib/cosmic/docs_guide_test.tl
+++ b/lib/cosmic/docs_guide_test.tl
@@ -18,7 +18,8 @@ local function clean_env(): {string}
 end
 
 local function test_guide_no_topic()
-  local ok, out = (spawn.spawn({cosmic, "--docs", "guide"}, {env = clean_env()}) as spawn.Handle):read()
+  local __r1 = (spawn.spawn({cosmic, "--docs", "guide"}, {env = clean_env()}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   assert(ok, "cosmic --docs guide should succeed")
   local s = out as string
   assert(s:find("cosmic", 1, true), "default guide output should mention cosmic")
@@ -27,7 +28,8 @@ end
 test_guide_no_topic()
 
 local function test_guide_testing()
-  local ok, out = (spawn.spawn({cosmic, "--docs", "guide.testing"}, {env = clean_env()}) as spawn.Handle):read()
+  local __r2 = (spawn.spawn({cosmic, "--docs", "guide.testing"}, {env = clean_env()}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r2.ok, __r2.stdout
   assert(ok, "cosmic --docs guide.testing should succeed")
   local s = out as string
   assert(s:find("Testing", 1, true), "testing guide should contain Testing header")
@@ -36,7 +38,8 @@ end
 test_guide_testing()
 
 local function test_guide_checking()
-  local ok, out = (spawn.spawn({cosmic, "--docs", "guide.checking"}, {env = clean_env()}) as spawn.Handle):read()
+  local __r3 = (spawn.spawn({cosmic, "--docs", "guide.checking"}, {env = clean_env()}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r3.ok, __r3.stdout
   assert(ok, "cosmic --docs guide.checking should succeed")
   local s = out as string
   assert(s:find("Type Checking", 1, true), "checking guide should contain Type Checking header")
@@ -44,7 +47,8 @@ end
 test_guide_checking()
 
 local function test_guide_formatting()
-  local ok, out = (spawn.spawn({cosmic, "--docs", "guide.formatting"}, {env = clean_env()}) as spawn.Handle):read()
+  local __r4 = (spawn.spawn({cosmic, "--docs", "guide.formatting"}, {env = clean_env()}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r4.ok, __r4.stdout
   assert(ok, "cosmic --docs guide.formatting should succeed")
   local s = out as string
   assert(s:find("Formatting", 1, true), "formatting guide should contain Formatting header")
@@ -53,7 +57,8 @@ end
 test_guide_formatting()
 
 local function test_guide_makefile()
-  local ok, out = (spawn.spawn({cosmic, "--docs", "guide.makefile"}, {env = clean_env()}) as spawn.Handle):read()
+  local __r5 = (spawn.spawn({cosmic, "--docs", "guide.makefile"}, {env = clean_env()}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r5.ok, __r5.stdout
   assert(ok, "cosmic --docs guide.makefile should succeed")
   local s = out as string
   assert(s:find("Makefile", 1, true), "makefile guide should contain Makefile header")
@@ -62,7 +67,8 @@ end
 test_guide_makefile()
 
 local function test_guide_modules()
-  local ok, out = (spawn.spawn({cosmic, "--docs", "guide.modules"}, {env = clean_env()}) as spawn.Handle):read()
+  local __r6 = (spawn.spawn({cosmic, "--docs", "guide.modules"}, {env = clean_env()}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r6.ok, __r6.stdout
   assert(ok, "cosmic --docs guide.modules should succeed")
   local s = out as string
   assert(s:find("Modules", 1, true), "modules guide should contain Modules header")
@@ -71,7 +77,8 @@ end
 test_guide_modules()
 
 local function test_guide_docs()
-  local ok, out = (spawn.spawn({cosmic, "--docs", "guide.docs"}, {env = clean_env()}) as spawn.Handle):read()
+  local __r7 = (spawn.spawn({cosmic, "--docs", "guide.docs"}, {env = clean_env()}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r7.ok, __r7.stdout
   assert(ok, "cosmic --docs guide.docs should succeed")
   local s = out as string
   assert(s:find("Documentation", 1, true), "docs guide should contain Documentation header")
@@ -79,7 +86,8 @@ end
 test_guide_docs()
 
 local function test_guide_make()
-  local ok, out = (spawn.spawn({cosmic, "--docs", "guide.make"}, {env = clean_env()}) as spawn.Handle):read()
+  local __r8 = (spawn.spawn({cosmic, "--docs", "guide.make"}, {env = clean_env()}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r8.ok, __r8.stdout
   assert(ok, "cosmic --docs guide.make should succeed")
   local s = out as string
   assert(s:find("Makefile", 1, true), "make guide should contain Makefile header")
@@ -88,9 +96,10 @@ end
 test_guide_make()
 
 local function test_guide_unknown()
-  local ok, _, code = (spawn.spawn(
-      {cosmic, "--docs", "guide.nonexistent"}, {env = clean_env(), stderr = 1}
-    ) as spawn.Handle):read()
+  local r = spawn.run(
+    {cosmic, "--docs", "guide.nonexistent"}, {env = clean_env(), stderr = 1}
+  ) as spawn.Result
+  local ok, code = r.ok, r.code
   assert(not ok, "cosmic --docs guide.nonexistent should fail")
   assert(code == 1, "expected exit code 1, got " .. tostring(code))
 end
@@ -113,7 +122,8 @@ end
 test_strip_frontmatter_without_frontmatter()
 
 local function test_default_guide_no_frontmatter()
-  local ok, out = (spawn.spawn({cosmic, "--docs", "guide"}, {env = clean_env()}) as spawn.Handle):read()
+  local __r9 = (spawn.spawn({cosmic, "--docs", "guide"}, {env = clean_env()}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r9.ok, __r9.stdout
   assert(ok, "cosmic --docs guide should succeed")
   local s = out as string
   assert(not s:match("^---"), "default guide output should not start with frontmatter delimiter")

--- a/lib/cosmic/embed_advanced_test.tl
+++ b/lib/cosmic/embed_advanced_test.tl
@@ -45,7 +45,8 @@ end
 local function test_extract()
   local extractdir = fs.join(tmpdir, "extracted")
 
-  local ok, out = (spawn.spawn({cosmic, "--extract", extractdir}) as spawn.Handle):read()
+  local __r1 = (spawn.spawn({cosmic, "--extract", extractdir}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   assert(ok, "extract should succeed: " .. (out or ""))
 
   -- main.lua should be extracted
@@ -63,7 +64,8 @@ test_extract()
 local function test_extract_embed_roundtrip()
   -- Extract the cosmic binary
   local extractdir = fs.join(tmpdir, "roundtrip-extract")
-  local ok, out = (spawn.spawn({cosmic, "--extract", extractdir}) as spawn.Handle):read()
+  local __r2 = (spawn.spawn({cosmic, "--extract", extractdir}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r2.ok, __r2.stdout
   assert(ok, "extract should succeed: " .. (out or ""))
 
   -- Read original main.lua from the zip
@@ -79,7 +81,8 @@ local function test_extract_embed_roundtrip()
 
   -- Re-embed the extracted directory
   local output = fs.join(tmpdir, "roundtrip-output")
-  ok, out = (spawn.spawn({cosmic, "--embed", extractdir, "--output", output}) as spawn.Handle):read()
+  local __r3 = (spawn.spawn({cosmic, "--embed", extractdir, "--output", output}) as spawn.Handle):wait() as spawn.Result
+  ok, out = __r3.ok, __r3.stdout
   assert(ok, "re-embed should succeed: " .. (out or ""))
 
   -- Read main.lua from the re-embedded binary
@@ -95,7 +98,8 @@ test_extract_embed_roundtrip()
 local function test_extract_modify_embed()
   -- Extract
   local extractdir = fs.join(tmpdir, "modify-extract")
-  local ok, out = (spawn.spawn({cosmic, "--extract", extractdir}) as spawn.Handle):read()
+  local __r4 = (spawn.spawn({cosmic, "--extract", extractdir}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r4.ok, __r4.stdout
   assert(ok, "extract should succeed: " .. (out or ""))
 
   -- Modify main.lua
@@ -103,11 +107,13 @@ local function test_extract_modify_embed()
 
   -- Re-embed
   local output = fs.join(tmpdir, "modified-cosmic")
-  ok, out = (spawn.spawn({cosmic, "--embed", extractdir, "--output", output}) as spawn.Handle):read()
+  local __r5 = (spawn.spawn({cosmic, "--embed", extractdir, "--output", output}) as spawn.Handle):wait() as spawn.Result
+  ok, out = __r5.ok, __r5.stdout
   assert(ok, "embed modified should succeed: " .. (out or ""))
 
   -- Run the modified executable
-  ok, out = (spawn.spawn({output}) as spawn.Handle):read()
+  local __r6 = (spawn.spawn({output}) as spawn.Handle):wait() as spawn.Result
+  ok, out = __r6.ok, __r6.stdout
   assert(ok, "modified executable should run: " .. (out or ""))
   assert(out:match("modified"), "should print modified output, got: " .. (out or ""))
 end
@@ -133,7 +139,8 @@ local function test_embed_overwrites_cleanly()
   cio.barf(fs.join(appdir, "main.lua"), 'print("new")\n')
 
   local output = fs.join(tmpdir, "cosmic-overwrite")
-  local ok, out = (spawn.spawn({cosmic, "--embed", appdir, "--output", output}) as spawn.Handle):read()
+  local __r7 = (spawn.spawn({cosmic, "--embed", appdir, "--output", output}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r7.ok, __r7.stdout
   assert(ok, "embed should succeed: " .. (out or ""))
 
   -- The new zip should have main.lua with the new content
@@ -172,7 +179,8 @@ local function test_embed_preserves_file_modes()
   fs.chmod(secret, tonumber("600", 8))
 
   local output = fs.join(tmpdir, "cosmic-modes")
-  local ok, out = (spawn.spawn({cosmic, "--embed", appdir, "--output", output}) as spawn.Handle):read()
+  local __r8 = (spawn.spawn({cosmic, "--embed", appdir, "--output", output}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r8.ok, __r8.stdout
   assert(ok, "embed should succeed: " .. (out or ""))
 
   -- Check modes in the zip archive
@@ -221,12 +229,14 @@ local function test_extract_preserves_file_modes()
   fs.chmod(secret, tonumber("600", 8))
 
   local embedded = fs.join(tmpdir, "cosmic-extract-modes")
-  local ok, out = (spawn.spawn({cosmic, "--embed", appdir, "--output", embedded}) as spawn.Handle):read()
+  local __r9 = (spawn.spawn({cosmic, "--embed", appdir, "--output", embedded}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r9.ok, __r9.stdout
   assert(ok, "embed should succeed: " .. (out or ""))
 
   -- Extract to a new directory
   local extractdir = fs.join(tmpdir, "extracted-modes")
-  ok, out = (spawn.spawn({embedded, "--extract", extractdir}) as spawn.Handle):read()
+  local __r10 = (spawn.spawn({embedded, "--extract", extractdir}) as spawn.Handle):wait() as spawn.Result
+  ok, out = __r10.ok, __r10.stdout
   assert(ok, "extract should succeed: " .. (out or ""))
 
   -- Check modes of extracted files
@@ -268,7 +278,8 @@ io.write("OK:" .. #result)
 ]])
 
   local binary = fs.join(tmpdir, "cosmic-running")
-  local ok, out = (spawn.spawn({cosmic, "--embed", appdir, "--output", binary}) as spawn.Handle):read()
+  local __r11 = (spawn.spawn({cosmic, "--embed", appdir, "--output", binary}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r11.ok, __r11.stdout
   assert(ok, "initial embed should succeed: " .. (out or ""))
 
   -- Start the binary as a subprocess
@@ -279,11 +290,13 @@ io.write("OK:" .. #result)
 
   -- Re-embed over the same path while the process is running.
   -- Without atomic write, this would corrupt the running process.
-  local ok2, out2 = (spawn.spawn({cosmic, "--embed", appdir, "--output", binary}) as spawn.Handle):read()
+  local __r12 = (spawn.spawn({cosmic, "--embed", appdir, "--output", binary}) as spawn.Handle):wait() as spawn.Result
+  local ok2, out2 = __r12.ok, __r12.stdout
   assert(ok2, "re-embed should succeed: " .. (out2 or ""))
 
   -- Wait for the original process to finish
-  local read_ok, stdout = handle:read()
+  local __rh = (handle as spawn.Handle):wait() as spawn.Result
+  local read_ok, stdout = __rh.ok, __rh.stdout
 
   -- The process should have exited cleanly, not crashed with SIGSEGV
   assert(read_ok, "running process should not crash after re-embed, got: " .. tostring(stdout))

--- a/lib/cosmic/embed_env_test.tl
+++ b/lib/cosmic/embed_env_test.tl
@@ -48,7 +48,8 @@ local function test_embed_via_env()
   env[#env + 1] = "COSMIC_OUTPUT=" .. output
 
   -- Invoke without --embed or --output flags
-  local ok, out = (spawn.spawn({cosmic}, {env = env}) as spawn.Handle):read()
+  local __r1 = (spawn.spawn({cosmic}, {env = env}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   assert(ok, "cosmic with COSMIC_EMBED env should succeed: " .. (out or ""))
 
   -- Verify output exists and content is embedded
@@ -80,7 +81,8 @@ local function test_extract_via_env()
   env[#env + 1] = "COSMIC_EXTRACT=" .. extractdir
 
   -- Invoke without --extract flag
-  local ok, out = (spawn.spawn({cosmic}, {env = env}) as spawn.Handle):read()
+  local __r2 = (spawn.spawn({cosmic}, {env = env}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r2.ok, __r2.stdout
   assert(ok, "cosmic with COSMIC_EXTRACT env should succeed: " .. (out or ""))
 
   -- main.lua should be extracted
@@ -104,7 +106,8 @@ local function test_cli_priority_over_env()
   env[#env + 1] = "COSMIC_OUTPUT=" .. output
 
   -- Pass --embed via CLI (should override env)
-  local ok, out = (spawn.spawn({cosmic, "--embed", cli_input, "--output", output}, {env = env}) as spawn.Handle):read()
+  local __r3 = (spawn.spawn({cosmic, "--embed", cli_input, "--output", output}, {env = env}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r3.ok, __r3.stdout
   assert(ok, "cosmic --embed with env override should succeed: " .. (out or ""))
 
   local data = cio.slurp(output)

--- a/lib/cosmic/embed_example.tl
+++ b/lib/cosmic/embed_example.tl
@@ -22,15 +22,13 @@ local function Example_embed_directory()
 
   -- Build it
   local output = fs.join(tmpdir, "hello")
-  local h = spawn.spawn({cosmic, "--embed", appdir, "--output", output}) as spawn.Handle
-  local ok, out = h:read()
-  assert(ok, out)
+  local r = spawn.run({cosmic, "--embed", appdir, "--output", output}) as spawn.Result
+  assert(r.ok, r.stderr)
 
   -- Run it
-  h = spawn.spawn({output}) as spawn.Handle
-  ok, out = h:read()
+  r = spawn.run({output}) as spawn.Result
   fs.rmrf(tmpdir)
-  print(out)
+  print(r.stdout)
   -- Output:
   -- hello from myapp
 end
@@ -45,9 +43,8 @@ local function Example_extract_roundtrip()
 
   -- Extract the running executable's zip contents
   local extractdir = fs.join(tmpdir, "extracted")
-  local h = spawn.spawn({cosmic, "--extract", extractdir}) as spawn.Handle
-  local ok, out = h:read()
-  assert(ok, out)
+  local r = spawn.run({cosmic, "--extract", extractdir}) as spawn.Result
+  assert(r.ok, r.stderr)
 
   -- The extracted directory contains main.lua and all bundled files
   local main_exists = fs.isfile(fs.join(extractdir, "main.lua"))
@@ -71,20 +68,17 @@ local function Example_embed_with_libraries()
   fs.makedirs(appdir)
   cio.barf(fs.join(appdir, "main.lua"), [[
 local child = require("cosmic.child")
-local h = child.spawn({"echo", "it works"})
-local ok, out = h:read()
-io.write(out)
+local r = child.run({"echo", "it works"})
+io.write(r.stdout)
 ]])
 
   local output = fs.join(tmpdir, "myapp")
-  local h = spawn.spawn({cosmic, "--embed", appdir, "--output", output}) as spawn.Handle
-  local ok, out = h:read()
-  assert(ok, out)
+  local r = spawn.run({cosmic, "--embed", appdir, "--output", output}) as spawn.Result
+  assert(r.ok, r.stderr)
 
-  h = spawn.spawn({output}) as spawn.Handle
-  ok, out = h:read()
+  r = spawn.run({output}) as spawn.Result
   fs.rmrf(tmpdir)
-  print(out)
+  print(r.stdout)
   -- Output:
   -- it works
 end
@@ -107,23 +101,21 @@ local function Example_embed_from_teal()
   cio.barf(tl_file, 'local msg: string = "hello from teal"\nprint(msg)\n')
 
   -- Compile .tl to .lua using cosmic --compile
-  local h = spawn.spawn({cosmic, "--compile", tl_file}) as spawn.Handle
-  local ok, lua_source = h:read()
-  assert(ok, lua_source)
+  local r = spawn.run({cosmic, "--compile", tl_file}) as spawn.Result
+  assert(r.ok, r.stderr)
+  local lua_source = r.stdout
 
   -- Write the compiled Lua as the entry point
   cio.barf(fs.join(appdir, "main.lua"), lua_source)
 
   -- Embed and run
   local output = fs.join(tmpdir, "from_teal")
-  h = spawn.spawn({cosmic, "--embed", appdir, "--output", output}) as spawn.Handle
-  ok, lua_source = h:read()
-  assert(ok, lua_source)
+  r = spawn.run({cosmic, "--embed", appdir, "--output", output}) as spawn.Result
+  assert(r.ok, r.stderr)
 
-  h = spawn.spawn({output}) as spawn.Handle
-  ok, lua_source = h:read()
+  r = spawn.run({output}) as spawn.Result
   fs.rmrf(tmpdir)
-  print(lua_source)
+  print(r.stdout)
   -- Output:
   -- hello from teal
 end

--- a/lib/cosmic/embed_test.tl
+++ b/lib/cosmic/embed_test.tl
@@ -41,7 +41,8 @@ local function test_embed_single_file()
   local input = write_temp("hello.txt", "hello world")
   local output = fs.join(tmpdir, "cosmic-single")
 
-  local ok, out = (spawn.spawn({cosmic, "--embed", input, "--output", output}) as spawn.Handle):read()
+  local __r1 = (spawn.spawn({cosmic, "--embed", input, "--output", output}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   assert(ok, "cosmic --embed should succeed: " .. (out or ""))
 
   -- Verify output exists and is executable
@@ -79,7 +80,8 @@ local function test_embed_multiple_files()
   local file2 = write_temp("multi/two.txt", "content two")
   local output = fs.join(tmpdir, "cosmic-multi")
 
-  local ok, out = (spawn.spawn({cosmic, "--embed", file1, "--embed", file2, "--output", output}) as spawn.Handle):read()
+  local __r2 = (spawn.spawn({cosmic, "--embed", file1, "--embed", file2, "--output", output}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r2.ok, __r2.stdout
   assert(ok, "cosmic --embed with multiple files should succeed: " .. (out or ""))
 
   local data = cio.slurp(output)
@@ -104,7 +106,8 @@ local function test_embed_custom_output()
   local output = fs.join(tmpdir, "subdir/myapp")
   fs.makedirs(fs.dirname(output))
 
-  local ok, out = (spawn.spawn({cosmic, "--embed", input, "--output", output}) as spawn.Handle):read()
+  local __r3 = (spawn.spawn({cosmic, "--embed", input, "--output", output}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r3.ok, __r3.stdout
   assert(ok, "cosmic --embed with custom output path should succeed: " .. (out or ""))
 
   local stat = fs.stat(output)
@@ -115,7 +118,8 @@ test_embed_custom_output()
 -- Test error on missing input file
 local function test_embed_missing_file()
   local output = fs.join(tmpdir, "cosmic-missing")
-  local ok, _out = (spawn.spawn({cosmic, "--embed", "/nonexistent/file.txt", "--output", output}) as spawn.Handle):read()
+  local __r4 = (spawn.spawn({cosmic, "--embed", "/nonexistent/file.txt", "--output", output}) as spawn.Handle):wait() as spawn.Result
+  local ok, _out = __r4.ok, __r4.stdout
   assert(not ok, "cosmic --embed should fail on missing file")
 end
 test_embed_missing_file()
@@ -125,7 +129,8 @@ local function test_embed_lua_file()
   local modfile = write_temp("mymod.lua", [[return { value = 42 }]])
   local output = fs.join(tmpdir, "cosmic-lua")
 
-  local ok, out = (spawn.spawn({cosmic, "--embed", modfile, "--output", output}) as spawn.Handle):read()
+  local __r5 = (spawn.spawn({cosmic, "--embed", modfile, "--output", output}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r5.ok, __r5.stdout
   assert(ok, "embed should succeed: " .. (out or ""))
 
   -- Verify the lua file is in the zip with correct content
@@ -147,7 +152,8 @@ local function test_embed_binary_file()
   local input = write_temp("binary.bin", binary)
   local output = fs.join(tmpdir, "cosmic-binary")
 
-  local ok, out = (spawn.spawn({cosmic, "--embed", input, "--output", output}) as spawn.Handle):read()
+  local __r6 = (spawn.spawn({cosmic, "--embed", input, "--output", output}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r6.ok, __r6.stdout
   assert(ok, "embed binary should succeed: " .. (out or ""))
 
   local data = cio.slurp(output)
@@ -171,7 +177,8 @@ local function test_embed_directory()
   cio.barf(fs.join(appdir, "data.txt"), "some data")
 
   local output = fs.join(tmpdir, "cosmic-dir")
-  local ok, out = (spawn.spawn({cosmic, "--embed", appdir, "--output", output}) as spawn.Handle):read()
+  local __r7 = (spawn.spawn({cosmic, "--embed", appdir, "--output", output}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r7.ok, __r7.stdout
   assert(ok, "embed directory should succeed: " .. (out or ""))
 
   -- Verify files are stored relative to directory root
@@ -202,7 +209,8 @@ local function test_embed_nested_directory()
   cio.barf(fs.join(appdir, "a/b/c/deep.txt"), "deep")
 
   local output = fs.join(tmpdir, "cosmic-nested")
-  local ok, out = (spawn.spawn({cosmic, "--embed", appdir, "--output", output}) as spawn.Handle):read()
+  local __r8 = (spawn.spawn({cosmic, "--embed", appdir, "--output", output}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r8.ok, __r8.stdout
   assert(ok, "embed nested directory should succeed: " .. (out or ""))
 
   local data = cio.slurp(output)
@@ -226,7 +234,8 @@ local function test_embed_mixed()
   local extra = write_temp("extra.txt", "extra content")
   local output = fs.join(tmpdir, "cosmic-mixed")
 
-  local ok, out = (spawn.spawn({cosmic, "--embed", appdir, "--embed", extra, "--output", output}) as spawn.Handle):read()
+  local __r9 = (spawn.spawn({cosmic, "--embed", appdir, "--embed", extra, "--output", output}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r9.ok, __r9.stdout
   assert(ok, "embed mixed should succeed: " .. (out or ""))
 
   local data = cio.slurp(output)
@@ -251,11 +260,13 @@ local function test_embed_directory_executable()
   cio.barf(fs.join(appdir, "main.lua"), 'io.write("it works\\n")\n')
 
   local output = fs.join(tmpdir, "cosmic-runapp")
-  local ok, out = (spawn.spawn({cosmic, "--embed", appdir, "--output", output}) as spawn.Handle):read()
+  local __r10 = (spawn.spawn({cosmic, "--embed", appdir, "--output", output}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r10.ok, __r10.stdout
   assert(ok, "embed should succeed: " .. (out or ""))
 
   -- Run the custom executable
-  ok, out = (spawn.spawn({output}) as spawn.Handle):read()
+  local __r11 = (spawn.spawn({output}) as spawn.Handle):wait() as spawn.Result
+  ok, out = __r11.ok, __r11.stdout
   assert(ok, "custom executable should run: " .. (out or ""))
   assert(out:match("it works"), "should print expected output, got: " .. (out or ""))
 end
@@ -268,7 +279,8 @@ local function test_embed_uses_deflate()
   local input = write_temp("deflate_test.txt", compressible)
   local output = fs.join(tmpdir, "cosmic-deflate")
 
-  local ok, out = (spawn.spawn({cosmic, "--embed", input, "--output", output}) as spawn.Handle):read()
+  local __r12 = (spawn.spawn({cosmic, "--embed", input, "--output", output}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r12.ok, __r12.stdout
   assert(ok, "embed should succeed: " .. (out or ""))
 
   local data = cio.slurp(output)
@@ -298,7 +310,8 @@ local function test_embed_stores_lua()
   local input = write_temp("store_test.lua", compressible)
   local output = fs.join(tmpdir, "cosmic-store")
 
-  local ok, out = (spawn.spawn({cosmic, "--embed", input, "--output", output}) as spawn.Handle):read()
+  local __r13 = (spawn.spawn({cosmic, "--embed", input, "--output", output}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r13.ok, __r13.stdout
   assert(ok, "embed should succeed: " .. (out or ""))
 
   local data = cio.slurp(output)

--- a/lib/cosmic/envd_example.tl
+++ b/lib/cosmic/envd_example.tl
@@ -45,9 +45,8 @@ local function Example_extract_update_embed()
 
   -- 1. extract current executable
   local extractdir = fs.join(tmpdir, "extracted")
-  local h = spawn.spawn({cosmic, "--extract", extractdir}) as spawn.Handle
-  local ok, out = h:read()
-  assert(ok, out)
+  local r = spawn.run({cosmic, "--extract", extractdir}) as spawn.Result
+  assert(r.ok, r.stderr)
 
   -- 2. add env.d with a credential
   local envd_dir = fs.join(extractdir, "embed", "env.d")
@@ -66,15 +65,13 @@ print("MY_SECRET_TOKEN is " .. (env.get("MY_SECRET_TOKEN") and "set" or "unset")
 
   -- 4. build new executable
   local output = fs.join(tmpdir, "myapp")
-  h = spawn.spawn({cosmic, "--embed", extractdir, "--output", output}) as spawn.Handle
-  ok, out = h:read()
-  assert(ok, out)
+  r = spawn.run({cosmic, "--embed", extractdir, "--output", output}) as spawn.Result
+  assert(r.ok, r.stderr)
 
   -- 5. run it
-  h = spawn.spawn({output}) as spawn.Handle
-  ok, out = h:read()
+  r = spawn.run({output}) as spawn.Result
   fs.rmrf(tmpdir)
-  print(out)
+  print(r.stdout)
   -- Output:
   -- envd loaded 1 var(s)
   -- MY_SECRET_TOKEN is set

--- a/lib/cosmic/example_test.tl
+++ b/lib/cosmic/example_test.tl
@@ -133,7 +133,8 @@ local function Example_cmd()
 end
 ]])
   local h = spawn.spawn({cosmic, "--check-examples", input})
-  local ok, out = (h as spawn.Handle):read()
+  local __r1 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   assert(ok, "cosmic --check-examples should succeed")
   assert((out as string):find("PASS"), "output should show PASS")
 end
@@ -149,7 +150,8 @@ local function Example_cmd()
 end
 ]])
   local h = spawn.spawn({cosmic, "--check-examples", input})
-  local ok, out = (h as spawn.Handle):read()
+  local __r2 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r2.ok, __r2.stdout
   assert(not ok, "cosmic --check-examples should fail")
   assert((out as string):find("FAIL"), "output should show FAIL")
 end
@@ -160,13 +162,9 @@ local function test_cosmic_example_skip()
   local input = write_temp("cmd_skip.tl", [[
 local x = 1
 ]])
-  local h = spawn.spawn({cosmic, "--check-examples", input})
-  local hh = h as spawn.Handle
-  hh.stdin:close()
-  local out = hh.stdout:read()
-  local code = hh:wait()
-  assert(code == 2, "should return skip code 2")
-  assert((out as string):find("SKIP"), "output should show SKIP")
+  local r = spawn.run({cosmic, "--check-examples", input}) as spawn.Result
+  assert(r.code == 2, "should return skip code 2")
+  assert(r.stdout:find("SKIP"), "output should show SKIP")
 end
 test_cosmic_example_skip()
 

--- a/lib/cosmic/include_dir_test.tl
+++ b/lib/cosmic/include_dir_test.tl
@@ -41,7 +41,8 @@ print(s)
   -- Without --include-dir, compilation should still succeed (lax mode)
   -- but with it, types are resolved properly
   local h1 = spawn.spawn({cosmic, "--include-dir", typedir, "--compile", input})
-  local ok, out = (h1 as spawn.Handle):read()
+  local __r1 = (h1 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   assert(ok, "compile with --include-dir should succeed: " .. tostring(out))
   assert((out as string):find("local custommod"), "output should contain compiled Lua")
 end
@@ -59,12 +60,14 @@ print(s)
 
   -- Without --include-dir, check should fail (strict mode, module not found)
   local h2 = spawn.spawn({cosmic, "--check-types", input})
-  local ok_without, _ = (h2 as spawn.Handle):read()
+  local __r2 = (h2 as spawn.Handle):wait() as spawn.Result
+  local ok_without, _ = __r2.ok, __r2.stdout
   assert(not ok_without, "check should fail without --include-dir for custom module")
 
   -- With --include-dir, check should succeed
   local h3 = spawn.spawn({cosmic, "--include-dir", typedir, "--check-types", input})
-  local ok_with, out = (h3 as spawn.Handle):read()
+  local __r3 = (h3 as spawn.Handle):wait() as spawn.Result
+  local ok_with, out = __r3.ok, __r3.stdout
   assert(ok_with, "check with --include-dir should succeed: " .. tostring(out))
 end
 test_check_types_include_dir()
@@ -101,7 +104,8 @@ print(mod_a.hello() .. mod_b.world())
       "--include-dir", typedir2,
       "--check-types", input,
     })
-  local ok, out = (h as spawn.Handle):read()
+  local __r4 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r4.ok, __r4.stdout
   assert(ok, "check with multiple --include-dir should succeed: " .. tostring(out))
 end
 test_multiple_include_dirs()
@@ -121,7 +125,8 @@ print(custommod.greet("test"))
       "--include-dir", typedir,
       "--compile", input,
     })
-  local ok, _ = (h as spawn.Handle):read()
+  local __r5 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, _ = __r5.ok, __r5.stdout
   assert(ok, "compile with --include-dir and --output should succeed")
 
   local f = io.open(output, "r")
@@ -146,7 +151,8 @@ print(s, p)
 ]])
 
   local h4 = spawn.spawn({cosmic, "--include-dir", typedir, "--check-types", input})
-  local ok, out = (h4 as spawn.Handle):read()
+  local __r6 = (h4 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r6.ok, __r6.stdout
   assert(ok, "check with --include-dir should still find built-in types: " .. tostring(out))
 end
 test_include_dir_merges_with_defaults()

--- a/lib/cosmic/landlock_test.tl
+++ b/lib/cosmic/landlock_test.tl
@@ -98,7 +98,8 @@ if g then io.write("denied-leaked\n"); g:close() else io.write("denied-blocked\n
   -- strict skip that the enforce lane (COSMIC_ENFORCE=1, no outer sandbox)
   -- turns into a hard failure.
   local h = spawn.spawn({cosmic, script})
-  local ok, out = (h as spawn.Handle):read()
+  local __r1 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   -- Under an outer seccomp/pledge filter the landlock syscall may be
   -- blocked with SIGSYS rather than EPERM, killing the subprocess
   -- before it can emit "skipped".

--- a/lib/cosmic/net_connect_test.tl
+++ b/lib/cosmic/net_connect_test.tl
@@ -2,7 +2,7 @@
 --- Network connect and interface tests.
 local net = require("cosmic.net")
 local fs = require("cosmic.fs")
-local child = require("cosmic.child")
+local proc = require("cosmic.proc")
 
 local function test_interfaces()
   local ifaces, err = net.interfaces()
@@ -56,7 +56,7 @@ local function test_unix_domain_socket_bind_connect()
   assert(ok, "listen failed: " .. tostring(err))
 
   -- Fork to create a client
-  local pid = child.fork()
+  local pid = proc.fork()
   if pid == 0 then
     local client = net.socket(net.AF_UNIX, net.SOCK_STREAM, 0)
     if not client then os.exit(1) end
@@ -80,7 +80,7 @@ local function test_unix_domain_socket_bind_connect()
 
   client:close()
   server:close()
-  child.wait(pid)
+  proc.wait(pid)
   os.remove(path)
   os.remove(tmpdir)
 end
@@ -96,7 +96,7 @@ local function test_listen_unix_connect_unix()
   local server = server as net.Socket
 
   -- Fork to create a client using module-level connect_unix helper
-  local pid = child.fork()
+  local pid = proc.fork()
   if pid == 0 then
     local client, cerr = net.connect_unix(path)
     if not client then
@@ -125,7 +125,7 @@ local function test_listen_unix_connect_unix()
 
   client:close()
   server:close()
-  child.wait(pid)
+  proc.wait(pid)
   os.remove(path)
   os.remove(tmpdir)
 end
@@ -210,7 +210,7 @@ local function test_connect_tcp()
   assert(ok, "listen failed: " .. tostring(err))
 
   -- Fork to create a client using connect_tcp
-  local pid = child.fork()
+  local pid = proc.fork()
   if pid == 0 then
     local client, cerr = net.connect_tcp(0x7f000001, server_port)
     if not client then
@@ -235,7 +235,7 @@ local function test_connect_tcp()
 
   client:close()
   server:close()
-  child.wait(pid)
+  proc.wait(pid)
 end
 test_connect_tcp()
 

--- a/lib/cosmic/net_test.tl
+++ b/lib/cosmic/net_test.tl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cosmic
 local net = require("cosmic.net")
 local fs = require("cosmic.fs")
-local child = require("cosmic.child")
+local proc = require("cosmic.proc")
 
 local function test_socket_creation()
   -- Test TCP socket creation
@@ -95,7 +95,7 @@ local function test_listen_accept_connect()
   assert(ok, "listen failed: " .. tostring(err))
 
   -- Fork to create a client
-  local pid = child.fork()
+  local pid = proc.fork()
   if pid == 0 then
     -- Child: connect to server
     local client = net.socket()
@@ -136,7 +136,7 @@ local function test_listen_accept_connect()
   server:close()
 
   -- Wait for child
-  child.wait(pid)
+  proc.wait(pid)
 end
 test_listen_accept_connect()
 
@@ -403,7 +403,7 @@ local function test_accept_socket_has_close_metamethod()
   assert(ok, "listen failed: " .. tostring(err))
 
   -- Fork to create a client
-  local pid = child.fork()
+  local pid = proc.fork()
   if pid == 0 then
     local client = net.socket()
     if not client then os.exit(1) end
@@ -428,7 +428,7 @@ local function test_accept_socket_has_close_metamethod()
 
   client:close()
   server:close()
-  child.wait(pid)
+  proc.wait(pid)
 end
 test_accept_socket_has_close_metamethod()
 
@@ -450,7 +450,7 @@ local function test_listen_tcp_connect_to_returned_port()
   local srv = srv as net.Socket
 
   -- Fork: child connects and sends, parent accepts and reads
-  local pid = child.fork()
+  local pid = proc.fork()
   if pid == 0 then
     local csock = net.connect_tcp(0x7f000001, port)
     if not csock then
@@ -469,7 +469,7 @@ local function test_listen_tcp_connect_to_returned_port()
   assert(data == "hi", "expected 'hi', got '" .. tostring(data) .. "'")
   conn:close()
   srv:close()
-  child.wait(pid)
+  proc.wait(pid)
 end
 test_listen_tcp_connect_to_returned_port()
 

--- a/lib/cosmic/pledge_example.tl
+++ b/lib/cosmic/pledge_example.tl
@@ -13,9 +13,8 @@ local pledge = require("cosmic.pledge")
 assert(pledge.apply("stdio"))
 io.write("stdio only\n")
 ]]
-  local h = spawn.spawn({cosmic, "-e", script})
-  local _, out = (h as spawn.Handle):read()
-  io.write(tostring(out))
+  local r = spawn.run({cosmic, "-e", script}) as spawn.Result
+  io.write(r.stdout)
   -- Output:
   -- stdio only
 end

--- a/lib/cosmic/pledge_test.tl
+++ b/lib/cosmic/pledge_test.tl
@@ -25,7 +25,8 @@ end
 io.write("pledged\n")
 ]])
   local h = spawn.spawn({cosmic, script})
-  local ok, out = (h as spawn.Handle):read()
+  local __r1 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   assert(ok, "pledge stdio should allow io.write: " .. tostring(out))
   assert((out as string):find("pledged"), "should print after pledge: " .. tostring(out))
 end
@@ -52,7 +53,8 @@ end
 io.write("restricted\n")
 ]])
   local h = spawn.spawn({cosmic, script})
-  local ok, out = (h as spawn.Handle):read()
+  local __r2 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r2.ok, __r2.stdout
   local s = (out or "") as string
   if s:find("skipped") then
     -- pledge is supported on every platform cosmic targets (Linux via

--- a/lib/cosmic/poll_test.tl
+++ b/lib/cosmic/poll_test.tl
@@ -171,23 +171,28 @@ end
 test_poll_with_socket()
 
 local function test_poll_with_child_pipes()
-  local handle, err = child.spawn({"echo", "hello"})
+  -- Redirect the child's stdout into a pipe we own, then poll the read end.
+  local pp0, perr = cio.pipe()
+  assert(pp0 ~= nil, "pipe creation failed: " .. tostring(perr))
+  local pp = pp0 as cio.Pipe
+  local handle, err = child.spawn({"echo", "hello"}, {stdout = pp.writer:fd()})
   assert(handle ~= nil, "spawn failed: " .. tostring(err))
-  local handle = handle as child.Handle
+  local h = handle as child.Handle
+  pp.writer:close()
 
   local p = poll.new()
-  -- child.Pipe has .fd field
-  p:add(handle.stdout.fd, poll.POLLIN)
+  p:add(pp.reader:fd(), poll.POLLIN)
 
   local count = 0
   for fd, events in p:wait(1000) do
-    assert(fd == handle.stdout.fd, "expected stdout fd")
+    assert(fd == pp.reader:fd(), "expected reader fd")
     assert(events.readable or events.hangup, "expected readable or hangup")
     count = count + 1
   end
   assert(count >= 1, "expected at least 1 event from child stdout")
 
-  handle:wait()
+  pp.reader:close()
+  h:wait()
 end
 test_poll_with_child_pipes()
 

--- a/lib/cosmic/proc.tl
+++ b/lib/cosmic/proc.tl
@@ -174,6 +174,71 @@ local function fexecve(fd: number, argv: {string}, envp?: {string}): nil, string
   return nil, err
 end
 
+-- Process Control (children) --
+
+--- Creates a new process (fork).
+--- @return number The child pid in the parent, 0 in the child
+local function fork(): number
+  return (unix.fork())
+end
+
+--- Spawns a program via posix_spawn (no PATH search).
+--- @param prog string Absolute path to the executable
+--- @param argv {string} Argument vector passed to the program
+--- @param envp {string}? Environment (KEY=value); inherits if omitted
+--- @return number The child pid on success
+local function posix_spawn(prog: string, argv: {string}, envp?: {string}): number
+  return (unix.spawn(prog, argv, envp))
+end
+
+--- Spawns a program via posix_spawnp (PATH search).
+--- @param prog string Program name to execute
+--- @param argv {string} Argument vector passed to the program
+--- @param envp {string}? Environment (KEY=value); inherits if omitted
+--- @return number The child pid on success
+local function posix_spawnp(prog: string, argv: {string}, envp?: {string}): number
+  return (unix.spawnp(prog, argv, envp))
+end
+
+--- Waits for a child process to change state.
+--- @param pid number? Child pid to wait for (-1 or nil for any child)
+--- @param options number? Wait options (e.g. WNOHANG)
+--- @return number The pid that changed state (0 with WNOHANG if none)
+--- @return number Status word (interpret with WIFEXITED/WEXITSTATUS/...)
+--- @return Rusage Resource usage for the reaped child
+local function wait(pid?: number, options?: number): number, number, Rusage
+  local wpid, status, rusage = unix.wait(pid, options)
+  return wpid, status, rusage as Rusage
+end
+
+--- Sends a signal to a process.
+--- @param pid number Process id to signal
+--- @param sig number Signal number (e.g. SIGTERM, SIGKILL)
+--- @return boolean True on success
+local function kill(pid: number, sig: number): boolean
+  return (unix.kill(pid, sig))
+end
+
+--- True if the child exited normally.
+local function WIFEXITED(status: number): boolean
+  return unix.WIFEXITED(status)
+end
+
+--- The exit code (valid when WIFEXITED is true).
+local function WEXITSTATUS(status: number): number
+  return unix.WEXITSTATUS(status)
+end
+
+--- True if the child was terminated by a signal.
+local function WIFSIGNALED(status: number): boolean
+  return unix.WIFSIGNALED(status)
+end
+
+--- The terminating signal number (valid when WIFSIGNALED is true).
+local function WTERMSIG(status: number): number
+  return unix.WTERMSIG(status)
+end
+
 -- Resource Usage --
 
 --- Gets resource usage statistics.
@@ -257,16 +322,6 @@ end
 --- Returns true if current script is being run as the main program.
 --- Returns false if the script is being loaded as a module via require().
 --- Use this to guard code that should only run when executed directly.
----
---- Example:
----   local proc = require("cosmic.proc")
----   local function greet(name: string): string
----     return "hello, " .. name
----   end
----   if proc.is_main() then
----     print(greet(arg[1] or "world"))
----   end
----   return { greet = greet }
 --- @return boolean True if running as main script
 -- Assigned directly to avoid adding a stack frame, since cosmo.is_main()
 -- inspects the call stack to determine if the caller is the main script.
@@ -295,6 +350,17 @@ local record ProcModule
   execvp: function(prog: string, argv?: {string}): nil, string
   execvpe: function(prog: string, argv: {string}, envp?: {string}): nil, string
   fexecve: function(fd: number, argv: {string}, envp?: {string}): nil, string
+
+  -- Process control (children)
+  fork: function(): number
+  posix_spawn: function(prog: string, argv: {string}, envp?: {string}): number
+  posix_spawnp: function(prog: string, argv: {string}, envp?: {string}): number
+  wait: function(pid?: number, options?: number): number, number, Rusage
+  kill: function(pid: number, sig: number): boolean
+  WIFEXITED: function(status: number): boolean
+  WEXITSTATUS: function(status: number): number
+  WIFSIGNALED: function(status: number): boolean
+  WTERMSIG: function(status: number): number
 
   -- Resource usage
   getrusage: function(who?: number): Rusage
@@ -332,6 +398,11 @@ local record ProcModule
   PRIO_PROCESS: number
   PRIO_PGRP: number
   PRIO_USER: number
+
+  -- Wait options
+  WNOHANG: number
+  WUNTRACED: number
+  WCONTINUED: number
 end
 
 local M: ProcModule = {
@@ -357,6 +428,17 @@ local M: ProcModule = {
   execvp = execvp,
   execvpe = execvpe,
   fexecve = fexecve,
+
+  -- Process control (children)
+  fork = fork,
+  posix_spawn = posix_spawn,
+  posix_spawnp = posix_spawnp,
+  wait = wait,
+  kill = kill,
+  WIFEXITED = WIFEXITED,
+  WEXITSTATUS = WEXITSTATUS,
+  WIFSIGNALED = WIFSIGNALED,
+  WTERMSIG = WTERMSIG,
 
   -- Resource usage
   getrusage = getrusage,
@@ -394,6 +476,11 @@ local M: ProcModule = {
   PRIO_PROCESS = unix.PRIO_PROCESS,
   PRIO_PGRP = unix.PRIO_PGRP,
   PRIO_USER = unix.PRIO_USER,
+
+  -- Wait options
+  WNOHANG = unix.WNOHANG,
+  WUNTRACED = unix.WUNTRACED,
+  WCONTINUED = unix.WCONTINUED,
 }
 
 return M

--- a/lib/cosmic/proc_test.tl
+++ b/lib/cosmic/proc_test.tl
@@ -2,7 +2,6 @@
 local fs = require("cosmic.fs")
 local cio = require("cosmic.io")
 local proc = require("cosmic.proc")
-local child = require("cosmic.child")
 
 local lua_bin = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
@@ -117,10 +116,10 @@ else
 end
 ]])
 
-  local pid = child.posix_spawnp(lua_bin, {lua_bin, script_path})
-  local _, status = child.wait(pid)
-  assert(child.WIFEXITED(status), "expected normal exit")
-  local exit_code = child.WEXITSTATUS(status)
+  local pid = proc.posix_spawnp(lua_bin, {lua_bin, script_path})
+  local _, status = proc.wait(pid)
+  assert(proc.WIFEXITED(status), "expected normal exit")
+  local exit_code = proc.WEXITSTATUS(status)
   assert(exit_code == 0, "expected is_main to return true when script is run directly, got exit code " .. tostring(exit_code))
 end
 test_is_main_true_when_run_directly()
@@ -136,10 +135,10 @@ else
 end
 ]])
 
-  local pid = child.posix_spawnp(lua_bin, {lua_bin, script_path})
-  local _, status = child.wait(pid)
-  assert(child.WIFEXITED(status), "expected normal exit")
-  local exit_code = child.WEXITSTATUS(status)
+  local pid = proc.posix_spawnp(lua_bin, {lua_bin, script_path})
+  local _, status = proc.wait(pid)
+  assert(proc.WIFEXITED(status), "expected normal exit")
+  local exit_code = proc.WEXITSTATUS(status)
   assert(exit_code == 0, "expected proc.is_main to return true when script is run directly, got exit code " .. tostring(exit_code))
 end
 test_proc_is_main_true_when_run_directly()
@@ -162,10 +161,10 @@ else
 end
 ]], TEST_TMPDIR))
 
-  local pid = child.posix_spawnp(lua_bin, {lua_bin, script_path})
-  local _, status = child.wait(pid)
-  assert(child.WIFEXITED(status), "expected normal exit")
-  local exit_code = child.WEXITSTATUS(status)
+  local pid = proc.posix_spawnp(lua_bin, {lua_bin, script_path})
+  local _, status = proc.wait(pid)
+  assert(proc.WIFEXITED(status), "expected normal exit")
+  local exit_code = proc.WEXITSTATUS(status)
   assert(exit_code == 0, "expected is_main to return false when script is required, got exit code " .. tostring(exit_code))
 end
 test_is_main_false_when_required()
@@ -265,3 +264,110 @@ local function test_sched_yield()
   proc.sched_yield()
 end
 test_sched_yield()
+
+-- Process control (children) --
+-- These low-level fork/wait/kill/W* passthroughs moved here from cosmic.child,
+-- which now hosts only the high-level spawn API.
+local time = require("cosmic.time")
+local signal = require("cosmic.signal")
+
+local function test_fork_and_wait()
+  local pid = proc.fork()
+  if pid == 0 then
+    proc.exit(42)
+  else
+    assert(pid > 0, "expected positive child pid in parent, got " .. tostring(pid))
+    local waited_pid, status = proc.wait(pid)
+    assert(waited_pid == pid, "expected to wait for child " .. tostring(pid) .. ", got " .. tostring(waited_pid))
+    assert(proc.WIFEXITED(status), "expected child to exit normally")
+    assert(proc.WEXITSTATUS(status) == 42, "expected exit code 42, got " .. tostring(proc.WEXITSTATUS(status)))
+  end
+end
+test_fork_and_wait()
+
+local function test_fork_child_has_different_pid()
+  local parent_pid = proc.getpid()
+  local marker_file = fs.join(TEST_TMPDIR, "fork_test_" .. tostring(parent_pid))
+  local pid = proc.fork()
+  if pid == 0 then
+    local f = io.open(marker_file, "w")
+    if f then
+      f:write(tostring(proc.getpid()))
+      f:close()
+    end
+    proc.exit(0)
+  else
+    proc.wait(pid)
+    local f = io.open(marker_file, "r")
+    assert(f ~= nil, "expected marker file to exist")
+    local child_pid = tonumber(f:read("*a"))
+    f:close()
+    os.remove(marker_file)
+    assert(child_pid ~= parent_pid, "expected child to have different pid")
+    assert(child_pid == pid, "expected child pid " .. tostring(pid) .. ", got " .. tostring(child_pid))
+  end
+end
+test_fork_child_has_different_pid()
+
+local function test_wexitstatus_values()
+  for _, expected_code in ipairs({0, 1, 42, 127, 255}) do
+    local pid = proc.fork()
+    if pid == 0 then
+      proc.exit(expected_code)
+    else
+      local _, status = proc.wait(pid)
+      assert(proc.WIFEXITED(status), "expected WIFEXITED for code " .. tostring(expected_code))
+      assert(proc.WEXITSTATUS(status) == expected_code,
+        "expected exit code " .. tostring(expected_code) .. ", got " .. tostring(proc.WEXITSTATUS(status)))
+    end
+  end
+end
+test_wexitstatus_values()
+
+local function test_wifsignaled_on_kill()
+  local pid = proc.fork()
+  if pid == 0 then
+    time.sleep(10)
+    proc.exit(0)
+  else
+    assert(proc.kill(pid, signal.SIGKILL), "expected kill to succeed")
+    local _, status = proc.wait(pid)
+    assert(proc.WIFSIGNALED(status), "expected WIFSIGNALED to be true")
+    assert(proc.WTERMSIG(status) == signal.SIGKILL,
+      "expected SIGKILL (" .. tostring(signal.SIGKILL) .. "), got " .. tostring(proc.WTERMSIG(status)))
+  end
+end
+test_wifsignaled_on_kill()
+
+local function test_wnohang_returns_zero_for_running_process()
+  local pid = proc.fork()
+  if pid == 0 then
+    time.sleep(0, 100000000) -- 100ms
+    proc.exit(0)
+  else
+    local waited_pid = proc.wait(pid, proc.WNOHANG)
+    assert(waited_pid == 0 or waited_pid == pid, "expected 0 or pid, got " .. tostring(waited_pid))
+    if waited_pid == 0 then
+      proc.wait(pid)
+    end
+  end
+end
+test_wnohang_returns_zero_for_running_process()
+
+local function test_posix_spawn_returns_pid()
+  local ls_path = proc.commandv("ls")
+  if ls_path then
+    local pid = proc.posix_spawn(ls_path, {"ls"})
+    assert(pid > 0, "expected positive pid, got " .. tostring(pid))
+    proc.wait(pid)
+  end
+end
+test_posix_spawn_returns_pid()
+
+local function test_wait_option_constants_defined()
+  assert(type(proc.WNOHANG) == "number", "WNOHANG should be a number")
+  assert(type(proc.WUNTRACED) == "number", "WUNTRACED should be a number")
+  assert(proc.WCONTINUED == nil or type(proc.WCONTINUED) == "number",
+    "WCONTINUED should be a number or nil")
+end
+test_wait_option_constants_defined()

--- a/lib/cosmic/quicksand/box/run_test.tl
+++ b/lib/cosmic/quicksand/box/run_test.tl
@@ -41,7 +41,8 @@ io.write("skipped: exit=" .. tostring(code) .. "\n"); os.exit(0)
 ]])
 
   local h = spawn.spawn({cosmic, script})
-  local ok, out = (h as spawn.Handle):read()
+  local __r1 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   -- An outer seccomp filter may SIGSYS the subprocess outright; that
   -- still counts as a skip because we never reached enforcement.
   if not ok then return end
@@ -74,7 +75,8 @@ end
 ]])
 
   local h = spawn.spawn({cosmic, script})
-  local ok, out = (h as spawn.Handle):read()
+  local __r2 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r2.ok, __r2.stdout
   if not ok then return end
   local s = out as string
   assert(s:find("ok") or s:find("skipped"),
@@ -102,7 +104,8 @@ end
 ]])
 
   local h = spawn.spawn({cosmic, script})
-  local ok, out = (h as spawn.Handle):read()
+  local __r3 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r3.ok, __r3.stdout
   if not ok then return end
   local s = out as string
   assert(s:find("ok") or s:find("skipped"),
@@ -131,7 +134,8 @@ io.write("ok\n")
 ]])
 
   local h = spawn.spawn({cosmic, script})
-  local ok, out = (h as spawn.Handle):read()
+  local __r4 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r4.ok, __r4.stdout
   if not ok then return end
   local s = out as string
   assert(s:find("ok") or s:find("skipped"),

--- a/lib/cosmic/quicksand/caps_test.tl
+++ b/lib/cosmic/quicksand/caps_test.tl
@@ -102,7 +102,8 @@ local function test_drop_bounding_child()
   if not c.linux or not test_bin then return end
   local cosmic = fs.join(test_bin, "cosmic")
   local h = spawn.spawn({cosmic, "-e", CHILD_DROP})
-  local ok, out = (h as spawn.Handle):read()
+  local __r1 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   if not ok then return end
   local s = out as string
   assert(s:find("dropped") or s:find("skipped"),

--- a/lib/cosmic/quicksand/netns_test.tl
+++ b/lib/cosmic/quicksand/netns_test.tl
@@ -62,7 +62,8 @@ if not up then io.stderr:write("bring_up: " .. tostring(uerr) .. "\n"); os.exit(
 io.write("ok\n")
 ]])
   local h = spawn.spawn({cosmic, script})
-  local ok, out = (h as spawn.Handle):read()
+  local __r1 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   -- An outer seccomp/pledge filter may SIGSYS the subprocess on unshare.
   -- Accept signal death as a skip.
   if not ok then return end

--- a/lib/cosmic/quicksand/proc_test.tl
+++ b/lib/cosmic/quicksand/proc_test.tl
@@ -38,7 +38,8 @@ else
 end
 ]])
   local h = spawn.spawn({cosmic, script})
-  local ok, out = (h as spawn.Handle):read()
+  local __r1 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   if not ok then return end
   local s = out as string
   assert(s:find("ok") or s:find("skipped"),
@@ -78,7 +79,8 @@ end
 io.write("ok\n")
 ]])
   local h = spawn.spawn({cosmic, script})
-  local ok, out = (h as spawn.Handle):read()
+  local __r2 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r2.ok, __r2.stdout
   -- An outer seccomp/pledge filter may SIGSYS the subprocess on prctl.
   -- Accept signal death as a skip.
   if not ok then return end
@@ -116,7 +118,8 @@ unix.wait(pid)
 io.write("done\n")
 ]])
   local h = spawn.spawn({cosmic, script})
-  local ok, out = (h as spawn.Handle):read()
+  local __r3 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r3.ok, __r3.stdout
   -- Signal death under an outer sandbox counts as skip.
   if not ok then return end
   local s = out as string

--- a/lib/cosmic/script_test.tl
+++ b/lib/cosmic/script_test.tl
@@ -30,7 +30,8 @@ print("answer=" .. x)
 ]])
 
   local h1 = spawn.spawn({cosmic, script})
-  local ok, out = (h1 as spawn.Handle):read()
+  local __r1 = (h1 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   assert(ok, "cosmic should execute .tl file")
   assert((out as string):find("answer=42"), "output should contain expected result")
 end
@@ -44,7 +45,8 @@ print("value=" .. x)
 ]])
 
   local h2 = spawn.spawn({cosmic, script})
-  local ok, out = (h2 as spawn.Handle):read()
+  local __r2 = (h2 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r2.ok, __r2.stdout
   assert(ok, "cosmic should execute .lua file")
   assert((out as string):find("value=99"), "output should contain expected result")
 end
@@ -59,7 +61,8 @@ print(x)
 
   -- stderr = 1 merges stderr into stdout so we can capture the error message
   local h3 = spawn.spawn({cosmic, script}, {stderr = 1})
-  local ok, out = (h3 as spawn.Handle):read()
+  local __r3 = (h3 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r3.ok, __r3.stdout
   assert(not ok, "cosmic should fail on .tl file with type error")
   assert((out as string):find("type_error.tl"), "error should reference the file name")
 end
@@ -72,7 +75,8 @@ if if if
 ]])
 
   local h4 = spawn.spawn({cosmic, script})
-  local ok, out = (h4 as spawn.Handle):read()
+  local __r4 = (h4 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r4.ok, __r4.stdout
   assert(not ok, "cosmic should fail on .tl file with syntax error")
 end
 test_teal_syntax_error()
@@ -90,7 +94,8 @@ print("point=" .. p.x .. "," .. p.y)
 ]])
 
   local h5 = spawn.spawn({cosmic, script})
-  local ok, out = (h5 as spawn.Handle):read()
+  local __r5 = (h5 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r5.ok, __r5.stdout
   assert(ok, "cosmic should execute .tl file with records")
   assert((out as string):find("point=10,20"), "output should contain expected result")
 end
@@ -106,7 +111,8 @@ print("result=" .. identity(123))
 ]])
 
   local h6 = spawn.spawn({cosmic, script})
-  local ok, out = (h6 as spawn.Handle):read()
+  local __r6 = (h6 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r6.ok, __r6.stdout
   assert(ok, "cosmic should execute .tl file with generics")
   assert((out as string):find("result=123"), "output should contain expected result")
 end
@@ -121,7 +127,8 @@ print("bytes=" .. #data)
 ]])
 
   local h7 = spawn.spawn({cosmic, script})
-  local ok, out = (h7 as spawn.Handle):read()
+  local __r7 = (h7 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r7.ok, __r7.stdout
   assert(ok, "cosmic should execute .tl file with cosmic module requires")
   assert((out as string):find("bytes=0"), "output should contain expected result")
 end
@@ -136,7 +143,8 @@ print("arg2=" .. (arg[2] or "nil"))
 ]])
 
   local h8 = spawn.spawn({cosmic, script, "first", "second"})
-  local ok, out = (h8 as spawn.Handle):read()
+  local __r8 = (h8 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r8.ok, __r8.stdout
   assert(ok, "cosmic should execute .tl file with args")
   assert((out as string):find("arg0=" .. script), "arg[0] should be script path")
   assert((out as string):find("arg1=first"), "arg[1] should be first argument")
@@ -152,7 +160,8 @@ print("arg1=" .. (arg[1] or "nil"))
 ]])
 
   local h9 = spawn.spawn({cosmic, script, "test"})
-  local ok, out = (h9 as spawn.Handle):read()
+  local __r9 = (h9 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r9.ok, __r9.stdout
   assert(ok, "cosmic should execute .lua file with args")
   assert((out as string):find("arg0=" .. script), "arg[0] should be script path")
   assert((out as string):find("arg1=test"), "arg[1] should be argument")
@@ -171,7 +180,8 @@ print("shebang=" .. x)
   assert(verify:find("shebang="), "script file should contain shebang test code, got: " .. verify:sub(1, 100))
 
   local h10 = spawn.spawn({cosmic, script}, {stderr = 1})
-  local ok, out = (h10 as spawn.Handle):read()
+  local __r10 = (h10 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r10.ok, __r10.stdout
   assert(ok, "cosmic should execute .tl file with shebang, got: " .. tostring(out))
   assert((out as string):find("shebang=777"), "output should contain expected result, got: " .. tostring(out))
 end
@@ -191,7 +201,8 @@ print("value=" .. x)
 
   for _ = 1, 2 do
     local h11 = spawn.spawn({cosmic, script})
-    local ok, out = (h11 as spawn.Handle):read()
+    local __r11 = (h11 as spawn.Handle):wait() as spawn.Result
+    local ok, out = __r11.ok, __r11.stdout
     assert(ok, "cosmic should execute .tl file: " .. tostring(out))
     assert((out as string):find("value=1"), "expected value=1, got: " .. tostring(out))
   end
@@ -203,7 +214,8 @@ local x: number = 2
 print("value=" .. x)
 ]])
   local h12 = spawn.spawn({cosmic, script})
-  local ok, out = (h12 as spawn.Handle):read()
+  local __r12 = (h12 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r12.ok, __r12.stdout
   assert(ok, "cosmic should execute changed .tl file: " .. tostring(out))
   assert((out as string):find("value=2"),
     "expected value=2 after script change (stale cache?), got: " .. tostring(out))

--- a/lib/cosmic/skill_test.tl
+++ b/lib/cosmic/skill_test.tl
@@ -21,7 +21,8 @@ end
 
 local function test_skill_writes_file()
   local dir = fs.join(tmpdir, "skill-out")
-  local ok, out = (spawn.spawn({cosmic, "--skill", dir}, {env = clean_env()}) as spawn.Handle):read()
+  local __r1 = (spawn.spawn({cosmic, "--skill", dir}, {env = clean_env()}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   assert(ok, "cosmic --skill should succeed, got: " .. tostring(out))
   local skill_path = fs.join(dir, "SKILL.md")
   assert(fs.isfile(skill_path), "SKILL.md should exist at " .. skill_path)
@@ -37,7 +38,8 @@ test_skill_writes_file()
 
 local function test_skill_content()
   local dir = fs.join(tmpdir, "skill-content")
-  local ok, _ = (spawn.spawn({cosmic, "--skill", dir}, {env = clean_env()}) as spawn.Handle):read()
+  local __r2 = (spawn.spawn({cosmic, "--skill", dir}, {env = clean_env()}) as spawn.Handle):wait() as spawn.Result
+  local ok, _ = __r2.ok, __r2.stdout
   assert(ok, "cosmic --skill should succeed")
   local content = assert(cio.slurp(fs.join(dir, "SKILL.md"))) as string
   assert(content:find("curl", 1, true),
@@ -68,7 +70,8 @@ test_skill_content()
 
 local function test_skill_creates_nested_dir()
   local dir = fs.join(tmpdir, "skill-nested", "a", "b")
-  local ok, _ = (spawn.spawn({cosmic, "--skill", dir}, {env = clean_env()}) as spawn.Handle):read()
+  local __r3 = (spawn.spawn({cosmic, "--skill", dir}, {env = clean_env()}) as spawn.Handle):wait() as spawn.Result
+  local ok, _ = __r3.ok, __r3.stdout
   assert(ok, "cosmic --skill should create nested directories")
   assert(fs.isfile(fs.join(dir, "SKILL.md")), "SKILL.md should exist in nested dir")
 end
@@ -76,7 +79,8 @@ test_skill_creates_nested_dir()
 
 local function test_skill_prints_path()
   local dir = fs.join(tmpdir, "skill-path")
-  local ok, out = (spawn.spawn({cosmic, "--skill", dir}, {env = clean_env()}) as spawn.Handle):read()
+  local __r4 = (spawn.spawn({cosmic, "--skill", dir}, {env = clean_env()}) as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r4.ok, __r4.stdout
   assert(ok, "cosmic --skill should succeed")
   local s = out as string
   local expected = fs.join(dir, "SKILL.md")

--- a/lib/cosmic/style_test.tl
+++ b/lib/cosmic/style_test.tl
@@ -24,7 +24,8 @@ add(1, 2)
 ]])
 
   local h = spawn.spawn({cosmic, "--check-style", input})
-  local ok, _ = (h as spawn.Handle):read()
+  local __r1 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, _ = __r1.ok, __r1.stdout
   assert(ok, "cosmic --check-style should succeed on valid file")
 end
 test_style_valid()
@@ -35,7 +36,8 @@ local function test_style_long_line()
   local input = write_temp("style_long.tl", long_line .. "\n")
 
   local h = spawn.spawn({cosmic, "--check-style", input})
-  local ok, _ = (h as spawn.Handle):read()
+  local __r2 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, _ = __r2.ok, __r2.stdout
   assert(not ok, "cosmic --check-style should fail on file with long line")
 end
 test_style_long_line()
@@ -56,7 +58,8 @@ bar()
 ]])
 
   local h = spawn.spawn({cosmic, "--check-style", input})
-  local ok, _ = (h as spawn.Handle):read()
+  local __r3 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, _ = __r3.ok, __r3.stdout
   assert(not ok, "cosmic --check-style should fail when function not called immediately after definition")
 end
 test_style_call_after_define()
@@ -64,7 +67,8 @@ test_style_call_after_define()
 -- Missing file: should fail
 local function test_style_missing_file()
   local h = spawn.spawn({cosmic, "--check-style", "/nonexistent/file.tl"})
-  local ok, _ = (h as spawn.Handle):read()
+  local __r4 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, _ = __r4.ok, __r4.stdout
   assert(not ok, "cosmic --check-style should fail on missing file")
 end
 test_style_missing_file()

--- a/lib/cosmic/testrun.tl
+++ b/lib/cosmic/testrun.tl
@@ -49,41 +49,26 @@ local function run(argv: {string}, output_base: string): integer
   end
   child_env[#child_env + 1] = "TEST_TMPDIR=" .. tmpdir
 
-  -- Spawn the process
-  local handle0, err = child.spawn(argv, {env = child_env})
-  if not handle0 then
-    fs.rmrf(tmpdir)
-    io.stderr:write("testrun: " .. (err or "spawn failed") .. "\n")
-    instrument.finish(span, 1)
-    return 1
-  end
-  local handle = handle0 as child.Handle
-
-  -- Close stdin, read stdout and stderr
-  if handle.stdin then
-    handle.stdin:close()
-  end
-
+  -- Run the process to completion, capturing both streams without deadlock.
+  local result, err = child.run(argv, {env = child_env})
   local stdout_content = ""
   local stderr_content = ""
-
-  if handle.stdout then
-    stdout_content = handle.stdout:read() or ""
-    handle.stdout:close()
-  end
-
-  if handle.stderr then
-    stderr_content = handle.stderr:read() or ""
-    handle.stderr:close()
-  end
-
-  -- Wait for exit
-  local _, status = child.wait(handle.pid)
   local exit_code: integer = 1
-  if child.WIFEXITED(status) then
-    exit_code = child.WEXITSTATUS(status) as integer
-  elseif child.WIFSIGNALED(status) then
-    exit_code = (128 + child.WTERMSIG(status)) as integer
+  if not result then
+    -- The executable could not be started (e.g. a missing binary): report the
+    -- conventional 127 "command not found" code and surface the error.
+    exit_code = 127
+    stderr_content = err or "spawn failed"
+  else
+    local r = result as child.Result
+    stdout_content = r.stdout
+    stderr_content = r.stderr
+    -- Signal death is reported as the conventional 128+signal exit code.
+    if r.code ~= nil then
+      exit_code = r.code
+    elseif r.signal ~= nil then
+      exit_code = (128 + r.signal) as integer
+    end
   end
 
   -- Clean up temp directory

--- a/lib/cosmic/tl_loader_test.tl
+++ b/lib/cosmic/tl_loader_test.tl
@@ -55,7 +55,8 @@ end
 ]])
 
   local h1 = spawn.spawn({cosmic, script})
-  local ok, out = (h1 as spawn.Handle):read()
+  local __r1 = (h1 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   assert(ok, "script should succeed: " .. tostring(out))
   assert((out as string):find("PASS"),
     "searcher[2] should not be tl_package_loader: " .. tostring(out))
@@ -79,7 +80,8 @@ print("answer=" .. tostring(mymod.answer))
 ]])
 
   local h2 = spawn.spawn({cosmic, "-e", "package.path='" .. moddir .. "/?.tl;' .. package.path", script})
-  local ok, out = (h2 as spawn.Handle):read()
+  local __r2 = (h2 as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r2.ok, __r2.stdout
   -- This may not work exactly this way, but the point is tl_package_loader
   -- should still work for .tl-only modules
   -- For now, just verify the tl_package_loader exists in searchers
@@ -98,7 +100,8 @@ end
 ]])
 
   local h3 = spawn.spawn({cosmic, check_script})
-  local ok2, out2 = (h3 as spawn.Handle):read()
+  local __r3 = (h3 as spawn.Handle):wait() as spawn.Result
+  local ok2, out2 = __r3.ok, __r3.stdout
   assert(ok2, "check script should succeed: " .. tostring(out2))
   assert((out2 as string):find("PASS"),
     "tl_package_loader should still be present: " .. tostring(out2))

--- a/lib/cosmic/unveil_example.tl
+++ b/lib/cosmic/unveil_example.tl
@@ -20,9 +20,8 @@ assert(unveil.apply("/tmp", "r"))
 assert(unveil.apply(nil, nil))
 io.write("committed\n")
 ]]
-  local h = spawn.spawn({cosmic, "-e", script})
-  local _, out = (h as spawn.Handle):read()
-  io.write(tostring(out))
+  local r = spawn.run({cosmic, "-e", script}) as spawn.Result
+  io.write(r.stdout)
   -- Output:
   -- skipped
 end

--- a/lib/cosmic/unveil_test.tl
+++ b/lib/cosmic/unveil_test.tl
@@ -66,7 +66,8 @@ end
 ]], allowed_dir, allowed_file, hidden_file))
 
   local h = spawn.spawn({cosmic, script})
-  local ok, out = (h as spawn.Handle):read()
+  local __r1 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r1.ok, __r1.stdout
   local s = (out or "") as string
   if s:find("skipped") then
     a.skip("unveil unavailable / not enforcing (OpenBSD-only, or no backing): " .. s)

--- a/lib/cosmic/version_test.tl
+++ b/lib/cosmic/version_test.tl
@@ -8,41 +8,33 @@ local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 
 --- cosmic -v should output version info and exit 0
 local function test_v_flag()
-  local h = spawn.spawn({cosmic, "-v"})
-  local ok, out = (h as spawn.Handle):read()
-  assert(ok, "cosmic -v should succeed")
-  local output = out as string
-  -- should contain at least the Lua version
-  assert(output:find("Lua 5.4"), "should contain Lua version, got: " .. output)
+  local r = spawn.run({cosmic, "-v"}) as spawn.Result
+  assert(r.ok, "cosmic -v should succeed")
+  assert(r.stdout:find("Lua 5.4"), "should contain Lua version, got: " .. r.stdout)
 end
 test_v_flag()
 
 --- cosmic --version should produce the same output as -v
 local function test_version_flag()
-  local h = spawn.spawn({cosmic, "--version"})
-  local ok, out = (h as spawn.Handle):read()
-  assert(ok, "cosmic --version should succeed")
-  local output = out as string
-  assert(output:find("Lua 5.4"), "should contain Lua version, got: " .. output)
+  local r = spawn.run({cosmic, "--version"}) as spawn.Result
+  assert(r.ok, "cosmic --version should succeed")
+  assert(r.stdout:find("Lua 5.4"), "should contain Lua version, got: " .. r.stdout)
 end
 test_version_flag()
 
 --- -v and --version should produce identical output
 local function test_v_and_version_match()
-  local hv = spawn.spawn({cosmic, "-v"})
-  local _, out_v = (hv as spawn.Handle):read()
-  local hver = spawn.spawn({cosmic, "--version"})
-  local _, out_ver = (hver as spawn.Handle):read()
-  assert(out_v == out_ver, "-v and --version should match: " .. (out_v as string) .. " vs " .. (out_ver as string))
+  local rv = spawn.run({cosmic, "-v"}) as spawn.Result
+  local rver = spawn.run({cosmic, "--version"}) as spawn.Result
+  assert(rv.stdout == rver.stdout, "-v and --version should match: " .. rv.stdout .. " vs " .. rver.stdout)
 end
 test_v_and_version_match()
 
 --- when cosmic.version is embedded, output should match the full format
 local function test_full_version_format()
-  local h = spawn.spawn({cosmic, "-v"})
-  local ok, out = (h as spawn.Handle):read()
-  assert(ok, "cosmic -v should succeed")
-  local output = (out as string):gsub("%s+$", "")
+  local r = spawn.run({cosmic, "-v"}) as spawn.Result
+  assert(r.ok, "cosmic -v should succeed")
+  local output = r.stdout:gsub("%s+$", "")
   -- the binary has version.lua embedded, so should show full format:
   -- cosmic-lua <version> (cosmos <version>, Lua 5.4)
   if output:find("^cosmic%-lua ") then
@@ -58,9 +50,8 @@ test_full_version_format()
 
 --- version output should be a single line
 local function test_version_single_line()
-  local h = spawn.spawn({cosmic, "-v"})
-  local _, out = (h as spawn.Handle):read()
-  local output = (out as string):gsub("%s+$", "")
+  local r = spawn.run({cosmic, "-v"}) as spawn.Result
+  local output = r.stdout:gsub("%s+$", "")
   local lines = 0
   for _ in output:gmatch("[^\n]+") do
     lines = lines + 1
@@ -71,12 +62,10 @@ test_version_single_line()
 
 --- cosmic.version module should be requireable
 local function test_require_version_module()
-  local h = spawn.spawn({cosmic, "-e", "local v = require('cosmic.version'); print(v.cosmic); print(v.cosmos)"})
-  local ok, out = (h as spawn.Handle):read()
-  if ok then
-    local output = out as string
+  local r = spawn.run({cosmic, "-e", "local v = require('cosmic.version'); print(v.cosmic); print(v.cosmos)"}) as spawn.Result
+  if r.ok then
     -- both fields should be non-empty strings
-    local cosmic_ver, cosmos_ver = output:match("^(%S+)\n(%S+)")
+    local cosmic_ver, cosmos_ver = r.stdout:match("^(%S+)\n(%S+)")
     assert(cosmic_ver and cosmic_ver ~= "", "cosmic version should be non-empty")
     assert(cosmos_ver and cosmos_ver ~= "", "cosmos version should be non-empty")
   end

--- a/lib/cosmic/welcome_test.tl
+++ b/lib/cosmic/welcome_test.tl
@@ -11,10 +11,9 @@ local tmpdir = os.getenv("TEST_TMPDIR")
 
 -- Test --welcome shows message
 local function test_welcome_flag()
-  local h = spawn.spawn({cosmic, "--welcome"})
-  local ok, out = (h as spawn.Handle):read()
-  assert(ok, "cosmic --welcome should succeed")
-  local s = out as string
+  local r = spawn.run({cosmic, "--welcome"}) as spawn.Result
+  assert(r.ok, "cosmic --welcome should succeed")
+  local s = r.stdout
   assert(s:find("Welcome to cosmic%-lua!"), "should show welcome message")
   assert(s:find("cosmic %-%-docs"), "should mention --docs")
   assert(s:find("cosmic %-%-help"), "should mention --help")
@@ -25,10 +24,9 @@ test_welcome_flag()
 
 -- Test --help mentions --welcome and COSMIC_NO_WELCOME
 local function test_help_mentions_welcome()
-  local h = spawn.spawn({cosmic, "--help"})
-  local ok, out = (h as spawn.Handle):read()
-  assert(ok, "cosmic --help should succeed")
-  local s = out as string
+  local r = spawn.run({cosmic, "--help"}) as spawn.Result
+  assert(r.ok, "cosmic --help should succeed")
+  local s = r.stdout
   assert(s:find("%-%-welcome"), "help should mention --welcome flag")
   assert(s:find("COSMIC_NO_WELCOME"), "help should mention COSMIC_NO_WELCOME env var")
   print("test_help_mentions_welcome: PASS")
@@ -49,10 +47,9 @@ end
 ]])
 
   local env = {"COSMIC_NO_WELCOME=1"}
-  local h = spawn.spawn({cosmic, test_script}, {env = env})
-  local ok, out = (h as spawn.Handle):read()
-  local s = out as string
-  assert(ok, "script should succeed: " .. s)
+  local r = spawn.run({cosmic, test_script}, {env = env}) as spawn.Result
+  local s = r.stdout
+  assert(r.ok, "script should succeed: " .. s)
   assert(s:find("COSMIC_NO_WELCOME is set"), "env var should be accessible: " .. s)
   print("test_no_welcome_env: PASS")
 end
@@ -75,10 +72,9 @@ local function pty_available(): boolean
   end
   -- Run cosmic through script to simulate a PTY (suppress welcome to avoid mutating binary)
   local cmd = "COSMIC_NO_WELCOME=1 " .. cosmic .. " " .. probe
-  local h = spawn.spawn({"script", "-qc", cmd, "/dev/null"})
-  local ok, out = (h as spawn.Handle):read()
-  local s = out as string
-  if not (ok as boolean) then
+  local r = spawn.run({"script", "-qc", cmd, "/dev/null"}) as spawn.Result
+  local s = r.stdout
+  if not r.ok then
     return false
   end
   if s:find("failed to create pseudo%-terminal") or s:find("Permission denied") then
@@ -100,9 +96,8 @@ end
 local function run_with_pty(args: {string}): boolean, string
   -- Copy binary to temp location so it's fresh (no embedded marker)
   local fresh_cosmic = fs.join(tmpdir, "cosmic-fresh-" .. tostring(os.time()))
-  local cp_h = spawn.spawn({"cp", cosmic, fresh_cosmic})
-  local copy_ok = (cp_h as spawn.Handle):wait()
-  assert(copy_ok, "failed to copy cosmic binary")
+  local cp = spawn.run({"cp", cosmic, fresh_cosmic}) as spawn.Result
+  assert(cp.ok, "failed to copy cosmic binary")
 
   -- Build command string for script
   local cmd = fresh_cosmic
@@ -112,9 +107,8 @@ local function run_with_pty(args: {string}): boolean, string
   end
 
   -- Use script command to provide PTY (merges stdout/stderr)
-  local h = spawn.spawn({"script", "-qc", cmd, "/dev/null"})
-  local ok, out = (h as spawn.Handle):read()
-  return ok as boolean, out as string
+  local r = spawn.run({"script", "-qc", cmd, "/dev/null"}) as spawn.Result
+  return r.ok, r.stdout
 end
 
 -- Test welcome appears on first run with -e flag
@@ -141,23 +135,20 @@ test_welcome_skipped_with_v_flag()
 local function test_welcome_not_shown_twice()
   -- Copy binary to temp location
   local fresh_cosmic = fs.join(tmpdir, "cosmic-twice-test")
-  local cp_h = spawn.spawn({"cp", cosmic, fresh_cosmic})
-  local copy_ok = (cp_h as spawn.Handle):wait()
-  assert(copy_ok, "failed to copy cosmic binary")
+  local cp = spawn.run({"cp", cosmic, fresh_cosmic}) as spawn.Result
+  assert(cp.ok, "failed to copy cosmic binary")
 
   -- First run - should show welcome (use -e to avoid early-return)
   local cmd1 = fresh_cosmic .. " -e 'print(1)'"
-  local h1 = spawn.spawn({"script", "-qc", cmd1, "/dev/null"})
-  local ok1, out1 = (h1 as spawn.Handle):read()
-  local s1 = out1 as string
-  assert(ok1, "first run should succeed: " .. s1)
+  local r1 = spawn.run({"script", "-qc", cmd1, "/dev/null"}) as spawn.Result
+  local s1 = r1.stdout
+  assert(r1.ok, "first run should succeed: " .. s1)
   assert(s1:find("Welcome to cosmic%-lua!"), "first run should show welcome: " .. s1)
 
   -- Second run with SAME binary - should NOT show welcome (marker embedded)
-  local h2 = spawn.spawn({"script", "-qc", cmd1, "/dev/null"})
-  local ok2, out2 = (h2 as spawn.Handle):read()
-  local s2 = out2 as string
-  assert(ok2, "second run should succeed: " .. s2)
+  local r2 = spawn.run({"script", "-qc", cmd1, "/dev/null"}) as spawn.Result
+  local s2 = r2.stdout
+  assert(r2.ok, "second run should succeed: " .. s2)
   assert(not s2:find("Welcome to cosmic%-lua!"), "second run should NOT show welcome: " .. s2)
 
   print("test_welcome_not_shown_twice: PASS")
@@ -168,16 +159,14 @@ test_welcome_not_shown_twice()
 local function test_no_welcome_env_suppresses()
   -- Copy binary to temp location
   local fresh_cosmic = fs.join(tmpdir, "cosmic-no-welcome-test")
-  local cp_h = spawn.spawn({"cp", cosmic, fresh_cosmic})
-  local copy_ok = (cp_h as spawn.Handle):wait()
-  assert(copy_ok, "failed to copy cosmic binary")
+  local cp = spawn.run({"cp", cosmic, fresh_cosmic}) as spawn.Result
+  assert(cp.ok, "failed to copy cosmic binary")
 
   -- Run with COSMIC_NO_WELCOME set (use -e to avoid early-return)
   local cmd = "COSMIC_NO_WELCOME=1 " .. fresh_cosmic .. " -e 'print(1)'"
-  local h = spawn.spawn({"script", "-qc", cmd, "/dev/null"})
-  local ok, out = (h as spawn.Handle):read()
-  local s = out as string
-  assert(ok, "should succeed: " .. s)
+  local r = spawn.run({"script", "-qc", cmd, "/dev/null"}) as spawn.Result
+  local s = r.stdout
+  assert(r.ok, "should succeed: " .. s)
   assert(not s:find("Welcome to cosmic%-lua!"), "welcome should be suppressed: " .. s)
 
   print("test_no_welcome_env_suppresses: PASS")

--- a/lib/docs/publish.tl
+++ b/lib/docs/publish.tl
@@ -152,13 +152,13 @@ local function make_readme(docs_dir: string): string
 end
 
 local function run(argv: {string}): boolean, string
-  local h, err = spawn.spawn(argv)
-  if not h then
+  local result, err = spawn.run(argv)
+  if not result then
     return nil, err
   end
-  local code = (h as spawn.Handle):wait()
-  if code ~= 0 then
-    return nil, table.concat(argv, " ") .. " failed with exit code " .. code
+  local r = result as spawn.Result
+  if not r.ok then
+    return nil, table.concat(argv, " ") .. " failed with exit code " .. tostring(r.code)
   end
   return true
 end
@@ -183,8 +183,8 @@ local function main(source_sha: string, docs_dir: string, branch: string): boole
   if not ok then return nil, err end
 
   -- fetch and checkout docs branch, or create orphan
-  local fetch_h = spawn.spawn({"git", "fetch", "origin", branch})
-  local fetch_ok = fetch_h and (fetch_h as spawn.Handle):wait() == 0
+  local fetch_res = spawn.run({"git", "fetch", "origin", branch})
+  local fetch_ok = fetch_res ~= nil and (fetch_res as spawn.Result).ok
 
   if fetch_ok then
     ok, err = run({"git", "switch", branch})
@@ -196,8 +196,7 @@ local function main(source_sha: string, docs_dir: string, branch: string): boole
   end
 
   -- remove old content (ignore errors for empty repos)
-  local rm_h = spawn.spawn({"git", "rm", "-rf", "."})
-  if rm_h then (rm_h as spawn.Handle):wait() end
+  local _ = spawn.run({"git", "rm", "-rf", "."})
 
   -- clear working directory
   local dir0 = fs.opendir(".")
@@ -226,8 +225,8 @@ local function main(source_sha: string, docs_dir: string, branch: string): boole
   if not ok then return nil, err end
 
   -- check if there are changes
-  local diff_h = spawn.spawn({"git", "diff", "--staged", "--quiet"})
-  if diff_h and (diff_h as spawn.Handle):wait() == 0 then
+  local diff_res = spawn.run({"git", "diff", "--staged", "--quiet"})
+  if diff_res ~= nil and (diff_res as spawn.Result).ok then
     io.stderr:write("no documentation changes detected\n")
     return true
   end

--- a/lib/perf/bench/child_bench.tl
+++ b/lib/perf/bench/child_bench.tl
@@ -12,11 +12,9 @@ local function scenarios(): {pt.Scenario}, string
     {
       name = "child_spawn_true",
       fn = function(_: any): any
-        local handle, err = child.spawn({"/bin/true"})
-        assert(handle, err)
-        local hh = handle as child.Handle
-        local _, _, code = hh:read()
-        return code
+        local result, err = child.run({"/bin/true"})
+        assert(result, err)
+        return (result as child.Result).code
       end,
       check = function(_: any, res: any): boolean, string
         if res as integer ~= 0 then

--- a/lib/perf/bench/embed_startup_bench.tl
+++ b/lib/perf/bench/embed_startup_bench.tl
@@ -98,12 +98,11 @@ end
 --- @param bin string Binary path
 --- @return string Trimmed stdout
 local function spawn_capture(bin: string): string
-  local handle, serr = child.spawn({bin})
-  assert(handle, serr)
-  local hh = handle as child.Handle
-  local ok, out, code = hh:read()
-  assert(ok, "exit code " .. tostring(code) .. ": " .. tostring(out))
-  return ((out as string):gsub("%s+$", ""))
+  local result, serr = child.run({bin})
+  assert(result, serr)
+  local r = result as child.Result
+  assert(r.ok, "exit code " .. tostring(r.code) .. ": " .. tostring(r.stdout))
+  return (r.stdout:gsub("%s+$", ""))
 end
 
 local function scenarios(): {pt.Scenario}, string

--- a/lib/perf/bench/http_bench.tl
+++ b/lib/perf/bench/http_bench.tl
@@ -6,7 +6,7 @@
 
 local net = require("cosmic.net")
 local fetch = require("cosmic.fetch")
-local child = require("cosmic.child")
+local proc = require("cosmic.proc")
 local signal = require("cosmic.signal")
 local pt = require("perf.perf_types")
 
@@ -57,7 +57,7 @@ local function scenarios(): {pt.Scenario}, string
     return nil, "listen_tcp: " .. tostring(lerr)
   end
   listener = srv
-  local pid = child.fork()
+  local pid = proc.fork()
   if pid == 0 then
     serve_loop(srv)
     os.exit(0)
@@ -162,8 +162,8 @@ end
 
 local function cleanup()
   if server_pid and server_pid > 0 then
-    child.kill(server_pid, signal.SIGKILL)
-    child.wait(server_pid)
+    proc.kill(server_pid, signal.SIGKILL)
+    proc.wait(server_pid)
     server_pid = nil
   end
   if listener then

--- a/lib/perf/bench/startup_bench.tl
+++ b/lib/perf/bench/startup_bench.tl
@@ -62,12 +62,11 @@ local function spawn_capture(bin: string, argv_tail: {string}): string
   for _, a in ipairs(argv_tail) do
     table.insert(argv, a)
   end
-  local handle, serr = child.spawn(argv)
-  assert(handle, serr)
-  local hh = handle as child.Handle
-  local ok, out, code = hh:read()
-  assert(ok, "exit code " .. tostring(code) .. ": " .. tostring(out))
-  return ((out as string):gsub("%s+$", ""))
+  local result, serr = child.run(argv)
+  assert(result, serr)
+  local r = result as child.Result
+  assert(r.ok, "exit code " .. tostring(r.code) .. ": " .. tostring(r.stdout))
+  return (r.stdout:gsub("%s+$", ""))
 end
 
 local function scenarios(): {pt.Scenario}, string

--- a/lib/perf/bench/stream_bench.tl
+++ b/lib/perf/bench/stream_bench.tl
@@ -8,7 +8,7 @@
 
 local net = require("cosmic.net")
 local fetch = require("cosmic.fetch")
-local child = require("cosmic.child")
+local proc = require("cosmic.proc")
 local signal = require("cosmic.signal")
 local pt = require("perf.perf_types")
 
@@ -101,7 +101,7 @@ local function scenarios(): {pt.Scenario}, string
     return nil, "listen_tcp: " .. tostring(lerr)
   end
   listener = srv
-  local pid = child.fork()
+  local pid = proc.fork()
   if pid == 0 then
     serve_loop(srv)
     os.exit(0)
@@ -155,8 +155,8 @@ end
 
 local function cleanup()
   if server_pid and server_pid > 0 then
-    child.kill(server_pid, signal.SIGKILL)
-    child.wait(server_pid)
+    proc.kill(server_pid, signal.SIGKILL)
+    proc.wait(server_pid)
     server_pid = nil
   end
   if listener then


### PR DESCRIPTION
Closes #527 (review item 11 / T3 of the pre-stable API review).

The flagship process API could not manage a running child, leaked zombies, and had a result shape that would freeze badly at stable. This reworks it into a structured, ergonomic layer over the raw syscalls.

## New surface (`cosmic.child`)

```teal
local record Result
  code: integer   -- nil if signaled
  signal: integer -- nil if exited
  ok: boolean     -- code == 0
  stdout: string
  stderr: string
end
local record Handle
  pid: integer
  kill: function(self, sig?: number): boolean, string          -- default SIGTERM
  try_wait: function(self): Result | nil, string                -- WNOHANG; nil,nil if running
  wait: function(self, timeout_ms?: integer): Result | nil, string  -- nil,"timeout"
  read: function(self, size: integer): string | nil, string     -- size REQUIRED; streaming only
end
child.spawn: function(argv, opts?): Handle | nil, string
child.run:   function(argv, opts?): Result | nil, string        -- one-shot
```

## What changed

- **Signal death is data**, not a string to parse: `Result.signal` / `Result.code` (exactly one set), `ok`, plus captured `stdout`/`stderr`.
- **Visible exec failures**: an extra `O_CLOEXEC` status pipe lets the forked child report the errno on exec failure, so `spawn` itself returns `nil, "exec failed: ENOENT: ..."` instead of a bogus later exit 127. The pipe EOFs instantly on success.
- **No zombies**: `__gc`/`__close` SIGKILL and reap an un-waited child and close its fds, so dropping a handle never leaks (verified end-to-end: the child is fully reaped, not left as `Z`).
- **Timeouts + kill**: `child_io.pump` is now deadline-aware and resumable via a shared `PumpState`, computing remaining time before each `poll` and returning partial output on expiry. `kill(sig?)` defaults to SIGTERM.
- **Idempotent wait**: the reaped `Result` is cached, so a second `wait()` returns it instead of failing with "No child process".
- **Low-level relocation**: raw `fork`/`wait`/`kill`/`posix_spawn`/`posix_spawnp` and the `W*` status helpers (+ `WNOHANG`/`WUNTRACED`/`WCONTINUED`) move to `cosmic.proc` — one home for raw process control; `child` is now the high-level spawn API.

## TDD cases from the issue (all in `child_test.tl`)

(a) kill sleep-10 → `r.signal == 15`; (b) two `wait()`s return the same `Result`; (c) `wait(100)` on sleep-10 → `nil, "timeout"`; (d) `spawn({"/no/such/bin"})` → `nil, err:match("ENOENT")`; (e) `run({"sh","-c","echo o; echo e >&2; exit 3"})` → stdout `"o\n"`, stderr `"e\n"`, code 3. Plus an anti-zombie GC-reap guard.

## Knock-ons

Every in-repo spawn call site (`~40` test/example/bench files), `child_example.tl` (now demonstrates `run`, `kill`, and bounded `wait`), `testrun.tl`, `build-stage.tl`, `docs/publish.tl`, and the perf benches are migrated to `run()`/`wait()`/`Result`. `testrun.run` maps an exec failure to the conventional exit 127.

## Gates

`bin/make ci` green: format (226) + teal (226) + test (102) + example (18) + lint (292).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAth2YDDUuauZSjCcRVnpb)_