### PR TITLE
cosmos: bump pin to 2026.07.09-f57a1e433 (vfork-backed posix_spawn)

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "a3905e93e2d40a5843a9aeffee4a27a2ccd3ddb31e78cb1c9b2c681142b9bf29"}},
+  platforms = {["*"] = {sha = "eb7602b25036f42d88fe77fa8e4b2a6cc70a7dcd782e834bf53ec8f58109fd6a"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.07-d8630464a"
+  version = "2026.07.09-f57a1e433"
 }


### PR DESCRIPTION
## What

Bumps the cosmos pin to `2026.07.09-f57a1e433`, the release carrying whilp/cosmopolitan#171: posix_spawn's vfork fast path is now reachable and enabled in the `unix.spawn`/`unix.spawnp` bindings, which `child.spawn`'s fast path (#583) uses for every non-`/zip/`, non-`cwd` spawn. No binding contract changed, so `bin/make regen-types` is a byte-for-byte no-op — this bump is version + sha only.

Verified the released binary issues `vfork(2)` (kernel strace: 11 vfork for 10 spawns) before bumping.

## perf-compare (baseline on the previous pin, `2026.07.07-d8630464a`)

The end-to-end confirmation of the C-layer win:

```
embed_run_startup   2.76 ms ->  1.74 ms  -37.0%  faster
startup_run_lua     8.26 ms ->  5.33 ms  -35.5%  faster
startup_run_teal    8.06 ms ->  5.26 ms  -34.8%  faster
child_spawn_true    1.48 ms ->  1.23 ms  -16.6%  ok (bar ±21.0%)
35 scenarios: 3 faster, 30 ok
```

Two fixed-overhead microbenches tripped the 10% bar and were investigated with direct A/B of the two pinned binaries (tight loops, three interleaved runs each):

- `json_roundtrip_small` +11.1% — **noise**: ranges fully overlap (old 1233–1485 vs new 1260–1337 ns/op).
- `net_ip_roundtrip` +11.7% — **code layout, not a real cost**: a consistent ~5 ns/op shift on a 75 ns/op loop, with `posix_spawn.c`/`lunix.c` as the *only* code delta between the pins (mechanistically unrelated to `ParseIp`/`FormatIp`). `lib/perf/optimize/cosmopolitan.md` names `net_ip_*` as exactly this false-alarm class.

## Gates

- `bin/make ci` passes (format, teal, 115 tests, examples, lint)
- `bin/make test only=gentype` passes (no type drift)

Closes the loop on whilp/cosmopolitan#137 / #476: with this pin, the full spawn stack (cosmic fast path + vfork posix_spawn) is live in releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QU58bJFXfpv1XdssRaRwAg

---
_Generated by [Claude Code](https://claude.ai/code/session_01QU58bJFXfpv1XdssRaRwAg)_