### PR TITLE
sqlite: release the statement when a query iterator is abandoned

### DIFF
--- a/lib/cosmic/sqlite/close_test.tl
+++ b/lib/cosmic/sqlite/close_test.tl
@@ -1,0 +1,118 @@
+#!/usr/bin/env cosmic
+--- Tests for abandoned cosmic.sqlite query iterators: close(), the
+--- __close metamethod, and the GC backstop all release the underlying
+--- prepared statement. Lives in its own file so advanced_test.tl stays
+--- under the 500-line cap.
+
+local sqlite = require("cosmic.sqlite")
+
+-- Mirror of cosmic.sqlite's Rows iterator record (not exported; Teal
+-- records are nominal, so the boundary crosses through a cast).
+local record Rows
+  metamethod __call: function(self: Rows): {string: any}
+  metamethod __close: function(self: Rows)
+  err: function(self: Rows): string
+  close: function(self: Rows)
+end
+
+-- Abandoned query iterators: close(), <close>, and GC release the statement
+
+local function test_query_close_releases_early()
+  local db = sqlite.open(":memory:") as sqlite.Database
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+  db:exec("INSERT INTO t (name) VALUES ('a'), ('b'), ('c')")
+
+  local rows = db:query("SELECT * FROM t ORDER BY id") as Rows
+  local first = rows()
+  assert(first and first.name == "a", "should get first row")
+  rows:close()
+  assert(rows() == nil, "closed iterator must yield nil")
+  assert(rows:err() == nil, "close is not a step error")
+
+  -- The cached statement slot must be usable again for the same SQL.
+  local n = 0
+  for _ in db:query("SELECT * FROM t ORDER BY id") as Rows do
+    n = n + 1
+  end
+  assert(n == 3, "re-query after close should see all rows, got: " .. tostring(n))
+  db:close()
+end
+test_query_close_releases_early()
+
+local function test_query_close_idempotent()
+  local db = sqlite.open(":memory:") as sqlite.Database
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+  db:exec("INSERT INTO t DEFAULT VALUES")
+
+  local rows = db:query("SELECT * FROM t") as Rows
+  rows:close()
+  rows:close()
+
+  local drained = db:query("SELECT * FROM t") as Rows
+  while drained() ~= nil do end
+  drained:close()
+  db:close()
+end
+test_query_close_idempotent()
+
+local function test_query_to_be_closed_scope()
+  local db = sqlite.open(":memory:") as sqlite.Database
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+  db:exec("INSERT INTO t (name) VALUES ('a'), ('b')")
+
+  -- The repo build compiles Teal targeting 5.3 syntax, so exercise the
+  -- __close metamethod directly instead of a `local rows <close> = ...`
+  -- declaration (which works in user scripts running on the 5.4 runtime).
+  local rows = db:query("SELECT * FROM t ORDER BY id") as Rows
+  local first = rows()
+  assert(first and first.name == "a", "should get first row")
+  local mt = getmetatable(rows as any) as {string: any}
+  local close_mm = mt["__close"] as function(any, any)
+  assert(close_mm, "Rows must have a __close metamethod")
+  close_mm(rows, nil)
+  assert(rows() == nil, "__close must release the iterator")
+
+  local n = 0
+  for _ in db:query("SELECT * FROM t ORDER BY id") as Rows do
+    n = n + 1
+  end
+  assert(n == 2, "re-query after <close> should see all rows, got: " .. tostring(n))
+  db:close()
+end
+test_query_to_be_closed_scope()
+
+local function test_query_abandoned_iterator_collected()
+  local db = sqlite.open(":memory:") as sqlite.Database
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+  db:exec("INSERT INTO t DEFAULT VALUES")
+
+  do
+    local rows = db:query("SELECT * FROM t") as Rows
+    assert(rows() ~= nil, "should get a row")
+    -- Abandon without close: the GC backstop must release the statement.
+  end
+  collectgarbage("collect")
+  collectgarbage("collect")
+
+  local n = 0
+  for _ in db:query("SELECT * FROM t") as Rows do
+    n = n + 1
+  end
+  assert(n == 1, "query after GC of abandoned iterator should work")
+  db:close()
+end
+test_query_abandoned_iterator_collected()
+
+local function test_query_list_close_early()
+  local db = sqlite.open(":memory:") as sqlite.Database
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+  db:exec("INSERT INTO t (name) VALUES ('a'), ('b')")
+
+  local rows = db:query_list("SELECT * FROM t WHERE name != ? ORDER BY id", {"z"}) as Rows
+  local first = rows()
+  assert(first and first.name == "a", "should get first row")
+  rows:close()
+  assert(rows() == nil, "closed query_list iterator must yield nil")
+  db:close()
+end
+test_query_list_close_early()

