### PR TITLE
types: stop dropping | nil from generated union returns

### DIFF
--- a/lib/cosmic/fs/ops.tl
+++ b/lib/cosmic/fs/ops.tl
@@ -54,7 +54,7 @@ local function copy(src: string, dst: string): boolean, string
     unix.close(srcfd)
     return false, errstr(serr, "copy: fstat: " .. src)
   end
-  local mode = st:mode() & 0x1ff
+  local mode = (st as unix.Stat):mode() & 0x1ff
   local dstfd, derr = unix.open(dst,
     unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, mode)
   if not dstfd then
@@ -71,7 +71,7 @@ local function copy(src: string, dst: string): boolean, string
     if data == "" then break end
     local off: integer = 1
     while off <= #data do
-      local n, werr = unix.write(dstfd, data:sub(off))
+      local n, werr = unix.write(dstfd, string.sub(data, off))
       if not n then
         unix.close(srcfd)
         unix.close(dstfd)

--- a/lib/cosmic/fs/path.tl
+++ b/lib/cosmic/fs/path.tl
@@ -45,7 +45,7 @@ end
 --- @return boolean True if the path is a regular file
 local function isfile(p: string): boolean
   local st = unix.stat(p)
-  return st ~= nil and unix.S_ISREG(st:mode())
+  return st ~= nil and unix.S_ISREG((st as unix.Stat):mode())
 end
 
 --- Check if path is a directory.
@@ -56,7 +56,7 @@ end
 --- @return boolean True if the path is a directory
 local function isdir(p: string): boolean
   local st = unix.stat(p)
-  return st ~= nil and unix.S_ISDIR(st:mode())
+  return st ~= nil and unix.S_ISDIR((st as unix.Stat):mode())
 end
 
 --- Check if path is a symbolic link.

--- a/lib/cosmic/fs/tree.tl
+++ b/lib/cosmic/fs/tree.tl
@@ -35,7 +35,7 @@ local function copy_entries(src: string, dst: string): boolean, string
         h:close()
         return false, errstr(serr, "copytree: stat: " .. s)
       end
-      local mode = st:mode()
+      local mode = (st as unix.Stat):mode()
       if unix.S_ISLNK(mode) then
         local target, rerr = unix.readlink(s)
         if not target then
@@ -71,10 +71,10 @@ copytree_into = function(src: string, dst: string): boolean, string
   if not st then
     return false, errstr(serr, "copytree: stat: " .. src)
   end
-  if not unix.S_ISDIR(st:mode()) then
+  if not unix.S_ISDIR((st as unix.Stat):mode()) then
     return false, "copytree: not a directory: " .. src
   end
-  local ok, merr = unix.makedirs(dst, st:mode() & tonumber("777", 8))
+  local ok, merr = unix.makedirs(dst, (st as unix.Stat):mode() & tonumber("777", 8))
   if not ok then
     return false, errstr(merr, "copytree: makedirs: " .. dst)
   end

