### PR TITLE
cosmos: bump pin to 2026.07.07-d8630464a; adapt to #170 data-format contracts

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "5e174f95819212e1d66083d9796ee1e510bda485033db82461f2094ea6a38e67"}},
+  platforms = {["*"] = {sha = "a3905e93e2d40a5843a9aeffee4a27a2ccd3ddb31e78cb1c9b2c681142b9bf29"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.07-e3fc92474"
+  version = "2026.07.07-d8630464a"
 }

--- a/lib/cosmic/compress.tl
+++ b/lib/cosmic/compress.tl
@@ -2,22 +2,33 @@
 --- Provides zlib and raw deflate compression with consistent error handling.
 local cosmo = require("cosmo")
 
---- Compress data using zlib (with header).
---- The compressed output includes size information and can be decompressed
+--- Compress data using standard zlib framing.
+--- The zlib format carries its own integrity check (Adler-32), and the
+--- output interoperates with other zlib tooling. It can be decompressed
 --- without knowing the original size.
 --- @param data string The data to compress
 --- @return string The compressed data
 local function compress(data: string): string
-  return cosmo.Compress(data)
+  local result, err = cosmo.Deflate(data, {format = "zlib"})
+  if not result then
+    -- Unreachable with valid options; surface a loud failure rather than
+    -- silently breaking the infallible contract.
+    error("compress: " .. tostring(err))
+  end
+  return result
 end
 
 --- Decompress zlib-compressed data.
+--- The decompressed size need not be known in advance; output is bounded
+--- by max_output (default 64 MiB, enforced by the binding) so untrusted
+--- input cannot balloon memory.
 --- @param data string The compressed data (from compress())
+--- @param max_output number? Cap on the decompressed size in bytes
 --- @return string | nil The decompressed data, or nil on error
 --- @return string? Error message if decompression failed
-local function uncompress(data: string): string | nil, string
+local function uncompress(data: string, max_output?: number): string | nil, string
   -- The binding reports truncated or corrupt input as nil, err.
-  local result, err = cosmo.Uncompress(data)
+  local result, err = cosmo.Inflate(data, {format = "zlib", maxsize = max_output})
   if not result then
     return nil, err as string
   end
@@ -64,7 +75,9 @@ local MAX_DEFLATE_RATIO < const > = 1032
 --- validated BEFORE the output buffer is allocated: a declared size larger
 --- than max_output (when given), or implausibly large for the compressed
 --- payload (beyond DEFLATE's ~1032:1 maximum ratio), is rejected without
---- allocating.
+--- allocating, and the binding additionally caps decompression at the
+--- declared size. Output that does not match the declared size exactly is
+--- reported as corrupt.
 --- Note: Only compatible with data produced by deflate() in this module.
 --- @param data string The compressed data with size prefix
 --- @param max_output number? Reject a declared size larger than this many bytes
@@ -85,17 +98,22 @@ local function inflate(data: string, max_output?: number): string | nil, string
     return nil, "inflate: declared size " .. size .. " is implausible for " .. compressed_len .. " compressed bytes"
   end
   local compressed = data:sub(5)
-  -- The binding reports invalid input as nil, err.
-  local result, err = cosmo.Inflate(compressed, size)
+  -- The binding reports invalid input as nil, err. maxsize of 0 is not a
+  -- valid cap, so an empty payload uses 1 and the exactness check below
+  -- rejects any unexpected output.
+  local result, err = cosmo.Inflate(compressed, {maxsize = math.max(size, 1)})
   if not result then
     return nil, err as string
+  end
+  if #result ~= size then
+    return nil, "inflate: output size " .. #result .. " does not match declared size " .. size
   end
   return result
 end
 
 local record CompressModule
   compress: function(data: string): string
-  uncompress: function(data: string): string | nil, string
+  uncompress: function(data: string, max_output?: number): string | nil, string
   deflate: function(data: string): string | nil, string
   inflate: function(data: string, max_output?: number): string | nil, string
 end

--- a/lib/cosmic/embed.tl
+++ b/lib/cosmic/embed.tl
@@ -58,17 +58,17 @@ local record ZipAppender
   close: function(self: ZipAppender)
 end
 
---- Stat record for zip file metadata.
-local record ZipStat
+--- Directory entry returned by ZipReader:list().
+local record ZipEntry
+  name: string
+  size: number
   mode: number
-  method: number
 end
 
 --- Reader interface for reading files from a ZIP archive.
 local record ZipReader
-  list: function(self: ZipReader): {string}
+  list: function(self: ZipReader): {ZipEntry}
   read: function(self: ZipReader, name: string): string | nil, string | nil
-  stat: function(self: ZipReader, name: string): ZipStat | nil
   close: function(self: ZipReader)
 end
 
@@ -359,7 +359,8 @@ local function extract(output_dir: string, exe_path?: string): EmbedResult
   -- instead of one per file.
   local made_dirs: {string: boolean} = {}
 
-  for _, name in ipairs(entries) do
+  for _, entry in ipairs(entries) do
+    local name = entry.name
     -- Guard against zip-slip: an entry with an absolute path or a ".."
     -- component could otherwise be written outside output_dir.
     if unsafe_entry(name) then
@@ -387,14 +388,11 @@ local function extract(output_dir: string, exe_path?: string): EmbedResult
         made_dirs[dir] = true
       end
 
-      -- Get file mode from zip, default to 644
+      -- Sane-masked mode from the archive entry: permission bits only.
       local file_mode = tonumber("644", 8)
-      local zst = reader:stat(name)
-      if zst then
-        local mode = (zst as ZipStat).mode & tonumber("777", 8)
-        if mode > 0 then
-          file_mode = mode
-        end
+      local mode = entry.mode & tonumber("777", 8)
+      if mode > 0 then
+        file_mode = mode
       end
 
       local write_ok = fs.write(filepath, content, file_mode)

--- a/lib/cosmic/embed_advanced_test.tl
+++ b/lib/cosmic/embed_advanced_test.tl
@@ -12,8 +12,14 @@ local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 -- Local declaration of Reader interface for type casting
+local record Entry
+  name: string
+  size: number
+  mode: number
+end
+
 local record Reader
-  list: function(self: Reader): {string}
+  list: function(self: Reader): {Entry}
   read: function(self: Reader, name: string): string | nil, string | nil
   stat: function(self: Reader, name: string): Stat | nil
   close: function(self: Reader)
@@ -124,10 +130,10 @@ local function test_embed_overwrites_cleanly()
   local orig_data = fs.read(cosmic)
   local orig_reader = zip.from(orig_data) as Reader
   local orig_files: {string: boolean} = {}
-  for _, name in ipairs(orig_reader:list()) do
+  for _, entry in ipairs(orig_reader:list()) do
     -- Skip directory entries
-    if name:sub(-1) ~= "/" then
-      orig_files[name] = true
+    if entry.name:sub(-1) ~= "/" then
+      orig_files[entry.name] = true
     end
   end
   orig_reader:close()
@@ -349,7 +355,7 @@ local function test_embed_symlink_loop_terminates()
   local reader = zip.from(data) as Reader
   local files = reader:list()
   for _, f in ipairs(files) do
-    assert(not f:match("loop"), "embedded zip should not contain loop path: " .. f)
+    assert(not f.name:match("loop"), "embedded zip should not contain loop path: " .. f.name)
   end
   reader:close()
 end
@@ -374,7 +380,7 @@ local function test_embed_symlink_to_outside_file_skipped()
   local reader = zip.from(data) as Reader
   local files = reader:list()
   for _, f in ipairs(files) do
-    assert(not f:match("leaked"), "symlink to outside file should not be embedded: " .. f)
+    assert(not f.name:match("leaked"), "symlink to outside file should not be embedded: " .. f.name)
   end
   reader:close()
 end

--- a/lib/cosmic/embed_test.tl
+++ b/lib/cosmic/embed_test.tl
@@ -10,8 +10,14 @@ local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 -- Local declaration of Reader interface for type casting
+local record Entry
+  name: string
+  size: number
+  mode: number
+end
+
 local record Reader
-  list: function(self: Reader): {string}
+  list: function(self: Reader): {Entry}
   read: function(self: Reader, name: string): string | nil, string | nil
   stat: function(self: Reader, name: string): Stat | nil
   close: function(self: Reader)
@@ -59,7 +65,7 @@ local function test_embed_single_file()
   local found = false
   local expected_name = input:gsub("^/+", "")
   for _, f in ipairs(files) do
-    if f == expected_name then
+    if f.name == expected_name then
       found = true
       break
     end

--- a/lib/cosmic/json.tl
+++ b/lib/cosmic/json.tl
@@ -7,11 +7,14 @@
 --- - `{"a":null,"b":1}` decodes with `a` absent and re-encodes as `{"b":1}`.
 --- - `[1,null,2]` decodes with a hole at index 2; re-encoding sees a table
 ---   of length 1 and truncates to `[1]`.
---- - NaN encodes as `null`; +/-Inf encodes as the out-of-range literal
----   `1e5000`/`-1e5000`, which this module decodes back to +/-Inf but
----   stricter JSON parsers may reject.
+--- - NaN and +/-Inf fail encode() with an error unless `nan="null"` is
+---   given, which serializes them as `null` (the v8 behavior).
 --- If null-preserving round-trips matter, restructure the data (e.g. encode
 --- explicit sentinel values) rather than relying on this module.
+---
+--- Decoded arrays carry a shared marker metatable so an empty `[]`
+--- re-encodes as `[]` instead of `{}`; use array() to mark empty tables
+--- you build yourself.
 local cosmo = require("cosmo")
 
 --- Options accepted by encode(). All fields are optional.
@@ -25,6 +28,9 @@ local record EncodeOptions
   indent: string
   --- Maximum serializer recursion depth (default 64, max 32767).
   maxdepth: number
+  --- The only accepted value is "null": encode NaN and Infinity as
+  --- `null` (the v8 behavior) instead of failing with nil, error.
+  nan: string
 end
 
 --- Decode a JSON string into a Lua value.
@@ -42,10 +48,11 @@ end
 
 --- Encode a Lua value as a JSON string.
 --- Converts Lua tables, strings, numbers, booleans, and nil into JSON format.
---- NaN encodes as `null`, +/-Inf as `1e5000`/`-1e5000`; nil-valued table
---- entries are absent (see the module-level null policy above).
+--- NaN and +/-Inf fail with an error unless `nan="null"` is given;
+--- nil-valued table entries are absent (see the module-level null policy
+--- above).
 --- @param value any The Lua value to encode
---- @param options EncodeOptions? pretty, sorted, indent, maxdepth
+--- @param options EncodeOptions? pretty, sorted, indent, maxdepth, nan
 --- @return string | nil The JSON string representation
 --- @return string? Error message if encoding failed
 local function encode(value: any, options?: EncodeOptions): string | nil, string
@@ -59,6 +66,7 @@ local function encode(value: any, options?: EncodeOptions): string | nil, string
         sorted = options.sorted,
         indent = options.indent,
         maxdepth = options.maxdepth,
+        nan = options.nan,
       })
   else
     result, err = cosmo.EncodeJson(value)
