### PR TITLE
networking reshape: honest headers, working retries, streaming errors, url/ip redesign

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "83aaf85c0ecb878ab487b3959f319c446f2aa856e80e1e229ce1034be84c0c6e"}},
+  platforms = {["*"] = {sha = "5e174f95819212e1d66083d9796ee1e510bda485033db82461f2094ea6a38e67"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.06-2d00678fc"
+  version = "2026.07.07-e3fc92474"
 }

--- a/lib/cosmic/fetch.tl
+++ b/lib/cosmic/fetch.tl
@@ -1,16 +1,41 @@
---- Structured HTTP fetch with optional retry.
---- Wraps cosmo.Fetch with structured results to prevent accidentally discarding errors.
+--- Structured HTTP fetch with retry, streaming, and honest error channels.
+--- Wraps cosmo.Fetch/FetchStream with structured results so errors, the
+--- effective URL, and the machine-readable failure kind are never discarded.
 
 local cosmo = require("cosmo")
+local fetch_headers = require("cosmic.fetch_headers")
 local time = require("cosmic.time")
+
+--- Machine-readable failure category, from the C fetch error channel.
+--- nil on wrapper-side validation failures (bad URL, bad header).
+local enum ErrorKind
+  "dns"
+  "connect"
+  "tls"
+  "timeout"
+  "proxy"
+  "protocol"
+  "too_large"
+  "blocked"
+end
 
 --- Result from a fetch operation.
 local record Result
   ok: boolean
-  status: number
+  status: integer
+  --- Response headers: lowercase names; repeated headers joined ", "
+  --- (RFC 9110 §5.3), so every value is a plain string.
   headers: {string: string}
+  --- Response headers with every value: lowercase names, values in
+  --- arrival order. Use for repeatable headers like Set-Cookie.
+  raw_headers: {string: {string}}
   body: string
+  --- Effective URL of the final request, after any redirects.
+  url: string
   error: string
+  error_kind: ErrorKind
+  --- True when ok and status is 2xx.
+  is_success: function(self: Result): boolean
 end
 
 --- Options for fetch requests.
@@ -21,21 +46,34 @@ local record Opts
   body: string
   --- HTTP headers to send with the request.
   headers: {string: string}
+  --- Follow 3xx redirects (default true).
+  follow_redirects: boolean
+  --- Maximum redirect hops when following redirects (default 5).
+  max_redirects: integer
+  --- Allow requests to loopback/private addresses, disabling the SSRF
+  --- guard for every hop of the redirect chain (default false).
+  allow_private: boolean
   --- HTTP proxy URL.
   proxy: string
   --- Maximum response body size in bytes.
-  maxresponse: number
-  --- Total number of attempts (1 = no retry, default 1).
-  --- Retries only occur when result.ok is true and should_retry returns true.
-  max_attempts: number
-  --- Maximum backoff delay in seconds (default 30).
-  --- Backoff is exponential: 2^attempt seconds, capped at this value.
-  max_delay: number
-  --- Predicate called after each successful HTTP response to decide retry.
-  --- Return true to retry (e.g. on status 429 or 503). If nil, no retries.
-  should_retry: function(Result): boolean
-  --- Request timeout in seconds. If nil, no timeout is applied.
+  maxresponse: integer
+  --- Per-socket-operation timeout in seconds (connect, each read/write,
+  --- TLS handshake) — NOT a whole-request deadline. 0 or nil keeps the
+  --- 60-second default; there is no "infinite" option.
   timeout: number
+  --- Total number of attempts (1 = no retry, default 1).
+  max_attempts: integer
+  --- Base backoff delay in seconds (default 0.5). Attempt n waits a
+  --- uniformly random ("full jitter") delay in
+  --- [0, min(max_delay, base_delay * 2^(n-1))].
+  base_delay: number
+  --- Backoff delay cap in seconds (default 30).
+  max_delay: number
+  --- Predicate consulted after every attempt (success or failure).
+  --- Return true to retry. When nil, the default policy retries
+  --- transport errors (dns/connect/timeout) and 429/502/503/504
+  --- responses, for idempotent methods only.
+  should_retry: function(Result): boolean
 end
 
 --- Streaming reader for incremental body access.
@@ -44,17 +82,34 @@ local record Reader
   read: function(self: Reader): string | nil, string
   close: function(self: Reader): boolean
   closed: function(self: Reader): boolean
-  lines: function(self: Reader): function(): string
+  lines: function(self: Reader): function(): string | nil, string
 end
 
 --- Result from a streaming fetch operation.
 local record StreamResult
   ok: boolean
-  status: number
+  status: integer
   headers: {string: string}
+  raw_headers: {string: {string}}
   reader: Reader
+  --- Effective URL of the final request, after any redirects.
+  url: string
   error: string
+  error_kind: ErrorKind
+  --- True when ok and status is 2xx.
+  is_success: function(self: StreamResult): boolean
 end
+
+-- Shared is_success helper, attached via metatable so successful and
+-- failed results alike answer the 2xx question without carrying a field.
+local result_mt = {
+  __index = {
+    is_success = function(self: Result): boolean
+      return self.ok and self.status ~= nil
+      and self.status >= 200 and self.status < 300
+    end,
+  },
+}
 
 local function validate_url(url: string): string
   if url == "" then
@@ -102,74 +157,129 @@ local function validate_headers(headers: {string: string}): string
   return nil
 end
 
---- Project the transport-relevant Opts fields onto a typed cosmo.FetchOptions.
---- Retry-loop fields (max_attempts, max_delay, should_retry) stay wrapper-side.
+--- Project the transport-relevant Opts fields onto a fresh typed
+--- cosmo.FetchOptions, shallow-copying headers so no attempt can observe
+--- another attempt's table (the C layer no longer mutates its options,
+--- but the copy keeps that a C-layer detail). Retry-loop fields stay
+--- wrapper-side.
 --- @param opts Opts? wrapper options, or nil
 --- @return cosmo.FetchOptions? options for cosmo.Fetch/FetchStream, or nil
 local function to_fetch_options(opts?: Opts): cosmo.FetchOptions
   if not opts then
     return nil
   end
-  return {
+  local headers: {string: string} = nil
+  if opts.headers then
+    headers = {}
+    for name, value in pairs(opts.headers) do
+      headers[name] = value
+    end
+  end
+  local fo: cosmo.FetchOptions = {
     method = opts.method,
     body = opts.body,
-    headers = opts.headers,
+    headers = headers,
     proxy = opts.proxy,
     maxresponse = opts.maxresponse,
     timeout = opts.timeout,
+    maxredirects = opts.max_redirects,
+    allowprivate = opts.allow_private,
   }
+  if opts.follow_redirects ~= nil then
+    fo.followredirect = opts.follow_redirects
+  end
+  return fo
+end
+
+local function fail(err: any, kind: any): Result
+  return setmetatable({
+      ok = false,
+      error = tostring(err or "unknown error"),
+      error_kind = kind as ErrorKind,
+    } as Result, result_mt) as Result
 end
 
 local function do_fetch(url: string, opts?: Opts): Result
   local verr = validate_url(url)
   if verr then
-    return {ok = false, error = verr}
+    return fail(verr, nil)
   end
   local herr = opts and validate_headers(opts.headers)
   if herr then
-    return {ok = false, error = herr}
+    return fail(herr, nil)
   end
 
-  local status: number
-  local headers_or_err: {string: string} | string
-  local body: string
-
-  status, headers_or_err, body = cosmo.Fetch(url, to_fetch_options(opts))
-
+  local status, headers_or_err, body_or_kind, final_url = cosmo.Fetch(url, to_fetch_options(opts))
   if not status then
-    return {ok = false, error = tostring(headers_or_err or "unknown error")}
+    return fail(headers_or_err, body_or_kind)
   end
 
-  return {
-    ok = true,
-    status = status,
-    headers = headers_or_err as {string: string},
-    body = body,
-  }
+  local headers, raw_headers = fetch_headers.normalize(headers_or_err as {string: any})
+  return setmetatable({
+      ok = true,
+      status = status as integer,
+      headers = headers,
+      raw_headers = raw_headers,
+      body = body_or_kind,
+      url = final_url,
+    } as Result, result_mt) as Result
 end
 
---- Fetch a URL and return structured result.
+local IDEMPOTENT: {string: boolean} = {
+  GET = true, HEAD = true, OPTIONS = true, PUT = true, DELETE = true, TRACE = true,
+}
+local RETRYABLE_KIND: {string: boolean} = {dns = true, connect = true, timeout = true}
+local RETRYABLE_STATUS: {integer: boolean} = {[429] = true, [502] = true, [503] = true, [504] = true}
+
+--- Default retry policy: transport blips (dns/connect/timeout) and
+--- 429/502/503/504 responses are retried, but only for idempotent methods.
+--- Validation failures (no error_kind) and tls/blocked/protocol/proxy/
+--- too_large failures are never retried.
+local function default_should_retry(result: Result, method: string): boolean
+  if not IDEMPOTENT[method] then
+    return false
+  end
+  if not result.ok then
+    return RETRYABLE_KIND[result.error_kind] or false
+  end
+  return RETRYABLE_STATUS[result.status] or false
+end
+
+local function backoff(attempt: integer, base_delay: number, max_delay: number)
+  -- Full jitter: uniform in [0, min(max_delay, base_delay * 2^(attempt-1))].
+  local delay = math.random() * math.min(max_delay, base_delay * 2 ^ (attempt - 1))
+  local secs = math.floor(delay)
+  time.sleep(secs, math.floor((delay - secs) * 1e9))
+end
+
+--- Fetch a URL and return a structured result.
 --- @param url string URL to fetch
---- @param opts Opts optional fetch options (retry, headers, etc.)
---- @return Result fetch result with ok, status, headers, body, or error
+--- @param opts Opts optional fetch options (retry, headers, redirects, ...)
+--- @return Result fetch result with ok, status, headers, body, url, or error
 local function Fetch(url: string, opts?: Opts): Result
   local max_attempts = (opts and opts.max_attempts) or 1
+  local base_delay = (opts and opts.base_delay) or 0.5
   local max_delay = (opts and opts.max_delay) or 30
   local should_retry = opts and opts.should_retry
+  local method = string.upper((opts and opts.method) or "GET")
 
   local result: Result
   for attempt = 1, max_attempts do
     result = do_fetch(url, opts)
-
-    if not result.ok or not should_retry or not should_retry(result) then
-      return result
+    if attempt == max_attempts then
+      break
     end
-
-    if attempt < max_attempts then
-      time.sleep(math.min(max_delay, 2 ^ attempt))
+    local retry: boolean
+    if should_retry then
+      retry = should_retry(result)
+    else
+      retry = default_should_retry(result, method)
     end
+    if not retry then
+      break
+    end
+    backoff(attempt, base_delay, max_delay)
   end
-
   return result
 end
 
@@ -181,8 +291,8 @@ local function make_reader(raw_reader: cosmo.StreamReader): Reader
   local reader: Reader = {}
 
   --- Read the next chunk from the stream.
-  --- @return string | nil chunk or nil on EOF
-  --- @return string error message on failure
+  --- @return string | nil chunk, or nil on EOF or failure
+  --- @return string error message on failure (nil on clean EOF)
   function reader:read(): string | nil, string
     if is_closed then
       return nil, "reader closed"
@@ -212,19 +322,22 @@ local function make_reader(raw_reader: cosmo.StreamReader): Reader
 
   --- Return an iterator that yields complete lines.
   --- Buffers partial lines across chunks until a newline is received.
+  --- On clean EOF a final unterminated line is yielded, then nil. On a
+  --- read error (reset, truncation, TLS failure) the iterator yields
+  --- nil plus the error message once — the buffered partial line is
+  --- truncated data and is discarded — then plain nil forever.
   --- @return function iterator yielding lines without trailing newline
-  function reader:lines(): function(): string
+  function reader:lines(): function(): string | nil, string
     -- Scan-position index into buffer: `pos` is the first unread byte.
     -- Advancing it instead of slicing off each returned line, and dropping
     -- the consumed prefix only when we must read more, keeps the whole loop
-    -- linear in the byte count. The previous buffer:sub()-per-line and
-    -- buffer..chunk-per-chunk both re-copied the entire buffer, making line
-    -- iteration O(n²) in the body size (audit §7.2 P1).
+    -- linear in the byte count (audit §7.2 P1).
     local buffer = ""
     local pos = 1
     local done = false
+    local pending_err: string = nil
 
-    return function(): string
+    return function(): string | nil, string
       while true do
         local newline_pos = buffer:find("\n", pos, true)
         if newline_pos then
@@ -233,8 +346,16 @@ local function make_reader(raw_reader: cosmo.StreamReader): Reader
           return line
         end
 
+        if pending_err then
+          local err = pending_err
+          pending_err = nil
+          done = true
+          return nil, err
+        end
+
         if done then
-          -- EOF with a final unterminated line still buffered: yield it once.
+          -- Clean EOF with a final unterminated line still buffered:
+          -- yield it once.
           if pos <= #buffer then
             local remaining = buffer:sub(pos)
             pos = #buffer + 1
@@ -250,8 +371,14 @@ local function make_reader(raw_reader: cosmo.StreamReader): Reader
           buffer = buffer:sub(pos)
           pos = 1
         end
-        local chunk = self:read()
-        if not chunk then
+        local chunk, err = self:read()
+        if err then
+          -- The buffered tail has no newline: it is truncated data, not a
+          -- line. Drop it and surface the error on the next iteration.
+          pending_err = err
+          buffer = ""
+          pos = 1
+        elseif not chunk then
           done = true
         else
           buffer = buffer .. chunk
@@ -265,44 +392,46 @@ local function make_reader(raw_reader: cosmo.StreamReader): Reader
     }) as Reader
 end
 
+local function stream_fail(err: any, kind: any): StreamResult
+  return setmetatable({
+      ok = false,
+      error = tostring(err or "unknown error"),
+      error_kind = kind as ErrorKind,
+    } as StreamResult, result_mt) as StreamResult
+end
+
 --- Open a streaming HTTP request.
---- Unlike Fetch, returns immediately with a reader for incremental body access.
+--- Unlike Fetch, returns immediately with a reader for incremental body
+--- access. Takes the same options as Fetch except the retry fields
+--- (max_attempts, base_delay, max_delay, should_retry), which do not
+--- apply to streams.
 --- @param url string URL to fetch
 --- @param opts Opts optional fetch options
 --- @return StreamResult with reader for incremental body access
 local function stream(url: string, opts?: Opts): StreamResult
   local verr = validate_url(url)
   if verr then
-    return {ok = false, error = verr}
+    return stream_fail(verr, nil)
   end
   local herr = opts and validate_headers(opts.headers)
   if herr then
-    return {ok = false, error = herr}
+    return stream_fail(herr, nil)
   end
 
-  local status: number
-  local headers_or_err: {string: string} | string
-  local raw_reader: cosmo.StreamReader
-
-  status, headers_or_err, raw_reader = cosmo.FetchStream(url, to_fetch_options(opts))
-
+  local status, headers_or_err, reader_or_kind, final_url = cosmo.FetchStream(url, to_fetch_options(opts))
   if not status then
-    return {ok = false, error = tostring(headers_or_err or "unknown error")}
+    return stream_fail(headers_or_err, reader_or_kind)
   end
 
-  return {
-    ok = true,
-    status = status,
-    headers = headers_or_err as {string: string},
-    reader = make_reader(raw_reader),
-  }
-end
-
---- Report whether the streaming fetch primitive is available in this build.
---- When false, stream() cannot be used; callers should fall back to Fetch().
---- @return boolean true if fetch.stream() is supported
-local function has_stream(): boolean
-  return cosmo.FetchStream ~= nil
+  local headers, raw_headers = fetch_headers.normalize(headers_or_err as {string: any})
+  return setmetatable({
+      ok = true,
+      status = status as integer,
+      headers = headers,
+      raw_headers = raw_headers,
+      reader = make_reader(reader_or_kind as cosmo.StreamReader),
+      url = final_url,
+    } as StreamResult, result_mt) as StreamResult
 end
 
 --- Build a unix domain socket proxy URL from a socket path.
@@ -329,8 +458,8 @@ end
 local record fetch
   Fetch: function(url: string, opts?: Opts): Result
   stream: function(url: string, opts?: Opts): StreamResult
-  has_stream: function(): boolean
   unix_proxy: function(path: string): string | nil, string
+  type ErrorKind = ErrorKind
   Opts: Opts
   Result: Result
   Reader: Reader
@@ -340,7 +469,6 @@ end
 local M: fetch = {
   Fetch = Fetch,
   stream = stream,
-  has_stream = has_stream,
   unix_proxy = unix_proxy,
 }
 

--- a/lib/cosmic/fetch_example.tl
+++ b/lib/cosmic/fetch_example.tl
@@ -1,79 +1,106 @@
 --- Examples for the cosmic.fetch module.
---- Demonstrates HTTP requests and retry configuration.
----
---- These examples call a live HTTP endpoint (httpbin.org), so their exact
---- response depends on network conditions. They are deliberately written
---- without `-- Output:` assertions so CI does not flake when the endpoint is
---- slow, unreachable, or answers 5xx under load. The example runner still
---- compiles and executes each body, verifying the API is used correctly, and
---- every body guards against request failure so it never throws.
+--- Demonstrates HTTP requests, redirects, retry, and streaming — all
+--- against a forked loopback server, so the output is deterministic and
+--- no external host is contacted. allow_private opts out of the SSRF
+--- guard, which otherwise blocks requests to loopback/private addresses.
 
--- Example_get demonstrates a simple HTTP GET request.
+-- Example_get demonstrates a simple HTTP GET request against a local
+-- server: fork a child to answer one request, then fetch from it.
 local function Example_get()
   local fetch = require("cosmic.fetch")
-  local result = fetch.Fetch("https://httpbin.org/get")
-  -- result.ok reports whether the HTTP request completed; result.status holds
-  -- the response code on success, and result.error the reason on failure.
-  if result.ok then
-    print("status:", result.status)
-  else
-    print("request failed:", result.error)
+  local net = require("cosmic.net")
+  local proc = require("cosmic.proc")
+
+  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  local s = srv as net.Socket
+  local pid = proc.fork()
+  if pid == 0 then
+    local conn = s:accept() as net.Socket
+    conn:recv(4096)
+    conn:send("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello")
+    conn:close()
+    os.exit(0)
   end
+  s:close()
+
+  local result = fetch.Fetch("http://127.0.0.1:" .. math.tointeger(port) .. "/",
+    {allow_private = true})
+  proc.wait(pid)
+  print(result.status, result.body, result:is_success())
+  -- Output:
+  -- 200	hello	true
 end
 
--- Example_get_json demonstrates fetching and parsing a JSON response.
-local function Example_get_json()
-  local fetch = require("cosmic.fetch")
-  local json = require("cosmic.json")
-  local result = fetch.Fetch("https://httpbin.org/json")
-  -- Guard on ok/body before decoding: a failed request has a nil body.
-  if result.ok and result.body then
-    local data = json.decode(result.body) as {string: {string: string}}
-    if data and data.slideshow then
-      print("title:", data.slideshow.title)
-    end
-  end
-end
-
--- Example_retry demonstrates retry with a should_retry callback.
--- The retry loop in Fetch only retries when result.ok is true (the HTTP
--- request succeeded) and should_retry returns true. Connection failures
--- (result.ok == false) are returned immediately without retry.
--- Backoff is exponential: 2^attempt seconds, capped by max_delay.
+-- Example_retry demonstrates the default retry policy: transport errors
+-- (dns/connect/timeout) and 429/502/503/504 responses are retried for
+-- idempotent methods, with full-jitter exponential backoff. Here the
+-- server answers 503 once, then 200; max_attempts = 2 rides it out.
 local function Example_retry()
   local fetch = require("cosmic.fetch")
+  local net = require("cosmic.net")
+  local proc = require("cosmic.proc")
 