--- a/lib/cosmic/fs/walk.tl
+++ b/lib/cosmic/fs/walk.tl
@@ -48,7 +48,7 @@ local function walk_entries < T > (dir: string, h: WalkDirHandle,
           h:close()
           return true
         end
-        if action ~= "skip" and unix.S_ISDIR(st:mode()) then
+        if action ~= "skip" and unix.S_ISDIR((st as unix.Stat):mode()) then
           if walk_tree(full_path, visitor, ctx, errbox) then
             h:close()
             return true
@@ -224,10 +224,10 @@ local function collect_all(dir: string): {string: FileInfo} | nil, string
           -- S_ISDIR, preserving the same cycle prevention as above.
           local st, serr = unix.stat(full_path, unix.AT_SYMLINK_NOFOLLOW)
           if st then
-            if unix.S_ISDIR(st:mode()) then
+            if unix.S_ISDIR((st as unix.Stat):mode()) then
               do_walk(full_path, rel_path)
-            elseif unix.S_ISREG(st:mode()) then
-              local mode = st:mode() & 0x1ff
+            elseif unix.S_ISREG((st as unix.Stat):mode()) then
+              local mode = (st as unix.Stat):mode() & 0x1ff
               files[rel_path] = {mode = mode}
             end
           elseif not errbox[1] then
@@ -317,7 +317,7 @@ local type FileIter = function(): string
             -- S_ISLNK, not S_ISDIR, preserving the same cycle prevention.
             local st = unix.stat(full_path, unix.AT_SYMLINK_NOFOLLOW)
             if st then
-              if unix.S_ISDIR(st:mode()) then
+              if unix.S_ISDIR((st as unix.Stat):mode()) then
                 local subhandle = unix.opendir(full_path)
                 if subhandle then
                   table.insert(stack, {full_path, subhandle as WalkDirHandle})

--- a/lib/cosmic/landlock.tl
+++ b/lib/cosmic/landlock.tl
@@ -177,7 +177,7 @@ local function restrict(opts: RestrictOptions): boolean, string
     -- (READ, RW, ...). A rule left with no grantable bits is skipped —
     -- landlock denies by default, so granting nothing needs no rule.
     local st = unix.fstat(pfd as integer)
-    if st and not unix.S_ISDIR(st:mode()) then
+    if st and not unix.S_ISDIR((st as unix.Stat):mode()) then
       access = access & FILE_BITS
     end
     if access ~= 0 then

--- a/lib/types/cosmo.d.tl
+++ b/lib/types/cosmo.d.tl
@@ -102,7 +102,7 @@ local record cosmo
   ---     assert(Barf('x.txt', 'abc123'))
   ---     assert(Barf('x.txt', 'XX', {offset = 3}))
   ---     assert(assert(Slurp('x.txt', 1, 6)) == 'abXX23')
-  Barf: function(filename: string, data: string, options?: BarfOptions): boolean, string | nil, number | nil
+  Barf: function(filename: string, data: string, options?: BarfOptions): boolean | nil, string | nil, number | nil
   CategorizeIp: function(ip: number): string
   --- Compresses data using zlib DEFLATE with a small framing header.
   --- By default the result starts with a header that stores the
@@ -125,7 +125,7 @@ local record cosmo
   --- (up to 128) may be supplied, which allows alternative base32
   --- encodings to be decoded. Returns nil, err if the alphabet length is
   --- not a power of 2 in the range 2..128.
-  DecodeBase32: function(ascii: string, alphabet?: string): string, string | nil
+  DecodeBase32: function(ascii: string, alphabet?: string): string | nil, string | nil
   --- Decodes binary data encoded as base64.
   --- This turns ASCII into binary, in a permissive way that ignores
   --- characters outside the base64 alphabet, such as whitespace. See
@@ -134,7 +134,7 @@ local record cosmo
   --- Turns ASCII base-16 hexadecimal byte string into binary string,
   --- case-insensitively. Returns nil, err if the string has an odd length
   --- or contains a non-hex character.
-  DecodeHex: function(ascii: string): string, string | nil
+  DecodeHex: function(ascii: string): string | nil, string | nil
   --- Turns JSON string into a Lua data structure.
   --- This is a generally permissive parser, in the sense that like
   --- v8, it permits scalars as top-level values. Therefore we must
@@ -163,7 +163,7 @@ local record cosmo
   --- `EncodeJson()` and may not round-trip with original intent.
   --- This parser has perfect conformance with JSONTestSuite.
   --- This parser validates utf-8 and utf-16.
-  DecodeJson: function(input: string): any, string | nil
+  DecodeJson: function(input: string): any | nil, string | nil
   --- Turns ISO-8859-1 string into UTF-8.
   DecodeLatin1: function(iso_8859_1: string): string
   --- Compresses data.
@@ -176,13 +176,13 @@ local record cosmo
   --- `Crc32()` checksum in addition to the original uncompressed size.
   --- Lower numbers go faster (4 for instance is a sweet spot) and higher numbers go
   --- slower but have better compression.
-  Deflate: function(uncompressed: string, level?: number): string, string | nil
+  Deflate: function(uncompressed: string, level?: number): string | nil, string | nil
   --- Turns binary into ASCII using the provided alphabet (Crockford's
   --- base32 alphabet by default). Any alphabet that has a power of 2
   --- length (up to 128) may be supplied for encoding and decoding, which
   --- allows alternative base32 encodings to be produced. Returns nil, err
   --- if the alphabet length is not a power of 2 in the range 2..128.
-  EncodeBase32: function(binary: string, alphabet?: string): string, string | nil
+  EncodeBase32: function(binary: string, alphabet?: string): string | nil, string | nil
   --- Turns binary into ASCII. This can be used to create HTML data:
   --- URIs that do things like embed a PNG file in a web page. See
   --- encodebase64.c.
@@ -259,7 +259,7 @@ local record cosmo
   --- encodings in your input strings will be canonicalized rather than validated.
   --- NaNs are serialized as `null` and Infinities are `null` which is consistent
   --- with the v8 behavior.
-  EncodeJson: function(value: any, options?: EncoderOptions): string, string | nil
+  EncodeJson: function(value: any, options?: EncoderOptions): string | nil, string | nil
   --- Turns UTF-8 into ISO-8859-1 string.
   EncodeLatin1: function(utf8: string, flags?: number): string
   --- Turns Lua data structure into Lua code string.
@@ -329,7 +329,7 @@ local record cosmo
   ---     >: -9223372036854775807 - 1
   ---     -9223372036854775807 - 1
   --- The only failure return condition currently implemented is when C runs out of heap memory.
-  EncodeLua: function(value: any, options?: EncoderOptions): string, string | nil
+  EncodeLua: function(value: any, options?: EncoderOptions): string | nil, string | nil
   --- This function is the inverse of ParseUrl. The output will always be correctly
   --- formatted. The exception is if illegal characters are supplied in the scheme
   --- field, since there's no way of escaping those. Opaque parts are escaped as
@@ -442,7 +442,7 @@ local record cosmo
   --- (malformed request or response), `"too_large"` (response exceeded
   --- `maxresponse`), or `"blocked"` (refused by SSRF protection or the
   --- HTTPS-to-HTTP downgrade guard).
-  Fetch: function(url: string, body?: string | FetchOptions): number, {string: string}, string, string, string | nil, string | nil
+  Fetch: function(url: string, body?: string | FetchOptions): number | nil, {string: string}, string, string, string | nil, string | nil
   --- Sends an HTTP/HTTPS request and returns a streaming reader for the response body.
   --- Useful for Server-Sent Events (SSE), large downloads, or processing data incrementally.
   --- Accepts the same options table as `Fetch()`, including `timeout`, `maxresponse`,
@@ -457,14 +457,14 @@ local record cosmo
   --- redirects. On failure, returns `nil`, a descriptive error message,
   --- and a machine-readable failure kind with the same values as
   --- `Fetch()`.
-  FetchStream: function(url: string, options?: FetchOptions): number, {string: string}, StreamReader, string, string | nil, string | nil
+  FetchStream: function(url: string, options?: FetchOptions): number | nil, {string: string}, StreamReader, string, string | nil, string | nil
   --- Converts UNIX timestamp to an RFC1123 string that looks like this:
   --- `Mon, 29 Mar 2021 15:37:13 GMT`. See `formathttpdatetime.c`.
   FormatHttpDateTime: function(seconds: number): string
   --- Turns integer like `0x01020304` into a string like `"1.2.3.4"`. See also
   --- `ParseIp` for the inverse operation.
   FormatIp: function(uint32: number): string
-  GetCryptoHash: function(name: string, payload: string, key?: string): string, string | nil
+  GetCryptoHash: function(name: string, payload: string, key?: string): string | nil, string | nil
   --- Returns string describing host instruction set architecture.
   --- This can return:
   --- - `"X86_64"` for Intel and AMD systems
@@ -478,7 +478,7 @@ local record cosmo
   --- characters, which are discounted, as well as control codes and ANSI escape
   --- sequences.
   GetMonospaceWidth: function(str: string | number): number
-  GetRandomBytes: function(length?: number): string, string | nil
+  GetRandomBytes: function(length?: number): string | nil, string | nil
   --- Returns `true` if the string contains forbidden control codes.
   --- `flags` selects which characters are considered forbidden and may be
   --- any combination of:
@@ -498,7 +498,7 @@ local record cosmo
   --- However, it is permissable (although not advised) to specify some large number
   --- in which case (on success) the byte length of the output string may be less
   --- than `maxoutsize`.
-  Inflate: function(compressed: string, maxoutsize: number): string, string | nil
+  Inflate: function(compressed: string, maxoutsize: number): string | nil, string | nil
   --- Check if the calling script is being run directly (not require'd).
   --- This function provides a Python-like `if __name__ == "__main__"` idiom
   --- for Lua scripts. It returns true when the script is executed directly
@@ -545,7 +545,7 @@ local record cosmo
   --- Returns nil, err for invalid inputs (previously it returned the -1
   --- sentinel, which `FormatIp` rendered as the broadcast address). See also
   --- `FormatIp` for the inverse operation.
-  ParseIp: function(ip: string): number, string | nil
+  ParseIp: function(ip: string): number | nil, string | nil
   --- Parses `application/x-www-form-urlencoded` key/value parameters,
   --- e.g. `"a=b&c"` becomes `{{"a", "b"}, {"c"}}`. This returns the same
   --- data structure as the `params` field of the `Url` object returned by
@@ -603,7 +603,7 @@ local record cosmo
   --- If no IP address could be found, then `nil` is returned alongside a string of
   --- unspecified format describing the error. Calls to this function may be wrapped
   --- in `assert()` if an exception is desired.
-  ResolveIp: function(hostname: string): number, string | nil
+  ResolveIp: function(hostname: string): number | nil, string | nil
   --- Computes SHA256 checksum, returning 32 bytes of binary.
   Sha256: function(str: string): string
   --- Reads all data from file the easy way.
@@ -616,7 +616,7 @@ local record cosmo
   --- This function is uninterruptible so `unix.EINTR` errors will be ignored. This
   --- should only be a concern if you've installed signal handlers. Use the UNIX API
   --- if you need to react to it.
-  Slurp: function(filename: string, i?: number, j?: number): string, string | nil, number | nil
+  Slurp: function(filename: string, i?: number, j?: number): string | nil, string | nil, number | nil
   --- Formats a timestamp using strftime(3) format specifiers.
   --- Common format specifiers:
   --- - `%Y` four-digit year
@@ -634,7 +634,7 @@ local record cosmo
   ---     Strftime("%F %T", os.time())            -- "2024-12-29 15:30:00"
   ---     Strftime("%a, %d %b %Y", 0)             -- "Thu, 01 Jan 1970"
   ---     Strftime("%F %T", os.time(), true)      -- local time instead of UTC
-  Strftime: function(format: string, timestamp?: number, localtime?: boolean): string, string | nil
+  Strftime: function(format: string, timestamp?: number, localtime?: boolean): string | nil, string | nil
   --- Decompresses data produced by `Compress`.
   --- If `maxoutsize` is absent, the input is expected to begin with the
   --- header that `Compress` writes by default; the embedded length and
@@ -642,7 +642,7 @@ local record cosmo
   --- must be a raw zlib stream that decompresses to exactly `maxoutsize`
   --- bytes.
   --- This function returns nil, err if the input is truncated or corrupt.
-  Uncompress: function(compressed: string, maxoutsize?: number): string, string | nil
+  Uncompress: function(compressed: string, maxoutsize?: number): string | nil, string | nil
   --- Unescapes URL parameter name or value. Decodes `%XX` hex sequences and
   --- converts `+` to space (common in application/x-www-form-urlencoded).
   --- This is the inverse of EscapeParam.

--- a/lib/types/cosmo/argon2.d.tl
+++ b/lib/types/cosmo/argon2.d.tl
@@ -37,7 +37,7 @@ local record argon2
   --- - `"argon2id"` blend of other two methods [default]
   --- - `"argon2i"` maximize resistance to side-channel attacks
   --- - `"argon2d"` maximize resistance to gpu cracking attacks
-  hash_encoded: function(pass: string, salt?: string, config?: Config): string, string | nil
+  hash_encoded: function(pass: string, salt?: string, config?: Config): string | nil, string | nil
   --- Verifies a password against an encoded hash, e.g.
   ---     >: argon2.verify(encoded, "password")
   ---     true

--- a/lib/types/cosmo/getopt.d.tl
+++ b/lib/types/cosmo/getopt.d.tl
@@ -70,7 +70,7 @@ local record getopt
   ---       end
   ---     end
   ---     -- Now excludes contains all -e values: {"foo", "bar", "spam"}
-  parse: function(args: {string}, optstring: string, longopts?: {table}): Result, string | nil
+  parse: function(args: {string}, optstring: string, longopts?: {table}): Result | nil, string | nil
 end
 
 return getopt

--- a/lib/types/cosmo/lsqlite3.d.tl
+++ b/lib/types/cosmo/lsqlite3.d.tl
@@ -89,7 +89,7 @@ local record Database
   --- This prints:
   ---     Sum of col 1:   6
   ---     Sum of col 2:   66
-  create_aggregate: function(self: Database, name: string, nargs: number, step: function(ctx: Context, ...: string | number), final: function(ctx: Context), userdata?: any): boolean
+  create_aggregate: function(self: Database, name: string, nargs: number, step: function(ctx: Context, ...: string | number | nil), final: function(ctx: Context), userdata?: any): boolean
   --- This creates a collation callback. A collation callback is used to establish
   --- a collation order, mostly for string comparisons and sorting purposes.
   --- A simple example:
@@ -176,7 +176,7 @@ local record Database
   --- Returns `true` if the database `name` of connection `db` is read-only,
   --- `false` if it is read/write. Returns `nil` plus an error message if
   --- `name` is not the name of a database on connection `db`.
-  readonly: function(self: Database, name?: string): boolean, string | nil
+  readonly: function(self: Database, name?: string): boolean | nil, string | nil
   --- This function installs a rollback_hook callback handler.
   --- See: `db:commit_hook` and `db:update_hook`
   rollback_hook: function(self: Database, func: function(udata: any), udata: any)
@@ -233,7 +233,7 @@ local record Database
   ---     2       22
   ---     3       33
   urows: function(self: Database, sql: string): function, VM
-  wal_checkpoint: function(self: Database, mode?: number, name?: string): number, number, number | nil
+  wal_checkpoint: function(self: Database, mode?: number, name?: string): number | nil, number, number | nil
   wal_hook: function(self: Database, func?: (function(udata: any, db: Database, name: string, page_count: number): number), udata?: any)
 end
 
@@ -246,7 +246,7 @@ local record Statement
   --- `lua_isinteger`. If `value` is a boolean then it is bound as `0` for
   --- `false` or `1` for `true`. If `value` is `nil` or missing, any
   --- previous binding is removed.
-  bind: function(self: Statement, n: number, value: string | number | boolean): number
+  bind: function(self: Statement, n: number, value: string | number | boolean | nil): number
   --- Binds string `blob` (which can be a binary string) as a blob to
   --- statement parameter `n`.
   bind_blob: function(self: Statement, n: number, blob: string): number
@@ -274,7 +274,7 @@ local record Statement
   --- then `nil` is returned.
   bind_parameter_name: function(self: Statement, n: number): string | nil
   --- Binds the given values to statement parameters.
-  bind_values: function(self: Statement, ...: string | number): number
+  bind_values: function(self: Statement, ...: string | number | nil): number
   columns: function(self: Statement): number
   --- This function frees the prepared statement.
   finalize: function(self: Statement): number
@@ -335,12 +335,12 @@ local record Statement
 end
 
 local record VM
-  bind: function(self: VM, index: number, value: string | number | boolean): number
+  bind: function(self: VM, index: number, value: string | number | boolean | nil): number
   bind_blob: function(self: VM, index: number, value: string): number
   bind_names: function(self: VM, names: {string}): number
   bind_parameter_count: function(self: VM): number
   bind_parameter_name: function(self: VM, index: number): string
-  bind_values: function(self: VM, ...: string | number): number
+  bind_values: function(self: VM, ...: string | number | nil): number
   columns: function(self: VM): number
   finalize: function(self: VM): number
   get_name: function(self: VM, index: number): string
@@ -371,7 +371,7 @@ local record VM
   --- the content of the database file, `false` otherwise.
   readonly: function(self: VM): boolean
   reset: function(self: VM): number
-  rows: function(self: VM, sql: string): function(self: VM): {string | number}
+  rows: function(self: VM, sql: string): function(self: VM): {string | number | nil}
   step: function(self: VM): number
   urows: function(self: VM, sql: string): function(self: VM): any...
 end
@@ -691,11 +691,11 @@ local record lsqlite3
   --- Since `0.9.4`, there is a second optional `flags` argument to `lsqlite3.open`.
   --- See https://www.sqlite.org/c3ref/open.html for an explanation of these flags and options.
   ---     local db = lsqlite3.open('foo.db', lsqlite3.OPEN_READWRITE + lsqlite3.OPEN_CREATE + lsqlite3.OPEN_SHAREDCACHE)
-  open: function(filename: string, flags?: number): Database, number | nil, string | nil
+  open: function(filename: string, flags?: number): Database | nil, number | nil, string | nil
   --- Opens an SQLite database in memory and returns its handle as userdata. In case
   --- of an error, the function returns `nil`, an error code and an error message.
   --- (In-memory databases are volatile as they are never stored on disk.)
-  open_memory: function(): Database, number | nil, string | nil
+  open_memory: function(): Database | nil, number | nil, string | nil
   lversion: function(): string
   version: function(): string
   --- Sets global SQLite3 library configuration options.
@@ -709,7 +709,7 @@ local record lsqlite3
   ---   removes the current callback when `func` is `nil`. Returns
   ---   `lsqlite3.OK` followed by the previously installed callback and its
   ---   user data.
-  config: function(option: number, func?: function, udata?: any): number, function | nil, any, number | nil
+  config: function(option: number, func?: function, udata?: any): number | nil, function | nil, any, number | nil
 end
 
 return lsqlite3

--- a/lib/types/cosmo/re.d.tl
+++ b/lib/types/cosmo/re.d.tl
@@ -14,7 +14,7 @@ local record Regex
   --- - `re.NOTBOL`
   --- - `re.NOTEOL`
   --- This has an O(𝑛) cost.
-  search: function(self: Regex, str: string, flags?: number): string, {string}, string | nil
+  search: function(self: Regex, str: string, flags?: number): string | nil, {string}, string | nil
 end
 
 local record re
@@ -91,7 +91,7 @@ local record re
   --- - `re.NOTEOL`
   --- This has exponential complexity. Please use `re.compile()` to compile your regular expressions once from `/.init.lua`. This API exists for convenience. This isn't recommended for prod.
   --- This uses POSIX extended syntax by default.
-  search: function(regex: string, text: string, flags?: number): string, {string}, string | nil
+  search: function(regex: string, text: string, flags?: number): string | nil, {string}, string | nil
   --- Compiles regular expression.
   --- - `re.BASIC`
   --- - `re.ICASE`
@@ -102,7 +102,7 @@ local record re
   --- If regex is an untrusted user value, then `unix.setrlimit` should be
   --- used to impose cpu and memory quotas for security.
   --- This uses POSIX extended syntax by default.
-  compile: function(regex: string, flags?: number): Regex, string | nil
+  compile: function(regex: string, flags?: number): Regex | nil, string | nil
 end
 
 return re

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -129,7 +129,7 @@ local record Memory
   --- `EAGAIN` is raised if, upon entry, the word at `word_index` had a
   --- different value than what's specified at `expect`.
   --- `ETIMEDOUT` is raised when the absolute deadline expires.
-  wait: function(self: Memory, word_index: number, expect: number, abs_deadline?: number, nanos?: number): number, string | nil, number | nil
+  wait: function(self: Memory, word_index: number, expect: number, abs_deadline?: number, nanos?: number): number | nil, string | nil, number | nil
   --- Wakes other processes waiting on word.
   --- This method may be used to signal or broadcast to waiters. The
   --- `count` specifies the number of processes that should be woken,
@@ -145,7 +145,7 @@ local record Dir
   --- Closes directory stream object and associated its file descriptor.
   --- This is called automatically by the garbage collector.
   --- This may be called multiple times.
-  close: function(self: Dir): boolean, string | nil, number | nil
+  close: function(self: Dir): boolean | nil, string | nil, number | nil
   --- Reads entry from directory stream.
   --- Returns `nil` if there are no more entries.
   --- On error, `nil` will be returned and `errno` will be non-nil.
@@ -160,10 +160,10 @@ local record Dir
   --- - `DT_UNKNOWN`
   --- Note: This function also serves as the `__call` metamethod, so that
   --- `unix.Dir` objects may be used as a for loop iterator.
-  read: function(self: Dir): string, number, number, number
+  read: function(self: Dir): string | nil, number, number, number
   --- Returns `EOPNOTSUPP` if using a `/zip/...` path or if using Windows NT.
-  fd: function(self: Dir): number, string | nil, number | nil
-  tell: function(self: Dir): number, string | nil, number | nil
+  fd: function(self: Dir): number | nil, string | nil, number | nil
+  tell: function(self: Dir): number | nil, string | nil, number | nil
   --- Resets stream back to beginning.
   rewind: function(self: Dir)
 end
@@ -1438,7 +1438,7 @@ local record unix
   --- Returns `ENOTDIR` if `path` contained a directory component that
   --- wasn't a directory
   --- .
-  open: function(path: string, flags: number, mode?: number, dirfd?: number): number, string | nil, number | nil
+  open: function(path: string, flags: number, mode?: number, dirfd?: number): number | nil, string | nil, number | nil
   --- Closes file descriptor.
   --- This function should never be called twice for the same file
   --- descriptor, regardless of whether or not an error happened. The file
@@ -1454,14 +1454,14 @@ local record unix
   --- Returns `EBADF` if `fd` wasn't valid.
   --- Returns `EINTR` possibly maybe.
   --- Returns `EIO` if an i/o error occurred.
-  close: function(fd: number): boolean, string | nil, number | nil
+  close: function(fd: number): boolean | nil, string | nil, number | nil
   --- Reads from file descriptor.
   --- This function returns empty string on end of file. The exception is
   --- if `bufsiz` is zero, in which case an empty returned string means
   --- the file descriptor works.
-  read: function(fd: number, bufsiz?: number, offset?: number): string, string | nil, number | nil
+  read: function(fd: number, bufsiz?: number, offset?: number): string | nil, string | nil, number | nil
   --- Writes to file descriptor.
-  write: function(fd: number, data: string, offset?: number): number, string | nil, number | nil
+  write: function(fd: number, data: string, offset?: number): number | nil, string | nil, number | nil
   --- Invokes `_Exit(exitcode)` on the process. This will immediately
   --- halt the current process. Memory will be freed. File descriptors
   --- will be closed. Any open connections it owns will be reset. This
@@ -1484,19 +1484,19 @@ local record unix
   --- Sets environment variable.
   --- This wraps the C `setenv()` function to allow Lua scripts to set
   --- environment variables.
-  setenv: function(name: string, value: string, overwrite?: boolean): boolean, string | nil, number | nil
+  setenv: function(name: string, value: string, overwrite?: boolean): boolean | nil, string | nil, number | nil
   --- Unsets environment variable.
   --- This wraps the C `unsetenv()` function to allow Lua scripts to remove
   --- environment variables.
-  unsetenv: function(name: string): boolean, string | nil, number | nil
+  unsetenv: function(name: string): boolean | nil, string | nil, number | nil
   --- Clears all environment variables.
   --- This wraps the C `clearenv()` function to allow Lua scripts to remove
   --- all environment variables at once.
-  clearenv: function(): boolean, string | nil, number | nil
+  clearenv: function(): boolean | nil, string | nil, number | nil
   --- Gets login name of current user.
   --- This wraps the C `getlogin()` function to retrieve the login name
   --- associated with the current session.
-  getlogin: function(): string, string | nil, number | nil
+  getlogin: function(): string | nil, string | nil, number | nil
   --- Creates a new process mitosis style.
   --- This system call returns twice. The parent process gets the nonzero
   --- pid. The child gets zero.
@@ -1552,7 +1552,7 @@ local record unix
   --- Hence it should come as no surprise that `fork()` would go slower on
   --- operating systems that have more security features. So depending on
   --- your use case, you can choose the operating system that suits you.
-  fork: function(): number, string | nil, number | nil
+  fork: function(): number | nil, string | nil, number | nil
   --- Performs `$PATH` lookup of executable.
   ---     unix = require 'unix'
   ---     prog = assert(unix.commandv('ls'))
@@ -1565,7 +1565,7 @@ local record unix
   --- they can be discovered like they would on UNIX. If you want to find
   --- a program like notepad on the $PATH using this function, then you
   --- need to specify "notepad.exe" so it includes the extension.
-  commandv: function(prog: string): string, string | nil, number | nil
+  commandv: function(prog: string): string | nil, string | nil, number | nil
   --- Exits current process, replacing it with a new instance of the
   --- specified program. `prog` needs to be an absolute path, see
   --- commandv(). `env` defaults to to the current `environ`. Here's
@@ -1622,12 +1622,12 @@ local record unix
   --- `envp` is the environment. If not specified, inherits the
   --- current environment.
   --- Returns the child process id on success.
-  spawn: function(prog: string, argv: {string}, envp?: {string}): number, string | nil, number | nil
+  spawn: function(prog: string, argv: {string}, envp?: {string}): number | nil, string | nil, number | nil
   --- Spawns a new process with PATH search.
   --- Like `spawn()` but searches for `prog` in the directories
   --- listed in the `PATH` environment variable.
   --- Returns the child process id on success.
-  spawnp: function(prog: string, argv: {string}, envp?: {string}): number, string | nil, number | nil
+  spawnp: function(prog: string, argv: {string}, envp?: {string}): number | nil, string | nil, number | nil
   --- Duplicates file descriptor.
   --- `newfd` may be specified to choose a specific number for the new
   --- file descriptor. If it's already open, then the preexisting one will
@@ -1642,7 +1642,7 @@ local record unix
   --- Will ensure that, in the rare event standard output or standard
   --- error are closed, you won't accidentally duplicate standard input to
   --- those numbers.
-  dup: function(oldfd: number, newfd?: number, flags?: number, lowest?: number): number, string | nil, number | nil
+  dup: function(oldfd: number, newfd?: number, flags?: number, lowest?: number): number | nil, string | nil, number | nil
   --- Creates fifo which enables communication between processes.
   --- - `O_CLOEXEC`: Automatically close file descriptor upon execve()
   --- - `O_NONBLOCK`: Request `EAGAIN` be raised rather than blocking
@@ -1681,7 +1681,7 @@ local record unix
   ---        assert(unix.close(reader))
   ---        assert(unix.wait())
   ---     end
-  pipe: function(flags?: number): number, number, string | nil, number | nil
+  pipe: function(flags?: number): number | nil, number, string | nil, number | nil
   --- Waits for subprocess to terminate.
   --- `pid` defaults to `-1` which means any child process. Setting
   --- `pid` to `0` is equivalent to `-getpid()`. If `pid < -1` then
@@ -1715,7 +1715,7 @@ local record unix
   ---           break
   ---        end
   ---     end
-  wait: function(pid?: number, options?: number): number, number, Rusage, string | nil, number | nil
+  wait: function(pid?: number, options?: number): number | nil, number, Rusage, string | nil, number | nil
   --- Returns `true` if process exited cleanly.
   WIFEXITED: function(wstatus: number): boolean
   --- Returns code passed to exit() assuming `WIFEXITED(wstatus)` is true.
@@ -1749,20 +1749,20 @@ local record unix
   --- standard, which are `SIGINT` and `SIGQUIT`. All other signals on the
   --- Windows platform that are sent to another process via kill() will be
   --- treated like `SIGKILL`.
-  kill: function(pid: number, sig: number): boolean, string | nil, number | nil
+  kill: function(pid: number, sig: number): boolean | nil, string | nil, number | nil
   --- Sends signal to process group.
   --- This is similar to `kill()` but sends the signal to all processes
   --- in the specified process group.
   --- `pgrp` is the process group id. If 0, sends to the calling process's
   --- process group.
   --- `sig` can be any signal value (e.g., `SIGTERM`, `SIGKILL`, etc.).
-  killpg: function(pgrp: number, sig: number): boolean, string | nil, number | nil
+  killpg: function(pgrp: number, sig: number): boolean | nil, string | nil, number | nil
   --- Triggers signal in current process.
   --- This is pretty much the same as `kill(getpid(), sig)`.
-  raise: function(sig: number): number, string | nil, number | nil
+  raise: function(sig: number): number | nil, string | nil, number | nil
   --- Checks if effective user of current process has permission to access file.
   --- - `AT_SYMLINK_NOFOLLOW`: do not follow symbolic links.
-  access: function(path: string, how: number, flags?: number, dirfd?: number): boolean, string | nil, number | nil
+  access: function(path: string, how: number, flags?: number, dirfd?: number): boolean | nil, string | nil, number | nil
   --- Makes directory.
   --- `path` is the path of the directory you wish to create.
   --- `mode` is octal permission bits, e.g. `0755`.
@@ -1776,14 +1776,14 @@ local record unix
   --- Fails with `EACCES` if the parent directory doesn't grant write
   --- permission to the current user.
   --- Fails with `ENAMETOOLONG` if the path is too long.
-  mkdir: function(path: string, mode?: number, dirfd?: number): boolean, string | nil, number | nil
+  mkdir: function(path: string, mode?: number, dirfd?: number): boolean | nil, string | nil, number | nil
   --- Unlike mkdir() this convenience wrapper will automatically create
   --- parent parent directories as needed. If the directory already exists
   --- then, unlike mkdir() which returns EEXIST, the makedirs() function
   --- will return success.
   --- `path` is the path of the directory you wish to create.
   --- `mode` is octal permission bits, e.g. `0755`.
-  makedirs: function(path: string, mode?: number): boolean, string | nil, number | nil
+  makedirs: function(path: string, mode?: number): boolean | nil, string | nil, number | nil
   --- Creates a temporary directory with a unique name.
   --- `template` must end with "XXXXXX" which will be replaced with random
   --- characters to create a unique directory name.
@@ -1791,7 +1791,7 @@ local record unix
   --- Example:
   ---     local tmpdir = unix.mkdtemp("/tmp/myapp_XXXXXX")
   ---     -- tmpdir is now something like "/tmp/myapp_a3b2c1"
-  mkdtemp: function(template: string): string, string | nil, number | nil
+  mkdtemp: function(template: string): string | nil, string | nil, number | nil
   --- Creates a temporary file with a unique name.
   --- `template` must end with "XXXXXX" which will be replaced with random
   --- characters to create a unique filename.
@@ -1802,26 +1802,26 @@ local record unix
   ---     unix.write(fd, "hello")
   ---     unix.close(fd)
   ---     unix.unlink(path)
-  mkstemp: function(template: string): number, string, string | nil, number | nil
+  mkstemp: function(template: string): number | nil, string, string | nil, number | nil
   --- Changes current directory to `path`.
-  chdir: function(path: string): boolean, string | nil, number | nil
+  chdir: function(path: string): boolean | nil, string | nil, number | nil
   --- Removes file at `path`.
   --- If `path` refers to a symbolic link, the link is removed.
   --- Returns `EISDIR` if `path` refers to a directory. See `rmdir()`.
-  unlink: function(path: string, dirfd?: number): boolean, string | nil, number | nil
+  unlink: function(path: string, dirfd?: number): boolean | nil, string | nil, number | nil
   --- Removes empty directory at `path`.
   --- Returns `ENOTDIR` if `path` isn't a directory, or a path component
   --- in `path` exists yet wasn't a directory.
-  rmdir: function(path: string, dirfd?: number): boolean, string | nil, number | nil
+  rmdir: function(path: string, dirfd?: number): boolean | nil, string | nil, number | nil
   --- Renames file or directory.
-  rename: function(oldpath: string, newpath: string, olddirfd: number, newdirfd: number): boolean, string | nil, number | nil
+  rename: function(oldpath: string, newpath: string, olddirfd: number, newdirfd: number): boolean | nil, string | nil, number | nil
   --- Creates hard link, so your underlying inode has two names.
-  link: function(existingpath: string, newpath: string, flags: number, olddirfd: number, newdirfd: number): boolean, string | nil, number | nil
+  link: function(existingpath: string, newpath: string, flags: number, olddirfd: number, newdirfd: number): boolean | nil, string | nil, number | nil
   --- Creates symbolic link.
   --- On Windows NT a symbolic link is called a "reparse point" and can
   --- only be created from an administrator account. Your redbean will
   --- automatically request the appropriate permissions.
-  symlink: function(target: string, linkpath: string, newdirfd?: number): boolean, string | nil, number | nil
+  symlink: function(target: string, linkpath: string, newdirfd?: number): boolean | nil, string | nil, number | nil
   --- Reads contents of symbolic link.
   --- Note that broken links are supported on all platforms. A symbolic
   --- link can contain just about anything. It's important to not assume
@@ -1830,10 +1830,10 @@ local record unix
   --- furthermore prefixes `//?/` to WIN32 DOS-style absolute paths,
   --- thereby assisting with simple absolute filename checks in addition
   --- to enabling one to exceed the traditional 260 character limit.
-  readlink: function(path: string, dirfd?: number): string, string | nil, number | nil
+  readlink: function(path: string, dirfd?: number): string | nil, string | nil, number | nil
   --- Returns absolute path of filename, with `.` and `..` components
   --- removed, and symlinks will be resolved.
-  realpath: function(path: string): string, string | nil, number | nil
+  realpath: function(path: string): string | nil, string | nil, number | nil
   --- Changes access and/or modified timestamps on file.
   --- `path` is a string with the name of the file.
   --- The `asecs` and `ananos` parameters set the access time. If they're
@@ -1855,7 +1855,7 @@ local record unix
   --- - `AT_SYMLINK_NOFOLLOW`: Do not follow symbolic links. This makes it
   --- possible to edit the timestamps on the symbolic link itself,
   --- rather than the file it points to.
-  utimensat: function(path: string, asecs: number, ananos: number, msecs: number, mnanos: number, dirfd?: number, flags?: number): number, string | nil, number | nil
+  utimensat: function(path: string, asecs: number, ananos: number, msecs: number, mnanos: number, dirfd?: number, flags?: number): number | nil, string | nil, number | nil
   --- Changes access and/or modified timestamps on file descriptor.
   --- `fd` is the file descriptor of a file opened with `unix.open`.
   --- The `asecs` and `ananos` parameters set the access time. If they're
@@ -1871,25 +1871,25 @@ local record unix
   --- - `unix.UTIME_OMIT`: Do not alter this timestamp.
   --- This system call is currently not available on very old versions of
   --- Linux, e.g. RHEL5.
-  futimens: function(fd: number, asecs: number, ananos: number, msecs: number, mnanos: number): number, string | nil, number | nil
+  futimens: function(fd: number, asecs: number, ananos: number, msecs: number, mnanos: number): number | nil, string | nil, number | nil
   --- Changes user and group on file.
   --- Returns `ENOSYS` on Windows NT.
-  chown: function(path: string, uid: number, gid: number, flags?: number, dirfd?: number): boolean, string | nil, number | nil
+  chown: function(path: string, uid: number, gid: number, flags?: number, dirfd?: number): boolean | nil, string | nil, number | nil
   --- Changes mode bits on file.
   --- On Windows NT the chmod system call only changes the read-only
   --- status of a file.
-  chmod: function(path: string, mode: number, flags?: number, dirfd?: number): boolean, string | nil, number | nil
+  chmod: function(path: string, mode: number, flags?: number, dirfd?: number): boolean | nil, string | nil, number | nil
   --- Returns current working directory.
   --- On Windows NT, this function transliterates `\` to `/` and
   --- furthermore prefixes `//?/` to WIN32 DOS-style absolute paths,
   --- thereby assisting with simple absolute filename checks in addition
   --- to enabling one to exceed the traditional 260 character limit.
-  getcwd: function(): string, string | nil, number | nil
+  getcwd: function(): string | nil, string | nil, number | nil
   --- Recursively removes filesystem path.
   --- Like `unix.makedirs()` this function isn't actually a system call but
   --- rather is a Libc convenience wrapper. It's intended to be equivalent
   --- to using the UNIX shell's `rm -rf path` command.
-  rmrf: function(path: string): boolean, string | nil, number | nil
+  rmrf: function(path: string): boolean | nil, string | nil, number | nil
   --- Manipulates file descriptor.
   --- `cmd` may be one of:
   --- - `unix.F_GETFD` Returns file descriptor flags.
@@ -1988,21 +1988,21 @@ local record unix
   ---   Returned `pid` is the process id of the current lock owner.
   ---   This function is currently not supported on Windows.
   ---   Returns `EBADF` if `fd` wasn't open.
-  fcntl: function(fd: number, cmd: number, ...: any): any, string | nil, number | nil
+  fcntl: function(fd: number, cmd: number, ...: any): any | nil, string | nil, number | nil
   --- Gets session id.
-  getsid: function(pid: number): number, string | nil, number | nil
+  getsid: function(pid: number): number | nil, string | nil, number | nil
   --- Gets process group id.
-  getpgrp: function(): number, string | nil, number | nil
+  getpgrp: function(): number | nil, string | nil, number | nil
   --- Sets process group id. This is the same as `setpgid(0,0)`.
-  setpgrp: function(): number, string | nil, number | nil
+  setpgrp: function(): number | nil, string | nil, number | nil
   --- Sets process group id the modern way.
-  setpgid: function(pid: number, pgid: number): boolean, string | nil, number | nil
+  setpgid: function(pid: number, pgid: number): boolean | nil, string | nil, number | nil
   --- Gets process group id the modern way.
-  getpgid: function(pid: number): number, string | nil, number | nil
+  getpgid: function(pid: number): number | nil, string | nil, number | nil
   --- Sets session id.
   --- This function can be used to create daemons.
   --- Fails with `ENOSYS` on Windows NT.
-  setsid: function(): number, string | nil, number | nil
+  setsid: function(): number | nil, string | nil, number | nil
   --- Daemonizes the current process.
   --- This function performs the standard Unix daemonization steps:
   --- forks, creates a new session, and optionally changes directory
@@ -2013,7 +2013,7 @@ local record unix
   --- `/dev/null`. Defaults to false (will redirect to `/dev/null`).
   --- This is a convenience wrapper that combines `fork()`, `setsid()`,
   --- and related operations.
-  daemon: function(nochdir?: boolean, noclose?: boolean): boolean, string | nil, number | nil
+  daemon: function(nochdir?: boolean, noclose?: boolean): boolean | nil, string | nil, number | nil
   --- Gets real user id.
   --- On Windows this system call is polyfilled by running `GetUserNameW()`
   --- through Knuth's multiplicative hash.
@@ -2036,7 +2036,7 @@ local record unix
   getegid: function(): number
   --- Changes root directory.
   --- Returns `ENOSYS` on Windows NT.
-  chroot: function(path: string): boolean, string | nil, number | nil
+  chroot: function(path: string): boolean | nil, string | nil, number | nil
   --- Sets user id.
   --- One use case for this function is dropping root privileges. Should
   --- you ever choose to run redbean as root and decide not to use the
@@ -2056,24 +2056,24 @@ local record unix
   --- system manual about the subtleties of changing user id in a way that
   --- isn't restorable.
   --- Returns `ENOSYS` on Windows NT if `uid` isn't `getuid()`.
-  setuid: function(uid: number): boolean, string | nil, number | nil
+  setuid: function(uid: number): boolean | nil, string | nil, number | nil
   --- Sets user id for file system ops.
-  setfsuid: function(uid: number): boolean, string | nil, number | nil
+  setfsuid: function(uid: number): boolean | nil, string | nil, number | nil
   --- Sets group id for file system ops.
-  setfsgid: function(gid: number): boolean, string | nil, number | nil
+  setfsgid: function(gid: number): boolean | nil, string | nil, number | nil
   --- Sets group id.
   --- Returns `ENOSYS` on Windows NT if `gid` isn't `getgid()`.
-  setgid: function(gid: number): boolean, string | nil, number | nil
+  setgid: function(gid: number): boolean | nil, string | nil, number | nil
   --- Sets real, effective, and saved user ids.
   --- If any of the above parameters are -1, then it's a no-op.
   --- Returns `ENOSYS` on Windows NT.
   --- Returns `ENOSYS` on Macintosh and NetBSD if `saved` isn't -1.
-  setresuid: function(real: number, effective: number, saved: number): boolean, string | nil, number | nil
+  setresuid: function(real: number, effective: number, saved: number): boolean | nil, string | nil, number | nil
   --- Sets real, effective, and saved group ids.
   --- If any of the above parameters are -1, then it's a no-op.
   --- Returns `ENOSYS` on Windows NT.
   --- Returns `ENOSYS` on Macintosh and NetBSD if `saved` isn't -1.
-  setresgid: function(real: number, effective: number, saved: number): boolean, string | nil, number | nil
+  setresgid: function(real: number, effective: number, saved: number): boolean | nil, string | nil, number | nil
   --- Sets file permission mask and returns the old one.
   --- This is used to remove bits from the `mode` parameter of functions
   --- like open() and mkdir(). The masks typically used are 027 and 022.
@@ -2092,7 +2092,7 @@ local record unix
   ---     unix.sysconf(unix.SC_PAGESIZE)          -- mmap() page size
   ---     unix.sysconf(unix.SC_CLK_TCK)           -- clock ticks per second
   --- Returns `nil` with an `EINVAL` errno when `name` isn't recognized.
-  sysconf: function(name: number): number, string | nil, number | nil
+  sysconf: function(name: number): number | nil, string | nil, number | nil
   --- Returns identity of the current operating system.
   --- Example:
   ---     local u = assert(unix.uname())
@@ -2176,32 +2176,32 @@ local record unix
   --- Returns `EINVAL` if clock isn't supported on platform.
   --- This function only fails if `clock` is invalid.
   --- This function goes fastest on Linux and Windows.
-  clock_gettime: function(clock?: number): number, number, string | nil, number | nil
+  clock_gettime: function(clock?: number): number | nil, number, string | nil, number | nil
   --- Sleeps with nanosecond precision.
   --- Returns `EINTR` if a signal was received while waiting.
-  nanosleep: function(seconds: number, nanos?: number): number, number, string | nil, number | nil
+  nanosleep: function(seconds: number, nanos?: number): number | nil, number, string | nil, number | nil
   --- These functions are used to make programs slower by asking the
   --- operating system to flush data to the physical medium.
   sync: function()
   --- These functions are used to make programs slower by asking the
   --- operating system to flush data to the physical medium.
-  fsync: function(fd: number): boolean, string | nil, number | nil
+  fsync: function(fd: number): boolean | nil, string | nil, number | nil
   --- These functions are used to make programs slower by asking the
   --- operating system to flush data to the physical medium.
-  fdatasync: function(fd: number): boolean, string | nil, number | nil
+  fdatasync: function(fd: number): boolean | nil, string | nil, number | nil
   --- Seeks to file position.
   --- `whence` can be one of:
   --- - `SEEK_SET`: Sets the file position to `offset` [default]
   --- - `SEEK_CUR`: Sets the file position to `position + offset`
   --- - `SEEK_END`: Sets the file position to `filesize + offset`
   --- Returns the new position relative to the start of the file.
-  lseek: function(fd: number, offset: number, whence?: number): number, string | nil, number | nil
+  lseek: function(fd: number, offset: number, whence?: number): number | nil, string | nil, number | nil
   --- Reduces or extends underlying physical medium of file.
   --- If file was originally larger, content >length is lost.
-  truncate: function(path: string, length?: number): boolean, string | nil, number | nil
+  truncate: function(path: string, length?: number): boolean | nil, string | nil, number | nil
   --- Reduces or extends underlying physical medium of open file.
   --- If file was originally larger, content >length is lost.
-  ftruncate: function(fd: number, length?: number): boolean, string | nil, number | nil
+  ftruncate: function(fd: number, length?: number): boolean | nil, string | nil, number | nil
   --- - `AF_INET`: Creates Internet Protocol Version 4 (IPv4) socket.
   --- - `AF_UNIX`: Creates local UNIX domain socket. On the New Technology
   --- this requires Windows 10 and only works with `SOCK_STREAM`.
@@ -2219,7 +2219,7 @@ local record unix
   --- - `IPPROTO_RAW`
   --- - `IPPROTO_IP`
   --- - `IPPROTO_ICMP`
-  socket: function(family?: number, type?: number, protocol?: number): number, string | nil, number | nil
+  socket: function(family?: number, type?: number, protocol?: number): number | nil, string | nil, number | nil
   --- Creates bidirectional pipe.
   --- - `SOCK_STREAM`
   --- - `SOCK_DGRAM`
@@ -2227,7 +2227,7 @@ local record unix
   --- You may bitwise OR any of the following into `type`:
   --- - `SOCK_CLOEXEC`
   --- - `SOCK_NONBLOCK`
-  socketpair: function(family?: number, type?: number, protocol?: number): number, number, string | nil, number | nil
+  socketpair: function(family?: number, type?: number, protocol?: number): number | nil, number, string | nil, number | nil
   ---  Binds socket.
   ---  `ip` and `port` are in host endian order. For example, if you
   ---  wanted to listen on `1.2.3.4:31337` you could do any of these
@@ -2249,7 +2249,7 @@ local record unix
   ---      end
   ---  Further note that calling `unix.bind(sock)` is equivalent to not
   ---  calling bind() at all, since the above behavior is the default.
-  bind: function(fd: number, ip?: number, port?: number): boolean, string | nil, number | nil
+  bind: function(fd: number, ip?: number, port?: number): boolean | nil, string | nil, number | nil
   --- Returns list of network adapter addresses.
   siocgifconf: function(): any, string | nil, number | nil
   --- Tunes networking parameters.
@@ -2339,7 +2339,7 @@ local record unix
   --- earlier on the listening socket. This is Linux-only. You can use the
   --- `OnServerListen` hook to enable SYN saving in your Redbean. When the
   --- `TCP_SAVE_SYN` option isn't used, this may return empty string.
-  getsockopt: function(fd: number, level: number, optname: number): number, string | nil, number | nil
+  getsockopt: function(fd: number, level: number, optname: number): number | nil, string | nil, number | nil
   --- Tunes networking parameters.
   --- `level` and `optname` may be one of the following pairs. The ellipses
   --- type signature above changes depending on which options are used.
@@ -2427,7 +2427,7 @@ local record unix
   --- earlier on the listening socket. This is Linux-only. You can use the
   --- `OnServerListen` hook to enable SYN saving in your Redbean. When the
   --- `TCP_SAVE_SYN` option isn't used, this may return empty string.
-  setsockopt: function(fd: number, level: number, optname: number, value: boolean | number): boolean, string | nil, number | nil
+  setsockopt: function(fd: number, level: number, optname: number, value: boolean | number): boolean | nil, string | nil, number | nil
   --- Checks for events on a set of file descriptors.
   --- The table of file descriptors to poll uses sparse integer keys. Any
   --- pairs with non-integer keys will be ignored. Pairs with negative
@@ -2449,61 +2449,61 @@ local record unix
   --- - `POLLNVAL` (revents): Invalid request.
   --- If this is set to -1 then that means block as long as it takes until there's an
   --- event or an interrupt. If the timeout expires, an empty table is returned.
-  poll: function(fds: {number: number}, timeoutms?: number): {number: number}, string | nil, number | nil
+  poll: function(fds: {number: number}, timeoutms?: number): {number: number} | nil, string | nil, number | nil
   --- Returns hostname of system.
-  gethostname: function(): string, string | nil, number | nil
+  gethostname: function(): string | nil, string | nil, number | nil
   --- Sets hostname of system.
   --- Requires CAP_SYS_ADMIN on Linux (or root on BSDs); returns `EPERM`
   --- otherwise. Not supported on Windows, where it returns `ENOSYS`.
-  sethostname: function(name: string): boolean, string | nil, number | nil
+  sethostname: function(name: string): boolean | nil, string | nil, number | nil
   --- Begins listening for incoming connections on a socket.
-  listen: function(fd: number, backlog?: number): boolean, string | nil, number | nil
+  listen: function(fd: number, backlog?: number): boolean | nil, string | nil, number | nil
   --- Accepts new client socket descriptor for a listening tcp socket.
   --- `flags` may have any combination (using bitwise OR) of:
   --- - `SOCK_CLOEXEC`
   --- - `SOCK_NONBLOCK`
-  accept: function(serverfd: number, flags?: number): number, number, number, string | nil, number | nil
+  accept: function(serverfd: number, flags?: number): number | nil, number, number, string | nil, number | nil
   ---  Connects a TCP socket to a remote host.
   ---  With TCP this is a blocking operation. For a UDP socket it simply
   ---  remembers the intended address so that `send()` or `write()` may be used
   ---  rather than `sendto()`.
-  connect: function(fd: number, ip: number, port: number): boolean, string | nil, number | nil
+  connect: function(fd: number, ip: number, port: number): boolean | nil, string | nil, number | nil
   --- Retrieves the local address of a socket.
-  getsockname: function(fd: number): number, number, string | nil, number | nil
+  getsockname: function(fd: number): number | nil, number, string | nil, number | nil
   --- Retrieves the remote address of a socket.
   --- This operation will either fail on `AF_UNIX` sockets or return an
   --- empty string.
-  getpeername: function(fd: number): number, number, string | nil, number | nil
+  getpeername: function(fd: number): number | nil, number, string | nil, number | nil
   --- - `MSG_WAITALL`
   --- - `MSG_DONTROUTE`
   --- - `MSG_PEEK`
   --- - `MSG_OOB`
-  recv: function(fd: number, bufsiz?: number, flags?: number): string, string | nil, number | nil
+  recv: function(fd: number, bufsiz?: number, flags?: number): string | nil, string | nil, number | nil
   --- - `MSG_WAITALL`
   --- - `MSG_DONTROUTE`
   --- - `MSG_PEEK`
   --- - `MSG_OOB`
-  recvfrom: function(fd: number, bufsiz?: number, flags?: number): string, number, number, string | nil, number | nil
+  recvfrom: function(fd: number, bufsiz?: number, flags?: number): string | nil, number, number, string | nil, number | nil
   --- This is the same as `write` except it has a `flags` argument
   --- that's intended for sockets.
   --- - `MSG_NOSIGNAL`: Don't SIGPIPE on EOF
   --- - `MSG_OOB`: Send stream data through out of bound channel
   --- - `MSG_DONTROUTE`: Don't go through gateway (for diagnostics)
   --- - `MSG_MORE`: Manual corking to belay nodelay (0 on non-Linux)
-  send: function(fd: number, data: string, flags?: number, offset?: number): number, string | nil, number | nil
+  send: function(fd: number, data: string, flags?: number, offset?: number): number | nil, string | nil, number | nil
   --- This is useful for sending messages over UDP sockets to specific
   --- addresses.
   --- - `MSG_OOB`
   --- - `MSG_DONTROUTE`
   --- - `MSG_NOSIGNAL`
-  sendto: function(fd: number, data: string, ip: number, port: number, flags?: number): number, string | nil, number | nil
+  sendto: function(fd: number, data: string, ip: number, port: number, flags?: number): number | nil, string | nil, number | nil
   --- Partially closes socket.
   --- - `SHUT_RD`: sends a tcp half close for reading
   --- - `SHUT_WR`: sends a tcp half close for writing
   --- - `SHUT_RDWR`
   --- This system call currently has issues on Macintosh, so portable code
   --- should log rather than assert failures reported by `shutdown()`.
-  shutdown: function(fd: number, how: number): boolean, string | nil, number | nil
+  shutdown: function(fd: number, how: number): boolean | nil, string | nil, number | nil
   --- Manipulates bitset of signals blocked by process.
   --- - `SIG_BLOCK`: applies `mask` to set of blocked signals using bitwise OR
   --- - `SIG_UNBLOCK`: removes bits in `mask` from set of blocked signals
@@ -2515,7 +2515,7 @@ local record unix
   ---   oldmask = assert(unix.sigprocmask(unix.SIG_BLOCK, newmask))
   ---   -- do something...
   ---   assert(unix.sigprocmask(unix.SIG_SETMASK, oldmask))
-  sigprocmask: function(how: number, newmask: Sigset): Sigset, string | nil, number | nil
+  sigprocmask: function(how: number, newmask: Sigset): Sigset | nil, string | nil, number | nil
   --- - `unix.SIGINT`
   --- - `unix.SIGQUIT`
   --- - `unix.SIGTERM`
@@ -2582,13 +2582,13 @@ local record unix
   --- handlers (e.g. `unix.SIG_IGN`, `unix.SIG_DFL`, or a raw function pointer)
   --- are installed directly and are not deferred.
   --- It's a good idea to not do too much work in a signal handler.
-  sigaction: function(sig: number, handler?: function | number, flags?: number, mask?: Sigset): function | number, number, Sigset, string | nil, number | nil
+  sigaction: function(sig: number, handler?: function | number, flags?: number, mask?: Sigset): function | number | nil, number, Sigset, string | nil, number | nil
   --- Waits for signal to be delivered.
   --- The signal mask is temporarily replaced with `mask` during this system call.
   sigsuspend: function(mask?: Sigset): nil, string | nil, number | nil
   --- Returns the set of signals pending delivery to the calling process
   --- that are currently blocked.
-  sigpending: function(): Sigset, string | nil, number | nil
+  sigpending: function(): Sigset | nil, string | nil, number | nil
   --- Causes `SIGALRM` signals to be generated at some point(s) in the
   --- future. The `which` parameter should be `ITIMER_REAL`.
   --- Here's an example of how to create a 400 ms interval timer:
@@ -2604,7 +2604,7 @@ local record unix
   --- Here's how you'd do a single-shot timeout in 1 second:
   ---     unix.sigaction(unix.SIGALRM, MyOnSigAlrm, unix.SA_RESETHAND)
   ---     unix.setitimer(unix.ITIMER_REAL, 0, 0, 1, 0)
-  setitimer: function(which: number, intervalsec: number, intervalns: number, valuesec: number, valuens: number): number, number, number, number, string | nil, number | nil
+  setitimer: function(which: number, intervalsec: number, intervalns: number, valuesec: number, valuens: number): number | nil, number, number, number, string | nil, number | nil
   --- Turns platform-specific `sig` code into its symbolic name.
   --- For example:
   ---     >: unix.strsignal(9)
@@ -2634,9 +2634,9 @@ local record unix
   --- If a limit isn't supported by the host platform, it'll be set to
   --- 127. On most platforms these limits are enforced by the kernel and
   --- as such are inherited by subprocesses.
-  setrlimit: function(resource: number, soft: number, hard?: number): boolean, string | nil, number | nil
+  setrlimit: function(resource: number, soft: number, hard?: number): boolean | nil, string | nil, number | nil
   --- Returns information about resource limits for current process.
-  getrlimit: function(resource: number): number, number, string | nil, number | nil
+  getrlimit: function(resource: number): number | nil, number, string | nil, number | nil
   --- Adjusts the nice value (scheduling priority) of the calling process.
   --- The nice value ranges from -20 (highest priority) to 19 (lowest priority).
   --- Only privileged processes can lower the nice value (increase priority).
@@ -2644,7 +2644,7 @@ local record unix
   --- priority, negative values increase it.
   --- Returns the new nice value on success. Note that -1 is a valid return
   --- value, so errors must be detected by checking the second return value.
-  nice: function(inc: number): number, string | nil, number | nil
+  nice: function(inc: number): number | nil, string | nil, number | nil
   --- Lowers the calling process to the lowest scheduling priority.
   --- On Linux this additionally requests the idle scheduling policy and a
   --- best-effort idle i/o priority. This function does not fail.
@@ -2657,7 +2657,7 @@ local record unix
   --- Returns the priority value (nice value) which ranges from -20 to 19.
   --- Note that -1 is a valid return value, so errors must be detected by
   --- checking the second return value.
-  getpriority: function(which: number, who: number): number, string | nil, number | nil
+  getpriority: function(which: number, who: number): number | nil, string | nil, number | nil
   --- Sets the scheduling priority of a process, process group, or user.
   --- `which` specifies what `who` refers to:
   --- - `PRIO_PROCESS`: `who` is a process id (0 = calling process)
@@ -2666,7 +2666,7 @@ local record unix
   --- `prio` is the new priority value (nice value), ranging from -20
   --- (highest priority) to 19 (lowest priority). Only privileged processes
   --- can set negative priority values.
-  setpriority: function(which: number, who: number, prio: number): boolean, string | nil, number | nil
+  setpriority: function(which: number, who: number, prio: number): boolean | nil, string | nil, number | nil
   --- Returns information about resource usage for current process, e.g.
   ---     >: unix.getrusage()
   ---     {utime={0, 53644000}, maxrss=44896, minflt=545, oublock=24, nvcsw=9}
@@ -2674,7 +2674,7 @@ local record unix
   --- - `RUSAGE_THREAD`: current thread
   --- - `RUSAGE_CHILDREN`: not supported on Windows NT
   --- - `RUSAGE_BOTH`: not supported on non-Linux
-  getrusage: function(who?: number): Rusage, string | nil, number | nil
+  getrusage: function(who?: number): Rusage | nil, string | nil, number | nil
   --- Restrict system operations.
   --- This can be used to sandbox your redbean workers. It allows finer
   --- customization compared to the `-S` flag.
@@ -2797,7 +2797,7 @@ local record unix
   ---   means that the `unix.WTERMSIG()` on your killed processes will
   ---   always be `unix.SIGABRT` on both Linux and OpenBSD. Otherwise,
   ---   Linux prefers to raise `unix.SIGSYS`.
-  pledge: function(promises?: string, execpromises?: string, mode?: number): boolean, string | nil, number | nil
+  pledge: function(promises?: string, execpromises?: string, mode?: number): boolean | nil, string | nil, number | nil
   --- Restricts filesystem operations, e.g.
   ---    unix.unveil(".", "r");     -- current dir + children visible
   ---    unix.unveil("/etc", "r");  -- make /etc readable too
@@ -2840,9 +2840,9 @@ local record unix
   ---   corresponding to the pledge promises "exec" and "execnative".
   --- - `c` allows `path` to be created and removed, corresponding to
   ---   the pledge promise "cpath".
-  unveil: function(path: string, permissions: string): boolean, string | nil, number | nil
+  unveil: function(path: string, permissions: string): boolean | nil, string | nil, number | nil
   --- Breaks down UNIX timestamp into Zulu Time numbers.
-  gmtime: function(unixts: number): number, number, number, number, number, number, number, number, number, number, string, string | nil, number | nil
+  gmtime: function(unixts: number): number | nil, number, number, number, number, number, number, number, number, number, string, string | nil, number | nil
   --- Breaks down UNIX timestamp into local time numbers, e.g.
   ---     >: unix.localtime(unix.clock_gettime())
   ---     2022    4       28      2       14      22      -25200  4       117     1       "PDT"
@@ -2868,10 +2868,10 @@ local record unix
   --- can simply copy it inside your redbean. The same is also the case
   --- for future updates to the database, which can be swapped out when
   --- needed, without having to recompile.
-  localtime: function(unixts: number): number, number, number, number, number, number, number, number, number, number, string, string | nil, number | nil
+  localtime: function(unixts: number): number | nil, number, number, number, number, number, number, number, number, number, string, string | nil, number | nil
   --- Gets information about file or directory.
   --- - `AT_SYMLINK_NOFOLLOW`: do not follow symbolic links.
-  stat: function(path: string, flags?: number, dirfd?: number): Stat, string | nil, number | nil
+  stat: function(path: string, flags?: number, dirfd?: number): Stat | nil, string | nil, number | nil
   --- Tests if file mode represents a directory.
   S_ISDIR: function(mode: number): boolean
   --- Tests if file mode represents a regular file.
@@ -2896,7 +2896,7 @@ local record unix
   ---     st = assert(unix.fstat(fd))
   ---     Log(kLogInfo, 'hello.txt is %d bytes in size' % {st:size()})
   ---     unix.close(fd)
-  fstat: function(fd: number): Stat, string | nil, number | nil
+  fstat: function(fd: number): Stat | nil, string | nil, number | nil
   --- Opens directory for listing its contents.
   --- For example, to print a simple directory listing:
   ---     Write('<ul>\r\n')
@@ -2906,19 +2906,19 @@ local record unix
   ---         end
   ---     end
   ---     Write('</ul>\r\n')
-  opendir: function(path: string): Dir, string | nil, number | nil
+  opendir: function(path: string): Dir | nil, string | nil, number | nil
   --- Opens directory for listing its contents, via an fd.
   --- The returned `unix.Dir` takes ownership of the file descriptor
   --- and will close it automatically when garbage collected.
-  fdopendir: function(fd: number): Dir, string | nil, number | nil
+  fdopendir: function(fd: number): Dir | nil, string | nil, number | nil
   --- Returns true if file descriptor is a teletypewriter. Otherwise nil
   --- with an Errno object holding one of the following values:
   --- - `ENOTTY` if `fd` is valid but not a teletypewriter
   --- - `EBADF` if `fd` isn't a valid file descriptor.
   --- - `EPERM` if pledge() is used without `tty` in lenient mode
   --- No other error numbers are possible.
-  isatty: function(fd: number): boolean, string | nil, number | nil
-  tiocgwinsz: function(fd: number): number, number, string | nil, number | nil
+  isatty: function(fd: number): boolean | nil, string | nil, number | nil
+  tiocgwinsz: function(fd: number): number | nil, number, string | nil, number | nil
   --- Gets terminal attributes.
   --- Returns a termios table containing the terminal I/O settings for the
   --- specified file descriptor. The table contains these fields:
@@ -2937,7 +2937,7 @@ local record unix
   ---     local password = io.read()
   ---     tio.lflag = old_lflag
   ---     unix.tcsetattr(0, unix.TCSANOW, tio)
-  tcgetattr: function(fd: number): Termios, string | nil, number | nil
+  tcgetattr: function(fd: number): Termios | nil, string | nil, number | nil
   --- Sets terminal attributes.
   --- Modifies the terminal I/O settings for the specified file descriptor
   --- using the provided termios table. The `action` parameter controls when
@@ -2948,7 +2948,7 @@ local record unix
   ---   input is discarded
   --- The termios table should contain the same fields as returned by
   --- `unix.tcgetattr()`. Missing fields default to zero.
-  tcsetattr: function(fd: number, action: number, termios: Termios): boolean, string | nil, number | nil
+  tcsetattr: function(fd: number, action: number, termios: Termios): boolean | nil, string | nil, number | nil
   --- Returns file descriptor of open anonymous file.
   --- This creates a secure temporary file inside `$TMPDIR`. If it isn't
   --- defined, then `/tmp` is used on UNIX and GetTempPath() is used on
@@ -2959,59 +2959,59 @@ local record unix
   --- On the New Technology, temporary files created by this function
   --- should have better performance, because `kNtFileAttributeTemporary`
   --- asks the kernel to more aggressively cache and reduce i/o ops.
-  tmpfd: function(): number, string | nil, number | nil
+  tmpfd: function(): number | nil, string | nil, number | nil
   --- Relinquishes scheduled quantum.
   sched_yield: function()
   --- Disassociates parts of the caller's execution context, placing it
   --- into fresh namespace(s) specified by `flags` (bitwise OR of
   --- `unix.CLONE_NEW*` constants). Linux-only; returns ENOSYS elsewhere.
-  unshare: function(flags: number): boolean, string | nil, number | nil
+  unshare: function(flags: number): boolean | nil, string | nil, number | nil
   --- Reassociates the calling thread with the namespace referenced by
   --- `fd` (typically from `/proc/<pid>/ns/*`). `nstype`, if nonzero,
   --- must match a `unix.CLONE_NEW*` constant and asserts the kind of
   --- namespace. Linux-only; returns ENOSYS elsewhere.
-  setns: function(fd: number, nstype?: number): boolean, string | nil, number | nil
+  setns: function(fd: number, nstype?: number): boolean | nil, string | nil, number | nil
   --- Mounts a filesystem. `flags` is a bitwise OR of `unix.MS_*`
   --- constants; `data` is a filesystem-specific options string.
-  mount: function(source?: string, target?: string, fstype?: string, flags?: number, data?: string): boolean, string | nil, number | nil
+  mount: function(source?: string, target?: string, fstype?: string, flags?: number, data?: string): boolean | nil, string | nil, number | nil
   --- Unmounts a filesystem. On Linux this is the `umount2` syscall.
   --- `flags` may include `unix.MNT_FORCE`, `unix.MNT_DETACH`,
   --- `unix.MNT_EXPIRE`, `unix.UMOUNT_NOFOLLOW`.
-  unmount: function(target: string, flags?: number): boolean, string | nil, number | nil
+  unmount: function(target: string, flags?: number): boolean | nil, string | nil, number | nil
   --- Moves the root filesystem of the current mount namespace to
   --- `put_old` and makes `new_root` the new root. Usually paired with
   --- `chdir("/")` in the child. Requires a private mount namespace.
-  pivot_root: function(new_root: string, put_old: string): boolean, string | nil, number | nil
+  pivot_root: function(new_root: string, put_old: string): boolean | nil, string | nil, number | nil
   --- Performs an operation on the calling process. `option` is one of
   --- the `unix.PR_*` constants; remaining arguments are option-specific.
   --- Returns the integer result (0 for most setters).
-  prctl: function(option: number, arg2?: number, arg3?: number, arg4?: number, arg5?: number): number, string | nil, number | nil
+  prctl: function(option: number, arg2?: number, arg3?: number, arg4?: number, arg5?: number): number | nil, string | nil, number | nil
   --- Returns the calling thread's (or `pid`'s) capability sets as
   --- 64-bit bitmasks. Each bit position N corresponds to `unix.CAP_*`
   --- constant N. Linux-only.
-  capget: function(pid?: number): number, number, number, string | nil, number | nil
+  capget: function(pid?: number): number | nil, number, number, string | nil, number | nil
   --- Sets the calling thread's (or `pid`'s) capability sets. Each
   --- argument is a 64-bit bitmask of `1 << unix.CAP_*` bits. Linux-only.
