### PR TITLE
rename cosmic.assert → cosmic.check: it shadowed a Lua global

### DIFF
--- a/lib/cosmic/check.tl
+++ b/lib/cosmic/check.tl
@@ -151,7 +151,7 @@ local function enforced(label: string)
   io.stderr:write("✓ enforce-ran: " .. label .. "\n")
 end
 
-local record AssertModule
+local record CheckModule
   eq: function(actual: any, expected: any, label?: string)
   ne: function(actual: any, expected: any, label?: string)
   ok: function(value: any, label?: string)
@@ -161,7 +161,7 @@ local record AssertModule
   enforced: function(label: string)
 end
 
-local M: AssertModule = {
+local M: CheckModule = {
   eq = eq,
   ne = ne,
   ok = ok,

--- a/lib/cosmic/check_assertions_test.tl
+++ b/lib/cosmic/check_assertions_test.tl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cosmic
-local a = require("cosmic.assert")
+local check = require("cosmic.check")
 local env = require("cosmic.env")
 
 -- must_fail wraps a function that is expected to throw and returns
@@ -16,49 +16,49 @@ end
 -- eq: passing cases
 
 local function test_eq_numbers()
-  a.eq(1, 1)
-  a.eq(0, 0)
-  a.eq(-5, -5)
+  check.eq(1, 1)
+  check.eq(0, 0)
+  check.eq(-5, -5)
 end
 test_eq_numbers()
 
 local function test_eq_strings()
-  a.eq("hello", "hello")
-  a.eq("", "")
+  check.eq("hello", "hello")
+  check.eq("", "")
 end
 test_eq_strings()
 
 local function test_eq_booleans()
-  a.eq(true, true)
-  a.eq(false, false)
+  check.eq(true, true)
+  check.eq(false, false)
 end
 test_eq_booleans()
 
 local function test_eq_nil()
-  a.eq(nil, nil)
+  check.eq(nil, nil)
 end
 test_eq_nil()
 
 local function test_eq_tables_shallow()
-  a.eq({1, 2, 3}, {1, 2, 3})
-  a.eq({a = 1, b = 2}, {a = 1, b = 2})
+  check.eq({1, 2, 3}, {1, 2, 3})
+  check.eq({a = 1, b = 2}, {a = 1, b = 2})
 end
 test_eq_tables_shallow()
 
 local function test_eq_tables_nested()
-  a.eq({a = {b = {c = 42}}}, {a = {b = {c = 42}}})
+  check.eq({a = {b = {c = 42}}}, {a = {b = {c = 42}}})
 end
 test_eq_tables_nested()
 
 local function test_eq_with_label()
-  a.eq(7, 7, "score check")
+  check.eq(7, 7, "score check")
 end
 test_eq_with_label()
 
 -- eq: failing cases
 
 local function test_eq_fails_on_number_mismatch()
-  local threw, msg = must_fail(function(): string a.eq(3, 4) return "" end)
+  local threw, msg = must_fail(function(): string check.eq(3, 4) return "" end)
   assert(threw, "expected eq to throw")
   assert(msg:match("eq failed"), "expected 'eq failed' in message, got: " .. msg)
   assert(msg:match("expected 4"), "expected '4' in message, got: " .. msg)
@@ -67,14 +67,14 @@ end
 test_eq_fails_on_number_mismatch()
 
 local function test_eq_fails_on_string_mismatch()
-  local threw, msg = must_fail(function(): string a.eq("actual", "expected") return "" end)
+  local threw, msg = must_fail(function(): string check.eq("actual", "expected") return "" end)
   assert(threw, "expected eq to throw")
   assert(msg:match("eq failed"), "expected 'eq failed' in message")
 end
 test_eq_fails_on_string_mismatch()
 
 local function test_eq_fails_with_label_prefix()
-  local threw, msg = must_fail(function(): string a.eq(1, 2, "my label") return "" end)
+  local threw, msg = must_fail(function(): string check.eq(1, 2, "my label") return "" end)
   assert(threw, "expected eq to throw")
   assert(msg:match("my label"), "expected label in message, got: " .. msg)
   assert(msg:match("eq failed"), "expected 'eq failed' in message, got: " .. msg)
@@ -82,14 +82,14 @@ end
 test_eq_fails_with_label_prefix()
 
 local function test_eq_fails_on_table_mismatch()
-  local threw, msg = must_fail(function(): string a.eq({a = 1}, {a = 2}) return "" end)
+  local threw, msg = must_fail(function(): string check.eq({a = 1}, {a = 2}) return "" end)
   assert(threw, "expected eq to throw for table mismatch")
   assert(msg:match("eq failed"), "expected 'eq failed' in message")
 end
 test_eq_fails_on_table_mismatch()
 
 local function test_eq_fails_nil_vs_value()
-  local threw, msg = must_fail(function(): string a.eq(nil, 42) return "" end)
+  local threw, msg = must_fail(function(): string check.eq(nil, 42) return "" end)
   assert(threw, "expected eq to throw when nil vs 42")
   assert(msg:match("eq failed"), "expected 'eq failed' in message")
 end
@@ -98,37 +98,37 @@ test_eq_fails_nil_vs_value()
 -- ne: passing cases
 
 local function test_ne_numbers()
-  a.ne(1, 2)
-  a.ne(0, -1)
+  check.ne(1, 2)
+  check.ne(0, -1)
 end
 test_ne_numbers()
 
 local function test_ne_strings()
-  a.ne("hello", "world")
-  a.ne("", "nonempty")
+  check.ne("hello", "world")
+  check.ne("", "nonempty")
 end
 test_ne_strings()
 
 local function test_ne_different_types()
-  a.ne(1, "1")
-  a.ne(nil, false)
+  check.ne(1, "1")
+  check.ne(nil, false)
 end
 test_ne_different_types()
 
 local function test_ne_tables_different_content()
-  a.ne({a = 1}, {a = 2})
+  check.ne({a = 1}, {a = 2})
 end
 test_ne_tables_different_content()
 
 local function test_ne_with_label()
-  a.ne(1, 2, "value check")
+  check.ne(1, 2, "value check")
 end
 test_ne_with_label()
 
 -- ne: failing cases
 
 local function test_ne_fails_when_equal()
-  local threw, msg = must_fail(function(): string a.ne(5, 5) return "" end)
+  local threw, msg = must_fail(function(): string check.ne(5, 5) return "" end)
   assert(threw, "expected ne to throw")
   assert(msg:match("ne failed"), "expected 'ne failed' in message, got: " .. msg)
   assert(msg:match("5"), "expected value in message")
@@ -136,14 +136,14 @@ end
 test_ne_fails_when_equal()
 
 local function test_ne_fails_when_tables_equal()
-  local threw, msg = must_fail(function(): string a.ne({x = 1}, {x = 1}) return "" end)
+  local threw, msg = must_fail(function(): string check.ne({x = 1}, {x = 1}) return "" end)
   assert(threw, "expected ne to throw for equal tables")
   assert(msg:match("ne failed"), "expected 'ne failed' in message")
 end
 test_ne_fails_when_tables_equal()
 
 local function test_ne_fails_with_label()
-  local threw, msg = must_fail(function(): string a.ne("same", "same", "tag") return "" end)
+  local threw, msg = must_fail(function(): string check.ne("same", "same", "tag") return "" end)
   assert(threw, "expected ne to throw")
   assert(msg:match("tag"), "expected label in message")
   assert(msg:match("ne failed"), "expected 'ne failed' in message")
@@ -153,23 +153,23 @@ test_ne_fails_with_label()
 -- ok: passing cases
 
 local function test_ok_truthy_values()
-  a.ok(true)
-  a.ok(1)
-  a.ok("nonempty")
-  a.ok({})
-  a.ok(0) -- 0 is truthy in Lua
+  check.ok(true)
+  check.ok(1)
+  check.ok("nonempty")
+  check.ok({})
+  check.ok(0) -- 0 is truthy in Lua
 end
 test_ok_truthy_values()
 
 local function test_ok_with_label()
-  a.ok(true, "must be set")
+  check.ok(true, "must be set")
 end
 test_ok_with_label()
 
 -- ok: failing cases
 
 local function test_ok_fails_on_nil()
-  local threw, msg = must_fail(function(): string a.ok(nil) return "" end)
+  local threw, msg = must_fail(function(): string check.ok(nil) return "" end)
   assert(threw, "expected ok to throw for nil")
   assert(msg:match("ok failed"), "expected 'ok failed' in message, got: " .. msg)
   assert(msg:match("nil"), "expected nil in message")
@@ -177,7 +177,7 @@ end
 test_ok_fails_on_nil()
 
 local function test_ok_fails_on_false()
-  local threw, msg = must_fail(function(): string a.ok(false) return "" end)
+  local threw, msg = must_fail(function(): string check.ok(false) return "" end)
   assert(threw, "expected ok to throw for false")
   assert(msg:match("ok failed"), "expected 'ok failed' in message")
   assert(msg:match("false"), "expected false in message")
@@ -185,7 +185,7 @@ end
 test_ok_fails_on_false()
 
 local function test_ok_fails_with_label()
-  local threw, msg = must_fail(function(): string a.ok(nil, "result") return "" end)
+  local threw, msg = must_fail(function(): string check.ok(nil, "result") return "" end)
   assert(threw, "expected ok to throw")
   assert(msg:match("result"), "expected label in message")
   assert(msg:match("ok failed"), "expected 'ok failed' in message")
@@ -195,19 +195,19 @@ test_ok_fails_with_label()
 -- err: passing cases
 
 local function test_err_nil_with_message()
-  a.err(nil, "something went wrong")
+  check.err(nil, "something went wrong")
 end
 test_err_nil_with_message()
 
 local function test_err_with_label()
-  a.err(nil, "oops", "network call")
+  check.err(nil, "oops", "network call")
 end
 test_err_with_label()
 
 -- err: failing cases
 
 local function test_err_fails_when_value_is_non_nil()
-  local threw, msg = must_fail(function(): string a.err(42, "some error") return "" end)
+  local threw, msg = must_fail(function(): string check.err(42, "some error") return "" end)
   assert(threw, "expected err to throw when value is 42")
   assert(msg:match("err failed"), "expected 'err failed' in message, got: " .. msg)
   assert(msg:match("42"), "expected value in message")
@@ -215,14 +215,14 @@ end
 test_err_fails_when_value_is_non_nil()
 
 local function test_err_fails_when_error_string_is_empty()
-  local threw, msg = must_fail(function(): string a.err(nil, "") return "" end)
+  local threw, msg = must_fail(function(): string check.err(nil, "") return "" end)
   assert(threw, "expected err to throw for empty error string")
   assert(msg:match("err failed"), "expected 'err failed' in message, got: " .. msg)
 end
 test_err_fails_when_error_string_is_empty()
 
 local function test_err_fails_with_label()
-  local threw, msg = must_fail(function(): string a.err("whoops" as any, "err msg", "ctx") return "" end)
+  local threw, msg = must_fail(function(): string check.err("whoops" as any, "err msg", "ctx") return "" end)
   assert(threw, "expected err to throw")
   assert(msg:match("ctx"), "expected label in message")
   assert(msg:match("err failed"), "expected 'err failed' in message")
@@ -232,7 +232,7 @@ test_err_fails_with_label()
 -- caller line attribution: error level 2 means throw points at caller
 
 local function test_eq_error_points_at_caller()
-  local threw, msg = must_fail(function(): string a.eq(1, 2) return "" end)
+  local threw, msg = must_fail(function(): string check.eq(1, 2) return "" end)
   assert(threw, "expected throw")
   assert(type(msg) == "string", "expected string error, got: " .. tostring(msg))
 end
@@ -249,8 +249,8 @@ local function with_enforce(on: boolean, f: function())
 end
 
 local function test_enforcing_reflects_env()
-  with_enforce(false, function() a.eq(a.enforcing(), false, "unset") end)
-  with_enforce(true, function() a.eq(a.enforcing(), true, "set") end)
+  with_enforce(false, function() check.eq(check.enforcing(), false, "unset") end)
+  with_enforce(true, function() check.eq(check.enforcing(), true, "set") end)
 end
 test_enforcing_reflects_env()
 
@@ -258,7 +258,7 @@ local function test_skip_soft_never_throws()
   -- A non-strict skip is visibility-only: it must never throw, even when
   -- enforcement is required (genuine platform gaps still skip on the lane).
   with_enforce(true, function()
-      local threw = must_fail(function(): string a.skip("kernel too old") return "" end)
+      local threw = must_fail(function(): string check.skip("kernel too old") return "" end)
       assert(not threw, "soft skip must not throw under enforcement")
     end)
 end
@@ -268,11 +268,11 @@ local function test_skip_strict_throws_only_under_enforce()
   -- Off the lane, even a strict skip is tolerated (the outer sandbox is
   -- expected). On the lane it is a hard failure.
   with_enforce(false, function()
-      local threw = must_fail(function(): string a.skip("blocked", true) return "" end)
+      local threw = must_fail(function(): string check.skip("blocked", true) return "" end)
       assert(not threw, "strict skip must not throw off the enforce lane")
     end)
   with_enforce(true, function()
-      local threw, msg = must_fail(function(): string a.skip("blocked", true) return "" end)
+      local threw, msg = must_fail(function(): string check.skip("blocked", true) return "" end)
       assert(threw, "strict skip must throw under enforcement")
       assert(msg:match("enforcement required but skipped"),
         "expected enforcement message, got: " .. msg)
@@ -283,7 +283,7 @@ test_skip_strict_throws_only_under_enforce()
 
 local function test_enforced_never_throws()
   with_enforce(true, function()
-      local threw = must_fail(function(): string a.enforced("pledge") return "" end)
+      local threw = must_fail(function(): string check.enforced("pledge") return "" end)
       assert(not threw, "enforced() is a marker and must not throw")
     end)
 end

--- a/lib/cosmic/landlock_test.tl
+++ b/lib/cosmic/landlock_test.tl
@@ -2,7 +2,7 @@
 local landlock = require("cosmic.landlock")
 local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
-local a = require("cosmic.assert")
+local check = require("cosmic.check")
 
 local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
@@ -55,7 +55,7 @@ local function test_restrict_denies_outside_allowlist()
     local v, err = landlock.abi()
     assert(v == nil, "abi() should return nil when landlock is unavailable")
     assert(err, "abi() should return an error string when unavailable")
-    a.skip("landlock unavailable (kernel lacks landlock)")
+    check.skip("landlock unavailable (kernel lacks landlock)")
     return
   end
 
@@ -103,19 +103,19 @@ if g then io.write("denied-leaked\n"); g:close() else io.write("denied-blocked\n
   -- blocked with SIGSYS rather than EPERM, killing the subprocess
   -- before it can emit "skipped".
   if not ok then
-    a.skip("landlock restrict blocked (subprocess died before enforcing)", true)
+    check.skip("landlock restrict blocked (subprocess died before enforcing)", true)
     return
   end
   local s = out as string
   if s:find("skipped") then
-    a.skip("landlock restrict blocked: " .. s, true)
+    check.skip("landlock restrict blocked: " .. s, true)
     return
   end
   -- Plain-text find: "-" is a Lua pattern metacharacter, so a pattern
   -- search for "allowed-ok" would not match the literal marker.
   assert(s:find("allowed-ok", 1, true), "allowed path should still read: " .. s)
   assert(s:find("denied-blocked", 1, true), "denied path must be blocked: " .. s)
-  a.enforced("landlock")
+  check.enforced("landlock")
 end
 test_restrict_denies_outside_allowlist()
 
@@ -127,7 +127,7 @@ test_restrict_denies_outside_allowlist()
 -- so the live check runs in a subprocess.
 local function test_restrict_single_file_rule()
   if not landlock.available() then
-    a.skip("landlock unavailable (kernel lacks landlock)")
+    check.skip("landlock unavailable (kernel lacks landlock)")
     return
   end
 
@@ -156,7 +156,7 @@ if g then io.write("sibling-leaked\n"); g:close() else io.write("sibling-blocked
   local __r2 = (h as spawn.Handle):wait() as spawn.Result
   local ok, out = __r2.ok, __r2.stdout
   if not ok then
-    a.skip("landlock restrict blocked (subprocess died before enforcing)", true)
+    check.skip("landlock restrict blocked (subprocess died before enforcing)", true)
     return
   end
   local s = out as string
@@ -168,13 +168,13 @@ if g then io.write("sibling-leaked\n"); g:close() else io.write("sibling-blocked
     -- blocked by an outer sandbox) is a strict skip.
     assert(not s:find("add_rule(", 1, true),
       "single-file READ rule must not fail in add_rule: " .. s)
-    a.skip("landlock restrict blocked: " .. s, true)
+    check.skip("landlock restrict blocked: " .. s, true)
     return
   end
   assert(s:find("file-ok", 1, true), "single-file rule should read: " .. s)
   assert(s:find("sibling-blocked", 1, true),
     "sibling outside the rule must be blocked: " .. s)
-  a.enforced("landlock single-file rule")
+  check.enforced("landlock single-file rule")
 end
 test_restrict_single_file_rule()
 

--- a/lib/cosmic/pledge_test.tl
+++ b/lib/cosmic/pledge_test.tl
@@ -2,7 +2,7 @@
 local pledge = require("cosmic.pledge")
 local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
-local a = require("cosmic.assert")
+local check = require("cosmic.check")
 
 local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
@@ -27,7 +27,7 @@ test_available_returns_boolean()
 -- exercised and enforcement is proven by the subprocess tests below.
 local function test_fail_closed_when_unavailable()
   if pledge.available() then
-    a.skip("pledge available on this host; fail-closed path not exercisable")
+    check.skip("pledge available on this host; fail-closed path not exercisable")
     return
   end
   local ok, err = pledge.apply("stdio")
@@ -60,7 +60,7 @@ io.write("pledged\n")
   local ok, out = __r1.ok, __r1.stdout
   local s = (out or "") as string
   if s:find("skipped") then
-    a.skip("pledge unsupported on this host: " .. s)
+    check.skip("pledge unsupported on this host: " .. s)
     return
   end
   assert(ok, "pledge stdio should allow io.write: " .. tostring(out))
@@ -98,14 +98,14 @@ io.write("restricted\n")
   local s = (out or "") as string
   if s:find("unsupported") then
     -- A genuine platform gap reported by the fail-closed probe: soft skip.
-    a.skip("pledge unsupported on this host: " .. s)
+    check.skip("pledge unsupported on this host: " .. s)
     return
   end
   if s:find("skipped") then
     -- available() was true yet apply failed: an outer sandbox pre-empted
     -- an otherwise-supported mechanism. Strict: a hard failure on the
     -- enforce lane.
-    a.skip("pledge apply failed: " .. s, true)
+    check.skip("pledge apply failed: " .. s, true)
     return
   end
   assert(not s:find("leaked"), "pledge must block filesystem open: " .. s)
@@ -116,6 +116,6 @@ io.write("restricted\n")
   -- Otherwise the process was killed (SIGSYS on Linux / kernel on OpenBSD)
   -- attempting the blocked open: enforcement by signal. It did not leak
   -- (asserted above) nor report pledge unavailable, so enforcement held.
-  a.enforced("pledge")
+  check.enforced("pledge")
 end
 test_restricts_filesystem()

--- a/lib/cosmic/public.tl
+++ b/lib/cosmic/public.tl
@@ -8,9 +8,17 @@
 --- disappear without notice, so user code must not require them.
 
 --- Public, documented, stable modules (see the module table in CLAUDE.md).
+---
+--- Names that shadow a Lua global when bound naturally are avoided:
+--- io became fd (#532), assert became check (#561). Decisions on the
+--- remaining stdlib-colliding names, recorded so this never re-opens:
+--- `string` collides but the entrenched `str` binding convention avoids
+--- the shadow and the module is a strict superset-by-addition — keep;
+--- `require` is already internal; `env`, `time`, and the rest carry no
+--- Lua global collision — keep.
 local public: {string} = {
-  "assert",
   "benchmark",
+  "check",
   "child",
   "codec",
   "compress",

--- a/lib/cosmic/quicksand/box/run_test.tl
+++ b/lib/cosmic/quicksand/box/run_test.tl
@@ -12,7 +12,7 @@
 local quicksand = require("cosmic.quicksand")
 local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
-local a = require("cosmic.assert")
+local check = require("cosmic.check")
 
 local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
@@ -26,7 +26,7 @@ local function run_script(name: string, body: string): spawn.Result
   local h = spawn.spawn({cosmic, script})
   local r = (h as spawn.Handle):wait() as spawn.Result
   if r.signal ~= nil then
-    a.skip("box subprocess killed by signal " .. tostring(r.signal)
+    check.skip("box subprocess killed by signal " .. tostring(r.signal)
       .. " (outer sandbox)", true)
     return nil
   end
@@ -36,7 +36,7 @@ end
 local function test_run_true_in_subprocess()
   local c = quicksand.capabilities()
   if not (c.linux and c.user_ns and c.net_ns) then
-    a.skip("box namespaces unavailable on this host")
+    check.skip("box namespaces unavailable on this host")
     return
   end
 
@@ -71,7 +71,7 @@ test_run_true_in_subprocess()
 local function test_setup_failure_returns_error_not_exit_code()
   local c = quicksand.capabilities()
   if not (c.linux and c.user_ns and c.net_ns and c.pledge) then
-    a.skip("box namespaces or pledge unavailable on this host")
+    check.skip("box namespaces or pledge unavailable on this host")
     return
   end
 
@@ -104,7 +104,7 @@ test_setup_failure_returns_error_not_exit_code()
 local function test_uid_drop_sets_no_new_privs_subprocess()
   local c = quicksand.capabilities()
   if not (c.linux and c.user_ns and c.net_ns) then
-    a.skip("box namespaces unavailable on this host")
+    check.skip("box namespaces unavailable on this host")
     return
   end
 
@@ -131,7 +131,7 @@ end
     .. tostring(r.stdout) .. tostring(r.stderr))
   local s = r.stdout as string
   if s:find("skipped") then
-    a.skip("uid_map write needs privileges: " .. s)
+    check.skip("uid_map write needs privileges: " .. s)
     return
   end
   assert(s:find("ok"), "NoNewPrivs should be 1, got: " .. s)
@@ -142,7 +142,7 @@ test_uid_drop_sets_no_new_privs_subprocess()
 local function test_pid_namespace_workload_has_low_pid_subprocess()
   local c = quicksand.capabilities()
   if not (c.linux and c.user_ns and c.net_ns and c.pid_ns) then
-    a.skip("box namespaces unavailable on this host")
+    check.skip("box namespaces unavailable on this host")
     return
   end
 
@@ -170,7 +170,7 @@ test_pid_namespace_workload_has_low_pid_subprocess()
 local function test_pid_namespace_opt_out_subprocess()
   local c = quicksand.capabilities()
   if not (c.linux and c.user_ns and c.net_ns) then
-    a.skip("box namespaces unavailable on this host")
+    check.skip("box namespaces unavailable on this host")
     return
   end
 

--- a/lib/cosmic/quicksand/init_test.tl
+++ b/lib/cosmic/quicksand/init_test.tl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cosmic
 local quicksand = require("cosmic.quicksand")
 local errno = require("cosmic.errno")
-local a = require("cosmic.assert")
+local check = require("cosmic.check")
 
 local function test_module_exports()
   assert(type(quicksand.capabilities) == "function", "capabilities should be a function")
@@ -45,10 +45,10 @@ local function test_user_ns_agrees_with_scratch_probe()
   assert(type(fresh) == "boolean", "probe_ns() should return a boolean")
   local c = quicksand.capabilities()
   if c.linux then
-    a.eq(c.user_ns, fresh,
+    check.eq(c.user_ns, fresh,
       "capabilities().user_ns must agree with a fresh scratch unshare probe")
   else
-    a.eq(c.user_ns, false, "user_ns must be false off Linux")
+    check.eq(c.user_ns, false, "user_ns must be false off Linux")
   end
 end
 test_user_ns_agrees_with_scratch_probe()
@@ -85,12 +85,12 @@ end
 -- so the ENOSYS branch was dead and every probe reported available. These
 -- cases fail if that regresses.
 local function test_probe_nil_binding_is_unavailable()
-  a.eq(quicksand.probe(nil), false, "a nil binding must probe as unavailable")
+  check.eq(quicksand.probe(nil), false, "a nil binding must probe as unavailable")
 end
 test_probe_nil_binding_is_unavailable()
 
 local function test_probe_success_is_available()
-  a.eq(quicksand.probe(function(): any return true end), true,
+  check.eq(quicksand.probe(function(): any return true end), true,
     "a successful no-op call means the syscall is wired up")
 end
 test_probe_success_is_available()
@@ -98,7 +98,7 @@ test_probe_success_is_available()
 local function test_probe_enosys_is_unavailable()
   local enosys = errno.code("ENOSYS")
   assert(enosys, "ENOSYS must be defined on this host")
-  a.eq(quicksand.probe(
+  check.eq(quicksand.probe(
       mk_fail("prctl: ENOSYS: Function not implemented", enosys)), false,
     "ENOSYS means the syscall is absent -> unavailable (the branch that was dead pre-fix)")
 end
@@ -107,7 +107,7 @@ test_probe_enosys_is_unavailable()
 local function test_probe_policy_error_is_available()
   local eperm = errno.code("EPERM")
   assert(eperm, "EPERM must be defined on this host")
-  a.eq(quicksand.probe(
+  check.eq(quicksand.probe(
       mk_fail("prctl: EPERM: Operation not permitted", eperm)), true,
     "a policy error (EPERM) still proves the syscall is wired up")
 end
@@ -117,7 +117,7 @@ local function test_probe_string_only_failure_is_available()
   -- A failure that carries no numeric errno (third slot nil) cannot be
   -- classified as ENOSYS; the error string alone must never match, so
   -- the probe reports the syscall wired up.
-  a.eq(quicksand.probe(function(): any, string, integer
+  check.eq(quicksand.probe(function(): any, string, integer
         return nil, "prctl: ENOSYS: Function not implemented", nil
       end), true,
     "an error string without a numeric errno is never classified as ENOSYS")
@@ -132,16 +132,16 @@ test_probe_string_only_failure_is_available()
 local function test_real_pledge_unveil_probe()
   local c = quicksand.capabilities()
   if not c.linux then
-    a.skip("quicksand pledge/unveil probe: non-Linux host")
+    check.skip("quicksand pledge/unveil probe: non-Linux host")
     return
   end
-  a.ok(c.pledge, "capabilities().pledge must be true on Linux (pledge via seccomp)")
+  check.ok(c.pledge, "capabilities().pledge must be true on Linux (pledge via seccomp)")
   if c.landlock then
-    a.ok(c.unveil, "capabilities().unveil must be true on Linux with landlock")
+    check.ok(c.unveil, "capabilities().unveil must be true on Linux with landlock")
   else
-    a.skip("quicksand unveil probe: host kernel lacks landlock")
+    check.skip("quicksand unveil probe: host kernel lacks landlock")
   end
-  a.enforced("quicksand pledge/unveil probe")
+  check.enforced("quicksand pledge/unveil probe")
 end
 test_real_pledge_unveil_probe()
 
@@ -170,10 +170,10 @@ local function test_unveil_matches_landlock_on_linux()
   -- capability must equal the landlock one (no independent, destructive probe).
   local c = quicksand.capabilities()
   if not c.linux then
-    a.skip("unveil/landlock equivalence: non-Linux host")
+    check.skip("unveil/landlock equivalence: non-Linux host")
     return
   end
-  a.eq(c.unveil, c.landlock,
+  check.eq(c.unveil, c.landlock,
     "on Linux unveil is derived from landlock and must equal it")
 end
 test_unveil_matches_landlock_on_linux()

--- a/lib/cosmic/sandbox_test.tl
+++ b/lib/cosmic/sandbox_test.tl
@@ -6,7 +6,7 @@ local unveil = require("cosmic.unveil")
 local sys = require("cosmic.sys")
 local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
-local a = require("cosmic.assert")
+local check = require("cosmic.check")
 
 local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
@@ -23,11 +23,11 @@ local function test_available_agrees_with_mechanisms()
   local avail = sandbox.available()
   assert(type(avail.fs) == "boolean", "available().fs should be boolean")
   assert(type(avail.sys) == "boolean", "available().sys should be boolean")
-  a.eq(avail.sys, pledge.available(), "sys must mirror pledge.available()")
+  check.eq(avail.sys, pledge.available(), "sys must mirror pledge.available()")
   if sys.host_os() == "linux" then
-    a.eq(avail.fs, landlock.available(), "fs must mirror landlock on Linux")
+    check.eq(avail.fs, landlock.available(), "fs must mirror landlock on Linux")
   else
-    a.eq(avail.fs, unveil.available(), "fs must mirror unveil off Linux")
+    check.eq(avail.fs, unveil.available(), "fs must mirror unveil off Linux")
   end
 end
 test_available_agrees_with_mechanisms()
@@ -93,7 +93,7 @@ local function test_fail_closed_when_unavailable()
   local avail = sandbox.available()
   local apply_any = sandbox.apply as function(any): boolean, string
   if avail.fs and avail.sys then
-    a.skip("sandbox fully available on this host; fail-closed path not exercisable")
+    check.skip("sandbox fully available on this host; fail-closed path not exercisable")
     return
   end
   if not avail.fs then
@@ -132,34 +132,34 @@ local function test_plan_landlock_mapping()
   local opts = plan_any({ro = {"/usr"}})
   local r = find_rule(opts.rules as {any}, "/usr")
   assert(r, "expected /usr rule")
-  a.eq(r.access as integer, landlock.READ | landlock.EXEC, "ro -> READ|EXEC")
+  check.eq(r.access as integer, landlock.READ | landlock.EXEC, "ro -> READ|EXEC")
 
   opts = plan_any({rw = {"/tmp"}})
   r = find_rule(opts.rules as {any}, "/tmp")
   assert(r, "expected /tmp rule")
-  a.eq(r.access as integer, landlock.RW, "rw -> RW (no exec)")
+  check.eq(r.access as integer, landlock.RW, "rw -> RW (no exec)")
   assert((landlock.RW & landlock.EXEC) == 0, "RW must not include EXEC")
 
   -- A path in several groups gets the union of their masks.
   opts = plan_any({ro = {"/shared"}, rw = {"/shared"}})
   r = find_rule(opts.rules as {any}, "/shared")
   assert(r, "expected /shared rule")
-  a.eq(r.access as integer, (landlock.READ | landlock.EXEC) | landlock.RW,
+  check.eq(r.access as integer, (landlock.READ | landlock.EXEC) | landlock.RW,
     "overlapping groups OR their masks")
 
   -- Empty policy plans to zero rules (deny-all when applied), full
   -- handled mask, and no_new_privs so it works unprivileged.
   opts = plan_any(nil)
-  a.eq(#(opts.rules as {any}), 0, "nil fs -> no rules")
-  a.eq(opts.handled as integer, landlock.ALL, "handled is ALL")
-  a.eq(opts.no_new_privs, true, "no_new_privs defaults on")
+  check.eq(#(opts.rules as {any}), 0, "nil fs -> no rules")
+  check.eq(opts.handled as integer, landlock.ALL, "handled is ALL")
+  check.eq(opts.no_new_privs, true, "no_new_privs defaults on")
 
   -- Rule order follows declaration order.
   opts = plan_any({ro = {"/a", "/b", "/c"}})
   local rules = opts.rules as {any}
-  a.eq((rules[1] as {string: any}).path, "/a")
-  a.eq((rules[2] as {string: any}).path, "/b")
-  a.eq((rules[3] as {string: any}).path, "/c")
+  check.eq((rules[1] as {string: any}).path, "/a")
+  check.eq((rules[2] as {string: any}).path, "/b")
+  check.eq((rules[3] as {string: any}).path, "/c")
 end
 test_plan_landlock_mapping()
 
@@ -170,7 +170,7 @@ test_plan_landlock_mapping()
 local function test_apply_enforces_fs_and_sys()
   local avail = sandbox.available()
   if not (avail.fs and avail.sys) then
-    a.skip("sandbox fs+sys unavailable on this host")
+    check.skip("sandbox fs+sys unavailable on this host")
     return
   end
 
@@ -201,7 +201,7 @@ if g then io.write("denied-leaked\n"); g:close() else io.write("denied-blocked\n
   local h = spawn.spawn({cosmic, script})
   local r = (h as spawn.Handle):wait() as spawn.Result
   if r.signal ~= nil then
-    a.skip("sandbox subprocess killed by signal " .. tostring(r.signal)
+    check.skip("sandbox subprocess killed by signal " .. tostring(r.signal)
       .. " (outer sandbox)", true)
     return
   end
@@ -209,13 +209,13 @@ if g then io.write("denied-leaked\n"); g:close() else io.write("denied-blocked\n
   if s:find("sandbox-blocked:", 1, true) then
     -- available() said yes yet apply failed: an outer sandbox
     -- pre-empted it. Strict: a hard failure on the enforce lane.
-    a.skip("sandbox.apply blocked by an outer sandbox: " .. s, true)
+    check.skip("sandbox.apply blocked by an outer sandbox: " .. s, true)
     return
   end
   assert(s:find("allowed-ok", 1, true), "allowed path should read: " .. s)
   assert(s:find("denied-blocked", 1, true),
     "path outside the allowlist must be blocked: " .. s)
-  a.enforced("sandbox fs+sys")
+  check.enforced("sandbox fs+sys")
 end
 test_apply_enforces_fs_and_sys()
 
@@ -225,7 +225,7 @@ test_apply_enforces_fs_and_sys()
 local function test_invalid_sys_leaves_fs_unapplied()
   local avail = sandbox.available()
   if not avail.fs then
-    a.skip("sandbox fs unavailable on this host")
+    check.skip("sandbox fs unavailable on this host")
     return
   end
 

--- a/lib/cosmic/unveil_test.tl
+++ b/lib/cosmic/unveil_test.tl
@@ -2,7 +2,7 @@
 local unveil = require("cosmic.unveil")
 local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
-local a = require("cosmic.assert")
+local check = require("cosmic.check")
 
 local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
@@ -29,7 +29,7 @@ test_available_returns_boolean()
 -- opt-in back to the old fail-open behavior.
 local function test_fail_closed_when_unavailable()
   if unveil.available() then
-    a.skip("unveil available on this host; fail-closed path not exercisable")
+    check.skip("unveil available on this host; fail-closed path not exercisable")
     return
   end
   local dir = fs.join(tmpdir, "fc")
@@ -60,7 +60,7 @@ test_fail_closed_when_unavailable()
 local function test_unveil_restricts_paths()
   if not unveil.available() then
     -- The fail-closed contract for this host is asserted above.
-    a.skip("unveil unavailable on this host (no landlock, not OpenBSD)")
+    check.skip("unveil unavailable on this host (no landlock, not OpenBSD)")
     return
   end
 
@@ -111,7 +111,7 @@ end
     -- available() was true yet the call failed: an outer sandbox
     -- pre-empted an otherwise-supported mechanism. Strict: a hard
     -- failure on the enforce lane.
-    a.skip("unveil blocked by an outer sandbox: " .. s, true)
+    check.skip("unveil blocked by an outer sandbox: " .. s, true)
     return
   end
   assert(ok, "unveil subprocess should exit cleanly: " .. s)
@@ -120,6 +120,6 @@ end
   -- real: a visible sibling is a fail-open bug, never a skip.
   assert(s:find("denied%-blocked"),
     "expected denial of the non-unveiled sibling: " .. s)
-  a.enforced("unveil")
+  check.enforced("unveil")
 end
 test_unveil_restricts_paths()

--- a/skills/cosmic/testing.md
+++ b/skills/cosmic/testing.md
@@ -34,14 +34,14 @@ key rules:
 
 ## Assert Patterns
 
-the preferred way to write assertions is with `cosmic.assert`, which produces auto-formatted failure messages:
+the preferred way to write assertions is with `cosmic.check`, which produces auto-formatted failure messages:
 
 ```teal
-local a = require("cosmic.assert")
+local check = require("cosmic.check")
 
-a.eq(result, "expected", "label")      -- equality with diff on failure
-a.ne(result, nil, "should not be nil")
-a.ok(result > 0, "expected positive")
+check.eq(result, "expected", "label")      -- equality with diff on failure
+check.ne(result, nil, "should not be nil")
+check.ok(result > 0, "expected positive")
 ```
 
 plain `assert()` also works and is fine for simple checks:


### PR DESCRIPTION
Closes #561 (follow-up to #532/#555; next item on the #533 tracker's breaking batch).

`cosmic.assert` could not be bound to its natural name without shadowing Lua's `assert()` — the same disease that motivated io→fd in #555. The tell was already in the tree: every consumer bound it as `local a = require("cosmic.assert")`, with unreadable one-letter call sites (`a.eq`, `a.ok`).

## Changes

- `assert.tl` → `check.tl`; `assert_test.tl` → `check_assertions_test.tl` (`check_test.tl` already covers `--check-types`, per the issue's collision note); `AssertModule` record → `CheckModule`.
- All `local a =` bindings swept to `local check =` (pledge/unveil/landlock/sandbox/quicksand tests) — call sites now read naturally: `check.eq(got, want)`, `check.ok(...)`.
- `cosmic.public`: `assert` → `check` (the docs surface follows automatically via #565: `--docs` lists `cosmic.check`, and `--docs assert` still finds it through description search).
- `skills/cosmic/testing.md` updated to the new name and binding.
- No alias — pre-stable.

## Stdlib-collision decisions recorded

Per the issue, the other colliding names are sanity-checked once, with the decisions recorded in `public.tl` next to the manifest so this never re-opens:

- `string` — collides, but the entrenched `str` binding convention avoids the shadow and the module is a strict superset-by-addition: **keep**.
- `require` — already internal.
- `env`, `time`, and the rest — no Lua global collision: **keep**.

## TDD

The type checker and `public_test.tl`'s staleness check are the red/green: any leftover `require("cosmic.assert")` fails to resolve, and a manifest miss fails the manifest lint. `bin/make ci` green; verified end to end (`--docs check` renders, `check.eq` works, `--docs assert` search-resolves to `cosmic.check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjGaMU98P7VEN8tvYHWTLZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjGaMU98P7VEN8tvYHWTLZ)_