--- a/lib/cosmic/sqlite/init.tl
+++ b/lib/cosmic/sqlite/init.tl
@@ -63,9 +63,16 @@ local sqlite3 = lsqlite3 as RawSqlite3
 --- `for row in ... do` loop, then call `:err()` afterward to detect a step
 --- error (SQLITE_BUSY / CORRUPT / a RETURNING constraint failure) a for-loop
 --- cannot observe inline. `:err()` is nil only on a clean SQLITE_DONE.
+---
+--- Draining the loop releases the underlying prepared statement. When
+--- iteration may stop early, call `:close()` (idempotent), or declare the
+--- iterator to-be-closed — `local rows <close> = db:query(...)` — so the
+--- statement is released on scope exit; garbage collection is the backstop.
 local record Rows
   metamethod __call: function(self: Rows): {string: any}
+  metamethod __close: function(self: Rows)
   err: function(self: Rows): string
+  close: function(self: Rows)
 end
 
 --- Callable positional-value iterator, the `Statement:values()` counterpart
@@ -327,18 +334,14 @@ local function make_database(raw_db: RawDatabase): Database
       return nil, err
     end
     local it = iter as Rows
-    -- Capture the first row, then drain the iterator so the statement is
-    -- finalized deterministically (returning early from a for-loop leaves
-    -- the iterator open and the prepared statement unfinalized until GC).
+    -- Capture the first row, then close the iterator so the statement is
+    -- released deterministically without stepping the remaining rows.
     local first: {string: any} = nil
     for row in it do
       first = row
       break
     end
-    -- Drain remaining rows so the wrapping closure calls stmt:close().
-    if first ~= nil then
-      while it() ~= nil do end
-    end
+    it:close()
     -- Surface a step error rather than a partial row that looks clean.
     local step_err = it:err()
     if step_err then

--- a/lib/cosmic/sqlite/params.tl
+++ b/lib/cosmic/sqlite/params.tl
@@ -8,7 +8,9 @@
 -- boundary crosses through `any`; same convention as sqlite_stmt_cache).
 local record Rows
   metamethod __call: function(self: Rows): {string: any}
+  metamethod __close: function(self: Rows)
   err: function(self: Rows): string
+  close: function(self: Rows)
 end
 
 local record Stmt
@@ -29,9 +31,18 @@ end
 
 -- Wrap a prepared+bound statement's row iterator: finalize the statement
 -- when iteration ends and forward the step error through `:err()`.
+-- `close` (also wired to `<close>` scope exit and garbage collection)
+-- finalizes the statement when iteration is abandoned early.
 local function make_query_iter(stmt: Stmt): Rows
   local raw_iter = stmt:rows()
   local done = false
+  local function release()
+    if done then
+      return
+    end
+    done = true
+    stmt:close()
+  end
   local iter = setmetatable({} as Rows, {
       __call = function(_: Rows): {string: any}
         if done then
@@ -39,14 +50,22 @@ local function make_query_iter(stmt: Stmt): Rows
         end
         local row = raw_iter()
         if row == nil then
-          done = true
-          stmt:close()
+          release()
           return nil
         end
         return row
       end,
+      __close = function(_: Rows)
+        release()
+      end,
+      __gc = function(_: Rows)
+        release()
+      end,
     })
   iter.err = function(_: Rows): string return raw_iter:err() end
