### PR TITLE
fs: install Stat predicates on the raw metatable; wrap() stops allocating

### DIFF
--- a/lib/cosmic/fs/types.tl
+++ b/lib/cosmic/fs/types.tl
@@ -104,9 +104,45 @@ local record fs_types
 
 end
 
---- Wrapper table: holds the raw stat userdata; a shared metatable
---- delegates the accessors and implements the predicates, so wrapping
---- costs one small table per stat call.
+--- Predicates for the raw stat userdata, installed once on the shared
+--- metatable every cosmo.unix Stat carries. After installation wrap()
+--- returns the userdata unchanged — no per-call allocation, which
+--- matters on walk-heavy paths where every visited entry is wrapped
+--- (measured at ~+13-17% on fs_walk_tree/fs_stat_tree, issue #563).
+local raw_predicates: {string: any} = {
+  is_dir = function(self: unix.Stat): boolean return unix.S_ISDIR(self:mode()) end,
+  is_file = function(self: unix.Stat): boolean return unix.S_ISREG(self:mode()) end,
+  is_link = function(self: unix.Stat): boolean return unix.S_ISLNK(self:mode()) end,
+  is_block_device = function(self: unix.Stat): boolean return unix.S_ISBLK(self:mode()) end,
+  is_char_device = function(self: unix.Stat): boolean return unix.S_ISCHR(self:mode()) end,
+  is_fifo = function(self: unix.Stat): boolean return unix.S_ISFIFO(self:mode()) end,
+  is_socket = function(self: unix.Stat): boolean return unix.S_ISSOCK(self:mode()) end,
+}
+
+--- Install the predicates on the raw stat's metatable. Lazy — uses the
+--- first stat wrap() sees, so module load never needs a stat(2) call
+--- (which a sandbox could deny). Returns false if the metatable is not
+--- an extensible Lua table, in which case wrap() falls back to the
+--- per-call wrapper table below.
+local function install_predicates(raw: unix.Stat): boolean
+  local mt = getmetatable(raw as any)
+  if type(mt) ~= "table" then
+    return false
+  end
+  local idx = (mt as {string: any}).__index
+  if type(idx) ~= "table" then
+    return false
+  end
+  local methods = idx as {string: any}
+  for name, fn in pairs(raw_predicates) do
+    methods[name] = fn
+  end
+  return true
+end
+
+--- Fallback wrapper table: holds the raw stat userdata; a shared
+--- metatable delegates the accessors and implements the predicates, so
+--- wrapping costs one small table per stat call.
 local record Wrapped
   raw: unix.Stat
 end
@@ -137,7 +173,15 @@ local stat_mt: metatable < Wrapped > = {
   __index = stat_methods,
 }
 
+local wrap_mode: string = "unknown"
+
 fs_types.wrap = function(raw: unix.Stat): fs_types.Stat
+  if wrap_mode == "unknown" then
+    wrap_mode = install_predicates(raw) and "direct" or "fallback"
+  end
+  if wrap_mode == "direct" then
+    return raw as fs_types.Stat
+  end
   local wrapped: Wrapped = setmetatable({raw = raw}, stat_mt)
   return wrapped as fs_types.Stat
 end


### PR DESCRIPTION
Closes #563 (verification debt from #555; next item on the #533 tracker).

## The measurement

Perf A/B of #555 against its merge-base (`a33976a`), same machine, two local builds, per `lib/perf/OPTIMIZE.md`. `perf-compare` reproduced the Stat-wrapper cost through the noise gate:

```
fs_walk_tree   394.61 µs -> 444.82 µs  +12.7%  regression
fs_stat_tree   315.50 µs -> 369.09 µs  +17.0%  regression
```

The alloc column shows the mechanism — one ~80-byte wrapper table per visited entry:

```
fs_walk_tree   41.87 -> 58.33 KB/op
fs_stat_tree   39.09 -> 54.72 KB/op
```

(`startup_run_teal` also tripped the gate at +24.5%, but isolated back-to-back runs read 4.88/4.75/4.81 ms pre vs 5.04 ms post — machine noise on a cpu/wall≈0.07 spawn microbench, not #555.)

## The fix

The raw `cosmo.unix` Stat userdata shares one metatable whose `__index` is a plain extensible Lua table. So instead of wrapping every stat in a delegating table, install the seven `is_*` predicates on that shared table once — lazily, using the first stat `wrap()` sees, so module load never issues a `stat(2)` call a sandbox could deny — and return the userdata unchanged. The old per-call wrapper stays as a fallback should a future cosmos pin make the metatable non-extensible.

This beats the mitigations sketched in #563 (reuse-one-wrapper / freelist): zero per-call allocation **and** no lifetime caveat — visitors may retain the stat value freely.

## After the fix

`perf-compare` vs the same pre-#555 baseline, exit 0:

```
fs_walk_tree   394.61 µs -> 417.12 µs   +5.7%  ok
fs_stat_tree   315.50 µs -> 339.63 µs   +7.6%  ok
35 scenarios: 0 regression, 1 faster, 34 ok, 0 noise, 0 new, 0 missing, 0 error
```

Isolated back-to-back A/B (three pre runs, then fixed): walk ~399 → 415 µs, stat ~320 → 328 µs, alloc back to baseline byte-for-byte. The residual few percent is the rest of #555's fs changes (under the gate).

`bin/make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjGaMU98P7VEN8tvYHWTLZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjGaMU98P7VEN8tvYHWTLZ)_