### PR TITLE
docs: the docs surface follows the PUBLIC manifest

### DIFF
--- a/lib/cosmic/doc_types.tl
+++ b/lib/cosmic/doc_types.tl
@@ -50,6 +50,11 @@ local record doc_types
     functions: {FunctionDoc}
     records: {RecordDoc}
     examples: {ExampleDoc}
+    --- True for modules outside the cosmic.public manifest's public
+    --- list: implementation shards, CLI internals, repo tooling. They
+    --- are hidden from listings, badged in search, and their doc pages
+    --- carry an internal-module header.
+    internal: boolean
   end
 
   --- A documentation index containing all modules.
@@ -64,6 +69,8 @@ local record doc_types
     symbol_type: string
     description: string
     match_score: integer
+    --- True when the entry comes from an internal (non-API) module.
+    internal: boolean
   end
 
   --- Entry for examples list.

--- a/lib/cosmic/docindex.tl
+++ b/lib/cosmic/docindex.tl
@@ -13,6 +13,49 @@ local record DocIndexModule
   main: function(args: {string}): integer
 end
 
+--- Normalize directory-module init shards to the module name users
+--- require: cosmic.fs.init -> cosmic.fs, cosmic.init -> cosmic.
+local function normalize_init(modules: {string: any})
+  local renames: {string: string} = {}
+  for name in pairs(modules) do
+    local parent = name:match("^(.+)%.init$")
+    if parent and not modules[parent] then
+      renames[name] = parent
+    end
+  end
+  for from, to in pairs(renames) do
+    modules[to] = modules[from]
+    modules[from] = nil
+  end
+end
+
+--- Mark each module's visibility from the cosmic.public manifest:
+--- public is exactly cosmic.<name> for names on the manifest's public
+--- list; every other cosmic.* entry and all repo tooling (perf.*, ...)
+--- is internal. cosmo.* C binding docs keep their own include_cosmo
+--- handling and are never marked. The manifest is loaded with a
+--- non-literal require (the handle_version pattern) because this
+--- script also runs under the pinned bootstrap binary, whose embedded
+--- stdlib may predate cosmic.public; without a manifest every module
+--- stays public rather than the index going dark.
+local function mark_visibility(modules: {string: any})
+  local manifest_mod = "cosmic.public"
+  local ok, manifest = pcall(require, manifest_mod)
+  if not ok then
+    return
+  end
+  local public: {string: boolean} = {}
+  for _, name in ipairs((manifest as {string: {string}}).public) do
+    public["cosmic." .. name] = true
+  end
+  for name, module_doc in pairs(modules) do
+    local is_cosmo = name == "cosmo" or name:match("^cosmo%.") ~= nil
+    if not is_cosmo and not public[name] then
+      (module_doc as {string: any}).internal = true
+    end
+  end
+end
+
 --- Generate serialized documentation index from source files.
 --- Merges examples from _example.tl files into their corresponding modules.
 --- @param files List of .tl or .d.tl file paths to process
@@ -67,6 +110,9 @@ local function generate(files: {string}): string | nil, string
       end
     end
   end
+
+  normalize_init(modules)
+  mark_visibility(modules)
 
   return codec.encode_lua({modules = modules})
 end

--- a/lib/cosmic/docs.tl
+++ b/lib/cosmic/docs.tl
@@ -131,7 +131,9 @@ local function is_cosmo_module(name: string): boolean
   return name:match("^cosmo%.") ~= nil
 end
 
---- List all available documentation topics.
+--- List all available documentation topics. Internal modules (per the
+--- cosmic.public manifest) are excluded: they are not API. They remain
+--- searchable and directly addressable by name.
 --- @param include_cosmo boolean Include low-level cosmo.* modules (default: false)
 --- @return {{string, string}} List of {name, description} pairs, sorted by name
 local function list_topics(include_cosmo?: boolean): {{string, string}}
