### PR TITLE
compress: standard raw/zlib/gzip formats only, delete the prefixed deflate (#590)

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -44,7 +44,7 @@ local sqlite = require("cosmic.sqlite")
 |--------|-------------|
 | `cosmic.sqlite` | SQLite with query/exec/transaction API |
 | `cosmic.codec` | hex encoding/decoding, Lua serialization |
-| `cosmic.compress` | zlib compress/decompress, raw deflate |
+| `cosmic.compress` | zlib/gzip/raw compress/decompress |
 | `cosmic.html` | HTML entity escaping |
 | `cosmic.zip` | ZIP archive reading and writing |
 

--- a/lib/cosmic/compress.tl
+++ b/lib/cosmic/compress.tl
@@ -1,15 +1,52 @@
 --- Compression and decompression utilities.
---- Provides zlib and raw deflate compression with consistent error handling.
+--- Wraps DEFLATE in the three standard framings — zlib (default), gzip,
+--- and raw (headerless, as used inside ZIP files) — so output
+--- interoperates with standard tooling for each format (api-review-2,
+--- #590). Raw callers who need the original length carry it themselves
+--- and should checksum the output separately.
 local cosmo = require("cosmo")
 
---- Compress data using standard zlib framing.
---- The zlib format carries its own integrity check (Adler-32), and the
---- output interoperates with other zlib tooling. It can be decompressed
---- without knowing the original size.
+--- Compressed stream framing produced by compress().
+local enum Format
+  "zlib"
+  "gzip"
+  "raw"
+end
+
+--- Framing accepted by decompress(). "auto" detects zlib or gzip from
+--- the stream header; raw streams carry no header and must be named
+--- explicitly.
+local enum DecompressFormat
+  "zlib"
+  "gzip"
+  "raw"
+  "auto"
+end
+
+--- Options for compress().
+local record CompressOptions
+  --- output framing; defaults to "zlib"
+  format: Format
+end
+
+--- Options for decompress().
+local record DecompressOptions
+  --- input framing; defaults to "zlib"
+  format: DecompressFormat
+  --- cap on the decompressed size in bytes (default 64 MiB)
+  max_output: number
+end
+
+--- Compress data using a standard framing.
+--- zlib (default) and gzip carry their own integrity checks and can be
+--- decompressed without knowing the original size. Raw is headerless
+--- DEFLATE, suitable for embedding into formats like ZIP files.
 --- @param data string The data to compress
+--- @param opts CompressOptions? format: "zlib" (default) | "gzip" | "raw"
 --- @return string The compressed data
-local function compress(data: string): string
-  local result, err = cosmo.Deflate(data, {format = "zlib"})
+local function compress(data: string, opts?: CompressOptions): string
+  local format: Format = opts and opts.format or "zlib"
+  local result, err = cosmo.Deflate(data, {format = format})
   if not result then
     -- Unreachable with valid options; surface a loud failure rather than
     -- silently breaking the infallible contract.
@@ -18,111 +55,37 @@ local function compress(data: string): string
   return result
 end
 
---- Decompress zlib-compressed data.
+--- Decompress data in a standard framing.
 --- The decompressed size need not be known in advance; output is bounded
 --- by max_output (default 64 MiB, enforced by the binding) so untrusted
 --- input cannot balloon memory.
---- @param data string The compressed data (from compress())
---- @param max_output number? Cap on the decompressed size in bytes
+--- @param data string The compressed data
+--- @param opts DecompressOptions? format: "zlib" (default) | "gzip" | "raw" | "auto"; max_output: output byte cap
 --- @return string | nil The decompressed data, or nil on error
 --- @return string? Error message if decompression failed
-local function uncompress(data: string, max_output?: number): string | nil, string
+local function decompress(data: string, opts?: DecompressOptions): string | nil, string
+  local format: DecompressFormat = opts and opts.format or "zlib"
+  local max_output = opts and opts.max_output
   -- The binding reports truncated or corrupt input as nil, err.
-  local result, err = cosmo.Inflate(data, {format = "zlib", maxsize = max_output})
+  local result, err = cosmo.Inflate(data, {format = format, maxsize = max_output})
   if not result then
     return nil, err as string
-  end
-  return result
-end
-
---- Compress data using raw deflate (no header).
---- The output is prefixed with a 4-byte little-endian size to enable
---- decompression without knowing the original size.
---- Maximum input size: ~4GB (limited by 32-bit size prefix).
---- Note: The output format is specific to this module and is not compatible
---- with standard raw deflate streams. Use compress/uncompress for
---- interoperable zlib format.
---- @param data string The data to compress
---- @return string | nil The compressed data with size prefix, or nil on error
---- @return string? Error message if input exceeds size limit
-local function deflate(data: string): string | nil, string
-  if #data > 0xFFFFFFFF then
-    return nil, "deflate: input too large (max 4GB)"
-  end
-  local size = #data
-  -- Store size as 4-byte little-endian prefix
-  local prefix = string.char(
-    size % 256,
-    math.floor(size / 256) % 256,
-    math.floor(size / 65536) % 256,
-    math.floor(size / 16777216) % 256
-  )
-  local compressed, err = cosmo.Deflate(data)
-  if not compressed then
-    return nil, err as string
-  end
-  return prefix .. compressed
-end
-
--- DEFLATE cannot expand by more than ~1032x (zlib's documented maximum
--- compression ratio), so a size prefix claiming more than that is forged.
-local MAX_DEFLATE_RATIO < const > = 1032
-
---- Decompress raw deflate data.
---- Expects data from deflate() with the 4-byte size prefix.
---- Maximum decompressed size: ~4GB (limited by 32-bit size prefix).
---- The size prefix is attacker-controlled in untrusted input, so it is
---- validated BEFORE the output buffer is allocated: a declared size larger
---- than max_output (when given), or implausibly large for the compressed
---- payload (beyond DEFLATE's ~1032:1 maximum ratio), is rejected without
---- allocating, and the binding additionally caps decompression at the
---- declared size. Output that does not match the declared size exactly is
---- reported as corrupt.
---- Note: Only compatible with data produced by deflate() in this module.
---- @param data string The compressed data with size prefix
---- @param max_output number? Reject a declared size larger than this many bytes
---- @return string | nil The decompressed data, or nil on error
---- @return string? Error message if decompression failed
-local function inflate(data: string, max_output?: number): string | nil, string
-  if #data < 4 then
-    return nil, "invalid deflate data: too short"
-  end
-  -- Read 4-byte little-endian size prefix
-  local b1, b2, b3, b4 = data:byte(1, 4)
-  local size = b1 + b2 * 256 + b3 * 65536 + b4 * 16777216
-  if max_output and size > max_output then
-    return nil, "inflate: declared size " .. size .. " exceeds max_output " .. max_output
-  end
-  local compressed_len = #data - 4
-  if size > compressed_len * MAX_DEFLATE_RATIO then
-    return nil, "inflate: declared size " .. size .. " is implausible for " .. compressed_len .. " compressed bytes"
-  end
-  local compressed = data:sub(5)
-  -- The binding reports invalid input as nil, err. maxsize of 0 is not a
-  -- valid cap, so an empty payload uses 1 and the exactness check below
-  -- rejects any unexpected output.
-  local result, err = cosmo.Inflate(compressed, {maxsize = math.max(size, 1)})
-  if not result then
-    return nil, err as string
-  end
-  if #result ~= size then
-    return nil, "inflate: output size " .. #result .. " does not match declared size " .. size
   end
   return result
 end
 
 local record CompressModule
-  compress: function(data: string): string
-  uncompress: function(data: string, max_output?: number): string | nil, string
-  deflate: function(data: string): string | nil, string
-  inflate: function(data: string, max_output?: number): string | nil, string
+  type Format = Format
+  type DecompressFormat = DecompressFormat
+  type CompressOptions = CompressOptions
+  type DecompressOptions = DecompressOptions
+  compress: function(data: string, opts?: CompressOptions): string
+  decompress: function(data: string, opts?: DecompressOptions): string | nil, string
 end
 
 local M: CompressModule = {
   compress = compress,
-  uncompress = uncompress,
-  deflate = deflate,
-  inflate = inflate,
+  decompress = decompress,
 }
 
 return M

--- a/lib/cosmic/compress_test.tl
+++ b/lib/cosmic/compress_test.tl
@@ -1,28 +1,41 @@
 #!/usr/bin/env cosmic
 local compress = require("cosmic.compress")
 
--- Zlib compression tests
+-- Round-trip tests per format
 
-local function test_compress_basic()
-  local data = "hello world"
+local function test_roundtrip_default_zlib()
+  local data = "Hello, World! This is a test of zlib compression.\x00\xff"
   local compressed = compress.compress(data)
   assert(#compressed > 0, "expected non-empty output")
   assert(compressed ~= data, "expected different output")
+  local result, err = compress.decompress(compressed)
+  assert(err == nil, "roundtrip failed: " .. (err or ""))
+  assert(result == data, "roundtrip mismatch")
 end
-test_compress_basic()
+test_roundtrip_default_zlib()
 
-local function test_compress_empty()
-  local compressed = compress.compress("")
-  assert(compressed ~= nil, "expected non-nil output for empty input")
+local function test_roundtrip_explicit_formats()
+  local data = "format round-trip \x00\xff\x10\x20 payload"
+  local formats: {compress.Format} = {"zlib", "gzip", "raw"}
+  for _, format in ipairs(formats) do
+    local compressed = compress.compress(data, {format = format})
+    local result, err = compress.decompress(compressed, {format = format as compress.DecompressFormat})
+    assert(err == nil, format .. " roundtrip failed: " .. (err or ""))
+    assert(result == data, format .. " roundtrip mismatch")
+  end
 end
-test_compress_empty()
+test_roundtrip_explicit_formats()
 
-local function test_compress_binary()
-  local data = "\x00\xff\x10\x20"
-  local compressed = compress.compress(data)
-  assert(#compressed > 0, "expected non-empty output")
+local function test_roundtrip_empty_per_format()
+  local formats: {compress.Format} = {"zlib", "gzip", "raw"}
+  for _, format in ipairs(formats) do
+    local compressed = compress.compress("", {format = format})
+    local result, err = compress.decompress(compressed, {format = format as compress.DecompressFormat})
+    assert(err == nil, format .. " empty roundtrip failed: " .. (err or ""))
+    assert(result == "", format .. ": expected empty string")
+  end
 end
-test_compress_binary()
+test_roundtrip_empty_per_format()
 
 local function test_compress_large()
   local data = string.rep("hello world, ", 1000)
@@ -31,185 +44,125 @@ local function test_compress_large()
 end
 test_compress_large()
 
--- Zlib decompression tests
+-- Format framing tests: outputs carry the standard headers, so they
+-- interoperate with other tooling.
 
-local function test_uncompress_basic()
-  local data = "hello world"
-  local compressed = compress.compress(data)
-  local result, err = compress.uncompress(compressed)
-  assert(err == nil, "unexpected error: " .. (err or ""))
-  assert(result == data, "expected '" .. data .. "', got '" .. (result or "nil") .. "'")
+local function test_zlib_magic_bytes()
+  local compressed = compress.compress("hello", {format = "zlib"})
+  assert(string.byte(compressed, 1) == 0x78, "expected zlib CMF byte 0x78")
 end
-test_uncompress_basic()
+test_zlib_magic_bytes()
 
-local function test_uncompress_empty()
-  local compressed = compress.compress("")
-  local result, err = compress.uncompress(compressed)
-  assert(err == nil, "unexpected error: " .. (err or ""))
-  assert(result == "", "expected empty string")
+local function test_gzip_magic_bytes()
+  local compressed = compress.compress("hello", {format = "gzip"})
+  local b1, b2, b3 = string.byte(compressed, 1, 3)
+  assert(b1 == 0x1f and b2 == 0x8b, "expected gzip magic 1f 8b")
+  assert(b3 == 0x08, "expected deflate compression method byte 0x08")
 end
-test_uncompress_empty()
+test_gzip_magic_bytes()
 
-local function test_uncompress_binary()
-  local data = "\x00\xff\x10\x20"
-  local compressed = compress.compress(data)
-  local result, err = compress.uncompress(compressed)
-  assert(err == nil, "unexpected error: " .. (err or ""))
-  assert(result == data, "roundtrip mismatch for binary data")
+local function test_raw_has_no_header()
+  -- Raw is headerless DEFLATE: no zlib or gzip magic, and strictly
+  -- smaller than the framed encodings of the same input.
+  local data = "hello, raw deflate"
+  local raw = compress.compress(data, {format = "raw"})
+  local b1, b2 = string.byte(raw, 1, 2)
+  assert(not (b1 == 0x1f and b2 == 0x8b), "raw output must not carry gzip magic")
+  assert(b1 ~= 0x78, "raw output must not carry zlib header")
+  assert(#raw < #compress.compress(data, {format = "zlib"}), "raw must be smaller than zlib")
 end
-test_uncompress_binary()
+test_raw_has_no_header()
 
-local function test_uncompress_invalid()
-  local result, err = compress.uncompress("invalid data")
-  assert(result == nil, "expected nil for invalid data")
-  assert(err ~= nil, "expected error message")
+local function test_gzip_fixture_from_system_gzip()
+  -- Produced by `printf 'hello from system gzip\n' | gzip -n -9` on
+  -- GNU gzip: proof the format is the real one, not module-specific.
+  local fixture = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x02\x03"
+  .. "\xcb\x48\xcd\xc9\xc9\x57\x48\x2b\xca\xcf\x55\x28\xae\x2c\x2e"
+  .. "\x49\xcd\x55\x48\xaf\xca\x2c\xe0\x02\x00"
+  .. "\x45\xf2\xe3\x07\x17\x00\x00\x00"
+  local result, err = compress.decompress(fixture, {format = "gzip"})
+  assert(err == nil, "system gzip fixture failed: " .. (err or ""))
+  assert(result == "hello from system gzip\n", "fixture content mismatch")
 end
-test_uncompress_invalid()
+test_gzip_fixture_from_system_gzip()
 
-local function test_zlib_roundtrip()
-  local original = "Hello, World! This is a test of zlib compression.\x00\xff"
-  local compressed = compress.compress(original)
-  local result, err = compress.uncompress(compressed)
-  assert(err == nil, "roundtrip failed: " .. (err or ""))
-  assert(result == original, "roundtrip mismatch")
-end
-test_zlib_roundtrip()
+-- "auto" detection tests
 
--- Raw deflate tests
-
-local function test_deflate_basic()
-  local data = "hello world"
-  local deflated = compress.deflate(data)
-  assert(#deflated > 4, "expected output with size prefix")
-end
-test_deflate_basic()
-
-local function test_deflate_empty()
-  local deflated, derr = compress.deflate("")
-  if not deflated then error(derr) end
-  assert(#deflated >= 4, "expected at least size prefix")
-  -- First 4 bytes should be 0 (size = 0)
-  assert(string.byte(deflated, 1) == 0, "expected size byte 1 to be 0")
-  assert(string.byte(deflated, 2) == 0, "expected size byte 2 to be 0")
-  assert(string.byte(deflated, 3) == 0, "expected size byte 3 to be 0")
-  assert(string.byte(deflated, 4) == 0, "expected size byte 4 to be 0")
-end
-test_deflate_empty()
-
-local function test_deflate_large()
-  local data = string.rep("hello world, ", 1000)
-  local deflated = compress.deflate(data)
-  -- 4 bytes prefix + compressed data should be smaller than original
-  assert(#deflated < #data, "expected compression ratio for repetitive data")
-end
-test_deflate_large()
-
--- Raw inflate tests
-
-local function test_inflate_basic()
-  local data = "hello world"
-  local deflated = compress.deflate(data)
-  local result, err = compress.inflate(deflated)
-  assert(err == nil, "unexpected error: " .. (err or ""))
-  assert(result == data, "expected '" .. data .. "', got '" .. (result or "nil") .. "'")
-end
-test_inflate_basic()
-
-local function test_inflate_empty()
-  local deflated = compress.deflate("")
-  local result, err = compress.inflate(deflated)
-  assert(err == nil, "unexpected error: " .. (err or ""))
-  assert(result == "", "expected empty string")
-end
-test_inflate_empty()
-
-local function test_inflate_binary()
-  local data = "\x00\xff\x10\x20"
-  local deflated = compress.deflate(data)
-  local result, err = compress.inflate(deflated)
-  assert(err == nil, "unexpected error: " .. (err or ""))
-  assert(result == data, "roundtrip mismatch for binary data")
-end
-test_inflate_binary()
-
-local function test_inflate_too_short()
-  local result, err = compress.inflate("abc")
-  assert(result == nil, "expected nil for too-short data")
-  assert(err ~= nil, "expected error message")
-  assert(err:match("too short"), "error should mention 'too short'")
-end
-test_inflate_too_short()
-
-local function test_inflate_invalid()
-  -- 4-byte prefix claiming size 100, followed by garbage
-  local invalid = "\x64\x00\x00\x00invalid"
-  local result, err = compress.inflate(invalid)
-  assert(result == nil, "expected nil for invalid data")
-  assert(err ~= nil, "expected error message")
-end
-test_inflate_invalid()
-
-local function test_deflate_roundtrip()
-  local original = "Hello, World! This is a test of raw deflate compression.\x00\xff"
-  local deflated = compress.deflate(original)
-  local result, err = compress.inflate(deflated)
-  assert(err == nil, "roundtrip failed: " .. (err or ""))
-  assert(result == original, "roundtrip mismatch")
-end
-test_deflate_roundtrip()
-
--- Size prefix encoding test
-
-local function test_deflate_size_prefix()
-  -- Test with various sizes to verify little-endian encoding
-  local sizes = {0, 1, 255, 256, 65535, 65536, 100000}
-  for _, size in ipairs(sizes) do
-    local data = string.rep("x", size)
-    local deflated, derr = compress.deflate(data)
-    if not deflated then error(derr) end
-    -- Read back the size from prefix
-    local b1, b2, b3, b4 = string.byte(deflated, 1, 4)
-    local read_size = b1 + b2 * 256 + b3 * 65536 + b4 * 16777216
-    assert(read_size == size, "size mismatch for " .. size .. ": got " .. read_size)
-    -- Verify roundtrip
-    local result, err = compress.inflate(deflated)
-    assert(err == nil, "roundtrip failed for size " .. size .. ": " .. (err or ""))
-    assert(#result == size, "result size mismatch for " .. size)
+local function test_auto_detects_zlib_and_gzip()
+  local data = "auto-detected payload"
+  local formats: {compress.Format} = {"zlib", "gzip"}
+  for _, format in ipairs(formats) do
+    local compressed = compress.compress(data, {format = format})
+    local result, err = compress.decompress(compressed, {format = "auto"})
+    assert(err == nil, "auto failed on " .. format .. ": " .. (err or ""))
+    assert(result == data, "auto mismatch on " .. format)
   end
 end
-test_deflate_size_prefix()
+test_auto_detects_zlib_and_gzip()
 
--- Size limit check test
-
-local function test_deflate_size_check_normal()
-  -- Verify that normal-sized input returns result, not error
-  local result, err = compress.deflate(string.rep("x", 1000))
-  assert(result ~= nil, "expected success for 1000-byte input: " .. tostring(err))
-  assert(err == nil, "expected no error for 1000-byte input")
+local function test_auto_rejects_raw()
+  -- Raw streams carry no header, so auto detection cannot identify them.
+  local raw = compress.compress("headerless", {format = "raw"})
+  local result, err = compress.decompress(raw, {format = "auto"})
+  assert(result == nil, "auto must not accept a headerless raw stream")
+  assert(err ~= nil, "expected error message")
 end
-test_deflate_size_check_normal()
+test_auto_rejects_raw()
 
--- Forged size-prefix tests (issue #531): the 4-byte prefix is
--- attacker-controlled and must be validated before allocation.
+-- Error handling tests
 
-local function test_inflate_forged_huge_prefix()
-  -- 5-byte blob whose prefix claims ~4GB for 1 compressed byte. Must be
-  -- rejected up front (no 4GB allocation attempt).
-  local forged = string.char(0xFF, 0xFF, 0xFF, 0xFF) .. "x"
-  local result, err = compress.inflate(forged)
-  assert(result == nil, "forged size prefix should be rejected")
-  assert(err and err:match("implausible"), "expected implausibility error, got: " .. tostring(err))
+local function test_decompress_invalid()
+  local result, err = compress.decompress("invalid data")
+  assert(result == nil, "expected nil for invalid data")
+  assert(err ~= nil, "expected error message")
 end
-test_inflate_forged_huge_prefix()
+test_decompress_invalid()
 
-local function test_inflate_max_output()
-  local deflated = assert(compress.deflate(string.rep("x", 2000)))
-  local result, err = compress.inflate(deflated, 100)
-  assert(result == nil, "declared size beyond max_output should be rejected")
-  assert(err and err:match("max_output"), "expected max_output error, got: " .. tostring(err))
-
-  result, err = compress.inflate(deflated, 2000)
-  assert(result, "max_output at the exact size should pass: " .. tostring(err))
-  assert(#(result as string) == 2000, "roundtrip under max_output should succeed")
+local function test_decompress_wrong_format()
+  local gz = compress.compress("cross-format", {format = "gzip"})
+  local result, err = compress.decompress(gz, {format = "zlib"})
+  assert(result == nil, "gzip input must not decompress as zlib")
+  assert(err ~= nil, "expected error message")
 end
-test_inflate_max_output()
+test_decompress_wrong_format()
+
+local function test_decompress_truncated()
+  local compressed = compress.compress(string.rep("truncate me, ", 100))
+  local result, err = compress.decompress(compressed:sub(1, #compressed // 2))
+  assert(result == nil, "truncated input must fail")
+  assert(err ~= nil, "expected error message")
+end
+test_decompress_truncated()
+
+-- Zip-bomb bound tests: max_output is enforced per format, so
+-- attacker-controlled input cannot balloon memory.
+
+local function test_max_output_bound_per_format()
+  local data = string.rep("x", 2000)
+  local formats: {compress.DecompressFormat} = {"zlib", "gzip", "raw", "auto"}
+  for _, format in ipairs(formats) do
+    local cformat: compress.Format = "gzip"
+    if format ~= "auto" then
+      cformat = format as compress.Format
+    end
+    local compressed = compress.compress(data, {format = cformat})
+    local result, err = compress.decompress(compressed, {format = format, max_output = 100})
+    assert(result == nil, format .. ": output beyond max_output must be rejected")
+    assert(err ~= nil, format .. ": expected error message")
+
+    result, err = compress.decompress(compressed, {format = format, max_output = 2000})
+    assert(result, format .. ": max_output at the exact size should pass: " .. tostring(err))
+    assert(#(result as string) == 2000, format .. ": roundtrip under max_output should succeed")
+  end
+end
+test_max_output_bound_per_format()
+
+-- Contract test: the bespoke prefixed-deflate surface is gone (#590).
+
+local function test_prefixed_deflate_surface_removed()
+  local m = compress as {string: any}
+  assert(m["deflate"] == nil, "deflate must be removed")
+  assert(m["inflate"] == nil, "inflate must be removed")
+  assert(m["uncompress"] == nil, "uncompress must be removed (renamed decompress)")
+end
+test_prefixed_deflate_surface_removed()

--- a/lib/perf/bench/micro_bench.tl
+++ b/lib/perf/bench/micro_bench.tl
@@ -120,7 +120,7 @@ local function scenarios(): {pt.Scenario}, string
       name = "compress_roundtrip_64k",
       fn = function(_: any): any
         local packed = compress.compress(BLOB)
-        return (compress.uncompress(packed))
+        return (compress.decompress(packed))
       end,
       check = function(_: any, res: any): boolean, string
         if res as string ~= BLOB then
@@ -131,16 +131,18 @@ local function scenarios(): {pt.Scenario}, string
     },
     {
       -- A small input, unlike compress_roundtrip_64k: isolates the
-      -- deflate()/inflate() size-prefix pack/unpack overhead from the
-      -- zlib compute itself, which barely registers on this little data.
-      name = "compress_deflate_roundtrip_small",
+      -- per-call wrapper overhead from the zlib compute itself, which
+      -- barely registers on this little data. Replaces
+      -- compress_deflate_roundtrip_small when #590 deleted the
+      -- size-prefixed deflate format.
+      name = "compress_raw_roundtrip_small",
       fn = function(_: any): any
-        local packed = compress.deflate(ABC)
-        return (compress.inflate(packed))
+        local packed = compress.compress(ABC, {format = "raw"})
+        return (compress.decompress(packed, {format = "raw"}))
       end,
       check = function(_: any, res: any): boolean, string
         if res as string ~= ABC then
-          return false, "deflate roundtrip corrupted data"
+          return false, "raw roundtrip corrupted data"
         end
         return true
       end,


### PR DESCRIPTION
Implements #590 (B3 of the pre-stable breaking wave #594): `cosmic.compress` now speaks only the three standard DEFLATE framings, and the module-specific size-prefixed deflate format is deleted before anyone persists it.

## API

- `compress.compress(data, opts?: {format: "zlib" | "gzip" | "raw"}): string` — default zlib; the infallible contract is unchanged. gzip is newly exposed (the C layer has supported it since whilp/cosmopolitan#170).
- `compress.decompress(data, opts?: {format: "zlib" | "gzip" | "raw" | "auto", max_output: number}): string | nil, string` — replaces `uncompress` for symmetry; default zlib; `"auto"` detects zlib/gzip from the stream header (raw is headerless and must be named); output stays bounded (default 64 MiB, enforced by the binding).
- **Deleted**: `deflate`/`inflate` (the 4-byte little-endian size-prefixed format nothing else reads) and `uncompress` (renamed). Raw-deflate callers who need a length carry it themselves — that was always the honest contract. With the prefix arithmetic gone, the forged-prefix validation (#531) is obsolete: bounding is entirely the binding's `maxsize`.
- `Format`, `DecompressFormat`, `CompressOptions`, `DecompressOptions` are exported as module types.

## Tests

Per the issue's TDD list: round-trips per format (incl. empty input), zlib/gzip magic-byte checks, raw verified headerless, a fixture produced by GNU `gzip -n -9` decompressed for real-world interop, `"auto"` detection for zlib+gzip and its documented rejection of raw, cross-format and truncated-input errors, zip-bomb `max_output` bounds for all four decompress formats, and a contract test that the old surface is gone.

## Gates

`bin/make ci` — green (format, teal, test, example, lint: 318/318).

`bin/make perf-compare` against a fresh main baseline:

```
compress_roundtrip_64k          555.36 µs ->    556.05 µs     +0.1%  (noise  ±10.0%)  ok
compress_raw_roundtrip_small            - ->      7.47 µs         -  (noise       -)  new
compress_deflate_roundtrip_small      7.39 µs ->            -         -  (noise       -)  missing
```

- `compress_deflate_roundtrip_small` is **missing by design**: it benchmarked the deleted prefix format. Its successor `compress_raw_roundtrip_small` (same small-input isolation, now over standard raw framing) lands at ~7.2–7.6 µs, on par with the old scenario's 7.39 µs baseline.
- `sqlite_point_query`/`json_decode_large` were flagged in early runs; an interleaved same-window A/B of the two binaries on the flagged scenario passed (`+25.3% (noise ±40.0%) ok`) — the machine's noise floor during measurement was well above the 10% bar, and this diff touches neither module.

## Knock-ons

- `lib/perf/bench/micro_bench.tl`: `compress_roundtrip_64k` switched to `decompress` (same measurement, same name); prefix scenario replaced as above.
- `docs/stdlib.md` module-index line updated. No other in-repo callers of the removed functions existed.
- cosmic-side only; no cosmopolitan change or release-pin bump.

Closes #590.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvvedcNtYDdyPHiQuNnnCR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvvedcNtYDdyPHiQuNnnCR)_