### PR TITLE
docs: add root README; fix fetch.get -> fetch.fetch in stdlib.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,85 @@
+# cosmic
+
+cosmic is a batteries-included [Teal](https://github.com/teal-language/tl)
+(typed Lua) distribution built on
+[Cosmopolitan Libc](https://github.com/jart/cosmopolitan). it ships as a
+single fat binary — `cosmic-lua` — that runs on Linux, macOS, Windows,
+FreeBSD, OpenBSD, and NetBSD, on both x86_64 and aarch64, with no
+installation step and no dependencies.
+
+the binary contains the Lua 5.4 runtime, the Teal compiler and type
+checker, a typed standard library (`cosmic.*`: fs, net, fetch, json,
+sqlite, crypto hashing, sandboxing, and more), embedded documentation,
+and tooling for building your own single-file executables.
+
+## install
+
+download the latest release, make it executable, run it:
+
+```sh
+curl -fsSLO https://github.com/whilp/cosmic/releases/latest/download/cosmic-lua
+chmod +x cosmic-lua
+./cosmic-lua --version
+```
+
+to verify the download, fetch `SHA256SUMS` from the same release and
+check it:
+
+```sh
+curl -fsSLO https://github.com/whilp/cosmic/releases/latest/download/SHA256SUMS
+sha256sum --check --ignore-missing SHA256SUMS
+```
+
+`cosmic-lua` is an [αcτµαlly pδrταblε
+εxεcµταblε](https://justine.lol/ape.html): the same file is a valid
+program on every supported OS. one quirk: some Linux systems have a
+`binfmt_misc` rule (usually Wine's) that intercepts its MZ header and
+fails with `run-detectors: unable to find an interpreter`. run it
+through the shell once and the binary self-repairs into a form that
+executes directly from then on:
+
+```sh
+sh ./cosmic-lua --version
+```
+
+each release also includes `cosmic-lua-debug`, the same binary with
+symbols and debugging checks.
+
+## hello, world
+
+```teal
+-- hello.tl
+local json = require("cosmic.json")
+
+local function greet(name: string): string
+  return json.encode({hello = name})
+end
+
+print(greet(arg[1] or "world"))
+```
+
+```sh
+$ ./cosmic-lua hello.tl
+{"hello":"world"}
+```
+
+scripts are type checked as they run; `./cosmic-lua --check-types
+hello.tl` checks without running. `./cosmic-lua -i` starts a REPL, and
+`./cosmic-lua --docs fs` searches the embedded documentation.
+
+## learn more
+
+- [docs/stdlib.md](docs/stdlib.md) — standard library tour and error
+  handling conventions
+- [docs/architecture.md](docs/architecture.md) — how the binary is put
+  together
+- [docs/build.md](docs/build.md) — building custom executables with
+  embedded files
+- [docs/contributing.md](docs/contributing.md) and
+  [AGENTS.md](AGENTS.md) — developing cosmic itself
+- [whilp/cosmopolitan](https://github.com/whilp/cosmopolitan) — the
+  Cosmopolitan fork that provides the C core
+
+## license
+
+[MIT](LICENSE).

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -122,7 +122,7 @@ end
 complex operations return a record:
 
 ```teal
-local result = fetch.get("https://example.com")
+local result = fetch.fetch("https://example.com")
 if result.ok then
   print(result.status, result.body)
 else
@@ -204,7 +204,7 @@ db:close()
 ```teal
 local fetch = require("cosmic.fetch")
 
-local result = fetch.get("https://api.example.com/data")
+local result = fetch.fetch("https://api.example.com/data")
 if result.ok then
   local json = require("cosmic.json")
   local data = json.decode(result.body)


### PR DESCRIPTION
Closes #507 (audit §6.1).

## What

- **Root `README.md`** (new): what cosmic is, install steps — download the latest `cosmic-lua` release asset, `chmod +x`, verify against `SHA256SUMS`, and the APE `binfmt_misc` quirk with the `sh ./cosmic-lua` self-repair workaround — a typed hello-world, pointers into `docs/`, and license. The GitHub landing page was previously `AGENTS.md` + `LICENSE` with no install docs anywhere.
- **`docs/stdlib.md`**: both `fetch.get(...)` examples now use `fetch.fetch(...)`. `fetch.get` never existed; the `fetch.fetch` snake_case alias of `Fetch` is already on main (landed with the networking reshape, #554), so this PR is docs-only.

## Verification

- `bin/make lint` passes; README links all point at files that exist in-tree; install commands match the release workflow's actual artifact names (`cosmic-lua`, `cosmic-lua-debug`, `SHA256SUMS`)
- `grep -rn "fetch\.get" docs/` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1V1jxUCDu51r14FS51rQY

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1V1jxUCDu51r14FS51rQY)_