@@ -141,7 +143,7 @@ local function list_topics(include_cosmo?: boolean): {{string, string}}
 
   local topics: {{string, string}} = {}
   for name, doc in pairs(idx.modules) do
-    if include_cosmo or not is_cosmo_module(name) then
+    if not doc.internal and (include_cosmo or not is_cosmo_module(name)) then
       local desc = docs_render.first_paragraph(doc.module_doc)
       table.insert(topics, {name, desc})
     end
@@ -154,27 +156,11 @@ local function list_topics(include_cosmo?: boolean): {{string, string}}
   return topics
 end
 
---- Calculate match score for a search result.
-local function calc_score(
-    name_lower: string,
-    desc: string,
-    query_lower: string,
-    base_exact: integer,
-    base_partial: integer,
-    base_desc: integer
-  ): integer
-  if name_lower == query_lower then
-    return base_exact
-  elseif name_lower:find(query_lower, 1, true) then
-    return base_partial
-  end
-  if desc and desc:lower():find(query_lower, 1, true) then
-    return base_desc
-  end
-  return 0
-end
+local calc_score = docs_lookup.calc_score
 
---- Search documentation for a query string.
+--- Search documentation for a query string. Internal modules are
+--- included; their results carry internal = true so the renderer can
+--- badge them.
 --- @param query string The search query
 --- @param include_cosmo boolean Include low-level cosmo.* modules (default: false)
 --- @return {SearchResult} List of search results, sorted by relevance
@@ -195,7 +181,7 @@ local function search(query: string, include_cosmo?: boolean): {SearchResult}
     local mod_score = calc_score(simple_lower, mod_doc.module_doc, query_lower, 100, 80, 30)
     if mod_score > 0 then
       table.insert(results, {
-          module_name = mod_name, symbol_name = nil, symbol_type = "module",
+          module_name = mod_name, symbol_name = nil, symbol_type = "module", internal = mod_doc.internal,
           description = docs_render.first_paragraph(mod_doc.module_doc), match_score = mod_score,
         })
     end
@@ -205,7 +191,7 @@ local function search(query: string, include_cosmo?: boolean): {SearchResult}
         if score > 0 then
           if score <= 25 and module_boost > 0 then score = score + module_boost end
           table.insert(results, {
-              module_name = mod_name, symbol_name = func.name, symbol_type = "function",
+              module_name = mod_name, symbol_name = func.name, symbol_type = "function", internal = mod_doc.internal,
               description = docs_render.first_paragraph(func.description or ""), match_score = score,
             })
         end
@@ -217,7 +203,7 @@ local function search(query: string, include_cosmo?: boolean): {SearchResult}
         if score > 0 then
           if score <= 25 and module_boost > 0 then score = score + module_boost end
           table.insert(results, {
-              module_name = mod_name, symbol_name = rec.name, symbol_type = "record",
+              module_name = mod_name, symbol_name = rec.name, symbol_type = "record", internal = mod_doc.internal,
               description = docs_render.first_paragraph(rec.description or ""), match_score = score,
             })
         end
@@ -231,7 +217,7 @@ local function search(query: string, include_cosmo?: boolean): {SearchResult}
                 table.insert(results, {
                     module_name = mod_name, symbol_name = rec.name .. "." .. fname,
                     symbol_type = "method", description = docs_render.first_paragraph(fdesc or ""),
-                    match_score = ms,
+                    match_score = ms, internal = mod_doc.internal,
                   })
               end
             end
@@ -246,7 +232,7 @@ local function search(query: string, include_cosmo?: boolean): {SearchResult}
         if score > 0 then
           if score <= 20 and module_boost > 0 then score = score + module_boost end
           table.insert(results, {
-              module_name = mod_name, symbol_name = example_name, symbol_type = "example",
+              module_name = mod_name, symbol_name = example_name, symbol_type = "example", internal = mod_doc.internal,
               description = docs_render.first_paragraph(example.description or ""), match_score = score,
             })
         end
