### PR TITLE
sandboxing: fail-closed pledge/unveil, real capability probes, Box:run error channel, landlock file rules

### DIFF
--- a/lib/cosmic/landlock.tl
+++ b/lib/cosmic/landlock.tl
@@ -45,6 +45,12 @@ local TRUNCATE < const > = unix.LANDLOCK_ACCESS_FS_TRUNCATE as integer -- ABI 3+
 --- `READ` and `EXEC` are self-explanatory.
 local READ < const > = READ_FILE | READ_DIR
 local EXEC < const > = EXECUTE
+--- Access bits that can attach to a non-directory inode. The kernel
+--- rejects a rule carrying directory-only rights (READ_DIR, MAKE_*,
+--- REMOVE_*, REFER) on a regular file with EINVAL, so restrict() masks
+--- file rules down to these — mirroring what the libc unveil path does
+--- after fstat.
+local FILE_BITS < const > = READ_FILE | WRITE_FILE | EXECUTE | TRUNCATE
 local WRITE < const > = WRITE_FILE | REMOVE_FILE | REMOVE_DIR
 | MAKE_REG | MAKE_DIR | MAKE_SYM
 | MAKE_SOCK | MAKE_FIFO | MAKE_CHAR | MAKE_BLOCK
@@ -54,7 +60,9 @@ local ALL < const > = READ | WRITE | EXEC | REFER | TRUNCATE
 --- A single path -> access-mask rule in a restrict() call.
 --- `access` is an OR of cosmic.landlock.* flag constants (READ, EXEC,
 --- WRITE_FILE, MAKE_REG, etc.) and must be a subset of the call's
---- `handled` mask.
+--- `handled` mask. When `path` is not a directory, directory-only
+--- rights are stripped automatically, so `access = READ` works on a
+--- regular file even though READ bundles READ_DIR.
 local record Rule
   path: string
   access: integer
@@ -132,6 +140,12 @@ end
 --- Access categories above the running kernel's ABI are stripped from
 --- `handled` automatically, so `cosmic.landlock.ALL` stays portable.
 --- The ruleset fd is always closed before return.
+---
+--- Known gap: TRUNCATE is only handleable on landlock ABI >= 3, so on
+--- older kernels a restricted process can still truncate(2) files
+--- outside its allowlist. (Cosmopolitan's C unveil path plugs this with
+--- a seccomp filter; this module does not.) Pair with `cosmic.pledge`
+--- — truncate is governed by its "wpath" group — where that matters.
 local function restrict(opts: RestrictOpts): boolean, string
   opts = opts or {}
   local abi_version, aerr = abi()
@@ -156,11 +170,22 @@ local function restrict(opts: RestrictOpts): boolean, string
     if not pfd then
       return fail(string.format("open(%q): %s", rule.path, tostring(perr)))
     end
-    local ok, rerr = unix.landlock_add_rule(rsfd, pfd as integer, access, 0)
-    unix.close(pfd)
-    if not ok then
-      return fail(string.format("add_rule(%q): %s", rule.path, tostring(rerr)))
+    -- Directory-only rights on a non-directory rule are an EINVAL from
+    -- the kernel; strip them so file paths accept the composite masks
+    -- (READ, RW, ...). A rule left with no grantable bits is skipped —
+    -- landlock denies by default, so granting nothing needs no rule.
+    local st = unix.fstat(pfd as integer)
+    if st and not unix.S_ISDIR(st:mode()) then
+      access = access & FILE_BITS
     end
+    if access ~= 0 then
+      local ok, rerr = unix.landlock_add_rule(rsfd, pfd as integer, access, 0)
+      if not ok then
+        unix.close(pfd)
+        return fail(string.format("add_rule(%q): %s", rule.path, tostring(rerr)))
+      end
+    end
+    unix.close(pfd)
   end
   if opts.no_new_privs ~= false then
     local ok, err = unix.prctl(unix.PR_SET_NO_NEW_PRIVS, 1)

