### PR TITLE
address model: opaque ip.Addr in every public net/ip signature

### DIFF
--- a/lib/cosmic/ip.tl
+++ b/lib/cosmic/ip.tl
@@ -1,5 +1,11 @@
 --- IP address parsing, formatting, and classification utilities.
---- IPv4 only: IPv6 addresses are rejected with an explicit error.
+--- The typed Addr is the only address currency in public signatures
+--- (api-review-2, #588): parse and lookup return Addr, sockets accept
+--- and return Addr, and classification lives on Addr methods. The
+--- implementation is IPv4-only — IPv6 strings are rejected with an
+--- explicit error — but the shape is ready for IPv6 as a value
+--- extension: a later "inet6" family is a new Addr value, not a new
+--- API. Addr:int() exposes the raw v4 integer for the C boundary.
 local cosmo = require("cosmo")
 
 --- Category of an IPv4 address, as reported by categorize().
@@ -27,12 +33,21 @@ local enum Category
   "ANONYMOUS"
 end
 
---- A typed IP address.
---- Wraps the raw integer representation with convenience methods.
+--- Address family. IPv4 only today; IPv6 (whilp/cosmopolitan#144) adds
+--- "inet6" as a value, leaving every Addr-taking signature unchanged.
+local enum Family
+  "inet"
+end
+
+--- A typed IP address: the one address type in public signatures.
+--- Compares by value (two Addrs are == when they hold the same
+--- address) and formats with tostring().
 local record Addr
   _n: number
-  --- Get the raw integer representation.
-  --- Use this when passing to net.Socket:connect() or other APIs that take integer IPs.
+  --- Address family; "inet" for IPv4.
+  family: Family
+  --- Get the raw integer representation (the IPv4 payload).
+  --- Use this at the C boundary or for arithmetic on the raw value.
   --- @return integer The IP address as an integer
   int: function(Addr): number
   --- Format as a dotted-quad string (e.g., "192.168.1.1").
@@ -76,8 +91,11 @@ local function addr_is_public(self: Addr): boolean
   return cosmo.IsPublicIp(self._n)
 end
 
+-- Methods and the family constant live on the shared metatable (#563
+-- precedent), so make_addr allocates one two-field table and nothing else.
 local Addr_mt: metatable < Addr > = {
   __index = {
+    family = "inet",
     int = addr_int,
     format = addr_format,
     categorize = addr_categorize,
@@ -88,6 +106,9 @@ local Addr_mt: metatable < Addr > = {
   __tostring = function(self: Addr): string
     return cosmo.FormatIp(self._n)
   end,
+  __eq = function(a: Addr, b: Addr): boolean
+    return a._n == b._n
+  end,
 }
 
 local function make_addr(n: number): Addr
@@ -95,20 +116,23 @@ local function make_addr(n: number): Addr
 end
 
 --- Wrap a raw integer as a typed Addr.
+--- This is the explicit int-to-Addr constructor for the C boundary
+--- (e.g. values from cosmo bindings); everything else should already
+--- hold an Addr.
 --- @param n integer The IP address as an integer
 --- @return Addr The typed IP address
 local function addr(n: number): Addr
   return make_addr(n)
 end
 
---- Parse an IPv4 address string to its integer representation.
+--- Parse an IPv4 address string into a typed Addr.
 --- Strict dotted quad only: exactly four decimal octets 0-255, no
 --- leading zeros ("127.1", "1.2.3.4.5", "01.2.3.4" are all errors).
 --- IPv6 is rejected with an explicit error.
 --- @param str string The IP address string (e.g., "192.168.1.1")
---- @return integer | nil The IP address as an integer, or nil on error
+--- @return Addr | nil The typed IP address, or nil on error
 --- @return string Error message if parsing failed
-local function parse(str: string): integer | nil, string
+local function parse(str: string): Addr | nil, string
   if not str or str == "" then
     return nil, "empty IP address"
   end
@@ -131,44 +155,7 @@ local function parse(str: string): integer | nil, string
     end
     n = n * 256 + v
   end
-  return n
-end
-
---- Format an integer IP address as a string.
---- @param ip integer The IP address as an integer
---- @return string The formatted IP address string
-local function format(ip: number): string
-  return cosmo.FormatIp(ip)
-end
-
---- Categorize an IP address.
---- Returns categories like "LOOPBACK", "PRIVATE", "ARIN", etc.
---- @param ip integer The IP address as an integer
---- @return Category The category name
-local function categorize(ip: number): Category
-  return cosmo.CategorizeIp(ip) as Category
-end
-
---- Check if an IP address is a loopback address (127.x.x.x).
---- @param ip integer The IP address as an integer
---- @return boolean True if the address is a loopback address
-local function is_loopback(ip: number): boolean
-  return cosmo.IsLoopbackIp(ip)
-end
-
---- Check if an IP address is a private address.
---- Private ranges: 10.x.x.x, 172.16-31.x.x, 192.168.x.x
---- @param ip integer The IP address as an integer
---- @return boolean True if the address is private
-local function is_private(ip: number): boolean
-  return cosmo.IsPrivateIp(ip)
-end
-
---- Check if an IP address is a public/routable address.
---- @param ip integer The IP address as an integer
---- @return boolean True if the address is public
-local function is_public(ip: number): boolean
-  return cosmo.IsPublicIp(ip)
+  return make_addr(n)
 end
 
 --- Look up a hostname and return a typed Addr.
@@ -177,34 +164,25 @@ end
 --- @return Addr? The resolved IP address, or nil on error
 --- @return string? Error message on failure
 local function lookup(hostname: string): Addr | nil, string
-  local ip, err = cosmo.ResolveIp(hostname)
-  if not ip then
+  local raw, err = cosmo.ResolveIp(hostname)
+  if not raw then
     return nil, "dns: lookup failed for " .. hostname .. ": " .. tostring(err)
   end
-  return make_addr(ip)
+  return make_addr(raw)
 end
 
 local record IpModule
   Addr: Addr
   type Category = Category
+  type Family = Family
   addr: function(n: number): Addr
-  parse: function(str: string): integer | nil, string
-  format: function(ip: number): string
-  categorize: function(ip: number): Category
-  is_loopback: function(ip: number): boolean
-  is_private: function(ip: number): boolean
-  is_public: function(ip: number): boolean
+  parse: function(str: string): Addr | nil, string
   lookup: function(hostname: string): Addr | nil, string
 end
 
 local M: IpModule = {
   addr = addr,
   parse = parse,
-  format = format,
-  categorize = categorize,
-  is_loopback = is_loopback,
-  is_private = is_private,
-  is_public = is_public,
   lookup = lookup,
 }
 

--- a/lib/cosmic/ip_test.tl
+++ b/lib/cosmic/ip_test.tl
@@ -2,23 +2,24 @@
 local ip = require("cosmic.ip")
 
 --- Parse an address the test knows is valid, asserting success.
-local function p(s: string): integer
-  local n, err = ip.parse(s)
-  assert(n ~= nil, "parse failed for " .. s .. ": " .. tostring(err))
-  return n as integer
+local function p(s: string): ip.Addr
+  local a, err = ip.parse(s)
+  assert(a ~= nil, "parse failed for " .. s .. ": " .. tostring(err))
+  return a as ip.Addr
 end
 
--- parse tests
+-- parse tests: parse returns a typed Addr (api-review-2, #588)
 
 local function test_parse_ipv4_basic()
-  local result = ip.parse("192.168.1.1")
-  assert(result == 3232235777, "expected 3232235777, got " .. tostring(result))
+  local a = p("192.168.1.1")
+  assert(a:int() == 3232235777, "expected 3232235777, got " .. tostring(a:int()))
+  assert(a.family == "inet", "expected family 'inet', got " .. tostring(a.family))
 end
 test_parse_ipv4_basic()
 
 local function test_parse_localhost()
-  local result = ip.parse("127.0.0.1")
-  assert(result == 2130706433, "expected 2130706433, got " .. tostring(result))
+  local a = p("127.0.0.1")
+  assert(a:int() == 2130706433, "expected 2130706433, got " .. tostring(a:int()))
 end
 test_parse_localhost()
 
@@ -61,8 +62,8 @@ end
 test_parse_leading_zero_rejected()
 
 local function test_parse_zero_octets_ok()
-  local result, err = ip.parse("0.0.0.0")
-  assert(result == 0, "expected 0 for '0.0.0.0': " .. tostring(err))
+  local a = p("0.0.0.0")
+  assert(a:int() == 0, "expected 0 for '0.0.0.0'")
 end
 test_parse_zero_octets_ok()
 
@@ -83,131 +84,106 @@ test_parse_empty_rejected()
 
 local function test_parse_broadcast()
   -- 255.255.255.255 is a valid dotted quad, not an error sentinel.
-  local result = ip.parse("255.255.255.255")
-  assert(result == 4294967295, "expected 4294967295, got " .. tostring(result))
+  local a = p("255.255.255.255")
+  assert(a:int() == 4294967295, "expected 4294967295, got " .. tostring(a:int()))
 end
 test_parse_broadcast()
 
--- format tests
+-- Addr value semantics
 
-local function test_format_basic()
-  local result = ip.format(3232235777)
-  assert(result == "192.168.1.1", "expected '192.168.1.1', got '" .. result .. "'")
+local function test_addr_equality()
+  -- Two Addrs holding the same address compare equal (__eq), however
+  -- they were produced.
+  assert(p("10.0.0.1") == p("10.0.0.1"), "equal addresses must be ==")
+  assert(p("10.0.0.1") ~= p("10.0.0.2"), "different addresses must be ~=")
+  assert(p("127.0.0.1") == ip.addr(2130706433), "parse and addr agree")
 end
-test_format_basic()
+test_addr_equality()
 
-local function test_format_localhost()
-  local result = ip.format(2130706433)
-  assert(result == "127.0.0.1", "expected '127.0.0.1', got '" .. result .. "'")
+local function test_addr_family()
+  local a = p("8.8.8.8")
+  assert(a.family == "inet", "family is 'inet' for IPv4")
+  local b = ip.addr(0)
+  assert(b.family == "inet", "constructed Addr carries family too")
 end
-test_format_localhost()
+test_addr_family()
+
+-- format / tostring
 
 local function test_format_roundtrip()
   local original = "10.0.0.1"
-  local parsed = p(original)
-  local formatted = ip.format(parsed)
-  assert(formatted == original, "expected roundtrip to preserve '" .. original .. "', got '" .. formatted .. "'")
+  local formatted = p(original):format()
+  assert(formatted == original,
+    "expected roundtrip to preserve '" .. original .. "', got '" .. formatted .. "'")
 end
 test_format_roundtrip()
 
--- categorize tests
+local function test_addr_tostring()
+  local a = p("10.0.0.1")
+  assert(tostring(a) == "10.0.0.1", "expected '10.0.0.1', got '" .. tostring(a) .. "'")
+end
+test_addr_tostring()
+
+-- categorize
 
 local function test_categorize_loopback()
-  local result = ip.categorize(p("127.0.0.1"))
+  local result = p("127.0.0.1"):categorize()
   assert(result == "LOOPBACK", "expected 'LOOPBACK', got '" .. result .. "'")
 end
 test_categorize_loopback()
 
 local function test_categorize_private_192()
-  local result = ip.categorize(p("192.168.1.1"))
+  local result = p("192.168.1.1"):categorize()
   assert(result == "PRIVATE", "expected 'PRIVATE', got '" .. result .. "'")
 end
 test_categorize_private_192()
 
 local function test_categorize_private_10()
-  local result = ip.categorize(p("10.0.0.1"))
+  local result = p("10.0.0.1"):categorize()
   assert(result == "PRIVATE", "expected 'PRIVATE', got '" .. result .. "'")
 end
 test_categorize_private_10()
 
 local function test_categorize_public()
-  local result = ip.categorize(p("8.8.8.8"))
+  local result = p("8.8.8.8"):categorize()
   -- Public IPs return RIR name like "ARIN"
-  assert(result ~= "LOOPBACK" and result ~= "PRIVATE", "expected public category, got '" .. result .. "'")
+  assert(result ~= "LOOPBACK" and result ~= "PRIVATE",
+    "expected public category, got '" .. result .. "'")
 end
 test_categorize_public()
 
--- is_loopback tests
+-- is_loopback
 
 local function test_is_loopback_true()
-  local result = ip.is_loopback(p("127.0.0.1"))
-  assert(result == true, "expected true for loopback")
+  assert(p("127.0.0.1"):is_loopback() == true, "expected true for loopback")
+  assert(p("127.255.255.255"):is_loopback() == true, "expected true for 127.255.255.255")
 end
 test_is_loopback_true()
 
-local function test_is_loopback_127_255()
-  local result = ip.is_loopback(p("127.255.255.255"))
-  assert(result == true, "expected true for 127.255.255.255")
-end
-test_is_loopback_127_255()
-
 local function test_is_loopback_false()
-  local result = ip.is_loopback(p("192.168.1.1"))
-  assert(result == false, "expected false for non-loopback")
+  assert(p("192.168.1.1"):is_loopback() == false, "expected false for non-loopback")
 end
 test_is_loopback_false()
 
--- is_private tests
+-- is_private
 
-local function test_is_private_192_168()
-  local result = ip.is_private(p("192.168.1.1"))
-  assert(result == true, "expected true for 192.168.x.x")
+local function test_is_private_ranges()
+  assert(p("192.168.1.1"):is_private() == true, "expected true for 192.168.x.x")
+  assert(p("10.0.0.1"):is_private() == true, "expected true for 10.x.x.x")
+  assert(p("172.16.0.1"):is_private() == true, "expected true for 172.16.x.x")
+  assert(p("8.8.8.8"):is_private() == false, "expected false for public IP")
 end
-test_is_private_192_168()
+test_is_private_ranges()
 
-local function test_is_private_10()
-  local result = ip.is_private(p("10.0.0.1"))
-  assert(result == true, "expected true for 10.x.x.x")
+-- is_public
+
+local function test_is_public()
+  assert(p("8.8.8.8"):is_public() == true, "expected true for public IP")
+  assert(p("1.1.1.1"):is_public() == true, "expected true for Cloudflare DNS")
+  assert(p("192.168.1.1"):is_public() == false, "expected false for private IP")
+  assert(p("127.0.0.1"):is_public() == false, "expected false for loopback")
 end
-test_is_private_10()
-
-local function test_is_private_172_16()
-  local result = ip.is_private(p("172.16.0.1"))
-  assert(result == true, "expected true for 172.16.x.x")
-end
-test_is_private_172_16()
-
-local function test_is_private_false()
-  local result = ip.is_private(p("8.8.8.8"))
-  assert(result == false, "expected false for public IP")
-end
-test_is_private_false()
-
--- is_public tests
-
-local function test_is_public_true()
-  local result = ip.is_public(p("8.8.8.8"))
-  assert(result == true, "expected true for public IP")
-end
-test_is_public_true()
-
-local function test_is_public_cloudflare()
-  local result = ip.is_public(p("1.1.1.1"))
-  assert(result == true, "expected true for Cloudflare DNS")
-end
-test_is_public_cloudflare()
-
-local function test_is_public_false_private()
-  local result = ip.is_public(p("192.168.1.1"))
-  assert(result == false, "expected false for private IP")
-end
-test_is_public_false_private()
-
-local function test_is_public_false_loopback()
-  local result = ip.is_public(p("127.0.0.1"))
-  assert(result == false, "expected false for loopback")
-end
-test_is_public_false_loopback()
+test_is_public()
 
 -- lookup tests
 
@@ -217,6 +193,7 @@ local function test_lookup_localhost()
   assert(err == nil, "expected nil error, got " .. tostring(err))
   local aa = a as ip.Addr
   assert(aa:int() == 2130706433, "expected 127.0.0.1, got " .. tostring(aa:int()))
+  assert(aa == p("127.0.0.1"), "lookup and parse agree by value")
 end
 test_lookup_localhost()
 
@@ -228,7 +205,7 @@ local function test_lookup_invalid_returns_nil()
 end
 test_lookup_invalid_returns_nil()
 
--- addr tests
+-- addr constructor (the int-to-Addr escape hatch for the C boundary)
 
 local function test_addr_int()
   local a = ip.addr(2130706433)
@@ -236,47 +213,14 @@ local function test_addr_int()
 end
 test_addr_int()
 
-local function test_addr_format()
-  local a = ip.addr(p("192.168.1.1"))
-  assert(a:format() == "192.168.1.1", "expected '192.168.1.1', got '" .. a:format() .. "'")
-end
-test_addr_format()
-
-local function test_addr_tostring()
-  local a = ip.addr(p("10.0.0.1"))
-  assert(tostring(a) == "10.0.0.1", "expected '10.0.0.1', got '" .. tostring(a) .. "'")
-end
-test_addr_tostring()
-
-local function test_addr_categorize()
-  local a = ip.addr(p("127.0.0.1"))
+local function test_addr_methods()
+  local a = ip.addr(p("127.0.0.1"):int())
+  assert(a:format() == "127.0.0.1", "expected '127.0.0.1', got '" .. a:format() .. "'")
   assert(a:categorize() == "LOOPBACK", "expected 'LOOPBACK', got '" .. a:categorize() .. "'")
+  assert(a:is_loopback() == true, "expected loopback")
+  assert(a:is_public() == false, "expected not public")
 end
-test_addr_categorize()
-
-local function test_addr_is_loopback()
-  local a = ip.addr(p("127.0.0.1"))
-  assert(a:is_loopback() == true, "expected true for loopback")
-  local b = ip.addr(p("8.8.8.8"))
-  assert(b:is_loopback() == false, "expected false for non-loopback")
-end
-test_addr_is_loopback()
-
-local function test_addr_is_private()
-  local a = ip.addr(p("192.168.1.1"))
-  assert(a:is_private() == true, "expected true for private")
-  local b = ip.addr(p("8.8.8.8"))
-  assert(b:is_private() == false, "expected false for public")
-end
-test_addr_is_private()
-
-local function test_addr_is_public()
-  local a = ip.addr(p("8.8.8.8"))
-  assert(a:is_public() == true, "expected true for public")
-  local b = ip.addr(p("10.0.0.1"))
-  assert(b:is_public() == false, "expected false for private")
-end
-test_addr_is_public()
+test_addr_methods()
 
 local function test_lookup_returns_addr_with_methods()
   local a, err = ip.lookup("localhost")
@@ -284,7 +228,6 @@ local function test_lookup_returns_addr_with_methods()
   local aa = a as ip.Addr
   assert(aa:format() == "127.0.0.1", "expected '127.0.0.1', got '" .. aa:format() .. "'")
   assert(aa:is_loopback() == true, "expected loopback")
-  assert(aa:is_public() == false, "expected not public")
   assert(tostring(aa) == "127.0.0.1", "expected tostring '127.0.0.1'")
 end
 test_lookup_returns_addr_with_methods()

--- a/lib/cosmic/net/connect_test.tl
+++ b/lib/cosmic/net/connect_test.tl
@@ -18,8 +18,9 @@ local function test_interfaces()
     assert(iface.ip ~= nil, "interface should have ip")
     if iface.name == "lo" then
       has_loopback = true
-      -- Loopback should be 127.0.0.1 (0x7f000001)
-      assert(iface.ip == 0x7f000001, "loopback should have 127.0.0.1, got " .. ip.format(iface.ip))
+      -- Loopback should be 127.0.0.1; Addr compares by value (__eq)
+      assert(iface.ip == ip.addr(0x7f000001),
+        "loopback should have 127.0.0.1, got " .. iface.ip:format())
     end
   end
   assert(has_loopback, "should have loopback interface")
@@ -32,7 +33,7 @@ local function test_interfaces_format()
   if ifaces then
     local ifaces = ifaces as {net.Interface}
     for _, iface in ipairs(ifaces) do
-      local ip_str = ip.format(iface.ip)
+      local ip_str = iface.ip:format()
       assert(ip_str:match("^%d+%.%d+%.%d+%.%d+$"), "expected dotted IP format, got " .. ip_str)
     end
   end
@@ -141,7 +142,7 @@ local function test_nb_connect_loopback()
   local ok, setopt_err = server:setsockopt(net.SOL_SOCKET, net.SO_REUSEADDR, true)
   assert(ok, "setsockopt failed: " .. tostring(setopt_err))
 
-  ok, err = server:bind(0x7f000001, 0) -- 127.0.0.1
+  ok, err = server:bind("127.0.0.1", 0) -- 127.0.0.1
   assert(ok, "bind failed: " .. tostring(err))
 
   local _, server_port = server:getsockname()
@@ -186,7 +187,7 @@ local function test_nb_connect_refused()
   local client = client as net.Socket
 
   -- Connect to localhost port 1 — should be refused
-  local ok, conn_err = net.nb_connect(client, 0x7f000001, 1, 2000)
+  local ok, conn_err = net.nb_connect(client, "127.0.0.1", 1, 2000)
   assert(not ok, "expected nb_connect to fail on refused port")
   assert(conn_err ~= nil, "expected error message from nb_connect")
 
@@ -203,7 +204,7 @@ local function test_connect_tcp()
   local ok, setopt_err = server:setsockopt(net.SOL_SOCKET, net.SO_REUSEADDR, true)
   assert(ok, "setsockopt failed: " .. tostring(setopt_err))
 
-  ok, err = server:bind(0x7f000001, 0)
+  ok, err = server:bind("127.0.0.1", 0)
   assert(ok, "bind failed: " .. tostring(err))
 
   local _, server_port = server:getsockname()
@@ -215,7 +216,7 @@ local function test_connect_tcp()
   -- Fork to create a client using connect_tcp
   local pid = proc.fork()
   if pid == 0 then
-    local client, cerr = net.connect_tcp(0x7f000001, server_port)
+    local client, cerr = net.connect_tcp("127.0.0.1", server_port)
     if not client then
       io.stderr:write("connect_tcp failed: " .. tostring(cerr) .. "\n")
       os.exit(1)
@@ -286,7 +287,7 @@ local function test_connect_error_message()
   assert(sock ~= nil, "socket creation failed: " .. tostring(err))
   local sock = sock as net.Socket
 
-  local ok, conn_err = sock:connect(0x7f000001, 1) -- localhost port 1
+  local ok, conn_err = sock:connect("127.0.0.1", 1) -- localhost port 1
   assert(not ok, "expected connect to fail")
   assert(conn_err ~= nil, "expected error message")
   -- Should start with "connect: " prefix (Errno pattern) rather than generic "connect failed"
@@ -302,14 +303,41 @@ print("All net tests passed")
 local function test_bind_error_names_errno()
   -- Binding a second socket to an in-use address must name EADDRINUSE.
   local first = assert(net.socket(net.AF_INET, net.SOCK_STREAM)) as net.Socket
-  assert(first:bind(0x7f000001, 0))
+  assert(first:bind("127.0.0.1", 0))
   assert(first:listen())
   local _, port = first:getsockname()
   local second = assert(net.socket(net.AF_INET, net.SOCK_STREAM)) as net.Socket
-  local ok, berr = second:bind(0x7f000001, port as number)
+  local ok, berr = second:bind("127.0.0.1", port as number)
   assert(ok == false, "second bind to same port should fail")
   assert(berr:match("EADDRINUSE"), "bind error should name EADDRINUSE, got: " .. berr)
   second:close()
   first:close()
 end
 test_bind_error_names_errno()
+
+local function test_dial()
+  -- dial is the stable name-and-shape entry point (#588, from #501):
+  -- resolution happens inside, for literals and DNS names alike.
+  local srv, port, serr = net.listen_tcp("127.0.0.1", 0)
+  assert(srv ~= nil, "listen_tcp failed: " .. tostring(serr))
+  local s = srv as net.Socket
+
+  local c1, derr = net.dial("127.0.0.1", port)
+  assert(c1 ~= nil, "dial literal failed: " .. tostring(derr))
+  local a1 = s:accept() as net.Socket;
+  (c1 as net.Socket):close()
+  a1:close()
+
+  local c2, herr = net.dial("localhost", port)
+  assert(c2 ~= nil, "dial hostname failed: " .. tostring(herr))
+  local a2 = s:accept() as net.Socket;
+  (c2 as net.Socket):close()
+  a2:close()
+  s:close()
+
+  local bad, berr = net.dial("this.host.does.not.exist.invalid", 80)
+  assert(bad == nil, "dial to unresolvable host must fail")
+  assert(berr ~= nil and berr:find("dial", 1, true) ~= nil,
+    "dial failure names the operation: " .. tostring(berr))
+end
+test_dial()

--- a/lib/cosmic/net/init.tl
+++ b/lib/cosmic/net/init.tl
@@ -1,7 +1,10 @@
 --- Networking and socket utilities.
 --- Wraps cosmo.unix socket functions for TCP/UDP and Unix domain sockets.
---- IPv4 only: string addresses must be strict dotted quads; IPv6 is
---- rejected with an explicit "IPv6 not supported" error.
+--- Addresses are typed (api-review-2, #588): every public signature
+--- takes a dotted-quad string or an ip.Addr and returns ip.Addr — bare
+--- integers are not addresses. IPv4 only: IPv6 strings are rejected
+--- with an explicit "IPv6 not supported" error, and lands later as a
+--- new Addr family, not a new API.
 local unix = require("cosmo.unix")
 local ip = require("cosmic.ip")
 local net_socket = require("cosmic.net.socket")
@@ -10,32 +13,11 @@ local net_socket = require("cosmic.net.socket")
 --- Supports Lua 5.4's to-be-closed via __close metamethod.
 local type Socket = net_socket.Socket
 
+--- An address a helper accepts: a dotted-quad string ("127.0.0.1") or a
+--- typed ip.Addr. Wrap C-boundary integers with ip.addr().
+local type Address = net_socket.Address
+
 local make_socket = net_socket.make_socket
-
---- An address a TCP helper accepts: a dotted-quad string ("127.0.0.1"),
---- a raw integer (0x7f000001), or a typed ip.Addr.
-local type Address = string | number | ip.Addr
-
---- Resolve an Address union to a raw integer IP.
---- @param addr Address The address in any accepted form
---- @return integer | nil The IP as an integer, or nil on error
---- @return string Error message on failure
-local function resolve_addr(addr: Address): integer | nil, string
-  if addr is string then
-    return ip.parse(addr)
-  end
-  local n: number
-  if addr is number then
-    n = addr
-  else
-    n = (addr as ip.Addr):int()
-  end
-  local i = math.tointeger(n)
-  if not i then
-    return nil, "invalid IP integer: " .. tostring(n)
-  end
-  return i
-end
 
 --- Create a new socket.
 --- @param family number Address family (AF_INET, AF_UNIX). Default: AF_INET
@@ -115,28 +97,49 @@ local function connect_unix(path: string): Socket | nil, string
 end
 
 --- Create a TCP socket and connect to an address and port.
---- The address may be a dotted-quad string ("127.0.0.1"), a raw integer
---- (0x7f000001), or an ip.Addr. IPv6 is not supported.
+--- The address may be a dotted-quad string ("127.0.0.1") or an ip.Addr.
+--- IPv6 is not supported. For hostname resolution use dial().
 --- @param addr Address Remote IPv4 address
 --- @param port number Remote port
 --- @return Socket | nil Connected socket
 --- @return string Error message on failure
 local function connect_tcp(addr: Address, port: number): Socket | nil, string
-  local ipn, aerr = resolve_addr(addr)
-  if not ipn then
-    return nil, aerr
-  end
   local sock, err = socket(unix.AF_INET, unix.SOCK_STREAM, 0)
   if not sock then
     return nil, err
   end
   local s = sock as Socket
-  local ok, conn_err = s:connect(ipn, port)
+  local ok, conn_err = s:connect(addr, port)
   if not ok then
     s:close()
     return nil, conn_err
   end
   return s
+end
+
+--- Open a TCP connection to host:port. This name and shape are the
+--- stable dial contract (api-review-2, #588; reserved from #501): host
+--- is a dotted-quad literal or a DNS name — resolution happens inside —
+--- and the result is a connected Socket. Future address families and
+--- richer endpoint forms extend the values dial accepts, never the
+--- signature.
+--- @param host string Host to connect to: dotted-quad literal or DNS name
+--- @param port number Remote TCP port
+--- @return Socket | nil Connected socket
+--- @return string Error message on failure
+local function dial(host: string, port: number): Socket | nil, string
+  local a: ip.Addr
+  local parsed = ip.parse(host)
+  if parsed then
+    a = parsed as ip.Addr
+  else
+    local looked, lerr = ip.lookup(host)
+    if not looked then
+      return nil, "dial " .. host .. ": " .. tostring(lerr)
+    end
+    a = looked as ip.Addr
+  end
+  return connect_tcp(a, port)
 end
 
 --- Create a TCP socket, bind it to addr:port, and start listening.
@@ -156,17 +159,13 @@ end
 --- deliberate port-0 ergonomics, kept as-is rather than reshuffled to the
 --- usual value-then-error order.
 ---
---- @param addr Address Local IPv4 address to bind ("127.0.0.1", 0 for all)
+--- @param addr Address Local IPv4 address to bind ("127.0.0.1", "0.0.0.0" for all)
 --- @param port number Local port to bind; use 0 for an OS-assigned ephemeral port
 --- @param backlog number Maximum pending connections (default 128)
 --- @return Socket | nil Listening socket ready to accept
 --- @return number Actual bound port (useful when port 0 was requested)
 --- @return string Error message on failure
 local function listen_tcp(addr: Address, port: number, backlog?: number): Socket | nil, number, string
-  local ipn, aerr = resolve_addr(addr)
-  if not ipn then
-    return nil, nil, aerr
-  end
   local sock, serr = socket(unix.AF_INET, unix.SOCK_STREAM, 0)
   if not sock then
     return nil, nil, serr
@@ -177,7 +176,7 @@ local function listen_tcp(addr: Address, port: number, backlog?: number): Socket
     s:close()
     return nil, nil, setopt_err
   end
-  local bok, bind_err = s:bind(ipn, port)
+  local bok, bind_err = s:bind(addr, port)
   if not bok then
     s:close()
     return nil, nil, bind_err
@@ -208,15 +207,11 @@ end
 --- @return string Error message on failure
 local function nb_connect(s: Socket, addr: Address, port: number, timeoutms?: number): boolean, string
   timeoutms = timeoutms or 10000
-  local ipn, aerr = resolve_addr(addr)
-  if not ipn then
-    return false, aerr
-  end
   local nb_ok, nb_err = s:set_nonblocking()
   if not nb_ok then
     return false, nb_err
   end
-  local ok, conn_err = s:connect(ipn, port)
+  local ok, conn_err = s:connect(addr, port)
   if ok then return true end
   local fds: {number: number} = {[s.fd] = unix.POLLOUT}
   local revents = unix.poll(fds, timeoutms)
@@ -253,7 +248,7 @@ end
 --- Network interface information.
 local record Interface
   name: string
-  ip: number
+  ip: ip.Addr
 end
 
 --- List network interfaces and their IPv4 addresses.
@@ -264,7 +259,14 @@ local function interfaces(): {Interface} | nil, string
   if not raw then
     return nil, "siocgifconf failed"
   end
-  return raw as {Interface}
+  local list: {Interface} = {}
+  for i, entry in ipairs(raw as {{string: any}}) do
+    list[i] = {
+      name = entry["name"] as string,
+      ip = ip.addr(entry["ip"] as number),
+    }
+  end
+  return list
 end
 
 local record NetModule
@@ -277,6 +279,7 @@ local record NetModule
   listen_tcp: function(addr: Address, port: number, backlog?: number): Socket | nil, number, string
   connect_unix: function(path: string): Socket | nil, string
   connect_tcp: function(addr: Address, port: number): Socket | nil, string
+  dial: function(host: string, port: number): Socket | nil, string
   nb_connect: function(s: Socket, addr: Address, port: number, timeoutms?: number): boolean, string
   gethostname: function(): string | nil, string
   interfaces: function(): {Interface} | nil, string
@@ -358,6 +361,7 @@ local M: NetModule = {
   listen_tcp = listen_tcp,
   connect_unix = connect_unix,
   connect_tcp = connect_tcp,
+  dial = dial,
   nb_connect = nb_connect,
   gethostname = gethostname,
   interfaces = interfaces,

--- a/lib/cosmic/net/init_example.tl
+++ b/lib/cosmic/net/init_example.tl
@@ -4,12 +4,12 @@
 -- listen on an OS-assigned port, connect, accept, echo one message back
 local function Example_echo()
   local net = require("cosmic.net")
-  local srv, port, err = net.listen_tcp(0x7f000001, 0)
+  local srv, port, err = net.listen_tcp("127.0.0.1", 0)
   assert(srv, err)
   assert(port > 0)
   local srv = srv as net.Socket
 
-  local client, cerr = net.connect_tcp(0x7f000001, port)
+  local client, cerr = net.connect_tcp("127.0.0.1", port)
   assert(client, cerr)
   local client = client as net.Socket
 
@@ -34,11 +34,11 @@ end
 -- stream contract (cosmic.stream)
 local function Example_recv_eof()
   local net = require("cosmic.net")
-  local srv, port, err = net.listen_tcp(0x7f000001, 0)
+  local srv, port, err = net.listen_tcp("127.0.0.1", 0)
   assert(srv, err)
   local srv = srv as net.Socket
 
-  local client = net.connect_tcp(0x7f000001, port) as net.Socket
+  local client = net.connect_tcp("127.0.0.1", port) as net.Socket
   local conn = srv:accept() as net.Socket
 
   client:close()

--- a/lib/cosmic/net/init_test.tl
+++ b/lib/cosmic/net/init_test.tl
@@ -1,6 +1,7 @@
 #!/usr/bin/env cosmic
 local net = require("cosmic.net")
 local fs = require("cosmic.fs")
+local ip = require("cosmic.ip")
 local proc = require("cosmic.proc")
 
 local function test_socket_creation()
@@ -65,11 +66,12 @@ local function test_bind_and_getsockname()
   local sock = sock as net.Socket
 
   -- Bind to ephemeral port on all interfaces
-  local ok, bind_err = sock:bind(0, 0)
+  local ok, bind_err = sock:bind("0.0.0.0", 0)
   assert(ok, "bind failed: " .. tostring(bind_err))
 
-  local ip, port, name_err = sock:getsockname()
-  assert(ip ~= nil, "getsockname failed: " .. tostring(name_err))
+  local addr, port, name_err = sock:getsockname()
+  assert(addr ~= nil, "getsockname failed: " .. tostring(name_err))
+  assert((addr as ip.Addr).family == "inet", "local address must be a typed Addr")
   assert(port > 0, "expected non-zero port, got " .. tostring(port))
 
   sock:close()
@@ -85,7 +87,7 @@ local function test_listen_accept_connect()
   local ok, setopt_err = server:setsockopt(net.SOL_SOCKET, net.SO_REUSEADDR, true)
   assert(ok, "setsockopt failed: " .. tostring(setopt_err))
 
-  ok, err = server:bind(0, 0)
+  ok, err = server:bind("0.0.0.0", 0)
   assert(ok, "bind failed: " .. tostring(err))
 
   local _, server_port = server:getsockname()
@@ -104,7 +106,7 @@ local function test_listen_accept_connect()
     end
     local client = client as net.Socket
     -- Connect to localhost
-    local connect_ok = client:connect(0x7f000001, server_port) -- 127.0.0.1
+    local connect_ok = client:connect("127.0.0.1", server_port) -- 127.0.0.1
     if not connect_ok then
       os.exit(2)
     end
@@ -120,6 +122,8 @@ local function test_listen_accept_connect()
   local client, client_ip, client_port, accept_err = server:accept()
   assert(client ~= nil, "accept failed: " .. tostring(accept_err))
   assert(client_ip ~= nil, "expected client IP")
+  assert(client_ip.family == "inet", "peer address must be a typed Addr")
+  assert(client_ip:is_loopback(), "peer should be loopback, got " .. client_ip:format())
   assert(client_port ~= nil and client_port > 0, "expected client port")
   local client = client as net.Socket
 
@@ -200,20 +204,22 @@ local function test_udp_sendto_recvfrom()
   local receiver = receiver as net.Socket
 
   -- Bind receiver to ephemeral port
-  local ok, bind_err = receiver:bind(0x7f000001, 0) -- 127.0.0.1
+  local ok, bind_err = receiver:bind("127.0.0.1", 0)
   assert(ok, "bind failed: " .. tostring(bind_err))
 
   local _, recv_port = receiver:getsockname()
   assert(recv_port > 0, "expected non-zero port")
 
   -- Send datagram
-  local sent, send_err = sender:sendto("hello udp", 0x7f000001, recv_port)
+  local sent, send_err = sender:sendto("hello udp", "127.0.0.1", recv_port)
   assert(sent == 9, "expected 9 bytes sent, got " .. tostring(sent) .. ": " .. tostring(send_err))
 
-  -- Receive datagram
+  -- Receive datagram: the sender address arrives as a typed ip.Addr
   local data, from_ip, from_port, recv_err = receiver:recvfrom(100)
   assert(data == "hello udp", "expected 'hello udp', got '" .. tostring(data) .. "': " .. tostring(recv_err))
   assert(from_ip ~= nil, "expected sender IP")
+  assert(from_ip.family == "inet", "sender address must be a typed Addr")
+  assert(from_ip:format() == "127.0.0.1", "expected loopback sender, got " .. from_ip:format())
   assert(from_port ~= nil and from_port > 0, "expected sender port")
 
   sender:close()
@@ -370,7 +376,7 @@ local function test_accept_socket_has_close_metamethod()
   local ok, setopt_err = server:setsockopt(net.SOL_SOCKET, net.SO_REUSEADDR, true)
   assert(ok, "setsockopt failed: " .. tostring(setopt_err))
 
-  ok, err = server:bind(0, 0)
+  ok, err = server:bind("0.0.0.0", 0)
   assert(ok, "bind failed: " .. tostring(err))
 
   local _, server_port = server:getsockname()
@@ -383,7 +389,7 @@ local function test_accept_socket_has_close_metamethod()
     local client = net.socket()
     if not client then os.exit(1) end
     local client = client as net.Socket
-    local connect_ok = client:connect(0x7f000001, server_port)
+    local connect_ok = client:connect("127.0.0.1", server_port)
     if not connect_ok then os.exit(2) end
     client:send("test")
     client:close()
@@ -409,7 +415,7 @@ test_accept_socket_has_close_metamethod()
 
 local function test_listen_tcp_ephemeral_port()
   -- listen_tcp with port 0 should return a listening socket and a port > 0
-  local srv, port, err = net.listen_tcp(0x7f000001, 0)
+  local srv, port, err = net.listen_tcp("127.0.0.1", 0)
   assert(srv ~= nil, "listen_tcp failed: " .. tostring(err))
   assert(port ~= nil and port > 0, "expected non-zero port, got " .. tostring(port))
   local srv = srv as net.Socket
@@ -419,7 +425,7 @@ test_listen_tcp_ephemeral_port()
 
 local function test_listen_tcp_connect_to_returned_port()
   -- bind on 127.0.0.1:0, then connect_tcp to the returned port
-  local srv, port, serr = net.listen_tcp(0x7f000001, 0)
+  local srv, port, serr = net.listen_tcp("127.0.0.1", 0)
   assert(srv ~= nil, "listen_tcp failed: " .. tostring(serr))
   assert(port > 0, "expected non-zero port")
   local srv = srv as net.Socket
@@ -427,7 +433,7 @@ local function test_listen_tcp_connect_to_returned_port()
   -- Fork: child connects and sends, parent accepts and reads
   local pid = proc.fork()
   if pid == 0 then
-    local csock = net.connect_tcp(0x7f000001, port)
+    local csock = net.connect_tcp("127.0.0.1", port)
     if not csock then
       os.exit(1)
     end
@@ -451,14 +457,14 @@ test_listen_tcp_connect_to_returned_port()
 local function test_listen_tcp_double_bind_same_port_fails()
   -- Bind a specific port, then try to bind the same port again without
   -- REUSEPORT; the second listen_tcp should fail.
-  local srv, port, serr = net.listen_tcp(0x7f000001, 0)
+  local srv, port, serr = net.listen_tcp("127.0.0.1", 0)
   assert(srv ~= nil, "first listen_tcp failed: " .. tostring(serr))
   assert(port > 0, "expected non-zero port")
   local srv = srv as net.Socket
 
   -- Second bind to the same explicit port should fail (SO_REUSEADDR alone
   -- does not allow two listeners on the same port simultaneously)
-  local srv2, _, serr2 = net.listen_tcp(0x7f000001, port)
+  local srv2, _, serr2 = net.listen_tcp("127.0.0.1", port)
   assert(srv2 == nil, "expected second listen_tcp to fail on same port")
   assert(serr2 ~= nil, "expected error message from second listen_tcp")
 
@@ -468,7 +474,7 @@ test_listen_tcp_double_bind_same_port_fails()
 
 local function test_listen_tcp_invalid_ip_bind_fails()
   -- Attempt to bind to a non-local IP should fail
-  local srv, _, serr = net.listen_tcp(0x01020304, 0) -- 1.2.3.4 is not local
+  local srv, _, serr = net.listen_tcp("1.2.3.4", 0) -- not a local address
   assert(srv == nil, "expected listen_tcp to fail on non-local IP")
   assert(serr ~= nil, "expected error message")
 end

--- a/lib/cosmic/net/socket.tl
+++ b/lib/cosmic/net/socket.tl
@@ -1,7 +1,30 @@
 --- Socket implementation for the networking module.
 --- Contains the Socket constructor and all Socket method implementations.
+--- Addresses are typed (api-review-2, #588): methods accept a dotted-quad
+--- string or an ip.Addr, and return ip.Addr — bare integers are not part
+--- of the public surface (wrap C-boundary integers with ip.addr()).
 local unix = require("cosmo.unix")
 local errstr = require("cosmic.errno").str
+local ip = require("cosmic.ip")
+
+--- An address the socket layer accepts: a dotted-quad string
+--- ("127.0.0.1") or a typed ip.Addr.
+local type Address = string | ip.Addr
+
+--- Resolve an Address to the raw integer the C bindings take.
+--- @param addr Address The address in any accepted form
+--- @return integer | nil The IP as an integer, or nil on error
+--- @return string Error message on failure
+local function resolve_addr(addr: Address): integer | nil, string
+  if addr is string then
+    local a, err = ip.parse(addr)
+    if not a then
+      return nil, err
+    end
+    return math.tointeger((a as ip.Addr):int())
+  end
+  return math.tointeger((addr as ip.Addr):int())
+end
 
 --- Socket handle for network I/O.
 --- Sockets are BLOCKING by default: recv and accept wait until data or a
@@ -17,8 +40,8 @@ local record Socket
   shutdown: function(self: Socket, how?: number): boolean, string
   --- Send data; returns bytes sent, or nil + error.
   send: function(self: Socket, data: string, flags?: number): number | nil, string
-  --- Send a datagram to ip:port; returns bytes sent, or nil + error.
-  sendto: function(self: Socket, data: string, ip: number, port: number, flags?: number): number | nil, string
+  --- Send a datagram to addr:port; returns bytes sent, or nil + error.
+  sendto: function(self: Socket, data: string, addr: Address, port: number, flags?: number): number | nil, string
   --- Receive up to bufsiz bytes (blocks until data arrives).
   --- Returns bare nil (no error) when the peer closed the connection —
   --- end of stream, matching the stream contract (cosmic.stream). ""
@@ -26,23 +49,23 @@ local record Socket
   --- nil + error message on failure. bufsiz must be positive when
   --- given (default 65536).
   recv: function(self: Socket, bufsiz?: number, flags?: number): string | nil, string
-  --- Receive a datagram; returns data, sender ip, sender port.
-  recvfrom: function(self: Socket, bufsiz?: number, flags?: number): string | nil, number, number, string
-  --- Local address as (ip, port); use after bind(0) for the real port.
-  getsockname: function(self: Socket): number | nil, number, string
-  --- Peer address as (ip, port).
-  getpeername: function(self: Socket): number | nil, number, string
-  --- Bind to a local ip:port (integers; port 0 = OS-assigned).
-  bind: function(self: Socket, ip?: number, port?: number): boolean, string
+  --- Receive a datagram; returns data, sender Addr, sender port.
+  recvfrom: function(self: Socket, bufsiz?: number, flags?: number): string | nil, ip.Addr, number, string
+  --- Local address as (Addr, port); use after bind for the real port.
+  getsockname: function(self: Socket): ip.Addr | nil, number, string
+  --- Peer address as (Addr, port).
+  getpeername: function(self: Socket): ip.Addr | nil, number, string
+  --- Bind to a local addr:port (default all interfaces, OS-assigned port).
+  bind: function(self: Socket, addr?: Address, port?: number): boolean, string
   --- Bind to a unix-domain socket path.
   bind_unix: function(self: Socket, path: string): boolean, string
   --- Start listening for connections.
   listen: function(self: Socket, backlog?: number): boolean, string
   --- Accept one connection (blocks until a client connects).
-  --- Returns the connection socket, peer ip, peer port.
-  accept: function(self: Socket, flags?: number): Socket | nil, number, number, string
-  --- Connect to ip:port (integers; see cosmic.ip.parse for strings).
-  connect: function(self: Socket, ip: number, port: number): boolean, string
+  --- Returns the connection socket, peer Addr, peer port.
+  accept: function(self: Socket, flags?: number): Socket | nil, ip.Addr, number, string
+  --- Connect to addr:port.
+  connect: function(self: Socket, addr: Address, port: number): boolean, string
   --- Connect to a unix-domain socket path.
   connect_unix: function(self: Socket, path: string): boolean, string
   --- Read a socket option value.
@@ -103,9 +126,13 @@ local function make_socket(fd: number): Socket
     return n
   end
 
-  function sock:sendto(data: string, ip: number, port: number, flags?: number): number | nil, string
+  function sock:sendto(data: string, addr: Address, port: number, flags?: number): number | nil, string
     if not self.fd then return nil, "socket closed" end
-    local n, err = unix.sendto(self.fd, data, ip, port, (flags or 0) | unix.MSG_NOSIGNAL)
+    local raw, aerr = resolve_addr(addr)
+    if not raw then
+      return nil, aerr
+    end
+    local n, err = unix.sendto(self.fd, data, raw, port, (flags or 0) | unix.MSG_NOSIGNAL)
     if not n then
       return nil, errstr(err, "sendto")
     end
@@ -133,42 +160,50 @@ local function make_socket(fd: number): Socket
     return data
   end
 
-  function sock:recvfrom(bufsiz?: number, flags?: number): string | nil, number, number, string
+  function sock:recvfrom(bufsiz?: number, flags?: number): string | nil, ip.Addr, number, string
     if not self.fd then return nil, nil, nil, "socket closed" end
-    local data, ip, port = unix.recvfrom(self.fd, bufsiz or 65536, flags or 0)
+    local data, sender, port = unix.recvfrom(self.fd, bufsiz or 65536, flags or 0)
     if not data then
       -- On failure the binding returns (nil, err, errno): the error string
       -- arrives in the second slot, where the sender ip would have been.
-      return nil, nil, nil, errstr(ip, "recvfrom")
+      return nil, nil, nil, errstr(sender, "recvfrom")
     end
-    return data, ip, port
+    return data, ip.addr(sender), port
   end
 
-  function sock:getsockname(): number | nil, number, string
+  function sock:getsockname(): ip.Addr | nil, number, string
     if not self.fd then return nil, nil, "socket closed" end
-    local ip, port = unix.getsockname(self.fd)
-    if not ip then
+    local raw, port = unix.getsockname(self.fd)
+    if not raw then
       -- On failure the binding returns (nil, err, errno): the error string
       -- arrives in the second slot, where the port would have been.
       return nil, nil, errstr(port, "getsockname")
     end
-    return ip, port
+    return ip.addr(raw), port
   end
 
-  function sock:getpeername(): number | nil, number, string
+  function sock:getpeername(): ip.Addr | nil, number, string
     if not self.fd then return nil, nil, "socket closed" end
-    local ip, port = unix.getpeername(self.fd)
-    if not ip then
+    local raw, port = unix.getpeername(self.fd)
+    if not raw then
       -- On failure the binding returns (nil, err, errno): the error string
       -- arrives in the second slot, where the port would have been.
       return nil, nil, errstr(port, "getpeername")
     end
-    return ip, port
+    return ip.addr(raw), port
   end
 
-  function sock:bind(ip?: number, port?: number): boolean, string
+  function sock:bind(addr?: Address, port?: number): boolean, string
     if not self.fd then return false, "socket closed" end
-    local ok, err = unix.bind(self.fd, ip or 0, port or 0)
+    local raw: integer = 0
+    if addr ~= nil then
+      local r, aerr = resolve_addr(addr)
+      if not r then
+        return false, aerr
+      end
+      raw = r
+    end
+    local ok, err = unix.bind(self.fd, raw, port or 0)
     if not ok then
       return false, errstr(err, "bind")
     end
@@ -193,20 +228,24 @@ local function make_socket(fd: number): Socket
     return true
   end
 
-  function sock:accept(flags?: number): Socket | nil, number, number, string
+  function sock:accept(flags?: number): Socket | nil, ip.Addr, number, string
     if not self.fd then return nil, nil, nil, "socket closed" end
-    local clientfd, ip, port = unix.accept(self.fd, flags or 0)
+    local clientfd, peer, port = unix.accept(self.fd, flags or 0)
     if not clientfd then
       -- On failure the binding returns (nil, err, errno): the error string
       -- arrives in the second slot, where the peer ip would have been.
-      return nil, nil, nil, errstr(ip, "accept")
+      return nil, nil, nil, errstr(peer, "accept")
     end
-    return make_socket(clientfd), ip, port
+    return make_socket(clientfd), ip.addr(peer), port
   end
 
-  function sock:connect(ip: number, port: number): boolean, string
+  function sock:connect(addr: Address, port: number): boolean, string
     if not self.fd then return false, "socket closed" end
-    local ok, err = unix.connect(self.fd, ip, port)
+    local raw, aerr = resolve_addr(addr)
+    if not raw then
+      return false, aerr
+    end
+    local ok, err = unix.connect(self.fd, raw, port)
     if not ok then
       return false, errstr(err, "connect")
     end
@@ -263,6 +302,7 @@ end
 
 local record NetSocketModule
   type Socket = Socket
+  type Address = Address
   make_socket: function(fd: number): Socket
 end
 

--- a/lib/cosmic/quicksand/proxy/dial_test.tl
+++ b/lib/cosmic/quicksand/proxy/dial_test.tl
@@ -33,7 +33,7 @@ local function test_resolve_literal_skips_resolver()
     function(_: string): integer, any
       error("resolver must not run for literals")
     end)
-  assert(got == ip.parse("8.8.8.8"),
+  assert(got == (ip.parse("8.8.8.8") as ip.Addr):int(),
     "literal should parse directly: " .. tostring(err))
 end
 test_resolve_literal_skips_resolver()

--- a/lib/cosmic/quicksand/proxy_test.tl
+++ b/lib/cosmic/quicksand/proxy_test.tl
@@ -3,7 +3,10 @@ local proxy = require("cosmic.quicksand.proxy")
 local quicksand = require("cosmic.quicksand")
 local net = require("cosmic.net")
 
+-- quicksand's bind_ip option is a raw integer (C-boundary internals);
+-- the cosmic.net surface takes dotted-quad strings or ip.Addr (#588).
 local LOOPBACK < const > = 0x7f000001
+local LOOPBACK_STR < const > = "127.0.0.1"
 
 local function test_module_exports()
   assert(type(proxy.start) == "function")
@@ -13,7 +16,7 @@ test_module_exports()
 -- Drive one request through a live proxy and return everything the
 -- server sends back before closing.
 local function roundtrip(port: integer, request: string): string
-  local sock = assert(net.connect_tcp(LOOPBACK, port)) as net.Socket
+  local sock = assert(net.connect_tcp(LOOPBACK_STR, port)) as net.Socket
   sock:send(request)
   local resp = ""
   while true do
@@ -67,7 +70,7 @@ local function test_start_stop_lifecycle()
 
   -- Connecting to the proxy and immediately closing should at least
   -- establish a TCP connection — verify by opening a client socket.
-  local sock = net.connect_tcp(LOOPBACK, h.port)
+  local sock = net.connect_tcp(LOOPBACK_STR, h.port)
   assert(sock, "failed to connect to proxy on port "
     .. tostring(h.port))
   local s = sock as net.Socket

--- a/lib/perf/bench/http_bench.tl
+++ b/lib/perf/bench/http_bench.tl
@@ -10,7 +10,7 @@ local proc = require("cosmic.proc")
 local signal = require("cosmic.signal")
 local pt = require("perf.perf_types")
 
-local LOCALHOST = 0x7f000001
+local LOCALHOST = "127.0.0.1"
 local BODY = "hello from the perf harness server"
 local RESPONSE = "HTTP/1.1 200 OK\r\n"
 .. "Content-Type: text/plain\r\n"

--- a/lib/perf/bench/micro_bench.tl
+++ b/lib/perf/bench/micro_bench.tl
@@ -164,8 +164,8 @@ local function scenarios(): {pt.Scenario}, string
     {
       name = "net_ip_roundtrip",
       fn = function(_: any): any
-        local n = ip.parse("192.168.1.1")
-        return ip.format(n)
+        local a = ip.parse("192.168.1.1")
+        return (a as ip.Addr):format()
       end,
       check = function(_: any, res: any): boolean, string
         if res as string ~= "192.168.1.1" then

--- a/lib/perf/bench/stream_bench.tl
+++ b/lib/perf/bench/stream_bench.tl
@@ -12,7 +12,7 @@ local proc = require("cosmic.proc")
 local signal = require("cosmic.signal")
 local pt = require("perf.perf_types")
 
-local LOCALHOST = 0x7f000001
+local LOCALHOST = "127.0.0.1"
 local NUM_LINES = 4000
 
 --- Build a deterministic multi-line body, each line newline-terminated.


### PR DESCRIPTION
Closes #588 — item 3 of the #594 pre-stable breaking wave (B1). Also closes #498 (folded in; see below). The typed `ip.Addr` becomes the only address currency in public signatures, so IPv6 (whilp/cosmopolitan#144) lands post-stable as a new Addr family *value* instead of a parallel `*6` API — the Go `net.IP` → `netip.Addr` lesson applied before the stable cut instead of after.

## ip: Addr-native, int forms deleted

- `ip.parse(str): Addr | nil, string` (was `integer | nil, string`)
- `Addr.family = "inet"` — an enum with one value today, so IPv6 later extends values, not types. It lives on the shared metatable (the #563 precedent), so constructing an Addr stays a single two-field table allocation.
- `Addr` compares by value: `__eq` on the payload, so `parse("127.0.0.1") == ip.addr(0x7f000001)` regardless of provenance.
- The int-taking module forms — `format`, `categorize`, `is_loopback`, `is_private`, `is_public` — are **deleted**; the Addr methods are the API. `ip.addr(n)` stays as the one explicit int→Addr constructor for the C boundary, and `Addr:int()` exposes the v4 payload.

## net: Address drops bare integer; sockets speak Addr

- `net.Address` is now `string | ip.Addr`. Raw integers like `0x7f000001` are no longer addresses anywhere in the public surface.
- Input side: `Socket:connect`, `Socket:bind`, `Socket:sendto` take `Address` (resolution inside, in `net.socket`'s shared resolver).
- Output side: `Socket:accept`, `getsockname`, `getpeername`, `recvfrom` return typed `Addr`.
- `net.Interface.ip` is a typed `Addr` (converted once in `interfaces()`).
- **`net.dial(host, port): Socket | nil, string`** — the reserved stable entry point from #501, implemented minimally: host is a dotted-quad literal or a DNS name, resolution happens inside, future families extend the values dial accepts, never the signature.

## #498 fold-in

Verified both remaining items are already resolved on main: `ip.parse` uses `nil, err` (no `−1` sentinel), and `url.parse_host("::1")` rejects unbracketed IPv6 with a bracket hint (regression test `test_parse_host_unbracketed_ipv6_rejected` already exists). The quicksand proxy's internal `cosmo.ParseIp` sentinel handling is the C binding's contract, untouched here.

## Tests

`ip_test` rewritten around the Addr surface (family, `__eq` value semantics, tostring, method classification). The net tests assert typed addresses where they flow out — `getsockname`/`accept`/`recvfrom` results checked for `family == "inet"` and loopback classification — encoding the "no bare integer addresses" contract as runtime assertions on every signature the issue names. New `test_dial` covers literal, hostname, and failure shapes. The sweep replaced every `0x7f000001` with `"127.0.0.1"` across net tests/examples and the perf benches; quicksand's `bind_ip` option keeps its raw integer (C-boundary internals, not the net/ip surface).

## Validation

- `bin/make ci` green: format 251, teal 251, tests 116, examples 20, lint 318.
- **Perf A/B** (main build as baseline → this branch, same machine, noise-aware gate): `35 scenarios: 0 regression, 1 faster, 34 ok, 0 noise, 0 new, 0 missing, 0 error`. The Addr-affected paths:
  ```
  http_tcp_roundtrip              106.23 µs ->    118.63 µs    +11.7%  (noise  ±16.0%)  ok
  net_ip_roundtrip                  1.34 µs ->      1.48 µs    +10.4%  (noise  ±14.2%)  ok
  http_fetch_get                   99.34 µs ->    101.97 µs     +2.6%  (noise  ±10.0%)  ok
  ```
  `net_ip_roundtrip` now allocates the Addr it returns (0.20 KB/op) — that is the deliberate cost of the typed surface, kept to one small table by the metatable design, and within the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XdWnoUpSW33ZhVA7scf7Z

---
_Generated by [Claude Code](https://claude.ai/code/session_019XdWnoUpSW33ZhVA7scf7Z)_