### PR TITLE
errno: export a name -> number constants table

### DIFF
--- a/lib/cosmic/errno.tl
+++ b/lib/cosmic/errno.tl
@@ -4,8 +4,9 @@
 --- (`"open: ENOENT: No such file or directory"`) plus the numeric errno.
 --- This module provides the canonical formatter (`str`) that most
 --- `cosmic.*` wrappers use to add operation context, and helpers for
---- programmatic errno handling (`is`, `code`), so error messages share
---- one shape across the stdlib:
+--- programmatic errno handling (`is`, `code`, and the `constants`
+--- name -> number table), so error messages share one shape across the
+--- stdlib:
 ---
 ---     local ok, err = unix.mkdir(path, mode)
 ---     if not ok then return false, errno.str(err, "mkdir: " .. path) end
@@ -85,9 +86,45 @@ local function name_of(msg: string): string
   return string.match(msg, "%f[%w](E[%u%d]+):")
 end
 
+-- Every errno name cosmo.unix may define. An explicit list rather than an
+-- `E*` scan of the module, which would pick up the termios flags (ECHO,
+-- ECHOE, ECHOK, ECHONL). Names the host does not define are skipped.
+local ERRNO_NAMES < const >: {string} = {
+  "E2BIG", "EACCES", "EADDRINUSE", "EADDRNOTAVAIL", "EAFNOSUPPORT",
+  "EAGAIN", "EALREADY", "EBADF", "EBADFD", "EBADMSG", "EBUSY",
+  "ECANCELED", "ECHILD", "ECONNABORTED", "ECONNREFUSED", "ECONNRESET",
+  "EDEADLK", "EDESTADDRREQ", "EDOM", "EDQUOT", "EEXIST", "EFAULT",
+  "EFBIG", "EFTYPE", "EHOSTDOWN", "EHOSTUNREACH", "EHWPOISON", "EIDRM",
+  "EILSEQ", "EINPROGRESS", "EINTR", "EINVAL", "EIO", "EISCONN",
+  "EISDIR", "ELOOP", "EMEDIUMTYPE", "EMFILE", "EMLINK", "EMSGSIZE",
+  "EMULTIHOP", "ENAMETOOLONG", "ENETDOWN", "ENETRESET", "ENETUNREACH",
+  "ENFILE", "ENOBUFS", "ENODATA", "ENODEV", "ENOENT", "ENOEXEC",
+  "ENOLCK", "ENOLINK", "ENOMEDIUM", "ENOMEM", "ENOMSG", "ENONET",
+  "ENOPROTOOPT", "ENOSPC", "ENOSR", "ENOSTR", "ENOSYS", "ENOTBLK",
+  "ENOTCONN", "ENOTDIR", "ENOTEMPTY", "ENOTRECOVERABLE", "ENOTSOCK",
+  "ENOTSUP", "ENOTTY", "ENXIO", "EOPNOTSUPP", "EOVERFLOW", "EOWNERDEAD",
+  "EPERM", "EPFNOSUPPORT", "EPIPE", "EPROTO", "EPROTONOSUPPORT",
+  "EPROTOTYPE", "ERANGE", "EREMOTE", "ERESTART", "ERFKILL", "EROFS",
+  "ESHUTDOWN", "ESOCKTNOSUPPORT", "ESPIPE", "ESRCH", "ESTALE", "ETIME",
+  "ETIMEDOUT", "ETOOMANYREFS", "ETXTBSY", "EUSERS", "EXDEV",
+}
+
+--- Errno name -> number for every constant the host defines
+--- (`constants.ENOENT`, `constants["EAGAIN"]`, ...). The table form of
+--- `code`: use it to iterate, to look names up dynamically, or to avoid
+--- reaching through `cosmo.unix` for a raw constant.
+local constants: {string: integer} = {}
+for _, name in ipairs(ERRNO_NAMES) do
+  local v = (unix as {string: any})[name]
+  if v is number then
+    constants[name] = v as integer
+  end
+end
+
 return {
   str = str,
   code = code,
   is = is,
   name_of = name_of,
+  constants = constants,
 }

--- a/lib/cosmic/errno_test.tl
+++ b/lib/cosmic/errno_test.tl
@@ -81,3 +81,35 @@ end
 test_name_of_no_match()
 
 print("errno_test: PASS")
+
+-- constants: a name -> number table mirroring errno.code.
+local function test_constants_lookup()
+  local enoent = errno.constants.ENOENT
+  assert(type(enoent) == "number", "ENOENT should be a number")
+  assert(enoent == errno.code("ENOENT"), "constants must agree with code()")
+  assert(errno.constants.EAGAIN == errno.code("EAGAIN"), "EAGAIN must agree")
+  assert(errno.constants["E_NOT_A_REAL_ERRNO"] == nil, "unknown name is nil")
+end
+test_constants_lookup()
+
+-- constants: every entry is a well-formed errno name with an integer
+-- value, usable with errno.is; and the table is non-trivially populated.
+local function test_constants_shape()
+  local n = 0
+  for name, value in pairs(errno.constants) do
+    n = n + 1
+    assert(string.match(name, "^E[%u%d]+$"), "bad errno name: " .. name)
+    assert(math.type(value) == "integer", name .. " value must be an integer")
+    assert(errno.is(value, name), name .. " must round-trip through errno.is")
+  end
+  assert(n >= 50, "expected a populated table, got " .. tostring(n) .. " entries")
+end
+test_constants_shape()
+
+-- constants: the termios ECHO* flags are not errnos and must be absent.
+local function test_constants_excludes_termios()
+  for _, name in ipairs({"ECHO", "ECHOE", "ECHOK", "ECHONL"}) do
+    assert(errno.constants[name] == nil, name .. " is a termios flag, not an errno")
+  end
+end
+test_constants_excludes_termios()


### PR DESCRIPTION
Closes #499 (audit §3, remaining sliver).

## What

Exports `errno.constants`, a `{string: integer}` table (`constants.ENOENT`, `constants["EAGAIN"]`, …) so callers can branch on specific errnos without reaching through `cosmo.unix` for the raw constant. It is the table form of the existing `errno.code()`.

Built at module load from an explicit errno-name list rather than an `E*` scan of `cosmo.unix` — a scan would wrongly pick up the termios flags (`ECHO`, `ECHOE`, `ECHOK`, `ECHONL`). Names the host does not define are skipped.

## Verification

- `bin/make test only=errno` — passes, including three new tests: lookup agrees with `code()`, every entry is a well-formed `E*` name with an integer value that round-trips through `errno.is` (≥50 entries), and the termios `ECHO*` flags are absent
- `bin/make teal`, `bin/make format`, `bin/make lint` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1V1jxUCDu51r14FS51rQY

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1V1jxUCDu51r14FS51rQY)_