### PR TITLE
public-list capstone: make goes internal; example-per-module ratchet

### DIFF
--- a/lib/cosmic/example_coverage_test.tl
+++ b/lib/cosmic/example_coverage_test.tl
@@ -1,0 +1,128 @@
+#!/usr/bin/env cosmic
+--- Example-per-public-module ratchet (issue #566): every public module
+--- ships a runnable *_example.tl. Modules that predate the ratchet live
+--- on the shrink-only allowlist below; #509 tracks burning it down.
+---
+--- The ratchet has three teeth:
+--- - a public module neither exampled nor allowlisted fails (a NEW
+---   public module cannot ship without an example);
+--- - an allowlist entry that HAS gained an example fails (delete the
+---   entry — the list may only shrink);
+--- - an allowlist entry that is no longer public fails (demoted or
+---   renamed modules must leave the list).
+---
+--- Coverage is read from the docs index embedded in the binary, which
+--- merges each X_example.tl into module X (and shard examples like
+--- quicksand/netns_example.tl into cosmic.<name>.<shard>).
+local manifest = require("cosmic.public")
+local doc = require("cosmic.doc")
+local doc_types = require("cosmic.doc.types")
+
+-- Shrink only. Never add an entry; delete each one as #509 lands its
+-- example. (31 of 46 public modules at ratchet birth.)
+local MISSING_ALLOWED: {string} = {
+  "benchmark",
+  "check",
+  "codec",
+  "compress",
+  "doc",
+  "errno",
+  "example",
+  "fd",
+  "format",
+  "fuzzy",
+  "getopt",
+  "hash",
+  "html",
+  "ip",
+  "poll",
+  "proc",
+  "rand",
+  "re",
+  "shm",
+  "signal",
+  "sse",
+  "string",
+  "sys",
+  "syslog",
+  "teal",
+  "time",
+  "tty",
+  "url",
+  "user",
+  "uuid",
+  "zip",
+}
+
+local index, ierr = doc.embedded_index()
+assert(index, "docs index must be embedded (run via the binary): " .. tostring(ierr))
+local idx = index as doc_types.DocIndex
+
+--- True when the module (or any shard beneath it) carries examples in
+--- the embedded docs index.
+local function has_example(name: string): boolean
+  local entry = idx.modules["cosmic." .. name]
+  if entry and entry.examples and #entry.examples > 0 then
+    return true
+  end
+  local prefix = "cosmic." .. name .. "."
+  for mod_name, mod_doc in pairs(idx.modules) do
+    if mod_name:sub(1, #prefix) == prefix
+    and mod_doc.examples and #mod_doc.examples > 0 then
+      return true
+    end
+  end
+  return false
+end
+
+local allowed: {string: boolean} = {}
+for _, name in ipairs(MISSING_ALLOWED) do
+  assert(not allowed[name], "duplicate allowlist entry: " .. name)
+  allowed[name] = true
+end
+
+local function test_every_public_module_has_example_or_waiver()
+  local missing: {string} = {}
+  for _, name in ipairs(manifest.public) do
+    if not allowed[name] and not has_example(name) then
+      missing[#missing + 1] = name
+    end
+  end
+  table.sort(missing)
+  assert(#missing == 0,
+    "public modules without a *_example.tl (write one; the allowlist is "
+    .. "closed to new entries): " .. table.concat(missing, ", "))
+end
+test_every_public_module_has_example_or_waiver()
+
+local function test_allowlist_only_shrinks()
+  local stale: {string} = {}
+  for _, name in ipairs(MISSING_ALLOWED) do
+    if has_example(name) then
+      stale[#stale + 1] = name
+    end
+  end
+  table.sort(stale)
+  assert(#stale == 0,
+    "allowlist entries that now HAVE examples — delete them: "
+    .. table.concat(stale, ", "))
+end
+test_allowlist_only_shrinks()
+
+local function test_allowlist_entries_are_public()
+  local public_set: {string: boolean} = {}
+  for _, name in ipairs(manifest.public) do
+    public_set[name] = true
+  end
+  local gone: {string} = {}
+  for _, name in ipairs(MISSING_ALLOWED) do
+    if not public_set[name] then
+      gone[#gone + 1] = name
+    end
+  end
+  table.sort(gone)
+  assert(#gone == 0,
+    "allowlist entries that are not public modules — delete them: "
+    .. table.concat(gone, ", "))
+end
+test_allowlist_entries_are_public()

--- a/lib/cosmic/public.tl
+++ b/lib/cosmic/public.tl
@@ -39,7 +39,6 @@ local public: {string} = {
   "ip",
   "json",
   "landlock",
-  "make",
   "net",
   "pledge",
   "poll",
@@ -79,8 +78,20 @@ local public: {string} = {
 --- index generator) and the embedded-index query surface behind
 --- `--docs` (run/search/list_topics) are both `cosmic.doc`; two
 --- top-level modules one letter apart was itself the ergonomics bug.
+---
+--- #566 capstone decisions, recorded so they never re-open without new
+--- evidence: `make` is internal — its sole consumer is the `--make` CLI
+--- handler; it is project-scaffolding tooling, not runtime API
+--- (promoting internal→public later is cheap; the reverse is impossible
+--- after the stable cut). `envd` stays public (a runtime battery for
+--- user binaries: embedded env.d + envd.load(); zero in-repo consumers
+--- is its expected shape). `check` stays public (the assertion half of
+--- the shipped test battery alongside testrun/example/benchmark).
+--- `errno` stays public (the error convention's user-facing interface:
+--- wrappers document errno.is/errno.name_of by name).
 local internal: {string} = {
   "cli",
+  "make",
   "public",
   "require",
   "version",


### PR DESCRIPTION
Implements #566, the final pre-stable pass over the PUBLIC manifest. The full audit with per-entry evidence is [on the issue](https://github.com/whilp/cosmic/issues/566#issuecomment-4917743206); this PR is the approved outcome.

## Manifest: `make` → internal (47 → 46 public modules)

Its sole consumer is the `--make` CLI handler — project-scaffolding tooling, not runtime API. The CLI keeps working (the `cli` dispatcher is itself internal and internal modules stay embedded); `cosmic.make` leaves the `--docs` listing and the published site and its page now carries the internal badge. Promoting internal→public later stays cheap; the reverse becomes impossible at the stable cut.

`envd`, `check`, and `errno` stay public. All four decisions are recorded in `public.tl` next to the existing io/assert/string naming notes, so none re-opens without new evidence:
- **envd** — a runtime battery for user binaries (embedded env.d + `envd.load()`); zero in-repo consumers is its expected shape.
- **check** — the assertion half of the shipped test battery alongside `testrun`/`example`/`benchmark`.
- **errno** — the error convention's user-facing interface; public contracts document `errno.is`/`errno.name_of` by name.

## New `example_coverage_test.tl`: the example-per-public-module ratchet

Coverage is read from the docs index embedded in the binary — which merges `X_example.tl` into module X and shard examples (e.g. `quicksand/netns_example.tl`) into `cosmic.X.shard` — rather than globbing files, since example `.tl` sources aren't embedded. Three teeth:

1. a public module neither exampled nor allowlisted **fails** — a new public module cannot ship without an example;
2. an allowlist entry that gains an example **fails until deleted** — the 31-entry allowlist (exactly #509's §6.3 backlog) can only shrink;
3. an allowlist entry that leaves the public list **fails until removed** — demoted or renamed modules can't linger.

The index-based measure already earned its keep during development: it caught `testrun` carrying doc-comment examples that the file-glob audit had missed, via tooth 2.

## Verification

- `bin/make ci` fully green: format 245, teal 245, **test 113/113** (112 + the new ratchet), example 19, lint 310.
- Smoke through the built binary: `--docs` lists 46 topics; `--docs cosmic.make` renders with the internal-module header; `cosmic --make` still generates and executes a Makefile end-to-end.

## Knock-on

None upstream — manifest + one test, cosmic-layer only. #509 burns down the allowlist over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148XhzsQsRnLuBjAYTsYPeD

---
_Generated by [Claude Code](https://claude.ai/code/session_0148XhzsQsRnLuBjAYTsYPeD)_