@@ -66,16 +74,29 @@ local function encode(value: any, options?: EncodeOptions): string | nil, string
   return result, err as string
 end
 
+--- Mark a table as a JSON array so encode() serializes it as `[]` even
+--- when it is empty (an unmarked empty table encodes as `{}`). decode()
+--- applies the same marker to every array it decodes, which is how an
+--- empty `[]` round-trips. Passing no argument creates and returns a
+--- fresh marked table.
+--- @param t {any}? The table to mark; a new empty table is created when omitted
+--- @return {any} The same table (or the new one), marked as an array
+local function array(t?: {any}): {any}
+  return cosmo.jsonarray(t)
+end
+
 local record JsonModule
   type EncodeOptions = EncodeOptions
 
   decode: function(str: string): any, string
   encode: function(value: any, options?: EncodeOptions): string | nil, string
+  array: function(t?: {any}): {any}
 end
 
 local M: JsonModule = {
   decode = decode,
   encode = encode,
+  array = array,
 }
 
 return M

--- a/lib/cosmic/json_test.tl
+++ b/lib/cosmic/json_test.tl
@@ -139,13 +139,32 @@ end
 test_null_array_element_truncates()
 
 local function test_nan_inf_encoding()
-  local nan_json = json.encode({0 / 0})
-  assert(nan_json == "[null]", "NaN is documented to encode as null, got: " .. tostring(nan_json))
-  -- Inf encodes as an out-of-range literal, not null: it round-trips back
-  -- to Inf here but is not standard JSON for stricter parsers.
-  local inf_json = json.encode({math.huge})
-  assert(inf_json == "[1e5000]", "Inf is documented to encode as 1e5000, got: " .. tostring(inf_json))
-  local ninf_json = json.encode({-math.huge})
-  assert(ninf_json == "[-1e5000]", "-Inf is documented to encode as -1e5000, got: " .. tostring(ninf_json))
+  -- Non-finite numbers are rejected by default: encoding them silently
+  -- would produce output that stricter JSON parsers refuse.
+  local nan_json, nan_err = json.encode({0 / 0})
+  assert(nan_json == nil, "NaN is documented to fail encode, got: " .. tostring(nan_json))
+  assert(nan_err ~= nil, "NaN encode failure should carry an error message")
+  local inf_json, inf_err = json.encode({math.huge})
+  assert(inf_json == nil, "Inf is documented to fail encode, got: " .. tostring(inf_json))
+  assert(inf_err ~= nil, "Inf encode failure should carry an error message")
+  -- nan="null" opts into the v8 behavior for both NaN and Infinity.
+  local nan_null = json.encode({0 / 0}, {nan = "null"})
+  assert(nan_null == "[null]", "NaN with nan='null' should encode as null, got: " .. tostring(nan_null))
+  local inf_null = json.encode({math.huge, -math.huge}, {nan = "null"})
+  assert(inf_null == "[null,null]", "Inf with nan='null' should encode as null, got: " .. tostring(inf_null))
 end
 test_nan_inf_encoding()