+  iter.close = function(_: Rows)
+    release()
+  end
   return iter
 end
 

--- a/lib/cosmic/sqlite/row_iter.tl
+++ b/lib/cosmic/sqlite/row_iter.tl
@@ -23,9 +23,14 @@ end
 
 -- Callable row iterator: `for row in iter do ... end`, then `iter:err()`
 -- surfaces a post-drain step error. Same shape as cosmic.sqlite's Rows.
+-- `close` releases the statement without draining; it also runs on scope
+-- exit (`local rows <close> = db:query(...)`) and on garbage collection,
+-- so an abandoned iterator cannot leak its prepared statement.
 local record Rows
   metamethod __call: function(self: Rows): {string: any}
+  metamethod __close: function(self: Rows)
   err: function(self: Rows): string
+  close: function(self: Rows)
 end
 
 -- on_close mirrors stmt_cache:checkout — non-nil returns the shared cached
@@ -51,6 +56,20 @@ local type OnClose = function(RawStatement)
     local first_call = true
     local done = false
 
+    -- Release exactly once: return the shared cached slot, or finalize a
+    -- throwaway. Reached from drain, from close/<close>, and from __gc.
+    local function release()
+      if done then
+        return
+      end
+      done = true
+      if on_close then
+        on_close(raw_stmt)
+      else
+        local _ = raw_stmt:finalize()
+      end
+    end
+
     local iter = setmetatable({} as Rows, {
         __call = function(_: Rows): {string: any}
           if done then
@@ -73,19 +92,23 @@ local type OnClose = function(RawStatement)
             return row
           end
           -- Anything but a clean SQLITE_DONE is a real error to surface.
-          done = true
           if rc ~= done_code then
             step_err = raw_db:errmsg()
           end
-          if on_close then
-            on_close(raw_stmt)
-          else
-            local _ = raw_stmt:finalize()
-          end
+          release()
           return nil
+        end,
+        __close = function(_: Rows)
+          release()
+        end,
+        __gc = function(_: Rows)
+          release()
         end,
       })
     iter.err = function(_: Rows): string return step_err end
+    iter.close = function(_: Rows)
+      release()
+    end
     return iter
   end
 


### PR DESCRIPTION
Closes #496 (audit §2.2 — the last open sub-item; `fetch.Reader:lines()` error surfacing and `shm.mapshared` failure returns already landed on main).

## Problem

Breaking out of a `for row in db:query(...)` loop early left the prepared statement held until `db:close()`: the drain path was the only release. For the cached-statement path that also left the cache slot flagged checked-out forever, so every later query for the same SQL prepared a throwaway statement. `query_list`/`query_named` had the same hole in their `Statement`-wrapping iterator.

## What

- `Rows` (both the `row_iter` hot path and the `params` wrapper) now has a single idempotent `release()` reached from four places: drain (as before), a new `close()` method, a `__close` metamethod (so user scripts on the 5.4 runtime can write `local rows <close> = db:query(...)`), and a `__gc` backstop so even an unclosed abandoned iterator frees its statement at collection.
- `db:query_one` now calls `close()` after taking the first row instead of stepping through every remaining row just to trigger the drain release.
- New `lib/cosmic/sqlite/close_test.tl` (kept separate so `advanced_test.tl` stays under the 500-line cap): early close releases and the same-SQL cached slot is reusable, double-close and close-after-drain are no-ops, the `__close` metamethod releases (invoked directly — repo Teal builds target 5.3 syntax, so the `<close>` declaration itself can't appear in-tree), GC of an abandoned iterator releases, and `query_list` close works.

## Verification

- `bin/make test only=sqlite` — 4/4 including the new file
- `bin/make teal` (246), `bin/make format` (246), `bin/make lint` (311) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1V1jxUCDu51r14FS51rQY

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1V1jxUCDu51r14FS51rQY)_