@@ -272,7 +258,7 @@ local function list_all_examples(include_cosmo?: boolean): {ExampleEntry}
 
   local examples: {ExampleEntry} = {}
   for mod_name, mod_doc in pairs(idx.modules) do
-    if not include_cosmo and is_cosmo_module(mod_name) then
+    if mod_doc.internal or (not include_cosmo and is_cosmo_module(mod_name)) then
       goto continue
     end
     if mod_doc.examples then

--- a/lib/cosmic/docs_lookup.tl
+++ b/lib/cosmic/docs_lookup.tl
@@ -5,6 +5,33 @@ local types = require("cosmic.doc_types")
 local ModuleDoc = types.ModuleDoc
 local DocIndex = types.DocIndex
 
+--- Calculate match score for a search result.
+--- @param name_lower string Lowercased candidate name
+--- @param desc string Candidate description (may be nil)
+--- @param query_lower string Lowercased query
+--- @param base_exact integer Score for an exact name match
+--- @param base_partial integer Score for a partial name match
+--- @param base_desc integer Score for a description match
+--- @return integer The match score, 0 for no match
+local function calc_score(
+    name_lower: string,
+    desc: string,
+    query_lower: string,
+    base_exact: integer,
+    base_partial: integer,
+    base_desc: integer
+  ): integer
+  if name_lower == query_lower then
+    return base_exact
+  elseif name_lower:find(query_lower, 1, true) then
+    return base_partial
+  end
+  if desc and desc:lower():find(query_lower, 1, true) then
+    return base_desc
+  end
+  return 0
+end
+
 --- Find where a symbol lives across all modules (for "did you mean" suggestions).
 --- @param symbol string The symbol name to locate
 --- @param index DocIndex The documentation index