+
+local function test_empty_array_roundtrip()
+  -- Decoded arrays carry the shared array marker, so [] survives a
+  -- round-trip instead of collapsing into {}.
+  local decoded = json.decode("[]")
+  assert(json.encode(decoded) == "[]", "decoded [] should re-encode as []")
+  -- Unmarked empty tables stay objects; array() opts a table in.
+  assert(json.encode({}) == "{}", "a plain empty table should encode as {}")
+  assert(json.encode(json.array({})) == "[]", "array({}) should encode as []")
+  assert(json.encode(json.array()) == "[]", "array() should create an empty array")
+  local marked = json.array({1, 2})
+  assert(json.encode(marked) == "[1,2]", "array() must not disturb elements")
+end
+test_empty_array_roundtrip()

--- a/lib/cosmic/zip.tl
+++ b/lib/cosmic/zip.tl
@@ -42,19 +42,32 @@ local record Stat
   mode: number
 end
 
+--- Directory entry returned by Reader:list().
+local record Entry
+  --- Entry path within the archive.
+  name: string
+  --- Uncompressed size in bytes.
+  size: number
+  --- Unix file mode/permissions.
+  mode: number
+end
+
 --- Reader for extracting files from a ZIP archive.
 local record Reader
-  --- Lists all files in the ZIP archive.
+  --- Lists all files in the ZIP archive, in archive order. Each record
+  --- carries the entry's name, uncompressed size, and mode, so bulk
+  --- operations don't need a follow-up stat per entry.
   --- Entry names come raw from the central directory: an archive built by
   --- another tool can contain absolute or "../" names. Validate before
   --- using a name as a filesystem path, or use extract().
