### PR TITLE
perf: bump cosmos pin, use C-speed percent-encoding validation in url.decode

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "eb7602b25036f42d88fe77fa8e4b2a6cc70a7dcd782e834bf53ec8f58109fd6a"}},
+  platforms = {["*"] = {sha = "c4e9ac143cb15b05a31a42fab90694415ae71b6e4c1b940adcab569dcf96acd5"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.09-f57a1e433"
+  version = "2026.07.09-b208ca89f"
 }

--- a/lib/cosmic/url.tl
+++ b/lib/cosmic/url.tl
@@ -1,6 +1,11 @@
 --- URL encoding, decoding, parsing, formatting, and escaping utilities.
 local cosmo = require("cosmo")
 
+-- C-speed percent-encoding validator (one scan, no allocation). Feature
+-- detected so this module still works on cosmos binaries older than the
+-- binding; decode() falls back to the Lua pattern check without it.
+local is_valid_percent_encoding = (cosmo as {string: any})["IsValidPercentEncoding"] as function(str: string): boolean
+
 --- Percent-encode a string for use as a URL query parameter value.
 --- Use this when building query strings manually: `"q=" .. url.encode(search_term)`.
 --- Spaces become %20, special characters become %XX hex sequences.
@@ -25,10 +30,18 @@ end
 local function decode(str: string): string | nil, string
   -- Check for invalid percent-encoding sequences before decoding
   -- Valid sequences are %XX where X is a hex digit
-  local check = str:gsub("%%(%x%x)", "") -- Remove valid sequences
-  if check:match("%%") then
-    -- Found a % that wasn't followed by two hex digits
-    return nil, "invalid percent-encoding"
+  if is_valid_percent_encoding then
+    if not is_valid_percent_encoding(str) then
+      return nil, "invalid percent-encoding"
+    end
+  else
+    -- Older cosmos binary: same check with Lua patterns (a full copy
+    -- via gsub plus a second scan, ~30x slower on multi-KB values).
+    local check = str:gsub("%%(%x%x)", "") -- Remove valid sequences
+    if check:match("%%") then
+      -- Found a % that wasn't followed by two hex digits
+      return nil, "invalid percent-encoding"
+    end
   end
 
   -- Use native C implementation for the actual decoding

--- a/lib/cosmic/url.tl
+++ b/lib/cosmic/url.tl
@@ -1,11 +1,6 @@
 --- URL encoding, decoding, parsing, formatting, and escaping utilities.
 local cosmo = require("cosmo")
 
--- C-speed percent-encoding validator (one scan, no allocation). Feature
--- detected so this module still works on cosmos binaries older than the
--- binding; decode() falls back to the Lua pattern check without it.
-local is_valid_percent_encoding = (cosmo as {string: any})["IsValidPercentEncoding"] as function(str: string): boolean
-
 --- Percent-encode a string for use as a URL query parameter value.
 --- Use this when building query strings manually: `"q=" .. url.encode(search_term)`.
 --- Spaces become %20, special characters become %XX hex sequences.
@@ -28,20 +23,12 @@ end
 --- @return string | nil The decoded string, or nil on error
 --- @return string? Error message if decoding failed
 local function decode(str: string): string | nil, string
-  -- Check for invalid percent-encoding sequences before decoding
-  -- Valid sequences are %XX where X is a hex digit
-  if is_valid_percent_encoding then
-    if not is_valid_percent_encoding(str) then
-      return nil, "invalid percent-encoding"
-    end
-  else
-    -- Older cosmos binary: same check with Lua patterns (a full copy
-    -- via gsub plus a second scan, ~30x slower on multi-KB values).
-    local check = str:gsub("%%(%x%x)", "") -- Remove valid sequences
-    if check:match("%%") then
-      -- Found a % that wasn't followed by two hex digits
-      return nil, "invalid percent-encoding"
-    end
+  -- Check for invalid percent-encoding sequences before decoding.
+  -- UnescapeParam is lenient (a % not followed by two hex digits passes
+  -- through unchanged), so reject malformed input up front; the C
+  -- predicate does it in one scan with no allocation.
+  if not cosmo.IsValidPercentEncoding(str) then
+    return nil, "invalid percent-encoding"
   end
 
   -- Use native C implementation for the actual decoding

--- a/lib/types/cosmo.d.tl
+++ b/lib/types/cosmo.d.tl
@@ -546,6 +546,13 @@ local record cosmo
   --- Note: we intentionally regard TEST-NET IPs as public.
   IsPublicIp: function(uint32: number): boolean
   IsReasonablePath: function(str: string): boolean
+  --- Returns `true` if a percent-encoded string is well-formed, i.e.
+  --- every `%` byte begins a valid `%XX` sequence where both `X` are hex
+  --- digits. Decoders like `UnescapeParam` are lenient and pass malformed
+  --- sequences through unchanged; this predicate lets callers reject such
+  --- input up front with a single scan and no allocation. See
+  --- `isvalidpercentencoding.c`.
+  IsValidPercentEncoding: function(str: string): boolean
   --- Marks a table with the shared `json.array` metatable so `EncodeJson`
   --- serializes it as a JSON array even when it's empty. `DecodeJson`
   --- applies the same marker to every array it decodes, which is how an


### PR DESCRIPTION
`decode()`'s pre-check was a Lua pattern scan — `gsub` builds a full modified copy of the input, then `match` re-scans it — costing ~50 µs on a 2.7 KB query value while the delegated C decode (`UnescapeParam`) costs ~1.6 µs. 97% of the wrapper's time was validation overhead. Cheaper pure-Lua checks aren't available: plain find-per-percent and POSIX `re` both measured slower, and `UnescapeParam` is lenient, so validity can't be derived from its result.

whilp/cosmopolitan#173 (merged, released as `2026.07.09-b208ca89f`) added `cosmo.IsValidPercentEncoding` — one C scan, no allocation, byte-for-byte the same verdicts (equivalence edge cases like `%%25`, `%2%30`, and trailing `%` are covered upstream). This PR:

- bumps `3p/cosmos/version.lua` to `2026.07.09-b208ca89f` (which also brings in the DecodeJson array-marker metatable caching from the same upstream PR)
- regenerates `lib/types/cosmo.d.tl` (`bin/make regen-types`; gentype test green)
- switches `url.decode` to call `cosmo.IsValidPercentEncoding` directly — no feature detection or fallback needed now that the pin carries the binding

## Measurement

`bin/make perf-compare` against a baseline taken on the previous pin (`2026.07.09-f57a1e433`), end to end on the release binaries:

```
url_decode_query_value    76.38 µs ->  3.34 µs   -95.6%  faster
35 scenarios: 0 regression, 2 faster, 33 ok, 0 noise, 0 new, 0 missing, 0 error
```

## Gates

- `bin/make ci` — pass against the new pin (format + teal + test + example)
- `bin/make test only=gentype` — pass (committed types match generator output byte-for-byte)
- `bin/make perf-compare` — exit 0, lines above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHyPKbwNL6Q7fncmsdpuXB