### PR TITLE
lint: ban require("cosmo") in tests and examples

### DIFF
--- a/lib/build/lint.tl
+++ b/lib/build/lint.tl
@@ -139,6 +139,65 @@ local function check_call_after_define(file: string, lines: {string}): {Diagnost
   return diagnostics
 end
 
+--- Tests and examples must use cosmic.* wrappers, never raw cosmo.* bindings
+--- (AGENTS.md "cosmo vs cosmic"). These files are the enumerated exceptions
+--- from the July audit's §1.7 — each needs the raw layer for a reason the
+--- wrappers cannot provide. Additions here require the same justification.
+local COSMO_REQUIRE_ALLOWLIST < const >: {string: boolean} = {
+  -- fault injection: monkey-patches unix.fork, so it must share the exact
+  -- cosmo.unix module table that child.tl uses
+  ["lib/cosmic/child/init_test.tl"] = true,
+  -- fault injection via the shared cosmo.unix table, plus a heredoc child
+  -- payload that raises SIGKILL on itself
+  ["lib/cosmic/child/io_test.tl"] = true,
+  -- exercises the require machinery itself, including raw cosmo modules
+  ["lib/cosmic/require_test.tl"] = true,
+  -- raw-fd fixtures: sets up open file descriptors without going through
+  -- the fs module under test
+  ["lib/cosmic/fs/init_test.tl"] = true,
+  ["lib/cosmic/fs/dir_test.tl"] = true,
+  -- heredoc payload run inside a namespaced child process
+  ["lib/cosmic/quicksand/proc_test.tl"] = true,
+  -- heredoc payloads exercising the script runner / compiler on sources
+  -- that themselves use cosmo
+  ["lib/cosmic/script_test.tl"] = true,
+  ["lib/cosmic/compile_test.tl"] = true,
+  -- fixture strings in this file quote the forbidden pattern itself
+  ["lib/build/lint_test.tl"] = true,
+  -- third-party Teal compiler test scaffold
+  ["3p/tl/tl_test.tl"] = true,
+}
+
+--- Flag require("cosmo") / require("cosmo.<mod>") in test and example files.
+--- Only `cosmo` exactly or a `cosmo.` prefix counts — `cosmos`, `cosmic`,
+--- etc. are unrelated modules.
+local function check_cosmo_require(file: string, lines: {string}): {Diagnostic}
+  if not (file:match("_test%.tl$") or file:match("_example%.tl$")) then
+    return {}
+  end
+  if COSMO_REQUIRE_ALLOWLIST[file] then
+    return {}
+  end
+  local diagnostics: {Diagnostic} = {}
+  for i, line in ipairs(lines) do
+    local col = line:find("require%s*%(%s*[\"']cosmo[\"'%.]")
+    if col then
+      table.insert(diagnostics, {
+          file = file,
+          line = i,
+          col = col as integer,
+          rule = "cosmo-require",
+          message = string.format(
+            "%s:%d: require(\"cosmo...\") forbidden in tests/examples; "
+              .. "use cosmic.* wrappers",
+            file, i
+          ),
+        })
+    end
+  end
+  return diagnostics
+end
+
 --- Files exempt from lint: .d.tl type declaration files (they describe C
 --- binding interfaces and cannot be split due to Teal's record system).
 local function is_exempt(path: string): boolean
@@ -203,13 +262,28 @@ local function main(...: string): integer
 
   local all_diagnostics: {Diagnostic} = {}
   for _, file in ipairs(files) do
-    -- The standalone lint binary only enforces file-length (run on all tracked files).
-    -- Column-length and assert-order are enforced via --check-style on .tl files.
+    -- The standalone lint binary enforces file-length (run on all tracked
+    -- files) and cosmo-require (tests/examples). Column-length and
+    -- assert-order are enforced via --check-style on .tl files.
     if not is_exempt(file) then
       local n = count_lines(file)
       local diags = check_file_length(file, n, DEFAULT_FILE_LINES)
       for _, d in ipairs(diags) do
         table.insert(all_diagnostics, d)
+      end
+      if file:match("_test%.tl$") or file:match("_example%.tl$") then
+        local f = io.open(file, "r")
+        if f then
+          local content = f:read("*a")
+          f:close()
+          local lines: {string} = {}
+          for line in ((content or "") .. "\n"):gmatch("([^\n]*)\n") do
+            lines[#lines + 1] = line
+          end
+          for _, d in ipairs(check_cosmo_require(file, lines)) do
+            table.insert(all_diagnostics, d)
+          end
+        end
       end
     end
   end
@@ -239,6 +313,7 @@ return {
   check_file_length = check_file_length,
   check_column_length = check_column_length,
   check_call_after_define = check_call_after_define,
+  check_cosmo_require = check_cosmo_require,
   lint_file = lint_file,
   main = main,
 }

--- a/lib/build/lint_test.tl
+++ b/lib/build/lint_test.tl
@@ -244,3 +244,48 @@ local function test_check_call_after_define_one_line_if()
   assert(#diags == 0, "expected no diagnostic for function with one-line if, got: " .. tostring(#diags))
 end
 test_check_call_after_define_one_line_if()
+
+-- cosmo-require: the forbidden pattern is spelled via concatenation below so
+-- this file's own fixtures don't trip the rule (it is allowlisted anyway).
+local REQ_COSMO = 'require("cosmo' .. '")'
+local REQ_COSMO_UNIX = 'require("cosmo' .. '.unix")'
+
+local function test_cosmo_require_flags_test_file()
+  local lines = {"local unix = " .. REQ_COSMO_UNIX, "print(unix)"}
+  local diags = lint.check_cosmo_require("lib/cosmic/foo_test.tl", lines)
+  assert(#diags == 1, "expected 1 diagnostic, got: " .. tostring(#diags))
+  assert(diags[1].rule == "cosmo-require", "expected cosmo-require rule")
+  assert(diags[1].line == 1, "expected line 1, got: " .. tostring(diags[1].line))
+end
+test_cosmo_require_flags_test_file()
+
+local function test_cosmo_require_flags_bare_cosmo_in_example()
+  local lines = {"local cosmo = " .. REQ_COSMO}
+  local diags = lint.check_cosmo_require("lib/cosmic/foo_example.tl", lines)
+  assert(#diags == 1, "expected 1 diagnostic, got: " .. tostring(#diags))
+end
+test_cosmo_require_flags_bare_cosmo_in_example()
+
+local function test_cosmo_require_ignores_non_test_files()
+  local lines = {"local unix = " .. REQ_COSMO_UNIX}
+  local diags = lint.check_cosmo_require("lib/cosmic/foo.tl", lines)
+  assert(#diags == 0, "library internals may require cosmo directly")
+end
+test_cosmo_require_ignores_non_test_files()
+
+local function test_cosmo_require_ignores_cosmic_requires()
+  local lines = {
+    'local fs = require("cosmic.fs")',
+    'local cosmos = require("cosmos")',
+  }
+  local diags = lint.check_cosmo_require("lib/cosmic/foo_test.tl", lines)
+  assert(#diags == 0, "cosmic.* and cosmos are not cosmo requires")
+end
+test_cosmo_require_ignores_cosmic_requires()
+
+local function test_cosmo_require_honors_allowlist()
+  local lines = {"local unix = " .. REQ_COSMO_UNIX}
+  local diags = lint.check_cosmo_require("lib/cosmic/child/init_test.tl", lines)
+  assert(#diags == 0, "allowlisted files must not be flagged")
+end
+test_cosmo_require_honors_allowlist()

--- a/lib/types/gentype.tl
+++ b/lib/types/gentype.tl
@@ -2,8 +2,8 @@
 --- Generate Teal .d.tl type definitions from cosmo-lua definitions.lua.
 --- Parses LuaLS annotations and produces Teal-compatible type declarations.
 
-local cosmo = require("cosmo")
 local cosmic = require("cosmic")
+local fs = require("cosmic.fs")
 local tl = require("tl")
 local gt = require("types.gentype_types")
 local Param = gt.Param
@@ -392,7 +392,7 @@ end
 
 --- Run the generator for a specific module or all modules.
 local function run(module_name: string): Result
-  local source = cosmo.Slurp(defs_path())
+  local source = fs.read(defs_path())
   if not source then
     return {success = false, error = "Failed to read " .. defs_path()}
   end

--- a/lib/types/gentype_test.tl
+++ b/lib/types/gentype_test.tl
@@ -8,13 +8,13 @@
 --- definitions.lua source (default: the copy embedded in this binary) for
 --- validating against a cosmopolitan checkout before a release is cut.
 
-local cosmo = require("cosmo")
+local fs = require("cosmic.fs")
 local gentype = require("types.gentype")
 local teal = require("cosmic.teal")
 
 local function defs_source(): string
   local path = os.getenv("GENTYPE_DEFS") or "/zip/.lua/definitions.lua"
-  local source = cosmo.Slurp(path)
+  local source = fs.read(path)
   assert(source, "Failed to read definitions.lua from " .. path)
   return source
 end
@@ -380,7 +380,7 @@ local function test_drift_all_modules()
     local result = gentype.run(m)
     assert(result.success, "generator failed for " .. m .. ": " .. (result.error or ""))
     local path = committed_path(m)
-    local committed = cosmo.Slurp(path)
+    local committed = fs.read(path)
     assert(committed, "missing committed type file " .. path
       .. " -- run `bin/make regen-types` and commit the result")
     if committed ~= result.output then


### PR DESCRIPTION
Closes #495 (audit §1.7).

## What

- Adds a `cosmo-require` rule to the standalone lint binary (`lib/build/lint.tl`): any `require("cosmo")` / `require("cosmo.<mod>")` in a `*_test.tl` or `*_example.tl` file now fails `bin/make lint`, so the #427 migration can't regress. The pattern matches only `cosmo` exactly or a `cosmo.` prefix — `cosmos`, `cosmic.*` etc. are untouched.
- Allowlists the enumerated §1.7 exceptions by path, each with the reason it needs the raw layer: fault injection through the shared `cosmo.unix` module table (`child/init_test`, `child/io_test`), the require-machinery test, raw-fd fixtures (`fs/init_test`, `fs/dir_test`), heredoc payloads (`quicksand/proc_test`, `script_test`, `compile_test`), `lint_test` itself (fixture strings quote the pattern), and the third-party `3p/tl/tl_test.tl` scaffold.
- Migrates the two remaining `cosmo.Slurp` script call sites the issue names — `lib/types/gentype.tl` and `lib/types/gentype_test.tl` — to `cosmic.fs.read`.

## Verification

- `bin/make lint` — 311/311 pass (allowlist covers exactly the current tree)
- Negative test: the lint binary run on a fixture `*_test.tl` containing `require("cosmo.unix")` exits 1 with a `cosmo-require` diagnostic
- `bin/make test only=lint` (5 new rule tests), `bin/make test only=gentype`, `bin/make teal`, `bin/make format` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1V1jxUCDu51r14FS51rQY

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1V1jxUCDu51r14FS51rQY)_