### PR TITLE
fs iteration semantics: strict files() root errors; walk skip/stop protocol

### DIFF
--- a/lib/cosmic/fs/init.tl
+++ b/lib/cosmic/fs/init.tl
@@ -205,8 +205,17 @@ local fs_walk = require("cosmic.fs.walk")
 --- Iterator over file paths, as returned by files().
 local type FileIter = fs_walk.FileIter
 
+--- Visitor verdict for walk(): nil continues, "skip" prunes, "stop" ends the walk.
+local type WalkAction = fs_walk.WalkAction
+
 --- Module interface
 local record FsModule
+  --- Iterator over file paths, as returned by files().
+  type FileIter = FileIter
+
+  --- Visitor verdict for walk(): nil continues, "skip" prunes, "stop" ends the walk.
+  type WalkAction = WalkAction
+
   -- Path manipulation
   dirname: function(str: string): string
   basename: function(str: string): string
@@ -276,16 +285,18 @@ local record FsModule
   minor: function(dev: number): number
 
   -- Directory walking.
-  -- walk visitor signature: visitor(path, name, st, ctx)
+  -- walk visitor signature: visitor(path, name, st, ctx): nil | "skip" | "stop"
   --   path = full path to the entry (e.g. "dir/sub/file.txt") — do NOT join with name.
   --   name = basename of the entry (e.g. "file.txt").
   --   st   = WalkStat (import: local types = require("cosmic.fs.types"); types.WalkStat).
+  -- Returning "skip" does not descend into the entry (dirs only); "stop"
+  -- ends the walk now; returning nothing continues.
   -- Root open failure returns nil, err; subtree failures return the first
   -- error alongside the results.
-  walk: function < T > (dir: string, visitor: function(string, string, WalkStat, T), ctx?: T): T | nil, string
+  walk: function < T > (dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T): T | nil, string
   collect: function(dir: string, pattern: string): {string} | nil, string
   collect_all: function(dir: string): {string: FileInfo} | nil, string
-  files: function(dir: string, pattern?: string): FileIter, string, any, any
+  files: function(dir: string, pattern?: string): FileIter | nil, string, any, any
 
   -- Access mode constants
   F_OK: number

--- a/lib/cosmic/fs/path_test.tl
+++ b/lib/cosmic/fs/path_test.tl
@@ -145,14 +145,13 @@ local function test_walk_with_visitor()
   local walk_dir = setup_walk()
   local ctx: WalkContext = {count = 0, dirs = 0}
 