-  capset: function(effective: number, permitted: number, inheritable: number, pid?: number): boolean, string | nil, number | nil
+  capset: function(effective: number, permitted: number, inheritable: number, pid?: number): boolean | nil, string | nil, number | nil
   --- Generic device control. When `arg` is nil or absent, the ioctl is
   --- invoked with a null pointer. When `arg` is an integer, it's passed
   --- by value. When `arg` is a string, a mutable copy of the same size
   --- is passed to the kernel and the (possibly-modified) buffer of the
   --- same length is returned.
-  ioctl: function(fd: number, request: number, arg?: number | string): boolean | string, string | nil, number | nil
+  ioctl: function(fd: number, request: number, arg?: number | string): boolean | string | nil, string | nil, number | nil
   --- Landlock: create ruleset. With no args, returns the kernel's
   --- supported ABI version. With `handled_access_fs`, creates a new
   --- ruleset file descriptor that handles the given access categories
   --- (bitwise OR of `unix.LANDLOCK_ACCESS_FS_*`). Linux 5.13+.
-  landlock_create_ruleset: function(handled_access_fs?: number, flags?: number): number, string | nil, number | nil
+  landlock_create_ruleset: function(handled_access_fs?: number, flags?: number): number | nil, string | nil, number | nil
   --- Landlock: add a PATH_BENEATH rule granting `allowed` access to the
   --- subtree rooted at `parent_fd` (opened with `unix.O_PATH`). `allowed`
   --- must be a subset of the ruleset's handled set.