-  -- Retry up to 3 times on 5xx server errors.
-  -- Attempt 1: immediate. Attempt 2: after 4s. Attempt 3: after 8s.
-  local result = fetch.Fetch("https://httpbin.org/get", {
-      max_attempts = 3,
-      max_delay = 10,
-      should_retry = function(r: fetch.Result): boolean
-        return r.ok and r.status >= 500
-      end,
+  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  local s = srv as net.Socket
+  local pid = proc.fork()
+  if pid == 0 then
+    local responses = {
+      "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+      "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+    }
+    for _, resp in ipairs(responses) do
+      local conn = s:accept() as net.Socket
+      conn:recv(4096)
+      conn:send(resp)
+      conn:close()
+    end
+    os.exit(0)
+  end
+  s:close()
+
+  local result = fetch.Fetch("http://127.0.0.1:" .. math.tointeger(port) .. "/", {
+      allow_private = true,
+      max_attempts = 2,
+      base_delay = 0.01, -- keep the example fast; default is 0.5s
     })
-  print("ok:", result.ok)
+  proc.wait(pid)
+  print(result.status, result.body)
+  -- Output:
+  -- 200	ok
 end
 
--- Example_retry_on_status demonstrates retrying on specific HTTP status
--- codes like 429 (Too Many Requests) and 503 (Service Unavailable).
-local function Example_retry_on_status()
+-- Example_stream_lines demonstrates streaming a response and iterating
+-- its lines incrementally instead of buffering the whole body.
+local function Example_stream_lines()
   local fetch = require("cosmic.fetch")
+  local net = require("cosmic.net")
+  local proc = require("cosmic.proc")
 
-  local retryable: {number: boolean} = {
-    [429] = true, -- Too Many Requests
-    [503] = true, -- Service Unavailable
-    [502] = true, -- Bad Gateway
-  }
+  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  local s = srv as net.Socket
+  local pid = proc.fork()
+  if pid == 0 then
+    local body = "alpha\nbeta\ngamma\n"
+    local conn = s:accept() as net.Socket
+    conn:recv(4096)
+    conn:send("HTTP/1.1 200 OK\r\nContent-Length: " .. #body
+      .. "\r\nConnection: close\r\n\r\n" .. body)
+    conn:close()
+    os.exit(0)
+  end
+  s:close()
 
-  local result = fetch.Fetch("https://httpbin.org/get", {
-      max_attempts = 5,
-      max_delay = 30,
-      should_retry = function(r: fetch.Result): boolean
-        return r.ok and (retryable[r.status] or false)
-      end,
-    })
-  print("ok:", result.ok)
+  local result = fetch.stream("http://127.0.0.1:" .. math.tointeger(port) .. "/",
+    {allow_private = true})
+  for line in result.reader:lines() do
+    print(line)
+  end
+  result.reader:close()
+  proc.wait(pid)
+  -- Output:
+  -- alpha
+  -- beta
+  -- gamma
 end
 
 return {}

--- a/lib/cosmic/fetch_headers.tl
+++ b/lib/cosmic/fetch_headers.tl
@@ -1,0 +1,47 @@
+--- Response-header normalization for the cosmic.fetch module.
+--- cosmo.Fetch/FetchStream return headers with original-case names, and
+--- repeatable headers (Vary, Cache-Control, ...) arrive as nested array
+--- tables even though the binding declares {string: string}. This chunk
+--- flattens that into two honest views in one pass:
+--- - headers: lowercase names, repeated values joined ", " (RFC 9110 §5.3)
+--- - raw_headers: lowercase names, every value in arrival order
+
+--- Normalize a raw header table from cosmo.Fetch/FetchStream.
+--- @param raw {string: any} headers as returned by the C binding, or nil
+--- @return {string: string} lowercase names; repeats joined with ", "
+--- @return {string: {string}} lowercase names; all values in order
+local function normalize(raw: {string: any}): {string: string}, {string: {string}}
+  local headers: {string: string} = {}
+  local raw_headers: {string: {string}} = {}
+  if raw then
+    for name, value in pairs(raw) do
+      local key = string.lower(name)
+      local list = raw_headers[key]
+      if not list then
+        list = {}
+        raw_headers[key] = list
+      end
+      if value is table then
+        for _, v in ipairs(value as {string}) do
+          table.insert(list, v)
+        end
+      else
+        table.insert(list, value as string)
+      end
+    end
+    for key, list in pairs(raw_headers) do
+      headers[key] = table.concat(list, ", ")
+    end
+  end
+  return headers, raw_headers
+end
+
+local record FetchHeadersModule
+  normalize: function(raw: {string: any}): {string: string}, {string: {string}}
+end
+
+local M: FetchHeadersModule = {
+  normalize = normalize,
+}
+
+return M

--- a/lib/cosmic/fetch_headers_test.tl
+++ b/lib/cosmic/fetch_headers_test.tl
@@ -6,11 +6,6 @@
 -- request is rejected during validation, before any connection is attempted.
 local fetch = require("cosmic.fetch")
 
-local has_fetch_stream = fetch.has_stream()
-if not has_fetch_stream then
-  io.stderr:write("SKIP: fetch.stream header tests (FetchStream primitive not available)\n")
-end
-
 -- A dead loopback port: any request that passes validation fails to connect,
 -- so a header-validation error is unambiguously from validation, not the wire.
 local dead = "http://127.0.0.1:1"
@@ -75,7 +70,6 @@ end
 test_allows_clean_headers()
 
 local function test_stream_rejects_crlf_in_header_value()
-  if not has_fetch_stream then return end
   local result = fetch.stream(dead, {headers = {["X-Test"] = "value\r\nX-Injected: evil"}})
   assert(result.ok == false, "stream should reject CRLF in a header value")
   assert(result.error ~= nil and result.error:find("CR, LF, or NUL") ~= nil,
@@ -84,7 +78,6 @@ end
 test_stream_rejects_crlf_in_header_value()
 
 local function test_stream_rejects_crlf_in_header_name()
-  if not has_fetch_stream then return end
   local result = fetch.stream(dead, {headers = {["X-Bad\r\nX-Injected"] = "value"}})
   assert(result.ok == false, "stream should reject CRLF in a header name")
   assert(result.error ~= nil and result.error:find("header name") ~= nil,

--- a/lib/cosmic/fetch_multiheader_test.tl
+++ b/lib/cosmic/fetch_multiheader_test.tl
@@ -1,0 +1,87 @@
+#!/usr/bin/env cosmic
+--- Header normalization tests (issue #530 part 1): repeated response
+--- headers must surface as a joined string in result.headers and as an
+--- ordered list in result.raw_headers, with lowercase names in both.
+local fetch = require("cosmic.fetch")
+local net = require("cosmic.net")
+local proc = require("cosmic.proc")
+
+local RESPONSE = "HTTP/1.1 200 OK\r\n"
+.. "Content-Type: text/plain\r\n"
+.. "Vary: Accept\r\n"
+.. "Vary: Origin\r\n"
+.. "Content-Length: 2\r\n"
+.. "Connection: close\r\n\r\nhi"
+
+--- Fork a loopback server answering n requests with RESPONSE.
+local function serve(n: integer): integer, number
+  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  assert(srv ~= nil, "listen_tcp failed")
+  local s = srv as net.Socket
+  local pid = proc.fork()
+  if pid == 0 then
+    for _ = 1, n do
+      local conn = s:accept()
+      if conn then
+        local c = conn as net.Socket
+        local buf = ""
+        while not buf:find("\r\n\r\n", 1, true) do
+          local data = c:recv(4096)
+          if not data or #data == 0 then break end
+          buf = buf .. data
+        end
+        c:send(RESPONSE)
+        c:close()
+      end
+    end
+    os.exit(0)
+  end
+  s:close()
+  return math.tointeger(port), pid
+end
+
+local function test_fetch_repeated_headers_normalized()
+  local port, pid = serve(1)
+  local result = fetch.Fetch("http://127.0.0.1:" .. port .. "/", {allow_private = true})
+  proc.wait(pid)
+  assert(result.ok == true, "fetch should succeed: " .. tostring(result.error))
+
+  -- headers: lowercase keys, repeats joined ", " — always a plain string
+  assert(type(result.headers.vary) == "string",
+    "headers.vary must be a string, got " .. type(result.headers.vary))
+  assert(result.headers.vary == "Accept, Origin",
+    "repeated Vary must join in order, got: " .. tostring(result.headers.vary))
+  assert(result.headers["content-type"] == "text/plain",
+    "names must be lowercase: content-type, got " .. tostring(result.headers["content-type"]))
+  assert(result.headers["Content-Type"] == nil,
+    "original-case names must not leak through")
+  -- calling a string method on a header value must not crash (the old
+  -- nested-table representation made this throw for repeated headers)
+  assert(result.headers.vary:lower() == "accept, origin", "string methods must work")
+
+  -- raw_headers: lowercase keys, every value in arrival order
+  assert(#result.raw_headers.vary == 2,
+    "raw_headers.vary must keep both values, got " .. tostring(#result.raw_headers.vary))
+  assert(result.raw_headers.vary[1] == "Accept" and result.raw_headers.vary[2] == "Origin",
+    "raw_headers.vary must preserve order")
+  assert(#result.raw_headers["content-type"] == 1
+    and result.raw_headers["content-type"][1] == "text/plain",
+    "single-valued headers appear as one-element lists")
+end
+test_fetch_repeated_headers_normalized()
+
+local function test_stream_repeated_headers_normalized()
+  local port, pid = serve(1)
+  local result = fetch.stream("http://127.0.0.1:" .. port .. "/", {allow_private = true})
+  assert(result.ok == true, "stream should succeed: " .. tostring(result.error))
+  assert(type(result.headers.vary) == "string",
+    "stream headers.vary must be a string")
+  assert(result.headers.vary == "Accept, Origin",
+    "stream repeated Vary must join, got: " .. tostring(result.headers.vary))
+  assert(#result.raw_headers.vary == 2, "stream raw_headers.vary must keep both values")
+  -- drain and close so the server child can exit
+  while result.reader:read() do end
+  result.reader:close()
+  proc.wait(pid)
+end
+test_stream_repeated_headers_normalized()

--- a/lib/cosmic/fetch_retry_test.tl
+++ b/lib/cosmic/fetch_retry_test.tl
@@ -1,0 +1,161 @@
+#!/usr/bin/env cosmic
+--- Retry policy tests (issue #530 part 2): transport errors retry under
+--- the default policy, retryable statuses retry for idempotent methods,
+--- and custom should_retry sees failures too. All against forked
+--- loopback servers; base_delay is tiny so backoff never slows the suite.
+local fetch = require("cosmic.fetch")
+local net = require("cosmic.net")
+local proc = require("cosmic.proc")
+
+local function body_response(status_line: string, body: string): string
+  return "HTTP/1.1 " .. status_line .. "\r\nContent-Length: " .. #body
+  .. "\r\nConnection: close\r\n\r\n" .. body
+end
+
+--- Fork a loopback server that answers #responses requests in order.
+--- An empty-string response closes the connection immediately WITHOUT
+--- reading the request: the unread bytes make the kernel answer with an
+--- RST, so the client sees a connection reset (error kind "connect").
+--- (Reading the request first and then closing would send a clean FIN,
+--- which the client reports as an EOF-before-headers "protocol" error —
+--- deliberately not retryable.)
+local function serve(responses: {string}): integer, number
+  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  assert(srv ~= nil, "listen_tcp failed")
+  local s = srv as net.Socket
+  local pid = proc.fork()
+  if pid == 0 then
+    for _, resp in ipairs(responses) do
+      local conn = s:accept()
+      if conn then
+        local c = conn as net.Socket
+        if #resp > 0 then
+          local buf = ""
+          while not buf:find("\r\n\r\n", 1, true) do
+            local data = c:recv(4096)
+            if not data or #data == 0 then break end
+            buf = buf .. data
+          end
+          c:send(resp)
+        end
+        c:close()
+      end
+    end
+    os.exit(0)
+  end
+  s:close()
+  return math.tointeger(port), pid
+end
+
+local function test_default_policy_retries_transport_error()
+  -- first connection is accepted then closed without a response (a
+  -- transport error, kind "connect"); the second attempt gets a 200.
+  -- Before #530 the retry loop only consulted should_retry when
+  -- result.ok was true, so this could never succeed.
+  local port, pid = serve({"", body_response("200 OK", "recovered")})
+  local result = fetch.Fetch("http://127.0.0.1:" .. port .. "/",
+    {allow_private = true, max_attempts = 2, base_delay = 0.01})
+  proc.wait(pid)
+  assert(result.ok == true,
+    "transport error must be retried under the default policy, got: " .. tostring(result.error))
+  assert(result.body == "recovered", "second attempt's body expected")
+end
+test_default_policy_retries_transport_error()
+
+local function test_default_policy_retries_503()
+  local port, pid = serve({
+      body_response("503 Service Unavailable", "busy"),
+      body_response("200 OK", "fine"),
+    })
+  local result = fetch.Fetch("http://127.0.0.1:" .. port .. "/",
+    {allow_private = true, max_attempts = 2, base_delay = 0.01})
+  proc.wait(pid)
+  assert(result.ok == true and result.status == 200,
+    "503 must be retried under the default policy, got " .. tostring(result.status))
+end
+test_default_policy_retries_503()
+
+local function test_default_policy_does_not_retry_post()
+  -- POST is not idempotent: the default policy must return the 503
+  -- untouched instead of replaying the request.
+  local port, pid = serve({body_response("503 Service Unavailable", "busy")})
+  local result = fetch.Fetch("http://127.0.0.1:" .. port .. "/",
+    {allow_private = true, method = "POST", body = "x",
+      max_attempts = 3, base_delay = 0.01})
+  proc.wait(pid)
+  assert(result.ok == true and result.status == 503,
+    "POST must not be retried by default, got " .. tostring(result.status))
+end
+test_default_policy_does_not_retry_post()
+
+local function test_default_policy_does_not_retry_404()
+  local port, pid = serve({body_response("404 Not Found", "gone")})
+  local result = fetch.Fetch("http://127.0.0.1:" .. port .. "/",
+    {allow_private = true, max_attempts = 3, base_delay = 0.01})
+  proc.wait(pid)
+  assert(result.ok == true and result.status == 404,
+    "404 is not retryable, got " .. tostring(result.status))
+end
+test_default_policy_does_not_retry_404()
+
+local function test_custom_should_retry_sees_failures()
+  -- a custom predicate is consulted for failed attempts too (the old
+  -- loop returned transport errors immediately, without asking)
+  local seen: {boolean} = {}
+  local port, pid = serve({"", body_response("200 OK", "again")})
+  local result = fetch.Fetch("http://127.0.0.1:" .. port .. "/", {
+      allow_private = true,
+      max_attempts = 2,
+      base_delay = 0.01,
+      should_retry = function(r: fetch.Result): boolean
+        table.insert(seen, r.ok)
+        return not r.ok
+      end,
+    })
+  proc.wait(pid)
+  assert(result.ok == true, "custom retry of a transport error must succeed")
+  assert(#seen == 1 and seen[1] == false,
+    "should_retry must have been consulted with the failed result")
+end
+test_custom_should_retry_sees_failures()
+
+local function test_custom_should_retry_false_stops()
+  local port, pid = serve({body_response("503 Service Unavailable", "busy")})
+  local attempts = 0
+  local result = fetch.Fetch("http://127.0.0.1:" .. port .. "/", {
+      allow_private = true,
+      max_attempts = 5,
+      base_delay = 0.01,
+      should_retry = function(_: fetch.Result): boolean
+        attempts = attempts + 1
+        return false
+      end,
+    })
+  proc.wait(pid)
+  assert(result.status == 503, "the 503 must be returned as-is")
+  assert(attempts == 1, "should_retry must be asked exactly once, got " .. attempts)
+end
+test_custom_should_retry_false_stops()
+
+local function test_exhausted_attempts_return_last_failure()
+  local port, pid = serve({"", ""})
+  local result = fetch.Fetch("http://127.0.0.1:" .. port .. "/",
+    {allow_private = true, max_attempts = 2, base_delay = 0.01})
+  proc.wait(pid)
+  assert(result.ok == false, "both attempts failed; ok must be false")
+  assert(result.error_kind == "connect",
+    "the transport failure kind survives, got " .. tostring(result.error_kind))
+end
+test_exhausted_attempts_return_last_failure()
+
+local function test_validation_error_has_no_kind_and_default_never_retries()
+  -- validation failures carry no error_kind, so the default policy's
+  -- retryable-kind check can never match them
+  local result = fetch.Fetch("ftp://example.com/",
+    {max_attempts = 3, base_delay = 0.01})
+  assert(result.ok == false, "validation failure expected")
+  assert(result.error_kind == nil, "validation failures have no error_kind")
+  assert(result.error:find("unsupported URL scheme") ~= nil,
+    "the validation error must survive retries untouched")
+end
+test_validation_error_has_no_kind_and_default_never_retries()

--- a/lib/cosmic/fetch_stream_test.tl
+++ b/lib/cosmic/fetch_stream_test.tl
@@ -1,0 +1,169 @@
+#!/usr/bin/env cosmic
+--- Streaming fetch tests (issue #530 parts 2-3) against forked loopback
+--- servers: chunk reads, line iteration, bodyless-response EOF, and
+--- mid-body failure propagation through read() and lines().
+local fetch = require("cosmic.fetch")
+local net = require("cosmic.net")
+local proc = require("cosmic.proc")
+
+--- Fork a loopback server answering one request per response string,
+--- closing the connection right after each send.
+local function serve(responses: {string}): integer, number
+  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  assert(srv ~= nil, "listen_tcp failed")
+  local s = srv as net.Socket
+  local pid = proc.fork()
+  if pid == 0 then
+    for _, resp in ipairs(responses) do
+      local conn = s:accept()
+      if conn then
+        local c = conn as net.Socket
+        local buf = ""
+        while not buf:find("\r\n\r\n", 1, true) do
+          local data = c:recv(4096)
+          if not data or #data == 0 then break end
+          buf = buf .. data
+        end
+        if #resp > 0 then
+          c:send(resp)
+        end
+        c:close()
+      end
+    end
+    os.exit(0)
+  end
+  s:close()
+  return math.tointeger(port), pid
+end
+
+local function body_response(body: string): string
+  return "HTTP/1.1 200 OK\r\nContent-Length: " .. #body
+  .. "\r\nConnection: close\r\n\r\n" .. body
+end
+
+local function test_stream_reads_body_and_reports_url()
+  local port, pid = serve({body_response("streamed body")})
+  local url = "http://127.0.0.1:" .. port .. "/"
+  local result = fetch.stream(url, {allow_private = true})
+  assert(result.ok == true, "stream should succeed: " .. tostring(result.error))
+  assert(result.status == 200, "status should be 200")
+  assert(result.url == url, "result.url should be the effective URL")
+  assert(result:is_success() == true, "is_success must be true for 200")
+  local chunks: {string} = {}
+  while true do
+    local chunk, err = result.reader:read()
+    assert(err == nil, "no read error expected, got: " .. tostring(err))
+    if not chunk then break end
+    table.insert(chunks, chunk)
+  end
+  assert(table.concat(chunks) == "streamed body", "body should arrive intact")
+  result.reader:close()
+  proc.wait(pid)
+end
+test_stream_reads_body_and_reports_url()
+
+local function test_stream_lines_iterates()
+  local port, pid = serve({body_response("one\ntwo\nthree")})
+  local result = fetch.stream("http://127.0.0.1:" .. port .. "/", {allow_private = true})
+  assert(result.ok == true, "stream should succeed: " .. tostring(result.error))
+  local lines: {string} = {}
+  for line in result.reader:lines() do
+    table.insert(lines, line)
+  end
+  assert(#lines == 3, "expected 3 lines, got " .. #lines)
+  assert(lines[1] == "one" and lines[2] == "two" and lines[3] == "three",
+    "lines must arrive in order; final unterminated line included")
+  result.reader:close()
+  proc.wait(pid)
+end
+test_stream_lines_iterates()
+
+local function test_stream_204_is_clean_eof()
+  -- a bodyless 204 must read as EOF (nil, no error), not "reader closed"
+  local port, pid = serve({"HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n"})
+  local result = fetch.stream("http://127.0.0.1:" .. port .. "/", {allow_private = true})
+  assert(result.ok == true, "204 stream should succeed: " .. tostring(result.error))
+  assert(result.status == 204, "status should be 204")
+  local chunk, err = result.reader:read()
+  assert(chunk == nil, "204 has no body")
+  assert(err == nil, "204 EOF must not be an error, got: " .. tostring(err))
+  result.reader:close()
+  proc.wait(pid)
+end
+test_stream_204_is_clean_eof()
+
+local function test_stream_truncated_body_surfaces_error()
+  -- Content-Length promises 100 bytes but the server closes after 21:
+  -- read() must eventually return an error, not a clean EOF.
+  local truncated = "HTTP/1.1 200 OK\r\nContent-Length: 100\r\nConnection: close\r\n\r\n"
+  .. "partial line no end\r\n"
+  local port, pid = serve({truncated})
+  local result = fetch.stream("http://127.0.0.1:" .. port .. "/", {allow_private = true})
+  assert(result.ok == true, "response head arrived; stream opens: " .. tostring(result.error))
+  local saw_error: string = nil
+  while true do
+    local chunk, err = result.reader:read()
+    if err then
+      saw_error = err
+      break
+    end
+    if not chunk then break end
+  end
+  assert(saw_error ~= nil, "a truncated body must surface a read error, not clean EOF")
+  result.reader:close()
+  proc.wait(pid)
+end
+test_stream_truncated_body_surfaces_error()
+
+local function test_stream_lines_propagates_error_then_stops()
+  -- lines() yields nil, err once for a mid-stream failure, then plain nil;
+  -- a truncated stream is distinguishable from a graceful close.
+  local truncated = "HTTP/1.1 200 OK\r\nContent-Length: 100\r\nConnection: close\r\n\r\n"
+  .. "complete line\npartial"
+  local port, pid = serve({truncated})
+  local result = fetch.stream("http://127.0.0.1:" .. port .. "/", {allow_private = true})
+  assert(result.ok == true, "stream opens: " .. tostring(result.error))
+  local iter = result.reader:lines()
+  local first, err1 = iter()
+  assert(first == "complete line", "the complete line arrives first, got: " .. tostring(first))
+  assert(err1 == nil, "no error on the complete line")
+  local second, err2 = iter()
+  assert(second == nil, "truncation must not fake a line")
+  assert(err2 ~= nil, "the error must be yielded, not swallowed as clean EOF")
+  local third, err3 = iter()
+  assert(third == nil and err3 == nil, "after the error, the iterator is exhausted")
+  result.reader:close()
+  proc.wait(pid)
+end
+test_stream_lines_propagates_error_then_stops()
+
+local function test_stream_reader_close_idempotent()
+  local port, pid = serve({body_response("x")})
+  local result = fetch.stream("http://127.0.0.1:" .. port .. "/", {allow_private = true})
+  assert(result.ok == true, "stream should succeed")
+  assert(not result.reader:closed(), "reader should not be closed initially")
+  assert(result.reader:close() == true, "first close should return true")
+  assert(result.reader:close() == true, "second close should also return true")
+  assert(result.reader:closed(), "reader should be closed after close()")
+  local chunk, err = result.reader:read()
+  assert(chunk == nil and err == "reader closed", "read after close is an error")
+  proc.wait(pid)
+end
+test_stream_reader_close_idempotent()
+
+local function test_stream_validation_and_error_kind()
+  local result = fetch.stream("ftp://example.com/x")
+  assert(result.ok == false, "ftp scheme must be rejected")
+  assert(result.error:find("unsupported URL scheme") ~= nil,
+    "validation error expected, got: " .. tostring(result.error))
+
+  local refused = fetch.stream("http://127.0.0.1:1/", {allow_private = true})
+  assert(refused.ok == false, "dead port must fail")
+  assert(refused.error_kind == "connect",
+    "stream error_kind should be 'connect', got " .. tostring(refused.error_kind))
+
+  local blocked = fetch.stream("http://127.0.0.1:1/")
+  assert(blocked.ok == false and blocked.error_kind == "blocked",
+    "SSRF guard applies to streams, got " .. tostring(blocked.error_kind))
+end
+test_stream_validation_and_error_kind()

--- a/lib/cosmic/fetch_test.tl
+++ b/lib/cosmic/fetch_test.tl
@@ -1,313 +1,279 @@
 #!/usr/bin/env cosmic
+--- Core fetch tests against forked loopback servers: no external hosts,
+--- no skip scaffolding. allow_private opts out of the SSRF guard so the
+--- success path is exercised hermetically.
 local fetch = require("cosmic.fetch")
+local net = require("cosmic.net")
+local proc = require("cosmic.proc")
+
+--- Read one HTTP request (head plus Content-Length body) from a connection.
+local function read_request(conn: net.Socket): string
+  local buf = ""
+  while true do
+    local head_end = buf:find("\r\n\r\n", 1, true)
+    if head_end then
+      local cl = buf:match("[Cc]ontent%-[Ll]ength:%s*(%d+)")
+      local want = head_end + 3 + ((cl and math.tointeger(tonumber(cl))) or 0)
+      if #buf >= want then
+        return buf
+      end
+    end
+    local data = conn:recv(4096)
+    if not data or #data == 0 then
+      return buf
+    end
+    buf = buf .. data
+  end
+end
+
+--- Fork a loopback HTTP server that answers #responses requests in order,
+--- then exits. An empty-string response means: accept, read the request,
+--- and close without answering (a transport failure for the client).
+--- A response of "echo" answers 200 with the raw request as the body.
+--- @return integer port, integer child pid (caller must proc.wait it)
+local function serve(responses: {string}): integer, number
+  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  assert(srv ~= nil, "listen_tcp failed")
+  local s = srv as net.Socket
+  local pid = proc.fork()
+  if pid == 0 then
+    for _, resp in ipairs(responses) do
+      local conn = s:accept()
+      if conn then
+        local c = conn as net.Socket
+        local req = read_request(c)
+        if resp == "echo" then
+          c:send("HTTP/1.1 200 OK\r\nContent-Length: " .. #req
+            .. "\r\nConnection: close\r\n\r\n" .. req)
+        elseif #resp > 0 then
+          c:send(resp)
+        end
+        c:close()
+      end
+    end
+    os.exit(0)
+  end
+  s:close()
+  return math.tointeger(port), pid
+end
+
+local function body_response(status_line: string, body: string, extra?: string): string
+  return "HTTP/1.1 " .. status_line .. "\r\n" .. (extra or "")
+  .. "Content-Length: " .. #body .. "\r\nConnection: close\r\n\r\n" .. body
+end
 
 local function test_module_loads()
   assert(fetch ~= nil, "fetch module should not be nil")
-  assert(fetch.Fetch ~= nil, "fetch.Fetch should not be nil")
   assert(type(fetch.Fetch) == "function", "fetch.Fetch should be a function")
+  assert(type(fetch.stream) == "function", "fetch.stream should be a function")
 end
 test_module_loads()
 
-local function test_result_structure()
-  -- Test that result has correct structure
-  -- Use a guaranteed-to-fail protocol to test error handling
+local function test_result_structure_on_failure()
   local result = fetch.Fetch("invalid://this-will-definitely-fail")
-
   assert(result ~= nil, "result should not be nil")
-  assert(result.ok == false, "result.ok should be false for failed fetch, got: " .. tostring(result.ok))
+  assert(result.ok == false, "result.ok should be false for failed fetch")
   assert(result.status == nil, "result.status should be nil on error")
   assert(result.headers == nil, "result.headers should be nil on error")
   assert(result.body == nil, "result.body should be nil on error")
-  assert(result.error ~= nil, "result.error should not be nil on failure")
-  assert(type(result.error) == "string", "result.error should be a string")
-  assert(#result.error > 0, "result.error should not be empty")
-end
-test_result_structure()
-
--- Test with a data URL to verify success path without network dependency
-local function test_success_structure()
-  -- Use a data URL which should always work
-  local result = fetch.Fetch("data:text/plain,Hello%20World")
-
-  -- Verify the result has consistent structure regardless of outcome
-  assert(result ~= nil, "result should not be nil")
-  assert(type(result.ok) == "boolean", "result.ok should be a boolean")
-  if result.ok then
-    assert(result.status ~= nil, "result.status should be set on success")
-    assert(result.headers ~= nil, "result.headers should be set on success")
-    assert(type(result.headers) == "table", "result.headers should be a table")
-    assert(result.body ~= nil, "result.body should be set on success")
-    assert(result.error == nil, "result.error should be nil on success")
-  else
-    -- data URLs not supported — verify error structure and report skip
-    assert(result.error ~= nil, "result.error should be set on failure")
-    assert(type(result.error) == "string", "result.error should be a string")
-    io.stderr:write("SKIP: test_success_structure success-path assertions (data URLs not supported)\n")
-  end
-end
-test_success_structure()
-
--- Test that error messages are preserved (the main point of this wrapper)
-local function test_error_preservation()
-  local result = fetch.Fetch("invalid://guaranteed-failure")
-
-  -- The key feature: error message should be accessible and non-empty
-  assert(result.error ~= nil, "error should be preserved")
-  assert(type(result.error) == "string", "error should be a string")
-  assert(#result.error > 0, "error should not be empty")
-  -- Should not be "nil" string which was the original problem
+  assert(type(result.error) == "string" and #result.error > 0,
+    "result.error should be a non-empty string")
   assert(result.error ~= "nil", "error should not be 'nil' string")
+  assert(result:is_success() == false, "is_success must be false on failure")
 end
-test_error_preservation()
+test_result_structure_on_failure()
 
--- Test that HTTP error statuses (4xx, 5xx) still return ok=true
--- because the HTTP request itself succeeded
-local function test_http_error_status()
-  -- Use httpbin's 404 endpoint - skip if network unavailable
-  local result = fetch.Fetch("https://httpbin.org/status/404")
+local function test_loopback_get()
+  local port, pid = serve({body_response("200 OK", "hello loopback")})
+  local url = "http://127.0.0.1:" .. port .. "/"
+  local result = fetch.Fetch(url, {allow_private = true})
+  proc.wait(pid)
+  assert(result.ok == true, "ok should be true, got error: " .. tostring(result.error))
+  assert(result.status == 200, "status should be 200, got " .. tostring(result.status))
+  assert(result.body == "hello loopback", "body mismatch: " .. tostring(result.body))
+  assert(type(result.headers) == "table", "headers should be a table")
+  assert(result.url == url, "result.url should be the effective URL, got " .. tostring(result.url))
+  assert(result.error == nil, "error should be nil on success")
+  assert(result.error_kind == nil, "error_kind should be nil on success")
+  assert(result:is_success() == true, "is_success must be true for 200")
+end
+test_loopback_get()
 
-  if not result.ok then
-    -- Network failure - skip this test
-    io.stderr:write("SKIP: test_http_error_status (network unavailable)\n")
-    return
-  end
-
-  if result.status ~= 404 then
-    -- httpbin under load answers 5xx instead of the requested status.
-    io.stderr:write("SKIP: test_http_error_status (httpbin returned " .. tostring(result.status) .. ", expected 404)\n")
-    return
-  end
-  -- HTTP 404 is still a successful HTTP request
-  assert(result.ok == true, "ok should be true for HTTP error status")
-  assert(result.headers ~= nil, "headers should be present")
+local function test_http_error_status_is_ok_but_not_success()
+  local port, pid = serve({body_response("404 Not Found", "nope")})
+  local result = fetch.Fetch("http://127.0.0.1:" .. port .. "/", {allow_private = true})
+  proc.wait(pid)
+  assert(result.ok == true, "ok should be true for HTTP 404: " .. tostring(result.error))
+  assert(result.status == 404, "status should be 404, got " .. tostring(result.status))
   assert(result.error == nil, "error should be nil on HTTP success")
+  assert(result:is_success() == false, "is_success must be false for 404")
 end
-test_http_error_status()
+test_http_error_status_is_ok_but_not_success()
 
--- Streaming API tests
-
-local function test_stream_module_exports()
-  assert(fetch.stream ~= nil, "fetch.stream should not be nil")
-  assert(type(fetch.stream) == "function", "fetch.stream should be a function")
+local function test_post_body_reaches_server()
+  local port, pid = serve({"echo"})
+  local result = fetch.Fetch("http://127.0.0.1:" .. port .. "/submit",
+    {allow_private = true, method = "POST", body = "hello=world"})
+  proc.wait(pid)
+  assert(result.ok == true, "POST should succeed: " .. tostring(result.error))
+  assert(result.body:find("POST /submit", 1, true) ~= nil,
+    "server should have seen the POST request line: " .. tostring(result.body))
+  assert(result.body:find("hello=world", 1, true) ~= nil,
+    "server should have seen the POST body")
 end
-test_stream_module_exports()
+test_post_body_reaches_server()
 
--- Check if the streaming fetch primitive is available in this build.
-local has_fetch_stream = fetch.has_stream()
-if not has_fetch_stream then
-  io.stderr:write("SKIP: streaming tests (FetchStream primitive not available)\n")
+local function test_ssrf_guard_blocks_private_by_default()
+  local port, pid = serve({body_response("200 OK", "x")})
+  local result = fetch.Fetch("http://127.0.0.1:" .. port .. "/")
+  assert(result.ok == false, "loopback fetch without allow_private must fail")
+  assert(result.error_kind == "blocked",
+    "error_kind should be 'blocked', got " .. tostring(result.error_kind))
+  -- unblock the waiting child so the test can reap it
+  local unblock = fetch.Fetch("http://127.0.0.1:" .. port .. "/", {allow_private = true})
+  assert(unblock.ok == true, "allow_private fetch should succeed")
+  proc.wait(pid)
 end
+test_ssrf_guard_blocks_private_by_default()
 
-local function test_stream_invalid_url_returns_error()
-  if not has_fetch_stream then return end
-  local result = fetch.stream("invalid://this-will-definitely-fail")
-
-  assert(result ~= nil, "result should not be nil")
-  assert(result.ok == false, "result.ok should be false for failed fetch")
-  assert(result.error ~= nil, "result.error should not be nil on failure")
-  assert(result.reader == nil, "result.reader should be nil on error")
+local function test_error_kind_connect_for_refused_port()
+  local result = fetch.Fetch("http://127.0.0.1:1/", {allow_private = true})
+  assert(result.ok == false, "connection to a dead port must fail")
+  assert(result.error_kind == "connect",
+    "error_kind should be 'connect', got " .. tostring(result.error_kind))
 end
-test_stream_invalid_url_returns_error()
+test_error_kind_connect_for_refused_port()
 
-local function test_stream_successful_returns_reader()
-  if not has_fetch_stream then return end
-  local result = fetch.stream("https://httpbin.org/stream/3")
-
-  if not result.ok then
-    io.stderr:write("SKIP: test_stream_successful_returns_reader (network unavailable)\n")
-    return
-  end
-
-  if result.status ~= 200 then
-    -- httpbin under load answers 5xx instead of 200.
-    io.stderr:write("SKIP: test_stream_successful_returns_reader (httpbin returned " .. tostring(result.status) .. ", expected 200)\n")
-    if result.reader then result.reader:close() end
-    return
-  end
-  assert(result.reader ~= nil, "reader should not be nil")
-  assert(result.headers ~= nil, "headers should be present")
-  result.reader:close()
+local function test_follow_redirects_false_returns_redirect()
+  local port, pid = serve({
+      "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:1/next\r\n"
+      .. "Content-Length: 0\r\nConnection: close\r\n\r\n",
+    })
+  local result = fetch.Fetch("http://127.0.0.1:" .. port .. "/",
+    {allow_private = true, follow_redirects = false})
+  proc.wait(pid)
+  assert(result.ok == true, "redirect response should be returned: " .. tostring(result.error))
+  assert(result.status == 302, "status should be 302, got " .. tostring(result.status))
+  assert(result.headers.location == "http://127.0.0.1:1/next",
+    "location header should be exposed, got " .. tostring(result.headers.location))
 end
-test_stream_successful_returns_reader()
+test_follow_redirects_false_returns_redirect()
 
-local function test_stream_reader_read_returns_chunks()
-  if not has_fetch_stream then return end
-  local result = fetch.stream("https://httpbin.org/stream/3")
-
-  if not result.ok then
-    io.stderr:write("SKIP: test_stream_reader_read_returns_chunks (network unavailable)\n")
-    return
+local function test_redirect_followed_reports_final_url()
+  -- serve() can't express a redirect that targets its own port (the
+  -- response text needs the port), so fork by hand here.
+  local srv, port2 = net.listen_tcp("127.0.0.1", 0)
+  assert(srv ~= nil, "listen_tcp failed")
+  local s = srv as net.Socket
+  local final_url = "http://127.0.0.1:" .. math.tointeger(port2) .. "/final"
+  local pid2 = proc.fork()
+  if pid2 == 0 then
+    for i = 1, 2 do
+      local conn = s:accept()
+      if conn then
+        local c = conn as net.Socket
+        read_request(c)
+        if i == 1 then
+          c:send("HTTP/1.1 302 Found\r\nLocation: " .. final_url
+            .. "\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+        else
+          c:send(body_response("200 OK", "made it"))
+        end
+        c:close()
+      end
+    end
+    os.exit(0)
   end
-
-  if result.status ~= 200 then
-    -- httpbin under load answers 5xx instead of 200.
-    io.stderr:write("SKIP: test_stream_reader_read_returns_chunks (httpbin returned " .. tostring(result.status) .. ", expected 200)\n")
-    if result.reader then result.reader:close() end
-    return
-  end
-
-  local chunks: {string} = {}
-  while true do
-    local chunk = result.reader:read()
-    if not chunk then break end
-    table.insert(chunks, chunk)
-  end
-
-  assert(#chunks > 0, "should have read at least one chunk")
-  result.reader:close()
+  s:close()
+  local result = fetch.Fetch("http://127.0.0.1:" .. math.tointeger(port2) .. "/",
+    {allow_private = true})
+  proc.wait(pid2)
+  assert(result.ok == true, "redirected fetch should succeed: " .. tostring(result.error))
+  assert(result.status == 200, "status should be 200 after redirect")
+  assert(result.body == "made it", "body should come from the final URL")
+  assert(result.url == final_url,
+    "result.url should be the post-redirect URL, got " .. tostring(result.url))
 end
-test_stream_reader_read_returns_chunks()
+test_redirect_followed_reports_final_url()
 
-local function test_stream_reader_lines_yields_complete_lines()
-  if not has_fetch_stream then return end
-  local result = fetch.stream("https://httpbin.org/stream/3")
-
-  if not result.ok then
-    io.stderr:write("SKIP: test_stream_reader_lines_yields_complete_lines (network unavailable)\n")
-    return
+local function test_opts_table_not_mutated()
+  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  assert(srv ~= nil, "listen_tcp failed")
+  local s = srv as net.Socket
+  local redirect_url = "http://127.0.0.1:" .. math.tointeger(port) .. "/after"
+  local pid = proc.fork()
+  if pid == 0 then
+    for i = 1, 2 do
+      local conn = s:accept()
+      if conn then
+        local c = conn as net.Socket
+        read_request(c)
+        if i == 1 then
+          c:send("HTTP/1.1 303 See Other\r\nLocation: " .. redirect_url
+            .. "\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+        else
+          c:send(body_response("200 OK", "done"))
+        end
+        c:close()
+      end
+    end
+    os.exit(0)
   end
-
-  local lines: {string} = {}
-  for line in result.reader:lines() do
-    table.insert(lines, line)
-  end
-
-  if #lines ~= 3 then
-    io.stderr:write("SKIP: test_stream_reader_lines_yields_complete_lines (httpbin returned " .. tostring(#lines) .. " lines, expected 3)\n")
-    return
-  end
+  s:close()
+  local headers = {["X-Custom"] = "keep", ["Authorization"] = "Bearer secret"}
+  local opts: fetch.Opts = {
+    allow_private = true,
+    method = "POST",
+    body = "payload",
+    headers = headers,
+  }
+  local result = fetch.Fetch("http://127.0.0.1:" .. math.tointeger(port) .. "/", opts)
+  proc.wait(pid)
+  assert(result.ok == true, "303-redirected POST should succeed: " .. tostring(result.error))
+  -- a 303 turns the redirected request into a bodyless GET, but the
+  -- caller's table must be untouched
+  assert(opts.method == "POST", "opts.method must not be mutated, got " .. tostring(opts.method))
+  assert(opts.body == "payload", "opts.body must not be mutated, got " .. tostring(opts.body))
+  assert(opts.headers == headers, "opts.headers must still be the same table")
+  assert(headers["X-Custom"] == "keep", "header value must not be mutated")
+  assert(headers["Authorization"] == "Bearer secret",
+    "Authorization must not be deleted from the caller's table")
 end
-test_stream_reader_lines_yields_complete_lines()
-
-local function test_stream_reader_closed_reflects_state()
-  if not has_fetch_stream then return end
-  local result = fetch.stream("https://httpbin.org/get")
-
-  if not result.ok then
-    io.stderr:write("SKIP: test_stream_reader_closed_reflects_state (network unavailable)\n")
-    return
-  end
-
-  assert(not result.reader:closed(), "reader should not be closed initially")
-  result.reader:close()
-  assert(result.reader:closed(), "reader should be closed after close()")
-end
-test_stream_reader_closed_reflects_state()
-
-local function test_stream_reader_close_idempotent()
-  if not has_fetch_stream then return end
-  local result = fetch.stream("https://httpbin.org/get")
-
-  if not result.ok then
-    io.stderr:write("SKIP: test_stream_reader_close_idempotent (network unavailable)\n")
-    return
-  end
-
-  assert(result.reader:close() == true, "first close should return true")
-  assert(result.reader:close() == true, "second close should also return true")
-  assert(result.reader:closed(), "reader should be closed")
-end
-test_stream_reader_close_idempotent()
-
-local function test_stream_http_error_status_returns_reader()
-  if not has_fetch_stream then return end
-  local result = fetch.stream("https://httpbin.org/status/404")
-
-  if not result.ok then
-    io.stderr:write("SKIP: test_stream_http_error_status_returns_reader (network unavailable)\n")
-    return
-  end
-
-  if result.status ~= 404 then
-    -- httpbin under load answers 5xx instead of the requested status.
-    io.stderr:write("SKIP: test_stream_http_error_status_returns_reader (httpbin returned " .. tostring(result.status) .. ", expected 404)\n")
-    if result.reader then result.reader:close() end
-    return
-  end
-  assert(result.ok == true, "ok should be true for HTTP error status")
-  assert(result.reader ~= nil, "reader should be present even for 4xx status")
-  result.reader:close()
-end
-test_stream_http_error_status_returns_reader()
+test_opts_table_not_mutated()
 
 -- scheme validation tests
 
 local function test_fetch_empty_url_rejected()
   local result = fetch.Fetch("")
-  assert(result ~= nil, "result should not be nil")
   assert(result.ok == false, "result.ok should be false for empty URL")
   assert(result.error == "empty URL", "expected 'empty URL', got: " .. tostring(result.error))
+  assert(result.error_kind == nil, "validation failures have no error_kind")
 end
 test_fetch_empty_url_rejected()
 
 local function test_fetch_unsupported_scheme_rejected()
   local result = fetch.Fetch("ftp://example.com/file.txt")
-  assert(result ~= nil, "result should not be nil")
   assert(result.ok == false, "result.ok should be false for ftp scheme")
-  assert(result.error ~= nil, "result.error should be set")
-  assert(result.error:find("unsupported URL scheme") ~= nil, "error should mention unsupported scheme, got: " .. tostring(result.error))
+  assert(result.error:find("unsupported URL scheme") ~= nil,
+    "error should mention unsupported scheme, got: " .. tostring(result.error))
 end
 test_fetch_unsupported_scheme_rejected()
 
 local function test_fetch_file_scheme_rejected()
   local result = fetch.Fetch("file:///etc/passwd")
-  assert(result ~= nil, "result should not be nil")
   assert(result.ok == false, "result.ok should be false for file scheme")
-  assert(result.error ~= nil, "result.error should be set")
-  assert(result.error:find("unsupported URL scheme") ~= nil, "error should mention unsupported scheme, got: " .. tostring(result.error))
+  assert(result.error:find("unsupported URL scheme") ~= nil,
+    "error should mention unsupported scheme, got: " .. tostring(result.error))
 end
 test_fetch_file_scheme_rejected()
 
 local function test_fetch_no_scheme_rejected()
   local result = fetch.Fetch("example.com/path")
-  assert(result ~= nil, "result should not be nil")
   assert(result.ok == false, "result.ok should be false for no-scheme URL")
-  assert(result.error ~= nil, "result.error should be set")
-  assert(result.error:find("unsupported URL scheme") ~= nil, "error should mention unsupported scheme, got: " .. tostring(result.error))
+  assert(result.error:find("unsupported URL scheme") ~= nil,
+    "error should mention unsupported scheme, got: " .. tostring(result.error))
 end
 test_fetch_no_scheme_rejected()
-
-local function test_fetch_http_passes_validation()
-  -- http:// should pass validation; connection failure is expected (no network)
-  local result = fetch.Fetch("http://127.0.0.1:1")
-  assert(result ~= nil, "result should not be nil")
-  -- The error (if any) should not be a scheme error
-  if not result.ok then
-    assert(result.error ~= "unsupported URL scheme: http", "http scheme should pass validation")
-    assert(result.error ~= "empty URL", "http URL should not be empty")
-  end
-end
-test_fetch_http_passes_validation()
-
-local function test_fetch_https_passes_validation()
-  -- https:// should pass validation; connection failure is expected (no network)
-  local result = fetch.Fetch("https://127.0.0.1:1")
-  assert(result ~= nil, "result should not be nil")
-  if not result.ok then
-    assert(result.error ~= "unsupported URL scheme: https", "https scheme should pass validation")
-    assert(result.error ~= "empty URL", "https URL should not be empty")
-  end
-end
-test_fetch_https_passes_validation()
-
-local function test_stream_empty_url_rejected()
-  if not has_fetch_stream then return end
-  local result = fetch.stream("")
-  assert(result ~= nil, "result should not be nil")
-  assert(result.ok == false, "result.ok should be false for empty URL")
-  assert(result.error == "empty URL", "expected 'empty URL', got: " .. tostring(result.error))
-end
-test_stream_empty_url_rejected()
-
-local function test_stream_unsupported_scheme_rejected()
-  if not has_fetch_stream then return end
-  local result = fetch.stream("ftp://example.com/file.txt")
-  assert(result ~= nil, "result should not be nil")
-  assert(result.ok == false, "result.ok should be false for ftp scheme")
-  assert(result.error ~= nil, "result.error should be set")
-  assert(result.error:find("unsupported URL scheme") ~= nil, "error should mention unsupported scheme, got: " .. tostring(result.error))
-end
-test_stream_unsupported_scheme_rejected()
 
 -- unix_proxy helper tests
 
@@ -354,121 +320,20 @@ local function test_unix_proxy_too_long_path()
 end
 test_unix_proxy_too_long_path()
 
-local function test_unix_proxy_trailing_dotdot()
-  local url, err = fetch.unix_proxy("/tmp/..")
-  assert(url == nil, "expected nil for path ending with ..")
-  assert(err == "socket path must not contain . or .. segments", "expected segment error, got: " .. tostring(err))
-end
-test_unix_proxy_trailing_dotdot()
-
-local function test_unix_proxy_trailing_dot()
-  local url, err = fetch.unix_proxy("/tmp/.")
-  assert(url == nil, "expected nil for path ending with .")
-  assert(err == "socket path must not contain . or .. segments", "expected segment error, got: " .. tostring(err))
-end
-test_unix_proxy_trailing_dot()
-
--- method and body option tests
-
-local function test_fetch_post_method()
-  -- Use httpbin's POST endpoint to verify POST works
-  local result = fetch.Fetch("https://httpbin.org/post", {method = "POST", body = "hello=world"})
-
-  if not result.ok then
-    io.stderr:write("SKIP: test_fetch_post_method (network unavailable)\n")
-    return
-  end
-
-  if result.status ~= 200 then
-    -- httpbin under load answers 5xx instead of echoing the POST.
-    io.stderr:write("SKIP: test_fetch_post_method (httpbin returned " .. tostring(result.status) .. ", expected 200)\n")
-    return
-  end
-  assert(result.ok == true, "ok should be true")
-  assert(result.body ~= nil, "body should not be nil")
-  assert(result.body:find("hello=world") ~= nil, "body should echo posted data")
-end
-test_fetch_post_method()
-
-local function test_fetch_method_passthrough()
-  -- Verify that method option doesn't cause type errors
-  -- Use an invalid URL so this test doesn't require network
-  local result = fetch.Fetch("invalid://test", {method = "POST", body = "test"})
-  assert(result ~= nil, "result should not be nil")
-  assert(result.ok == false, "result.ok should be false for invalid URL")
-  assert(result.error ~= nil, "result.error should be set")
-end
-test_fetch_method_passthrough()
-
-local function test_stream_post_method()
-  if not has_fetch_stream then return end
-  local result = fetch.stream("https://httpbin.org/post", {method = "POST", body = "stream=test"})
-
-  if not result.ok then
-    io.stderr:write("SKIP: test_stream_post_method (network unavailable)\n")
-    return
-  end
-
-  if result.status ~= 200 then
-    -- httpbin under load answers 5xx instead of echoing the POST.
-    io.stderr:write("SKIP: test_stream_post_method (httpbin returned " .. tostring(result.status) .. ", expected 200)\n")
-    if result.reader then result.reader:close() end
-    return
-  end
-  assert(result.ok == true, "ok should be true")
-  assert(result.reader ~= nil, "reader should not be nil")
-
-  local chunks: {string} = {}
-  while true do
-    local chunk = result.reader:read()
-    if not chunk then break end
-    table.insert(chunks, chunk)
-  end
-
-  local body = table.concat(chunks)
-  assert(body:find("stream=test") ~= nil, "streamed body should echo posted data")
-  result.reader:close()
-end
-test_stream_post_method()
-
--- proxy option passthrough test
 local function test_fetch_with_proxy_nonexistent_socket()
-  -- Verify that the proxy option is passed through to cosmo.Fetch
-  -- by using a socket path that doesn't exist (should produce a connection error)
+  -- the proxy option is passed through to cosmo.Fetch: a socket path that
+  -- doesn't exist produces a connection error
   local result = fetch.Fetch("http://example.com", {proxy = "unix:///tmp/nonexistent-cosmic-test.sock"})
-  assert(result ~= nil, "result should not be nil")
   assert(result.ok == false, "result.ok should be false for nonexistent socket")
   assert(result.error ~= nil, "result.error should describe the failure")
 end
 test_fetch_with_proxy_nonexistent_socket()
 
-local function test_stream_with_proxy_nonexistent_socket()
-  if not has_fetch_stream then return end
-  local result = fetch.stream("http://example.com", {proxy = "unix:///tmp/nonexistent-cosmic-test.sock"})
-  assert(result ~= nil, "result should not be nil")
-  assert(result.ok == false, "result.ok should be false for nonexistent socket")
-  assert(result.error ~= nil, "result.error should describe the failure")
-end
-test_stream_with_proxy_nonexistent_socket()
-
--- timeout option tests
-
 local function test_timeout_option_accepted()
-  -- Verify that passing timeout does not cause a type error or crash
-  -- Use an invalid URL so this test doesn't require network
-  local result = fetch.Fetch("invalid://this-will-fail", {timeout = 30})
-  assert(result ~= nil, "result should not be nil")
-  assert(result.ok == false, "result.ok should be false for invalid URL")
-  assert(result.error ~= nil, "result.error should be set")
+  local port, pid = serve({body_response("200 OK", "quick")})
+  local result = fetch.Fetch("http://127.0.0.1:" .. port .. "/",
+    {allow_private = true, timeout = 30})
+  proc.wait(pid)
+  assert(result.ok == true, "fetch with timeout option should succeed: " .. tostring(result.error))
 end
 test_timeout_option_accepted()
-
-local function test_timeout_option_passthrough_stream()
-  if not has_fetch_stream then return end
-  -- Verify that passing timeout to stream does not cause a type error or crash
-  local result = fetch.stream("invalid://this-will-fail", {timeout = 5})
-  assert(result ~= nil, "result should not be nil")
-  assert(result.ok == false, "result.ok should be false for invalid URL")
-  assert(result.error ~= nil, "result.error should be set")
-end
-test_timeout_option_passthrough_stream()

--- a/lib/cosmic/ip.tl
+++ b/lib/cosmic/ip.tl
@@ -1,5 +1,31 @@
 --- IP address parsing, formatting, and classification utilities.
+--- IPv4 only: IPv6 addresses are rejected with an explicit error.
 local cosmo = require("cosmo")
+
+--- Category of an IPv4 address, as reported by categorize().
+--- LOOPBACK/PRIVATE/TESTNET/MULTICAST are special-use ranges; the rest
+--- name the registry or organization the block is delegated to.
+local enum Category
+  "MULTICAST"
+  "LOOPBACK"
+  "PRIVATE"
+  "TESTNET"
+  "AFRINIC"
+  "LACNIC"
+  "APNIC"
+  "ARIN"
+  "RIPE"
+  "DOD"
+  "AT&T"
+  "APPLE"
+  "FORD"
+  "COGENT"
+  "PRUDENTIAL"
+  "USPS"
+  "COMCAST"
+  "FUTURE"
+  "ANONYMOUS"
+end
 
 --- A typed IP address.
 --- Wraps the raw integer representation with convenience methods.
@@ -13,8 +39,8 @@ local record Addr
   --- @return string The formatted IP address
   format: function(Addr): string
   --- Categorize the address (e.g., "LOOPBACK", "PRIVATE", "ARIN").
-  --- @return string The category name
-  categorize: function(Addr): string
+  --- @return Category The category name
+  categorize: function(Addr): Category
   --- Check if this is a loopback address (127.x.x.x).
   --- @return boolean True if loopback
   is_loopback: function(Addr): boolean
@@ -34,8 +60,8 @@ local function addr_format(self: Addr): string
   return cosmo.FormatIp(self._n)
 end
 
-local function addr_categorize(self: Addr): string
-  return cosmo.CategorizeIp(self._n)
+local function addr_categorize(self: Addr): Category
+  return cosmo.CategorizeIp(self._n) as Category
 end
 
 local function addr_is_loopback(self: Addr): boolean
@@ -75,17 +101,37 @@ local function addr(n: number): Addr
   return make_addr(n)
 end
 
---- Parse an IP address string to its integer representation.
---- Invalid or unsupported addresses (including IPv6) are errors.
+--- Parse an IPv4 address string to its integer representation.
+--- Strict dotted quad only: exactly four decimal octets 0-255, no
+--- leading zeros ("127.1", "1.2.3.4.5", "01.2.3.4" are all errors).
+--- IPv6 is rejected with an explicit error.
 --- @param str string The IP address string (e.g., "192.168.1.1")
 --- @return integer | nil The IP address as an integer, or nil on error
 --- @return string Error message if parsing failed
 local function parse(str: string): integer | nil, string
-  local n, err = cosmo.ParseIp(str)
-  if not n then
-    return nil, err as string
+  if not str or str == "" then
+    return nil, "empty IP address"
   end
-  return n as integer
+  if str:find(":", 1, true) then
+    return nil, "IPv6 not supported: " .. str
+  end
+  local a, b, c, d = str:match("^(%d+)%.(%d+)%.(%d+)%.(%d+)$")
+  if not a then
+    return nil, "invalid IPv4 address (want dotted quad): " .. str
+  end
+  local n: integer = 0
+  for _, octet in ipairs({a, b, c, d}) do
+    -- no leading zeros: "0" is fine, "01" reads as octal in other parsers
+    if #octet > 3 or (#octet > 1 and octet:sub(1, 1) == "0") then
+      return nil, "invalid IPv4 octet '" .. octet .. "' in: " .. str
+    end
+    local v = math.tointeger(tonumber(octet))
+    if v > 255 then
+      return nil, "invalid IPv4 octet '" .. octet .. "' in: " .. str
+    end
+    n = n * 256 + v
+  end
+  return n
 end
 
 --- Format an integer IP address as a string.
@@ -98,9 +144,9 @@ end
 --- Categorize an IP address.
 --- Returns categories like "LOOPBACK", "PRIVATE", "ARIN", etc.
 --- @param ip integer The IP address as an integer
---- @return string The category name
-local function categorize(ip: number): string
-  return cosmo.CategorizeIp(ip)
+--- @return Category The category name
+local function categorize(ip: number): Category
+  return cosmo.CategorizeIp(ip) as Category
 end
 
 --- Check if an IP address is a loopback address (127.x.x.x).
@@ -125,18 +171,6 @@ local function is_public(ip: number): boolean
   return cosmo.IsPublicIp(ip)
 end
 
---- Resolve a hostname to an IP address.
---- @param hostname string The hostname to resolve
---- @return integer | nil The IP address as an integer, or nil on error
---- @return string Error message if resolution failed
-local function resolve(hostname: string): integer | nil, string
-  local ip, err = cosmo.ResolveIp(hostname)
-  if not ip then
-    return nil, err as string
-  end
-  return ip as integer
-end
-
 --- Look up a hostname and return a typed Addr.
 --- Returns nil and an error message on failure.
 --- @param hostname string The hostname to look up
@@ -152,14 +186,14 @@ end
 
 local record IpModule
   Addr: Addr
+  type Category = Category
   addr: function(n: number): Addr
   parse: function(str: string): integer | nil, string
   format: function(ip: number): string
-  categorize: function(ip: number): string
+  categorize: function(ip: number): Category
   is_loopback: function(ip: number): boolean
   is_private: function(ip: number): boolean
   is_public: function(ip: number): boolean
-  resolve: function(hostname: string): integer | nil, string
   lookup: function(hostname: string): Addr | nil, string
 end
 
@@ -171,7 +205,6 @@ local M: IpModule = {
   is_loopback = is_loopback,
   is_private = is_private,
   is_public = is_public,
-  resolve = resolve,
   lookup = lookup,
 }
 

--- a/lib/cosmic/ip_test.tl
+++ b/lib/cosmic/ip_test.tl
@@ -36,6 +36,58 @@ local function test_parse_out_of_range()
 end
 test_parse_out_of_range()
 
+local function test_parse_shorthand_rejected()
+  -- inet_aton-style shorthand ("127.1" == 127.0.0.1 in some parsers)
+  -- must be rejected: strict dotted quad only.
+  local result, err = ip.parse("127.1")
+  assert(result == nil, "expected nil for '127.1', got " .. tostring(result))
+  assert(type(err) == "string", "expected error message, got " .. tostring(err))
+end
+test_parse_shorthand_rejected()
+
+local function test_parse_five_octets_rejected()
+  local result, err = ip.parse("1.2.3.4.5")
+  assert(result == nil, "expected nil for '1.2.3.4.5', got " .. tostring(result))
+  assert(type(err) == "string", "expected error message, got " .. tostring(err))
+end
+test_parse_five_octets_rejected()
+
+local function test_parse_leading_zero_rejected()
+  -- "010" reads as octal in other parsers; ambiguity is rejected outright.
+  local result, err = ip.parse("010.2.3.4")
+  assert(result == nil, "expected nil for leading-zero octet, got " .. tostring(result))
+  assert(type(err) == "string", "expected error message, got " .. tostring(err))
+end
+test_parse_leading_zero_rejected()
+
+local function test_parse_zero_octets_ok()
+  local result, err = ip.parse("0.0.0.0")
+  assert(result == 0, "expected 0 for '0.0.0.0': " .. tostring(err))
+end
+test_parse_zero_octets_ok()
+
+local function test_parse_ipv6_rejected_with_clear_error()
+  local result, err = ip.parse("::1")
+  assert(result == nil, "expected nil for IPv6 address")
+  assert(err ~= nil and err:find("IPv6 not supported") ~= nil,
+    "expected 'IPv6 not supported' error, got " .. tostring(err))
+end
+test_parse_ipv6_rejected_with_clear_error()
+
+local function test_parse_empty_rejected()
+  local result, err = ip.parse("")
+  assert(result == nil, "expected nil for empty string")
+  assert(type(err) == "string", "expected error message")
+end
+test_parse_empty_rejected()
+
+local function test_parse_broadcast()
+  -- 255.255.255.255 is a valid dotted quad, not an error sentinel.
+  local result = ip.parse("255.255.255.255")
+  assert(result == 4294967295, "expected 4294967295, got " .. tostring(result))
+end
+test_parse_broadcast()
+
 -- format tests
 
 local function test_format_basic()
@@ -156,21 +208,6 @@ local function test_is_public_false_loopback()
   assert(result == false, "expected false for loopback")
 end
 test_is_public_false_loopback()
-
--- resolve tests
-
-local function test_resolve_localhost()
-  local result = ip.resolve("localhost")
-  assert(result == 2130706433, "expected 127.0.0.1 for localhost, got " .. tostring(result))
-end
-test_resolve_localhost()
-
-local function test_resolve_invalid_returns_nil()
-  local result, err = ip.resolve("this.host.does.not.exist.invalid")
-  assert(result == nil, "expected nil for unresolvable hostname, got " .. tostring(result))
-  assert(type(err) == "string", "expected error message, got " .. tostring(err))
-end
-test_resolve_invalid_returns_nil()
 
 -- lookup tests
 

--- a/lib/cosmic/net.tl
+++ b/lib/cosmic/net.tl
@@ -1,38 +1,40 @@
 --- Networking and socket utilities.
 --- Wraps cosmo.unix socket functions for TCP/UDP and Unix domain sockets.
+--- IPv4 only: string addresses must be strict dotted quads; IPv6 is
+--- rejected with an explicit "IPv6 not supported" error.
 local unix = require("cosmo.unix")
-local cosmo = require("cosmo")
+local ip = require("cosmic.ip")
+local net_socket = require("cosmic.net_socket")
 
-local record NetSocket
-  make_socket: function(fd: number): Socket
-end
-local net_socket = require("cosmic.net_socket") as NetSocket
-
---- Socket handle for network I/O.
+--- Socket handle for network I/O (see cosmic.net_socket for the methods).
 --- Supports Lua 5.4's to-be-closed via __close metamethod.
-local record Socket
-  fd: number
-  close: function(self: Socket): boolean
-  closed: function(self: Socket): boolean
-  shutdown: function(self: Socket, how?: number): boolean, string
-  send: function(self: Socket, data: string, flags?: number): number | nil, string
-  sendto: function(self: Socket, data: string, ip: number, port: number, flags?: number): number | nil, string
-  recv: function(self: Socket, bufsiz?: number, flags?: number): string | nil, string
-  recvfrom: function(self: Socket, bufsiz?: number, flags?: number): string | nil, number, number, string
-  getsockname: function(self: Socket): number | nil, number, string
-  getpeername: function(self: Socket): number | nil, number, string
-  bind: function(self: Socket, ip?: number, port?: number): boolean, string
-  bind_unix: function(self: Socket, path: string): boolean, string
-  listen: function(self: Socket, backlog?: number): boolean, string
-  accept: function(self: Socket, flags?: number): Socket | nil, number, number, string
-  connect: function(self: Socket, ip: number, port: number): boolean, string
-  connect_unix: function(self: Socket, path: string): boolean, string
-  getsockopt: function(self: Socket, level: number, optname: number): number | boolean | nil, string
-  setsockopt: function(self: Socket, level: number, optname: number, value: number | boolean): boolean, string
-end
+local type Socket = net_socket.Socket
 
-local function make_socket(fd: number): Socket
-  return net_socket.make_socket(fd) as Socket
+local make_socket = net_socket.make_socket
+
+--- An address a TCP helper accepts: a dotted-quad string ("127.0.0.1"),
+--- a raw integer (0x7f000001), or a typed ip.Addr.
+local type Address = string | number | ip.Addr
+
+--- Resolve an Address union to a raw integer IP.
+--- @param addr Address The address in any accepted form
+--- @return integer | nil The IP as an integer, or nil on error
+--- @return string Error message on failure
+local function resolve_addr(addr: Address): integer | nil, string
+  if addr is string then
+    return ip.parse(addr)
+  end
+  local n: number
+  if addr is number then
+    n = addr
+  else
+    n = (addr as ip.Addr):int()
+  end
+  local i = math.tointeger(n)
+  if not i then
+    return nil, "invalid IP integer: " .. tostring(n)
+  end
+  return i
 end
 
 --- Create a new socket.
@@ -112,22 +114,24 @@ local function connect_unix(path: string): Socket | nil, string
   return s
 end
 
---- Create a TCP socket and connect to an IP address and port.
---- The IP is an integer (e.g. 0x7f000001 for 127.0.0.1). To convert a
---- dotted-quad string, use cosmic.ip:
----   local ip = require("cosmic.ip")
----   local addr = ip.parse("127.0.0.1")  -- 0x7f000001
---- @param ip number Remote IP address
+--- Create a TCP socket and connect to an address and port.
+--- The address may be a dotted-quad string ("127.0.0.1"), a raw integer
+--- (0x7f000001), or an ip.Addr. IPv6 is not supported.
+--- @param addr Address Remote IPv4 address
 --- @param port number Remote port
 --- @return Socket | nil Connected socket
 --- @return string Error message on failure
-local function connect_tcp(ip: number, port: number): Socket | nil, string
+local function connect_tcp(addr: Address, port: number): Socket | nil, string
+  local ipn, aerr = resolve_addr(addr)
+  if not ipn then
+    return nil, aerr
+  end
   local sock, err = socket(unix.AF_INET, unix.SOCK_STREAM, 0)
   if not sock then
     return nil, err
   end
   local s = sock as Socket
-  local ok, conn_err = s:connect(ip, port)
+  local ok, conn_err = s:connect(ipn, port)
   if not ok then
     s:close()
     return nil, conn_err
@@ -135,25 +139,29 @@ local function connect_tcp(ip: number, port: number): Socket | nil, string
   return s
 end
 
---- Create a TCP socket, bind it to host:port, and start listening.
+--- Create a TCP socket, bind it to addr:port, and start listening.
 --- Passing port 0 lets the OS assign an ephemeral port; the actual port is
 --- returned as the second value so callers never need a separate getsockname
---- call. The IP is an integer; convert strings with
---- require("cosmic.ip").parse("127.0.0.1").
+--- call. The address may be a dotted-quad string, a raw integer, or an
+--- ip.Addr (0 binds all interfaces). IPv6 is not supported.
 ---
 --- Example — listen on an OS-assigned port:
 ---   local net = require("cosmic.net")
----   local srv, port, err = net.listen_tcp(0x7f000001, 0)
+---   local srv, port, err = net.listen_tcp("127.0.0.1", 0)
 ---   -- port is now the OS-assigned port, e.g. 54321
----   local client = net.connect_tcp(0x7f000001, port)
+---   local client = net.connect_tcp("127.0.0.1", port)
 ---
---- @param ip number Local IP address to bind (e.g. 0x7f000001 for 127.0.0.1, 0 for all)
+--- @param addr Address Local IPv4 address to bind ("127.0.0.1", 0 for all)
 --- @param port number Local port to bind; use 0 for an OS-assigned ephemeral port
 --- @param backlog number Maximum pending connections (default 128)
 --- @return Socket | nil Listening socket ready to accept
 --- @return number Actual bound port (useful when port 0 was requested)
 --- @return string Error message on failure
-local function listen_tcp(ip: number, port: number, backlog?: number): Socket | nil, number, string
+local function listen_tcp(addr: Address, port: number, backlog?: number): Socket | nil, number, string
+  local ipn, aerr = resolve_addr(addr)
+  if not ipn then
+    return nil, nil, aerr
+  end
   local sock, serr = socket(unix.AF_INET, unix.SOCK_STREAM, 0)
   if not sock then
     return nil, nil, serr
@@ -164,7 +172,7 @@ local function listen_tcp(ip: number, port: number, backlog?: number): Socket | 
     s:close()
     return nil, nil, setopt_err
   end
-  local bok, bind_err = s:bind(ip, port)
+  local bok, bind_err = s:bind(ipn, port)
   if not bok then
     s:close()
     return nil, nil, bind_err
@@ -182,16 +190,28 @@ local function listen_tcp(ip: number, port: number, backlog?: number): Socket | 
   return s, bound_port
 end
 
---- Perform a non-blocking connect on a socket.
---- @param s Socket The non-blocking socket to connect
---- @param ip number Remote IP address
+--- Connect with a bounded wait instead of blocking indefinitely.
+--- Switches the socket to non-blocking mode (via Socket:set_nonblocking),
+--- starts the connect, and polls for completion up to timeoutms. The
+--- socket remains in non-blocking mode afterwards; call
+--- s:set_nonblocking(false) to restore blocking I/O.
+--- @param s Socket The socket to connect
+--- @param addr Address Remote IPv4 address
 --- @param port number Remote port
 --- @param timeoutms number Timeout in milliseconds (default 10000)
 --- @return boolean True on success
 --- @return string Error message on failure
-local function nb_connect(s: Socket, ip: number, port: number, timeoutms?: number): boolean, string
+local function nb_connect(s: Socket, addr: Address, port: number, timeoutms?: number): boolean, string
   timeoutms = timeoutms or 10000
-  local ok, conn_err = s:connect(ip, port)
+  local ipn, aerr = resolve_addr(addr)
+  if not ipn then
+    return false, aerr
+  end
+  local nb_ok, nb_err = s:set_nonblocking()
+  if not nb_ok then
+    return false, nb_err
+  end
+  local ok, conn_err = s:connect(ipn, port)
   if ok then return true end
   local fds: {number: number} = {[s.fd] = unix.POLLOUT}
   local revents = unix.poll(fds, timeoutms)
@@ -214,19 +234,6 @@ local function nb_connect(s: Socket, ip: number, port: number, timeoutms?: numbe
   return false, "nb_connect: unexpected poll events=" .. tostring(ev)
 end
 
---- Poll file descriptors for events.
---- @param fds {number:number} Map of fd to events to poll for
---- @param timeoutms number Timeout in milliseconds (-1 for infinite, 0 for non-blocking)
---- @return {number:number} | nil Map of fd to revents
---- @return string Error message on failure
-local function poll(fds: {number: number}, timeoutms?: number): {number: number} | nil, string
-  local result = unix.poll(fds, timeoutms or -1)
-  if not result then
-    return nil, "poll failed"
-  end
-  return result
-end
-
 --- Get the local hostname.
 --- @return string | nil The hostname
 --- @return string Error message on failure
@@ -236,25 +243,6 @@ local function gethostname(): string | nil, string
     return nil, "gethostname failed"
   end
   return name
-end
-
---- Parse an IP address string to numeric form.
---- @param str string IP address in dotted notation (e.g., "127.0.0.1")
---- @return number | nil Numeric IP address
---- @return string Error message on failure
-local function parseip(str: string): number | nil, string
-  local ip, err = cosmo.ParseIp(str)
-  if not ip then
-    return nil, err or "invalid IP address format"
-  end
-  return ip
-end
-
---- Format a numeric IP address to string.
---- @param ip number Numeric IP address
---- @return string IP address in dotted notation
-local function formatip(ip: number): string
-  return cosmo.FormatIp(ip)
 end
 
 --- Network interface information.
@@ -275,19 +263,17 @@ local function interfaces(): {Interface} | nil, string
 end
 
 local record NetModule
-  Socket: Socket
+  type Socket = Socket
+  type Address = Address
   Interface: Interface
   socket: function(family?: number, socktype?: number, protocol?: number): Socket | nil, string
   socketpair: function(family?: number, socktype?: number, protocol?: number): Socket | nil, Socket, string
   listen_unix: function(path: string, backlog?: number): Socket | nil, string
-  listen_tcp: function(ip: number, port: number, backlog?: number): Socket | nil, number, string
+  listen_tcp: function(addr: Address, port: number, backlog?: number): Socket | nil, number, string
   connect_unix: function(path: string): Socket | nil, string
-  connect_tcp: function(ip: number, port: number): Socket | nil, string
-  nb_connect: function(s: Socket, ip: number, port: number, timeoutms?: number): boolean, string
-  poll: function(fds: {number: number}, timeoutms?: number): {number: number} | nil, string
+  connect_tcp: function(addr: Address, port: number): Socket | nil, string
+  nb_connect: function(s: Socket, addr: Address, port: number, timeoutms?: number): boolean, string
   gethostname: function(): string | nil, string
-  parseip: function(str: string): number | nil, string
-  formatip: function(ip: number): string
   interfaces: function(): {Interface} | nil, string
   AF_INET: number
   AF_UNIX: number
@@ -368,10 +354,7 @@ local M: NetModule = {
   connect_unix = connect_unix,
   connect_tcp = connect_tcp,
   nb_connect = nb_connect,
-  poll = poll,
   gethostname = gethostname,
-  parseip = parseip,
-  formatip = formatip,
   interfaces = interfaces,
   AF_INET = unix.AF_INET,
   AF_UNIX = unix.AF_UNIX,

--- a/lib/cosmic/net_connect_test.tl
+++ b/lib/cosmic/net_connect_test.tl
@@ -2,6 +2,7 @@
 --- Network connect and interface tests.
 local net = require("cosmic.net")
 local fs = require("cosmic.fs")
+local ip = require("cosmic.ip")
 local proc = require("cosmic.proc")
 
 local function test_interfaces()
@@ -18,25 +19,25 @@ local function test_interfaces()
     if iface.name == "lo" then
       has_loopback = true
       -- Loopback should be 127.0.0.1 (0x7f000001)
-      assert(iface.ip == 0x7f000001, "loopback should have 127.0.0.1, got " .. net.formatip(iface.ip))
+      assert(iface.ip == 0x7f000001, "loopback should have 127.0.0.1, got " .. ip.format(iface.ip))
     end
   end
   assert(has_loopback, "should have loopback interface")
 end
 test_interfaces()
 
-local function test_interfaces_formatip()
+local function test_interfaces_format()
   -- Test that we can format interface IPs
   local ifaces = net.interfaces()
   if ifaces then
     local ifaces = ifaces as {net.Interface}
     for _, iface in ipairs(ifaces) do
-      local ip_str = net.formatip(iface.ip)
+      local ip_str = ip.format(iface.ip)
       assert(ip_str:match("^%d+%.%d+%.%d+%.%d+$"), "expected dotted IP format, got " .. ip_str)
     end
   end
 end
-test_interfaces_formatip()
+test_interfaces_format()
 
 local function test_unix_domain_socket_bind_connect()
   local tmpdir = assert(fs.mkdtemp("/tmp/cosmic_net_test_XXXXXX"))
@@ -149,13 +150,15 @@ local function test_nb_connect_loopback()
   ok, err = server:listen()
   assert(ok, "listen failed: " .. tostring(err))
 
-  -- Create a non-blocking client socket
-  local client, cerr = net.socket(net.AF_INET, net.SOCK_STREAM | net.SOCK_NONBLOCK, 0)
+  -- A plain blocking socket: nb_connect switches it to non-blocking
+  -- itself via Socket:set_nonblocking (it used to silently block when
+  -- handed a blocking socket).
+  local client, cerr = net.socket()
   assert(client ~= nil, "client socket creation failed: " .. tostring(cerr))
   local client = client as net.Socket
 
-  -- nb_connect to the listening server
-  ok, err = net.nb_connect(client, 0x7f000001, server_port, 5000)
+  -- nb_connect to the listening server, by dotted-quad string
+  ok, err = net.nb_connect(client, "127.0.0.1", server_port, 5000)
   assert(ok, "nb_connect failed: " .. tostring(err))
 
   -- Accept the connection on the server side
@@ -238,6 +241,44 @@ local function test_connect_tcp()
   proc.wait(pid)
 end
 test_connect_tcp()
+
+local function test_connect_tcp_accepts_string_and_addr()
+  local server, port, lerr = net.listen_tcp("127.0.0.1", 0)
+  assert(server ~= nil, "listen_tcp with string address failed: " .. tostring(lerr))
+  local server = server as net.Socket
+
+  -- connect by dotted-quad string
+  local c1, e1 = net.connect_tcp("127.0.0.1", port)
+  assert(c1 ~= nil, "connect_tcp by string failed: " .. tostring(e1))
+  local c1s = c1 as net.Socket
+  local a1 = server:accept() as net.Socket
+  c1s:close()
+  a1:close()
+
+  -- connect by typed ip.Addr
+  local addr = ip.addr(0x7f000001)
+  local c2, e2 = net.connect_tcp(addr, port)
+  assert(c2 ~= nil, "connect_tcp by Addr failed: " .. tostring(e2))
+  local c2s = c2 as net.Socket
+  local a2 = server:accept() as net.Socket
+  c2s:close()
+  a2:close()
+
+  server:close()
+end
+test_connect_tcp_accepts_string_and_addr()
+
+local function test_connect_tcp_rejects_bad_addresses()
+  local sock, err = net.connect_tcp("not-an-ip", 80)
+  assert(sock == nil, "hostname strings are not addresses")
+  assert(err ~= nil, "expected an error message")
+
+  local sock6, err6 = net.connect_tcp("::1", 80)
+  assert(sock6 == nil, "IPv6 must be rejected")
+  assert(err6 ~= nil and err6:find("IPv6 not supported") ~= nil,
+    "expected 'IPv6 not supported', got: " .. tostring(err6))
+end
+test_connect_tcp_rejects_bad_addresses()
 
 local function test_connect_error_message()
   -- Connect to a port with no listener — should get a descriptive error, not just "connect failed"

--- a/lib/cosmic/net_socket.tl
+++ b/lib/cosmic/net_socket.tl
@@ -46,6 +46,8 @@ local record Socket
   getsockopt: function(self: Socket, level: number, optname: number): number | boolean | nil, string
   --- Set a socket option value.
   setsockopt: function(self: Socket, level: number, optname: number, value: number | boolean): boolean, string
+  --- Switch O_NONBLOCK on (default) or off for this socket.
+  set_nonblocking: function(self: Socket, enable?: boolean): boolean, string
 end
 
 --- Create a socket handle from a file descriptor.
@@ -53,6 +55,14 @@ end
 --- @return Socket The socket handle
 local function make_socket(fd: number): Socket
   local sock: Socket = {fd = fd}
+
+  -- macOS honors SO_NOSIGPIPE, not MSG_NOSIGNAL, on send(); set it once at
+  -- creation so writes there get EPIPE instead of a fatal SIGPIPE. The
+  -- constant is 0 on platforms that use MSG_NOSIGNAL instead (Linux,
+  -- OpenBSD, Windows), so the guard skips them.
+  if unix.SO_NOSIGPIPE ~= nil and unix.SO_NOSIGPIPE ~= 0 then
+    unix.setsockopt(fd, unix.SOL_SOCKET, unix.SO_NOSIGPIPE, true)
+  end
 
   function sock:close(): boolean
     if self.fd then
@@ -206,6 +216,22 @@ local function make_socket(fd: number): Socket
     return val
   end
 
+  function sock:set_nonblocking(enable?: boolean): boolean, string
+    if not self.fd then return false, "socket closed" end
+    -- unix.fcntl coerces F_GETFL's result to a boolean, so the current
+    -- flags cannot be read back. Sockets carry no other fcntl status
+    -- flag worth preserving, so set the flag word absolutely.
+    local want: integer = 0
+    if enable ~= false then
+      want = unix.O_NONBLOCK as integer
+    end
+    local ok, serr = unix.fcntl(self.fd, unix.F_SETFL, want)
+    if not ok then
+      return false, errstr(serr, "set_nonblocking")
+    end
+    return true
+  end
+
   function sock:setsockopt(level: number, optname: number, value: number | boolean): boolean, string
     if not self.fd then return false, "socket closed" end
     local ok, err = unix.setsockopt(self.fd, level, optname, value)
@@ -221,6 +247,7 @@ local function make_socket(fd: number): Socket
 end
 
 local record NetSocketModule
+  type Socket = Socket
   make_socket: function(fd: number): Socket
 end
 

--- a/lib/cosmic/net_test.tl
+++ b/lib/cosmic/net_test.tl
@@ -140,34 +140,6 @@ local function test_listen_accept_connect()
 end
 test_listen_accept_connect()
 
-local function test_parseip_formatip()
-  -- Test parseip
-  local ip, err = net.parseip("127.0.0.1")
-  assert(ip ~= nil, "parseip failed: " .. tostring(err))
-  assert(ip == 0x7f000001, "expected 0x7f000001, got " .. string.format("0x%x", ip as integer))
-
-  ip, err = net.parseip("192.168.1.1")
-  assert(ip ~= nil, "parseip failed: " .. tostring(err))
-  assert(ip == 0xc0a80101, "expected 0xc0a80101, got " .. string.format("0x%x", ip as integer))
-
-  -- Test formatip
-  local str = net.formatip(0x7f000001)
-  assert(str == "127.0.0.1", "expected '127.0.0.1', got '" .. str .. "'")
-
-  str = net.formatip(0xc0a80101)
-  assert(str == "192.168.1.1", "expected '192.168.1.1', got '" .. str .. "'")
-
-  -- Test invalid IP
-  ip, err = net.parseip("invalid")
-  assert(ip == nil, "expected nil for invalid IP")
-  assert(err ~= nil, "expected error message for invalid IP")
-
-  -- Test out of range
-  ip, err = net.parseip("256.0.0.1")
-  assert(ip == nil, "expected nil for out of range IP")
-end
-test_parseip_formatip()
-
 local function test_gethostname()
   local name, err = net.gethostname()
   assert(name ~= nil, "gethostname failed: " .. tostring(err))
@@ -193,7 +165,10 @@ local function test_shutdown()
 end
 test_shutdown()
 
-local function test_poll()
+local function test_poll_readiness()
+  -- net.poll was a duplicate of cosmic.poll and is gone; sockets compose
+  -- with the Poller directly via their fd.
+  local poll = require("cosmic.poll")
   local sock1, sock2, err = net.socketpair()
   assert(sock1 ~= nil and sock2 ~= nil, "socketpair failed: " .. tostring(err))
   local sock1 = sock1 as net.Socket
@@ -201,18 +176,17 @@ local function test_poll()
   -- Send data on sock1
   sock1:send("hello")
 
-  -- Poll sock2 for readable data using net.poll
-  local fds: {number: number} = {[sock2.fd] = net.POLLIN}
-  local result, poll_err = net.poll(fds, 1000)
-  assert(result ~= nil, "poll failed: " .. tostring(poll_err))
-  local result = result as {number: number}
-  assert(result[sock2.fd] ~= nil, "expected socket to be ready")
-  assert((result[sock2.fd] & net.POLLIN) > 0, "expected POLLIN event")
+  local poller = poll.new()
+  poller:add(sock2.fd, poll.POLLIN)
+  local ready, poll_err = poller:poll(1000)
+  assert(ready == 1, "expected one ready fd: " .. tostring(poll_err))
+  local ev = poller:events(sock2.fd)
+  assert(ev ~= nil and (ev as poll.Events).readable, "expected socket to be readable")
 
   sock1:close()
   sock2:close()
 end
-test_poll()
+test_poll_readiness()
 
 local function test_udp_sendto_recvfrom()
   -- Create two UDP sockets

--- a/lib/cosmic/sse.tl
+++ b/lib/cosmic/sse.tl
@@ -1,5 +1,9 @@
 --- Server-Sent Events parser for streaming HTTP responses.
---- Parses SSE format from a fetch.Reader and yields complete events.
+--- Parses SSE format from a fetch.Reader and yields complete events,
+--- following the WHATWG event stream processing model: unterminated
+--- events at EOF are discarded, empty-data dispatches reset the event
+--- type buffer, the last event ID updates as soon as an `id:` line is
+--- seen, and `retry:` accepts only ASCII digits.
 
 local fetch = require("cosmic.fetch")
 
@@ -9,6 +13,18 @@ local record Event
   event: string -- event type, defaults to "message"
   id: string -- last event ID
   retry: number -- reconnection time in milliseconds
+end
+
+--- An open SSE event stream.
+local record Stream
+  --- Iterator over parsed events: yields Event values; on a mid-stream
+  --- transport failure yields nil plus the error message once, then
+  --- plain nil — so truncation is distinguishable from a graceful close.
+  next: function(): Event | nil, string
+  --- The last seen event ID (nil until an id: line is seen), for
+  --- reconnecting with a Last-Event-ID request header. Updates as soon
+  --- as an id: line is parsed, even when no event is dispatched.
+  last_event_id: function(): string
 end
 
 --- Parse a single field line into name and value.
@@ -39,66 +55,61 @@ local function parse_field(line: string): string, string
 end
 
 --- Parse SSE events from a streaming reader.
+--- Returns a Stream whose next() yields Event values (iterate with
+--- `for ev in stream.next do`); when the underlying reader fails
+--- mid-body (reset, truncation, TLS error) next() yields nil plus the
+--- error message once, then nil — so a truncated stream is
+--- distinguishable from a graceful close. A partially accumulated event
+--- at end-of-stream is discarded per the SSE spec, not dispatched.
+--- stream.last_event_id() exposes the id for reconnects.
 --- @param reader fetch.Reader the reader to parse events from
---- @return function iterator yielding Event or nil, error string
-local function events(reader: fetch.Reader): function(): Event | nil, string
+--- @return Stream the open event stream
+local function events(reader: fetch.Reader): Stream
   local current_data: {string} = {}
   local current_event: string = nil
-  local current_id: string = nil
   local current_retry: number = nil
   local last_id: string = nil
   local lines_iter = reader:lines()
   local done = false
 
-  return function(): Event | nil, string
+  local function next_event(): Event | nil, string
     if done then
       return nil
     end
 
     while true do
-      local line = lines_iter()
+      local line, read_err = lines_iter()
       if not line then
         done = true
-        -- stream ended: dispatch final event if we have pending data
-        if #current_data > 0 then
-          local ev: Event = {
-            data = table.concat(current_data, "\n"),
-            event = current_event or "message",
-            id = current_id or last_id,
-            retry = current_retry,
-          }
-          current_data = {}
-          return ev
+        -- Stream ended. A pending unterminated event is discarded per
+        -- spec: without its blank line it may be truncated mid-field.
+        if read_err then
+          return nil, read_err
         end
         return nil
       end
 
       -- strip trailing CR if present (handles \r\n line endings)
-      if line:sub(-1) == "\r" then
-        line = line:sub(1, -2)
+      if string.sub(line, -1) == "\r" then
+        line = string.sub(line, 1, -2)
       end
 
       if line == "" then
-        -- blank line: dispatch event if we have data
-        if #current_data > 0 then
+        -- blank line: dispatch the accumulated event
+        local data = table.concat(current_data, "\n")
+        current_data = {}
+        if data == "" then
+          -- empty data buffer: reset the event type too, dispatch nothing
+          current_event = nil
+        else
           local ev: Event = {
-            data = table.concat(current_data, "\n"),
+            data = data,
             event = current_event or "message",
-            id = current_id or last_id,
+            id = last_id,
             retry = current_retry,
           }
-
-          -- update last_id for subsequent events
-          if current_id then
-            last_id = current_id
-          end
-
-          -- reset accumulators for next event
-          current_data = {}
           current_event = nil
-          current_id = nil
           current_retry = nil
-
           return ev
         end
       else
@@ -109,11 +120,15 @@ local function events(reader: fetch.Reader): function(): Event | nil, string
           elseif name == "event" then
             current_event = value
           elseif name == "id" then
-            current_id = value
+            -- takes effect immediately, even if no event is dispatched;
+            -- ids carrying a NUL are ignored per spec
+            if not value:find("\0", 1, true) then
+              last_id = value
+            end
           elseif name == "retry" then
-            local n = tonumber(value)
-            if n then
-              current_retry = n
+            -- digits-only per spec; anything else is ignored
+            if value:match("^%d+$") then
+              current_retry = tonumber(value)
             end
           end
           -- ignore unknown field names per spec
@@ -122,11 +137,21 @@ local function events(reader: fetch.Reader): function(): Event | nil, string
       end
     end
   end
+
+  local function last_event_id(): string
+    return last_id
+  end
+
+  return {
+    next = next_event,
+    last_event_id = last_event_id,
+  }
 end
 
 local record sse
   Event: Event
-  events: function(reader: fetch.Reader): function(): Event | nil, string
+  Stream: Stream
+  events: function(reader: fetch.Reader): Stream
 end
 
 local M: sse = {

--- a/lib/cosmic/sse_test.tl
+++ b/lib/cosmic/sse_test.tl
@@ -2,10 +2,13 @@
 local sse = require("cosmic.sse")
 local fetch = require("cosmic.fetch")
 
---- Create a mock reader from a string.
-local function mock_reader(content: string): fetch.Reader
+--- Create a mock reader over a string. When fail_with is given, read()
+--- returns nil, fail_with after the content is consumed — a mid-stream
+--- transport failure — instead of a clean EOF.
+local function mock_reader(content: string, fail_with?: string): fetch.Reader
   local pos = 1
   local is_closed = false
+  local failed = false
 
   local reader: fetch.Reader = {}
 
@@ -14,6 +17,10 @@ local function mock_reader(content: string): fetch.Reader
       return nil, "reader closed"
     end
     if pos > #content then
+      if fail_with and not failed then
+        failed = true
+        return nil, fail_with
+      end
       return nil
     end
     -- return small chunks to test line buffering
@@ -32,12 +39,15 @@ local function mock_reader(content: string): fetch.Reader
     return is_closed
   end
 
-  function reader:lines(): function(): string
+  function reader:lines(): function(): string | nil, string
     local buffer = ""
     local done = false
 
-    return function(): string
-      while not done do
+    return function(): string | nil, string
+      if done then
+        return nil
+      end
+      while true do
         local newline_pos = buffer:find("\n")
         if newline_pos then
           local line = buffer:sub(1, newline_pos - 1)
@@ -45,7 +55,11 @@ local function mock_reader(content: string): fetch.Reader
           return line
         end
 
-        local chunk = self:read()
+        local chunk, err = self:read()
+        if err then
+          done = true
+          return nil, err
+        end
         if not chunk then
           done = true
           if #buffer > 0 then
@@ -57,28 +71,37 @@ local function mock_reader(content: string): fetch.Reader
         end
         buffer = buffer .. chunk
       end
-      return nil
     end
   end
 
   return reader
 end
 
+--- Collect every event; return the events, the terminal error (if any),
+--- and the stream's final last_event_id.
+local function collect(content: string, fail_with?: string): {sse.Event}, string, string
+  local stream = sse.events(mock_reader(content, fail_with))
+  local events_list: {sse.Event} = {}
+  local terminal_err: string
+  while true do
+    local event, err = stream.next()
+    if not event then
+      terminal_err = err
+      break
+    end
+    table.insert(events_list, event)
+  end
+  return events_list, terminal_err, stream.last_event_id()
+end
+
 local function test_module_loads()
   assert(sse ~= nil, "sse module should not be nil")
-  assert(sse.events ~= nil, "sse.events should not be nil")
   assert(type(sse.events) == "function", "sse.events should be a function")
 end
 test_module_loads()
 
 local function test_simple_event()
-  local reader = mock_reader("data: hello world\n\n")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
+  local events_list = collect("data: hello world\n\n")
   assert(#events_list == 1, "should have 1 event, got: " .. #events_list)
   assert(events_list[1].data == "hello world", "data should be 'hello world', got: " .. events_list[1].data)
   assert(events_list[1].event == "message", "event type should default to 'message', got: " .. tostring(events_list[1].event))
@@ -86,13 +109,7 @@ end
 test_simple_event()
 
 local function test_event_type()
-  local reader = mock_reader("event: custom\ndata: payload\n\n")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
+  local events_list = collect("event: custom\ndata: payload\n\n")
   assert(#events_list == 1, "should have 1 event")
   assert(events_list[1].event == "custom", "event type should be 'custom', got: " .. tostring(events_list[1].event))
   assert(events_list[1].data == "payload", "data should be 'payload'")
@@ -100,39 +117,21 @@ end
 test_event_type()
 
 local function test_event_id()
-  local reader = mock_reader("id: 123\ndata: test\n\n")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
+  local events_list = collect("id: 123\ndata: test\n\n")
   assert(#events_list == 1, "should have 1 event")
   assert(events_list[1].id == "123", "id should be '123', got: " .. tostring(events_list[1].id))
 end
 test_event_id()
 
 local function test_retry_field()
-  local reader = mock_reader("retry: 5000\ndata: test\n\n")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
+  local events_list = collect("retry: 5000\ndata: test\n\n")
   assert(#events_list == 1, "should have 1 event")
   assert(events_list[1].retry == 5000, "retry should be 5000, got: " .. tostring(events_list[1].retry))
 end
 test_retry_field()
 
 local function test_multiline_data()
-  local reader = mock_reader("data: line one\ndata: line two\ndata: line three\n\n")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
+  local events_list = collect("data: line one\ndata: line two\ndata: line three\n\n")
   assert(#events_list == 1, "should have 1 event")
   local expected = "line one\nline two\nline three"
   assert(events_list[1].data == expected, "data should be multiline, got: " .. events_list[1].data)
@@ -140,26 +139,14 @@ end
 test_multiline_data()
 
 local function test_comments_ignored()
-  local reader = mock_reader(": this is a comment\ndata: actual data\n: another comment\n\n")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
+  local events_list = collect(": this is a comment\ndata: actual data\n: another comment\n\n")
   assert(#events_list == 1, "should have 1 event")
   assert(events_list[1].data == "actual data", "comment content should be ignored")
 end
 test_comments_ignored()
 
 local function test_multiple_events()
-  local reader = mock_reader("data: first\n\ndata: second\n\ndata: third\n\n")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
+  local events_list = collect("data: first\n\ndata: second\n\ndata: third\n\n")
   assert(#events_list == 3, "should have 3 events, got: " .. #events_list)
   assert(events_list[1].data == "first", "first event data should be 'first'")
   assert(events_list[2].data == "second", "second event data should be 'second'")
@@ -168,78 +155,70 @@ end
 test_multiple_events()
 
 local function test_crlf_line_endings()
-  local reader = mock_reader("data: with crlf\r\n\r\n")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
+  local events_list = collect("data: with crlf\r\n\r\n")
   assert(#events_list == 1, "should have 1 event")
   assert(events_list[1].data == "with crlf", "should handle CRLF, got: '" .. events_list[1].data .. "'")
 end
 test_crlf_line_endings()
 
 local function test_field_without_space_after_colon()
-  local reader = mock_reader("data:no space\n\n")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
+  local events_list = collect("data:no space\n\n")
   assert(#events_list == 1, "should have 1 event")
   assert(events_list[1].data == "no space", "should parse field without space after colon")
 end
 test_field_without_space_after_colon()
 
-local function test_field_without_value()
-  local reader = mock_reader("data\n\n")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
-  assert(#events_list == 1, "should have 1 event")
-  assert(events_list[1].data == "", "field without value should have empty string")
+local function test_lone_data_field_not_dispatched()
+  -- "data" alone leaves the data buffer empty at the blank line; the spec
+  -- resets the buffers and dispatches nothing.
+  local events_list = collect("data\n\n")
+  assert(#events_list == 0, "empty-data event must not dispatch, got: " .. #events_list)
 end
-test_field_without_value()
+test_lone_data_field_not_dispatched()
+
+local function test_two_empty_data_lines_dispatch_newline()
+  -- two empty data lines join to "\n", which is non-empty and dispatches
+  local events_list = collect("data\ndata\n\n")
+  assert(#events_list == 1, "should have 1 event, got: " .. #events_list)
+  assert(events_list[1].data == "\n", "data should be a single newline")
+end
+test_two_empty_data_lines_dispatch_newline()
+
+local function test_empty_data_dispatch_resets_event_type()
+  -- an event type buffered before an empty-data dispatch must not leak
+  -- into the next event
+  local events_list = collect("event: custom\n\ndata: hi\n\n")
+  assert(#events_list == 1, "should have 1 event")
+  assert(events_list[1].event == "message",
+    "event type must reset on empty-data dispatch, got: " .. tostring(events_list[1].event))
+end
+test_empty_data_dispatch_resets_event_type()
 
 local function test_unknown_fields_ignored()
-  local reader = mock_reader("unknown: value\ndata: test\ncustom: ignored\n\n")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
+  local events_list = collect("unknown: value\ndata: test\ncustom: ignored\n\n")
   assert(#events_list == 1, "should have 1 event")
   assert(events_list[1].data == "test", "should only parse known fields")
 end
 test_unknown_fields_ignored()
 
 local function test_invalid_retry_ignored()
-  local reader = mock_reader("retry: not-a-number\ndata: test\n\n")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
+  local events_list = collect("retry: not-a-number\ndata: test\n\n")
   assert(#events_list == 1, "should have 1 event")
   assert(events_list[1].retry == nil, "invalid retry should be nil")
 end
 test_invalid_retry_ignored()
 
+local function test_retry_digits_only()
+  -- "3000ms" is not digits-only; tonumber-style prefixes must not pass
+  local events_list = collect("retry: 3000ms\ndata: a\n\nretry: 0x10\ndata: b\n\n")
+  assert(#events_list == 2, "should have 2 events")
+  assert(events_list[1].retry == nil, "'3000ms' must be ignored")
+  assert(events_list[2].retry == nil, "'0x10' must be ignored")
+end
+test_retry_digits_only()
+
 local function test_id_persists_across_events()
-  local reader = mock_reader("id: 100\ndata: first\n\ndata: second\n\nid: 200\ndata: third\n\n")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
+  local events_list = collect("id: 100\ndata: first\n\ndata: second\n\nid: 200\ndata: third\n\n")
   assert(#events_list == 3, "should have 3 events")
   assert(events_list[1].id == "100", "first event should have id 100")
   assert(events_list[2].id == "100", "second event should inherit id 100")
@@ -247,52 +226,48 @@ local function test_id_persists_across_events()
 end
 test_id_persists_across_events()
 
+local function test_last_event_id_updates_on_sight()
+  -- id: takes effect as soon as the line is seen, even when no event is
+  -- ever dispatched — that is what reconnection needs
+  local events_list, err, last_id = collect("id: 42\n: comment\n\n")
+  assert(#events_list == 0, "no events expected")
+  assert(err == nil, "no error expected")
+  assert(last_id == "42", "last_event_id must update on sight of id:, got " .. tostring(last_id))
+end
+test_last_event_id_updates_on_sight()
+
+local function test_id_with_nul_ignored()
+  local events_list, _, last_id = collect("id: bad\0id\ndata: x\n\n")
+  assert(#events_list == 1, "should have 1 event")
+  assert(events_list[1].id == nil, "an id containing NUL is ignored")
+  assert(last_id == nil, "last_event_id must not pick up a NUL id")
+end
+test_id_with_nul_ignored()
+
 local function test_empty_stream()
-  local reader = mock_reader("")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
+  local events_list = collect("")
   assert(#events_list == 0, "empty stream should yield no events")
 end
 test_empty_stream()
 
-local function test_stream_without_trailing_blank_line()
-  local reader = mock_reader("data: final")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
-  assert(#events_list == 1, "should dispatch pending event at stream end")
-  assert(events_list[1].data == "final", "data should be 'final'")
+local function test_unterminated_event_discarded_at_eof()
+  -- an event without its terminating blank line may be truncated
+  -- mid-field; the spec discards it rather than dispatching it
+  local events_list = collect("data: final")
+  assert(#events_list == 0,
+    "unterminated event must be discarded at EOF, got: " .. #events_list)
 end
-test_stream_without_trailing_blank_line()
+test_unterminated_event_discarded_at_eof()
 
 local function test_blank_lines_without_data_ignored()
-  local reader = mock_reader("\n\n\ndata: actual\n\n")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
+  local events_list = collect("\n\n\ndata: actual\n\n")
   assert(#events_list == 1, "blank lines without data should not create events")
   assert(events_list[1].data == "actual", "data should be 'actual'")
 end
 test_blank_lines_without_data_ignored()
 
 local function test_complete_event_with_all_fields()
-  local reader = mock_reader("event: update\nid: 42\nretry: 3000\ndata: line 1\ndata: line 2\n\n")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
+  local events_list = collect("event: update\nid: 42\nretry: 3000\ndata: line 1\ndata: line 2\n\n")
   assert(#events_list == 1, "should have 1 event")
   assert(events_list[1].event == "update", "event type should be 'update'")
   assert(events_list[1].id == "42", "id should be '42'")
@@ -302,60 +277,64 @@ end
 test_complete_event_with_all_fields()
 
 local function test_comments_only()
-  local reader = mock_reader(": comment1\n: comment2\n\n")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
+  local events_list = collect(": comment1\n: comment2\n\n")
   assert(#events_list == 0, "comments-only stream should yield no events, got: " .. #events_list)
 end
 test_comments_only()
 
 local function test_binary_input()
   -- Binary bytes in data field: parser should not crash
-  local reader = mock_reader("data: \x00\x01\x02\xff\xfe\n\n")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
-  -- Just verify it does not error and yields one event
+  local events_list = collect("data: \x01\x02\xff\xfe\n\n")
   assert(#events_list == 1, "binary input should yield one event, got: " .. #events_list)
 end
 test_binary_input()
 
 local function test_utf8_data()
-  local reader = mock_reader("data: héllo wörld\n\n")
-  local events_list: {sse.Event} = {}
-
-  for event in sse.events(reader) do
-    table.insert(events_list, event)
-  end
-
+  local events_list = collect("data: héllo wörld\n\n")
   assert(#events_list == 1, "should have 1 event")
   assert(events_list[1].data == "héllo wörld", "UTF-8 data should pass through unchanged, got: " .. events_list[1].data)
 end
 test_utf8_data()
 
--- Network test with real SSE endpoint (skip if unavailable)
-local function test_real_sse_endpoint()
-  if not fetch.has_stream() then
-    io.stderr:write("SKIP: test_real_sse_endpoint (streaming fetch not available)\n")
-    return
-  end
-
-  -- Use httpbin's SSE-like streaming endpoint
-  local result = fetch.stream("https://httpbin.org/stream/2")
-  if not result.ok then
-    io.stderr:write("SKIP: test_real_sse_endpoint (network unavailable)\n")
-    return
-  end
-
-  -- Note: httpbin/stream returns JSON lines, not SSE format
-  -- This test just verifies the integration path works
-  result.reader:close()
+local function test_read_error_propagates()
+  -- issue #530 part 3 TDD: a reader whose read() errors after one chunk
+  -- must surface nil, "connection reset" — not a clean nil
+  local events_list, err = collect("data: one\n\n", "connection reset")
+  assert(#events_list == 1, "the complete event still arrives")
+  assert(events_list[1].data == "one", "first event data intact")
+  assert(err == "connection reset",
+    "the iterator must yield the transport error, got: " .. tostring(err))
 end
-test_real_sse_endpoint()
+test_read_error_propagates()
+
+local function test_read_error_then_iterator_exhausted()
+  local stream = sse.events(mock_reader("data: one\n\n", "boom"))
+  local first = stream.next()
+  assert(first ~= nil and (first as sse.Event).data == "one", "first event expected")
+  local second, err = stream.next()
+  assert(second == nil and err == "boom", "error must be yielded once")
+  local third, err3 = stream.next()
+  assert(third == nil and err3 == nil, "after the error the iterator returns plain nil")
+end
+test_read_error_then_iterator_exhausted()
+
+local function test_stream_iterates_with_for_in()
+  local stream = sse.events(mock_reader("data: a\n\ndata: b\n\n"))
+  local seen: {string} = {}
+  for event in stream.next do
+    table.insert(seen, (event as sse.Event).data)
+  end
+  assert(#seen == 2 and seen[1] == "a" and seen[2] == "b",
+    "stream.next must work as a for-in iterator")
+end
+test_stream_iterates_with_for_in()
+
+local function test_error_discards_partial_event()
+  -- data buffered before the failure belongs to an unterminated event;
+  -- it must be discarded, not dispatched as if complete
+  local events_list, err = collect("data: complete\n\ndata: doomed\n", "reset")
+  assert(#events_list == 1, "only the terminated event arrives, got: " .. #events_list)
+  assert(events_list[1].data == "complete", "the terminated event is intact")
+  assert(err == "reset", "the failure is reported")
+end
+test_error_discards_partial_event()

--- a/lib/cosmic/url.tl
+++ b/lib/cosmic/url.tl
@@ -1,5 +1,4 @@
---- URL encoding, decoding, parsing, and escaping utilities.
---- Provides functions for URL query encoding, parsing, and component escaping.
+--- URL encoding, decoding, parsing, formatting, and escaping utilities.
 local cosmo = require("cosmo")
 
 --- Percent-encode a string for use as a URL query parameter value.
@@ -36,16 +35,22 @@ local function decode(str: string): string | nil, string
   return cosmo.UnescapeParam(str)
 end
 
---- Parse a query string into key-value pairs.
---- Handles URL-encoded keys and values.
---- Duplicate keys: last value wins.
+--- Parse a query string into its key-value pairs, keeping every value.
+--- Keys and values are percent-decoded; a repeated key's values arrive
+--- in order. A flag-style key with no `=` yields one empty-string value.
 --- @param query string The query string (without leading ?)
---- @return {string:string} Table of key-value pairs
-local function parse(query: string): {string: string}
-  local pairs_list = cosmo.ParseParams(query) as {{string, string}}
-  local result: {string: string} = {}
+--- @return {string:{string}} Decoded keys, each with all its values in order
+local function parse_query(query: string): {string: {string}}
+  local pairs_list = cosmo.ParseParams(query) as {{string}}
+  local result: {string: {string}} = {}
   for _, pair in ipairs(pairs_list) do
-    result[pair[1]] = pair[2]
+    local key = pair[1]
+    local list = result[key]
+    if not list then
+      list = {}
+      result[key] = list
+    end
+    table.insert(list, pair[2] or "")
   end
   return result
 end
@@ -62,34 +67,25 @@ local record Url
   fragment: string
 end
 
-local record UrlModule
-  Url: Url
-
-  encode: function(str: string): string
-  decode: function(str: string): string | nil, string
-  parse: function(query: string): {string: string}
-  parse_url: function(url: string): Url
-  parse_host: function(hostport: string): string | nil, integer
-  escape_host: function(str: string): string
-  escape_path: function(str: string): string
-  escape_segment: function(str: string): string
-  escape_fragment: function(str: string): string
-  escape_literal: function(str: string): string
-  escape_user: function(str: string): string
-  escape_pass: function(str: string): string
-  escape_ip: function(str: string): string
-end
-
 --- Parse a URL into its components.
+--- The query field is re-encoded so delimiters inside values survive
+--- (e.g. `?a=x%26y` stays one parameter); decode it with `parse_query`.
 --- @param url string The URL to parse
---- @return Url The parsed URL components
-local function parse_url(url: string): Url
+--- @return Url | nil The parsed URL components, or nil on error
+--- @return string? Error message if parsing failed
+local function parse(url: string): Url | nil, string
+  if not url or url == "" then
+    return nil, "empty URL"
+  end
   local parsed = cosmo.ParseUrl(url)
 
-  -- Convert port from string to integer if present
+  -- Convert port from string to integer if present, validating range
   local port: integer = nil
   if parsed.port and parsed.port ~= "" then
-    port = tonumber(parsed.port) as integer
+    port = math.tointeger(tonumber(parsed.port))
+    if not port or port < 1 or port > 65535 then
+      return nil, "invalid port: " .. parsed.port
+    end
   end
 
   -- Reconstruct query string from params, re-encoding each decoded key and
@@ -123,35 +119,80 @@ local function parse_url(url: string): Url
   }
 end
 
+--- Format a Url back into a string — the inverse of `parse`.
+--- Each component is escaped for its position, so a parse/format round
+--- trip yields an equivalent URL.
+--- @param u Url The URL components to format
+--- @return string The formatted URL
+local function format(u: Url): string
+  local params: {{string}} = nil
+  if u.query then
+    params = cosmo.ParseParams(u.query) as {{string}}
+  end
+  return cosmo.EncodeUrl({
+      scheme = u.scheme,
+      user = u.user,
+      pass = u.pass,
+      host = u.host,
+      port = u.port ~= nil and tostring(u.port) or nil,
+      path = u.path,
+      params = params,
+      fragment = u.fragment,
+    } as cosmo.Url)
+end
+
 --- Parse a host:port string into its components.
+--- IPv6 hosts must be bracketed ("[::1]" or "[::1]:8080"); a port, when
+--- present, must be an integer in 1..65535.
 --- @param hostport string The host:port string (e.g., "example.com:8080")
---- @return string | nil The host
+--- @return string | nil The host, or nil on error
 --- @return integer? The port, or nil if not specified
-local function parse_host(hostport: string): string | nil, integer
+--- @return string? Error message if parsing failed
+local function parse_host(hostport: string): string | nil, integer, string
   if not hostport or hostport == "" then
-    return nil, nil
+    return nil, nil, "empty host"
   end
 
-  -- Handle IPv6 addresses in brackets: [::1]:8080
-  local ipv6_host, ipv6_port = hostport:match("^%[([^%]]+)%]:(%d+)$")
-  if ipv6_host then
-    return ipv6_host, tonumber(ipv6_port) as integer
+  local port_str: string = nil
+  local host: string
+
+  local bracket_host, rest = hostport:match("^%[([^%]]+)%](.*)$")
+  if bracket_host then
+    host = bracket_host as string
+    local r = rest as string
+    if r ~= "" then
+      port_str = r:match("^:(%d+)$")
+      if not port_str then
+        return nil, nil, "invalid host:port: " .. hostport
+      end
+    end
+  else
+    local colon = hostport:find(":", 1, true)
+    if not colon then
+      host = hostport
+    else
+      host = hostport:sub(1, colon - 1)
+      port_str = hostport:sub(colon + 1)
+      if port_str:find(":", 1, true) then
+        return nil, nil, "IPv6 host must be bracketed, e.g. [::1]:8080"
+      end
+      if host == "" then
+        return nil, nil, "empty host in: " .. hostport
+      end
+      if not port_str:match("^%d+$") then
+        return nil, nil, "invalid port: " .. port_str
+      end
+    end
   end
 
-  -- Handle IPv6 without port: [::1]
-  local ipv6_only = hostport:match("^%[([^%]]+)%]$")
-  if ipv6_only then
-    return ipv6_only, nil
+  if port_str then
+    local port = math.tointeger(tonumber(port_str))
+    if not port or port < 1 or port > 65535 then
+      return nil, nil, "invalid port: " .. port_str
+    end
+    return host, port
   end
-
-  -- Handle regular host:port
-  local host, port_str = hostport:match("^(.+):(%d+)$")
-  if host and port_str then
-    return host, tonumber(port_str) as integer
-  end
-
-  -- No port specified
-  return hostport, nil
+  return host, nil
 end
 
 --- Escape a hostname for use in a URL.
@@ -215,11 +256,31 @@ local function escape_ip(str: string): string
   return cosmo.EscapeIp(str)
 end
 
+local record UrlModule
+  Url: Url
+
+  encode: function(str: string): string
+  decode: function(str: string): string | nil, string
+  parse: function(url: string): Url | nil, string
+  format: function(u: Url): string
+  parse_query: function(query: string): {string: {string}}
+  parse_host: function(hostport: string): string | nil, integer, string
+  escape_host: function(str: string): string
+  escape_path: function(str: string): string
+  escape_segment: function(str: string): string
+  escape_fragment: function(str: string): string
+  escape_literal: function(str: string): string
+  escape_user: function(str: string): string
+  escape_pass: function(str: string): string
+  escape_ip: function(str: string): string
+end
+
 local M: UrlModule = {
   encode = encode,
   decode = decode,
   parse = parse,
-  parse_url = parse_url,
+  format = format,
+  parse_query = parse_query,
   parse_host = parse_host,
   escape_host = escape_host,
   escape_path = escape_path,

--- a/lib/cosmic/url_test.tl
+++ b/lib/cosmic/url_test.tl
@@ -25,19 +25,19 @@ test_encode_unreserved_chars()
 
 local function test_decode_percent_sequences()
   local result = url.decode("hello%20world")
-  assert(result == "hello world", "expected 'hello world', got '" .. result .. "'")
+  assert(result == "hello world", "expected 'hello world', got '" .. tostring(result) .. "'")
 end
 test_decode_percent_sequences()
 
 local function test_decode_plus_as_space()
   local result = url.decode("hello+world")
-  assert(result == "hello world", "expected 'hello world', got '" .. result .. "'")
+  assert(result == "hello world", "expected 'hello world', got '" .. tostring(result) .. "'")
 end
 test_decode_plus_as_space()
 
 local function test_decode_mixed()
   local result = url.decode("a%2Cb%26c%3Dd")
-  assert(result == "a,b&c=d", "expected 'a,b&c=d', got '" .. result .. "'")
+  assert(result == "a,b&c=d", "expected 'a,b&c=d', got '" .. tostring(result) .. "'")
 end
 test_decode_mixed()
 
@@ -45,7 +45,7 @@ local function test_roundtrip_basic()
   local original = "hello world"
   local encoded = url.encode(original)
   local decoded = url.decode(encoded)
-  assert(decoded == original, "roundtrip failed: expected '" .. original .. "', got '" .. decoded .. "'")
+  assert(decoded == original, "roundtrip failed: expected '" .. original .. "', got '" .. tostring(decoded) .. "'")
 end
 test_roundtrip_basic()
 
@@ -53,7 +53,7 @@ local function test_roundtrip_special()
   local original = "name=value&foo=bar"
   local encoded = url.encode(original)
   local decoded = url.decode(encoded)
-  assert(decoded == original, "roundtrip failed: expected '" .. original .. "', got '" .. decoded .. "'")
+  assert(decoded == original, "roundtrip failed: expected '" .. original .. "', got '" .. tostring(decoded) .. "'")
 end
 test_roundtrip_special()
 
@@ -101,104 +101,191 @@ test_encode_empty_string()
 
 local function test_decode_lowercase_hex()
   local result = url.decode("%2f%3a")
-  assert(result == "/:", "expected '/:' for lowercase hex, got '" .. result .. "'")
+  assert(result == "/:", "expected '/:' for lowercase hex, got '" .. tostring(result) .. "'")
 end
 test_decode_lowercase_hex()
 
 local function test_decode_uppercase_hex()
   local result = url.decode("%2F%3A")
-  assert(result == "/:", "expected '/:' for uppercase hex, got '" .. result .. "'")
+  assert(result == "/:", "expected '/:' for uppercase hex, got '" .. tostring(result) .. "'")
 end
 test_decode_uppercase_hex()
 
--- parse tests
+-- parse_query tests
 
-local function test_parse_basic()
-  local result = url.parse("key=value")
-  assert(result.key == "value", "expected 'value', got '" .. tostring(result.key) .. "'")
+local function test_parse_query_basic()
+  local result = url.parse_query("key=value")
+  assert(#result.key == 1, "expected one value for key")
+  assert(result.key[1] == "value", "expected 'value', got '" .. tostring(result.key[1]) .. "'")
 end
-test_parse_basic()
+test_parse_query_basic()
 
-local function test_parse_multiple_params()
-  local result = url.parse("a=1&b=2&c=3")
-  assert(result.a == "1", "expected '1' for a")
-  assert(result.b == "2", "expected '2' for b")
-  assert(result.c == "3", "expected '3' for c")
+local function test_parse_query_multiple_params()
+  local result = url.parse_query("a=1&b=2&c=3")
+  assert(result.a[1] == "1", "expected '1' for a")
+  assert(result.b[1] == "2", "expected '2' for b")
+  assert(result.c[1] == "3", "expected '3' for c")
 end
-test_parse_multiple_params()
+test_parse_query_multiple_params()
 
-local function test_parse_encoded_values()
-  local result = url.parse("name=hello%20world")
-  assert(result.name == "hello world", "expected 'hello world', got '" .. tostring(result.name) .. "'")
+local function test_parse_query_repeated_key_keeps_all_values()
+  -- The old parse() silently dropped every value but the last.
+  local result = url.parse_query("tag=a&tag=b&tag=c")
+  assert(#result.tag == 3, "expected 3 values, got " .. #result.tag)
+  assert(result.tag[1] == "a" and result.tag[2] == "b" and result.tag[3] == "c",
+    "values must arrive in order")
 end
-test_parse_encoded_values()
+test_parse_query_repeated_key_keeps_all_values()
 
-local function test_parse_empty_string()
-  local result = url.parse("")
+local function test_parse_query_encoded_values()
+  local result = url.parse_query("name=hello%20world")
+  assert(result.name[1] == "hello world", "expected 'hello world', got '" .. tostring(result.name[1]) .. "'")
+end
+test_parse_query_encoded_values()
+
+local function test_parse_query_empty_string()
+  local result = url.parse_query("")
   local count = 0
   for _ in pairs(result) do
     count = count + 1
   end
   assert(count == 0, "expected empty table for empty string")
 end
-test_parse_empty_string()
+test_parse_query_empty_string()
 
-local function test_parse_empty_value()
-  local result = url.parse("key=")
-  assert(result.key == "", "expected empty string for 'key='")
+local function test_parse_query_empty_value()
+  local result = url.parse_query("key=")
+  assert(result.key[1] == "", "expected empty string for 'key='")
 end
-test_parse_empty_value()
+test_parse_query_empty_value()
 
-local function test_parse_plus_as_space()
-  local result = url.parse("msg=hello+world")
-  assert(result.msg == "hello world", "expected 'hello world', got '" .. tostring(result.msg) .. "'")
+local function test_parse_query_flag_key()
+  -- A key with no '=' yields one empty-string value, not nil.
+  local result = url.parse_query("flag")
+  assert(#result.flag == 1 and result.flag[1] == "", "expected {''} for flag key")
 end
-test_parse_plus_as_space()
+test_parse_query_flag_key()
 
--- parse_url tests
-
-local function test_parse_url_full()
-  local result = url.parse_url("https://user:pass@example.com:8080/path?foo=1&bar=2#frag")
-  assert(result.scheme == "https", "expected 'https', got '" .. tostring(result.scheme) .. "'")
-  assert(result.user == "user", "expected 'user', got '" .. tostring(result.user) .. "'")
-  assert(result.pass == "pass", "expected 'pass', got '" .. tostring(result.pass) .. "'")
-  assert(result.host == "example.com", "expected 'example.com', got '" .. tostring(result.host) .. "'")
-  assert(result.port == 8080, "expected 8080, got " .. tostring(result.port))
-  assert(result.path == "/path", "expected '/path', got '" .. tostring(result.path) .. "'")
-  assert(result.query == "foo=1&bar=2", "expected 'foo=1&bar=2', got '" .. tostring(result.query) .. "'")
-  assert(result.fragment == "frag", "expected 'frag', got '" .. tostring(result.fragment) .. "'")
+local function test_parse_query_plus_as_space()
+  local result = url.parse_query("msg=hello+world")
+  assert(result.msg[1] == "hello world", "expected 'hello world', got '" .. tostring(result.msg[1]) .. "'")
 end
-test_parse_url_full()
+test_parse_query_plus_as_space()
 
-local function test_parse_url_minimal()
-  local result = url.parse_url("http://example.com")
-  assert(result.scheme == "http", "expected 'http', got '" .. tostring(result.scheme) .. "'")
-  assert(result.host == "example.com", "expected 'example.com', got '" .. tostring(result.host) .. "'")
-  assert(result.port == nil, "expected nil port, got " .. tostring(result.port))
-  assert(result.path == "" or result.path == nil, "expected empty path, got '" .. tostring(result.path) .. "'")
-  assert(result.query == nil, "expected nil query, got '" .. tostring(result.query) .. "'")
+-- parse tests (url.parse is the URL parser; query strings are parse_query)
+
+local function test_parse_full()
+  local result = url.parse("https://user:pass@example.com:8080/path?foo=1&bar=2#frag")
+  assert(result ~= nil, "parse should succeed")
+  local u = result as url.Url
+  assert(u.scheme == "https", "expected 'https', got '" .. tostring(u.scheme) .. "'")
+  assert(u.user == "user", "expected 'user', got '" .. tostring(u.user) .. "'")
+  assert(u.pass == "pass", "expected 'pass', got '" .. tostring(u.pass) .. "'")
+  assert(u.host == "example.com", "expected 'example.com', got '" .. tostring(u.host) .. "'")
+  assert(u.port == 8080, "expected 8080, got " .. tostring(u.port))
+  assert(u.path == "/path", "expected '/path', got '" .. tostring(u.path) .. "'")
+  assert(u.query == "foo=1&bar=2", "expected 'foo=1&bar=2', got '" .. tostring(u.query) .. "'")
+  assert(u.fragment == "frag", "expected 'frag', got '" .. tostring(u.fragment) .. "'")
 end
-test_parse_url_minimal()
+test_parse_full()
 
-local function test_parse_url_with_path_only()
-  local result = url.parse_url("http://example.com/api/v1/users")
+local function test_parse_is_a_url_parser_not_a_query_parser()
+  -- The old url.parse treated its input as a query string, so a full URL
+  -- came back as {["http://example.com/path?a"] = "1"}. It must parse as
+  -- a URL now.
+  local result = url.parse("http://example.com/path?a=1")
+  assert(result ~= nil, "parse should succeed")
+  local u = result as url.Url
+  assert(u.scheme == "http", "expected scheme 'http', got '" .. tostring(u.scheme) .. "'")
+  assert(u.host == "example.com", "expected host, got '" .. tostring(u.host) .. "'")
+  assert(u.path == "/path", "expected path '/path', got '" .. tostring(u.path) .. "'")
+  assert(u.query == "a=1", "expected query 'a=1', got '" .. tostring(u.query) .. "'")
+end
+test_parse_is_a_url_parser_not_a_query_parser()
+
+local function test_parse_minimal()
+  local result = url.parse("http://example.com")
+  assert(result ~= nil, "parse should succeed")
+  local u = result as url.Url
+  assert(u.scheme == "http", "expected 'http', got '" .. tostring(u.scheme) .. "'")
+  assert(u.host == "example.com", "expected 'example.com', got '" .. tostring(u.host) .. "'")
+  assert(u.port == nil, "expected nil port, got " .. tostring(u.port))
+  assert(u.path == "" or u.path == nil, "expected empty path, got '" .. tostring(u.path) .. "'")
+  assert(u.query == nil, "expected nil query, got '" .. tostring(u.query) .. "'")
+end
+test_parse_minimal()
+
+local function test_parse_empty_url()
+  local result, err = url.parse("")
+  assert(result == nil, "expected nil for empty URL")
+  assert(err == "empty URL", "expected 'empty URL', got '" .. tostring(err) .. "'")
+end
+test_parse_empty_url()
+
+local function test_parse_invalid_port()
+  local result, err = url.parse("http://example.com:99999/")
+  assert(result == nil, "port 99999 must be rejected, got port " ..
+    tostring(result and (result as url.Url).port))
+  assert(err ~= nil and err:find("invalid port") ~= nil,
+    "expected invalid-port error, got '" .. tostring(err) .. "'")
+end
+test_parse_invalid_port()
+
+local function test_parse_with_path_only()
+  local result = url.parse("http://example.com/api/v1/users") as url.Url
   assert(result.scheme == "http", "expected 'http'")
   assert(result.host == "example.com", "expected 'example.com'")
   assert(result.path == "/api/v1/users", "expected '/api/v1/users', got '" .. tostring(result.path) .. "'")
 end
-test_parse_url_with_path_only()
+test_parse_with_path_only()
 
-local function test_parse_url_with_query_only()
-  local result = url.parse_url("http://example.com?search=test")
+local function test_parse_with_query_only()
+  local result = url.parse("http://example.com?search=test") as url.Url
   assert(result.query == "search=test", "expected 'search=test', got '" .. tostring(result.query) .. "'")
 end
-test_parse_url_with_query_only()
+test_parse_with_query_only()
 
-local function test_parse_url_with_fragment_only()
-  local result = url.parse_url("http://example.com#section")
+local function test_parse_with_fragment_only()
+  local result = url.parse("http://example.com#section") as url.Url
   assert(result.fragment == "section", "expected 'section', got '" .. tostring(result.fragment) .. "'")
 end
-test_parse_url_with_fragment_only()
+test_parse_with_fragment_only()
+
+-- format tests
+
+local function test_format_roundtrip_basic()
+  local u = url.parse("https://example.com:8080/path?foo=1&bar=2#frag") as url.Url
+  local formatted = url.format(u)
+  local reparsed = url.parse(formatted) as url.Url
+  assert(reparsed.scheme == "https" and reparsed.host == "example.com"
+    and reparsed.port == 8080 and reparsed.path == "/path"
+    and reparsed.fragment == "frag",
+    "roundtrip must preserve components, got: " .. formatted)
+  local params = url.parse_query(reparsed.query)
+  assert(params.foo[1] == "1" and params.bar[1] == "2",
+    "roundtrip must preserve query params, got: " .. formatted)
+end
+test_format_roundtrip_basic()
+
+local function test_format_preserves_encoded_delimiters()
+  -- ?a=x%26y is ONE param whose value contains '&'; format must keep it
+  -- one param instead of decoding %26 into a delimiter.
+  local u = url.parse("http://x.com/?a=x%26y") as url.Url
+  local formatted = url.format(u)
+  local reparsed = url.parse(formatted) as url.Url
+  local params = url.parse_query(reparsed.query)
+  assert(params.a ~= nil and params.a[1] == "x&y",
+    "param 'a' must survive as 'x&y', got: " .. formatted)
+end
+test_format_preserves_encoded_delimiters()
+
+local function test_format_minimal()
+  local formatted = url.format({scheme = "http", host = "example.com", path = "/x"})
+  local u = url.parse(formatted) as url.Url
+  assert(u.scheme == "http" and u.host == "example.com" and u.path == "/x",
+    "format of a hand-built Url must parse back, got: " .. formatted)
+end
+test_format_minimal()
 
 -- parse_host tests
 
@@ -215,13 +302,6 @@ local function test_parse_host_without_port()
   assert(port == nil, "expected nil port, got " .. tostring(port))
 end
 test_parse_host_without_port()
-
-local function test_parse_host_localhost()
-  local host, port = url.parse_host("localhost:3000")
-  assert(host == "localhost", "expected 'localhost', got '" .. tostring(host) .. "'")
-  assert(port == 3000, "expected 3000, got " .. tostring(port))
-end
-test_parse_host_localhost()
 
 local function test_parse_host_ipv4()
   local host, port = url.parse_host("192.168.1.1:80")
@@ -244,28 +324,60 @@ local function test_parse_host_ipv6_without_port()
 end
 test_parse_host_ipv6_without_port()
 
+local function test_parse_host_unbracketed_ipv6_rejected()
+  -- The old parser returned host ":" port 1 for "::1".
+  local host, _, err = url.parse_host("::1")
+  assert(host == nil, "unbracketed IPv6 must be rejected, got '" .. tostring(host) .. "'")
+  assert(err ~= nil and err:find("bracket") ~= nil,
+    "error should say brackets are required, got '" .. tostring(err) .. "'")
+end
+test_parse_host_unbracketed_ipv6_rejected()
+
+local function test_parse_host_port_out_of_range()
+  -- The old parser accepted port 99999.
+  local host, _, err = url.parse_host("example.com:99999")
+  assert(host == nil, "port 99999 must be rejected")
+  assert(err ~= nil and err:find("invalid port") ~= nil,
+    "expected invalid-port error, got '" .. tostring(err) .. "'")
+end
+test_parse_host_port_out_of_range()
+
+local function test_parse_host_port_zero_rejected()
+  local host, _, err = url.parse_host("example.com:0")
+  assert(host == nil, "port 0 must be rejected")
+  assert(err ~= nil, "expected error for port 0")
+end
+test_parse_host_port_zero_rejected()
+
+local function test_parse_host_trailing_colon_rejected()
+  local host, _, err = url.parse_host("example.com:")
+  assert(host == nil, "trailing colon without digits must be rejected")
+  assert(err ~= nil, "expected error message")
+end
+test_parse_host_trailing_colon_rejected()
+
 local function test_parse_host_empty()
-  local host, port = url.parse_host("")
+  local host, port, err = url.parse_host("")
   assert(host == nil, "expected nil host for empty string")
   assert(port == nil, "expected nil port for empty string")
+  assert(err ~= nil, "expected error for empty string")
 end
 test_parse_host_empty()
 
--- escape_host tests
+local function test_parse_host_empty_host_rejected()
+  local host, _, err = url.parse_host(":8080")
+  assert(host == nil, "empty host must be rejected")
+  assert(err ~= nil, "expected error message")
+end
+test_parse_host_empty_host_rejected()
+
+-- escape tests
 
 local function test_escape_host_basic()
   local result = url.escape_host("example.com")
   assert(result == "example.com", "expected 'example.com', got '" .. result .. "'")
 end
 test_escape_host_basic()
-
-local function test_escape_host_with_subdomain()
-  local result = url.escape_host("api.example.com")
-  assert(result == "api.example.com", "expected 'api.example.com', got '" .. result .. "'")
-end
-test_escape_host_with_subdomain()
-
--- escape_path tests
 
 local function test_escape_path_basic()
   local result = url.escape_path("/api/users")
@@ -285,27 +397,11 @@ local function test_escape_path_preserves_slashes()
 end
 test_escape_path_preserves_slashes()
 
--- escape_segment tests
-
 local function test_escape_segment_escapes_slash()
   local result = url.escape_segment("foo/bar")
   assert(result:match("%%2F") or result:match("%%2f"), "expected / to be encoded, got '" .. result .. "'")
 end
 test_escape_segment_escapes_slash()
-
-local function test_escape_segment_basic()
-  local result = url.escape_segment("users")
-  assert(result == "users", "expected 'users', got '" .. result .. "'")
-end
-test_escape_segment_basic()
-
--- escape_fragment tests
-
-local function test_escape_fragment_basic()
-  local result = url.escape_fragment("section-1")
-  assert(result == "section-1", "expected 'section-1', got '" .. result .. "'")
-end
-test_escape_fragment_basic()
 
 local function test_escape_fragment_with_spaces()
   local result = url.escape_fragment("section 1")
@@ -313,21 +409,11 @@ local function test_escape_fragment_with_spaces()
 end
 test_escape_fragment_with_spaces()
 
--- escape_literal tests
-
 local function test_escape_literal_basic()
   local result = url.escape_literal("test")
   assert(result == "test", "expected 'test', got '" .. result .. "'")
 end
 test_escape_literal_basic()
-
--- escape_user tests
-
-local function test_escape_user_basic()
-  local result = url.escape_user("username")
-  assert(result == "username", "expected 'username', got '" .. result .. "'")
-end
-test_escape_user_basic()
 
 local function test_escape_user_with_special_chars()
   local result = url.escape_user("user@domain")
@@ -335,21 +421,11 @@ local function test_escape_user_with_special_chars()
 end
 test_escape_user_with_special_chars()
 
--- escape_pass tests
-
-local function test_escape_pass_basic()
-  local result = url.escape_pass("secret123")
-  assert(result == "secret123", "expected 'secret123', got '" .. result .. "'")
-end
-test_escape_pass_basic()
-
 local function test_escape_pass_with_special_chars()
   local result = url.escape_pass("p@ss:word")
   assert(result:match("%%"), "expected special chars to be encoded")
 end
 test_escape_pass_with_special_chars()
-
--- escape_ip tests
 
 local function test_escape_ip_ipv4()
   local result = url.escape_ip("192.168.1.1")
@@ -363,29 +439,26 @@ local function test_escape_ip_ipv6()
 end
 test_escape_ip_ipv6()
 
--- FIX 4: parse_url must preserve percent-encoding in the query field.
--- ?a=x%26y has ONE param (key=a, value=x&y); the reconstructed query must
--- not turn %26 into a literal & (which would look like two params).
+-- parse must preserve percent-encoding in the query field: ?a=x%26y has
+-- ONE param (key=a, value=x&y); the reconstructed query must not turn %26
+-- into a literal & (which would look like two params).
 
-local function test_parse_url_query_preserves_encoding()
-  local result = url.parse_url("http://x.com/?a=x%26y")
+local function test_parse_query_field_preserves_encoding()
+  local result = url.parse("http://x.com/?a=x%26y") as url.Url
   assert(result.query ~= nil, "query should not be nil")
-  -- The query must not be decoded to "a=x&y" (that reads as two params).
   assert(result.query ~= "a=x&y",
     "query must not decode %26 to &, got: " .. tostring(result.query))
-  -- Parsing the reconstructed query must yield exactly one param with value "x&y".
-  local params = url.parse(result.query)
-  assert(params.a == "x&y",
-    "parsed param 'a' must equal 'x&y', got: " .. tostring(params.a))
+  local params = url.parse_query(result.query)
+  assert(params.a[1] == "x&y",
+    "parsed param 'a' must equal 'x&y', got: " .. tostring(params.a and params.a[1]))
 end
-test_parse_url_query_preserves_encoding()
+test_parse_query_field_preserves_encoding()
 
-local function test_parse_url_query_flag_param()
+local function test_parse_query_field_flag_param()
   -- ?flag has a key with no value; reconstructing must not emit a bare "=".
-  local result = url.parse_url("http://x.com/?flag")
+  local result = url.parse("http://x.com/?flag") as url.Url
   assert(result.query ~= nil, "query should not be nil for flag param")
-  -- The query string must contain "flag" and must not end in bare "=".
   assert(result.query:match("flag"), "query should contain 'flag'")
   assert(not result.query:match("flag=$"), "query must not end with 'flag='")
 end
-test_parse_url_query_flag_param()
+test_parse_query_field_flag_param()

--- a/lib/perf/bench/http_bench.tl
+++ b/lib/perf/bench/http_bench.tl
@@ -66,18 +66,15 @@ local function scenarios(): {pt.Scenario}, string
     return nil, "fork failed"
   end
   server_pid = pid
-  -- cosmo.Fetch refuses direct connections to private IPs (SSRF
-  -- protection, no opt-out), but proxied requests skip that check.
-  -- Point the proxy at the loopback server; it answers every request
-  -- with the same fixed response, so the full fetch code path runs.
-  local proxy = "http://127.0.0.1:" .. port
-  local url = "http://bench.invalid/"
+  -- allow_private opts out of the SSRF guard so the loopback server is
+  -- reachable directly, without the old point-a-proxy-at-it workaround.
+  local url = "http://127.0.0.1:" .. port .. "/"
 
   return {
     {
       name = "http_fetch_get",
       fn = function(_: any): any
-        return fetch.Fetch(url, {proxy = proxy})
+        return fetch.Fetch(url, {allow_private = true})
       end,
       check = function(_: any, res: any): boolean, string
         local r = res as fetch.Result
@@ -103,7 +100,7 @@ local function scenarios(): {pt.Scenario}, string
       name = "http_fetch_get_with_headers",
       fn = function(_: any): any
         return fetch.Fetch(url, {
-            proxy = proxy,
+            allow_private = true,
             headers = {
               ["Accept"] = "application/json",
               ["X-Test"] = "a moderately realistic header value, not just a few bytes",

--- a/lib/perf/bench/micro_bench.tl
+++ b/lib/perf/bench/micro_bench.tl
@@ -7,7 +7,7 @@ local hash = require("cosmic.hash")
 local codec = require("cosmic.codec")
 local compress = require("cosmic.compress")
 local cstr = require("cosmic.string")
-local net = require("cosmic.net")
+local ip = require("cosmic.ip")
 local url = require("cosmic.url")
 local pt = require("perf.perf_types")
 
@@ -164,8 +164,8 @@ local function scenarios(): {pt.Scenario}, string
     {
       name = "net_ip_roundtrip",
       fn = function(_: any): any
-        local n = net.parseip("192.168.1.1")
-        return net.formatip(n)
+        local n = ip.parse("192.168.1.1")
+        return ip.format(n)
       end,
       check = function(_: any, res: any): boolean, string
         if res as string ~= "192.168.1.1" then

--- a/lib/perf/bench/stream_bench.tl
+++ b/lib/perf/bench/stream_bench.tl
@@ -92,10 +92,6 @@ local function serve_loop(srv: net.Socket)
 end
 
 local function scenarios(): {pt.Scenario}, string
-  if not fetch.has_stream() then
-    -- Streaming primitive absent in this build; nothing to measure.
-    return {}
-  end
   local srv, port, lerr = net.listen_tcp(LOCALHOST, 0)
   if srv == nil then
     return nil, "listen_tcp: " .. tostring(lerr)
@@ -110,17 +106,15 @@ local function scenarios(): {pt.Scenario}, string
     return nil, "fork failed"
   end
   server_pid = pid
-  -- cosmo.Fetch/FetchStream refuse direct connections to private IPs
-  -- (SSRF protection); proxied requests skip that check. Point the proxy
-  -- at the loopback server so the full streaming path runs.
-  local proxy = "http://127.0.0.1:" .. port
-  local url = "http://bench.invalid/"
+  -- allow_private opts out of the SSRF guard so the loopback server is
+  -- reachable directly, without the old point-a-proxy-at-it workaround.
+  local url = "http://127.0.0.1:" .. port .. "/"
 
   return {
     {
       name = "stream_lines_iterate",
       fn = function(_: any): any
-        local res = fetch.stream(url, {proxy = proxy})
+        local res = fetch.stream(url, {allow_private = true})
         if not res.ok then
           return {count = -1, last = tostring(res.error)}
         end

--- a/lib/types/cosmo.d.tl
+++ b/lib/types/cosmo.d.tl
@@ -46,6 +46,8 @@ local record FetchOptions
   maxredirects: number
   --- whether to follow redirects. Defaults to `true`.
   followredirect: boolean
+  --- allow requests to private, loopback, and other non-public network addresses (disables the SSRF guard). Applies to every hop of a redirect chain. Defaults to `false`.
+  allowprivate: boolean
   --- whether to keep the connection alive.
   keepalive: boolean
   --- proxy URL to route the request through.
@@ -54,8 +56,6 @@ local record FetchOptions
   maxresponse: number
   --- request timeout in seconds. `0` or absent keeps the 60-second default; there is no "infinite" option.
   timeout: number
-  --- whether to reset TLS session state before the request.
-  resettls: boolean
 end
 
 local record BarfOptions
@@ -73,12 +73,12 @@ end
 --- promptly is recommended.
 local record StreamReader
   --- Reads the next chunk of the response body.
-  --- Returns a string chunk on success. An empty string may be returned
-  --- for chunked transfer encodings when framing data arrived without any
-  --- payload; callers should skip empty chunks rather than treating them
-  --- as EOF. Returns `nil` when the stream ends. Returns `nil` plus an
-  --- error message string if the reader is closed, the connection failed,
-  --- or the response was truncated.
+  --- Returns a non-empty string chunk on success (chunked transfer framing
+  --- that arrives without payload is consumed internally and never surfaces
+  --- as an empty chunk). Returns `nil` with no error when the stream ends,
+  --- including for bodyless responses such as 204 and 304. Returns `nil`
+  --- plus an error message string if the reader was closed with `close`,
+  --- the connection failed, or the response was truncated.
   read: function(self: StreamReader): string | nil, string | nil
   --- Closes the reader and releases the connection, buffer, and TLS
   --- state. Idempotent: closing an already-closed reader is a no-op.
@@ -401,12 +401,17 @@ local record cosmo
   ---   connection open (unless closed by the server) and reuse for the
   ---   next request to the same host. This option is disabled when SSL
   ---   connection is used.
-  ---   The mapping of hosts and their sockets is stored in a table
-  ---   assigned to the `keepalive` field itself, so it can be passed to
-  ---   the next call.
-  ---   If the table includes the `close` field set to a true value,
-  ---   then the connection is closed after the request is made and the
-  ---   host is removed from the mapping table.
+  ---   When a table is passed, it is used as the socket pool: the mapping
+  ---   of hosts to their sockets is stored in it, so the same table can be
+  ---   passed to the next call. If that table includes the `close` field
+  ---   set to a true value, then the connection is closed after the
+  ---   request is made and the host is removed from the mapping table.
+  ---   When `true` is passed, a process-wide internal pool is used
+  ---   instead; the options table is never modified.
+  --- - `allowprivate` (default: `false`): allow requests to private,
+  ---   loopback, and other non-public network addresses, which are
+  ---   otherwise blocked to prevent SSRF. The opt-out covers every hop of
+  ---   a redirect chain.
   --- - `proxy` (string): HTTP proxy URL, e.g. `"http://proxy:8080"`.
   ---   Supports Basic authentication: `"http://user:pass@proxy:8080"`.
   --- - `maxresponse` (default: `104857600`): maximum response size in bytes.
@@ -416,8 +421,6 @@ local record cosmo
   ---   connect).  A value of `0` or absent keeps the 60-second default.  There
   ---   is no "infinite" option — use a large positive value if needed.  The
   ---   timeout also bounds the TLS handshake.
-  --- - `resettls` (default: `true`): reset TLS state after fork.
-  ---   Ensures child processes get fresh DRBG entropy.
   --- Environment variables:
   --- - `http_proxy` / `HTTP_PROXY`: default proxy URL when `proxy` option
   ---   is not specified. Supports same format as the option.
@@ -427,18 +430,34 @@ local record cosmo
   ---   Only embedded certificates will be used.
   --- When the redirect is being followed, the same method and body values are being
   --- sent in all cases except when 303 status is returned. In that case the method
-  --- is set to GET and the body is removed before the redirect is followed. Note
-  --- that if these (method/body) values are provided as table fields, they will be
-  --- modified in place.
-  Fetch: function(url: string, body?: string | FetchOptions): number, {string: string}, string, string | nil
+  --- is set to GET and the body is removed before the redirect is followed. The
+  --- options table is read-only: it is never modified, even across redirects.
+  --- On success, the fourth return value is the effective URL: the URL of
+  --- the final request after any redirects were followed.
+  --- On failure, returns `nil`, a descriptive error message, and a
+  --- machine-readable failure kind, one of `"dns"` (name resolution
+  --- failed), `"connect"` (connection failed or was reset), `"tls"`
+  --- (handshake or certificate verification failed), `"timeout"`,
+  --- `"proxy"` (proxy configuration or tunnel failure), `"protocol"`
+  --- (malformed request or response), `"too_large"` (response exceeded
+  --- `maxresponse`), or `"blocked"` (refused by SSRF protection or the
+  --- HTTPS-to-HTTP downgrade guard).
+  Fetch: function(url: string, body?: string | FetchOptions): number, {string: string}, string, string, string | nil, string | nil
   --- Sends an HTTP/HTTPS request and returns a streaming reader for the response body.
   --- Useful for Server-Sent Events (SSE), large downloads, or processing data incrementally.
   --- Accepts the same options table as `Fetch()`, including `timeout`, `maxresponse`,
-  --- `headers`, `method`, `body`, `proxy`, `followredirect`, and `maxredirects`.
+  --- `headers`, `method`, `body`, `proxy`, `allowprivate`, `followredirect`,
+  --- and `maxredirects` (`keepalive` is ignored: streaming connections are
+  --- always closed). The options table is read-only: it is never modified,
+  --- even across redirects.
   --- Note: `timeout=0` (or absent) retains the 60-second default; there is no
   --- "infinite" option.  `maxresponse` limits per-read buffer growth; negative
   --- values are rejected.
-  FetchStream: function(url: string, options?: FetchOptions): number, {string: string}, StreamReader, string | nil
+  --- On success, the fourth return value is the effective URL after any
+  --- redirects. On failure, returns `nil`, a descriptive error message,
+  --- and a machine-readable failure kind with the same values as
+  --- `Fetch()`.
+  FetchStream: function(url: string, options?: FetchOptions): number, {string: string}, StreamReader, string, string | nil, string | nil
   --- Converts UNIX timestamp to an RFC1123 string that looks like this:
   --- `Mon, 29 Mar 2021 15:37:13 GMT`. See `formathttpdatetime.c`.
   FormatHttpDateTime: function(seconds: number): string


### PR DESCRIPTION
Closes #530. Implements all five parts of the networking reshape on top of the fetch C contract (whilp/cosmopolitan#152, released in `2026.07.07-e3fc92474`).

## Pin bump

`3p/cosmos/version.lua` → `2026.07.07-e3fc92474`; types regenerated (`Fetch`/`FetchStream` gain `allowprivate`, effective-URL return, and a `nil, err, kind` failure channel; `resettls` is gone; the streaming reader's 204/empty-chunk contract is documented).

## 1. Honest fetch headers (P0)

- `Result.headers: {string: string}` — lowercase names, repeated headers joined `", "` (RFC 9110 §5.3). `result.headers.vary:lower()` now type-checks *and* runs.
- `Result.raw_headers: {string: {string}}` — lowercase names, every value in arrival order (for Set-Cookie and friends).
- One-pass normalizer in a new `fetch_headers` chunk, shared by `Fetch` and `stream`.
- TDD: `fetch_multiheader_test.tl` asserts `type(headers.vary) == "string"`, `headers.vary == "Accept, Origin"`, `#raw_headers.vary == 2`, for both `Fetch` and `stream`, against a loopback server.

## 2. fetch options/retry restructure (P1)

- `Opts` gains `follow_redirects`, `max_redirects`, `allow_private`; `Result`/`StreamResult` gain `url` (effective URL after redirects), `error_kind` (`"dns" | "connect" | "tls" | "timeout" | "proxy" | "protocol" | "too_large" | "blocked"`, nil for wrapper-side validation), and `:is_success()` (2xx). `has_stream()` deleted.
- **Retries retry transport errors now.** The old loop consulted `should_retry` only when `result.ok` was true, so `max_attempts` without a predicate was a no-op and no transport error ever retried. Default policy: dns/connect/timeout failures + 429/502/503/504 responses, idempotent methods only; full-jitter backoff over `base_delay` (0.5s) capped by `max_delay` (30s). A custom `should_retry` is consulted for every attempt, success or failure.
- Per-attempt shallow copies of the options and headers tables.
- `timeout` doc corrected: per-socket-op timeout, 60s default, not a whole-request deadline.
- TDD (`fetch_retry_test.tl`, loopback): connection-reset-then-200 succeeds with `max_attempts = 2` under the default policy (impossible before); 503-then-200 retried; POST not retried; `error_kind == "connect"` for a refused port. Note: a server that closes *after reading the request* (clean FIN before response headers) is classified `"protocol"` by the C layer and deliberately not retried by default; the test provokes an RST (close with the request unread) for the retryable flavor.

## 3. Streaming error propagation + SSE conformance (P1)

- `Reader:lines()` yields `nil, err` once on a mid-body failure (reset/truncation/TLS), then plain `nil`; buffered truncated tails are discarded rather than dressed up as lines. A truncated body via `read()` is verified to surface an error, and a 204 reads as clean EOF (`fetch_stream_test.tl`).
- `sse.events(reader)` now returns a `Stream` record: `stream.next` (works directly with `for ev in stream.next do`) and `stream.last_event_id()` for Last-Event-ID reconnects. Transport failures propagate as `nil, err` — the issue's mock-reader TDD case yields `nil, "connection reset"` where it used to fake a graceful close.
- Spec fixes: unterminated events at EOF discarded (not dispatched); empty-data dispatch resets the event-type buffer; `last_event_id` updates at sight of `id:` (NUL ids ignored); `retry:` accepts ASCII digits only.

## 4. url/ip redesign (P1)

- `url.parse(url): Url | nil, string` is the URL parser (the old `parse_url`; ports range-checked); the old query-string `parse` meaning is gone.
- `url.format(u): string` wraps `cosmo.EncodeUrl` as the inverse; `%26`-style encoded delimiters survive a parse/format round trip.
- `url.parse_query(q): {string: {string}}` keeps every value of repeated keys.
- `url.parse_host` is strict: port 1..65535, IPv6 requires brackets (`"::1"` errors instead of returning host `":"` port `1`), empty host/trailing colon rejected.
- `ip.parse` is a strict dotted-quad parser: `"127.1"`, `"1.2.3.4.5"`, `"256.1.1.1"`, leading-zero octets all return `nil, err`; IPv6 returns a crisp `"IPv6 not supported"`. No more `-1` sentinel aliasing the broadcast address.
- `ip.categorize` returns a Teal enum (`Category`); `ip.resolve` deleted (`ip.lookup` remains the hostname path).

## 5. net ergonomics + test hygiene (P2)

- `connect_tcp` / `listen_tcp` / `nb_connect` accept `"127.0.0.1"`, a raw integer, or an `ip.Addr`.
- `net.parseip` / `net.formatip` / `net.poll` duplicates deleted (use `cosmic.ip` / `cosmic.poll`).
- The `Socket` record is defined once in `net_socket` and shared via a type alias — the duplicated record in `net.tl` is gone.
- `nb_connect` fixed: it switches the socket to non-blocking itself via the new `Socket:set_nonblocking(enable?)` (it used to silently block on blocking sockets). Note: `unix.fcntl` coerces `F_GETFL` to a boolean, so `set_nonblocking` sets the flag word absolutely — sockets carry no other status flag worth preserving.
- `make_socket` sets `SO_NOSIGPIPE` where the constant is nonzero (macOS `send()` ignores `MSG_NOSIGNAL`), per the follow-up note on #530 / whilp/cosmopolitan#154.
- **Tests are hermetic**: `fetch_test`, `fetch_example`, and the new suites run against forked loopback servers via `allow_private`; httpbin and all its `SKIP:` scaffolding are gone. The perf benches (`http_bench`, `stream_bench`) drop the point-a-proxy-at-loopback SSRF workaround for `allow_private = true`.

## Verification

`bin/make ci` green: format 232, teal 232, test 105, example 19, lint 294 — all passed.

Downstream note: this is the breaking wave from #530 — `fetch.has_stream`, `url.parse` (old meaning), `url.parse_url`, `ip.resolve`, `net.parseip`, `net.formatip`, `net.poll` are removed, and `sse.events` returns a `Stream` instead of a bare iterator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vEqE2w7F7BvkfqwNfwTZ6

---
_Generated by [Claude Code](https://claude.ai/code/session_013vEqE2w7F7BvkfqwNfwTZ6)_