-  fs.walk(walk_dir, function(_full_path: string, _entry: string, st: any, c: any): boolean
+  fs.walk(walk_dir, function(_full_path: string, _entry: string, st: any, c: any)
       local wctx = c as WalkContext
       wctx.count = wctx.count + 1
       local stat_obj = st as WalkStat
       if stat_obj:is_dir() then
         wctx.dirs = wctx.dirs + 1
       end
-      return true
     end, ctx)
 
   assert(ctx.count > 0, "expected count > 0")
@@ -180,7 +179,7 @@ local function test_files_iterator()
   local walk_dir = setup_walk()
   local found: {string: boolean} = {}
 
-  for filepath in fs.files(walk_dir, "*.lua") do
+  for filepath in assert(fs.files(walk_dir, "*.lua")) as fs.FileIter do
     found[fs.basename(filepath)] = true
   end
 
@@ -196,7 +195,7 @@ local function test_files_iterator_all()
   local walk_dir = setup_walk()
   local count = 0
 
-  for _ in fs.files(walk_dir) do
+  for _ in assert(fs.files(walk_dir)) as fs.FileIter do
     count = count + 1
   end
 

--- a/lib/cosmic/fs/walk.tl
+++ b/lib/cosmic/fs/walk.tl
@@ -17,20 +17,23 @@ local record WalkDirHandle
   close: function(self)
 end
 
---- Recursive walk helper. Records the first subtree error (opendir or
---- stat failure below the root) in errbox[1] rather than swallowing it.
-local function walk_tree < T > (dir: string,
-    visitor: function(string, string, WalkStat, T), ctx: T,
-    errbox: {string})
-  local handle, oerr = unix.opendir(dir)
-  if not handle then
-    if not errbox[1] then
-      errbox[1] = errstr(oerr, "opendir: " .. dir)
-    end
-    return
-  end
-  local h = handle as WalkDirHandle
+--- Visitor verdict for walk(): returning nothing continues as before,
+--- "skip" does not descend into the entry (dirs only; no-op for files),
+--- "stop" ends the walk immediately.
+local enum WalkAction
+  "skip"
+  "stop"
+end
 
+local walk_tree: function < T > (string,
+function(string, string, WalkStat, T): (WalkAction ...), T, {string}): boolean
+
+--- Shared per-directory loop. Consumes (and closes) an already-open
+--- handle, records the first subtree error in errbox[1], and returns
+--- true when a visitor asked to stop the walk.
+local function walk_entries < T > (dir: string, h: WalkDirHandle,
+    visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx: T,
+    errbox: {string}): boolean
   while true do
     local entry = h:read()
     if not entry then break end
@@ -40,9 +43,16 @@ local function walk_tree < T > (dir: string,
       -- This prevents infinite recursion through symlink cycles.
       local st, serr = unix.stat(full_path, unix.AT_SYMLINK_NOFOLLOW)
       if st then
-        visitor(full_path, entry, types.wrap(st), ctx)
-        if unix.S_ISDIR(st:mode()) then
-          walk_tree(full_path, visitor, ctx, errbox)
+        local action = visitor(full_path, entry, types.wrap(st), ctx)
+        if action == "stop" then
+          h:close()
+          return true
+        end
+        if action ~= "skip" and unix.S_ISDIR(st:mode()) then
+          if walk_tree(full_path, visitor, ctx, errbox) then
+            h:close()
+            return true
+          end
         end
       elseif not errbox[1] then
         errbox[1] = errstr(serr, "stat: " .. full_path)
@@ -50,6 +60,22 @@ local function walk_tree < T > (dir: string,
     end
   end
   h:close()
+  return false
+end
+
+--- Recursive walk helper. An opendir failure below the root is recorded
+--- in errbox[1] rather than swallowed or fatal.
+walk_tree = function < T > (dir: string,
+    visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx: T,
+    errbox: {string}): boolean
+  local handle, oerr = unix.opendir(dir)
+  if not handle then
+    if not errbox[1] then
+      errbox[1] = errstr(oerr, "opendir: " .. dir)
+    end
+    return false
+  end
+  return walk_entries(dir, handle as WalkDirHandle, visitor, ctx, errbox)
 end
 
 --- Walk a directory tree, calling visitor for each entry.
@@ -61,6 +87,11 @@ end
 ---   name  (string)  — the basename of the entry (e.g. "file.txt").
 ---   st    (WalkStat) — stat result for the entry.
 ---   ctx   (T)       — the context value passed to walk().
+---
+--- The visitor's return value controls the traversal:
+---   nil    — continue (a visitor that returns nothing keeps today's behavior)
+---   "skip" — do not descend into this entry (dirs only; no-op for files)
+---   "stop" — end the walk now; walk returns ctx plus any first error
 ---
 --- IMPORTANT: do NOT join path and name — path is already the full path.
 --- Joining them produces doubled paths like "dir/sub/file.txt/file.txt".
@@ -74,36 +105,18 @@ end
 --- not stop the walk; the first such error is returned alongside the
 --- context so callers never mistake a partial walk for a complete one.
 --- @param dir string The directory to walk
---- @param visitor function Called for each entry: function(path, name, st, ctx)
+--- @param visitor function Called for each entry: function(path, name, st, ctx): nil|"skip"|"stop"
 --- @param ctx T Optional context passed to every visitor call
 --- @return T | nil The context object, or nil if the root could not be opened
 --- @return string First error encountered, if any
-local function walk < T > (dir: string, visitor: function(string, string, WalkStat, T), ctx?: T): T | nil, string
+local function walk < T > (dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T): T | nil, string
   ctx = ctx or {} as T
   local handle, oerr = unix.opendir(dir)
   if not handle then
     return nil, errstr(oerr, "opendir: " .. dir)
   end
-  local h = handle as WalkDirHandle
   local errbox: {string} = {}
-
-  while true do
-    local entry = h:read()
-    if not entry then break end
-    if entry ~= "." and entry ~= ".." then
-      local full_path = cosmo_path.join(dir, entry)
-      local st, serr = unix.stat(full_path, unix.AT_SYMLINK_NOFOLLOW)
-      if st then
-        visitor(full_path, entry, types.wrap(st), ctx)
-        if unix.S_ISDIR(st:mode()) then
-          walk_tree(full_path, visitor, ctx, errbox)
-        end
-      elseif not errbox[1] then
-        errbox[1] = errstr(serr, "stat: " .. full_path)
-      end
-    end
-  end
-  h:close()
+  walk_entries(dir, handle as WalkDirHandle, visitor, ctx, errbox)
   return ctx, errbox[1]
 end
 
@@ -230,15 +243,17 @@ local type FileIter = function(): string
   --- is a to-be-closed guard: a plain `for f in fs.files(dir) do ... end`
   --- loop adopts it as the loop's closing value (Lua 5.4), so directory
   --- handles are closed even when the loop exits early via break/error.
-  --- If the root directory cannot be opened, the iterator yields nothing
-  --- and the error is returned as the second value.
+  --- If the root directory cannot be opened, returns nil plus the error —
+  --- iterate the checked value: `for f in assert(fs.files(dir)) as fs.FileIter do`
+  --- (assert passes all four returns through, keeping the closing guard;
+  --- the cast only narrows the type, it does not drop return values).
   --- @param dir string The directory to search
   --- @param pattern string Glob pattern (*.lua) - defaults to all files (*)
-  --- @return function Iterator yielding file paths
+  --- @return function | nil Iterator yielding file paths, or nil if the root could not be opened
   --- @return string Error if the root directory could not be opened
   --- @return nil Unused (generic-for control slot)
   --- @return any Closing guard that releases open directory handles
-  local function files(dir: string, pattern?: string): FileIter, string, any, any
+  local function files(dir: string, pattern?: string): FileIter | nil, string, any, any
     pattern = pattern or "*"
 
     -- Detect if it's a glob or Lua pattern
@@ -254,8 +269,7 @@ local type FileIter = function(): string
     local stack: {{string, WalkDirHandle}} = {}
     local handle, oerr = unix.opendir(dir)
     if not handle then
-      return function(): string return nil end,
-      errstr(oerr, "opendir: " .. dir), nil, nil
+      return nil, errstr(oerr, "opendir: " .. dir)
     end
     table.insert(stack, {dir, handle as WalkDirHandle})
 
@@ -319,12 +333,16 @@ local type FileIter = function(): string
     --- Iterator over file paths, as returned by files().
     type FileIter = FileIter
 
+    --- Visitor verdict: nil continues, "skip" prunes, "stop" ends the walk.
+    type WalkAction = WalkAction
+
     --- Walk dir tree. visitor(path, name, st, ctx): path is the FULL path; name is the basename.
     --- Do NOT join path and name — path is already complete.
-    walk: function < T > (dir: string, visitor: function(string, string, WalkStat, T), ctx?: T): T | nil, string
+    --- The visitor may return "skip" (don't descend) or "stop" (end the walk).
+    walk: function < T > (dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T): T | nil, string
     collect: function(dir: string, pattern: string): {string} | nil, string
     collect_all: function(dir: string): {string: FileInfo} | nil, string
-    files: function(dir: string, pattern?: string): FileIter, string, any, any
+    files: function(dir: string, pattern?: string): FileIter | nil, string, any, any
   end
 
   local M: FsWalkModule = {

--- a/lib/cosmic/fs/walk_example.tl
+++ b/lib/cosmic/fs/walk_example.tl
@@ -77,7 +77,10 @@ local function Example_files()
   assert(fs.write(fs.join(tmpdir, "b.txt"), "b\n"))
 
   local names: {string} = {}
-  for p in fs.files(tmpdir, "*.txt") do
+  -- files() returns nil, err if the root cannot be opened; assert passes
+  -- the iterator and its closing guard through on success (the cast only
+  -- narrows the type — it does not drop the extra return values).
+  for p in assert(fs.files(tmpdir, "*.txt")) as fs.FileIter do
     table.insert(names, fs.basename(p))
   end
   table.sort(names)

--- a/lib/cosmic/fs/walk_test.tl
+++ b/lib/cosmic/fs/walk_test.tl
@@ -2,6 +2,8 @@
 --- Tests for fs_walk module (symlink cycle safety)
 local fs_walk = require("cosmic.fs.walk")
 local fs = require("cosmic.fs")
+local type FileIter = fs_walk.FileIter
+local type WalkAction = fs_walk.WalkAction
 
 local tmpdir = os.getenv("TEST_TMPDIR") as string
 
@@ -84,7 +86,7 @@ local function test_files_symlink_cycle_terminates()
   fs.symlink("..", fs.join(subdir, "loop"))
 
   local collected: {string} = {}
-  for p in fs_walk.files(base, "*.lua") do
+  for p in assert(fs_walk.files(base, "*.lua")) as FileIter do
     collected[#collected + 1] = p
     -- Safety: abort if we find more than a small number
     assert(#collected <= 10,
@@ -147,13 +149,121 @@ end
 test_collect_all_missing_root_errors()
 
 local function test_files_missing_root_errors()
+  -- #558a: strict, like collect — a typo'd directory must be an error,
+  -- not an iterator that silently yields zero files.
   local missing = fs.join(tmpdir, "no", "such", "dir")
   local iter, err = fs_walk.files(missing)
-  assert(iter() == nil, "iterator over a missing root should be empty")
+  assert(iter == nil, "files() on a missing root should return nil")
   assert(err and err:match("ENOENT"),
     "files error should name ENOENT: " .. tostring(err))
 end
 test_files_missing_root_errors()
+
+-- #558b: visitor return protocol — "skip" prunes a subtree, "stop" ends
+-- the walk. Visitors that return nothing keep today's behavior.
+
+local record SkipCtx
+  visited: {string: boolean}
+end
+
+local function test_walk_skip_prunes_subtree()
+  local base = mksubdir("walk_skip")
+  local keep = fs.join(base, "keep")
+  local prune = fs.join(base, "prune")
+  fs.makedirs(keep)
+  fs.makedirs(prune)
+  write_file(fs.join(keep, "a.txt"), "a")
+  write_file(fs.join(prune, "b.txt"), "b")
+
+  local ctx: SkipCtx = {visited = {}}
+  local got, err = fs_walk.walk(base, function(_p: string, name: string,
+        _st: any, c: SkipCtx): WalkAction
+      c.visited[name] = true
+      if name == "prune" then
+        return "skip"
+      end
+      if name == "a.txt" then
+        return "skip" -- "skip" on a file is a no-op
+      end
+    end, ctx)
+  assert(got, "walk should succeed: " .. tostring(err))
+  assert(ctx.visited["prune"], "the pruned dir itself is visited")
+  assert(ctx.visited["keep"], "sibling dirs are visited")
+  assert(ctx.visited["a.txt"], "children of kept dirs are visited")
+  assert(not ctx.visited["b.txt"],
+    "children of a skipped dir must not be visited")
+end
+test_walk_skip_prunes_subtree()
+
+local record StopCtx
+  count: integer
+  stopped: boolean
+  after: integer
+end
+
+local function test_walk_stop_ends_walk()
+  local base = mksubdir("walk_stop")
+  for i = 1, 5 do
+    write_file(fs.join(base, "f" .. i .. ".txt"), "x")
+  end
+
+  local ctx: StopCtx = {count = 0, stopped = false, after = 0}
+  local got, err = fs_walk.walk(base, function(_p: string, _n: string,
+        _st: any, c: StopCtx): WalkAction
+      c.count = c.count + 1
+      return "stop"
+    end, ctx)
+  assert(got, "walk should return ctx after stop: " .. tostring(err))
+  assert(ctx.count == 1,
+    "stop must end the walk after the first visit, got " .. tostring(ctx.count))
+end
+test_walk_stop_ends_walk()
+
+local function test_walk_stop_in_subtree_aborts_walk()
+  local base = mksubdir("walk_stop_deep")
+  local subsub = fs.join(base, "sub", "subsub")
+  fs.makedirs(subsub)
+  write_file(fs.join(subsub, "deep.txt"), "x")
+  write_file(fs.join(base, "top1.txt"), "x")
+  write_file(fs.join(base, "top2.txt"), "x")
+
+  local ctx: StopCtx = {count = 0, stopped = false, after = 0}
+  fs_walk.walk(base, function(_p: string, name: string,
+        _st: any, c: StopCtx): WalkAction
+      if c.stopped then
+        c.after = c.after + 1
+      end
+      if name == "deep.txt" then
+        c.stopped = true
+        return "stop"
+      end
+    end, ctx)
+  assert(ctx.stopped, "deep.txt should have been visited")
+  assert(ctx.after == 0, "no entry may be visited after stop, got "
+    .. tostring(ctx.after))
+end
+test_walk_stop_in_subtree_aborts_walk()
+
+local function test_walk_skip_with_symlink_cycle_terminates()
+  local base = mksubdir("walk_skip_cycle")
+  local sub = fs.join(base, "sub")
+  fs.makedirs(sub)
+  write_file(fs.join(sub, "real.txt"), "hello")
+  fs.symlink("..", fs.join(sub, "loop"))
+
+  local ctx: StopCtx = {count = 0, stopped = false, after = 0}
+  local got, err = fs_walk.walk(base, function(_p: string, name: string,
+        _st: any, c: StopCtx): WalkAction
+      c.count = c.count + 1
+      if name == "loop" then
+        return "skip"
+      end
+    end, ctx)
+  assert(got, "walk should succeed: " .. tostring(err))
+  -- sub, real.txt, loop — pruning on top of cycle safety must terminate.
+  assert(ctx.count == 3, "expected 3 entries, got " .. tostring(ctx.count))
+end
+test_walk_skip_with_symlink_cycle_terminates()
 
 local function test_collect_success_has_no_error()
   local base = mksubdir("collect_ok")
@@ -171,7 +281,7 @@ test_collect_success_has_no_error()
 local function count_open_fds(): integer
   -- Exhausting the iterator closes its own handle as it goes.
   local n = 0
-  local iter = fs_walk.files("/proc/self/fd")
+  local iter = assert(fs_walk.files("/proc/self/fd")) as FileIter
   for _ in iter do n = n + 1 end
   return n
 end
@@ -188,7 +298,7 @@ local function test_files_early_break_closes_handles()
   end
 
   local before = count_open_fds()
-  for p in fs_walk.files(base, "*.txt") do
+  for p in assert(fs_walk.files(base, "*.txt")) as FileIter do
     assert(p, "expected a path")
     break -- abandon the iterator with directories still open
   end

--- a/lib/perf/bench/fs_bench.tl
+++ b/lib/perf/bench/fs_bench.tl
@@ -84,7 +84,7 @@ local function scenarios(): {pt.Scenario}, string
       name = "fs_files_tree",
       fn = function(_: any): any
         local count = 0
-        for _ in fs.files(tmpdir, "*.txt") do
+        for _ in assert(fs.files(tmpdir, "*.txt")) as fs.FileIter do
           count = count + 1
         end
         return count


### PR DESCRIPTION
Implements #558 (follow-up to #532 / #555). Both halves are breaking, batched as the issue asks.

## (a) `fs.files()` no longer swallows a missing root

`files()` used to return an *empty iterator* with the error tucked into the second (for-state) return, so `for f in fs.files(dir)` over a typo'd directory silently iterated zero files — the exact bug class the walk-error work eliminated for `collect`. It is now strict and consistent with `walk`/`collect`/`collect_all`:

```teal
files: function(dir: string, pattern?: string): FileIter | nil, string, any, any
```

- Root open failure → `nil, err` (the error names the errno, e.g. `opendir: /no/such: ENOENT: ...`).
- The closing guard stays the 4th return of the **successful** call, so early `break` still releases directory handles.
- The Teal caller idiom is `for f in assert(fs.files(dir)) as fs.FileIter do` — verified that the cast only narrows the type; the generated Lua keeps all four values, so `assert` passes the guard through and uses the returned error as its message. (tl 0.24.8 does not flow-narrow function unions, hence the cast; `fs` now exports the `FileIter` type for this.)
- Swept the in-repo callers (`walk_test`, `path_test`, `walk_example`, `fs_bench`).

## (b) Walk visitors can prune and stop

`walk()` adopts the visitor return protocol from the issue:

```
visitor(path, name, st, ctx): nil | "skip" | "stop"
  nil    — continue (a visitor that returns nothing keeps today's behavior)
  "skip" — do not descend into this entry (dirs only; no-op for files)
  "stop" — end the walk now; walk returns ctx plus any first error
```

- The return type is a new `WalkAction` enum (`"skip" | "stop"`), declared as a **vararg** return (`(WalkAction...)`) so existing zero-return visitors typecheck unchanged — backward compatible as promised. Visitors that do return an action annotate `: fs.WalkAction`.
- The previously duplicated root/subtree readdir loops in `walk`/`walk_tree` are unified into one `walk_entries` helper with stop propagation, so the two copies can't drift.
- `collect` did not grow a prune option (the issue marked it optional); callers drop to `walk`.

## Tests (red first)

All four TDD cases from the issue, in `lib/cosmic/fs/walk_test.tl`:
- `fs.files("/no/such")` returns `nil` plus an error naming ENOENT (reproduced red against the old empty-iterator behavior);
- `"skip"` on a subdir: none of its children are visited (and `"skip"` on a file is a no-op);
- `"stop"` after the first visit visits nothing further, including a nested-subtree stop aborting the whole walk (asserted via a visited-after-stop counter);
- prune on top of a symlink cycle still terminates with the expected visit count.

## Verification

- `bin/make ci` green (format + teal + test + example + lint).
- End-to-end smoke through the built binary: strict root error message, `.git` pruned, early stop, `fs.WalkAction`/`fs.FileIter` usable from user code.

## Knock-on

None upstream — this is cosmic-layer only (no `cosmo.*` contract change, no `definitions.lua`/pin involvement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148XhzsQsRnLuBjAYTsYPeD

---
_Generated by [Claude Code](https://claude.ai/code/session_0148XhzsQsRnLuBjAYTsYPeD)_