-  landlock_add_rule: function(ruleset_fd: number, parent_fd: number, allowed: number, flags?: number): boolean, string | nil, number | nil
+  landlock_add_rule: function(ruleset_fd: number, parent_fd: number, allowed: number, flags?: number): boolean | nil, string | nil, number | nil
   --- Landlock: apply the ruleset to the current thread (and its future
   --- children). Caller must set `PR_SET_NO_NEW_PRIVS` first or hold
   --- `CAP_SYS_ADMIN`. The restriction is irrevocable.
-  landlock_restrict_self: function(ruleset_fd: number, flags?: number): boolean, string | nil, number | nil
+  landlock_restrict_self: function(ruleset_fd: number, flags?: number): boolean | nil, string | nil, number | nil
   --- Creates interprocess shared memory mapping.
   --- This function allocates special memory that'll be inherited across
   --- fork in a shared way. By default all memory in Redbean is "private"
@@ -3070,9 +3070,9 @@ local record unix
   --- Extracts the minor device number from a device id such as `Stat:rdev()`.
   minor: function(rdev: number): number
   --- Gets filesystem statistics for the filesystem that contains `path`.
-  statfs: function(path: string): Statfs, string | nil, number | nil
+  statfs: function(path: string): Statfs | nil, string | nil, number | nil
   --- Gets filesystem statistics via an open file descriptor.