--- a/lib/cosmic/landlock_test.tl
+++ b/lib/cosmic/landlock_test.tl
@@ -161,7 +161,9 @@ if g then io.write("sibling-leaked\n"); g:close() else io.write("sibling-blocked
     return
   end
   local s = out as string
-  if s:find("restrict-failed") then
+  -- Plain-text find: "-" is a Lua pattern quantifier, so a pattern
+  -- search for "restrict-failed" would never match the literal marker.
+  if s:find("restrict-failed", 1, true) then
     -- The EINVAL this test pins came from add_rule; that regression is
     -- a hard failure. Anything else (create_ruleset / restrict_self
     -- blocked by an outer sandbox) is a strict skip.

--- a/lib/cosmic/landlock_test.tl
+++ b/lib/cosmic/landlock_test.tl
@@ -120,6 +120,63 @@ if g then io.write("denied-leaked\n"); g:close() else io.write("denied-blocked\n
 end
 test_restrict_denies_outside_allowlist()
 
+-- A rule whose path is a regular file must work with the composite
+-- READ mask: READ bundles READ_DIR, and the kernel EINVALs a
+-- directory-only right attached to a non-directory — restrict() must
+-- mask file rules down to the file-applicable bits (as the C unveil
+-- path does) instead of failing opaquely. Enforcement is irreversible,
+-- so the live check runs in a subprocess.
+local function test_restrict_single_file_rule()
+  if not landlock.available() then
+    a.skip("landlock unavailable (kernel lacks landlock)")
+    return
+  end
+
+  local dir = fs.join(tmpdir, "filerule")
+  fs.makedirs(dir)
+  local target = fs.join(dir, "target.txt")
+  local sibling = fs.join(dir, "sibling.txt")
+  cio.barf(target, "target-content")
+  cio.barf(sibling, "sibling-content")
+
+  local script = fs.join(tmpdir, "landlock_filerule.lua")
+  cio.barf(script, string.format([[
+local ll = require("cosmic.landlock")
+local ok, err = ll.restrict{ rules = { { path = %q, access = ll.READ } } }
+if not ok then
+  io.write("restrict-failed: " .. tostring(err) .. "\n")
+  os.exit(0)
+end
+local f = io.open(%q, "r")
+if f then io.write("file-ok\n"); f:close() else io.write("file-fail\n") end
+local g = io.open(%q, "r")
+if g then io.write("sibling-leaked\n"); g:close() else io.write("sibling-blocked\n") end
+]], target, target, sibling))
+
+  local h = spawn.spawn({cosmic, script})
+  local __r2 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, out = __r2.ok, __r2.stdout
+  if not ok then
+    a.skip("landlock restrict blocked (subprocess died before enforcing)", true)
+    return
+  end
+  local s = out as string
+  if s:find("restrict-failed") then
+    -- The EINVAL this test pins came from add_rule; that regression is
+    -- a hard failure. Anything else (create_ruleset / restrict_self
+    -- blocked by an outer sandbox) is a strict skip.
+    assert(not s:find("add_rule(", 1, true),
+      "single-file READ rule must not fail in add_rule: " .. s)
+    a.skip("landlock restrict blocked: " .. s, true)
+    return
+  end
+  assert(s:find("file-ok", 1, true), "single-file rule should read: " .. s)
+  assert(s:find("sibling-blocked", 1, true),
+    "sibling outside the rule must be blocked: " .. s)
+  a.enforced("landlock single-file rule")
+end
+test_restrict_single_file_rule()
+
 -- The rule-loop error path runs before any enforcement, so it is safe
 -- in-process. This exercises the O_PATH open of each rule path (the
 -- vendored Lua predecessor crashed here on a nil unix.O_PATH instead

--- a/lib/cosmic/pledge.tl
+++ b/lib/cosmic/pledge.tl
@@ -5,6 +5,13 @@
 --- kernel terminates the process. Use pledge in conjunction with
 --- `cosmic.unveil` to also narrow filesystem visibility.
 ---
+--- The API is fail-closed: on hosts where the libc cannot enforce a
+--- pledge (anything other than Linux or OpenBSD), `apply` returns
+--- `false, "pledge unsupported on this host"` instead of reporting a
+--- sandbox that does not exist. Callers that prefer the old fail-open
+--- behavior opt in explicitly with `best_effort = true`, or branch on
+--- `available()` themselves.
+---
 --- Common promise groups:
 ---
 ---   stdio     standard I/O (read, write, close)
@@ -19,32 +26,76 @@
 ---   exec      execve
 ---   unveil    permit subsequent unveil calls
 local unix = require("cosmo.unix")
-local errstr = require("cosmic.errno").str
+local errno = require("cosmic.errno")
+
+--- Options for `apply`. `exec` sets the promises children keep after
+--- execve. `best_effort` turns an unsupported host into a successful
+--- no-op instead of an error — the explicit fail-open escape hatch.
+local record ApplyOpts
+  exec: string
+  best_effort: boolean
+end
+
+local avail: boolean = nil
+
+--- True when pledge(2) is actually enforceable on this host (Linux via
+--- seccomp, OpenBSD natively). Probed once with a no-op
+--- `unix.pledge(nil, nil)` call — the libc fails that probe closed with
+--- ENOSYS where enforcement is impossible — and cached. A non-ENOSYS
+--- failure (e.g. EPERM from an outer filter) still proves the syscall
+--- is wired up.
+---
+--- @return boolean True when a pledge can be enforced
+local function available(): boolean
+  if avail ~= nil then return avail end
+  if unix.pledge == nil then
+    avail = false
+    return avail
+  end
+  local ok, _, eno = unix.pledge(nil, nil)
+  if ok then
+    avail = true
+  elseif errno.is(eno, "ENOSYS") then
+    avail = false
+  else
+    avail = true
+  end
+  return avail
+end
 
 --- Apply a pledge to the current process.
 ---
 --- The call is irreversible; subsequent invocations may only narrow the
---- set of permitted promises. Passing nil leaves that tier unrestricted.
+--- set of permitted promises. Fail-closed: on a host where pledge
+--- cannot be enforced this returns `false, "pledge unsupported on this
+--- host"` rather than succeeding without a sandbox; pass
+--- `best_effort = true` to treat that case as a successful no-op.
 ---
---- @param promises string|nil Space-separated promise groups for this process
---- @param execpromises string|nil Promises for child processes after exec
---- @param mode number|nil Optional mode flags
+--- @param promises string Space-separated promise groups for this process
+--- @param opts ApplyOpts? `exec` promises after execve; `best_effort` escape hatch
 --- @return boolean True on success
 --- @return string? Error message on failure
-local function apply(promises: string, execpromises: string, mode: number): boolean, string
-  local ok, err = unix.pledge(promises, execpromises, mode)
+local function apply(promises: string, opts?: ApplyOpts): boolean, string
+  if not available() then
+    if opts and opts.best_effort then return true end
+    return false, "pledge unsupported on this host"
+  end
+  local ok, err = unix.pledge(promises, opts and opts.exec)
   if not ok then
-    return false, errstr(err, "pledge")
+    return false, errno.str(err, "pledge")
   end
   return true
 end
 
 local record PledgeModule
-  apply: function(promises: string, execpromises: string, mode: number): boolean, string
+  type ApplyOpts = ApplyOpts
+  apply: function(promises: string, opts?: ApplyOpts): boolean, string
+  available: function(): boolean
 end
 
 local M: PledgeModule = {
   apply = apply,
+  available = available,
 }
 
 return M

--- a/lib/cosmic/pledge_test.tl
+++ b/lib/cosmic/pledge_test.tl
@@ -10,13 +10,45 @@ local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function test_module_exports()
   assert(type(pledge.apply) == "function", "apply should be a function")
+  assert(type(pledge.available) == "function", "available should be a function")
 end
 test_module_exports()
+
+local function test_available_returns_boolean()
+  local v = pledge.available()
+  assert(type(v) == "boolean", "available() should return a boolean, got " .. type(v))
+end
+test_available_returns_boolean()
+
+-- Fail-closed contract: on a host where pledge cannot be enforced,
+-- apply() must say so instead of reporting a sandbox that does not
+-- exist — unless the caller opts into best_effort explicitly. The
+-- unsupported branch never reaches the syscall, so this is safe
+-- in-process; on supported hosts (Linux, OpenBSD) it cannot be
+-- exercised and enforcement is proven by the subprocess tests below.
+local function test_fail_closed_when_unavailable()
+  if pledge.available() then
+    a.skip("pledge available on this host; fail-closed path not exercisable")
+    return
+  end
+  local ok, err = pledge.apply("stdio")
+  assert(not ok, "apply must fail when pledge is unsupported")
+  assert(type(err) == "string" and err:find("unsupported"),
+    "error should say unsupported: " .. tostring(err))
+  local ok2, err2 = pledge.apply("stdio", {best_effort = true})
+  assert(ok2 and err2 == nil,
+    "best_effort must turn unsupported into a successful no-op")
+end
+test_fail_closed_when_unavailable()
 
 local function test_stdio_allows_write()
   local script = fs.join(tmpdir, "pledge_stdio.lua")
   cio.barf(script, [[
 local pledge = require("cosmic.pledge")
+if not pledge.available() then
+  io.write("skipped: pledge unsupported on this host\n")
+  os.exit(0)
+end
 local ok, err = pledge.apply("stdio")
 if not ok then
   io.stderr:write("pledge failed: " .. tostring(err) .. "\n")
@@ -27,8 +59,13 @@ io.write("pledged\n")
   local h = spawn.spawn({cosmic, script})
   local __r1 = (h as spawn.Handle):wait() as spawn.Result
   local ok, out = __r1.ok, __r1.stdout
+  local s = (out or "") as string
+  if s:find("skipped") then
+    a.skip("pledge unsupported on this host: " .. s)
+    return
+  end
   assert(ok, "pledge stdio should allow io.write: " .. tostring(out))
-  assert((out as string):find("pledged"), "should print after pledge: " .. tostring(out))
+  assert(s:find("pledged"), "should print after pledge: " .. tostring(out))
 end
 test_stdio_allows_write()
 
@@ -39,6 +76,10 @@ local function test_restricts_filesystem()
   local script = fs.join(tmpdir, "pledge_no_fs.lua")
   cio.barf(script, [[
 local pledge = require("cosmic.pledge")
+if not pledge.available() then
+  io.write("unsupported: pledge unsupported on this host\n")
+  os.exit(0)
+end
 local ok, err = pledge.apply("stdio")
 if not ok then
   io.write("skipped: pledge apply failed: " .. tostring(err) .. "\n")
@@ -56,10 +97,15 @@ io.write("restricted\n")
   local __r2 = (h as spawn.Handle):wait() as spawn.Result
   local ok, out = __r2.ok, __r2.stdout
   local s = (out or "") as string
+  if s:find("unsupported") then
+    -- A genuine platform gap reported by the fail-closed probe: soft skip.
+    a.skip("pledge unsupported on this host: " .. s)
+    return
+  end
   if s:find("skipped") then
-    -- pledge is supported on every platform cosmic targets (Linux via
-    -- seccomp, OpenBSD native); an apply failure means an outer sandbox
-    -- pre-empted it. Strict: a hard failure on the enforce lane.
+    -- available() was true yet apply failed: an outer sandbox pre-empted
+    -- an otherwise-supported mechanism. Strict: a hard failure on the
+    -- enforce lane.
     a.skip("pledge apply failed: " .. s, true)
     return
   end

--- a/lib/cosmic/quicksand/box/init.tl
+++ b/lib/cosmic/quicksand/box/init.tl
@@ -140,6 +140,13 @@ end
 -- a specific error naming the first missing capability so callers can
 -- distinguish "not on Linux" from "landlock unavailable" etc.
 local function preflight(opts: BoxOpts): boolean, string
+  -- Policy-shape problems are reported before host-capability gaps:
+  -- they are actionable everywhere and must not be masked by whatever
+  -- capability this particular host happens to lack.
+  if opts and opts.fs and opts.fs.deny
+  and not (opts.fs.ro or opts.fs.rw or opts.fs.exec) then
+    return false, "quicksand: fs.deny requires at least one of fs.ro, fs.rw, or fs.exec (deny is informational; landlock is allowlist-based)"
+  end
   local c = caps()
   if not c.linux then
     return false, "quicksand: Linux only"
@@ -156,9 +163,6 @@ local function preflight(opts: BoxOpts): boolean, string
     end
     local fs = opts.fs
     local has_fs = fs and (fs.ro or fs.rw or fs.exec)
-    if fs and fs.deny and not has_fs then
-      return false, "quicksand: fs.deny requires at least one of fs.ro, fs.rw, or fs.exec (deny is informational; landlock is allowlist-based)"
-    end
     if has_fs and not c.landlock then
       return false, "quicksand: landlock unavailable (fs policy requested)"
     end

--- a/lib/cosmic/quicksand/box/init_example.tl
+++ b/lib/cosmic/quicksand/box/init_example.tl
@@ -34,21 +34,27 @@ local function Example_merge()
 end
 
 -- Example_run_return_shape demonstrates that run() always comes back
--- as a clean (integer|nil, string|nil) pair, whether the workload ran
--- to completion or the box could not be assembled on this host. The
--- caller distinguishes "assembly failed" from "process exited" by
--- checking whether code is nil.
+-- as a clean (integer|nil, string|nil) pair with exactly one side set:
+-- an integer exit code when the workload actually ran, or nil plus an
+-- error string when the box could not be assembled on this host (setup
+-- failures are never disguised as workload exit codes). The caller
+-- distinguishes the two by checking whether code is nil.
 local function Example_run_return_shape()
   local Box = require("cosmic.quicksand.box")
   local j = assert(Box.new()) as Box.Box
   local code, err = j:run({"/bin/true"})
-  if code == nil then
-    io.write("err " .. tostring((err or ""):sub(1, 10)) .. "\n")
+  -- Which side is set varies by host capability, so assert the shape
+  -- invariant rather than printing the values: exactly one of
+  -- (code, err) is ever set.
+  assert((code == nil) ~= (err == nil), "run() must set exactly one of code/err")
+  if code ~= nil then
+    assert(type(code) == "number", "exit code must be an integer")
   else
-    io.write("code " .. type(code) .. "\n")
+    assert(type(err) == "string", "assembly failure must carry a message")
   end
+  io.write("exclusive\n")
   -- Output:
-  -- code number
+  -- exclusive
 end
 
 return {}

--- a/lib/cosmic/quicksand/box/run.tl
+++ b/lib/cosmic/quicksand/box/run.tl
@@ -19,6 +19,14 @@
 ---   6. supervisor runs become_init(workload_pid, {sidecars={proxy_pid}})
 ---      and os.exit()s with the returned code. parent maps wait status
 ---      to an exit code and returns it from run().
+---
+--- Setup failures are reported over a CLOEXEC error pipe (the same
+--- pattern proxy.start uses for its bound port): the supervisor and the
+--- pre-exec workload write the failing step there before exiting, and a
+--- successful execve closes the workload's end automatically. run()
+--- drains the pipe after wait() — a non-empty pipe always means setup
+--- failed before the workload ran, so run() returns nil + the message
+--- instead of masquerading the failure as a workload exit code.
 local unix = require("cosmo.unix")
 local cosmo = require("cosmo")
 local netns = require("cosmic.quicksand.netns")
@@ -125,32 +133,38 @@ local function workload_setup(opts: {string: any}): string
     if not ok then return "drop_privs: " .. tostring(err) end
   end
   if pr and pr.pledge then
-    local ok, err = pledge.apply(pr.pledge as string, nil, nil)
+    local ok, err = pledge.apply(pr.pledge as string)
     if not ok then return "pledge: " .. tostring(err) end
   end
   return nil
 end
 
-local function exec_workload(argv: {string}, env_list: {string})
+local function exec_workload(err_fd: integer, argv: {string}, env_list: {string})
   local ok, err = (u.execvpe as function(string, {string}, {string}): boolean, any)(
     argv[1], argv, env_list)
   if not ok then
-    io.stderr:write("quicksand: execvpe " .. tostring(argv[1])
-      .. ": " .. tostring(err) .. "\n")
+    unix.write(err_fd, "execvpe " .. tostring(argv[1])
+      .. ": " .. tostring(err))
   end
   os.exit(127)
 end
 
 -- Supervisor child entry point. Never returns: always exits the process.
+-- Setup failures are written to err_fd (run()'s error pipe) so the
+-- parent surfaces them as nil + error instead of an exit code.
 local function supervisor(
     parent_netns_fd: integer,
+    err_fd: integer,
     opts: {string: any},
     argv: {string})
+  local function die(msg: string)
+    unix.write(err_fd, msg)
+    os.exit(126)
+  end
   local flags = clone_flags(opts)
   local ok, err = (u.unshare as function(integer): boolean, any)(flags)
   if not ok then
-    io.stderr:write("quicksand: unshare: " .. tostring(err) .. "\n")
-    os.exit(126)
+    die("unshare: " .. tostring(err))
   end
 
   local pr = opts and opts.proc as {string: any}
@@ -158,23 +172,19 @@ local function supervisor(
   local gid: integer = pr and pr.gid as integer
   local ok2, err2 = qproc.setup_userns_maps(uid, gid)
   if not ok2 then
-    io.stderr:write("quicksand: setup_userns_maps: "
-      .. tostring(err2) .. "\n")
-    os.exit(126)
+    die("setup_userns_maps: " .. tostring(err2))
   end
 
   local ok3, err3 = netns.bring_up("lo")
   if not ok3 then
-    io.stderr:write("quicksand: bring_up lo: " .. tostring(err3) .. "\n")
-    os.exit(126)
+    die("bring_up lo: " .. tostring(err3))
   end
 
   if opts and opts.hostname then
     local ok4, err4 = (u.sethostname as function(string): boolean, any)(
       opts.hostname as string)
     if not ok4 then
-      io.stderr:write("quicksand: sethostname: " .. tostring(err4) .. "\n")
-      os.exit(126)
+      die("sethostname: " .. tostring(err4))
     end
   end
 
@@ -192,9 +202,7 @@ local function supervisor(
     }
     local h, perr = proxy_start(popts)
     if not h then
-      io.stderr:write("quicksand: proxy.start: "
-        .. tostring(perr) .. "\n")
-      os.exit(126)
+      die("proxy.start: " .. tostring(perr))
     end
     table.insert(sidecars, h.pid as integer)
     proxy_port = h.port as integer
@@ -213,17 +221,15 @@ local function supervisor(
 
   local pid, ferr = (u.fork as function(): integer, any)()
   if not pid then
-    io.stderr:write("quicksand: fork workload: "
-      .. tostring(ferr) .. "\n")
-    os.exit(126)
+    die("fork workload: " .. tostring(ferr))
   end
   if pid == 0 then
     local serr = workload_setup(opts)
     if serr then
-      io.stderr:write("quicksand: " .. serr .. "\n")
+      unix.write(err_fd, serr)
       os.exit(126)
     end
-    exec_workload(argv, env_list)
+    exec_workload(err_fd, argv, env_list)
     return -- unreachable
   end
 
@@ -232,8 +238,11 @@ local function supervisor(
 end
 
 --- Fork+orchestrate a Box policy around argv. Returns an integer exit
---- code on success, or nil + string when setup itself failed before the
---- fork (e.g. couldn't open the parent netns fd).
+--- code on success, or nil + string when setup failed — either before
+--- the fork (e.g. couldn't open the parent netns fd) or inside the
+--- supervisor / pre-exec workload (unshare, uid_map, landlock, pledge,
+--- execvpe, ...), which report over the error pipe. An integer return
+--- is therefore always the workload's own exit status.
 local function run(opts: {string: any}, argv: {string}): integer | nil, string
   local parent_fd: integer = nil
   local net = opts and opts.net as {string: any}
@@ -245,23 +254,56 @@ local function run(opts: {string: any}, argv: {string}): integer | nil, string
     parent_fd = fd
   end
 
+  -- CLOEXEC error pipe: a successful execve closes the workload's
+  -- write end automatically, so a non-empty pipe always means setup
+  -- failed before the workload ran.
+  local er, ew = unix.pipe(unix.O_CLOEXEC)
+  if not er then
+    if parent_fd then
+      (u.close as function(integer): boolean)(parent_fd)
+    end
+    return nil, "quicksand: pipe: " .. tostring(ew)
+  end
+  local erfd = er as integer
+  local ewfd = ew as integer
+
   local pid, ferr = (u.fork as function(): integer, any)()
   if not pid then
+    unix.close(erfd)
+    unix.close(ewfd)
     if parent_fd then
       (u.close as function(integer): boolean)(parent_fd)
     end
     return nil, "quicksand: fork: " .. tostring(ferr)
   end
   if pid == 0 then
-    supervisor(parent_fd, opts, argv)
+    unix.close(erfd)
+    supervisor(parent_fd, ewfd, opts, argv)
     os.exit(127) -- unreachable
   end
 
+  unix.close(ewfd)
   if parent_fd then
     (u.close as function(integer): boolean)(parent_fd)
   end
 
   local _, status = (u.wait as function(integer): integer, integer)(pid as integer)
+
+  -- Drain the error pipe. Every write end is closed by now — the
+  -- supervisor exited, and become_init reaped the workload and sidecars
+  -- before that — so this reads to EOF without blocking.
+  local parts: {string} = {}
+  while true do
+    local chunk = unix.read(erfd, 4096)
+    if not chunk or #chunk == 0 then break end
+    table.insert(parts, chunk)
+  end
+  unix.close(erfd)
+  if #parts > 0 then
+    local msg = table.concat(parts):gsub("%s+$", "")
+    return nil, "quicksand: " .. msg
+  end
+
   if (u.WIFEXITED as function(integer): boolean)(status) then
     return (u.WEXITSTATUS as function(integer): integer)(status)
   end

--- a/lib/cosmic/quicksand/box/run_test.tl
+++ b/lib/cosmic/quicksand/box/run_test.tl
@@ -2,95 +2,152 @@
 --- Integration test for cosmic.quicksand.Box:run.
 ---
 --- box:run unshares CLONE_NEWUSER, which is irreversible for the
---- calling thread — and can be blocked entirely by an outer seccomp /
---- pledge filter. Run the workload in a fresh cosmic subprocess so
---- failures don't poison the rest of the test harness, and follow the
---- same "ok | skipped | signal death = skip" pattern the raw netns /
---- proc tests use.
+--- calling thread, so every workload runs in a fresh cosmic subprocess.
+--- capabilities().user_ns is a real scratch-child unshare probe now, so
+--- when the guard passes, setup is expected to succeed: setup failures
+--- surface as nil + error over Box:run's error pipe and are hard test
+--- failures, not skips. The only tolerated skips are named, specific
+--- conditions (an outer seccomp filter SIGSYS-ing the subprocess, or a
+--- uid_map write that needs privileges this test does not have).
 local quicksand = require("cosmic.quicksand")
 local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
 local cio = require("cosmic.io")
+local a = require("cosmic.assert")
 
 local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
+-- Run `script` in a fresh cosmic subprocess. Returns the Result, or nil
+-- after registering a strict skip when the subprocess was killed by a
+-- signal (an outer seccomp filter SIGSYS-ing a namespace syscall).
+local function run_script(name: string, body: string): spawn.Result
+  local script = fs.join(tmpdir, name)
+  cio.barf(script, body)
+  local h = spawn.spawn({cosmic, script})
+  local r = (h as spawn.Handle):wait() as spawn.Result
+  if r.signal ~= nil then
+    a.skip("box subprocess killed by signal " .. tostring(r.signal)
+      .. " (outer sandbox)", true)
+    return nil
+  end
+  return r
+end
+
 local function test_run_true_in_subprocess()
   local c = quicksand.capabilities()
-  if not (c.linux and c.user_ns and c.net_ns) then return end
+  if not (c.linux and c.user_ns and c.net_ns) then
+    a.skip("box namespaces unavailable on this host")
+    return
+  end
 
-  local script = fs.join(tmpdir, "box_run_true.lua")
-  cio.barf(script, [[
+  -- user_ns probed true above, so setup must succeed: a nil + error
+  -- return or a non-zero exit from /bin/true is a real failure.
+  local r = run_script("box_run_true.lua", [[
 local qs = require("cosmic.quicksand")
 local j, nerr = qs.Box.new({})
 if not j then io.stderr:write("new: " .. tostring(nerr) .. "\n"); os.exit(1) end
 local code, rerr = j:run({"/bin/true"})
 if code == nil then
-  -- Setup failed before fork (e.g. netns.open). With an empty policy
-  -- there's no net allowlist so netns.open isn't called; any nil here
-  -- is a genuine infrastructure problem. Surface the error instead of
-  -- masking it as a skip.
   io.stderr:write("run nil: " .. tostring(rerr) .. "\n"); os.exit(1)
 end
-if code == 0 then io.write("ok exit=0\n"); os.exit(0) end
--- Non-zero: the supervisor child exited 126 after unshare / userns
--- setup failed under an outer pledge / seccomp filter. Distinguishing
--- that from a real /bin/true crash here isn't reliable, so treat any
--- non-zero as a skip.
-io.write("skipped: exit=" .. tostring(code) .. "\n"); os.exit(0)
+if code ~= 0 then
+  io.stderr:write("run exit=" .. tostring(code) .. "\n"); os.exit(1)
+end
+io.write("ok exit=0\n")
 ]])
-
-  local h = spawn.spawn({cosmic, script})
-  local __r1 = (h as spawn.Handle):wait() as spawn.Result
-  local ok, out = __r1.ok, __r1.stdout
-  -- An outer seccomp filter may SIGSYS the subprocess outright; that
-  -- still counts as a skip because we never reached enforcement.
-  if not ok then return end
-  local s = out as string
-  assert(s:find("ok exit=0") or s:find("skipped"),
-    "expected ok or skipped, got: " .. s)
+  if not r then return end
+  assert(r.ok, "box run of /bin/true must succeed: "
+    .. tostring(r.stdout) .. tostring(r.stderr))
+  assert((r.stdout as string):find("ok exit=0"),
+    "expected ok, got: " .. tostring(r.stdout))
 end
 test_run_true_in_subprocess()
 
+-- Setup failures must come back on the error channel as nil + message,
+-- not masquerade as a workload exit code (they used to surface as
+-- 126, nil with the reason only on stderr). A bogus pledge promise
+-- fails workload_setup after the fork; run() must return nil and an
+-- error naming the pledge step.
+local function test_setup_failure_returns_error_not_exit_code()
+  local c = quicksand.capabilities()
+  if not (c.linux and c.user_ns and c.net_ns and c.pledge) then
+    a.skip("box namespaces or pledge unavailable on this host")
+    return
+  end
+
+  local r = run_script("box_bogus_pledge.lua", [[
+local qs = require("cosmic.quicksand")
+local j, nerr = qs.Box.new({ proc = { pledge = "bogus_promise" } })
+if not j then io.stderr:write("new: " .. tostring(nerr) .. "\n"); os.exit(1) end
+local code, rerr = j:run({"/bin/true"})
+if code ~= nil then
+  io.stderr:write("expected nil, got exit=" .. tostring(code) .. "\n"); os.exit(1)
+end
+if not (type(rerr) == "string" and rerr:find("pledge")) then
+  io.stderr:write("error should name pledge: " .. tostring(rerr) .. "\n"); os.exit(1)
+end
+io.write("ok nil-error: " .. tostring(rerr) .. "\n")
+]])
+  if not r then return end
+  assert(r.ok, "bogus pledge must return nil + pledge error: "
+    .. tostring(r.stdout) .. tostring(r.stderr))
+  assert((r.stdout as string):find("ok nil%-error"),
+    "expected nil-error report, got: " .. tostring(r.stdout))
+end
+test_setup_failure_returns_error_not_exit_code()
+
 -- FIX 1: proc.uid without no_new_privs must still set NoNewPrivs.
 -- The workload reads /proc/self/status and greps for NoNewPrivs:1.
+-- Mapping host uid 65534 into the userns needs privileges an
+-- unprivileged runner lacks; the error channel now names that exact
+-- failure (uid_map write EPERM), which is the one tolerated skip.
 local function test_uid_drop_sets_no_new_privs_subprocess()
   local c = quicksand.capabilities()
-  if not (c.linux and c.user_ns and c.net_ns) then return end
+  if not (c.linux and c.user_ns and c.net_ns) then
+    a.skip("box namespaces unavailable on this host")
+    return
+  end
 
-  local script = fs.join(tmpdir, "box_nnp_uid.lua")
-  cio.barf(script, [[
+  local r = run_script("box_nnp_uid.lua", [[
 local qs = require("cosmic.quicksand")
 local j, nerr = qs.Box.new({ proc = { uid = 65534 } })
 if not j then io.stderr:write("new: " .. tostring(nerr) .. "\n"); os.exit(1) end
 local code, rerr = j:run({"/bin/sh", "-c",
   "grep 'NoNewPrivs:' /proc/self/status | grep -q 1 && echo ok || echo fail"})
 if code == nil then
-  io.stderr:write("run nil: " .. tostring(rerr) .. "\n"); os.exit(1)
+  local e = tostring(rerr)
+  if e:find("uid_map") or e:find("setup_userns_maps") then
+    io.write("skipped: mapping uid 65534 needs privileges: " .. e .. "\n")
+    os.exit(0)
+  end
+  io.stderr:write("run nil: " .. e .. "\n"); os.exit(1)
 end
 if code ~= 0 then
-  -- unshare failed under outer sandbox; treat as skip
-  io.write("skipped: exit=" .. tostring(code) .. "\n"); os.exit(0)
+  io.stderr:write("run exit=" .. tostring(code) .. "\n"); os.exit(1)
 end
 ]])
-
-  local h = spawn.spawn({cosmic, script})
-  local __r2 = (h as spawn.Handle):wait() as spawn.Result
-  local ok, out = __r2.ok, __r2.stdout
-  if not ok then return end
-  local s = out as string
-  assert(s:find("ok") or s:find("skipped"),
-    "expected ok or skipped (NoNewPrivs should be 1), got: " .. s)
+  if not r then return end
+  assert(r.ok, "uid-drop box must succeed or name the uid_map gap: "
+    .. tostring(r.stdout) .. tostring(r.stderr))
+  local s = r.stdout as string
+  if s:find("skipped") then
+    a.skip("uid_map write needs privileges: " .. s)
+    return
+  end
+  assert(s:find("ok"), "NoNewPrivs should be 1, got: " .. s)
 end
 test_uid_drop_sets_no_new_privs_subprocess()
 
 -- FIX 2: PID namespace isolation — workload should get a low PID (<= 2).
 local function test_pid_namespace_workload_has_low_pid_subprocess()
   local c = quicksand.capabilities()
-  if not (c.linux and c.user_ns and c.net_ns and c.pid_ns) then return end
+  if not (c.linux and c.user_ns and c.net_ns and c.pid_ns) then
+    a.skip("box namespaces unavailable on this host")
+    return
+  end
 
-  local script = fs.join(tmpdir, "box_pidns.lua")
-  cio.barf(script, [[
+  local r = run_script("box_pidns.lua", [[
 local qs = require("cosmic.quicksand")
 local j, nerr = qs.Box.new({})
 if not j then io.stderr:write("new: " .. tostring(nerr) .. "\n"); os.exit(1) end
@@ -99,27 +156,26 @@ if code == nil then
   io.stderr:write("run nil: " .. tostring(rerr) .. "\n"); os.exit(1)
 end
 if code ~= 0 then
-  io.write("skipped: exit=" .. tostring(code) .. "\n"); os.exit(0)
+  io.stderr:write("run exit=" .. tostring(code) .. "\n"); os.exit(1)
 end
 ]])
-
-  local h = spawn.spawn({cosmic, script})
-  local __r3 = (h as spawn.Handle):wait() as spawn.Result
-  local ok, out = __r3.ok, __r3.stdout
-  if not ok then return end
-  local s = out as string
-  assert(s:find("ok") or s:find("skipped"),
-    "expected ok or skipped (PID should be <= 2), got: " .. s)
+  if not r then return end
+  assert(r.ok, "pid-ns box must succeed: "
+    .. tostring(r.stdout) .. tostring(r.stderr))
+  assert((r.stdout as string):find("ok"),
+    "workload PID should be <= 2, got: " .. tostring(r.stdout))
 end
 test_pid_namespace_workload_has_low_pid_subprocess()
 
 -- FIX 2: Opt-out of PID namespace via pid_ns = false still runs.
 local function test_pid_namespace_opt_out_subprocess()
   local c = quicksand.capabilities()
-  if not (c.linux and c.user_ns and c.net_ns) then return end
+  if not (c.linux and c.user_ns and c.net_ns) then
+    a.skip("box namespaces unavailable on this host")
+    return
+  end
 
-  local script = fs.join(tmpdir, "box_nopidns.lua")
-  cio.barf(script, [[
+  local r = run_script("box_nopidns.lua", [[
 local qs = require("cosmic.quicksand")
 local j, nerr = qs.Box.new({ pid_ns = false })
 if not j then io.stderr:write("new: " .. tostring(nerr) .. "\n"); os.exit(1) end
@@ -128,17 +184,14 @@ if code == nil then
   io.stderr:write("run nil: " .. tostring(rerr) .. "\n"); os.exit(1)
 end
 if code ~= 0 then
-  io.write("skipped: exit=" .. tostring(code) .. "\n"); os.exit(0)
+  io.stderr:write("run exit=" .. tostring(code) .. "\n"); os.exit(1)
 end
 io.write("ok\n")
 ]])
-
-  local h = spawn.spawn({cosmic, script})
-  local __r4 = (h as spawn.Handle):wait() as spawn.Result
-  local ok, out = __r4.ok, __r4.stdout
-  if not ok then return end
-  local s = out as string
-  assert(s:find("ok") or s:find("skipped"),
-    "expected ok or skipped, got: " .. s)
+  if not r then return end
+  assert(r.ok, "pid_ns opt-out box must succeed: "
+    .. tostring(r.stdout) .. tostring(r.stderr))
+  assert((r.stdout as string):find("ok"),
+    "expected ok, got: " .. tostring(r.stdout))
 end
 test_pid_namespace_opt_out_subprocess()

--- a/lib/cosmic/quicksand/init.tl
+++ b/lib/cosmic/quicksand/init.tl
@@ -19,6 +19,7 @@ local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
 local box = require("cosmic.quicksand.box")
 local caps = require("cosmic.quicksand.caps")
+local qproc = require("cosmic.quicksand.proc")
 local errno = require("cosmic.errno")
 
 --- Fine-grained feature availability on the current host.
@@ -27,7 +28,7 @@ local errno = require("cosmic.errno")
 --- partway through a setup sequence.
 local record Capabilities
   linux: boolean -- host is Linux
-  user_ns: boolean -- CLONE_NEWUSER available (unprivileged usernet)
+  user_ns: boolean -- unshare(NEWUSER|NEWNET|NEWNS) + uid_map verified in a scratch child
   mount_ns: boolean -- CLONE_NEWNS available
   net_ns: boolean -- CLONE_NEWNET available
   uts_ns: boolean -- CLONE_NEWUTS available (for hostname isolation)
@@ -44,6 +45,7 @@ local record QuicksandModule
   capabilities: function(): Capabilities
   is_supported: function(): boolean
   probe: function(fn: any): boolean
+  probe_ns: function(): boolean
   Box: any -- re-export of cosmic.quicksand.box
 end
 
@@ -79,6 +81,55 @@ local function probe_landlock(): boolean
   return abi ~= nil and abi >= 1
 end
 
+--- Probe whether the Box namespace trio can actually be entered: a
+--- scratch child attempts unshare(CLONE_NEWUSER | CLONE_NEWNET |
+--- CLONE_NEWNS) followed by the uid_map / gid_map writes — exactly the
+--- setup sequence Box:run's supervisor performs — and reports the
+--- outcome over a pipe. unshare is irreversible for the caller, so the
+--- attempt must never run in this process.
+---
+--- CLONE_NEWUSER exists as a compile-time constant on every Linux
+--- build, but hosts routinely disable unprivileged user namespaces
+--- (sysctls, seccomp, AppArmor), and others allow the unshare while
+--- blocking the /proc/self/*_map writes; testing the constant reported
+--- user_ns = true on such hosts and Box:run then failed partway
+--- through setup with EPERM. Any probe failure (pipe, fork, unshare,
+--- map writes) reports unavailable — fail-closed.
+---
+--- @return boolean true when the Box userns setup sequence works here
+local function probe_ns(): boolean
+  if unix.CLONE_NEWUSER == nil or unix.CLONE_NEWNET == nil
+  or unix.CLONE_NEWNS == nil then
+    return false
+  end
+  local flags = (unix.CLONE_NEWUSER as integer)
+  | (unix.CLONE_NEWNET as integer)
+  | (unix.CLONE_NEWNS as integer)
+  local r, w = unix.pipe(unix.O_CLOEXEC)
+  if not r then return false end
+  local rfd = r as integer
+  local wfd = w as integer
+  local pid = unix.fork()
+  if pid == nil then
+    unix.close(rfd)
+    unix.close(wfd)
+    return false
+  end
+  if pid == 0 then
+    local ok = unix.unshare(flags)
+    if ok then
+      ok = qproc.setup_userns_maps(nil, nil)
+    end
+    unix.write(wfd, ok and "1" or "0")
+    unix.exit(0)
+  end
+  unix.close(wfd)
+  local b = unix.read(rfd, 1)
+  unix.close(rfd)
+  unix.wait(pid as integer)
+  return b == "1"
+end
+
 local cached: Capabilities = nil
 
 --- Returns a cached Capabilities record for the current host.
@@ -93,7 +144,7 @@ local function capabilities(): Capabilities
   local has_landlock = is_linux and probe_landlock()
   cached = {
     linux = is_linux,
-    user_ns = is_linux and unix.CLONE_NEWUSER ~= nil,
+    user_ns = is_linux and probe_ns(),
     mount_ns = is_linux and unix.CLONE_NEWNS ~= nil,
     net_ns = is_linux and unix.CLONE_NEWNET ~= nil,
     uts_ns = is_linux and unix.CLONE_NEWUTS ~= nil,
@@ -124,6 +175,7 @@ local M: QuicksandModule = {
   capabilities = capabilities,
   is_supported = is_supported,
   probe = probe,
+  probe_ns = probe_ns,
   Box = box,
 }
 

--- a/lib/cosmic/quicksand/init_test.tl
+++ b/lib/cosmic/quicksand/init_test.tl
@@ -33,6 +33,26 @@ local function test_capabilities_cached()
 end
 test_capabilities_cached()
 
+-- capabilities().user_ns is computed by a scratch-child unshare probe
+-- (not the compile-time CLONE_NEWUSER constant, which is defined even on
+-- hosts that forbid unprivileged user namespaces and used to report a
+-- capability that then failed with EPERM mid-setup). Assert the cached
+-- report agrees with a fresh probe, and that the probe is exported and
+-- deterministic.
+local function test_user_ns_agrees_with_scratch_probe()
+  assert(type(quicksand.probe_ns) == "function", "probe_ns should be a function")
+  local fresh = quicksand.probe_ns()
+  assert(type(fresh) == "boolean", "probe_ns() should return a boolean")
+  local c = quicksand.capabilities()
+  if c.linux then
+    a.eq(c.user_ns, fresh,
+      "capabilities().user_ns must agree with a fresh scratch unshare probe")
+  else
+    a.eq(c.user_ns, false, "user_ns must be false off Linux")
+  end
+end
+test_user_ns_agrees_with_scratch_probe()
+
 local function test_is_supported_returns_boolean()
   local v = quicksand.is_supported()
   assert(type(v) == "boolean", "is_supported() should return a boolean, got " .. type(v))

--- a/lib/cosmic/unveil.tl
+++ b/lib/cosmic/unveil.tl
@@ -1,10 +1,16 @@
 --- Restrict filesystem visibility to an allowlisted set of paths.
 ---
---- Once a process calls unveil with any path, the entire filesystem is
---- hidden except for the paths that have been unveiled. Paths are then
---- revealed one at a time with their allowed permission set. When done,
---- call `apply(nil, nil)` to commit the policy; further unveil calls
---- become no-ops or errors.
+--- Once a process unveils any path, the entire filesystem is hidden
+--- except for the paths that have been unveiled. Paths are revealed one
+--- at a time with `allow(path, permissions)`; when done, `commit()`
+--- seals the policy and further unveil calls become no-ops or errors.
+---
+--- The API is fail-closed: unveil is enforceable on OpenBSD (natively)
+--- and on Linux kernels with Landlock (the libc's backing mechanism).
+--- Anywhere else `allow`/`commit` return `false, "unveil unsupported on
+--- this host"` instead of reporting a sandbox that does not exist.
+--- Callers that prefer the old fail-open behavior opt in explicitly
+--- with `best_effort = true`, or branch on `available()` themselves.
 ---
 --- Unveil pairs naturally with `cosmic.pledge`: pledge narrows which
 --- system calls are allowed; unveil narrows which files those calls can
@@ -16,19 +22,60 @@
 ---   w  write operations           (matches pledge "wpath")
 ---   x  execute operations         (matches pledge "exec" / "execnative")
 ---   c  create and remove paths    (matches pledge "cpath")
+local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
 local errstr = require("cosmic.errno").str
 
---- Unveil a path, or commit the policy.
+--- Options for `allow` / `commit`. `best_effort` turns an unsupported
+--- host into a successful no-op instead of an error — the explicit
+--- fail-open escape hatch.
+local record UnveilOpts
+  best_effort: boolean
+end
+
+local avail: boolean = nil
+
+--- True when unveil is actually enforceable on this host: OpenBSD, or
+--- Linux with Landlock ABI >= 1. Derived, never probed with unveil
+--- itself — `unix.unveil(nil, nil)` is the commit call, so probing it
+--- would lock this very process into a deny-all sandbox. The libc backs
+--- unveil with Landlock on Linux, so it enforces exactly when Landlock
+--- does; everywhere else the raw call deliberately fails open, which is
+--- precisely what this wrapper refuses to pass through. Cached.
 ---
---- Call with a path and permission string to expose the path. Call with
---- (nil, nil) to commit the policy and prevent further unveil calls.
+--- @return boolean True when unveil can be enforced
+local function available(): boolean
+  if avail ~= nil then return avail end
+  local host = cosmo.GetHostOs()
+  if host == "OPENBSD" then
+    avail = true
+  elseif host == "LINUX" then
+    local abi = unix.landlock_create_ruleset()
+    avail = abi ~= nil and (abi as integer) >= 1
+  else
+    avail = false
+  end
+  return avail
+end
+
+local unsupported < const > = "unveil unsupported on this host"
+
+--- Unveil a path with the given permission set.
 ---
---- @param path string|nil Path to unveil (nil to commit)
---- @param permissions string|nil Permission string like "r", "rw", "rwxc" (nil to commit)
+--- Fail-closed: on a host where unveil cannot be enforced this returns
+--- `false, "unveil unsupported on this host"` rather than succeeding
+--- without a sandbox; pass `best_effort = true` to treat that case as a
+--- successful no-op.
+---
+--- @param path string Path to unveil
+--- @param permissions string Permission string like "r", "rw", "rwxc"
 --- @return boolean True on success
 --- @return string? Error message on failure
-local function apply(path: string, permissions: string): boolean, string
+local function allow(path: string, permissions: string, opts?: UnveilOpts): boolean, string
+  if not available() then
+    if opts and opts.best_effort then return true end
+    return false, unsupported
+  end
   local ok, err = unix.unveil(path, permissions)
   if not ok then
     return false, errstr(err, "unveil")
@@ -36,11 +83,50 @@ local function apply(path: string, permissions: string): boolean, string
   return true
 end
 
+--- Commit the unveil policy: the allowlist becomes final and further
+--- unveil calls are rejected. Fail-closed like `allow`.
+---
+--- @return boolean True on success
+--- @return string? Error message on failure
+local function commit(opts?: UnveilOpts): boolean, string
+  if not available() then
+    if opts and opts.best_effort then return true end
+    return false, unsupported
+  end
+  local ok, err = unix.unveil(nil, nil)
+  if not ok then
+    return false, errstr(err, "unveil commit")
+  end
+  return true
+end
+
+--- DEPRECATED compatibility shim for the pre-stable API: delegates to
+--- `allow(path, permissions)`, or to `commit()` when both arguments are
+--- nil (the old commit spelling). New code should call allow/commit.
+---
+--- @param path string|nil Path to unveil (nil to commit)
+--- @param permissions string|nil Permission string (nil to commit)
+--- @return boolean True on success
+--- @return string? Error message on failure
+local function apply(path: string, permissions: string): boolean, string
+  if path == nil and permissions == nil then
+    return commit()
+  end
+  return allow(path, permissions)
+end
+
 local record UnveilModule
+  type UnveilOpts = UnveilOpts
+  allow: function(path: string, permissions: string, opts?: UnveilOpts): boolean, string
+  commit: function(opts?: UnveilOpts): boolean, string
+  available: function(): boolean
   apply: function(path: string, permissions: string): boolean, string
 end
 
 local M: UnveilModule = {
+  allow = allow,
+  commit = commit,
+  available = available,
   apply = apply,
 }
 

--- a/lib/cosmic/unveil_example.tl
+++ b/lib/cosmic/unveil_example.tl
@@ -1,29 +1,31 @@
 --- Examples for the cosmic.unveil module.
---- Unveil is OpenBSD-only at runtime; on Linux the call returns ENOSYS.
---- Because unveil commits a process-wide policy, each example runs in a
---- subprocess via cosmic.child.
+--- Unveil enforces on OpenBSD natively and on Linux kernels with
+--- Landlock; `available()` reports which. Because a committed policy is
+--- process-wide and irreversible, each example runs in a subprocess via
+--- cosmic.child.
 
--- Example_apply demonstrates unveiling a single directory read-only and
--- committing the policy. After commit, reading the unveiled file works;
--- reading outside the unveiled tree fails on OpenBSD.
-local function Example_apply()
+-- Example_allow demonstrates unveiling a single directory read-only and
+-- committing the policy. The API is fail-closed: on hosts without a
+-- backing sandbox, allow() returns false + "unveil unsupported on this
+-- host" instead of pretending to restrict.
+local function Example_allow()
   local spawn = require("cosmic.child")
   local cosmic = arg[-1]
   local script = [[
 local unveil = require("cosmic.unveil")
-local sys = require("cosmic.sys")
-if sys.host_os() ~= "openbsd" then
-  io.write("skipped\n")
-  return
+if unveil.available() then
+  assert(unveil.allow("/tmp", "r"))
+  assert(unveil.commit())
+else
+  local ok, err = unveil.allow("/tmp", "r")
+  assert(not ok and err:find("unsupported"))
 end
-assert(unveil.apply("/tmp", "r"))
-assert(unveil.apply(nil, nil))
-io.write("committed\n")
+io.write("done\n")
 ]]
   local r = spawn.run({cosmic, "-e", script}) as spawn.Result
   io.write(r.stdout)
   -- Output:
-  -- skipped
+  -- done
 end
 
 return {}

--- a/lib/cosmic/unveil_test.tl
+++ b/lib/cosmic/unveil_test.tl
@@ -77,12 +77,12 @@ local function test_unveil_restricts_paths()
 local unveil = require("cosmic.unveil")
 local ok, err = unveil.allow(%q, "r")
 if not ok then
-  io.write("blocked: unveil allow failed: " .. tostring(err) .. "\n")
+  io.write("unveil-blocked: allow failed: " .. tostring(err) .. "\n")
   os.exit(0)
 end
 ok, err = unveil.commit()
 if not ok then
-  io.write("blocked: unveil commit failed: " .. tostring(err) .. "\n")
+  io.write("unveil-blocked: commit failed: " .. tostring(err) .. "\n")
   os.exit(0)
 end
 local f = io.open(%q, "r")
@@ -106,7 +106,9 @@ end
   local __r1 = (h as spawn.Handle):wait() as spawn.Result
   local ok, out = __r1.ok, __r1.stdout
   local s = (out or "") as string
-  if s:find("blocked") then
+  -- Plain-text find of the distinct setup marker: the success marker
+  -- "denied-blocked" must not match here.
+  if s:find("unveil-blocked:", 1, true) then
     -- available() was true yet the call failed: an outer sandbox
     -- pre-empted an otherwise-supported mechanism. Strict: a hard
     -- failure on the enforce lane.

--- a/lib/cosmic/unveil_test.tl
+++ b/lib/cosmic/unveil_test.tl
@@ -9,17 +9,62 @@ local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function test_module_exports()
-  assert(type(unveil.apply) == "function", "apply should be a function")
+  assert(type(unveil.allow) == "function", "allow should be a function")
+  assert(type(unveil.commit) == "function", "commit should be a function")
+  assert(type(unveil.available) == "function", "available should be a function")
+  assert(type(unveil.apply) == "function", "apply (compat shim) should be a function")
 end
 test_module_exports()
+
+local function test_available_returns_boolean()
+  local v = unveil.available()
+  assert(type(v) == "boolean", "available() should return a boolean, got " .. type(v))
+end
+test_available_returns_boolean()
+
+-- Fail-closed contract: on a host without a backing sandbox (no
+-- landlock, not OpenBSD), allow/commit/apply must report failure
+-- instead of pretending a sandbox exists — the raw libc call succeeds
+-- there while enforcing nothing. The unsupported branch never reaches
+-- the syscall, so this is safe in-process. best_effort is the explicit
+-- opt-in back to the old fail-open behavior.
+local function test_fail_closed_when_unavailable()
+  if unveil.available() then
+    a.skip("unveil available on this host; fail-closed path not exercisable")
+    return
+  end
+  local dir = fs.join(tmpdir, "fc")
+  fs.makedirs(dir)
+  local ok, err = unveil.allow(dir, "r")
+  assert(not ok, "allow must fail when unveil is unsupported")
+  assert(type(err) == "string" and err:match("unsupported"),
+    "error should say unsupported: " .. tostring(err))
+  local cok, cerr = unveil.commit()
+  assert(not cok and type(cerr) == "string" and cerr:match("unsupported"),
+    "commit must fail-closed too: " .. tostring(cerr))
+  local aok, aerr = unveil.apply(dir, "r")
+  assert(not aok and type(aerr) == "string" and aerr:match("unsupported"),
+    "apply (compat) must fail-closed too: " .. tostring(aerr))
+  assert(unveil.allow(dir, "r", {best_effort = true}),
+    "best_effort must turn unsupported allow into a successful no-op")
+  assert(unveil.commit({best_effort = true}),
+    "best_effort must turn unsupported commit into a successful no-op")
+end
+test_fail_closed_when_unavailable()
 
 -- Unveil only a sub-directory, then confirm both that the unveiled file
 -- reads AND that a sibling file left outside the unveil is hidden. Both
 -- files exist, so the denial is a genuine unveil effect, not a missing
--- path. unveil is OpenBSD-only; on Linux apply() returns ENOSYS and the
--- subprocess reports "skipped" — a genuine platform gap, so it is a soft
--- skip even on the enforce lane (a Linux runner cannot exercise unveil).
+-- path. Runs only where available() is true (OpenBSD natively, Linux
+-- with landlock backing); there a successful commit means enforcement
+-- is real, so a leaking sibling is a hard failure — no hedge.
 local function test_unveil_restricts_paths()
+  if not unveil.available() then
+    -- The fail-closed contract for this host is asserted above.
+    a.skip("unveil unavailable on this host (no landlock, not OpenBSD)")
+    return
+  end
+
   local allowed_dir = fs.join(tmpdir, "vis")
   fs.makedirs(allowed_dir)
   local allowed_file = fs.join(allowed_dir, "unveiled.txt")
@@ -30,14 +75,14 @@ local function test_unveil_restricts_paths()
   local script = fs.join(tmpdir, "unveil_test.lua")
   cio.barf(script, string.format([[
 local unveil = require("cosmic.unveil")
-local ok, err = unveil.apply(%q, "r")
+local ok, err = unveil.allow(%q, "r")
 if not ok then
-  io.write("skipped: unveil unavailable: " .. tostring(err) .. "\n")
+  io.write("blocked: unveil allow failed: " .. tostring(err) .. "\n")
   os.exit(0)
 end
-ok, err = unveil.apply(nil, nil)
+ok, err = unveil.commit()
 if not ok then
-  io.write("skipped: unveil commit failed: " .. tostring(err) .. "\n")
+  io.write("blocked: unveil commit failed: " .. tostring(err) .. "\n")
   os.exit(0)
 end
 local f = io.open(%q, "r")
@@ -48,18 +93,10 @@ if f then
 else
   io.write("read:failed\n")
 end
--- A sibling file outside the unveiled directory must be invisible. On Linux
--- cosmopolitan backs unveil with Landlock; if Landlock is unavailable the
--- apply() call succeeds but does not actually restrict (a no-op), so treat a
--- leak-without-backing as a skip rather than a failure.
 local g = io.open(%q, "r")
 if g then
   g:close()
-  if require("cosmic.landlock").available() then
-    io.write("denied-leaked\n")
-  else
-    io.write("skipped: unveil applied but did not restrict (no backing sandbox)\n")
-  end
+  io.write("denied-leaked\n")
 else
   io.write("denied-blocked\n")
 end
@@ -69,19 +106,19 @@ end
   local __r1 = (h as spawn.Handle):wait() as spawn.Result
   local ok, out = __r1.ok, __r1.stdout
   local s = (out or "") as string
-  if s:find("skipped") then
-    a.skip("unveil unavailable / not enforcing (OpenBSD-only, or no backing): " .. s)
+  if s:find("blocked") then
+    -- available() was true yet the call failed: an outer sandbox
+    -- pre-empted an otherwise-supported mechanism. Strict: a hard
+    -- failure on the enforce lane.
+    a.skip("unveil blocked by an outer sandbox: " .. s, true)
     return
   end
   assert(ok, "unveil subprocess should exit cleanly: " .. s)
   assert(s:find("read:visible"), "should read unveiled file: " .. s)
-  -- Backing sandbox present but the sibling still leaked: a real failure
-  -- off the lane it stays tolerant, on the enforce lane it is fatal.
-  if s:find("denied%-leaked") then
-    a.skip("unveil did not hide the non-unveiled sibling despite backing: " .. s, true)
-    return
-  end
-  assert(s:find("denied%-blocked"), "expected denial of the non-unveiled sibling: " .. s)
+  -- available() is true and commit succeeded, so enforcement must be
+  -- real: a visible sibling is a fail-open bug, never a skip.
+  assert(s:find("denied%-blocked"),
+    "expected denial of the non-unveiled sibling: " .. s)
   a.enforced("unveil")
 end
 test_unveil_restricts_paths()


### PR DESCRIPTION
Parts 1–3 of #528 (pre-stable API review T4). Part 4 (unified `cosmic.sandbox` facade + enums) is a larger reshape left for a follow-up, as the issue suggests.

## 1. pledge/unveil fail closed (P0)

The libc deliberately fails open where it cannot enforce, so `assert(unveil.apply(dir, "r"))` reported a sandbox that didn't exist.

- `cosmic.pledge`: new `available()` (cached no-op `unix.pledge(nil, nil)` probe; ENOSYS ⇒ unenforceable) and `apply(promises, opts?: {exec, best_effort})`.
- `cosmic.unveil`: new `allow(path, perms)`, `commit()` (replacing the `apply(nil, nil)` type lie), and `available()` — derived from landlock ABI / OpenBSD, never probed with the destructive commit call. `apply` stays as a deprecated compat shim.
- Both return `false, "… unsupported on this host"` on unenforceable hosts; `best_effort = true` is the explicit opt-in back to fail-open.
- `unveil_test`: the "leak-without-backing is a skip" hedge is deleted — a committed policy that leaks is now a hard failure, and the fail-closed contract is asserted on hosts without backing.

Verified on this landlock-less Linux host (the issue's exact scenario):

```
unveil.available()               false
unveil.allow('/tmp','r') ->      false   unveil unsupported on this host
unveil.commit() ->               false   unveil unsupported on this host
unveil.allow best_effort ->      true
```

## 2. quicksand capabilities honesty + Box:run error channel (P0/P1)

- `capabilities().user_ns` was the compile-time `CLONE_NEWUSER` constant. It now runs the supervisor's real setup sequence — `unshare(NEWUSER|NEWNET|NEWNS)` **plus the uid_map/gid_map writes** — in a scratch child reporting over a pipe (`probe_ns()`, exported and cached). The map writes matter: on this host the unshare succeeds but the uid_map write is EPERM, which the unshare-only probe from the issue text would still have mis-reported as available.
- `Box:run` setup failures (unshare, uid_map, landlock, pledge, execvpe) used to `os.exit(126/127)` and come back as if the workload exited, reason only on stderr. A CLOEXEC error pipe (reusing the `proxy.start` pattern) now carries them to the parent: `run()` returns `nil, "quicksand: pledge: EINVAL…"`, and an integer return is always the workload's own exit status.
- The exit-126-is-a-skip tolerances in `run_test.tl` are deleted; the only remaining skips are named, specific conditions (signal death under an outer seccomp filter, and mapping uid 65534 without privileges — now identifiable by message thanks to the error channel). New test: `proc = {pledge = "bogus_promise"}` must return `nil, err:find("pledge")`.
- Preflight reports policy-shape errors (`fs.deny` without an allowlist) before host-capability gaps, so the structural error isn't masked by whatever capability a given host lacks.
- `Example_run_return_shape` previously only "passed portably" because setup failure was disguised as exit code 126; it now asserts the exactly-one-of-(code, err) invariant instead.

## 3. landlock.restrict file rules (P1)

- `restrict()` now fstats each O_PATH fd and masks non-directory rules to `READ_FILE|WRITE_FILE|EXECUTE|TRUNCATE`, mirroring the C unveil path — so `restrict{rules={{path="/etc/passwd", access=ll.READ}}}` works instead of EINVALing on the bundled READ_DIR bit. A rule masked to zero grantable bits is skipped (landlock denies by default). New subprocess test pins the single-file READ rule.
- The ABI < 3 truncate gap is documented on `restrict()` (cosmic strips the bit; the C path plugs it with seccomp), with `cosmic.pledge` recommended as the companion.

## Gates

`bin/make ci` green: format 226, teal 226, test 102/102, example 18/18, lint 292. On this host the box/landlock/unveil enforcement paths skip honestly (no landlock, uid_map EPERM); the pledge enforcement test runs and enforces. The enforce lane on CI exercises the real enforcement paths.

Closes #528? No — part 4 remains; this lands parts 1–3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEsxYP3VhuB1WazNZV4726

---
_Generated by [Claude Code](https://claude.ai/code/session_01HEsxYP3VhuB1WazNZV4726)_