### PR TITLE
fd polish: nil on EOF, sync moves to fs, documented EINTR posture

### DIFF
--- a/lib/cosmic/fd.tl
+++ b/lib/cosmic/fd.tl
@@ -9,6 +9,12 @@
 ---
 --- For whole-file path-based operations use cosmic.fs: fs.read(path),
 --- fs.write(path, data), fs.truncate(path).
+---
+--- EINTR posture: Handle read/write/seek do NOT retry automatically. When
+--- a signal interrupts the call, it returns nil plus an EINTR-tagged
+--- error; callers that install signal handlers detect it with
+--- `errno.name_of(err) == "EINTR"` and retry themselves. (Automatic
+--- retry is deferred to the signal-safety wave.)
 local unix = require("cosmo.unix")
 local errstr = require("cosmic.errno").str
 
@@ -58,7 +64,11 @@ make_handle = function(fd: number): Handle
     return handle_fd or -1
   end
 
-  --- Read up to size bytes. Returns empty string on EOF.
+  --- Read up to size bytes. Returns nil with NO error on EOF (Lua
+  --- convention: `while true do local chunk = h:read(n); if not chunk
+  --- then break end ... end`), and nil WITH an error on failure —
+  --- including EAGAIN on a nonblocking fd with no data, and EINTR when
+  --- a signal interrupts the read (see the module header; not retried).
   --- If offset is provided, reads at that position (pread behavior).
   function handle:read(size?: number, offset?: number): string | nil, string
     if not handle_fd then
@@ -68,10 +78,15 @@ make_handle = function(fd: number): Handle
     if data == nil and err then
       return nil, errstr(err, "read")
     end
-    return data or ""
+    if data == nil or data == "" then
+      return nil -- EOF: nil with no error
+    end
+    return data
   end
 