-  fstatfs: function(fd: number): Statfs, string | nil, number | nil
+  fstatfs: function(fd: number): Statfs | nil, string | nil, number | nil
   --- Signal set for blocking, unblocking, and waiting on signals.
   --- Used with `unix.sigprocmask()`, `unix.sigaction()`, and `unix.sigsuspend()`.
   --- The unix.Sigset class defines a mutable bitset that may currently

--- a/lib/types/gentype_render.tl
+++ b/lib/types/gentype_render.tl
@@ -129,9 +129,12 @@ local function convert_type(t: string): string
   if t:match("|") then
     local parts: {string} = {}
     local seen: {string: boolean} = {}
+    local has_nil = false
     for part in t:gmatch("[^|]+") do
       part = part:match("^%s*(.-)%s*$")
-      if part ~= "nil" and part ~= "" then
+      if part == "nil" then
+        has_nil = true
+      elseif part ~= "" then
         local converted = convert_type(part)
         if not seen[converted] then
           seen[converted] = true
@@ -139,9 +142,14 @@ local function convert_type(t: string): string
         end
       end
     end
+    -- A `nil` member is meaningful: `integer|nil` is how upstream marks a
+    -- fallible success return, and dropping it hides the failure case from
+    -- the checker. `any` already admits nil.
+    local suffix = ""
+    if has_nil then suffix = " | nil" end
     if #parts == 0 then return "any"