-  --- @return {string} List of file paths in the archive
-  list: function(self: Reader): {string}
+  --- @return {Entry} Directory entry records for the archive
+  list: function(self: Reader): {Entry}
 
   --- Gets metadata for a specific file in the archive.
   --- @param name string The file path within the archive
-  --- @return Stat? File metadata, or nil if file not found
-  stat: function(self: Reader, name: string): Stat | nil
+  --- @return Stat | nil File metadata
+  --- @return string? Error message when the entry is absent
+  stat: function(self: Reader, name: string): Stat | nil, string
 
   --- Reads the contents of a file from the archive.
   --- @param name string The file path within the archive
@@ -231,16 +244,14 @@ local function extract(r: Reader, destdir: string, opts?: ExtractOptions): boole
   local entries = r:list()
 
   -- Validate everything up front: a single bad entry rejects the whole
-  -- archive before any bytes hit the filesystem.
-  for _, name in ipairs(entries) do
-    if unsafe_entry(name) then
-      return false, "unsafe path in archive: " .. name
+  -- archive before any bytes hit the filesystem. list() entries carry
+  -- size and mode, so no per-entry stat is needed.
+  for _, entry in ipairs(entries) do
+    if unsafe_entry(entry.name) then
+      return false, "unsafe path in archive: " .. entry.name
     end
-    if opts and opts.max_file_size then
-      local st = r:stat(name)
-      if st and (st as Stat).size > opts.max_file_size then
-        return false, "entry exceeds max_file_size: " .. name
-      end
+    if opts and opts.max_file_size and entry.size > opts.max_file_size then
+      return false, "entry exceeds max_file_size: " .. entry.name
     end
   end
 
@@ -258,7 +269,8 @@ local function extract(r: Reader, destdir: string, opts?: ExtractOptions): boole
   local ok, err = ensure_dir(destdir)
   if not ok then return false, err end
 
-  for _, name in ipairs(entries) do
+  for _, entry in ipairs(entries) do
+    local name = entry.name
     if name:sub(-1) == "/" then
       ok, err = ensure_dir(fs.join(destdir, name))
       if not ok then return false, err end
@@ -273,12 +285,9 @@ local function extract(r: Reader, destdir: string, opts?: ExtractOptions): boole
 
       -- Sane-masked mode from the archive: permission bits only.
       local file_mode = tonumber("644", 8)
-      local st = r:stat(name)
-      if st then
-        local mode = (st as Stat).mode & tonumber("777", 8)
-        if mode > 0 then
-          file_mode = mode
-        end
+      local mode = entry.mode & tonumber("777", 8)
+      if mode > 0 then
+        file_mode = mode
       end
 
       local write_ok, write_err = fs.write(filepath, content, file_mode)
