### PR TITLE
child: spawn via posix_spawn fast path instead of fork+execve

### DIFF
--- a/lib/cosmic/child/fast.tl
+++ b/lib/cosmic/child/fast.tl
@@ -1,0 +1,123 @@
+--- posix_spawn-backed fast path for `cosmic.child.spawn`.
+---
+--- `unix.spawn` (posix_spawn) creates the child without forking the Lua
+--- interpreter: no page-table copy, no Lua running in the child, and an
+--- exec failure (ENOENT, EACCES, ...) comes back as the call's own error
+--- return, so no exec-status pipe is needed. The binding exposes no file
+--- actions, so the child's stdio is wired by temporarily dup2'ing the
+--- child-side descriptors onto this process's fds 0/1/2 (the child
+--- inherits copies of them) and restoring the originals right after the
+--- spawn call returns. No Lua runs between the dup2s and the restore, so
+--- the window is not observable from library callers.
+local unix = require("cosmo.unix")
+local errno = require("cosmic.errno")
+
+-- Sentinel in `saves`: the std fd was not open, so restoring it means
+-- closing it again rather than dup2'ing a saved copy back.
+local CLOSED = -1
+
+-- Move std fd `n` out of the way. The copy is CLOEXEC (it must never
+-- leak into the child) and placed at 10+ so it cannot collide with the
+-- 0-2 range being wired.
+-- @param n number the std fd (0, 1, or 2)
+-- @return number | nil saved fd, CLOSED if `n` was not open, or nil when
+--   the caller should abandon the fast path
+local function save_fd(n: number): number | nil
+  local saved, _, eno = unix.dup(n, nil, unix.O_CLOEXEC, 10)
+  if saved then
+    return saved
+  end
+  if errno.is(eno, "EBADF") then
+    return CLOSED
+  end
+  return nil
+end
+
+--- Spawn `prog` via posix_spawn with fd0/fd1/fd2 as the child's stdio.
+--- Callers must ensure none of the fds is a CLOEXEC descriptor that
+--- already sits at its own std number (it would be skipped, and the
+--- child would then lose it at exec).
+--- @param prog string resolved executable path
+--- @param argv {string} argument vector (argv[1] is the program name)
+--- @param envp {string} | nil environment, or nil to inherit
+--- @param fd0 number child's stdin
+--- @param fd1 number child's stdout
+--- @param fd2 number child's stderr
+--- @return number | nil child pid; nil means failure or fallback
+--- @return string | nil error: set only for a real spawn failure that
+---   should be reported; `nil, nil` means "fall back to the fork path"
+local function spawn(prog: string, argv: {string}, envp: {string} | nil,
+    fd0: number, fd1: number, fd2: number): number | nil, string
+  local targets: {number} = {fd0, fd1, fd2}
+  local saves: {number} = {}
+
+  -- Save the std fds that are about to be replaced.
+  for i = 1, 3 do
+    local std = i - 1
+    if targets[i] ~= std then
+      local saved = save_fd(std)
+      if saved == nil then
+        for j = 1, 3 do
+          local s = saves[j]
+          if s and s ~= CLOSED then unix.close(s) end
+        end
+        return nil
+      end
+      saves[i] = saved
+    end
+  end
+
+  -- Wire the child-side fds onto 0/1/2. dup2 copies are not CLOEXEC, so
+  -- the child inherits exactly these three.
+  local wired = true
+  for i = 1, 3 do
+    local std = i - 1
+    if targets[i] ~= std then
+      if not unix.dup(targets[i], std) then
+        wired = false
+        break
+      end
+    end
+  end
+
+  local pid: number
+  local serr: string
+  if wired then
+    local p, e = unix.spawn(prog, argv, envp)
+    pid = p
+    serr = e
+  end
+
+  -- Restore the parent's own stdio, whether or not the spawn happened.
+  for i = 1, 3 do
+    local std = i - 1
+    local s = saves[i]
+    if s then
+      if s == CLOSED then
+        unix.close(std)
+      else
+        unix.dup(s, std)
+        unix.close(s)
+      end
+    end
+  end
+
+  if not wired then
+    return nil
+  end
+  if pid == nil then
+    return nil, errno.str(serr, "exec failed")
+  end
+  return pid
+end
+
+local record FastModule
+  spawn: function(prog: string, argv: {string}, envp: {string} | nil,
+  fd0: number, fd1: number, fd2: number): number | nil, string
+end
+
+local M: FastModule = {
+  spawn = spawn,
+}
+
+return M

