### PR TITLE
fs ops and traps: copytree, tmpfile Handle, glob-only patterns, Dir d_type, access default

### DIFF
--- a/lib/cosmic/fd.tl
+++ b/lib/cosmic/fd.tl
@@ -231,7 +231,7 @@ local function pipe(flags?: number): Pipe | nil, string
 end
 
 --- Wrap an already-open raw file descriptor in a Handle.
---- Lets fds from fs.mkstemp()/fs.tmpfd() (or any other source) enter the
+--- Lets fds from fs.tmpfd() (or any other source) enter the
 --- Handle world: h:read()/h:write()/h:close(), plus automatic cleanup
 --- via the __close metamethod. The Handle takes ownership: closing it
 --- closes the fd.

--- a/lib/cosmic/fd_test.tl
+++ b/lib/cosmic/fd_test.tl
@@ -278,16 +278,16 @@ local function test_wrap_tmpfd()
 end
 test_wrap_tmpfd()
 
-local function test_wrap_mkstemp()
-  local rawfd, path = fs.mkstemp(fs.join(TEST_TMPDIR, "wrap_XXXXXX"))
-  assert(rawfd, "mkstemp should succeed")
-  local h = cfd.wrap(rawfd)
-  assert(h:write("via mkstemp"))
-  assert(h:close())
-  assert(fs.read(path) == "via mkstemp", "data lands in the mkstemp file")
+local function test_tmpfile_handle()
+  local h, path = fs.tmpfile(fs.join(TEST_TMPDIR, "wrap_XXXXXX"))
+  assert(h, "tmpfile should succeed")
+  local hh = h as cfd.Handle
+  assert(hh:write("via tmpfile"))
+  assert(hh:close())
+  assert(fs.read(path) == "via tmpfile", "data lands in the tmpfile")
   fs.unlink(path)
 end
-test_wrap_mkstemp()
+test_tmpfile_handle()
 
 local function test_open_error_names_path_and_errno()
   local _, err = cfd.open("/nonexistent/path/to/file.txt", cfd.O_RDONLY)

--- a/lib/cosmic/fs/init.tl
+++ b/lib/cosmic/fs/init.tl
@@ -15,10 +15,12 @@ local fs_path = require("cosmic.fs.path")
 -- Re-export file operations from fs_ops / fs_file submodules
 local fs_ops = require("cosmic.fs.ops")
 local fs_file = require("cosmic.fs.file")
+local cfd = require("cosmic.fd")
+local type Handle = cfd.Handle
 
 -- Raw Dir type from cosmo.unix
 local record RawDir
-  read: function(self: RawDir): string
+  read: function(self: RawDir): string, number
   close: function(self: RawDir)
   fd: function(self: RawDir): number
   rewind: function(self: RawDir)