-    elseif #parts == 1 then return parts[1]
-    else return table.concat(parts, " | ") end
+    elseif #parts == 1 then return parts[1] .. suffix
+    else return table.concat(parts, " | ") .. suffix end
   end
   local prefix, suffix = t:match("^([%w_]+)%.([%w_]+)$")
   if prefix and suffix then


### PR DESCRIPTION
Closes #518 (batch T1, the remaining generated-types half — the stdlib half landed in #542).

## Problem

Upstream `definitions.lua` already annotates fallible success returns honestly (`@return integer|nil fd`), but `gentype_render.tl`'s union conversion **silently dropped `nil` members**, so every fallible C binding rendered with a bare success type. #518's repro held on main: `local s = cosmo.Slurp("/nonexistent"); print(#s)` passed `--check-types` and crashed at runtime.

## What

- `convert_type` keeps a `nil` union member and appends `| nil` to the converted union (a bare `any` result stays `any`, which already admits nil).
- `bin/make regen-types`: ~120 signatures across `cosmo.d.tl`, `unix.d.tl`, `lsqlite3.d.tl`, `re.d.tl`, `getopt.d.tl`, `argon2.d.tl` gain `T | nil` success returns (e.g. `unix.open: integer` → `integer | nil`; `Dir:read`, futex `wait`, etc.).
- Wrapper fallout was only five files — the #542 sweep had already narrowed everything else. Record unions don't flow-narrow in Teal, so per the AGENTS.md cast-at-use-site convention: `landlock.tl` and `fs/{ops,path,tree,walk}.tl` now use `(st as unix.Stat):mode()` after their nil guards, and `fs/ops.tl` switches to `string.sub(data, off)` on the narrowed read buffer (method-call syntax doesn't narrow).

No runtime behavior changes — types and casts only.

## Verification

- `bin/make test only=gentype` — drift test passes (committed files match generator output byte-for-byte)
- `bin/make teal` — 245/245 (the #518 repro now fails the checker as intended)
- Full `bin/make test` — 113/113; `bin/make format`, `bin/make lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1V1jxUCDu51r14FS51rQY

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1V1jxUCDu51r14FS51rQY)_