### PR TITLE
data modules: sqlite blob/busy_timeout, json options, zip safe extract, hash/rand additions

### DIFF
--- a/lib/cosmic/compress.tl
+++ b/lib/cosmic/compress.tl
@@ -53,20 +53,37 @@ local function deflate(data: string): string | nil, string
   return prefix .. compressed
 end
 
+-- DEFLATE cannot expand by more than ~1032x (zlib's documented maximum
+-- compression ratio), so a size prefix claiming more than that is forged.
+local MAX_DEFLATE_RATIO < const > = 1032
+
 --- Decompress raw deflate data.
 --- Expects data from deflate() with the 4-byte size prefix.
 --- Maximum decompressed size: ~4GB (limited by 32-bit size prefix).
+--- The size prefix is attacker-controlled in untrusted input, so it is
+--- validated BEFORE the output buffer is allocated: a declared size larger
+--- than max_output (when given), or implausibly large for the compressed
+--- payload (beyond DEFLATE's ~1032:1 maximum ratio), is rejected without
+--- allocating.
 --- Note: Only compatible with data produced by deflate() in this module.
 --- @param data string The compressed data with size prefix
+--- @param max_output number? Reject a declared size larger than this many bytes
 --- @return string | nil The decompressed data, or nil on error
 --- @return string? Error message if decompression failed
-local function inflate(data: string): string | nil, string
+local function inflate(data: string, max_output?: number): string | nil, string
   if #data < 4 then
     return nil, "invalid deflate data: too short"
   end
   -- Read 4-byte little-endian size prefix
   local b1, b2, b3, b4 = data:byte(1, 4)
   local size = b1 + b2 * 256 + b3 * 65536 + b4 * 16777216
+  if max_output and size > max_output then
+    return nil, "inflate: declared size " .. size .. " exceeds max_output " .. max_output
+  end
+  local compressed_len = #data - 4
+  if size > compressed_len * MAX_DEFLATE_RATIO then
+    return nil, "inflate: declared size " .. size .. " is implausible for " .. compressed_len .. " compressed bytes"
+  end
   local compressed = data:sub(5)
   -- The binding reports invalid input as nil, err.
   local result, err = cosmo.Inflate(compressed, size)
@@ -80,7 +97,7 @@ local record CompressModule
   compress: function(data: string): string
   uncompress: function(data: string): string | nil, string
   deflate: function(data: string): string | nil, string
-  inflate: function(data: string): string | nil, string
+  inflate: function(data: string, max_output?: number): string | nil, string
 end
 
 local M: CompressModule = {

--- a/lib/cosmic/compress_test.tl
+++ b/lib/cosmic/compress_test.tl
@@ -188,3 +188,28 @@ local function test_deflate_size_check_normal()
   assert(err == nil, "expected no error for 1000-byte input")
 end
 test_deflate_size_check_normal()
+
+-- Forged size-prefix tests (issue #531): the 4-byte prefix is
+-- attacker-controlled and must be validated before allocation.
+
+local function test_inflate_forged_huge_prefix()
+  -- 5-byte blob whose prefix claims ~4GB for 1 compressed byte. Must be
+  -- rejected up front (no 4GB allocation attempt).
+  local forged = string.char(0xFF, 0xFF, 0xFF, 0xFF) .. "x"
+  local result, err = compress.inflate(forged)
+  assert(result == nil, "forged size prefix should be rejected")
+  assert(err and err:match("implausible"), "expected implausibility error, got: " .. tostring(err))
+end
+test_inflate_forged_huge_prefix()
+
+local function test_inflate_max_output()
+  local deflated = assert(compress.deflate(string.rep("x", 2000)))
+  local result, err = compress.inflate(deflated, 100)
+  assert(result == nil, "declared size beyond max_output should be rejected")
+  assert(err and err:match("max_output"), "expected max_output error, got: " .. tostring(err))
+
+  result, err = compress.inflate(deflated, 2000)
+  assert(result, "max_output at the exact size should pass: " .. tostring(err))
+  assert(#(result as string) == 2000, "roundtrip under max_output should succeed")
+end
+test_inflate_max_output()

--- a/lib/cosmic/embed.tl
+++ b/lib/cosmic/embed.tl
@@ -265,7 +265,7 @@ local function run(paths: {string}, output?: string, exe_path?: string): EmbedRe
   -- Open the copy as an appender to modify its zip in-place
   local appender_result: any
   local appender_err: any
-  appender_result, appender_err = czip.open(tmp_path, "a")
+  appender_result, appender_err = czip.appender(tmp_path)
   if not appender_result then
     fs.unlink(tmp_path)
     return {ok = false, message = "error: failed to open zip for appending: " .. tostring(appender_err or "unknown error"), file_count = 0}

--- a/lib/cosmic/embed_advanced_test.tl
+++ b/lib/cosmic/embed_advanced_test.tl
@@ -313,7 +313,7 @@ local function test_extract_rejects_path_traversal()
   -- byte-patch it to a traversal name (no offsets change, so the zip stays
   -- valid). "XX/escaped.txt" -> "../escaped.txt".
   local safe = fs.join(tmpdir, "patched.zip")
-  local w = zip.open(safe, "w") as Writer
+  local w = zip.writer(safe) as Writer
   assert(w, "should open zip for writing")
   w:add("XX/escaped.txt", "pwned")
   w:close()

--- a/lib/cosmic/hash.tl
+++ b/lib/cosmic/hash.tl
@@ -54,6 +54,35 @@ local function sha256_hex(data: string): string
   return codec.encode_hex(cosmo.Sha256(data))
 end
 
+--- Compute HMAC-SHA256 of data with a secret key (RFC 2104).
+--- Returns raw bytes (32 bytes); hex-encode with cosmic.codec.encode_hex
+--- if needed. Compare MACs with constant_time_equal, not ==.
+--- @param key string The secret key
+--- @param data string The message to authenticate
+--- @return string The HMAC-SHA256 tag as raw bytes
+local function hmac_sha256(key: string, data: string): string
+  return (cosmo.GetCryptoHash("SHA256", data, key))
+end
+
+--- Compare two strings in constant time (for digests and MACs).
+--- A plain == comparison exits at the first differing byte, leaking how
+--- much of a secret an attacker has guessed; this XOR-accumulates over
+--- every byte instead. Only the lengths are allowed to short-circuit
+--- (digest/MAC lengths are public).
+--- @param a string First string
+--- @param b string Second string
+--- @return boolean True when a and b are equal
+local function constant_time_equal(a: string, b: string): boolean
+  if #a ~= #b then
+    return false
+  end
+  local acc = 0
+  for i = 1, #a do
+    acc = acc | (string.byte(a, i) ~ string.byte(b, i))
+  end
+  return acc == 0
+end
+
 --- Hash a password using Argon2.
 --- Returns an encoded string suitable for storage.
 --- @param pwd string The password to hash
@@ -108,6 +137,8 @@ local record HashModule
 
   sha256: function(data: string): string
   sha256_hex: function(data: string): string
+  hmac_sha256: function(key: string, data: string): string
+  constant_time_equal: function(a: string, b: string): boolean
   password: function(pwd: string, options?: HashOptions): string | nil, string
   verify_password: function(encoded: string, pwd: string): boolean, string
 end
@@ -115,6 +146,8 @@ end
 local M: HashModule = {
   sha256 = sha256,
   sha256_hex = sha256_hex,
+  hmac_sha256 = hmac_sha256,
+  constant_time_equal = constant_time_equal,
   password = password,
   verify_password = verify_password,
 }

--- a/lib/cosmic/hash_test.tl
+++ b/lib/cosmic/hash_test.tl
@@ -1,4 +1,5 @@
 #!/usr/bin/env cosmic
+local codec = require("cosmic.codec")
 local hash = require("cosmic.hash")
 
 -- SHA-256 tests
@@ -144,3 +145,38 @@ local function test_password_default_mcost_is_19456()
   assert(string.match(encoded, "m=19456"), "default m_cost should be 19456, encoded string: " .. encoded)
 end
 test_password_default_mcost_is_19456()
+
+-- HMAC-SHA256 (issue #531): RFC 4231 test vectors
+
+local function test_hmac_sha256_rfc4231_case1()
+  local key = string.rep("\x0b", 20)
+  local tag = hash.hmac_sha256(key, "Hi There")
+  local hex = codec.encode_hex(tag)
+  assert(hex == "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7",
+    "RFC 4231 case 1 mismatch: " .. hex)
+end
+test_hmac_sha256_rfc4231_case1()
+
+local function test_hmac_sha256_rfc4231_case2()
+  local tag = hash.hmac_sha256("Jefe", "what do ya want for nothing?")
+  local hex = codec.encode_hex(tag)
+  assert(hex == "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843",
+    "RFC 4231 case 2 mismatch: " .. hex)
+end
+test_hmac_sha256_rfc4231_case2()
+
+-- Constant-time comparison
+
+local function test_constant_time_equal()
+  assert(hash.constant_time_equal("", ""), "empty strings are equal")
+  assert(hash.constant_time_equal("abc", "abc"), "equal strings compare equal")
+  assert(not hash.constant_time_equal("abc", "abd"), "differing last byte")
+  assert(not hash.constant_time_equal("abc", "xbc"), "differing first byte")
+  assert(not hash.constant_time_equal("abc", "abcd"), "different lengths")
+  local d1 = hash.sha256("a")
+  local d2 = hash.sha256("a")
+  local d3 = hash.sha256("b")
+  assert(hash.constant_time_equal(d1, d2), "identical digests compare equal")
+  assert(not hash.constant_time_equal(d1, d3), "different digests compare unequal")
+end
+test_constant_time_equal()

--- a/lib/cosmic/json.tl
+++ b/lib/cosmic/json.tl
@@ -1,9 +1,37 @@
 --- JSON encoding and decoding utilities.
 --- Wraps cosmo.EncodeJson and cosmo.DecodeJson with convenient Teal-typed interface.
+---
+--- NULL POLICY (lossy — read before round-tripping):
+--- Lua tables cannot hold nil values, so JSON `null` does not survive a
+--- decode/encode round-trip:
+--- - `{"a":null,"b":1}` decodes with `a` absent and re-encodes as `{"b":1}`.
+--- - `[1,null,2]` decodes with a hole at index 2; re-encoding sees a table
+---   of length 1 and truncates to `[1]`.
+--- - NaN encodes as `null`; +/-Inf encodes as the out-of-range literal
+---   `1e5000`/`-1e5000`, which this module decodes back to +/-Inf but
+---   stricter JSON parsers may reject.
+--- If null-preserving round-trips matter, restructure the data (e.g. encode
+--- explicit sentinel values) rather than relying on this module.
 local cosmo = require("cosmo")
+
+--- Options accepted by encode(). All fields are optional.
+local record EncodeOptions
+  --- Format across multiple lines for readability (default false).
+  pretty: boolean
+  --- Sort object keys for deterministic output (default true). Setting
+  --- sorted=false can speed up serialization when ordering is irrelevant.
+  sorted: boolean
+  --- Indentation string used when pretty is true (default " ").
+  indent: string
+  --- Maximum serializer recursion depth (default 64, max 32767).
+  maxdepth: number
+end
 
 --- Decode a JSON string into a Lua value.
 --- Converts JSON strings, numbers, booleans, arrays, and objects into their Lua equivalents.
+--- JSON `null` becomes nil, so null-valued object keys vanish and arrays
+--- containing null are truncated at the first null when re-encoded (see the
+--- module-level null policy above).
 --- @param str string The JSON string to decode
 --- @return any The decoded Lua value (table, string, number, boolean, or nil)
 --- @return string? Error message if decoding failed
@@ -14,17 +42,35 @@ end
 
 --- Encode a Lua value as a JSON string.
 --- Converts Lua tables, strings, numbers, booleans, and nil into JSON format.
+--- NaN encodes as `null`, +/-Inf as `1e5000`/`-1e5000`; nil-valued table
+--- entries are absent (see the module-level null policy above).
 --- @param value any The Lua value to encode
+--- @param options EncodeOptions? pretty, sorted, indent, maxdepth
 --- @return string | nil The JSON string representation
 --- @return string? Error message if encoding failed
-local function encode(value: any): string | nil, string
-  local result, err = cosmo.EncodeJson(value)
-  return result as string, err as string
+local function encode(value: any, options?: EncodeOptions): string | nil, string
+  local result: string
+  local err: string | nil
+  if options then
+    -- Build a plain table to avoid a nominal type conflict with
+    -- cosmo's EncoderOptions record.
+    result, err = cosmo.EncodeJson(value, {
+        pretty = options.pretty,
+        sorted = options.sorted,
+        indent = options.indent,
+        maxdepth = options.maxdepth,
+      })
+  else
+    result, err = cosmo.EncodeJson(value)
+  end
+  return result, err as string
 end
 
 local record JsonModule
+  type EncodeOptions = EncodeOptions
+
   decode: function(str: string): any, string
-  encode: function(value: any): string | nil, string
+  encode: function(value: any, options?: EncodeOptions): string | nil, string
 end
 
 local M: JsonModule = {

--- a/lib/cosmic/json_test.tl
+++ b/lib/cosmic/json_test.tl
@@ -86,3 +86,66 @@ local function test_encode_invalid_value()
   assert(type(err) == "string", "error should be a string")
 end
 test_encode_invalid_value()
+
+-- Encode options (issue #531: options used to be silently ignored)
+
+local function test_encode_pretty()
+  local result = json.encode({a = 1, b = 2}, {pretty = true})
+  assert(result, "pretty encode should succeed")
+  assert(string.match(result as string, "\n"), "pretty output should contain a newline, got: " .. tostring(result))
+end
+test_encode_pretty()
+
+local function test_encode_pretty_indent()
+  local result = json.encode({a = {b = 1}, c = 2}, {pretty = true, indent = "    "})
+  assert(result, "pretty encode with indent should succeed")
+  assert(string.match(result as string, "\n    "), "output should use the custom indent, got: " .. tostring(result))
+end
+test_encode_pretty_indent()
+
+local function test_encode_default_stays_compact()
+  local result = json.encode({a = 1, b = 2})
+  assert(result == '{"a":1,"b":2}', "default encode should stay compact, got: " .. tostring(result))
+end
+test_encode_default_stays_compact()
+
+local function test_encode_maxdepth()
+  local result, err = json.encode({a = {b = {c = 1}}}, {maxdepth = 2})
+  assert(result == nil, "encode past maxdepth should fail")
+  assert(err ~= nil, "maxdepth failure should carry an error message")
+end
+test_encode_maxdepth()
+
+-- Null policy: these pin the documented (lossy) behavior so a change in the
+-- C encoder/decoder shows up as a test failure, not a silent contract drift.
+
+local function test_null_object_key_dropped()
+  local decoded = json.decode('{"a":null,"b":1}') as {string: any}
+  assert(decoded.a == nil, "null object value should decode to nil")
+  assert(decoded.b == 1, "sibling value should survive")
+  local reencoded = json.encode(decoded)
+  assert(reencoded == '{"b":1}', "null key is documented to vanish on re-encode, got: " .. tostring(reencoded))
+end
+test_null_object_key_dropped()
+
+local function test_null_array_element_truncates()
+  local decoded = json.decode("[1,null,2]") as {any}
+  assert(decoded[1] == 1, "first element should survive")
+  assert(decoded[2] == nil, "null element should decode to nil (hole)")
+  assert(decoded[3] == 2, "element after null should still be reachable")
+  local reencoded = json.encode(decoded)
+  assert(reencoded == "[1]", "array with hole is documented to truncate on re-encode, got: " .. tostring(reencoded))
+end
+test_null_array_element_truncates()
+
+local function test_nan_inf_encoding()
+  local nan_json = json.encode({0 / 0})
+  assert(nan_json == "[null]", "NaN is documented to encode as null, got: " .. tostring(nan_json))
+  -- Inf encodes as an out-of-range literal, not null: it round-trips back
+  -- to Inf here but is not standard JSON for stricter parsers.
+  local inf_json = json.encode({math.huge})
+  assert(inf_json == "[1e5000]", "Inf is documented to encode as 1e5000, got: " .. tostring(inf_json))
+  local ninf_json = json.encode({-math.huge})
+  assert(ninf_json == "[-1e5000]", "-Inf is documented to encode as -1e5000, got: " .. tostring(ninf_json))
+end
+test_nan_inf_encoding()

--- a/lib/cosmic/rand.tl
+++ b/lib/cosmic/rand.tl
@@ -5,6 +5,7 @@
 --- Example usage:
 ---   local rand = require("cosmic.rand")
 ---   local key, err = rand.bytes(32)     -- cryptographically secure
+---   local roll = rand.int(1, 6)         -- crypto-grade, unbiased
 ---   local n = rand.rand64()             -- fast pseudo-random (not secure)
 local cosmo = require("cosmo")
 
@@ -27,13 +28,61 @@ local function rand64(): number
   return cosmo.Rand64()
 end
 
+--- Generate a cryptographically secure uniform integer in [min, max]
+--- (both inclusive). Rejection-sampled over bytes(), so the result is
+--- unbiased — unlike the common `min + rand % range` shortcut.
+--- The range size (max - min + 1) must not exceed 2^53.
+--- @param min integer Lower bound (inclusive)
+--- @param max integer Upper bound (inclusive)
+--- @return integer | nil The random integer, or nil on failure
+--- @return string? Error message on failure
+local function int(min: integer, max: integer): integer | nil, string
+  if math.type(min) ~= "integer" or math.type(max) ~= "integer" then
+    return nil, "rand.int: min and max must be integers"
+  end
+  if min > max then
+    return nil, "rand.int: min must be <= max"
+  end
+  local range = max - min + 1
+  -- range <= 0 means max - min overflowed the signed 64-bit space.
+  if range <= 0 or range > (1 << 53) then
+    return nil, "rand.int: range too large (max 2^53)"
+  end
+  -- Smallest byte count whose value space covers the range.
+  local nbytes = 1
+  local space = 256
+  while space < range do
+    nbytes = nbytes + 1
+    space = space * 256
+  end
+  -- Rejection sampling: draw values until one lands under the largest
+  -- multiple of range, so every residue is equally likely. Each draw
+  -- accepts with probability > 1/2, so the expected iteration count is < 2.
+  local limit = space - (space % range)
+  while true do
+    local data, err = bytes(nbytes)
+    if not data then
+      return nil, err
+    end
+    local v = 0
+    for i = 1, nbytes do
+      v = v * 256 + string.byte(data as string, i)
+    end
+    if v < limit then
+      return min + v % range
+    end
+  end
+end
+
 local record RandModule
   bytes: function(n: number): string | nil, string
+  int: function(min: integer, max: integer): integer | nil, string
   rand64: function(): number
 end
 
 local M: RandModule = {
   bytes = bytes,
+  int = int,
   rand64 = rand64,
 }
 

--- a/lib/cosmic/rand_test.tl
+++ b/lib/cosmic/rand_test.tl
@@ -34,3 +34,58 @@ local function test_rand64()
   assert(n ~= n2, "rand64 should return different values each call")
 end
 test_rand64()
+
+-- Crypto-grade bounded integers (issue #531)
+
+local function test_int_bounds()
+  for _ = 1, 500 do
+    local n = assert(rand.int(-3, 7))
+    assert(n >= -3 and n <= 7, "int(-3, 7) out of bounds: " .. n)
+    assert(math.type(n) == "integer", "int should return an integer")
+  end
+end
+test_int_bounds()
+
+local function test_int_degenerate_range()
+  assert(rand.int(5, 5) == 5, "int(5, 5) must return 5")
+end
+test_int_degenerate_range()
+
+local function test_int_distribution_smoke()
+  -- Every value of a small range should appear in a modest sample
+  -- (P(miss) < 4 * (3/4)^400, effectively zero).
+  local seen: {integer: boolean} = {}
+  for _ = 1, 400 do
+    local n = assert(rand.int(0, 3))
+    seen[n] = true
+  end
+  for v = 0, 3 do
+    assert(seen[v], "int(0, 3) never produced " .. v .. " in 400 draws")
+  end
+end
+test_int_distribution_smoke()
+
+local function test_int_wide_range()
+  -- Multi-byte sampling path: range needs more than one random byte.
+  local lo, hi = 0, 100000
+  for _ = 1, 100 do
+    local n = assert(rand.int(lo, hi))
+    assert(n >= lo and n <= hi, "int(0, 100000) out of bounds: " .. n)
+  end
+end
+test_int_wide_range()
+
+local function test_int_invalid_args()
+  local n, err = rand.int(10, 1)
+  assert(n == nil, "min > max should fail")
+  assert(err and err:match("min"), "expected min/max error, got: " .. tostring(err))
+
+  n, err = rand.int(1.5 as integer, 3)
+  assert(n == nil, "non-integer min should fail")
+  assert(err, "expected error for non-integer min")
+
+  n, err = rand.int(math.mininteger, math.maxinteger)
+  assert(n == nil, "full 64-bit span should be rejected")
+  assert(err and err:match("range"), "expected range error, got: " .. tostring(err))
+end
+test_int_invalid_args()

--- a/lib/cosmic/sqlite.tl
+++ b/lib/cosmic/sqlite.tl
@@ -12,15 +12,22 @@
 ---       print(row.id, row.name)
 ---     end
 ---     db:close()
+---
+--- Binary values: wrap with `sqlite.blob(s)` to store with BLOB affinity
+--- (a bare Lua string always binds as TEXT). Opening sets a 5000ms busy
+--- timeout by default; see `OpenOptions`.
 
 local lsqlite3 = require("cosmo.lsqlite3")
 local stmt_cache_mod = require("cosmic.sqlite_stmt_cache")
 local row_iter = require("cosmic.sqlite_row_iter")
+local bind_mod = require("cosmic.sqlite_bind")
+local params_mod = require("cosmic.sqlite_params")
 
 -- Raw lsqlite3 types (0-indexed, requires manual cleanup)
 local record RawStatement
   bind_values: function(self: RawStatement, ...: any): number
   bind: function(self: RawStatement, n: number, value?: any): number
+  bind_blob: function(self: RawStatement, n: number, blob: string): number
   bind_names: function(self: RawStatement, params: {string: any}): number
   bind_parameter_count: function(self: RawStatement): number
   step: function(self: RawStatement): number
@@ -35,6 +42,7 @@ local record RawDatabase
   close: function(self: RawDatabase): number
   exec: function(self: RawDatabase, sql: string): number
   prepare: function(self: RawDatabase, sql: string): RawStatement, number, string
+  busy_timeout: function(self: RawDatabase, milliseconds: number)
   last_insert_rowid: function(self: RawDatabase): number
   changes: function(self: RawDatabase): number
   errmsg: function(self: RawDatabase): string
@@ -45,7 +53,8 @@ local record RawSqlite3
   ROW: number
   DONE: number
   SCHEMA: number
-  open: function(filename: string): RawDatabase, number, string
+  OPEN_READONLY: number
+  open: function(filename: string, flags?: number): RawDatabase, number, string
 end
 
 local sqlite3 = lsqlite3 as RawSqlite3
@@ -102,12 +111,13 @@ local function make_statement(raw_stmt: RawStatement, raw_db: RawDatabase): Stat
 
   --- Bind parameters by position. Handles trailing nil values correctly
   --- (unlike varargs with table.unpack which drops them).
+  --- Values wrapped with `sqlite.blob()` are bound with BLOB affinity.
   function stmt:bind(...: any): boolean, string
     raw_stmt:reset()
     local n = select("#", ...) as integer
     for i = 1, n do
       local val = select(i, ...)
-      local rc = raw_stmt:bind(i, val)
+      local rc = bind_mod.bind_at(raw_stmt, i, val)
       if rc ~= sqlite3.OK then
         return false, raw_db:errmsg()
       end
@@ -117,11 +127,12 @@ local function make_statement(raw_stmt: RawStatement, raw_db: RawDatabase): Stat
 
   --- Bind parameters from a list (table). The count is derived from the SQL,
   --- so nil values in the table are handled correctly without an explicit count.
+  --- Values wrapped with `sqlite.blob()` are bound with BLOB affinity.
   function stmt:bind_list(values: {any}): boolean, string
     raw_stmt:reset()
     local count = raw_stmt:bind_parameter_count() as integer
     for i = 1, count do
-      local rc = raw_stmt:bind(i, values[i as integer])
+      local rc = bind_mod.bind_at(raw_stmt, i, values[i as integer])
       if rc ~= sqlite3.OK then
         return false, raw_db:errmsg()
       end
@@ -132,8 +143,16 @@ local function make_statement(raw_stmt: RawStatement, raw_db: RawDatabase): Stat
   --- Bind named parameters from a key/value table.
   --- SQL should use :name placeholders (e.g. ":foo", ":bar").
   --- Table keys are names without the colon prefix.
+  --- `sqlite.blob()` wrappers are not supported here: the underlying
+  --- bind_names call binds the wrapper table itself, silently losing BLOB
+  --- affinity, so they are rejected — use positional binding for blobs.
   function stmt:bind_named(params: {string: any}): boolean, string
     raw_stmt:reset()
+    for name, v in pairs(params) do
+      if bind_mod.is_blob(v) then
+        return false, "blob value for :" .. name .. " requires positional binding"
+      end
+    end
     local rc = raw_stmt:bind_names(params)
     if rc ~= sqlite3.OK then
       return false, raw_db:errmsg()
@@ -234,29 +253,6 @@ local function make_statement(raw_stmt: RawStatement, raw_db: RawDatabase): Stat
     }) as Statement
 end
 
--- Wrap a prepared+bound statement's row iterator: finalize the statement
--- when iteration ends and forward the step error through `:err()`.
-local function make_query_iter(stmt: Statement): Rows
-  local raw_iter = stmt:rows()
-  local done = false
-  local iter = setmetatable({} as Rows, {
-      __call = function(_: Rows): {string: any}
-        if done then
-          return nil
-        end
-        local row = raw_iter()
-        if row == nil then
-          done = true
-          stmt:close()
-          return nil
-        end
-        return row
-      end,
-    })
-  iter.err = function(_: Rows): string return raw_iter:err() end
-  return iter
-end
-
 local function make_database(raw_db: RawDatabase): Database
   local db: Database = {}
   local closed = false
@@ -316,82 +312,10 @@ local function make_database(raw_db: RawDatabase): Database
     return stmt_cache:exec(sql, args, n)
   end
 
-  --- Execute SQL with parameters from a list (table). The count is derived
-  --- from the SQL itself, so nil values in the table are handled correctly.
-  function db:exec_list(sql: string, values: {any}): boolean, string
-    local stmt, err = self:prepare(sql)
-    if not stmt then
-      return false, err or "prepare failed"
-    end
-    local st = stmt as Statement
-
-    local ok, bind_err = st:bind_list(values)
-    if not ok then
-      st:close()
-      return false, bind_err or "bind failed"
-    end
-
-    local exec_ok, exec_err = st:exec()
-    st:close()
-    return exec_ok, exec_err
-  end
-
-  --- Execute SQL with named parameters.
-  --- SQL should use :name placeholders. Table keys are names without the colon.
-  function db:exec_named(sql: string, params: {string: any}): boolean, string
-    local stmt, err = self:prepare(sql)
-    if not stmt then
-      return false, err or "prepare failed"
-    end
-    local st = stmt as Statement
-
-    local ok, bind_err = st:bind_named(params)
-    if not ok then
-      st:close()
-      return false, bind_err or "bind failed"
-    end
-
-    local exec_ok, exec_err = st:exec()
-    st:close()
-    return exec_ok, exec_err
-  end
-
-  --- Query with parameters from a list (table).
-  --- The parameter count is derived from the SQL itself, so nil values
-  --- in the table are handled correctly.
-  function db:query_list(sql: string, values: {any}): Rows | nil, string
-    local stmt, err = self:prepare(sql)
-    if not stmt then
-      return nil, "query failed: " .. (err or "unknown error")
-    end
-    local st = stmt as Statement
-
-    local ok, bind_err = st:bind_list(values)
-    if not ok then
-      st:close()
-      return nil, "bind failed: " .. (bind_err or "unknown error")
-    end
-
-    return make_query_iter(st)
-  end
-
-  --- Query with named parameters.
-  --- SQL should use :name placeholders. Table keys are names without the colon.
-  function db:query_named(sql: string, params: {string: any}): Rows | nil, string
-    local stmt, err = self:prepare(sql)
-    if not stmt then
-      return nil, "query failed: " .. (err or "unknown error")
-    end
-    local st = stmt as Statement
-
-    local ok, bind_err = st:bind_named(params)
-    if not ok then
-      st:close()
-      return nil, "bind failed: " .. (bind_err or "unknown error")
-    end
-
-    return make_query_iter(st)
-  end
+  -- exec_list, exec_named, query_list, query_named live in
+  -- cosmic.sqlite_params (same prepare/bind/consume shape, split out to
+  -- keep this file under the 500-line cap).
+  params_mod.attach(db)
 
   --- Return the first row matching a query, or nil if no rows match.
   --- Convenience method for single-row lookups.
@@ -470,24 +394,55 @@ local function make_database(raw_db: RawDatabase): Database
     }) as Database
 end
 
+--- Options for opening a database.
+local record OpenOptions
+  --- Busy timeout in milliseconds (default 5000). When another connection
+  --- holds a conflicting lock, statements wait up to this long before
+  --- failing with SQLITE_BUSY. Pass 0 to fail immediately (SQLite's raw
+  --- default).
+  busy_timeout_ms: integer
+  --- Open the database read-only (default false). The file must exist.
+  read_only: boolean
+end
+
 --- Open or create an SQLite database.
 --- Relative paths are resolved against the current working directory.
 --- Absolute paths (e.g. "/var/data/app.db") work as expected.
 --- Use ":memory:" for an in-memory database that is not written to disk.
---- The file is created if it does not already exist.
+--- The file is created if it does not already exist (unless read_only).
+--- A 5000ms busy timeout is set by default so two processes sharing a
+--- file database wait for each other instead of failing instantly with
+--- SQLITE_BUSY; override with opts.busy_timeout_ms.
 --- @param filename string Database path (use ":memory:" for in-memory)
+--- @param opts OpenOptions? busy_timeout_ms and read_only
 --- @return Database | nil Database handle with __close support
 --- @return string Error message on failure
-local function open(filename: string): Database | nil, string
-  local raw_db, errcode, errmsg = sqlite3.open(filename)
+local function open(filename: string, opts?: OpenOptions): Database | nil, string
+  local raw_db: RawDatabase
+  local errcode: number
+  local errmsg: string
+  if opts and opts.read_only then
+    raw_db, errcode, errmsg = sqlite3.open(filename, sqlite3.OPEN_READONLY)
+  else
+    raw_db, errcode, errmsg = sqlite3.open(filename)
+  end
   if not raw_db then
     return nil, errmsg or ("error code " .. tostring(errcode))
   end
+  local timeout_ms = 5000
+  if opts and opts.busy_timeout_ms ~= nil then
+    timeout_ms = opts.busy_timeout_ms
+  end
+  raw_db:busy_timeout(timeout_ms)
   return make_database(raw_db)
 end
 
 local record sqlite
-  open: function(filename: string): Database | nil, string
+  type Blob = bind_mod.Blob
+  type OpenOptions = OpenOptions
+
+  open: function(filename: string, opts?: OpenOptions): Database | nil, string
+  blob: function(data: string): bind_mod.Blob
   Database: Database
   Statement: Statement
   Rows: Rows
@@ -495,6 +450,7 @@ end
 
 local M: sqlite = {
   open = open,
+  blob = bind_mod.blob,
 }
 
 return M

--- a/lib/cosmic/sqlite_bind.tl
+++ b/lib/cosmic/sqlite_bind.tl
@@ -1,0 +1,67 @@
+--- Internal helper for cosmic.sqlite: the BLOB value marker and the shared
+--- positional bind step. Every bind loop (Statement:bind/bind_list, the
+--- db:exec statement cache, the db:query hot path) funnels through
+--- `bind_at`, so a value wrapped with `blob()` is bound with SQLite blob
+--- affinity everywhere instead of defaulting to TEXT.
+--- Lives in its own file so cosmic/sqlite.tl stays under the 500-line cap.
+
+--- Marker wrapper produced by `cosmic.sqlite.blob()`. Bind loops detect it
+--- by metatable identity and bind `data` via `bind_blob` instead of `bind`.
+local record Blob
+  data: string
+end
+
+local record RawStatement
+  bind: function(self: RawStatement, n: number, value?: any): number
+  bind_blob: function(self: RawStatement, n: number, blob: string): number
+end
+
+-- Identity marker: getmetatable(v) == blob_mt is the only blob test, so a
+-- plain {data = ...} table can never be mistaken for a blob.
+local blob_mt: metatable < Blob > = {}
+
+--- Wrap a string so bind loops store it with BLOB affinity.
+--- @param data string The raw bytes to bind as a BLOB
+--- @return Blob The marker wrapper recognized by every bind path
+local function blob(data: string): Blob
+  return setmetatable({data = data} as Blob, blob_mt)
+end
+
+--- Report whether a value is a `blob()` wrapper.
+--- @param v any The value to test
+--- @return boolean true when v was produced by blob()
+local function is_blob(v: any): boolean
+  return getmetatable(v) == blob_mt as any
+end
+
+--- Bind one positional parameter, routing blob() wrappers to bind_blob.
+--- The raw statement is typed `any` so callers don't need a
+--- nominally-identical RawStatement type (same convention as
+--- sqlite_stmt_cache and sqlite_row_iter).
+--- @param raw_stmt_any any The prepared statement to bind into
+--- @param i integer 1-based parameter index
+--- @param v any The value (or blob() wrapper) to bind
+--- @return number The sqlite result code from the bind call
+local function bind_at(raw_stmt_any: any, i: integer, v: any): number
+  local raw_stmt = raw_stmt_any as RawStatement
+  if getmetatable(v) == blob_mt as any then
+    return raw_stmt:bind_blob(i, (v as Blob).data)
+  end
+  return raw_stmt:bind(i, v)
+end
+
+local record M
+  type Blob = Blob
+
+  blob: function(data: string): Blob
+  is_blob: function(v: any): boolean
+  bind_at: function(raw_stmt_any: any, i: integer, v: any): number
+end
+
+local mod: M = {
+  blob = blob,
+  is_blob = is_blob,
+  bind_at = bind_at,
+}
+
+return mod

--- a/lib/cosmic/sqlite_data_test.tl
+++ b/lib/cosmic/sqlite_data_test.tl
@@ -1,0 +1,139 @@
+#!/usr/bin/env cosmic
+--- Tests for cosmic.sqlite data-layer contracts: blob binding affinity,
+--- default busy timeout, and open() options (issue #531).
+
+local fs = require("cosmic.fs")
+local sqlite = require("cosmic.sqlite")
+
+local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
+
+-- The module's Rows iterator record is not exported; mirror its shape here so
+-- the fallible `db:query* -> Rows | nil` results can be cast for iteration.
+local record Rows
+  metamethod __call: function(self: Rows): {string: any}
+  err: function(self: Rows): string
+end
+
+-- Blob binding
+
+local function test_blob_bind_affinity()
+  local db = sqlite.open(":memory:") as sqlite.Database
+  db:exec("CREATE TABLE t (v BLOB)")
+  local payload = "\0\1\2\255"
+  local ok, err = db:exec("INSERT INTO t (v) VALUES (?)", sqlite.blob(payload))
+  assert(ok, "blob insert should succeed: " .. tostring(err))
+
+  local row = db:query_one("SELECT v, typeof(v) AS ty FROM t") as {string: any}
+  assert(row, "should read the row back")
+  assert(row.ty == "blob", "typeof should be blob, got " .. tostring(row.ty))
+  assert(row.v == payload, "blob bytes should round-trip")
+  db:close()
+end
+test_blob_bind_affinity()
+
+local function test_plain_string_stays_text()
+  local db = sqlite.open(":memory:") as sqlite.Database
+  db:exec("CREATE TABLE t (v BLOB)")
+  db:exec("INSERT INTO t (v) VALUES (?)", "\0\1\2")
+  local row = db:query_one("SELECT typeof(v) AS ty FROM t") as {string: any}
+  assert(row and row.ty == "text", "bare string should keep text affinity")
+  db:close()
+end
+test_plain_string_stays_text()
+
+local function test_blob_in_query_params()
+  -- db:query binds through the hot-path row iterator; make sure the blob
+  -- marker is honored there too.
+  local db = sqlite.open(":memory:") as sqlite.Database
+  local iter = db:query("SELECT typeof(?) AS ty", sqlite.blob("abc")) as Rows
+  assert(iter, "query should succeed")
+  local row = iter()
+  assert(row and row.ty == "blob", "query param should bind as blob")
+  while iter() ~= nil do end
+  db:close()
+end
+test_blob_in_query_params()
+
+local function test_blob_bind_and_bind_list()
+  local db = sqlite.open(":memory:") as sqlite.Database
+  db:exec("CREATE TABLE t (a BLOB, b BLOB)")
+
+  local stmt = db:prepare("INSERT INTO t (a, b) VALUES (?, ?)") as sqlite.Statement
+  local ok, err = stmt:bind(sqlite.blob("x"), "y")
+  assert(ok, "bind should succeed: " .. tostring(err))
+  assert(stmt:exec(), "exec should succeed")
+  stmt:close()
+
+  ok, err = db:exec_list("INSERT INTO t (a, b) VALUES (?, ?)", {sqlite.blob("p"), "q"})
+  assert(ok, "exec_list with blob should succeed: " .. tostring(err))
+
+  local iter = db:query("SELECT typeof(a) AS ta, typeof(b) AS tb FROM t") as Rows
+  local n = 0
+  for row in iter do
+    n = n + 1
+    assert(row.ta == "blob", "column a should be blob")
+    assert(row.tb == "text", "column b should be text")
+  end
+  assert(n == 2, "should have inserted 2 rows, got " .. n)
+  db:close()
+end
+test_blob_bind_and_bind_list()
+
+local function test_blob_named_rejected()
+  local db = sqlite.open(":memory:") as sqlite.Database
+  db:exec("CREATE TABLE t (v BLOB)")
+  local ok, err = db:exec_named("INSERT INTO t (v) VALUES (:v)", {v = sqlite.blob("x")})
+  assert(not ok, "blob via named parameters should be rejected")
+  assert(err and err:match("positional"), "error should point at positional binding, got: " .. tostring(err))
+  db:close()
+end
+test_blob_named_rejected()
+
+-- Busy timeout
+
+local function test_busy_timeout_applied()
+  -- PRAGMA busy_timeout reads back the connection's current timeout.
+  local db = sqlite.open(":memory:") as sqlite.Database
+  local row = db:query_one("PRAGMA busy_timeout") as {string: any}
+  assert(row, "pragma should return a row")
+  assert(row.timeout == 5000, "default busy timeout should be 5000ms, got " .. tostring(row.timeout))
+  db:close()
+
+  db = sqlite.open(":memory:", {busy_timeout_ms = 123}) as sqlite.Database
+  row = db:query_one("PRAGMA busy_timeout") as {string: any}
+  assert(row and row.timeout == 123, "busy_timeout_ms option should apply, got " .. tostring((row as {string: any}).timeout))
+  db:close()
+
+  db = sqlite.open(":memory:", {busy_timeout_ms = 0}) as sqlite.Database
+  row = db:query_one("PRAGMA busy_timeout") as {string: any}
+  assert(row and row.timeout == 0, "busy_timeout_ms=0 should disable waiting, got " .. tostring((row as {string: any}).timeout))
+  db:close()
+end
+test_busy_timeout_applied()
+
+-- read_only option
+
+local function test_read_only_open()
+  local path = fs.join(TEST_TMPDIR, "readonly_test.db")
+  local db = sqlite.open(path) as sqlite.Database
+  db:exec("CREATE TABLE t (v TEXT)")
+  db:exec("INSERT INTO t (v) VALUES (?)", "hello")
+  db:close()
+
+  local rdb = sqlite.open(path, {read_only = true}) as sqlite.Database
+  local row = rdb:query_one("SELECT v FROM t") as {string: any}
+  assert(row and row.v == "hello", "read-only handle should read existing data")
+  local ok, err = rdb:exec("INSERT INTO t (v) VALUES (?)", "nope")
+  assert(not ok, "write through read-only handle should fail")
+  assert(err, "read-only write failure should carry an error message")
+  rdb:close()
+end
+test_read_only_open()
+
+local function test_read_only_missing_file_fails()
+  local path = fs.join(TEST_TMPDIR, "missing.db")
+  local db, err = sqlite.open(path, {read_only = true})
+  assert(db == nil, "read-only open of a missing file should fail")
+  assert(err, "should return an error message")
+end
+test_read_only_missing_file_fails()

--- a/lib/cosmic/sqlite_params.tl
+++ b/lib/cosmic/sqlite_params.tl
@@ -1,0 +1,138 @@
+--- Internal helper for cosmic.sqlite: the list/named parameter convenience
+--- methods (exec_list, exec_named, query_list, query_named) attached onto a
+--- Database. They all follow the same prepare/bind/consume shape, so they
+--- live together here. Lives in its own file so cosmic/sqlite.tl stays
+--- under the 500-line cap.
+
+-- Mirrors of cosmic.sqlite's records (Teal records are nominal, so the
+-- boundary crosses through `any`; same convention as sqlite_stmt_cache).
+local record Rows
+  metamethod __call: function(self: Rows): {string: any}
+  err: function(self: Rows): string
+end
+
+local record Stmt
+  bind_list: function(self: Stmt, values: {any}): boolean, string
+  bind_named: function(self: Stmt, params: {string: any}): boolean, string
+  exec: function(self: Stmt): boolean, string
+  rows: function(self: Stmt): Rows
+  close: function(self: Stmt)
+end
+
+local record Db
+  prepare: function(self: Db, sql: string): Stmt | nil, string
+  exec_list: function(self: Db, sql: string, values: {any}): boolean, string
+  exec_named: function(self: Db, sql: string, params: {string: any}): boolean, string
+  query_list: function(self: Db, sql: string, values: {any}): Rows | nil, string
+  query_named: function(self: Db, sql: string, params: {string: any}): Rows | nil, string
+end
+
+-- Wrap a prepared+bound statement's row iterator: finalize the statement
+-- when iteration ends and forward the step error through `:err()`.
+local function make_query_iter(stmt: Stmt): Rows
+  local raw_iter = stmt:rows()
+  local done = false
+  local iter = setmetatable({} as Rows, {
+      __call = function(_: Rows): {string: any}
+        if done then
+          return nil
+        end
+        local row = raw_iter()
+        if row == nil then
+          done = true
+          stmt:close()
+          return nil
+        end
+        return row
+      end,
+    })
+  iter.err = function(_: Rows): string return raw_iter:err() end
+  return iter
+end
+
+--- Attach the list/named parameter methods to a Database under
+--- construction. The handle is typed `any` so cosmic.sqlite's nominal
+--- Database record doesn't need to be duplicated here.
+--- @param db_any any The Database being built by make_database
+local function attach(db_any: any)
+  local db = db_any as Db
+
+  --- Execute SQL with parameters from a list (table). The count is derived
+  --- from the SQL itself, so nil values in the table are handled correctly.
+  function db:exec_list(sql: string, values: {any}): boolean, string
+    local stmt, err = self:prepare(sql)
+    if not stmt then
+      return false, err or "prepare failed"
+    end
+    local st = stmt as Stmt
+
+    local ok, bind_err = st:bind_list(values)
+    if not ok then
+      st:close()
+      return false, bind_err or "bind failed"
+    end
+
+    local exec_ok, exec_err = st:exec()
+    st:close()
+    return exec_ok, exec_err
+  end
+
+  --- Execute SQL with named parameters.
+  --- SQL should use :name placeholders. Table keys are names without the colon.
+  function db:exec_named(sql: string, params: {string: any}): boolean, string
+    local stmt, err = self:prepare(sql)
+    if not stmt then
+      return false, err or "prepare failed"
+    end
+    local st = stmt as Stmt
+
+    local ok, bind_err = st:bind_named(params)
+    if not ok then
+      st:close()
+      return false, bind_err or "bind failed"
+    end
+
+    local exec_ok, exec_err = st:exec()
+    st:close()
+    return exec_ok, exec_err
+  end
+
+  --- Query with parameters from a list (table).
+  --- The parameter count is derived from the SQL itself, so nil values
+  --- in the table are handled correctly.
+  function db:query_list(sql: string, values: {any}): Rows | nil, string
+    local stmt, err = self:prepare(sql)
+    if not stmt then
+      return nil, "query failed: " .. (err or "unknown error")
+    end
+    local st = stmt as Stmt
+
+    local ok, bind_err = st:bind_list(values)
+    if not ok then
+      st:close()
+      return nil, "bind failed: " .. (bind_err or "unknown error")
+    end
+
+    return make_query_iter(st)
+  end
+
+  --- Query with named parameters.
+  --- SQL should use :name placeholders. Table keys are names without the colon.
+  function db:query_named(sql: string, params: {string: any}): Rows | nil, string
+    local stmt, err = self:prepare(sql)
+    if not stmt then
+      return nil, "query failed: " .. (err or "unknown error")
+    end
+    local st = stmt as Stmt
+
+    local ok, bind_err = st:bind_named(params)
+    if not ok then
+      st:close()
+      return nil, "bind failed: " .. (bind_err or "unknown error")
+    end
+
+    return make_query_iter(st)
+  end
+end
+
+return {attach = attach}

--- a/lib/cosmic/sqlite_row_iter.tl
+++ b/lib/cosmic/sqlite_row_iter.tl
@@ -5,6 +5,8 @@
 --- once on the first row, and releases the statement when iteration drains.
 --- Lives in its own file so cosmic/sqlite.tl stays under the 500-line cap.
 
+local bind_mod = require("cosmic.sqlite_bind")
+
 local record RawStatement
   bind: function(self: RawStatement, n: number, value?: any): number
   step: function(self: RawStatement): number
@@ -106,7 +108,7 @@ local type OnClose = function(RawStatement)
     raw_stmt:reset()
     local n = select("#", ...) as integer
     for i = 1, n do
-      local rc = raw_stmt:bind(i, (select(i, ...)))
+      local rc = bind_mod.bind_at(raw_stmt, i, (select(i, ...)))
       if rc ~= ok_code then
         local bind_err = raw_db:errmsg()
         if on_close then

--- a/lib/cosmic/sqlite_stmt_cache.tl
+++ b/lib/cosmic/sqlite_stmt_cache.tl
@@ -3,6 +3,8 @@
 --- same SQL (e.g. inside a loop in a transaction) instead of preparing
 --- and finalizing a fresh one every time.
 
+local bind_mod = require("cosmic.sqlite_bind")
+
 local record RawStatement
   bind: function(self: RawStatement, n: number, value?: any): number
   step: function(self: RawStatement): number
@@ -60,7 +62,7 @@ local type OnClose = function(RawStatement)
     local function bind_and_step(raw_stmt: RawStatement, args: {integer: any}, n: integer): number
       raw_stmt:reset()
       for i = 1, n do
-        local rc = raw_stmt:bind(i, args[i])
+        local rc = bind_mod.bind_at(raw_stmt, i, args[i])
         if rc ~= ok_code then
           return rc
         end

--- a/lib/cosmic/welcome.tl
+++ b/lib/cosmic/welcome.tl
@@ -3,11 +3,6 @@
 local cio = require("cosmic.io")
 local czip = require("cosmic.zip")
 
-local record Appender
-  add: function(self: Appender, name: string, content: string): boolean | nil, string | nil
-  close: function(self: Appender)
-end
-
 local MARKER < const > = ".cosmic/welcome-shown"
 
 --- Check if welcome has been shown.
@@ -20,11 +15,12 @@ end
 local function mark_shown()
   local exe = arg[-1]
   if exe then
-    local appender = czip.open(exe, "a") as Appender
+    local appender = czip.appender(exe)
     if appender then
+      local a = appender as czip.Appender
       -- Ignore result; showing welcome again on failure is acceptable
-      appender:add(MARKER, "")
-      appender:close()
+      a:add(MARKER, "")
+      a:close()
     end
   end
 end

--- a/lib/cosmic/zip.tl
+++ b/lib/cosmic/zip.tl
@@ -1,10 +1,17 @@
 --- ZIP archive reading and writing utilities.
---- Wraps cosmo.zip with a convenient Teal-typed interface for creating, reading, and modifying ZIP archives.
+--- Wraps cosmo.zip with a convenient Teal-typed interface for creating,
+--- reading, and modifying ZIP archives. Use `reader`/`writer`/`appender`
+--- to open by path, `from` for in-memory data, and `extract` to safely
+--- unpack a reader to a directory (entry names from an archive are
+--- attacker-controlled; never write them to disk without `extract`'s
+--- zip-slip validation).
 local zip = require("cosmo.zip")
+local fs = require("cosmic.fs")
+local cio = require("cosmic.io")
 
 --- Options for opening a ZIP archive.
 local record OpenOptions
-  --- Compression level 0-9 (0=none, 9=maximum). Used for "w" and "a" modes.
+  --- Compression level 0-9 (0=none, 9=maximum). Used when writing/appending.
   level: number
   --- Maximum file size limit in bytes.
   max_file_size: number
@@ -39,6 +46,9 @@ end
 --- Reader for extracting files from a ZIP archive.
 local record Reader
   --- Lists all files in the ZIP archive.
+  --- Entry names come raw from the central directory: an archive built by
+  --- another tool can contain absolute or "../" names. Validate before
+  --- using a name as a filesystem path, or use extract().
   --- @return {string} List of file paths in the archive
   list: function(self: Reader): {string}
 
@@ -91,33 +101,79 @@ local record Appender
   close: function(self: Appender)
 end
 
---- Open a ZIP archive for reading, writing, or appending.
---- The mode determines the type of handle returned:
---- - "r" (default): Returns a Reader for extracting files
---- - "w": Returns a Writer for creating a new archive (overwrites existing)
---- - "a": Returns an Appender for adding files to an existing archive
+--- Options for extract().
+local record ExtractOptions
+  --- Refuse any entry whose declared uncompressed size exceeds this many
+  --- bytes (checked before anything is read or written).
+  max_file_size: number
+end
+
+-- Build a plain options table so the nominal cosmo.zip.OpenOptions record
+-- doesn't conflict with this module's OpenOptions.
+local function raw_options(options: OpenOptions): {string: number}
+  return {
+    level = options.level,
+    max_file_size = options.max_file_size,
+  }
+end
+
+--- Open a ZIP archive for reading.
 --- @param path string|number File path or file descriptor
---- @param mode string? Mode: "r" (read), "w" (write), or "a" (append). Default is "r".
---- @param options OpenOptions? Compression level and size limits
---- @return any The archive handle (Reader, Writer, or Appender based on mode), or nil on error
+--- @param options OpenOptions? Size limits
+--- @return Reader | nil The archive reader, or nil on error
 --- @return string? Error message if opening failed
-local function open(path: string | number, mode?: string, options?: OpenOptions): any, string
+local function reader(path: string | number, options?: OpenOptions): Reader | nil, string
   local handle: any
   local err: string
   if options then
-    -- Build options table to avoid nominal type conflict with cosmo.zip's OpenOptions
-    local opts = {
-      level = options.level,
-      max_file_size = options.max_file_size,
-    }
-    handle, err = zip.open(path, mode, opts)
+    handle, err = zip.open(path, "r", raw_options(options) as zip.OpenOptions)
   else
-    handle, err = zip.open(path, mode)
+    handle, err = zip.open(path, "r")
   end
   if not handle then
     return nil, err or "failed to open zip archive"
   end
-  return handle
+  return handle as Reader
+end
+
+--- Create a new ZIP archive for writing. Any existing file is truncated.
+--- @param path string|number File path or file descriptor
+--- @param options OpenOptions? Compression level and size limits
+--- @return Writer | nil The archive writer, or nil on error
+--- @return string? Error message if opening failed
+local function writer(path: string | number, options?: OpenOptions): Writer | nil, string
+  local handle: any
+  local err: string
+  if options then
+    handle, err = zip.create(path, raw_options(options) as zip.OpenOptions)
+  else
+    handle, err = zip.create(path)
+  end
+  if not handle then
+    return nil, err or "failed to create zip archive"
+  end
+  return handle as Writer
+end
+
+--- Open a ZIP archive for appending, creating it if it does not exist.
+--- Unlike reader/writer, a file descriptor is not accepted; the archive
+--- must be given as a path.
+--- @param path string File path
+--- @param options OpenOptions? Compression level and size limits
+--- @return Appender | nil The archive appender, or nil on error
+--- @return string? Error message if opening failed
+local function appender(path: string, options?: OpenOptions): Appender | nil, string
+  local handle: any
+  local err: string
+  if options then
+    handle, err = zip.append(path, raw_options(options) as zip.OpenOptions)
+  else
+    handle, err = zip.append(path)
+  end
+  if not handle then
+    return nil, err or "failed to open zip archive for appending"
+  end
+  return handle as Appender
 end
 
 --- Open a ZIP archive from in-memory data for reading.
@@ -129,12 +185,7 @@ local function from(data: string, options?: OpenOptions): Reader | nil, string
   local handle: any
   local err: string
   if options then
-    -- Build options table to avoid nominal type conflict with cosmo.zip's OpenOptions
-    local opts = {
-      level = options.level,
-      max_file_size = options.max_file_size,
-    }
-    handle, err = zip.from(data, opts)
+    handle, err = zip.from(data, raw_options(options) as zip.OpenOptions)
   else
     handle, err = zip.from(data)
   end
@@ -144,11 +195,111 @@ local function from(data: string, options?: OpenOptions): Reader | nil, string
   return handle as Reader
 end
 
+--- Report whether a zip entry name would escape the extraction root
+--- (zip-slip). Rejects absolute paths — POSIX (`/x`), Windows/UNC
+--- (`\x`, `\\server\share`), and drive-letter (`C:\x`, `C:/x`, `C:x`) —
+--- and any `..` traversal component. Both `/` and `\` are treated as
+--- separators, since cosmic executables also run on Windows where a
+--- `..\evil` entry would otherwise slip past a POSIX-only guard.
+local function unsafe_entry(name: string): boolean
+  if name == "" then return true end
+  -- Absolute roots escape the destination directory.
+  if name:sub(1, 1) == "/" or name:sub(1, 1) == "\\" then return true end
+  if name:match("^%a:") then return true end
+  -- Normalize backslashes so ".." traversal is caught on either
+  -- separator ("..\evil" like "../evil").
+  local slashed = name:gsub("\\", "/")
+  if slashed == ".." or slashed:match("^%.%./") or slashed:match("/%.%./")
+  or slashed:match("/%.%.$") then
+    return true
+  end
+  return false
+end
+
+--- Extract every entry of an open reader into destdir, refusing archives
+--- that attempt zip-slip. All entry names (and sizes, when
+--- opts.max_file_size is set) are validated before anything is written, so
+--- a malicious archive fails without leaving partial output. File modes
+--- are taken from the archive masked to 0777 (setuid/setgid/sticky bits
+--- are stripped); entries without a mode default to 0644. Existing files
+--- are overwritten. The reader is left open.
+--- @param r Reader An open archive reader (from reader() or from())
+--- @param destdir string Directory to extract into (created if needed)
+--- @param opts ExtractOptions? Per-entry size limit
+--- @return boolean true when every entry was written
+--- @return string? Error message if validation or writing failed
+local function extract(r: Reader, destdir: string, opts?: ExtractOptions): boolean, string
+  local entries = r:list()
+
+  -- Validate everything up front: a single bad entry rejects the whole
+  -- archive before any bytes hit the filesystem.
+  for _, name in ipairs(entries) do
+    if unsafe_entry(name) then
+      return false, "unsafe path in archive: " .. name
+    end
+    if opts and opts.max_file_size then
+      local st = r:stat(name)
+      if st and (st as Stat).size > opts.max_file_size then
+        return false, "entry exceeds max_file_size: " .. name
+      end
+    end
+  end
+
+  local made_dirs: {string: boolean} = {}
+  local function ensure_dir(dir: string): boolean, string
+    if made_dirs[dir] then return true end
+    local ok, err = fs.makedirs(dir)
+    if not ok then
+      return false, "cannot create directory '" .. dir .. "': " .. (err or "unknown error")
+    end
+    made_dirs[dir] = true
+    return true
+  end
+
+  local ok, err = ensure_dir(destdir)
+  if not ok then return false, err end
+
+  for _, name in ipairs(entries) do
+    if name:sub(-1) == "/" then
+      ok, err = ensure_dir(fs.join(destdir, name))
+      if not ok then return false, err end
+    else
+      local content, read_err = r:read(name)
+      if not content then
+        return false, "cannot read '" .. name .. "' from archive: " .. (read_err or "unknown error")
+      end
+      local filepath = fs.join(destdir, name)
+      ok, err = ensure_dir(fs.dirname(filepath))
+      if not ok then return false, err end
+
+      -- Sane-masked mode from the archive: permission bits only.
+      local file_mode = tonumber("644", 8)
+      local st = r:stat(name)
+      if st then
+        local mode = (st as Stat).mode & tonumber("777", 8)
+        if mode > 0 then
+          file_mode = mode
+        end
+      end
+
+      local write_ok, write_err = cio.barf(filepath, content, file_mode)
+      if not write_ok then
+        return false, "cannot write '" .. filepath .. "': " .. (write_err or "unknown error")
+      end
+      -- barf's mode only applies on create; force it for overwrites.
+      fs.chmod(filepath, file_mode)
+    end
+  end
+  return true
+end
+
 local record ZipModule
   --- Options for opening a ZIP archive.
   type OpenOptions = OpenOptions
   --- Options for adding a file to a ZIP archive.
   type AddOptions = AddOptions
+  --- Options for extract().
+  type ExtractOptions = ExtractOptions
   --- File metadata within a ZIP archive.
   type Stat = Stat
   --- Reader for extracting files from a ZIP archive.
@@ -158,13 +309,19 @@ local record ZipModule
   --- Appender for adding files to an existing ZIP archive.
   type Appender = Appender
 
-  open: function(path: string | number, mode?: string, options?: OpenOptions): any, string
+  reader: function(path: string | number, options?: OpenOptions): Reader | nil, string
+  writer: function(path: string | number, options?: OpenOptions): Writer | nil, string
+  appender: function(path: string, options?: OpenOptions): Appender | nil, string
   from: function(data: string, options?: OpenOptions): Reader | nil, string
+  extract: function(r: Reader, destdir: string, opts?: ExtractOptions): boolean, string
 end
 
 local M: ZipModule = {
-  open = open,
+  reader = reader,
+  writer = writer,
+  appender = appender,
   from = from,
+  extract = extract,
 }
 
 return M

--- a/lib/cosmic/zip_test.tl
+++ b/lib/cosmic/zip_test.tl
@@ -3,6 +3,7 @@
 
 local cio = require("cosmic.io")
 local fs = require("cosmic.fs")
+local fs_types = require("cosmic.fs_types")
 local zip = require("cosmic.zip")
 
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
@@ -14,9 +15,9 @@ end
 
 -- Basic write operations
 
-local function test_open_write()
+local function test_writer()
   local p = zip_path("write_test.zip")
-  local w, err = zip.open(p, "w")
+  local w, err = zip.writer(p)
   assert(w, "should open for writing: " .. tostring(err))
   local writer = w as zip.Writer
   local ok, add_err = writer:add("hello.txt", "Hello, World!")
@@ -27,11 +28,11 @@ local function test_open_write()
   local data = cio.slurp(p)
   assert(data and #data > 0, "zip file should exist and have content")
 end
-test_open_write()
+test_writer()
 
-local function test_open_write_multiple_files()
+local function test_writer_multiple_files()
   local p = zip_path("multi_test.zip")
-  local w, err = zip.open(p, "w")
+  local w, err = zip.writer(p)
   assert(w, "should open for writing: " .. tostring(err))
   local writer = w as zip.Writer
   writer:add("file1.txt", "Content 1")
@@ -42,39 +43,38 @@ local function test_open_write_multiple_files()
   local data = cio.slurp(p)
   assert(data and #data > 0, "zip file should exist")
 end
-test_open_write_multiple_files()
+test_writer_multiple_files()
 
 -- Basic read operations
 
-local function test_open_read()
+local function test_reader()
   -- Create a zip first
   local p = zip_path("read_test.zip")
-  local w = zip.open(p, "w") as zip.Writer
+  local w = zip.writer(p) as zip.Writer
   w:add("test.txt", "Test content")
   w:close()
 
   -- Now read it
-  local r, err = zip.open(p, "r")
+  local r, err = zip.reader(p)
   assert(r, "should open for reading: " .. tostring(err))
   local reader = r as zip.Reader
   reader:close()
 end
-test_open_read()
+test_reader()
 
 local function test_read_list()
   local p = zip_path("list_test.zip")
-  local w = zip.open(p, "w") as zip.Writer
+  local w = zip.writer(p) as zip.Writer
   w:add("a.txt", "A")
   w:add("b.txt", "B")
   w:add("c/d.txt", "D")
   w:close()
 
-  local r = zip.open(p, "r") as zip.Reader
+  local r = zip.reader(p) as zip.Reader
   local files = r:list()
   r:close()
 
   assert(#files == 3, "should have 3 files, got " .. #files)
-  -- Files should be sorted or in order
   local found_a, found_b, found_d = false, false, false
   for _, name in ipairs(files) do
     if name == "a.txt" then found_a = true end
@@ -89,26 +89,26 @@ test_read_list()
 
 local function test_read_content()
   local p = zip_path("content_test.zip")
-  local w = zip.open(p, "w") as zip.Writer
+  local w = zip.writer(p) as zip.Writer
   w:add("hello.txt", "Hello, ZIP!")
   w:close()
 
-  local r = zip.open(p, "r") as zip.Reader
+  local r = zip.reader(p) as zip.Reader
   local content, err = r:read("hello.txt")
   r:close()
 
   assert(content, "should read content: " .. tostring(err))
-  assert(content == "Hello, ZIP!", "content should match, got: " .. content)
+  assert(content == "Hello, ZIP!", "content should match, got: " .. tostring(content))
 end
 test_read_content()
 
 local function test_read_stat()
   local p = zip_path("stat_test.zip")
-  local w = zip.open(p, "w") as zip.Writer
+  local w = zip.writer(p) as zip.Writer
   w:add("data.bin", "0123456789") -- 10 bytes
   w:close()
 
-  local r = zip.open(p, "r") as zip.Reader
+  local r = zip.reader(p) as zip.Reader
   local stat = r:stat("data.bin")
   r:close()
 
@@ -120,12 +120,12 @@ test_read_stat()
 
 local function test_read_nonexistent_file()
   local p = zip_path("nonexistent_test.zip")
-  local w = zip.open(p, "w") as zip.Writer
+  local w = zip.writer(p) as zip.Writer
   w:add("exists.txt", "I exist")
   w:close()
 
-  local r = zip.open(p, "r") as zip.Reader
-  local content, err = r:read("does_not_exist.txt")
+  local r = zip.reader(p) as zip.Reader
+  local content = r:read("does_not_exist.txt")
   r:close()
 
   assert(content == nil, "should not find nonexistent file")
@@ -134,16 +134,16 @@ test_read_nonexistent_file()
 
 -- Append operations
 
-local function test_open_append()
+local function test_appender()
   local p = zip_path("append_test.zip")
 
   -- Create initial zip
-  local w = zip.open(p, "w") as zip.Writer
+  local w = zip.writer(p) as zip.Writer
   w:add("first.txt", "First file")
   w:close()
 
   -- Append to it
-  local a, err = zip.open(p, "a")
+  local a, err = zip.appender(p)
   assert(a, "should open for appending: " .. tostring(err))
   local appender = a as zip.Appender
   local ok, add_err = appender:add("second.txt", "Second file")
@@ -151,7 +151,7 @@ local function test_open_append()
   appender:close()
 
   -- Verify both files exist
-  local r = zip.open(p, "r") as zip.Reader
+  local r = zip.reader(p) as zip.Reader
   local files = r:list()
   local first_content = r:read("first.txt")
   local second_content = r:read("second.txt")
@@ -161,23 +161,20 @@ local function test_open_append()
   assert(first_content == "First file", "first file content should match")
   assert(second_content == "Second file", "second file content should match")
 end
-test_open_append()
+test_appender()
 
 -- In-memory reading with from()
 
 local function test_from_memory()
-  -- Create a zip file first
   local p = zip_path("memory_test.zip")
-  local w = zip.open(p, "w") as zip.Writer
+  local w = zip.writer(p) as zip.Writer
   w:add("mem.txt", "In-memory content")
   w:close()
 
-  -- Read the zip data
   local zip_data = cio.slurp(p)
   assert(zip_data, "should read zip data")
 
-  -- Open from memory
-  local r, err = zip.from(zip_data)
+  local r, err = zip.from(zip_data as string)
   assert(r, "should open from memory: " .. tostring(err))
   local rr = r as zip.Reader
   local content = rr:read("mem.txt")
@@ -189,12 +186,34 @@ test_from_memory()
 
 -- Error handling
 
-local function test_open_invalid_path()
-  local r, err = zip.open("/nonexistent/path/to/file.zip", "r")
+local function test_reader_invalid_path()
+  local r, err = zip.reader("/nonexistent/path/to/file.zip")
   assert(r == nil, "should fail on invalid path")
   assert(err, "should return error message")
 end
-test_open_invalid_path()
+test_reader_invalid_path()
+
+local function test_appender_creates_missing_archive()
+  -- append has create-or-append semantics: a missing archive is created.
+  local p = zip_path("appender_creates.zip")
+  local a, err = zip.appender(p)
+  assert(a, "appender should create a missing archive: " .. tostring(err))
+  local appender = a as zip.Appender
+  appender:add("x.txt", "hi")
+  appender:close()
+
+  local r = zip.reader(p) as zip.Reader
+  assert(r:read("x.txt") == "hi", "created archive should contain the entry")
+  r:close()
+end
+test_appender_creates_missing_archive()
+
+local function test_appender_invalid_path()
+  local a, err = zip.appender("/nonexistent/dir/x.zip")
+  assert(a == nil, "should fail when the parent directory is missing")
+  assert(err, "should return error message")
+end
+test_appender_invalid_path()
 
 local function test_from_invalid_data()
   local r, err = zip.from("not valid zip data")
@@ -207,7 +226,7 @@ test_from_invalid_data()
 
 local function test_add_with_options()
   local p = zip_path("options_test.zip")
-  local w = zip.open(p, "w") as zip.Writer
+  local w = zip.writer(p) as zip.Writer
   -- Use larger content that will definitely compress
   local large_content = string.rep("Hello World! ", 100) -- 1300 bytes of repeated data
   local ok, err = w:add("stored.txt", large_content, {method = "store"})
@@ -216,7 +235,7 @@ local function test_add_with_options()
   assert(ok, "should add with deflate method: " .. tostring(err))
   w:close()
 
-  local r = zip.open(p, "r") as zip.Reader
+  local r = zip.reader(p) as zip.Reader
   local stored_stat = r:stat("stored.txt")
   local deflated_stat = r:stat("deflated.txt")
   r:close()
@@ -234,9 +253,9 @@ local function test_add_with_options()
 end
 test_add_with_options()
 
-local function test_open_with_compression_level()
+local function test_writer_with_compression_level()
   local p = zip_path("level_test.zip")
-  local w, err = zip.open(p, "w", {level = 9})
+  local w, err = zip.writer(p, {level = 9})
   assert(w, "should open with compression level: " .. tostring(err))
   local writer = w as zip.Writer
   -- Add a file that benefits from compression
@@ -245,7 +264,7 @@ local function test_open_with_compression_level()
   writer:close()
 
   -- Verify it compressed
-  local r = zip.open(p, "r") as zip.Reader
+  local r = zip.reader(p) as zip.Reader
   local stat = r:stat("compressible.txt")
   r:close()
 
@@ -254,22 +273,104 @@ local function test_open_with_compression_level()
   assert(st.size == 4000, "uncompressed size should be 4000")
   assert(st.compressed_size < st.size, "compressed size should be smaller")
 end
-test_open_with_compression_level()
+test_writer_with_compression_level()
 
--- Default mode is read
+-- extract(): safe extraction to a directory
 
-local function test_default_mode_is_read()
-  local p = zip_path("default_mode_test.zip")
-  local w = zip.open(p, "w") as zip.Writer
-  w:add("test.txt", "Test")
+local function test_extract_basic()
+  local p = zip_path("extract_basic.zip")
+  local w = zip.writer(p) as zip.Writer
+  w:add("top.txt", "top content")
+  w:add("sub/dir/nested.txt", "nested content")
+  w:add("run.sh", "#!/bin/sh\n", {mode = tonumber("755", 8)})
   w:close()
 
-  -- Open without specifying mode
-  local r, err = zip.open(p)
-  assert(r, "should open in default mode: " .. tostring(err))
-  local reader = r as zip.Reader
-  local files = reader:list()
-  reader:close()
-  assert(#files == 1, "should list files in default read mode")
+  local r = zip.reader(p) as zip.Reader
+  local dest = zip_path("extract_basic_out")
+  local ok, err = zip.extract(r, dest)
+  r:close()
+  assert(ok, "extract should succeed: " .. tostring(err))
+
+  assert(cio.slurp(fs.join(dest, "top.txt")) == "top content", "top.txt should round-trip")
+  assert(cio.slurp(fs.join(dest, "sub/dir/nested.txt")) == "nested content", "nested file should round-trip")
+  local st = fs.stat(fs.join(dest, "run.sh"))
+  assert(st, "run.sh should exist")
+  local mode = (st as fs_types.Stat):mode() & tonumber("777", 8)
+  assert(mode == tonumber("755", 8), "mode from the archive should apply, got " .. string.format("%o", mode))
 end
-test_default_mode_is_read()
+test_extract_basic()
+
+-- Craft an archive with a traversal entry. cosmic's own zip writer refuses
+-- ".." names, so write a same-length placeholder name and byte-patch it
+-- (no offsets change, so the zip stays valid): "XX/escaped.txt" ->
+-- "../escaped.txt".
+local function crafted_archive(patch_to: string): string
+  local safe = zip_path("crafted_" .. patch_to:gsub("%W", "_") .. ".zip")
+  local w = zip.writer(safe) as zip.Writer
+  w:add("good.txt", "innocent")
+  w:add("XX/escaped.txt", "pwned")
+  w:close()
+  local raw = cio.slurp(safe)
+  assert(#patch_to == #"XX/escaped.txt", "patch must preserve name length")
+  local patched = string.gsub(raw as string, "XX/escaped%.txt", patch_to)
+  return patched
+end
+
+local function test_extract_rejects_traversal()
+  local data = crafted_archive("../escaped.txt")
+  local r = zip.from(data) as zip.Reader
+  local dest = zip_path("traversal_out")
+  local ok, err = zip.extract(r, dest)
+  r:close()
+
+  assert(not ok, "extract should reject a ../ entry")
+  assert(err and err:match("unsafe path"), "expected unsafe path error, got: " .. tostring(err))
+  -- Nothing may be written: not the escaping file, and not the innocent
+  -- entry either (validation runs before any writes).
+  assert(not fs.exists(fs.join(TEST_TMPDIR, "escaped.txt")), "escaping file must not be written")
+  assert(not fs.exists(dest), "destination must stay untouched on rejection")
+end
+test_extract_rejects_traversal()
+
+local function test_extract_rejects_absolute()
+  local data = crafted_archive("/e/escaped.txt")
+  local r = zip.from(data) as zip.Reader
+  local dest = zip_path("absolute_out")
+  local ok, err = zip.extract(r, dest)
+  r:close()
+
+  assert(not ok, "extract should reject an absolute entry")
+  assert(err and err:match("unsafe path"), "expected unsafe path error, got: " .. tostring(err))
+  assert(not fs.exists(dest), "destination must stay untouched on rejection")
+end
+test_extract_rejects_absolute()
+
+local function test_extract_rejects_backslash_traversal()
+  local data = crafted_archive("..\\escaped.txt")
+  local r = zip.from(data) as zip.Reader
+  local dest = zip_path("backslash_out")
+  local ok, err = zip.extract(r, dest)
+  r:close()
+
+  assert(not ok, "extract should reject a ..\\ entry")
+  assert(err and err:match("unsafe path"), "expected unsafe path error, got: " .. tostring(err))
+end
+test_extract_rejects_backslash_traversal()
+
+local function test_extract_max_file_size()
+  local p = zip_path("extract_size.zip")
+  local w = zip.writer(p) as zip.Writer
+  w:add("small.txt", "ok")
+  w:add("big.txt", string.rep("x", 4096))
+  w:close()
+
+  local r = zip.reader(p) as zip.Reader
+  local dest = zip_path("size_out")
+  local ok, err = zip.extract(r, dest, {max_file_size = 1024})
+  r:close()
+
+  assert(not ok, "extract should reject oversized entries")
+  assert(err and err:match("max_file_size"), "expected size error, got: " .. tostring(err))
+  assert(not fs.exists(fs.join(dest, "small.txt")), "no partial output on size rejection")
+end
+test_extract_max_file_size()


### PR DESCRIPTION
Closes #531 (T7 of the pre-stable API review, #517). cosmic-layer data API changes; no C changes needed — everything builds on bindings already in the pinned cosmos release.

## sqlite

- **Blob binding**: `sqlite.blob(s)` returns a metatable-marked wrapper; every bind path recognizes it and calls `bind_blob` — `Statement:bind`/`bind_list` in `sqlite.tl`, the `db:exec` statement cache (`sqlite_stmt_cache.tl`), and the `db:query` hot path (`sqlite_row_iter.tl`) — via the new shared `cosmic.sqlite_bind` helper. Bare strings keep TEXT affinity (pinned by a control test). `bind_named` rejects blob wrappers with a clear error (the raw `bind_names` call would silently bind the wrapper table), pointing at positional binding.
- **Default busy timeout**: `open(filename, opts?: {busy_timeout_ms: integer, read_only: boolean})` sets a 5000ms busy timeout by default (overridable, `0` restores fail-fast) so two processes on one file DB wait instead of failing instantly with BUSY. `read_only` opens with `OPEN_READONLY`.
- The `prepare` tri-shape was already wrapped at this layer (`db:prepare` returns `Statement | nil, string`); no change needed.
- To stay under the 500-line cap, the list/named parameter conveniences (`exec_list`/`exec_named`/`query_list`/`query_named` + the query-iter wrapper) moved verbatim into new `cosmic.sqlite_params`.
- Tests (new `sqlite_data_test.tl`): blob affinity round-trip (`typeof == "blob"`), text control, blob through query/exec/bind_list paths, named rejection, `PRAGMA busy_timeout` readback for default/override/zero, read_only write refusal.

## json

- `encode(value, options?: EncodeOptions)` now forwards `{pretty, sorted, indent, maxdepth}` to the C encoder (previously silently ignored — `encode(v, {pretty=true})` returned compact).
- The lossy null policy is documented loudly on the module and pinned by tests: `{"a":null,"b":1}` re-encodes as `{"b":1}`, `[1,null,2]` truncates to `[1]`, NaN encodes as `null`. Testing revealed ±Inf actually encodes as `±1e5000` (not `null` as the issue assumed) — documented and pinned as such. Adopting a C-side array marker + `json.null` sentinel stays gated on whilp/cosmopolitan#153.

## zip

- **Typed constructors**: `zip.reader/writer/appender(path, opts?): T | nil, string` replace the `any`-returning `zip.open`, which is deleted. `appender` documents the raw binding's create-or-append semantics. Callers migrated: `welcome.tl`, `embed.tl`, `embed_advanced_test.tl`, `zip_test.tl`.
- **Safe extraction**: `zip.extract(r, destdir, opts?)` validates *all* entry names (absolute POSIX/Windows/drive-letter paths, `..` components on either separator) and sizes (`opts.max_file_size`) before writing anything, so a malicious archive is refused with zero partial output; modes come from `stat()` masked to 0777 (defaulting 0644).
- Tests craft real traversal archives by byte-patching a same-length entry name (`XX/escaped.txt` → `../escaped.txt`, `/e/…`, `..\…`) and assert extract refuses and writes nothing — including the innocent entry ordered before the bad one.

## compress

- `inflate(data, max_output?)` validates the attacker-controlled 4-byte size prefix before allocating: declared size beyond `max_output` (when given) or beyond DEFLATE's documented 1032:1 maximum ratio is rejected up front. A 5-byte blob claiming 4GB now returns an error without allocating (pinned by test).

## hash / rand

- `hash.hmac_sha256(key, data)` wraps `cosmo.GetCryptoHash("SHA256", data, key)`; tested against RFC 4231 vectors 1 and 2.
- `hash.constant_time_equal(a, b)` XOR-accumulates over every byte (only the public digest length short-circuits).
- `rand.int(min, max)` is crypto-grade and unbiased: rejection sampling over `bytes()`, range capped at 2^53. Tests cover bounds, degenerate range, distribution smoke, multi-byte ranges, and argument validation. (Dropping `rdrand`/`rdseed` fictions stays gated on whilp/cosmopolitan#150 — this module never exposed them.)

Argon2 defaults verified OWASP-correct already; untouched.

## Gates

`bin/make ci` green: format 231/231, teal 231/231, test 103/103, example 19/19, lint 294/294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1sNNf67rEkJGafva1ZuWJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1sNNf67rEkJGafva1ZuWJ)_