### PR TITLE
pre-stable recorded-decisions sweep: time exports, listen_tcp decision, stdlib.md drift

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -15,10 +15,13 @@ local sqlite = require("cosmic.sqlite")
 | module | description |
 |--------|-------------|
 | `cosmic.json` | JSON encode/decode |
-| `cosmic.io` | file descriptor I/O, pipes, slurp/spit |
+| `cosmic.fd` | file descriptor I/O: open/wrap handles, pipes |
 | `cosmic.fs` | filesystem paths, stat, walk, mkdir, temp files |
 | `cosmic.string` | trim, split, capitalize, starts_with |
 | `cosmic.env` | environment variable get/set/unset/list |
+| `cosmic.envd` | load environment variables from an embedded env.d directory |
+| `cosmic.errno` | errno names, numbers, and error-string helpers |
+| `cosmic.check` | assertion helpers for tests with auto-formatted failure messages |
 | `cosmic.sys` | OS and architecture detection |
 | `cosmic.time` | timestamps, sleep, clock, datetime breakdown |
 | `cosmic.uuid` | UUIDv4 (random) and UUIDv7 (time-ordered) |
@@ -50,8 +53,9 @@ local sqlite = require("cosmic.sqlite")
 |--------|-------------|
 | `cosmic.hash` | SHA-256 and Argon2 password hashing |
 | `cosmic.rand` | cryptographic random bytes |
+| `cosmic.sandbox` | one-call fail-closed facade over pledge, unveil, and landlock |
 | `cosmic.pledge` | restrict system calls on OpenBSD and Linux |
-| `cosmic.unveil` | restrict filesystem visibility on OpenBSD |
+| `cosmic.unveil` | restrict filesystem visibility on OpenBSD, or Linux via landlock |
 | `cosmic.landlock` | Linux >=5.13 self-restricting filesystem sandbox |
 | `cosmic.quicksand` | Linux namespace + allowlist proxy box primitives and declarative `Box` builder |
 
@@ -145,18 +149,19 @@ local id = uuid.v4()                       -- always succeeds
 ### File I/O
 
 ```teal
-local cio = require("cosmic.io")
+local fs = require("cosmic.fs")
+local fd = require("cosmic.fd")
 
 -- read entire file
-local content, err = cio.slurp("config.json")
+local content, err = fs.read("config.json")
 
 -- write entire file
-local ok, err = cio.spit("output.txt", content)
+local ok, err = fs.write("output.txt", content)
 
--- low-level fd operations
-local fd, err = cio.open("file.dat", cio.O_RDONLY)
-local data = cio.read(fd)
-cio.close(fd)
+-- low-level handle operations
+local h, err = fd.open("file.dat", fd.O_RDONLY)
+local data = h:read()
+h:close()
 ```
 
 ### Filesystem
@@ -216,11 +221,10 @@ end
 ```teal
 local child = require("cosmic.child")
 
-local handle, err = child.spawn({"ls", "-la"})
-if handle then
-  local ok, stdout = handle:read()
-  local status = handle:wait()
-  print(stdout)
+local result, err = child.run({"ls", "-la"})
+if result then
+  print(result.stdout)
+  print(result.ok, result.code)
 end
 ```
 