--- a/lib/cosmic/child/init.tl
+++ b/lib/cosmic/child/init.tl
@@ -14,6 +14,7 @@
 --- simply dropping the handle) never leaves a zombie.
 local unix = require("cosmo.unix")
 local childio = require("cosmic.child.io")
+local childfast = require("cosmic.child.fast")
 local errno = require("cosmic.errno")
 
 --- Structured outcome of a finished child.
@@ -281,6 +282,58 @@ local function spawn(argv: {string}, opts?: Options): Handle | nil, string
     if not stderr_w then return fail("pipe failed (stderr)") end
   end
 
+  -- Parent-side epilogue shared by both spawn paths: release the pipe ends
+  -- the child owns and build the pump state around the ends we keep.
+  local function parent_handle(pid: number): Handle
+    if not stdin_is_fd then unix.close(stdin_r) end
+    if not stdout_is_fd then unix.close(stdout_w) end
+    if not stderr_is_fd then unix.close(stderr_w) end
+    -- An opts.stdin string is delivered lazily by the pump (in wait/run), not
+    -- written synchronously here: a >pipe-buffer write before anyone drains
+    -- stdout/stderr would deadlock. The pump feeds stdin and drains both
+    -- output streams in one poll loop, so neither can happen.
+    local stdin_data: string = nil
+    if type(opts.stdin) == "string" then
+      stdin_data = opts.stdin as string
+    end
+    local st: childio.PumpState = {
+      stdout_fd = stdout_is_fd and nil or stdout_r,
+      stderr_fd = stderr_is_fd and nil or stderr_r,
+      stdin_fd = stdin_is_fd and nil or stdin_w,
+      stdin_data = stdin_data,
+      stdin_off = 0,
+      out = {},
+      err_out = {},
+    }
+    return make_handle(pid, st)
+  end
+
+  -- Fast path: posix_spawn (unix.spawn) needs no fork, runs no Lua in the
+  -- child, and reports exec failure from the call itself, so the exec-status
+  -- pipe below is unnecessary. It cannot fexecve a /zip/ binary or chdir, and
+  -- it skips wiring any fd that already sits at its std number — right for
+  -- caller-provided fds (the child inherits them as-is), wrong for our
+  -- CLOEXEC pipe ends, which land on 0-2 only when that std fd was closed;
+  -- fall back to fork for those cases.
+  if not exec_fd and not opts.cwd then
+    local pipe_on_std = (not stdin_is_fd and stdin_r == 0)
+    or (not stdout_is_fd and stdout_w == 1)
+    or (not stderr_is_fd and stderr_w == 2)
+    if not pipe_on_std then
+      local t0 = stdin_is_fd and opts.stdin as number or stdin_r
+      local t1 = stdout_is_fd and opts.stdout as number or stdout_w
+      local t2 = stderr_is_fd and opts.stderr as number or stderr_w
+      local env = opts.env and normalize_env(opts.env) or nil
+      local fpid, ferr = childfast.spawn(prog, argv, env, t0, t1, t2)
+      if ferr then
+        return fail(ferr)
+      end
+      if fpid then
+        return parent_handle(fpid)
+      end
+    end
+  end
+
   -- Exec-status pipe: CLOEXEC, so a successful execve closes the write end and
   -- the parent's read EOFs instantly. On exec failure the child writes the
   -- errno string here before _exit, making the failure visible to the parent.
@@ -388,26 +441,7 @@ local function spawn(argv: {string}, opts?: Options): Handle | nil, string
     return nil, errno.str(exec_msg, "exec failed")
   end
 
-  -- An opts.stdin string is delivered lazily by the pump (in wait/run), not
-  -- written synchronously here: a >pipe-buffer write before anyone drains
-  -- stdout/stderr would deadlock. The pump feeds stdin and drains both output
-  -- streams in one poll loop, so neither can happen.
-  local stdin_data: string = nil
-  if type(opts.stdin) == "string" then
-    stdin_data = opts.stdin as string
-  end
-
-  local st: childio.PumpState = {
-    stdout_fd = stdout_is_fd and nil or stdout_r,
-    stderr_fd = stderr_is_fd and nil or stderr_r,
-    stdin_fd = stdin_is_fd and nil or stdin_w,
-    stdin_data = stdin_data,
-    stdin_off = 0,
-    out = {},
-    err_out = {},
-  }
-
-  return make_handle(pid, st)
+  return parent_handle(pid)
 end
 
 --- One-shot spawn: run to completion and return the Result.

