### PR TITLE
stream contract: nil-on-EOF everywhere, structural Reader/Writer, sse over any Reader

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -16,6 +16,7 @@ local sqlite = require("cosmic.sqlite")
 |--------|-------------|
 | `cosmic.json` | JSON encode/decode |
 | `cosmic.fd` | file descriptor I/O: open/wrap handles, pipes |
+| `cosmic.stream` | the stream contract: Reader/Writer interfaces |
 | `cosmic.fs` | filesystem paths, stat, walk, mkdir, temp files |
 | `cosmic.string` | trim, split, capitalize, starts_with |
 | `cosmic.env` | environment variable get/set/unset/list |
@@ -235,7 +236,7 @@ local net = require("cosmic.net")
 
 local sock, err = net.connect_tcp("127.0.0.1", 8080)
 sock:send("GET / HTTP/1.0\r\n\r\n")
-local response = sock:recv(4096)
+local response = sock:recv(4096)  -- bare nil (no error) = peer closed
 sock:close()
 ```
 

--- a/lib/cosmic/child/init.tl
+++ b/lib/cosmic/child/init.tl
@@ -16,6 +16,7 @@ local unix = require("cosmo.unix")
 local childio = require("cosmic.child.io")
 local childfast = require("cosmic.child.fast")
 local errno = require("cosmic.errno")
+local stream = require("cosmic.stream")
 
 --- Structured outcome of a finished child.
 --- Exactly one of `code`/`signal` is set: `code` when the child exited,
@@ -30,7 +31,7 @@ end
 
 --- Handle for a spawned process.
 --- Fields prefixed `_` are internal bookkeeping; use the methods.
-local record Handle
+local record Handle is stream.Reader
   pid: integer
 
   -- internal state (do not touch)
@@ -49,10 +50,11 @@ local record Handle
   --- child has not finished in time; the handle stays usable (wait again, or
   --- kill it). Idempotent: repeat calls return the same cached Result.
   wait: function(self: Handle, timeout_ms?: integer): Result | nil, string
-  --- Streaming read of up to `size` bytes from the child's stdout. Returns
-  --- "" at end of file. `size` is required; for whole-output capture use
-  --- `wait`/`run`, which also collect stderr and cannot deadlock.
-  read: function(self: Handle, size: integer): string | nil, string
+  --- Streaming read of up to `size` bytes (default 65536) from the child's
+  --- stdout. Returns bare nil at end of file, matching the stream contract
+  --- (cosmic.stream). For whole-output capture use `wait`/`run`, which
+  --- also collect stderr and cannot deadlock.
+  read: function(self: Handle, size?: number): string | nil, string
 end
 
 --- Options for spawning a process.
@@ -191,14 +193,17 @@ local function make_handle(pid: number, st: childio.PumpState): Handle
     return finish(self, status as number)
   end
 
-  function handle:read(size: integer): string | nil, string
+  function handle:read(size?: number): string | nil, string
     local fd = self._st.stdout_fd
     if not fd then
       return nil, "stdout not captured"
     end
-    local chunk, err = unix.read(fd, size)
+    local chunk, err = unix.read(fd, size or 65536)
     if chunk == nil then
       return nil, errno.str(err, "read")
+    end
+    if chunk == "" then
+      return nil -- end of file (api-review-2, #589)
     end
     return chunk
   end

--- a/lib/cosmic/fd.tl
+++ b/lib/cosmic/fd.tl
@@ -18,10 +18,13 @@
 --- stream-contract EINTR decision is #589.)
 local unix = require("cosmo.unix")
 local errstr = require("cosmic.errno").str
+local stream = require("cosmic.stream")
 
 --- File handle for I/O operations.
+--- Conforms to the stream contract (cosmic.stream): read returns bare
+--- nil at end of file, write returns bytes written or nil + error.
 --- Supports Lua 5.4's to-be-closed via __close metamethod.
-local record Handle
+local record Handle is stream.Reader, stream.Writer
   close: function(self: Handle): boolean, string
   closed: function(self: Handle): boolean
   fd: function(self: Handle): number

--- a/lib/cosmic/fetch/init.tl
+++ b/lib/cosmic/fetch/init.tl
@@ -4,6 +4,7 @@
 
 local cosmo = require("cosmo")
 local fetch_headers = require("cosmic.fetch.headers")
+local stream = require("cosmic.stream")
 local time = require("cosmic.time")
 
 --- Machine-readable failure category, from the C fetch error channel.
@@ -77,8 +78,11 @@ local record Options
 end
 
 --- Streaming reader for incremental body access.
+--- Conforms to the stream contract (cosmic.stream): read returns the
+--- next chunk, bare nil at end of stream, or nil + error on failure.
+--- Chunk sizes are transport-determined; read takes no size argument.
 --- Supports Lua 5.4's to-be-closed via __close metamethod.
-local record Reader
+local record Reader is stream.Reader
   read: function(self: Reader): string | nil, string
   close: function(self: Reader): boolean
   closed: function(self: Reader): boolean

--- a/lib/cosmic/net/init_example.tl
+++ b/lib/cosmic/net/init_example.tl
@@ -29,8 +29,9 @@ local function Example_echo()
   -- echo: hello
 end
 
--- Example_recv_eof demonstrates end-of-stream detection: recv returns an
--- empty string (not nil) when the peer closes the connection
+-- Example_recv_eof demonstrates end-of-stream detection: recv returns
+-- bare nil (no error) when the peer closes the connection, matching the
+-- stream contract (cosmic.stream)
 local function Example_recv_eof()
   local net = require("cosmic.net")
   local srv, port, err = net.listen_tcp(0x7f000001, 0)
@@ -41,8 +42,9 @@ local function Example_recv_eof()
   local conn = srv:accept() as net.Socket
 
   client:close()
-  local data = conn:recv()
-  print(data == "" and "eof" or "data")
+  local data, recv_err = conn:recv()
+  assert(recv_err == nil)
+  print(data == nil and "eof" or "data")
 
   conn:close()
   srv:close()

--- a/lib/cosmic/net/init_test.tl
+++ b/lib/cosmic/net/init_test.tl
@@ -156,9 +156,10 @@ local function test_shutdown()
   local ok, shutdown_err = sock1:shutdown(net.SHUT_WR)
   assert(ok, "shutdown failed: " .. tostring(shutdown_err))
 
-  -- sock2 should now get EOF when reading
-  local data = sock2:recv()
-  assert(data == "", "expected empty string after shutdown, got '" .. tostring(data) .. "'")
+  -- sock2 should now get end-of-stream when reading: bare nil, no error
+  local data, recv_err = sock2:recv()
+  assert(data == nil, "expected nil after shutdown, got '" .. tostring(data) .. "'")
+  assert(recv_err == nil, "EOF must carry no error, got: " .. tostring(recv_err))
 
   sock1:close()
   sock2:close()

--- a/lib/cosmic/net/socket.tl
+++ b/lib/cosmic/net/socket.tl
@@ -20,8 +20,11 @@ local record Socket
   --- Send a datagram to ip:port; returns bytes sent, or nil + error.
   sendto: function(self: Socket, data: string, ip: number, port: number, flags?: number): number | nil, string
   --- Receive up to bufsiz bytes (blocks until data arrives).
-  --- Returns "" (empty string) with no error when the peer closed the
-  --- connection (EOF); returns nil + error message on failure.
+  --- Returns bare nil (no error) when the peer closed the connection —
+  --- end of stream, matching the stream contract (cosmic.stream). ""
+  --- is only ever a zero-byte datagram on message sockets. Returns
+  --- nil + error message on failure. bufsiz must be positive when
+  --- given (default 65536).
   recv: function(self: Socket, bufsiz?: number, flags?: number): string | nil, string
   --- Receive a datagram; returns data, sender ip, sender port.
   recvfrom: function(self: Socket, bufsiz?: number, flags?: number): string | nil, number, number, string
@@ -109,11 +112,23 @@ local function make_socket(fd: number): Socket
     return n
   end
 
+  -- Whether this socket is a message (datagram) socket; resolved on the
+  -- first empty recv and cached, so the common stream path pays nothing.
+  local dgram: boolean = nil
+
   function sock:recv(bufsiz?: number, flags?: number): string | nil, string
     if not self.fd then return nil, "socket closed" end
     local data, err = unix.recv(self.fd, bufsiz or 65536, flags or 0)
     if not data then
       return nil, errstr(err, "recv")
+    end
+    if data == "" then
+      if dgram == nil then
+        dgram = self:getsockopt(unix.SOL_SOCKET, unix.SO_TYPE) == unix.SOCK_DGRAM
+      end
+      if not dgram then
+        return nil -- peer closed: end of stream (api-review-2, #589)
+      end
     end
     return data
   end

--- a/lib/cosmic/public.tl
+++ b/lib/cosmic/public.tl
@@ -51,6 +51,7 @@ local public: {string} = {
   "signal",
   "sqlite",
   "sse",
+  "stream",
   "string",
   "sys",
   "syslog",

--- a/lib/cosmic/sse.tl
+++ b/lib/cosmic/sse.tl
@@ -1,11 +1,12 @@
 --- Server-Sent Events parser for streaming HTTP responses.
---- Parses SSE format from a fetch.Reader and yields complete events,
---- following the WHATWG event stream processing model: unterminated
---- events at EOF are discarded, empty-data dispatches reset the event
---- type buffer, the last event ID updates as soon as an `id:` line is
---- seen, and `retry:` accepts only ASCII digits.
+--- Parses SSE format from any stream.Reader (a fetch.Reader, an fd
+--- Handle wrapping a socket, a child's stdout) and yields complete
+--- events, following the WHATWG event stream processing model:
+--- unterminated events at EOF are discarded, empty-data dispatches
+--- reset the event type buffer, the last event ID updates as soon as
+--- an `id:` line is seen, and `retry:` accepts only ASCII digits.
 
-local fetch = require("cosmic.fetch")
+local stream = require("cosmic.stream")
 
 --- A parsed SSE event.
 local record Event
@@ -54,6 +55,64 @@ local function parse_field(line: string): string, string
   return name, value
 end
 
+--- Buffered line iterator over any stream.Reader, with the semantics of
+--- fetch.Reader:lines(): complete lines without the trailing newline; on
+--- clean EOF a final unterminated line is yielded once, then nil; on a
+--- read error the buffered partial line is truncated data and is
+--- discarded — the iterator yields nil plus the error once, then plain
+--- nil forever. Private to sse until the post-stable buffered-reader
+--- battery generalizes it (#501).
+local function line_iter(reader: stream.Reader): function(): string | nil, string
+  -- Scan-position index into buffer: `pos` is the first unread byte
+  -- (same linear-time scheme as fetch.Reader:lines()).
+  local buffer = ""
+  local pos = 1
+  local done = false
+  local pending_err: string = nil
+
+  return function(): string | nil, string
+    while true do
+      local newline_pos = buffer:find("\n", pos, true)
+      if newline_pos then
+        local line = buffer:sub(pos, newline_pos - 1)
+        pos = newline_pos + 1
+        return line
+      end
+
+      if pending_err then
+        local err = pending_err
+        pending_err = nil
+        done = true
+        return nil, err
+      end
+
+      if done then
+        if pos <= #buffer then
+          local remaining = buffer:sub(pos)
+          pos = #buffer + 1
+          return remaining
+        end
+        return nil
+      end
+
+      if pos > 1 then
+        buffer = buffer:sub(pos)
+        pos = 1
+      end
+      local chunk, err = reader:read()
+      if err then
+        pending_err = err
+        buffer = ""
+        pos = 1
+      elseif not chunk then
+        done = true
+      else
+        buffer = buffer .. chunk
+      end
+    end
+  end
+end
+
 --- Parse SSE events from a streaming reader.
 --- Returns a Stream whose next() yields Event values (iterate with
 --- `for ev in stream.next do`); when the underlying reader fails
@@ -62,14 +121,14 @@ end
 --- distinguishable from a graceful close. A partially accumulated event
 --- at end-of-stream is discarded per the SSE spec, not dispatched.
 --- stream.last_event_id() exposes the id for reconnects.
---- @param reader fetch.Reader the reader to parse events from
+--- @param reader stream.Reader the reader to parse events from
 --- @return Stream the open event stream
-local function events(reader: fetch.Reader): Stream
+local function events(reader: stream.Reader): Stream
   local current_data: {string} = {}
   local current_event: string = nil
   local current_retry: number = nil
   local last_id: string = nil
-  local lines_iter = reader:lines()
+  local lines_iter = line_iter(reader)
   local done = false
 
   local function next_event(): Event | nil, string
@@ -151,7 +210,7 @@ end
 local record sse
   Event: Event
   Stream: Stream
-  events: function(reader: fetch.Reader): Stream
+  events: function(reader: stream.Reader): Stream
 end
 
 local M: sse = {

--- a/lib/cosmic/sse_test.tl
+++ b/lib/cosmic/sse_test.tl
@@ -338,3 +338,30 @@ local function test_error_discards_partial_event()
   assert(err == "reset", "the failure is reported")
 end
 test_error_discards_partial_event()
+
+local function test_events_from_socket_backed_reader()
+  -- The stream contract (#589): sse consumes ANY stream.Reader, not just
+  -- fetch.Reader — here a socket wrapped as an fd Handle.
+  local net = require("cosmic.net")
+  local fd = require("cosmic.fd")
+
+  local s1, s2, serr = net.socketpair()
+  assert(s1 ~= nil and s2 ~= nil, "socketpair failed: " .. tostring(serr))
+  local a = s1 as net.Socket
+  local b = s2 as net.Socket
+
+  assert(a:send("data: from a socket\n\nevent: ping\ndata: second\n\n"))
+  a:close()
+
+  local stream_events = sse.events(fd.wrap(b.fd))
+  local ev1 = stream_events.next() as sse.Event
+  assert(ev1.data == "from a socket", "first event data: " .. tostring(ev1.data))
+  assert(ev1.event == "message", "default event type")
+  local ev2 = stream_events.next() as sse.Event
+  assert(ev2.data == "second", "second event data: " .. tostring(ev2.data))
+  assert(ev2.event == "ping", "explicit event type")
+  local done, derr = stream_events.next()
+  assert(done == nil and derr == nil, "clean close ends the stream")
+  b:close()
+end
+test_events_from_socket_backed_reader()

--- a/lib/cosmic/stream.tl
+++ b/lib/cosmic/stream.tl
@@ -1,0 +1,41 @@
+--- The stream contract: the byte-stream interfaces every producer and
+--- consumer in the standard library composes over (api-review-2, #589).
+---
+--- Reader is the one EOF convention: read() returns a non-empty chunk,
+--- or bare nil (no error) at end of stream, or nil plus an error message
+--- on failure. Reads after EOF keep returning bare nil. The optional
+--- size argument is an upper bound, not a demand — implementations may
+--- return fewer bytes — and must be positive when given.
+---
+--- Writer accepts a string and returns the number of bytes written
+--- (which may be short) or nil plus an error message.
+---
+--- Conforming types: fd.Handle (Reader and Writer), fetch.Reader
+--- (Reader), child.Handle (Reader, over the child's stdout). Sockets
+--- keep their native recv/send names but follow the same conventions
+--- (recv returns nil on peer close); wrap a socket's descriptor with
+--- fd.wrap(sock.fd) to use it where a Reader or Writer is expected.
+---
+--- EINTR posture, recorded (api-review-2, #589): conforming reads and
+--- writes do NOT retry automatically when a signal interrupts them —
+--- the call surfaces nil plus an EINTR-tagged error, detected with
+--- errno.name_of(err) == "EINTR", and callers that install signal
+--- handlers retry themselves. poll retries internally. Making retry
+--- automatic across the wrappers is the post-stable signal-safety
+--- wave, tracked in #595.
+local record stream
+  --- A source of bytes. read(n?) returns the next chunk (at most n
+  --- bytes when n is given), bare nil at end of stream, or nil plus an
+  --- error message on failure.
+  interface Reader
+    read: function(self: Reader, n?: number): string | nil, string
+  end
+
+  --- A sink for bytes. write(data) returns the number of bytes
+  --- written (possibly short), or nil plus an error message.
+  interface Writer
+    write: function(self: Writer, data: string): number | nil, string
+  end
+end
+
+return stream

--- a/lib/cosmic/stream_example.tl
+++ b/lib/cosmic/stream_example.tl
@@ -1,0 +1,56 @@
+--- Examples for cosmic.stream module.
+
+-- Example_reader demonstrates the stream contract: one drain loop works
+-- for ANY Reader — bare nil (no error) is end of stream. Here the Reader
+-- is an fd pipe Handle; a fetch.Reader or a child.Handle drains with the
+-- exact same code.
+local function Example_reader()
+  local fd = require("cosmic.fd")
+  local stream = require("cosmic.stream")
+
+  local function drain(r: stream.Reader): string
+    local parts: {string} = {}
+    while true do
+      local chunk, err = r:read(4096)
+      assert(err == nil, err)
+      if chunk == nil then
+        break
+      end
+      parts[#parts + 1] = chunk
+    end
+    return table.concat(parts)
+  end
+
+  local p = fd.pipe() as fd.Pipe
+  p.writer:write("hello, ")
+  p.writer:write("stream")
+  p.writer:close()
+
+  print(drain(p.reader))
+  p.reader:close()
+  -- Output:
+  -- hello, stream
+end
+
+-- Example_writer demonstrates the Writer half: anything with
+-- write(data) -> bytes | nil, err accepts bytes the same way.
+local function Example_writer()
+  local fd = require("cosmic.fd")
+  local stream = require("cosmic.stream")
+
+  local function put(w: stream.Writer, data: string): number
+    local n = assert(w:write(data))
+    return n
+  end
+
+  local p = fd.pipe() as fd.Pipe
+  print(put(p.writer, "ten bytes!"))
+  p.writer:close()
+  print(p.reader:read())
+  p.reader:close()
+  -- Output:
+  -- 10
+  -- ten bytes!
+end
+
+return {}

--- a/lib/cosmic/stream_test.tl
+++ b/lib/cosmic/stream_test.tl
@@ -1,0 +1,144 @@
+#!/usr/bin/env cosmic
+--- Stream-contract conformance suite (api-review-2, #589): every byte
+--- producer honors the one EOF convention — read returns a chunk, bare
+--- nil (no error) at end of stream, and keeps returning bare nil after
+--- EOF; failures return nil plus an error message. Run against
+--- fd.Handle, net.Socket, fetch.Reader, and child.Handle.
+local stream = require("cosmic.stream")
+local fd = require("cosmic.fd")
+local net = require("cosmic.net")
+local child = require("cosmic.child")
+local fetch = require("cosmic.fetch")
+local fs = require("cosmic.fs")
+local proc = require("cosmic.proc")
+
+local lua_bin = fs.join(os.getenv("TEST_BIN"), "cosmic")
+
+--- Drain a Reader to EOF and check the contract along the way: no
+--- errors, bare nil terminates, and reads after EOF stay bare nil.
+--- Taking stream.Reader here is itself the compile-time conformance
+--- check for every type passed in below.
+local function check_reader(r: stream.Reader, want: string, label: string)
+  local parts: {string} = {}
+  while true do
+    local chunk, err = r:read(4096)
+    assert(err == nil, label .. ": unexpected read error: " .. tostring(err))
+    if chunk == nil then
+      break
+    end
+    assert(chunk ~= "", label .. ": a Reader never yields \"\"")
+    parts[#parts + 1] = chunk
+  end
+  local got = table.concat(parts)
+  assert(got == want, label .. ": payload mismatch, got '" .. got .. "'")
+  for i = 1, 2 do
+    local again, err2 = r:read(4096)
+    assert(again == nil and err2 == nil,
+      label .. ": read " .. i .. " after EOF must stay bare nil, got "
+      .. tostring(again) .. ", " .. tostring(err2))
+  end
+end
+
+local function test_fd_handle_conforms()
+  local p = fd.pipe() as fd.Pipe
+  assert(p.writer:write("fd bytes"))
+  p.writer:close()
+  check_reader(p.reader, "fd bytes", "fd.Handle")
+  p.reader:close()
+end
+test_fd_handle_conforms()
+
+local function test_socket_recv_eof_is_nil()
+  local s1, s2, err = net.socketpair()
+  assert(s1 ~= nil and s2 ~= nil, "socketpair failed: " .. tostring(err))
+  local a = s1 as net.Socket
+  local b = s2 as net.Socket
+
+  assert(a:send("socket bytes"))
+  a:close()
+
+  local got = ""
+  while true do
+    local chunk, rerr = b:recv(4096)
+    assert(rerr == nil, "unexpected recv error: " .. tostring(rerr))
+    if chunk == nil then break end
+    got = got .. chunk
+  end
+  assert(got == "socket bytes", "payload mismatch, got '" .. got .. "'")
+  -- recv after end of stream stays bare nil
+  local again, aerr = b:recv(4096)
+  assert(again == nil and aerr == nil, "recv after EOF must stay bare nil")
+  b:close()
+
+  -- and the error channel is intact: recv on a closed socket errors
+  local d, cerr = b:recv()
+  assert(d == nil and cerr == "socket closed", "closed-socket recv shape")
+end
+test_socket_recv_eof_is_nil()
+
+local function test_socket_zero_byte_datagram_stays_empty()
+  -- "" is reserved for the one honest case: a zero-byte datagram on a
+  -- message socket. It must NOT be collapsed into nil.
+  local s1, s2, err = net.socketpair(nil, net.SOCK_DGRAM)
+  assert(s1 ~= nil and s2 ~= nil, "dgram socketpair failed: " .. tostring(err))
+  local a = s1 as net.Socket
+  local b = s2 as net.Socket
+
+  assert(a:send(""))
+  local dgram, derr = b:recv(4096)
+  assert(dgram == "", "zero-byte datagram must arrive as \"\", got "
+    .. tostring(dgram) .. " (" .. tostring(derr) .. ")")
+
+  assert(a:send("dgram"))
+  local data = b:recv(4096)
+  assert(data == "dgram", "datagram payload intact")
+
+  a:close()
+  b:close()
+end
+test_socket_zero_byte_datagram_stays_empty()
+
+local function test_child_handle_conforms()
+  local h = child.spawn({lua_bin, "-e", "io.write('child bytes'); io.flush()"}) as child.Handle
+  check_reader(h, "child bytes", "child.Handle")
+  h:wait()
+end
+test_child_handle_conforms()
+
+--- Fork a loopback server answering one request, closing right after.
+local function serve_once(response: string): integer, number
+  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  assert(srv ~= nil, "listen_tcp failed")
+  local s = srv as net.Socket
+  local pid = proc.fork()
+  if pid == 0 then
+    local conn = s:accept()
+    if conn then
+      local c = conn as net.Socket
+      local buf = ""
+      while not buf:find("\r\n\r\n", 1, true) do
+        local data = c:recv(4096)
+        if not data then break end
+        buf = buf .. data
+      end
+      c:send(response)
+      c:close()
+    end
+    os.exit(0)
+  end
+  s:close()
+  return math.tointeger(port), pid
+end
+
+local function test_fetch_reader_conforms()
+  local body = "fetch bytes"
+  local port, pid = serve_once("HTTP/1.1 200 OK\r\nContent-Length: " .. #body
+    .. "\r\nConnection: close\r\n\r\n" .. body)
+  local result = fetch.stream("http://127.0.0.1:" .. port .. "/",
+    {allow_private = true})
+  assert(result.ok == true, "stream failed: " .. tostring(result.error))
+  check_reader(result.reader, body, "fetch.Reader")
+  result.reader:close()
+  proc.wait(pid)
+end
+test_fetch_reader_conforms()


### PR DESCRIPTION
Closes #589 — item 2 of the #594 pre-stable breaking wave (B2). One EOF convention and one structural stream contract, frozen before the stable cut so post-stable batteries (tls, httpd, gzip streaming, bufio) compose as value extensions instead of forking per producer.

## The contract

**`cosmic.stream` (new public module)** exports `Reader` and `Writer` as Teal interfaces, documented as *the* stream contract:

- `Reader.read(n?)` → next chunk, **bare nil (no error) at end of stream**, `nil, err` on failure; reads after EOF stay bare nil; a Reader never yields `""`
- `Writer.write(data)` → bytes written (possibly short) or `nil, err`

The EINTR posture is recorded in the module header — **document, don't retry**: interrupted reads/writes surface `nil` + an EINTR-tagged error and callers that install signal handlers retry themselves; making retry automatic across the wrappers is the post-stable signal-safety wave (#595).

## Breaking changes

- **`net.Socket:recv`** returns bare nil on peer close instead of `""`, matching fd. `""` survives only in the one honest case — a zero-byte datagram on a message socket (SO_TYPE resolved lazily on the first empty recv and cached per socket, so the stream hot path pays nothing).
- **`child.Handle:read`** returns bare nil at end of file instead of `""`; `size` is now optional (default 65536).

## Conformance wiring

- `fd.Handle` declares `is stream.Reader, stream.Writer` (behavior already conformed)
- `fetch.Reader` declares `is stream.Reader` (behavior already conformed)
- `child.Handle` declares `is stream.Reader`
- Sockets keep their native recv/send names but follow the same conventions; `fd.wrap(sock.fd)` composes a socket into any Reader-taking API

**`sse.events` now takes any `stream.Reader`** — a fetch.Reader, an fd Handle wrapping a socket, a child's stdout — using a private buffered line iterator over `read()` (same semantics as `fetch.Reader:lines()`: final unterminated line on clean EOF, partial data discarded on error). It stays private to sse until the post-stable buffered-reader battery generalizes it (#501).

## Tests

`stream_test.tl` runs a shared conformance suite — EOF is bare nil, reads after EOF stay bare nil, `""` never yielded, error channel intact — against all four producers: fd.Handle (pipe), net.Socket (socketpair), child.Handle (spawned process), fetch.Reader (forked loopback HTTP server), plus the zero-byte-datagram carve-out. `sse_test.tl` gains a socket-backed-reader case. The net shutdown test and `Example_recv_eof` invert to the new convention. `stream_example.tl` demonstrates the contract (satisfying the example-per-public-module ratchet).

Audited every in-repo `recv()` loop for `== ""` EOF checks: the quicksand proxy uses raw `unix.recv` (C binding, unchanged) so its checks stay correct; `proxy_test.tl`'s loop already handles nil; the fetch test servers do single reads.

## Validation

`bin/make ci` green: format 251, teal 251, tests 116, examples 20, lint 315 — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XdWnoUpSW33ZhVA7scf7Z

---
_Generated by [Claude Code](https://claude.ai/code/session_019XdWnoUpSW33ZhVA7scf7Z)_