@@ -228,10 +232,8 @@ end
 
 ```teal
 local net = require("cosmic.net")
-local ip = require("cosmic.ip")
 
-local sock, err = net.tcp()
-sock:connect(ip.parse("127.0.0.1"):int(), 8080)
+local sock, err = net.connect_tcp("127.0.0.1", 8080)
 sock:send("GET / HTTP/1.0\r\n\r\n")
 local response = sock:recv(4096)
 sock:close()

--- a/lib/cosmic/fd.tl
+++ b/lib/cosmic/fd.tl
@@ -14,7 +14,8 @@
 --- a signal interrupts the call, it returns nil plus an EINTR-tagged
 --- error; callers that install signal handlers detect it with
 --- `errno.name_of(err) == "EINTR"` and retry themselves. (Automatic
---- retry is deferred to the signal-safety wave.)
+--- retry is deferred to the signal-safety wave, tracked in #595; the
+--- stream-contract EINTR decision is #589.)
 local unix = require("cosmo.unix")
 local errstr = require("cosmic.errno").str
 

--- a/lib/cosmic/net/init.tl
+++ b/lib/cosmic/net/init.tl
@@ -151,6 +151,11 @@ end
 ---   -- port is now the OS-assigned port, e.g. 54321
 ---   local client = net.connect_tcp("127.0.0.1", port)
 ---
+--- Recorded decision (api-review-2, #593): the (Socket, port, err) return
+--- order — the bound port between the value and the error slot — is
+--- deliberate port-0 ergonomics, kept as-is rather than reshuffled to the
+--- usual value-then-error order.
+---
 --- @param addr Address Local IPv4 address to bind ("127.0.0.1", 0 for all)
 --- @param port number Local port to bind; use 0 for an OS-assigned ephemeral port
 --- @param backlog number Maximum pending connections (default 128)

--- a/lib/cosmic/time.tl
+++ b/lib/cosmic/time.tl
@@ -1,5 +1,11 @@
 --- Time and clock utilities.
 --- Wraps cosmo.unix time functions for timestamps, sleeping, and time breakdown.
+---
+--- Recorded decision (api-review-2, #593): the formatting surface stays the
+--- curated trio — format_http/parse_http (RFC 7231), format_date/parse_date
+--- (YYYY-MM-DD), format_iso8601/parse_iso8601 — plus timegm. A general
+--- strftime passthrough (time.format(fmt, ts)) is deferred to post-stable
+--- demand.
 local unix = require("cosmo.unix")
 local cosmo = require("cosmo")
 local errno = require("cosmic.errno")
@@ -184,7 +190,9 @@ local function format_http(timestamp: number): string
   return cosmo.FormatHttpDateTime(timestamp)
 end
 
---- Return true if year is a leap year.
+--- Return true if year is a leap year (Gregorian rules).
+--- @param year number Full year (e.g., 2024)
+--- @return boolean True when the year has 366 days
 local function is_leap_year(year: number): boolean
   return year % 4 == 0 and (year % 100 ~= 0 or year % 400 == 0)
 end
@@ -193,7 +201,14 @@ end
 local MONTH_DAYS: {integer} = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
 
 --- Number of days in the given month, accounting for leap years.
-local function days_in_month(year: number, month: number): number
+--- @param year number Full year (e.g., 2024)
+--- @param month number Month (1-12)
+--- @return number | nil Days in that month (28-31), or nil when month is out of range
+--- @return string Error message when month is out of range
+local function days_in_month(year: number, month: number): number | nil, string
+  if month < 1 or month > 12 then
+    return nil, "days_in_month: month out of range (1-12): " .. tostring(month)
+  end
   if month == 2 and is_leap_year(year) then
     return 29
   end
@@ -216,7 +231,8 @@ local function timegm(year: number, month: number, day: number,
   if month < 1 or month > 12 then
     return nil, "timegm: month out of range (1-12): " .. tostring(month)
   end
-  local dim = days_in_month(year, month)
+  -- month is already range-checked, so the nil arm is unreachable
+  local dim = days_in_month(year, month) as number
   if day < 1 or day > dim then
     return nil, "timegm: day out of range (1-" .. tostring(dim) .. "): "
     .. tostring(day)
@@ -403,6 +419,8 @@ local record TimeModule
   format_iso8601: function(timestamp: number): string | nil, string
   parse_iso8601: function(str: string): number | nil, string
   timegm: function(year: number, month: number, day: number, hour: number, min: number, sec: number): number | nil, string
+  is_leap_year: function(year: number): boolean
+  days_in_month: function(year: number, month: number): number | nil, string
 end
 
 local M: TimeModule = {
@@ -433,6 +451,8 @@ local M: TimeModule = {
   format_iso8601 = format_iso8601,
   parse_iso8601 = parse_iso8601,
   timegm = timegm,
+  is_leap_year = is_leap_year,
+  days_in_month = days_in_month,
 }
 
 return M

--- a/lib/cosmic/time_test.tl
+++ b/lib/cosmic/time_test.tl
@@ -423,3 +423,32 @@ local function test_gmtime_isdst_boolean()
   assert(type(lt.isdst) == "boolean", "localtime isdst must be a boolean")
 end
 test_gmtime_isdst_boolean()
+
+-- is_leap_year / days_in_month (exported in #593)
+
+local function test_is_leap_year()
+  assert(time.is_leap_year(2024) == true, "2024 is a leap year")
+  assert(time.is_leap_year(2025) == false, "2025 is not a leap year")
+  assert(time.is_leap_year(1900) == false, "1900 is not a leap year (century)")
+  assert(time.is_leap_year(2000) == true, "2000 is a leap year (divisible by 400)")
+end
+test_is_leap_year()
+
+local function test_days_in_month()
+  assert(time.days_in_month(2025, 1) == 31, "January has 31 days")
+  assert(time.days_in_month(2025, 2) == 28, "February 2025 has 28 days")
+  assert(time.days_in_month(2024, 2) == 29, "February 2024 has 29 days")
+  assert(time.days_in_month(2025, 4) == 30, "April has 30 days")
+  assert(time.days_in_month(2025, 12) == 31, "December has 31 days")
+end
+test_days_in_month()
+
+local function test_days_in_month_out_of_range()
+  local d, err = time.days_in_month(2025, 13)
+  assert(d == nil, "month 13 must be rejected")
+  assert(err ~= nil and string.find(err, "out of range") ~= nil,
+    "error names the range: " .. tostring(err))
+  local d0 = time.days_in_month(2025, 0)
+  assert(d0 == nil, "month 0 must be rejected")
+end
+test_days_in_month_out_of_range()


### PR DESCRIPTION
Closes #593 — item 1 of the #594 pre-stable breaking wave (B6). Decisions are recorded in module headers so they never re-open, following the #566 pattern.

## Changes

**time** — exports `is_leap_year` and `days_in_month` (previously internal). `days_in_month` now validates its month argument and returns `nil, err` out of range, keeping the honest-nil contract; `timegm` is unchanged (it validates month before calling). The module header records the decision to keep the curated format trio (`format_http`/`format_date`/`format_iso8601` + matching parsers + `timegm`) and defer a general `time.format(fmt, ts)` strftime passthrough to post-stable demand. New tests cover leap-year rules (including the century/400 cases), per-month day counts, and the out-of-range error.

**net.listen_tcp** — the doc comment records the `(Socket, port, err)` return order as deliberate port-0 ergonomics, kept rather than churned to the usual value-then-error shape.

**fd** — the header's deferred "signal-safety wave" now points at tracking issue #595 instead of folklore, and cross-references the stream-contract EINTR decision (#589 / B2).

**docs/stdlib.md** — fixes the user-facing drift:
- `cosmic.io` → `cosmic.fd` in the module index and the File I/O example (whole-file ops now shown via `fs.read`/`fs.write`, low-level via `fd.open` Handles)
- module index gains the missing public modules: `fd`, `check`, `errno`, `envd` (Core) and `sandbox` (Security)
- `unveil` description no longer claims OpenBSD-only (works on Linux via landlock)
- networking example rewritten over `net.connect_tcp` (the old `net.tcp()` + `ip.parse(...):int()` chain doesn't exist in the current API)
- child example rewritten over `child.run` and the `Result` record (`Handle:read` requires a size and `wait` returns a Result, not a bare status)

## Review-era PRs (item 4)

Reconciled outside this diff: #538 closed as superseded by #577 (`errno.constants` already on main), #513 closed as superseded by #579 (README + `fetch.fetch` docs fix already on main).

## Validation

`bin/make ci` green: format 248, teal 248, tests 115, examples 19, lint 315 — all passing. No contract changes beyond the two time exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XdWnoUpSW33ZhVA7scf7Z

---
_Generated by [Claude Code](https://claude.ai/code/session_019XdWnoUpSW33ZhVA7scf7Z)_