@@ -30,7 +32,10 @@ local function make_dir(raw: RawDir): Dir
   local is_closed = false
 
   local dir: Dir = {
-    read = function(_self: Dir): string
+    -- The second return is the dirent d_type (fs.DT_DIR / DT_REG /
+    -- DT_LNK / ... / DT_UNKNOWN) where the filesystem supports it,
+    -- so "is this entry a directory" needs no stat(2) call.
+    read = function(_self: Dir): string, number
       if is_closed then return nil end
       return raw:read()
     end,
@@ -202,6 +207,9 @@ end
 -- Re-export walk functions from fs_walk submodule
 local fs_walk = require("cosmic.fs.walk")
 
+-- Recursive tree operations
+local fs_tree = require("cosmic.fs.tree")
+
 --- Iterator over file paths, as returned by files().
 local type FileIter = fs_walk.FileIter
 
@@ -261,9 +269,10 @@ local record FsModule
   readlink: function(path: string): string | nil, string
   realpath: function(path: string): string | nil, string
   rmrf: function(path: string): boolean, string
+  copytree: function(src: string, dst: string): boolean, string
 
   -- Permission operations
-  access: function(path: string, mode: number): boolean
+  access: function(path: string, mode?: number): boolean
   chmod: function(path: string, mode: number): boolean, string
   chown: function(path: string, uid: number, gid: number): boolean, string
 
@@ -273,7 +282,7 @@ local record FsModule
 
   -- Temporary file operations
   mkdtemp: function(template: string): string | nil, string
-  mkstemp: function(template: string): number | nil, string, string
+  tmpfile: function(template?: string): Handle | nil, string, string
   tmpfd: function(): number | nil, string
 
   -- Filesystem statistics
@@ -298,7 +307,9 @@ local record FsModule
   -- Root open failure returns nil, err; subtree failures return the first
   -- error alongside the results.
   walk: function < T > (dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T): T | nil, string
+  -- collect's pattern is ALWAYS a glob; collect_matching takes a Lua pattern.
   collect: function(dir: string, pattern: string): {string} | nil, string
+  collect_matching: function(dir: string, lua_pattern: string): {string} | nil, string
   collect_all: function(dir: string): {string: FileInfo} | nil, string
   files: function(dir: string, pattern?: string): FileIter | nil, string, any, any
 
@@ -307,6 +318,16 @@ local record FsModule
   R_OK: number
   W_OK: number
   X_OK: number
+
+  -- Dirent d_type constants, as returned by Dir:read()'s second value
+  DT_BLK: number
+  DT_CHR: number
+  DT_DIR: number
+  DT_FIFO: number
+  DT_LNK: number
+  DT_REG: number
+  DT_SOCK: number
+  DT_UNKNOWN: number
 end
 
 local M: FsModule = {
@@ -355,6 +376,7 @@ local M: FsModule = {
   readlink = fs_ops.readlink,
   realpath = fs_ops.realpath,
   rmrf = fs_ops.rmrf,
+  copytree = fs_tree.copytree,
 
   -- Permission operations (re-exported from fs_ops)
   access = fs_ops.access,
@@ -367,7 +389,7 @@ local M: FsModule = {
 
   -- Temporary file operations (re-exported from fs_ops)
   mkdtemp = fs_ops.mkdtemp,
-  mkstemp = fs_ops.mkstemp,
+  tmpfile = fs_ops.tmpfile,
   tmpfd = fs_ops.tmpfd,
 
   -- Filesystem statistics (re-exported from fs_ops)
@@ -382,6 +404,7 @@ local M: FsModule = {
   -- Directory walking
   walk = fs_walk.walk,
   collect = fs_walk.collect,
+  collect_matching = fs_walk.collect_matching,
   collect_all = fs_walk.collect_all,
   files = fs_walk.files,
 
@@ -390,6 +413,15 @@ local M: FsModule = {
   R_OK = fs_ops.R_OK,
   W_OK = fs_ops.W_OK,
   X_OK = fs_ops.X_OK,
+
+  DT_BLK = unix.DT_BLK,
+  DT_CHR = unix.DT_CHR,
+  DT_DIR = unix.DT_DIR,
+  DT_FIFO = unix.DT_FIFO,
+  DT_LNK = unix.DT_LNK,
+  DT_REG = unix.DT_REG,
+  DT_SOCK = unix.DT_SOCK,
+  DT_UNKNOWN = unix.DT_UNKNOWN,
 }
 
 return M

--- a/lib/cosmic/fs/init_test.tl
+++ b/lib/cosmic/fs/init_test.tl
@@ -1,5 +1,6 @@
 #!/usr/bin/env cosmic
 local fs = require("cosmic.fs")
+local cfd = require("cosmic.fd")
 local fs_types = require("cosmic.fs.types")
 local unix = require("cosmo.unix")
 
@@ -421,20 +422,21 @@ local function test_mkdtemp()
 end
 test_mkdtemp()
 
-local function test_mkstemp()
-  local fd, result = fs.mkstemp("/tmp/fs_test_XXXXXX")
-  assert(fd, "mkstemp should succeed: " .. (result or ""))
+local function test_tmpfile()
+  local h, result = fs.tmpfile("/tmp/fs_test_XXXXXX")
+  assert(h, "tmpfile should succeed: " .. (result or ""))
 
   local filepath = result
   assert(filepath:match("^/tmp/fs_test_"), "expected /tmp/fs_test_ prefix")
 
-  local st = fs.fstat(fd)
+  local hh = h as cfd.Handle
+  local st = fs.fstat(hh:fd())
   assert(st, "fstat should succeed")
 
-  unix.close(fd)
+  hh:close()
   fs.unlink(filepath)
 end
-test_mkstemp()
+test_tmpfile()
 
 local function test_tmpfd()
   local fd, err = fs.tmpfd()

--- a/lib/cosmic/fs/ops.tl
+++ b/lib/cosmic/fs/ops.tl
@@ -1,10 +1,12 @@
 --- Filesystem file operations, permissions, timestamps, and temp files.
 --- Internal submodule used by cosmic.fs.
 local unix = require("cosmo.unix")
+local cfd = require("cosmic.fd")
 local types = require("cosmic.fs.types")
 local errno = require("cosmic.errno")
 local errstr = errno.str
 local Statfs = types.Statfs
+local type Handle = cfd.Handle
 
 -- File operations
 
@@ -204,10 +206,11 @@ end
 
 --- Check if the current process has access to a file.
 --- @param path string Path to check
---- @param mode number Access mode: F_OK (exists), R_OK, W_OK, X_OK
+--- @param mode number Access mode: F_OK (exists, the default), R_OK, W_OK, X_OK
 --- @return boolean True if access is allowed
-local function access(path: string, mode: number): boolean
-  return (unix.access(path, mode))
+local function access(path: string, mode?: number): boolean
+  -- The binding returns true or nil, err; callers get an honest boolean.
+  return unix.access(path, mode or unix.F_OK) == true
 end
 
 --- Change file permissions.
@@ -285,20 +288,24 @@ local function mkdtemp(template: string): string | nil, string
   return path
 end
 
---- Create a temporary file.
+--- Create a temporary file, returning an open fd.Handle plus its path.
+--- The Handle owns the descriptor (h:close() releases it); the file is
+--- NOT unlinked automatically — remove the path when done. For an
+--- anonymous descriptor with no path, use tmpfd() + fd.wrap().
 --- The second return is always the path (nil on failure); the error, if
 --- any, is always in the third slot.
---- @param template string Path template ending in XXXXXX
---- @return number | nil File descriptor, or nil on error
+--- @param template string Path template ending in XXXXXX (default: $TMPDIR/cosmic_XXXXXX)
+--- @return Handle | nil Open handle to the created file, or nil on error
 --- @return string Path to the created file, or nil on error
 --- @return string Error message if failed
-local function mkstemp(template: string): number | nil, string, string
+local function tmpfile(template?: string): Handle | nil, string, string
+  template = template or ((os.getenv("TMPDIR") or "/tmp") .. "/cosmic_XXXXXX")
   -- The binding returns (fd, path) on success and (nil, Errno) on failure.
   local fd, path = unix.mkstemp(template)
   if not fd then
-    return nil, nil, errstr(path as any, "mkstemp: " .. template)
+    return nil, nil, errstr(path as any, "tmpfile: " .. template)
   end
-  return fd, path
+  return cfd.wrap(fd), path
 end
 
 --- Create a temporary file descriptor.
@@ -372,13 +379,13 @@ local record FsOpsModule
   readlink: function(path: string): string | nil, string
   realpath: function(path: string): string | nil, string
   rmrf: function(path: string): boolean, string
-  access: function(path: string, mode: number): boolean
+  access: function(path: string, mode?: number): boolean
   chmod: function(path: string, mode: number): boolean, string
   chown: function(path: string, uid: number, gid: number): boolean, string
   utimensat: function(path: string, atime_secs: number, atime_nsecs: number, mtime_secs: number, mtime_nsecs: number): boolean, string
   futimens: function(fd: number, atime_secs: number, atime_nsecs: number, mtime_secs: number, mtime_nsecs: number): boolean, string
   mkdtemp: function(template: string): string | nil, string
-  mkstemp: function(template: string): number | nil, string, string
+  tmpfile: function(template?: string): Handle | nil, string, string
   tmpfd: function(): number | nil, string
   statfs: function(path: string): Statfs | nil, string
   fstatfs: function(fd: number): Statfs | nil, string
@@ -408,7 +415,7 @@ local M: FsOpsModule = {
   utimensat = utimensat,
   futimens = futimens,
   mkdtemp = mkdtemp,
-  mkstemp = mkstemp,
+  tmpfile = tmpfile,
   tmpfd = tmpfd,
   statfs = statfs,
   fstatfs = fstatfs,

--- a/lib/cosmic/fs/ops_test.tl
+++ b/lib/cosmic/fs/ops_test.tl
@@ -1,6 +1,7 @@
 #!/usr/bin/env cosmic
---- Tests for fs file operations: copy, move, touch, write_atomic, mkstemp.
+--- Tests for fs file operations: copy, move, touch, write_atomic, tmpfile.
 local fs = require("cosmic.fs")
+local cfd = require("cosmic.fd")
 local fs_types = require("cosmic.fs.types")
 
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
@@ -161,25 +162,26 @@ local function test_write_atomic_failure_keeps_original()
 end
 test_write_atomic_failure_keeps_original()
 
-local function test_mkstemp_success_contract()
+local function test_tmpfile_success_contract()
   local test_dir = setup()
-  local fd, path, err = fs.mkstemp(fs.join(test_dir, "fs_ops_XXXXXX"))
-  assert(fd, "mkstemp should succeed: " .. (err or ""))
+  local h, path, err = fs.tmpfile(fs.join(test_dir, "fs_ops_XXXXXX"))
+  assert(h, "tmpfile should succeed: " .. (err or ""))
   assert(path and path:match("fs_ops_"), "second return should be the path")
   assert(err == nil, "error slot should be nil on success")
-  local handle = fs.fstat(fd)
-  assert(handle, "fstat on mkstemp fd should succeed")
-  require("cosmo.unix").close(fd)
+  local hh = h as cfd.Handle
+  local st = fs.fstat(hh:fd())
+  assert(st, "fstat on tmpfile fd should succeed")
+  hh:close()
   teardown(test_dir)
 end
-test_mkstemp_success_contract()
+test_tmpfile_success_contract()
 
-local function test_mkstemp_failure_contract()
+local function test_tmpfile_failure_contract()
   -- The second return is always the path (nil on failure); the error is
   -- always in the third slot.
-  local fd, path, err = fs.mkstemp("/no/such/dir/fs_ops_XXXXXX")
-  assert(fd == nil, "mkstemp should fail in a missing directory")
+  local h, path, err = fs.tmpfile("/no/such/dir/fs_ops_XXXXXX")
+  assert(h == nil, "tmpfile should fail in a missing directory")
   assert(path == nil, "path slot must be nil on failure, got " .. tostring(path))
   assert(err and err:match("ENOENT"), "error should name ENOENT: " .. (err or ""))
 end
-test_mkstemp_failure_contract()
+test_tmpfile_failure_contract()

--- a/lib/cosmic/fs/path_test.tl
+++ b/lib/cosmic/fs/path_test.tl
@@ -133,7 +133,7 @@ test_collect_glob_escapes_brackets()
 
 local function test_collect_with_lua_pattern()
   local walk_dir = setup_walk()
-  local found = (fs.collect(walk_dir, "%.txt$") or {}) as {string}
+  local found = (fs.collect_matching(walk_dir, "%.txt$") or {}) as {string}
 
   assert(#found == 1, "expected 1 txt file, got " .. #found)
   assert(fs.basename(found[1]) == "file2.txt", "expected file2.txt")

--- a/lib/cosmic/fs/traps_test.tl
+++ b/lib/cosmic/fs/traps_test.tl
@@ -1,0 +1,175 @@
+#!/usr/bin/env cosmic
+--- Tests for the #559 fs batch: copytree, tmpfile, glob-only patterns,
+--- Dir:read d_type, access default. New/changed surfaces are reached via
+--- casts so this file typechecks red (pre-change) and green alike.
+local fs = require("cosmic.fs")
+local fs_types = require("cosmic.fs.types")
+
+global TEST_TMPDIR: string
+
+local fsa = fs as {string: any}
+
+local function write_file(path: string, content: string, mode?: number)
+  assert(fs.write(path, content, mode))
+end
+
+-- 1. copytree: nested dirs, exec-bit file, symlinks recreated (never
+-- followed — same cycle policy as walk).
+local function test_copytree()
+  local base = fs.join(TEST_TMPDIR, "ct")
+  fs.rmrf(base)
+  local src = fs.join(base, "src")
+  assert(fs.makedirs(fs.join(src, "sub")))
+  write_file(fs.join(src, "a.txt"), "alpha", tonumber("755", 8))
+  write_file(fs.join(src, "sub", "b.txt"), "beta")
+  assert(fs.symlink("a.txt", fs.join(src, "link")))
+  -- symlink cycle: sub/loop -> .. must be recreated, not descended into
+  assert(fs.symlink("..", fs.join(src, "sub", "loop")))
+
+  local copytree = fsa.copytree as function(string, string): boolean, string
+  assert(copytree, "fs.copytree should exist")
+  local dst = fs.join(base, "dst")
+  local ok, err = copytree(src, dst)
+  assert(ok, "copytree failed: " .. tostring(err))
+
+  assert(fs.read(fs.join(dst, "a.txt")) == "alpha", "file content copied")
+  assert(fs.read(fs.join(dst, "sub", "b.txt")) == "beta", "nested content copied")
+  local st = assert(fs.stat(fs.join(dst, "a.txt"))) as fs_types.Stat
+  assert((st:mode() & tonumber("777", 8)) == tonumber("755", 8),
+    "exec bit preserved")
+  assert(fs.islink(fs.join(dst, "link")), "symlink recreated as symlink")
+  assert(fs.readlink(fs.join(dst, "link")) == "a.txt", "symlink target preserved")
+  assert(fs.islink(fs.join(dst, "sub", "loop")), "cycle symlink recreated")
+  assert(not fs.isdir(fs.join(dst, "sub", "loop", "dst")) or true,
+    "loop is a symlink, so no infinite copy happened (we finished)")
+  fs.rmrf(base)
+end
+test_copytree()
+
+local function test_copytree_missing_src_errors()
+  local copytree = fsa.copytree as function(string, string): boolean, string
+  local ok, err = copytree(fs.join(TEST_TMPDIR, "nope"), fs.join(TEST_TMPDIR, "out"))
+  assert(ok == false, "copytree of missing src must fail")
+  assert(err and err:match("ENOENT"), "error names ENOENT: " .. tostring(err))
+end
+test_copytree_missing_src_errors()
+
+-- 2. tmpfile: Handle + path on the happy path; fs.mkstemp is gone.
+local function test_tmpfile_handle_and_path()
+  local tmpfile = fsa.tmpfile as function(string): any, string, string
+  assert(tmpfile, "fs.tmpfile should exist")
+  local h, path, err = tmpfile(fs.join(TEST_TMPDIR, "traps_XXXXXX"))
+  assert(h, "tmpfile failed: " .. tostring(err))
+  local hh = h as {string: any}
+  assert((hh.write as function(any, string): number, string)(h, "via handle"))
+  assert((hh.close as function(any): boolean, string)(h))
+  assert(fs.read(path) == "via handle", "fs.read sees what the Handle wrote")
+  fs.unlink(path)
+end
+test_tmpfile_handle_and_path()
+
+local function test_tmpfile_default_template()
+  local tmpfile = fsa.tmpfile as function(): any, string, string
+  local h, path = tmpfile()
+  assert(h, "tmpfile() with no template should create somewhere sane")
+  local hh = h as {string: any}
+  assert((hh.close as function(any): boolean, string)(h))
+  assert(fs.isfile(path), "returned path exists")
+  fs.unlink(path)
+end
+test_tmpfile_default_template()
+
+local function test_mkstemp_is_gone()
+  assert(fsa.mkstemp == nil, "fs.mkstemp should be dropped in favor of tmpfile")
+  assert(type(fsa.tmpfd) == "function", "fs.tmpfd stays for raw-fd use")
+end
+test_mkstemp_is_gone()
+
+-- 3. patterns: the plain argument is ALWAYS a glob; Lua patterns move to
+-- collect_matching. No more contains-*-or-? guessing.
+local function test_collect_pattern_is_always_glob()
+  local dir = fs.join(TEST_TMPDIR, "globonly")
+  assert(fs.makedirs(dir))
+  write_file(fs.join(dir, "x.txt"), "x")
+  write_file(fs.join(dir, "%.txt$"), "literal")
+
+  -- Under the old heuristic "%.txt$" had no * or ?, so it silently ran as
+  -- a Lua pattern and matched x.txt. As a glob it matches only the file
+  -- literally named "%.txt$".
+  local hits = (fs.collect(dir, "%.txt$") or {}) as {string}
+  assert(#hits == 1, "glob should match exactly the literal file, got " .. #hits)
+  assert(fs.basename(hits[1]) == "%.txt$", "literal-name match")
+  fs.rmrf(dir)
+end
+test_collect_pattern_is_always_glob()
+
+local function test_collect_matching_takes_lua_patterns()
+  local dir = fs.join(TEST_TMPDIR, "luapat")
+  assert(fs.makedirs(dir))
+  write_file(fs.join(dir, "x.txt"), "x")
+  write_file(fs.join(dir, "y.lua"), "y")
+
+  local collect_matching = fsa.collect_matching as function(string, string): {string} | nil, string
+  assert(collect_matching, "fs.collect_matching should exist")
+  local hits = (collect_matching(dir, "%.txt$") or {}) as {string}
+  assert(#hits == 1 and fs.basename(hits[1]) == "x.txt",
+    "Lua pattern matches via collect_matching")
+  fs.rmrf(dir)
+end
+test_collect_matching_takes_lua_patterns()
+
+local function test_files_pattern_is_always_glob()
+  local dir = fs.join(TEST_TMPDIR, "globfiles")
+  assert(fs.makedirs(dir))
+  write_file(fs.join(dir, "foo.lua"), "1")
+  write_file(fs.join(dir, "foo1.lua"), "2")
+
+  -- "foo?.lua" is a glob: ? is exactly one character.
+  local seen: {string: boolean} = {}
+  for p in assert(fs.files(dir, "foo?.lua")) as fs.FileIter do
+    seen[fs.basename(p)] = true
+  end
+  assert(seen["foo1.lua"], "glob ? matches one char")
+  assert(not seen["foo.lua"], "glob ? must not match zero chars")
+  fs.rmrf(dir)
+end
+test_files_pattern_is_always_glob()
+
+-- 4. Dir:read exposes the dirent d_type; DT_* constants live on fs.
+local function test_dir_read_returns_d_type()
+  local dir = fs.join(TEST_TMPDIR, "dtype")
+  assert(fs.makedirs(fs.join(dir, "subdir")))
+  write_file(fs.join(dir, "plain.txt"), "p")
+
+  assert(fsa.DT_DIR ~= nil, "fs.DT_DIR should be exported")
+  assert(fsa.DT_REG ~= nil, "fs.DT_REG should be exported")
+  local d = assert(fs.opendir(dir))
+  local dd = d as {string: any}
+  local read = dd.read as function(any): string, number
+  local close = dd.close as function(any)
+  local kinds: {string: number} = {}
+  while true do
+    local name, kind = read(d)
+    if not name then break end
+    kinds[name] = kind
+  end
+  close(d)
+  assert(kinds["subdir"] == fsa.DT_DIR as number,
+    "Dir:read must report DT_DIR for a subdir, got " .. tostring(kinds["subdir"]))
+  assert(kinds["plain.txt"] == fsa.DT_REG as number,
+    "Dir:read must report DT_REG for a file, got " .. tostring(kinds["plain.txt"]))
+  fs.rmrf(dir)
+end
+test_dir_read_returns_d_type()
+
+-- 5. access defaults to F_OK.
+local function test_access_defaults_to_exists()
+  local path = fs.join(TEST_TMPDIR, "acc.txt")
+  write_file(path, "here")
+  local access = fsa.access as function(string): boolean
+  assert(access(path) == true, "access(path) with no mode means exists")
+  assert(access(fs.join(TEST_TMPDIR, "missing.txt")) == false,
+    "access on a missing path is false")
+  fs.unlink(path)
+end
+test_access_defaults_to_exists()

--- a/lib/cosmic/fs/tree.tl
+++ b/lib/cosmic/fs/tree.tl
@@ -1,0 +1,107 @@
+--- Recursive directory-tree operations.
+--- Internal submodule used by cosmic.fs.
+local unix = require("cosmo.unix")
+local cosmo_path = require("cosmo.path")
+local errstr = require("cosmic.errno").str
+local fs_ops = require("cosmic.fs.ops")
+
+--- Handle for reading directory entries (internal).
+local record TreeDirHandle
+  read: function(self): string, number
+  close: function(self)
+end
+
+local copytree_into: function(string, string): boolean, string
+
+--- Copy one directory level: entries are dispatched by lstat kind so a
+--- symlink is recreated (readlink + symlink), never followed — the same
+--- cycle policy as walk. Regular files go through fs_ops.copy, which
+--- preserves permission bits. Other kinds (fifos, sockets, devices) are
+--- not portably copyable and are skipped.
+local function copy_entries(src: string, dst: string): boolean, string
+  local handle, oerr = unix.opendir(src)
+  if not handle then
+    return false, errstr(oerr, "copytree: opendir: " .. src)
+  end
+  local h = handle as TreeDirHandle
+  while true do
+    local entry = h:read()
+    if not entry then break end
+    if entry ~= "." and entry ~= ".." then
+      local s = cosmo_path.join(src, entry)
+      local d = cosmo_path.join(dst, entry)
+      local st, serr = unix.stat(s, unix.AT_SYMLINK_NOFOLLOW)
+      if not st then
+        h:close()
+        return false, errstr(serr, "copytree: stat: " .. s)
+      end
+      local mode = st:mode()
+      if unix.S_ISLNK(mode) then
+        local target, rerr = unix.readlink(s)
+        if not target then
+          h:close()
+          return false, errstr(rerr, "copytree: readlink: " .. s)
+        end
+        local ok, lerr = unix.symlink(target, d)
+        if not ok then
+          h:close()
+          return false, errstr(lerr, "copytree: symlink: " .. d)
+        end
+      elseif unix.S_ISDIR(mode) then
+        local ok, cerr = copytree_into(s, d)
+        if not ok then
+          h:close()
+          return false, cerr
+        end
+      elseif unix.S_ISREG(mode) then
+        local ok, cerr = fs_ops.copy(s, d)
+        if not ok then
+          h:close()
+          return false, cerr
+        end
+      end
+    end
+  end
+  h:close()
+  return true
+end
+
+copytree_into = function(src: string, dst: string): boolean, string
+  local st, serr = unix.stat(src, unix.AT_SYMLINK_NOFOLLOW)
+  if not st then
+    return false, errstr(serr, "copytree: stat: " .. src)
+  end
+  if not unix.S_ISDIR(st:mode()) then
+    return false, "copytree: not a directory: " .. src
+  end
+  local ok, merr = unix.makedirs(dst, st:mode() & tonumber("777", 8))
+  if not ok then
+    return false, errstr(merr, "copytree: makedirs: " .. dst)
+  end
+  return copy_entries(src, dst)
+end
+
+--- Recursively copy a directory tree, preserving permission bits.
+--- Symlinks are recreated verbatim (readlink + symlink) and never
+--- followed — the same cycle policy as walk, so symlink loops cannot
+--- cause infinite copies, and a symlinked directory arrives as a
+--- symlink, not a second copy of its target. Fifos, sockets, and
+--- device nodes are skipped. Destination directories are created as
+--- needed; existing destination files are overwritten.
+--- @param src string The directory to copy
+--- @param dst string The destination directory (created if missing)
+--- @return boolean True on success
+--- @return string Error message on the first failure
+local function copytree(src: string, dst: string): boolean, string
+  return copytree_into(src, dst)
+end
+
+local record FsTreeModule
+  copytree: function(src: string, dst: string): boolean, string
+end
+
+local M: FsTreeModule = {
+  copytree = copytree,
+}
+
+return M

--- a/lib/cosmic/fs/types.tl
+++ b/lib/cosmic/fs/types.tl
@@ -80,8 +80,11 @@ local record fs_types
   --- Handle for reading directory entries.
   --- Supports automatic cleanup with `<close>` attribute.
   record Dir
-    --- Reads next directory entry. Returns nil when done.
-    read: function(self: Dir): string
+    --- Reads next directory entry. Returns nil when done. The second
+    --- return is the dirent d_type (fs.DT_DIR / DT_REG / DT_LNK / ... /
+    --- DT_UNKNOWN where the filesystem does not expose it), so callers
+    --- can classify entries without a stat(2) per entry.
+    read: function(self: Dir): string, number
     --- Closes directory handle.
     close: function(self: Dir)
     --- Returns file descriptor for this directory.

--- a/lib/cosmic/fs/walk.tl
+++ b/lib/cosmic/fs/walk.tl
@@ -121,7 +121,8 @@ local function walk < T > (dir: string, visitor: function(string, string, WalkSt
 end
 
 --- Convert a glob pattern to a Lua pattern.
---- Supports * (any chars), ? (single char), and character classes [abc].
+--- Supports * (any run) and ? (one char); every other character —
+--- including [ ] brackets and Lua-pattern magic like % — is literal.
 --- @param glob string The glob pattern
 --- @return string The equivalent Lua pattern
 local function glob_to_pattern(glob: string): string
@@ -135,26 +136,9 @@ local function glob_to_pattern(glob: string): string
   return "^" .. pattern .. "$"
 end
 
---- Collect file paths matching a pattern.
---- Recursively walks directory tree and returns matching file paths.
---- If the root directory cannot be opened, returns nil plus the error.
---- Failures below the root do not stop the collection; the first such
---- error is returned alongside the results.
---- @param dir string The directory to search
---- @param pattern string Glob pattern (*.lua) or Lua pattern (%.lua$)
---- @return {string} | nil List of matching paths, or nil if the root failed
---- @return string First error encountered, if any
-local function collect(dir: string, pattern: string): {string} | nil, string
-  -- Detect if it's a glob or Lua pattern
-  -- Globs use * and ?, Lua patterns use % for escaping
-  local is_glob = pattern:find("*", 1, true) or pattern:find("?", 1, true)
-  local lua_pattern: string
-  if is_glob then
-    lua_pattern = glob_to_pattern(pattern)
-  else
-    lua_pattern = pattern
-  end
-
+--- Shared body of collect/collect_matching: walk the tree gathering
+--- files whose basename matches the given Lua pattern.
+local function collect_by_pattern(dir: string, lua_pattern: string): {string} | nil, string
   local results: {string} = {}
   local ctx, err = walk(dir, function(full_path: string, entry: string, st: WalkStat, acc: {string})
       if not st:is_dir() and entry:match(lua_pattern) then
@@ -165,6 +149,33 @@ local function collect(dir: string, pattern: string): {string} | nil, string
     return nil, err
   end
   return results, err
+end
+
+--- Collect file paths matching a glob.
+--- The pattern is ALWAYS a glob (`*` any run, `?` one char); other
+--- characters — including brackets and Lua-pattern magic like `%` —
+--- match literally. For Lua patterns use collect_matching().
+--- Recursively walks the directory tree and returns matching file paths.
+--- If the root directory cannot be opened, returns nil plus the error.
+--- Failures below the root do not stop the collection; the first such
+--- error is returned alongside the results.
+--- @param dir string The directory to search
+--- @param pattern string Glob pattern (*.lua)
+--- @return {string} | nil List of matching paths, or nil if the root failed
+--- @return string First error encountered, if any
+local function collect(dir: string, pattern: string): {string} | nil, string
+  return collect_by_pattern(dir, glob_to_pattern(pattern))
+end
+
+--- Collect file paths whose basename matches a Lua pattern (%.lua$).
+--- The explicit Lua-pattern sibling of collect(); the two are never
+--- guessed apart from the pattern's contents.
+--- @param dir string The directory to search
+--- @param lua_pattern string Lua pattern matched against each basename
+--- @return {string} | nil List of matching paths, or nil if the root failed
+--- @return string First error encountered, if any
+local function collect_matching(dir: string, lua_pattern: string): {string} | nil, string
+  return collect_by_pattern(dir, lua_pattern)
 end
 
 --- Recursively collect all files with their Unix permissions.
@@ -256,14 +267,8 @@ local type FileIter = function(): string
   local function files(dir: string, pattern?: string): FileIter | nil, string, any, any
     pattern = pattern or "*"
 
-    -- Detect if it's a glob or Lua pattern
-    local is_glob = pattern:find("*", 1, true) or pattern:find("?", 1, true)
-    local lua_pattern: string
-    if is_glob then
-      lua_pattern = glob_to_pattern(pattern)
-    else
-      lua_pattern = pattern
-    end
+    -- The pattern is always a glob (see collect); no heuristics.
+    local lua_pattern = glob_to_pattern(pattern)
 
     -- Stack of (dir, handle) for depth-first traversal
     local stack: {{string, WalkDirHandle}} = {}
@@ -341,6 +346,7 @@ local type FileIter = function(): string
     --- The visitor may return "skip" (don't descend) or "stop" (end the walk).
     walk: function < T > (dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T): T | nil, string
     collect: function(dir: string, pattern: string): {string} | nil, string
+    collect_matching: function(dir: string, lua_pattern: string): {string} | nil, string
     collect_all: function(dir: string): {string: FileInfo} | nil, string
     files: function(dir: string, pattern?: string): FileIter | nil, string, any, any
   end
@@ -348,6 +354,7 @@ local type FileIter = function(): string
   local M: FsWalkModule = {
     walk = walk,
     collect = collect,
+    collect_matching = collect_matching,
     collect_all = collect_all,
     files = files,
   }


### PR DESCRIPTION
Implements #559 (follow-up to #532 / #555). Five small fs ergonomics fixes, batched to rebase once.

## 1. `fs.copytree(src, dst)`

New `fs/tree.tl` shard: recursive copy preserving permission bits. The symlink decision the issue asked for: **symlinks are recreated verbatim** (`readlink` + `symlink`) and never followed — the same cycle policy as walk, so symlink loops cannot cause infinite copies and a symlinked directory arrives as a symlink, not a second copy of its target. Fifos/sockets/devices are skipped (not portably copyable); regular files go through `fs.copy` (mode-preserving). Documented on the function.

## 2. `fs.tmpfile(template?)` replaces `fs.mkstemp`

`tmpfile` is mkstemp returning an open `fd.Handle` plus the path — nothing on the happy path forces raw integer fds. The template defaults to `$TMPDIR/cosmic_XXXXXX`; the failure contract keeps mkstemp's shape (path always second, error always third). The mkstemp-or-not decision: **`fs.mkstemp` is deleted** — its only in-repo consumers were tests (production code uses the raw `unix.mkstemp` binding, which is unaffected), and `fs.tmpfd` stays for the anonymous-fd case, so the raw-fd capability isn't lost.

## 3. Patterns are always globs; `collect_matching` takes Lua patterns

The contains-`*`-or-`?` heuristic is dead: `collect`/`files` patterns are **always globs** (`*` any run, `?` one char, everything else — including `%` and brackets — literal, matching the existing bracket-literal pin). Lua-pattern matching moves to the explicit sibling `fs.collect_matching(dir, lua_pattern)`; both share one walk body. The in-repo `%.txt$` caller in `path_test` moved to `collect_matching`; all production callers were already globs. (Also fixed `glob_to_pattern`'s doc comment, which claimed `[abc]` classes the implementation has always escaped.)

## 4. `Dir:read()` exposes the dirent d_type

The public `fs.opendir` wrapper now passes through the second return the internal walkers already used: `read(): string, number` with the kind as `fs.DT_DIR` / `DT_REG` / `DT_LNK` / … / `DT_UNKNOWN`, and fs re-exports the eight `DT_*` constants — "is this entry a directory" no longer costs a stat(2) per entry.

## 5. `fs.access(path)` defaults to `F_OK`

The common existence check needs no constant. Bonus honesty fix found by the new test: the binding returns `nil, err` on failure, which the old wrapper leaked through as `nil` despite its declared `boolean` return — it now returns a real `false`.

## Tests (red first)

New `lib/cosmic/fs/traps_test.tl` with the issue's TDD list: copytree fixture with nested dirs, an exec-bit file, a relative symlink, and a symlink cycle (layout + modes + link targets + termination asserted); tmpfile writes through the Handle and `fs.read(path)` sees it (default and explicit templates); `fs.mkstemp` gone / `fs.tmpfd` stays; the glob-only pin (a literal `%.txt$` file matches the glob, `x.txt` doesn't; `foo?.lua` matches exactly one char) plus the `collect_matching` sibling; `Dir:read` returns `DT_DIR` for a subdir and `DT_REG` for a file; `access(path)` with no mode. The mkstemp tests in `fd_test`/`init_test`/`ops_test` are rewritten onto `tmpfile`.

## Verification

- `bin/make ci` fully green: format 244, teal 244, test 112/112, example 19, lint 308.
- End-to-end smoke through the built binary: copytree layout + symlink, tmpfile round-trip at the default location, glob vs `collect_matching`, `DT_DIR` from `Dir:read`, `access` default true/false.

## Knock-on

None upstream — cosmic-layer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148XhzsQsRnLuBjAYTsYPeD

---
_Generated by [Claude Code](https://claude.ai/code/session_0148XhzsQsRnLuBjAYTsYPeD)_