-  --- Write data. Returns number of bytes written.
+  --- Write data. Returns number of bytes written (which may be fewer
+  --- than #data — callers writing everything must loop). On failure
+  --- returns nil plus an error; EINTR is not retried (see module header).
   --- If offset is provided, writes at that position (pwrite behavior).
   function handle:write(data: string, offset?: number): number | nil, string
     if not handle_fd then
@@ -85,6 +100,7 @@ make_handle = function(fd: number): Handle
   end
 
   --- Seek to position. whence: SEEK_SET (default), SEEK_CUR, SEEK_END.
+  --- On failure returns nil plus an error; EINTR is not retried.
   function handle:seek(offset: number, whence?: number): number | nil, string
     if not handle_fd then
       return nil, "handle closed"
@@ -214,11 +230,6 @@ local function pipe(flags?: number): Pipe | nil, string
   return make_pipe(make_handle(reader_fd), make_handle(writer_fd))
 end
 
---- Flush all file system buffers to disk.
-local function sync()
-  unix.sync()
-end
-
 --- Wrap an already-open raw file descriptor in a Handle.
 --- Lets fds from fs.mkstemp()/fs.tmpfd() (or any other source) enter the
 --- Handle world: h:read()/h:write()/h:close(), plus automatic cleanup
@@ -236,7 +247,6 @@ local record FdModule
   open: function(path: string, flags: number, mode?: number, dirfd?: number): Handle | nil, string
   wrap: function(rawfd: number): Handle
   pipe: function(flags?: number): Pipe | nil, string
-  sync: function()
 
   O_RDONLY: number
   O_WRONLY: number
@@ -274,7 +284,6 @@ local M: FdModule = {
   open = open,
   wrap = wrap,
   pipe = pipe,
-  sync = sync,
 
   O_RDONLY = unix.O_RDONLY,
   O_WRONLY = unix.O_WRONLY,

--- a/lib/cosmic/fd_read_test.tl
+++ b/lib/cosmic/fd_read_test.tl
@@ -1,0 +1,73 @@
+#!/usr/bin/env cosmic
+--- Tests for the #560 fd contract: read() EOF/EAGAIN shape, sync placement.
+local cfd = require("cosmic.fd")
+local fs = require("cosmic.fs")
+
+global TEST_TMPDIR: string
+
+-- read() EOF contract — nil with no error means EOF; nil with an error
+-- means failure. "" is never returned.
+
+local function test_read_eof_returns_nil()
+  local filepath = fs.join(TEST_TMPDIR, "io_test_eof.txt")
+  assert(fs.write(filepath, "abc"))
+  local f = assert(cfd.open(filepath, cfd.O_RDONLY)) as cfd.Handle
+  assert(f:read(100) == "abc", "first read returns the content")
+  local data, err = f:read(100)
+  assert(data == nil, "read at EOF should return nil, got '" .. tostring(data) .. "'")
+  assert(err == nil, "EOF is not an error, got: " .. tostring(err))
+  assert(f:close())
+  os.remove(filepath)
+end
+test_read_eof_returns_nil()
+
+local function test_read_empty_file_returns_nil()
+  local filepath = fs.join(TEST_TMPDIR, "io_test_empty.txt")
+  assert(fs.write(filepath, ""))
+  local f = assert(cfd.open(filepath, cfd.O_RDONLY)) as cfd.Handle
+  local data, err = f:read(100)
+  assert(data == nil, "first read of an empty file should return nil, got '" .. tostring(data) .. "'")
+  assert(err == nil, "EOF is not an error, got: " .. tostring(err))
+  assert(f:close())
+  os.remove(filepath)
+end
+test_read_empty_file_returns_nil()
+
+local function test_read_loop_terminates_on_nil()
+  local filepath = fs.join(TEST_TMPDIR, "io_test_loop.txt")
+  assert(fs.write(filepath, "0123456789"))
+  local f = assert(cfd.open(filepath, cfd.O_RDONLY)) as cfd.Handle
+  local parts: {string} = {}
+  while true do
+    local chunk, err = f:read(4)
+    if not chunk then
+      assert(err == nil, "loop should end on EOF, not an error: " .. tostring(err))
+      break
+    end
+    parts[#parts + 1] = chunk
+  end
+  assert(table.concat(parts) == "0123456789", "chunked loop reassembles the file")
+  assert(f:close())
+  os.remove(filepath)
+end
+test_read_loop_terminates_on_nil()
+
+-- Pin: a nonblocking read with no data is a FAILURE (nil + EAGAIN error),
+-- distinct from EOF (nil + no error).
+local function test_nonblocking_pipe_read_names_eagain()
+  local p = assert(cfd.pipe(cfd.O_NONBLOCK)) as cfd.Pipe
+  local data, err = p.reader:read(10)
+  assert(data == nil, "empty nonblocking pipe read should return nil")
+  assert(err and err:match("EAGAIN"), "error should name EAGAIN, got: " .. tostring(err))
+  p:close()
+end
+test_nonblocking_pipe_read_names_eagain()
+
+-- The system-wide sync(2) belongs to fs, not fd (no alias, pre-stable).
+local function test_sync_moved_to_fs()
+  assert((cfd as {string: any}).sync == nil, "fd.sync should be gone")
+  local fs_sync = (fs as {string: any}).sync
+  assert(type(fs_sync) == "function", "fs.sync should exist");
+  (fs_sync as function())()
+end
+test_sync_moved_to_fs()

--- a/lib/cosmic/fs/init.tl
+++ b/lib/cosmic/fs/init.tl
@@ -280,6 +280,10 @@ local record FsModule
   statfs: function(path: string): Statfs | nil, string
   fstatfs: function(fd: number): Statfs | nil, string
 
+  -- Flush all filesystem buffers to disk, system-wide (sync(2)).
+  -- Per-file flushing is Handle:sync()/Handle:datasync() in cosmic.fd.
+  sync: function()
+
   -- Device number utilities
   major: function(dev: number): number
   minor: function(dev: number): number
@@ -369,6 +373,7 @@ local M: FsModule = {
   -- Filesystem statistics (re-exported from fs_ops)
   statfs = fs_ops.statfs,
   fstatfs = fs_ops.fstatfs,
+  sync = fs_ops.sync,
 
   -- Device number utilities (re-exported from fs_ops)
   major = fs_ops.major,

--- a/lib/cosmic/fs/ops.tl
+++ b/lib/cosmic/fs/ops.tl
@@ -338,6 +338,13 @@ local function fstatfs(fd: number): Statfs | nil, string
   return info as Statfs
 end
 
+--- Flush all filesystem buffers to disk, system-wide (sync(2)).
+--- Infallible: the syscall reports nothing. For a single file use
+--- Handle:sync()/Handle:datasync() from cosmic.fd.
+local function sync()
+  unix.sync()
+end
+
 -- Device number utilities
 
 --- Extract major device number from a device ID.
@@ -375,6 +382,7 @@ local record FsOpsModule
   tmpfd: function(): number | nil, string
   statfs: function(path: string): Statfs | nil, string
   fstatfs: function(fd: number): Statfs | nil, string
+  sync: function()
   major: function(dev: number): number
   minor: function(dev: number): number
   F_OK: number
@@ -404,6 +412,7 @@ local M: FsOpsModule = {
   tmpfd = tmpfd,
   statfs = statfs,
   fstatfs = fstatfs,
+  sync = sync,
   major = major,
   minor = minor,
   F_OK = unix.F_OK,


### PR DESCRIPTION
Implements #560 (follow-up to #532 / #555). Three contract fixes on `cosmic.fd`, breaking, batched as the issue asks.

## 1. `Handle:read()` returns nil on EOF, never `""`

`read()` returned `""` on EOF (`return data or ""`), conflating EOF with an empty read and inverting Lua convention. Now the honest shape:

- `string` — data read
- `nil` + no error — EOF (`while true do local chunk = h:read(n); if not chunk then break end ... end`)
- `nil` + error — failure, **including EAGAIN** on a nonblocking fd with no data (pinned by a test so it never silently becomes "EOF")

Swept the in-repo consumers: no read loop actually relied on `""`-EOF — the `child_io` pump consumes the raw `unix.read` binding (whose semantics are unchanged), and the fd/pipe tests read exact content — so the sweep is the new pins in `fd_read_test.tl`.

## 2. `fd.sync()` → `fs.sync()`

`fd.sync()` was the system-wide `sync(2)` — not an operation on a Handle or fd. It now lives at `fs.sync()` (in `fs/ops.tl`, infallible: the syscall reports nothing); deleted from fd with no alias, pre-stable. Per-file flushing stays `Handle:sync()`/`Handle:datasync()`.

## 3. EINTR posture documented

The `cosmic.fd` module header and the read/write/seek docs now state it: no automatic retry — when a signal interrupts the call it returns nil plus an EINTR-tagged error, and callers that install signal handlers detect it with `errno.name_of(err) == "EINTR"` and retry themselves. (The issue sketched `errno.is(eno, ...)`, but Handle methods return string errors with no numeric errno slot, so `errno.name_of` is the accurate hook.) Automatic retry is deferred to the signal-safety wave per the issue. The write doc also now notes short writes are possible.

## Tests (red first)

New `lib/cosmic/fd_read_test.tl` (own file — the additions pushed `fd_test.tl` past the 500-line cap):
- read to the end: final `read()` returns nil with no error (red today: `""`);
- first read of an empty file returns nil with no error (red today: `""`);
- a chunked read loop terminates on falsy chunk and reassembles the file;
- nonblocking pipe read with no data returns nil + error naming EAGAIN (pin);
- `fs.sync` exists and is callable; `fd.sync` is gone.

## Verification

- `bin/make ci` green (format + teal + test + example + lint).
- End-to-end smoke through the built binary: chunked read loop ends cleanly on nil, nonblocking read reports `read: EAGAIN: Resource temporarily unavailable`, `fs.sync()` callable, `fd.sync` is nil.

## Knock-on

None upstream — cosmic-layer only (no `cosmo.*` contract change, no `definitions.lua`/pin involvement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148XhzsQsRnLuBjAYTsYPeD

---
_Generated by [Claude Code](https://claude.ai/code/session_0148XhzsQsRnLuBjAYTsYPeD)_