@@ -301,6 +310,8 @@ local record ZipModule
   type ExtractOptions = ExtractOptions
   --- File metadata within a ZIP archive.
   type Stat = Stat
+  --- Directory entry returned by Reader:list().
+  type Entry = Entry
   --- Reader for extracting files from a ZIP archive.
   type Reader = Reader
   --- Writer for creating new ZIP archives.

--- a/lib/cosmic/zip_test.tl
+++ b/lib/cosmic/zip_test.tl
@@ -75,10 +75,13 @@ local function test_read_list()
 
   assert(#files == 3, "should have 3 files, got " .. #files)
   local found_a, found_b, found_d = false, false, false
-  for _, name in ipairs(files) do
-    if name == "a.txt" then found_a = true end
-    if name == "b.txt" then found_b = true end
-    if name == "c/d.txt" then found_d = true end
+  for _, entry in ipairs(files) do
+    if entry.name == "a.txt" then
+      found_a = true
+      assert(entry.size == 1, "a.txt should report size 1, got " .. tostring(entry.size))
+    end
+    if entry.name == "b.txt" then found_b = true end
+    if entry.name == "c/d.txt" then found_d = true end
   end
   assert(found_a, "should contain a.txt")
   assert(found_b, "should contain b.txt")

--- a/lib/perf/bench/embed_bench.tl
+++ b/lib/perf/bench/embed_bench.tl
@@ -93,8 +93,8 @@ local function count_zip_files(exe_path: string): integer, string
   end
   local rr = reader as czip.Reader
   local count = 0
-  for _, name in ipairs(rr:list()) do
-    if name:sub(-1) ~= "/" then
+  for _, entry in ipairs(rr:list()) do
+    if entry.name:sub(-1) ~= "/" then
       count = count + 1
     end
   end

--- a/lib/types/cosmo.d.tl
+++ b/lib/types/cosmo.d.tl
@@ -33,6 +33,22 @@ local record EncoderOptions
   indent: string
   --- defaults to 64. This option controls the maximum amount of recursion the serializer is allowed to perform. The max is 32767. You might not be able to set it that high if there isn't enough C stack memory. Your serializer checks for this and will return an error rather than crashing.
   maxdepth: number
+  --- `EncodeJson` only: encode NaN and Infinity as `null` (the v8 behavior) instead of failing with `nil, error`.
+  nan: string
+end
+
+local record DeflateOptions
+  --- compression level `-1`..`9`; defaults to `-1`, the zlib default (currently 6). `0` stores without compressing; higher levels are slower but compress better.
+  level: number
+  --- framing of the compressed stream; defaults to `"raw"` (headerless DEFLATE, as used inside ZIP files).
+  format: string
+end
+
+local record InflateOptions
+  --- cap on the decompressed size in bytes; defaults to 64 MiB. Decompression streams into a growing buffer and fails with `nil, error` once the cap is exceeded, so no attacker-controlled length is ever trusted as an allocation size.
+  maxsize: number
+  --- framing of the compressed stream; defaults to `"raw"`. `"auto"` detects zlib or gzip framing from the stream header (but cannot detect `"raw"`).
+  format: string
 end
 
 local record FetchOptions
@@ -89,6 +105,8 @@ end
 local record cosmo
   type Url = Url
   type EncoderOptions = EncoderOptions
+  type DeflateOptions = DeflateOptions
+  type InflateOptions = InflateOptions
   type FetchOptions = FetchOptions
   type BarfOptions = BarfOptions
   type StreamReader = StreamReader
@@ -104,16 +122,6 @@ local record cosmo
   ---     assert(assert(Slurp('x.txt', 1, 6)) == 'abXX23')
   Barf: function(filename: string, data: string, options?: BarfOptions): boolean | nil, string | nil, number | nil
   CategorizeIp: function(ip: number): string
-  --- Compresses data using zlib DEFLATE with a small framing header.
-  --- By default the result starts with a header that stores the
-  --- uncompressed byte length (as a ULEB64 varint) followed by a `Crc32`
-  --- checksum, so `Uncompress` can decode it without being told the
-  --- original size. If `raw` is truthy then only the raw zlib stream is
-  --- returned, in which case `Uncompress` requires the uncompressed size
-  --- as its second argument.
-  --- This function raises an error if the level is invalid or the system
-  --- runs out of memory.
-  Compress: function(uncompressed: string, level?: number, raw?: boolean): string
   --- Computes Phil Katz CRC-32 used by zip/zlib/gzip/etc.
   Crc32: function(initial: number, data: string): number
   --- Computes 32-bit Castagnoli Cyclic Redundancy Check.
@@ -155,12 +163,17 @@ local record cosmo
   ---     end
   --- This parser supports 64-bit signed integers. If an overflow
   --- happens, then the integer is silently coerced to double, as
-  --- consistent with v8. If a double overflows into `Infinity`, we
-  --- coerce it to `null` since that's what v8 does, and the same
-  --- goes for underflows which, like v8, are coerced to `0.0`.
+  --- consistent with v8. If a double overflows, it decodes as
+  --- `Infinity`, which `EncodeJson` refuses to re-encode unless
+  --- `nan="null"` is given; underflows, like v8, are coerced to `0.0`.
   --- When objects are parsed, your Lua object can't preserve the
   --- original ordering of fields. As such, they'll be sorted by
   --- `EncodeJson()` and may not round-trip with original intent.
+  --- Decoded arrays are marked with a shared `json.array` metatable so
+  --- that an empty `[]` won't round-trip as `{}`. The marker carries no
+  --- data: `next()` on a decoded `[]` returns nil, and `pairs()` sees
+  --- only the array elements. Use `jsonarray()` to mark tables you build
+  --- yourself.
   --- This parser has perfect conformance with JSONTestSuite.
   --- This parser validates utf-8 and utf-16.
   DecodeJson: function(input: string): any | nil, string | nil
@@ -169,14 +182,17 @@ local record cosmo
   --- Compresses data.
   ---     >: Deflate("hello")
   ---     "\xcbH\xcd\xc9\xc9\x07\x00"
-  ---     >: Inflate("\xcbH\xcd\xc9\xc9\x07\x00", 5)
+  ---     >: Inflate("\xcbH\xcd\xc9\xc9\x07\x00")
   ---     "hello"
-  --- The output format is raw DEFLATE that's suitable for embedding into formats
-  --- like a ZIP file. It's recommended that, like ZIP, you also store separately a
-  --- `Crc32()` checksum in addition to the original uncompressed size.
-  --- Lower numbers go faster (4 for instance is a sweet spot) and higher numbers go
-  --- slower but have better compression.
-  Deflate: function(uncompressed: string, level?: number): string | nil, string | nil
+  --- The default output format is raw DEFLATE that's suitable for embedding
+  --- into formats like a ZIP file. Pass `{format = "zlib"}` or
+  --- `{format = "gzip"}` for streams that interoperate with other zlib and
+  --- gzip tooling; those framings carry their own integrity checks, whereas
+  --- with `"raw"` it's recommended that, like ZIP, you also store a `Crc32()`
+  --- checksum separately.
+  --- Returns `nil, error` when an option value is invalid (for example a
+  --- level outside `-1`..`9` or an unknown format).
+  Deflate: function(uncompressed: string, options?: DeflateOptions): string | nil, string | nil
   --- Turns binary into ASCII using the provided alphabet (Crockford's
   --- base32 alphabet by default). Any alphabet that has a power of 2
   --- length (up to 128) may be supplied for encoding and decoding, which
@@ -207,23 +223,24 @@ local record cosmo
   ---     "[]"
   ---     >: EncodeJson({[2]=1, [3]=3})
   ---     nil     "json objects must only use string keys"
-  --- If the raw length of a table is reported as zero, then we
-  --- check for the magic element `[0]=false`. If it's present, then
-  --- your table will be serialized as empty array `[]`. An entry is
-  --- inserted by `DecodeJson()` automatically, only when encountering
-  --- empty arrays, and it's necessary in order to make empty arrays
-  --- round-trip. If raw length is zero and `[0]=false` is absent,
-  --- then your table will be serialized as an iterated object.
+  --- If the raw length of a table is reported as zero, then we check
+  --- whether it carries the shared `json.array` marker metatable. If it
+  --- does, your table will be serialized as empty array `[]`. The marker
+  --- is applied by `DecodeJson()` to every decoded array, so empty arrays
+  --- round-trip; use `jsonarray()` to mark empty tables you build
+  --- yourself. If raw length is zero and the marker is absent, then your
+  --- table will be serialized as an iterated object.
   ---     >: EncodeJson({})
   ---     "{}"
-  ---     >: EncodeJson({[0]=false})
+  ---     >: EncodeJson(jsonarray({}))
   ---     "[]"
   ---     >: EncodeJson({["hi"]=1})
   ---     "{\"hi\":1}"
-  ---     >: EncodeJson({["hi"]=1, [0]=false})
-  ---     "[]"
   ---     >: EncodeJson({["hi"]=1, [7]=false})
   ---     nil     "json objects must only use string keys"
+  --- A table carrying the `json.null` sentinel metatable (see the
+  --- `null` value on this module) is serialized as `null`, which makes
+  --- lossless `{"a":null}` round-trips possible.
   --- The following options may be used:
   --- - `useoutput`: `(bool=false)` encodes the result directly to the output buffer
   ---   and returns nil value. This option is ignored if used outside of request
@@ -240,25 +257,20 @@ local record cosmo
   ---   the serializer is allowed to perform. The max is 32767. You might not be able
   ---   to set it that high if there isn't enough C stack memory. Your serializer
   ---   checks for this and will return an error rather than crashing.
-  --- If the raw length of a table is reported as zero, then we
-  --- check for the magic element `[0]=false`. If it's present, then
-  --- your table will be serialized as empty array `[]`. An entry is
-  --- inserted by `DecodeJson()` automatically, only when encountering
-  --- empty arrays, and it's necessary in order to make empty arrays
-  --- round-trip. If raw length is zero and `[0]=false` is absent,
-  --- then your table will be serialized as an iterated object.
+  --- - `nan`: `(str)` The only accepted value is `"null"`, which makes NaN
+  ---   and Infinity serialize as `null` (the v8 behavior) instead of
+  ---   failing the encode.
   --- This function will return an error if:
   --- - value is cyclic
   --- - value has depth greater than 64
   --- - value contains functions, user data, or threads
   --- - value is table that blends string / non-string keys
+  --- - value contains NaN or Infinity and `nan="null"` wasn't given
   --- - Your serializer runs out of C heap memory (setrlimit)
   --- We assume strings in value contain UTF-8. This serializer currently does not
   --- produce UTF-8 output. The output format is right now ASCII. Your UTF-8 data
   --- will be safely transcoded to `\uXXXX` sequences which are UTF-16. Overlong
   --- encodings in your input strings will be canonicalized rather than validated.
-  --- NaNs are serialized as `null` and Infinities are `null` which is consistent
-  --- with the v8 behavior.
   EncodeJson: function(value: any, options?: EncoderOptions): string | nil, string | nil
   --- Turns UTF-8 into ISO-8859-1 string.
   EncodeLatin1: function(utf8: string, flags?: number): string
@@ -493,12 +505,13 @@ local record cosmo
   --- bits outside the values above.
   HasControlCodes: function(str: string, flags?: number): boolean
   --- Decompresses data.
-  --- This function performs the inverse of Deflate(). It's recommended that you
-  --- perform a `Crc32()` check on the output string after this function succeeds.
-  --- However, it is permissable (although not advised) to specify some large number
-  --- in which case (on success) the byte length of the output string may be less
-  --- than `maxoutsize`.
-  Inflate: function(compressed: string, maxoutsize: number): string | nil, string | nil
+  --- This function performs the inverse of `Deflate()`. The decompressed
+  --- size need not be known in advance: output streams into a growing
+  --- buffer, bounded by `options.maxsize` (default 64 MiB). Corrupt or
+  --- truncated input yields `nil, error` rather than raising. When using
+  --- the default `"raw"` framing it's recommended that you perform a
+  --- `Crc32()` check on the output string after this function succeeds.
+  Inflate: function(compressed: string, options?: InflateOptions): string | nil, string | nil
   --- Check if the calling script is being run directly (not require'd).
   --- This function provides a Python-like `if __name__ == "__main__"` idiom
   --- for Lua scripts. It returns true when the script is executed directly
@@ -533,6 +546,16 @@ local record cosmo
   --- Note: we intentionally regard TEST-NET IPs as public.
   IsPublicIp: function(uint32: number): boolean
   IsReasonablePath: function(str: string): boolean
+  --- Marks a table with the shared `json.array` metatable so `EncodeJson`
+  --- serializes it as a JSON array even when it's empty. `DecodeJson`
+  --- applies the same marker to every array it decodes, which is how an
+  --- empty `[]` round-trips instead of turning into `{}`. Passing no
+  --- argument creates and returns a fresh marked table.
+  ---     >: EncodeJson({})
+  ---     "{}"
+  ---     >: EncodeJson(jsonarray({}))
+  ---     "[]"
+  jsonarray: function(t?: {any}): {any}
   --- Parses a `host[:port]` string, e.g. `"example.com:8080"`.
   --- Please note a longstanding quirk inherited from redbean: only the
   --- port component is currently returned. This function yields the port
@@ -635,14 +658,6 @@ local record cosmo
   ---     Strftime("%a, %d %b %Y", 0)             -- "Thu, 01 Jan 1970"
   ---     Strftime("%F %T", os.time(), true)      -- local time instead of UTC
   Strftime: function(format: string, timestamp?: number, localtime?: boolean): string | nil, string | nil
-  --- Decompresses data produced by `Compress`.
-  --- If `maxoutsize` is absent, the input is expected to begin with the
-  --- header that `Compress` writes by default; the embedded length and
-  --- `Crc32` checksum are verified. If `maxoutsize` is given, the input
-  --- must be a raw zlib stream that decompresses to exactly `maxoutsize`
-  --- bytes.
-  --- This function returns nil, err if the input is truncated or corrupt.
-  Uncompress: function(compressed: string, maxoutsize?: number): string | nil, string | nil
   --- Unescapes URL parameter name or value. Decodes `%XX` hex sequences and
   --- converts `+` to space (common in application/x-www-form-urlencoded).
   --- This is the inverse of EscapeParam.

--- a/lib/types/cosmo/zip.d.tl
+++ b/lib/types/cosmo/zip.d.tl
@@ -25,6 +25,16 @@ local record Stat
   mode: number
 end
 
+--- Directory entry returned by `zip.Reader:list`.
+local record Entry
+  --- Entry path within the archive
+  name: string
+  --- Uncompressed size in bytes
+  size: number
+  --- Unix file mode/permissions
+  mode: number
+end
+
 local record AddOptions
   --- Compression method: `"store"` or `"deflate"`
   method: string
@@ -36,10 +46,12 @@ end
 
 --- Reader for extracting files from a ZIP archive.
 local record Reader
-  --- Lists all files in the ZIP archive.
-  list: function(self: Reader): {string}
+  --- Lists all files in the ZIP archive, in archive order. Each record
+  --- carries the entry's name, uncompressed size, and mode, so bulk
+  --- operations don't need a follow-up `stat` per entry.
+  list: function(self: Reader): {Entry}
   --- Gets metadata for a specific file in the archive.
-  stat: function(self: Reader, name: string): Stat | nil
+  stat: function(self: Reader, name: string): Stat | nil, string | nil
   --- Reads the contents of a file from the archive.
   read: function(self: Reader, name: string): string | nil, string | nil
   --- Closes the ZIP reader and releases resources.
@@ -74,6 +86,7 @@ end
 local record zip
   type OpenOptions = OpenOptions
   type Stat = Stat
+  type Entry = Entry
   type AddOptions = AddOptions
   type Reader = Reader
   type Writer = Writer


### PR DESCRIPTION
## What

Bumps the cosmos pin from `2026.07.07-e3fc92474` to `2026.07.07-d8630464a` (the release carrying whilp/cosmopolitan#170's data-format redesign), regenerates the `cosmo.*` types, and lands the matching wrapper changes together:

- **compress**: `Compress`/`Uncompress` are gone upstream; `compress()`/`uncompress()` now use standard zlib framing via `Deflate`/`Inflate` options (Adler-32 integrity, interoperable with other zlib tooling). `uncompress()` gains an optional `max_output` cap (binding default 64 MiB). `inflate()` passes its declared size as the binding's `maxsize` cap and rejects output that doesn't match the size prefix exactly.
- **zip**: `Reader:list()` returns `{Entry}` records (`name`, `size`, `mode`) instead of `{string}`; `Reader:stat()` reports `"entry not found"` as an error second return. `extract()` and embed's extract path read size/mode straight from the list entries, dropping two per-entry `stat` calls.
- **json**: `encode()` fails on NaN/Infinity unless the new `EncodeOptions.nan = "null"` opts into the v8 behavior; decoded arrays carry the shared array marker so `[]` round-trips; new `json.array()` marks caller-built tables. (`cosmo.null` exists upstream but isn't emitted by gentype yet, so the null sentinel isn't exposed here.)

Note: this pin does **not** include whilp/cosmopolitan#171 (vfork posix_spawn) — that lands in a later release/bump once merged.

## perf-compare (baseline on the old pin)

Four scenarios were flagged; each was investigated with a direct A/B of the two pinned binaries carrying the same cosmic payload:

- `startup_run_lua` +20.4%, `startup_run_teal` +20.3%, `embed_run_startup` +18.2% — **not reproducible**: raw lua boot is identical across pins (2.09 vs 2.09 ms/boot, 100-iteration loops ×2) and so is full cosmic boot (5.3 vs 5.3 ms). Baseline-time drift on a shared runner.
- `json_decode_small` +10.4% — **real, and inherent to #170's array marker**: isolated A/B shows `DecodeJson` ~770 → ~905 ns/op on a small doc with two arrays; `luaL_setmetatable("json.array")` does a registry string lookup per decoded array. Accepted as the cost of empty-array round-tripping; a follow-up upstream perf issue tracks hoisting the metatable lookup out of the per-array path.

## Gates

- `bin/make ci` passes (format, teal, 115 tests, examples, lint)
- `bin/make test only=gentype` passes (types match generator output from the new pin byte-for-byte)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QU58bJFXfpv1XdssRaRwAg

---
_Generated by [Claude Code](https://claude.ai/code/session_01QU58bJFXfpv1XdssRaRwAg)_