@@ -97,12 +124,14 @@ local function symbol_not_found(symbol: string, matched_mod: string, index: DocI
 end
 
 local record DocsLookupModule
+  calc_score: function(name_lower: string, desc: string, query_lower: string, base_exact: integer, base_partial: integer, base_desc: integer): integer
   find_symbol_locations: function(symbol: string, index: DocIndex): {string}
   list_symbols: function(doc: ModuleDoc): {string}
   symbol_not_found: function(symbol: string, matched_mod: string, index: DocIndex): string
 end
 
 local M: DocsLookupModule = {
+  calc_score = calc_score,
   find_symbol_locations = find_symbol_locations,
   list_symbols = list_symbols,
   symbol_not_found = symbol_not_found,

--- a/lib/cosmic/docs_public_test.tl
+++ b/lib/cosmic/docs_public_test.tl
@@ -1,0 +1,97 @@
+#!/usr/bin/env lua
+--- The docs surface must follow the PUBLIC manifest (issue #556):
+--- `--docs` lists public modules only, internal modules stay searchable
+--- but badged, and their doc pages carry an internal-module header.
+
+local docs = require("cosmic.docs")
+local doc_types = require("cosmic.doc_types")
+local manifest = require("cosmic.public")
+
+-- These tests are about the embedded index; they must run in the built
+-- binary, where the index is always present.
+local index, ierr = docs.load_index()
+assert(index, "docs index must be embedded (run tests via the binary): "
+  .. tostring(ierr))
+local idx = index as doc_types.DocIndex
+
+local INTERNAL_SAMPLES = {
+  "cosmic.child_io",
+  "cosmic.cli.args",
+  "cosmic.sqlite_bind",
+  "cosmic.fs.walk",
+  "perf.harness",
+}
+
+local function topic_names(): {string: boolean}
+  local names: {string: boolean} = {}
+  for _, topic in ipairs(docs.list_topics()) do
+    names[topic[1] as string] = true
+  end
+  return names
+end
+
+local function test_listing_hides_internal_modules()
+  local names = topic_names()
+  for _, internal_name in ipairs(INTERNAL_SAMPLES) do
+    assert(not names[internal_name],
+      "--docs listing must not contain internal module: " .. internal_name)
+  end
+  print("test_listing_hides_internal_modules: PASS")
+end
+test_listing_hides_internal_modules()
+
+local function test_listing_is_exactly_the_public_manifest()
+  local names = topic_names()
+  local count = 0
+  for _ in pairs(names) do count = count + 1 end
+  assert(count == #manifest.public, string.format(
+      "--docs lists %d modules, want #manifest.public = %d",
+      count, #manifest.public))
+  for _, name in ipairs(manifest.public) do
+    assert(names["cosmic." .. name],
+      "public module missing from --docs listing: cosmic." .. name)
+  end
+  print("test_listing_is_exactly_the_public_manifest: PASS")
+end
+test_listing_is_exactly_the_public_manifest()
+
+local function test_directory_modules_indexed_under_their_name()
+  assert(idx.modules["cosmic.fs"],
+    "directory module must be indexed as cosmic.fs, not cosmic.fs.init")
+  assert(not idx.modules["cosmic.fs.init"],
+    "init shard must not appear as its own module")
+  local result = docs.run("fs")
+  assert(result.ok, "--docs fs must resolve to the fs module page")
+  print("test_directory_modules_indexed_under_their_name: PASS")
+end
+test_directory_modules_indexed_under_their_name()
+
+local function test_internal_modules_stay_searchable_with_badge()
+  local results = docs.search("child_io")
+  local found: doc_types.SearchResult = nil
+  for _, r in ipairs(results) do
+    if r.module_name == "cosmic.child_io" then found = r; break end
+  end
+  assert(found, "search must still find internal module cosmic.child_io")
+  assert((found as doc_types.SearchResult).internal,
+    "search result for an internal module must carry internal = true")
+  local rendered = docs.render_search_results(results, "child_io")
+  assert(rendered:find("cosmic.child_io", 1, true), "rendered search output")
+  assert(rendered:find("(internal)", 1, true),
+    "search results must badge internal modules with (internal)")
+  print("test_internal_modules_stay_searchable_with_badge: PASS")
+end
+test_internal_modules_stay_searchable_with_badge()
+
+local function test_internal_doc_page_carries_header()
+  local result = docs.run("cosmic.child_io")
+  assert(result.ok, "--docs cosmic.child_io must still render a page")
+  assert(result.output:find("internal module — not API, may change without notice", 1, true),
+    "internal module page must carry the internal-module header")
+  local public_page = docs.run("cosmic.json")
+  assert(public_page.ok, "--docs cosmic.json must render")
+  assert(not public_page.output:find("internal module — not API", 1, true),
+    "public module page must not carry the internal-module header")
+  print("test_internal_doc_page_carries_header: PASS")
+end
+test_internal_doc_page_carries_header()

--- a/lib/cosmic/docs_render.tl
+++ b/lib/cosmic/docs_render.tl
@@ -178,6 +178,10 @@ local function render_module(name: string, doc: ModuleDoc): string
   local simple_name = name:match("([^%.]+)$") or name
   table.insert(lines, "# " .. simple_name)
   table.insert(lines, "")
+  if doc.internal then
+    table.insert(lines, "**internal module — not API, may change without notice**")
+    table.insert(lines, "")
+  end
   if doc.module_doc then
     table.insert(lines, doc.module_doc)
     table.insert(lines, "")
@@ -353,6 +357,9 @@ local function render_search_results(results: {SearchResult}, query: string): st
     end
     local type_label = result.symbol_type
     local line = "  " .. symbol_ref .. " (" .. type_label .. ")"
+    if result.internal then
+      line = line .. "  (internal)"
+    end
     table.insert(lines, line)
     if result.description and result.description ~= "" then
       table.insert(lines, "    " .. result.description)

--- a/lib/cosmic/public_test.tl
+++ b/lib/cosmic/public_test.tl
@@ -89,3 +89,24 @@ local function test_public_modules_load()
   end
 end
 test_public_modules_load()
+
+--- Documented ⇔ public (issue #556): every public module must have an
+--- entry in the embedded docs index. docs_public_test.tl checks the
+--- other direction (the listing shows public modules only).
+local function test_public_modules_are_documented()
+  local docs = require("cosmic.docs")
+  local doc_types = require("cosmic.doc_types")
+  local index, ierr = docs.load_index()
+  assert(index, "docs index must be embedded: " .. tostring(ierr))
+  local idx = index as doc_types.DocIndex
+  local undocumented: {string} = {}
+  for _, name in ipairs(manifest.public) do
+    if not idx.modules["cosmic." .. name] then
+      undocumented[#undocumented + 1] = name
+    end
+  end
+  table.sort(undocumented)
+  assert(#undocumented == 0,
+    "public modules with no docs entry: " .. table.concat(undocumented, ", "))
+end
+test_public_modules_are_documented()

--- a/lib/docs/publish.tl
+++ b/lib/docs/publish.tl
@@ -68,6 +68,60 @@ local function scan_docs(docs_dir: string): {DocInfo}
   return docs
 end
 
+-- The docs surface follows the cosmic.public manifest (issue #556):
+-- the published site carries public module pages and the cosmo.* C
+-- binding docs only. The manifest is loaded with a non-literal require
+-- because this script also runs under the pinned bootstrap binary,
+-- whose embedded stdlib may predate cosmic.public; without a manifest
+-- everything stays published rather than the site going dark.
+local function load_public_set(): {string: boolean}
+  local manifest_mod = "cosmic.public"
+  local ok, manifest = pcall(require, manifest_mod)
+  if not ok then
+    return nil
+  end
+  local set: {string: boolean} = {}
+  for _, name in ipairs((manifest as {string: {string}}).public) do
+    set[name] = true
+  end
+  return set
+end
+
+-- Decide whether a doc page (path relative to the docs root) is part
+-- of the public surface: cosmo.* binding docs, a public module's page,
+-- or a public directory module's init page.
+local function is_public_page(rel_path: string, public_set: {string: boolean}): boolean
+  if not public_set then
+    return true
+  end
+  if rel_path:match("^cosmo/") then
+    return true
+  end
+  local name = rel_path:match("^lib/cosmic/([^/]+)%.md$")
+    or rel_path:match("^lib/cosmic/([^/]+)/init%.md$")
+  return name ~= nil and public_set[name] == true
+end
+
+-- Remove internal doc pages from a generated docs tree in place.
+local function prune_internal(docs_dir: string)
+  local public_set = load_public_set()
+  if not public_set then
+    return
+  end
+  local internal: {string} = {}
+  fs.walk(docs_dir, function(path: string, name: string, st: fs_types.Stat, acc: {string})
+      if not st:is_dir() and name:match("%.md$") then
+        local rel_path = path:sub(#docs_dir + 2)
+        if rel_path ~= "README.md" and not is_public_page(rel_path, public_set) then
+          table.insert(acc, path)
+        end
+      end
+    end, internal)
+  for _, path in ipairs(internal) do
+    fs.rmrf(path)
+  end
+end
+
 -- Extract package name from doc path
 local function get_package_name(doc_path: string): string
   if doc_path:match("^lib/") then
@@ -175,6 +229,9 @@ local function main(source_sha: string, docs_dir: string, branch: string): boole
     return nil, err
   end
 
+  -- the published site carries the public docs surface only
+  prune_internal(temp_dir)
+
   -- configure git
   ok, err = run({"git", "config", "user.name", "github-actions[bot]"})
   if not ok then return nil, err end
@@ -243,10 +300,12 @@ end
 
 local record PublishModule
   make_readme: function(docs_dir: string): string
+  prune_internal: function(docs_dir: string)
 end
 
 local M: PublishModule = {
   make_readme = make_readme,
+  prune_internal = prune_internal,
 }
 
 if proc.is_main() then

--- a/lib/docs/publish_test.tl
+++ b/lib/docs/publish_test.tl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cosmic
--- test docs-publish readme generation
+-- test docs-publish readme generation and the public-surface filter
 
 local fs = require("cosmic.fs")
 
@@ -7,29 +7,34 @@ local tmpdir = os.getenv("TEST_TMPDIR")
 
 local record PublishModule
   make_readme: function(docs_dir: string): string
+  prune_internal: function(docs_dir: string)
+end
+
+local function write_doc(docs_dir: string, rel: string, title: string, desc: string)
+  local path = fs.join(docs_dir, rel)
+  fs.makedirs(fs.dirname(path))
+  fs.write(path, "# " .. title .. "\n\n" .. desc .. "\n\n## Types\n")
+end
+
+-- Build a mock generated-docs tree with public and internal pages.
+local function make_mock_docs(name: string): string
+  local docs_dir = fs.join(tmpdir, name)
+  write_doc(docs_dir, "lib/cosmic/embed.md", "embed", "Embed files into cosmic executable.")
+  write_doc(docs_dir, "lib/cosmic/child.md", "child", "Process spawning utilities.")
+  write_doc(docs_dir, "lib/cosmic/fs/init.md", "fs", "Unified filesystem module.")
+  write_doc(docs_dir, "cosmo/unix.md", "unix", "System call bindings.")
+  -- internal: shard, CLI helper, directory-module shard, repo tooling
+  write_doc(docs_dir, "lib/cosmic/child_io.md", "child_io", "Low-level child-process I/O.")
+  write_doc(docs_dir, "lib/cosmic/cli/args.md", "args", "CLI option definitions.")
+  write_doc(docs_dir, "lib/cosmic/fs/walk.md", "walk", "Directory walking utilities.")
+  write_doc(docs_dir, "lib/perf/harness.md", "harness", "Benchmark harness.")
+  return docs_dir
 end
 
 -- Test that make_readme generates a table of doc links
 local function test_readme_has_doc_table()
   local publish = require("lib.docs.publish") as PublishModule
-
-  -- Create some mock doc files
-  local docs_dir = fs.join(tmpdir, "docs")
-  fs.makedirs(docs_dir .. "/lib/cosmic")
-
-  -- Write mock doc files with module descriptions
-  fs.write(fs.join(docs_dir, "lib/cosmic/embed.md"), [[# embed
-
-Embed files into cosmic executable.
-
-## Types
-]])
-  fs.write(fs.join(docs_dir, "lib/cosmic/spawn.md"), [[# spawn
-
-Process spawning utilities.
-
-## Types
-]])
+  local docs_dir = make_mock_docs("docs-readme")
 
   local readme = publish.make_readme(docs_dir)
 
@@ -38,12 +43,46 @@ Process spawning utilities.
 
   -- README should link to each doc file
   assert(readme:find("%[embed%]"), "should link to embed.md")
-  assert(readme:find("%[spawn%]"), "should link to spawn.md")
+  assert(readme:find("%[child%]"), "should link to child.md")
 
   -- README should include descriptions from the doc files
   assert(readme:find("Embed files"), "should include embed description")
-  assert(readme:find("Process spawning"), "should include spawn description")
+  assert(readme:find("Process spawning"), "should include child description")
 end
 test_readme_has_doc_table()
+
+-- The published site carries the public surface only (issue #556):
+-- prune_internal removes internal module pages, keeps public module
+-- pages (including directory-module init pages) and cosmo.* docs.
+local function test_prune_internal_keeps_public_surface_only()
+  local publish = require("lib.docs.publish") as PublishModule
+  local docs_dir = make_mock_docs("docs-prune")
+
+  publish.prune_internal(docs_dir)
+
+  local kept = {
+    "lib/cosmic/embed.md",
+    "lib/cosmic/child.md",
+    "lib/cosmic/fs/init.md",
+    "cosmo/unix.md",
+  }
+  for _, rel in ipairs(kept) do
+    assert(fs.isfile(fs.join(docs_dir, rel)), "must keep public page: " .. rel)
+  end
+
+  local pruned = {
+    "lib/cosmic/child_io.md",
+    "lib/cosmic/cli/args.md",
+    "lib/cosmic/fs/walk.md",
+    "lib/perf/harness.md",
+  }
+  for _, rel in ipairs(pruned) do
+    assert(not fs.isfile(fs.join(docs_dir, rel)), "must prune internal page: " .. rel)
+  end
+
+  local readme = publish.make_readme(docs_dir)
+  assert(not readme:find("child_io"), "README must not index internal pages")
+end
+test_prune_internal_keeps_public_surface_only()
 
 print("All publish tests passed!")


### PR DESCRIPTION
Closes #556 (follow-up to #532/#555; next item on the #533 tracker).

`cosmic.public` declares which top-level modules are API, but the docs surface ignored it: `--docs` listed **108 modules** — every internal shard, CLI helper, and perf tool — presented identically to API, actively teaching users to depend on internals.

## Changes

**Index generation** (`docindex.tl`)
- Records each module's visibility: public is exactly `cosmic.<name>` for names on the manifest's public list; every other `cosmic.*` entry and all repo tooling (`perf.*`) is marked internal. `cosmo.*` C binding docs keep their existing `include_cosmo` handling.
- Loads the manifest with a non-literal `pcall(require, …)` (the `handle_version` pattern), degrading to everything-public under a bootstrap binary that predates `cosmic.public` — the docs build works on both sides of the pin.
- Normalizes directory-module init shards to the name users require (`cosmic.fs.init` → `cosmic.fs`). Before this, `--docs fs` found no module page at all and fell through to fuzzy search (`cosmic.sandbox.Fs`, `perf.bench.fs_bench`, …).

**CLI surface** (`docs.tl`, `docs_render.tl`, `cli/help.tl` via `list_topics`)
- `--docs` listing and `--help`'s module list show public modules only: **exactly 48 entries, matching `#manifest.public`**.
- Internal modules remain searchable — results are badged `(internal)` — and directly addressable; their pages carry **"internal module — not API, may change without notice"**.
- `--docs examples` lists public modules' examples only.
- `docs.tl` sat at the 500-line cap, so `calc_score` moved to `docs_lookup.tl` with the other lookup helpers.

**Published site** (`lib/docs/publish.tl`)
- Prunes internal pages before committing to the docs branch — keeps `cosmo/*` binding docs and public module pages (including directory-module `init` pages) — with the same degrade-to-everything behavior when the manifest is not loadable.

## TDD (red first)

- `docs_public_test.tl` (new): listing hides `cosmic.child_io`/`cosmic.cli.args`/`cosmic.sqlite_bind`/`perf.*`; listing == `manifest.public` exactly; `cosmic.fs` resolves and `cosmic.fs.init` doesn't exist; search still finds internal modules with `internal = true` and the rendered `(internal)` badge; internal page header present, absent on public pages.
- `publish_test.tl`: `prune_internal` keeps the public surface only, README indexes no internal pages.
- `public_test.tl`: documented ⇔ public closed in both directions — every public module must have a docs index entry.

## Not in this PR

The #556 capstone — the final public-list review before the stable cut — needs owner judgment on borderline entries (`make`, `envd`, `doc` vs `docs`, `assert`) and interacts with #561/#557; filing it as its own follow-up so the tracker keeps sequencing it last.

`bin/make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjGaMU98P7VEN8tvYHWTLZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjGaMU98P7VEN8tvYHWTLZ)_