--- a/lib/cosmic/child/init_test.tl
+++ b/lib/cosmic/child/init_test.tl
@@ -214,15 +214,31 @@ test_spawn_with_env_list()
 local function test_spawn_fork_failure()
   -- Monkey-patch unix.fork to simulate a fork failure; child.tl calls
   -- unix.fork() via the shared module table, so this affects child.spawn.
+  -- cwd forces the fork path (the posix_spawn fast path cannot chdir).
   local real_fork = rawget(unix, "fork")
   rawset(unix, "fork", function(): number return nil end)
-  local handle, err = child.spawn({lua_bin, "-e", "print('x')"})
+  local handle, err = child.spawn({lua_bin, "-e", "print('x')"}, {cwd = "."})
   rawset(unix, "fork", real_fork)
   assert(handle == nil, "expected nil handle on fork failure, got: " .. tostring(handle))
   assert(type(err) == "string", "expected error string on fork failure, got: " .. type(err))
   assert(err:find("fork", 1, true), "expected 'fork' in error message: " .. tostring(err))
 end
 test_spawn_fork_failure()
+
+local function test_spawn_fast_failure()
+  -- Same cleanup contract for the posix_spawn fast path: a spawn failure
+  -- must surface from spawn() itself, with the handle nil.
+  local real_spawn = rawget(unix, "spawn")
+  rawset(unix, "spawn", function(): number, string, number
+      return nil, "spawn: EAGAIN: Resource temporarily unavailable", 11
+    end)
+  local handle, err = child.spawn({lua_bin, "-e", "print('x')"})
+  rawset(unix, "spawn", real_spawn)
+  assert(handle == nil, "expected nil handle on spawn failure, got: " .. tostring(handle))
+  assert(err ~= nil and err:find("exec failed", 1, true),
+    "expected 'exec failed' in error message: " .. tostring(err))
+end
+test_spawn_fast_failure()
 
 -- === deadlock regression: large stderr output ===
 


### PR DESCRIPTION
## What

`child.spawn` forked the ~20MB Lua interpreter and ran the stdio dup2 dance plus `execve` in Lua inside the child, with an extra exec-status pipe to surface exec failures. `unix.spawn` (posix_spawn) needs none of that: no page-table copy, no Lua in the child, and the exec errno comes back from the call itself.

The binding exposes no file actions, so the new `cosmic.child.fast` module wires the child's stdio by temporarily dup2'ing the child-side fds onto the parent's 0/1/2 around the call and restoring them (no Lua runs in the window). `/zip/` (fexecve) and `cwd` spawns keep the fork path, as does the corner case where a CLOEXEC pipe end lands on a closed std fd. Error contract is unchanged: a missing executable still fails from `spawn()` itself with `exec failed: ENOENT: ...`.

Tests: `test_spawn_fork_failure` now pins the fork path via `cwd` (its purpose is fork-failure cleanup); new `test_spawn_fast_failure` covers the same contract for the fast path.

## Measurement

`bin/make perf-compare` vs a clean-tree baseline, pinned cosmos binary (i.e. this is the cosmic-layer win alone, before whilp/cosmopolitan#171 makes posix_spawn vfork-backed):

```
child_spawn_true    1.74 ms ->  1.41 ms  -19.3%  faster
startup_run_teal   10.62 ms ->  7.61 ms  -28.3%  faster
startup_run_lua    10.16 ms ->  7.58 ms  -25.4%  ok (bar ±26.7%)
35 scenarios: 0 regression, 2 faster, 33 ok, 0 noise, 0 new, 0 missing, 0 error
```

With whilp/cosmopolitan#171 on top (A/B of local cosmopolitan builds at the pin, this branch's payload held constant), the joint effect reaches `startup_run_lua` -60.3%, `embed_run_startup` -48.4%.

`bin/make ci` passes (format, teal, tests, examples, lint).

Ref whilp/cosmopolitan#137 (backlog entry 26), #476 (backlog entry 12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QU58bJFXfpv1XdssRaRwAg

---
_Generated by [Claude Code](https://claude.ai/code/session_01QU58bJFXfpv1XdssRaRwAg)_