### PR TITLE
child: honest option types — fd.Handle in Options, raw ints out

### DIFF
--- a/lib/cosmic/binary_test.tl
+++ b/lib/cosmic/binary_test.tl
@@ -49,11 +49,10 @@ end
 test_cosmic_help()
 
 local function test_warnings_flag()
-  -- -W should convert warnings to errors
-  -- stderr = 1 merges stderr into stdout so we can capture the warning message
-  local h4 = spawn.spawn({cosmic, "-W", "-e", "warn('test warning')"}, {env = clean_env(), stderr = 1})
+  -- -W should convert warnings to errors; the warning message lands on stderr
+  local h4 = spawn.spawn({cosmic, "-W", "-e", "warn('test warning')"}, {env = clean_env()})
   local __r4 = (h4 as spawn.Handle):wait() as spawn.Result
-  local ok, out, code = __r4.ok, __r4.stdout, __r4.code
+  local ok, out, code = __r4.ok, __r4.stderr, __r4.code
   assert(not ok, "cosmic should fail with -W when warning is issued")
   assert((out as string):find("warning: test warning", 1, true), "expected output to contain 'warning: test warning'")
   assert(code == 1, "expected exit code 1, got " .. tostring(code))

--- a/lib/cosmic/check_test.tl
+++ b/lib/cosmic/check_test.tl
@@ -10,10 +10,11 @@ local tmpdir = os.getenv("TEST_TMPDIR")
 
 -- child.spawn now returns `Handle | nil`; tl 0.24.8 will not flow-narrow a
 -- record union, so wrap the spawn+read in one helper that casts the handle.
+-- Returns stdout..stderr so assertions see diagnostics (hints go to stderr).
 local function check_run(argv: {string}, opts?: spawn.Options): boolean | string, string
   local h = spawn.spawn(argv, opts)
   local __r1 = (h as spawn.Handle):wait() as spawn.Result
-  local ok, out = __r1.ok, __r1.stdout
+  local ok, out = __r1.ok, __r1.stdout .. __r1.stderr
   return ok, out
 end
 
@@ -211,7 +212,7 @@ end
 test_check_with_tl_path_double_semicolon()
 
 -- Test that fix-hints appear for common Teal type-check traps.
--- We redirect stderr to stdout (opts.stderr=1) so the hint output is captured.
+-- Hints go to stderr; check_run returns stdout..stderr so they are captured.
 
 -- Hint 1: got number, expected integer
 local function test_check_hint_number_integer()
@@ -221,7 +222,7 @@ local n: number = 3.14
 local c = s:sub(n, n)
 print(c)
 ]])
-  local ok, out = check_run({cosmic, "--check-types", input}, {stderr = 1})
+  local ok, out = check_run({cosmic, "--check-types", input})
   assert(not ok, "should fail with type error")
   assert(out:find("hint:"), "should include a hint, got: " .. out)
   assert(out:find("math%.tointeger"), "hint should mention math.tointeger, got: " .. out)
@@ -239,7 +240,7 @@ for i, v in ipairs(arr) do
   print(i, v)
 end
 ]])
-  local ok, out = check_run({cosmic, "--check-types", input}, {stderr = 1})
+  local ok, out = check_run({cosmic, "--check-types", input})
   assert(not ok, "should fail with type error")
   assert(out:find("hint:"), "should include a hint, got: " .. out)
   assert(out:find("as {any}"), "hint should mention casting to array, got: " .. out)
@@ -254,7 +255,7 @@ local function f(): string
 end
 f()
 ]])
-  local ok, out = check_run({cosmic, "--check-types", input}, {stderr = 1})
+  local ok, out = check_run({cosmic, "--check-types", input})
   assert(not ok, "should fail with type error")
   assert(out:find("hint:"), "should include a hint, got: " .. out)
   assert(out:find("local v, err"), "hint should mention capturing multiple returns, got: " .. out)
@@ -271,7 +272,7 @@ local v = get()
 local s = v .. " world"
 print(s)
 ]])
-  local ok, out = check_run({cosmic, "--check-types", input}, {stderr = 1})
+  local ok, out = check_run({cosmic, "--check-types", input})
   assert(not ok, "should fail with type error")
   assert(out:find("hint:"), "should include a hint, got: " .. out)
   assert(out:find("cast first"), "hint should suggest casting, got: " .. out)
@@ -287,7 +288,7 @@ end
 local obj = get()
 print(obj.name)
 ]])
-  local ok, out = check_run({cosmic, "--check-types", input}, {stderr = 1})
+  local ok, out = check_run({cosmic, "--check-types", input})
   assert(not ok, "should fail with type error")
   assert(out:find("hint:"), "should include a hint, got: " .. out)
   assert(out:find("cast first"), "hint should suggest casting, got: " .. out)
@@ -302,7 +303,7 @@ local n: number = 3.14
 local c = s:sub(n, n)
 print(c)
 ]])
-  local ok, out = check_run({cosmic, "--check-types", input}, {stderr = 1})
+  local ok, out = check_run({cosmic, "--check-types", input})
   assert(not ok, "should fail with type error")
   -- Count occurrences of "hint:"
   local count = 0

--- a/lib/cosmic/child/init.tl
+++ b/lib/cosmic/child/init.tl
@@ -13,6 +13,7 @@
 --- un-waited child and close its pipes, so `local h <close> = spawn{...}` (or
 --- simply dropping the handle) never leaves a zombie.
 local unix = require("cosmo.unix")
+local cfd = require("cosmic.fd")
 local childio = require("cosmic.child.io")
 local childfast = require("cosmic.child.fast")
 local errno = require("cosmic.errno")
@@ -58,12 +59,16 @@ local record Handle is stream.Reader
 end
 
 --- Options for spawning a process.
---- stdout/stderr as numbers are raw fds dup2'd onto the child's fd 1/2 (the
---- corresponding Result field is then ""). See Example_spawn_pipe.
+--- stdout/stderr Handles (cosmic.fd) become the child's fd 1/2 (the
+--- corresponding Result field is then ""). spawn does not take ownership
+--- of a Handle: the child gets its own copy of the descriptor, so close
+--- your end when you are done with it (see Example_run_pipe). Raw integer
+--- fds are not part of this surface (api-review-2, #602); wrap one with
+--- fd.wrap() if it comes from outside the fd module.
 local record Options
-  stdin: string | number -- string piped to stdin, or raw fd dup2'd onto fd 0
-  stdout: number -- raw fd -> fd 1
-  stderr: number -- raw fd -> fd 2
+  stdin: string | cfd.Handle -- string piped to stdin, or Handle -> fd 0
+  stdout: cfd.Handle -- child's fd 1
+  stderr: cfd.Handle -- child's fd 2
   env: {string}
   cwd: string
 end
@@ -223,6 +228,16 @@ end
 local function spawn(argv: {string}, opts?: Options): Handle | nil, string
   opts = opts or {}
 
+  -- Resolve caller-provided Handles to raw descriptors once, at the
+  -- public boundary; below this point the plumbing speaks raw fds.
+  local sio, sio_err = childio.resolve_stdio(opts.stdin, opts.stdout, opts.stderr)
+  if not sio then
+    return nil, sio_err
+  end
+  local stdio = sio as childio.Stdio
+  local stdin_data, stdin_fd = stdio.stdin_data, stdio.stdin_fd
+  local stdout_fd, stderr_fd = stdio.stdout_fd, stdio.stderr_fd
+
   -- Resolve the executable into a LOCAL, never by mutating the caller's argv:
   -- a PATH search that wrote back into argv[1] corrupts the caller's table.
   local exec_fd: number
@@ -265,7 +280,7 @@ local function spawn(argv: {string}, opts?: Options): Handle | nil, string
 
   local stdin_r: number
   local stdin_w: number
-  local stdin_is_fd = type(opts.stdin) == "number"
+  local stdin_is_fd = stdin_fd ~= nil
   if not stdin_is_fd then
     stdin_r, stdin_w = new_pipe()
     if not stdin_w then return fail("pipe failed (stdin)") end
@@ -273,7 +288,7 @@ local function spawn(argv: {string}, opts?: Options): Handle | nil, string
 
   local stdout_r: number
   local stdout_w: number
-  local stdout_is_fd = type(opts.stdout) == "number"
+  local stdout_is_fd = stdout_fd ~= nil
   if not stdout_is_fd then
     stdout_r, stdout_w = new_pipe()
     if not stdout_w then return fail("pipe failed (stdout)") end
@@ -281,7 +296,7 @@ local function spawn(argv: {string}, opts?: Options): Handle | nil, string
 
   local stderr_r: number
   local stderr_w: number
-  local stderr_is_fd = type(opts.stderr) == "number"
+  local stderr_is_fd = stderr_fd ~= nil
   if not stderr_is_fd then
     stderr_r, stderr_w = new_pipe()
     if not stderr_w then return fail("pipe failed (stderr)") end
@@ -297,10 +312,6 @@ local function spawn(argv: {string}, opts?: Options): Handle | nil, string
     -- written synchronously here: a >pipe-buffer write before anyone drains
     -- stdout/stderr would deadlock. The pump feeds stdin and drains both
     -- output streams in one poll loop, so neither can happen.
-    local stdin_data: string = nil
-    if type(opts.stdin) == "string" then
-      stdin_data = opts.stdin as string
-    end
     local st: childio.PumpState = {
       stdout_fd = stdout_is_fd and nil or stdout_r,
       stderr_fd = stderr_is_fd and nil or stderr_r,
@@ -325,9 +336,9 @@ local function spawn(argv: {string}, opts?: Options): Handle | nil, string
     or (not stdout_is_fd and stdout_w == 1)
     or (not stderr_is_fd and stderr_w == 2)
     if not pipe_on_std then
-      local t0 = stdin_is_fd and opts.stdin as number or stdin_r
-      local t1 = stdout_is_fd and opts.stdout as number or stdout_w
-      local t2 = stderr_is_fd and opts.stderr as number or stderr_w
+      local t0 = stdin_is_fd and stdin_fd or stdin_r
+      local t1 = stdout_is_fd and stdout_fd or stdout_w
+      local t2 = stderr_is_fd and stderr_fd or stderr_w
       local env = opts.env and normalize_env(opts.env) or nil
       local fpid, ferr = childfast.spawn(prog, argv, env, t0, t1, t2)
       if ferr then
@@ -351,8 +362,8 @@ local function spawn(argv: {string}, opts?: Options): Handle | nil, string
 
     -- stdin (fd 0)
     if stdin_is_fd then
-      if opts.stdin ~= 0 then
-        unix.dup(opts.stdin as number, 0)
+      if stdin_fd ~= 0 then
+        unix.dup(stdin_fd, 0)
       end
     else
       if stdin_r ~= 0 then
@@ -367,8 +378,8 @@ local function spawn(argv: {string}, opts?: Options): Handle | nil, string
 
     -- stdout (fd 1)
     if stdout_is_fd then
-      if opts.stdout ~= 1 then
-        unix.dup(opts.stdout as number, 1)
+      if stdout_fd ~= 1 then
+        unix.dup(stdout_fd, 1)
       end
     else
       if stdout_w ~= 1 then
@@ -383,8 +394,8 @@ local function spawn(argv: {string}, opts?: Options): Handle | nil, string
 
     -- stderr (fd 2)
     if stderr_is_fd then
-      if opts.stderr ~= 2 then
-        unix.dup(opts.stderr as number, 2)
+      if stderr_fd ~= 2 then
+        unix.dup(stderr_fd, 2)
       end
     else
       if stderr_w ~= 2 then

--- a/lib/cosmic/child/init_example.tl
+++ b/lib/cosmic/child/init_example.tl
@@ -62,7 +62,7 @@ end
 --
 -- Key steps:
 --   1. Create a pipe with cosmic.fd.pipe().
---   2. Pass the write end fd to spawn via opts.stdout.
+--   2. Pass the write-end Handle to spawn via opts.stdout.
 --   3. Close the write end in the parent BEFORE reading — otherwise the
 --      reader will block forever waiting for EOF.
 --   4. Read from the read end until EOF.
@@ -77,7 +77,7 @@ local function Example_run_pipe()
   local pp = p as cfd.Pipe
 
   -- Spawn echo, redirecting its stdout into the write end of the pipe.
-  local h, serr = child.spawn({"echo", "from pipe"}, {stdout = pp.writer:fd()})
+  local h, serr = child.spawn({"echo", "from pipe"}, {stdout = pp.writer})
   assert(h, "spawn failed: " .. tostring(serr))
 
   -- Close the write end in the parent so the reader sees EOF when the child exits.

--- a/lib/cosmic/child/init_test.tl
+++ b/lib/cosmic/child/init_test.tl
@@ -1,5 +1,6 @@
 #!/usr/bin/env cosmic
 local child = require("cosmic.child")
+local cfd = require("cosmic.fd")
 local fs = require("cosmic.fs")
 local proc = require("cosmic.proc")
 local env = require("cosmic.env")
@@ -391,3 +392,90 @@ local function test_spawn_overlap_no_stdin_leak()
   b:wait()
 end
 test_spawn_overlap_no_stdin_leak()
+
+-- === honest option types: fd.Handle in Options (#602 / api-review-2 B5) ===
+
+-- stdout as a Handle: the child writes into a pipe we own; run()'s own
+-- capture is then empty for that stream.
+local function test_spawn_stdout_handle()
+  local p = cfd.pipe() as cfd.Pipe
+  assert(p ~= nil, "pipe should succeed")
+  local h = child.spawn({"echo", "via-handle"}, {stdout = p.writer}) as child.Handle
+  assert(h ~= nil, "spawn with Handle stdout should succeed")
+  p.writer:close()
+  local out = p.reader:read() as string
+  p.reader:close()
+  local r = h:wait() as child.Result
+  assert(out == "via-handle\n", "expected 'via-handle\\n' through the pipe, got '" .. tostring(out) .. "'")
+  assert(r.stdout == "", "redirected stdout should leave Result.stdout empty")
+end
+test_spawn_stdout_handle()
+
+-- stderr as a Handle.
+local function test_spawn_stderr_handle()
+  local p = cfd.pipe() as cfd.Pipe
+  local h = child.spawn({"sh", "-c", "echo err-via-handle >&2"}, {stderr = p.writer}) as child.Handle
+  assert(h ~= nil, "spawn with Handle stderr should succeed")
+  p.writer:close()
+  local out = p.reader:read() as string
+  p.reader:close()
+  local r = h:wait() as child.Result
+  assert(out == "err-via-handle\n", "expected stderr through the pipe, got '" .. tostring(out) .. "'")
+  assert(r.stderr == "", "redirected stderr should leave Result.stderr empty")
+end
+test_spawn_stderr_handle()
+
+-- stdin as a Handle (the read end of a pipe we filled), alongside the
+-- string form which stays supported.
+local function test_spawn_stdin_handle()
+  local p = cfd.pipe() as cfd.Pipe
+  p.writer:write("handle stdin data")
+  p.writer:close()
+  local r = child.run({lua_bin, "-e", "io.write(io.read('*a'))"}, {stdin = p.reader}) as child.Result
+  p.reader:close()
+  assert(r ~= nil and r.ok, "run with Handle stdin should succeed")
+  assert(r.stdout == "handle stdin data",
+    "expected 'handle stdin data', got '" .. tostring(r.stdout) .. "'")
+end
+test_spawn_stdin_handle()
+
+-- A file Handle from fd.open works the same way as a pipe end.
+local function test_spawn_stdout_file_handle()
+  local path = fs.join(TEST_TMPDIR, "stdout-handle.txt")
+  local h = cfd.open(path, cfd.O_WRONLY | cfd.O_CREAT | cfd.O_TRUNC, 420) as cfd.Handle -- 0644
+  assert(h ~= nil, "open should succeed")
+  local r = child.run({"echo", "to-file"}, {stdout = h}) as child.Result
+  h:close()
+  assert(r ~= nil and r.ok, "run with file Handle stdout should succeed")
+  assert(fs.read(path) == "to-file\n", "child output should land in the file")
+end
+test_spawn_stdout_file_handle()
+
+-- A closed Handle is a caller bug surfaced from spawn itself, not a
+-- confusing EBADF from the plumbing.
+local function test_spawn_closed_handle_fails()
+  local p = cfd.pipe() as cfd.Pipe
+  p:close()
+  local h, err = child.spawn({"echo", "x"}, {stdout = p.writer})
+  assert(h == nil, "spawn with a closed Handle should fail")
+  assert(err ~= nil and err:find("closed", 1, true),
+    "expected a 'closed' error, got: " .. tostring(err))
+end
+test_spawn_closed_handle_fails()
+
+-- Type-level contract: Options mentions no bare integer fds. A raw int
+-- for stdout must be rejected by the type checker.
+local function test_options_reject_raw_int_fd()
+  local script = fs.join(TEST_TMPDIR, "raw_fd_options.tl")
+  fs.write(script, [[
+local child = require("cosmic.child")
+child.run({"echo", "x"}, {stdout = 5})
+]])
+  local r = child.run({lua_bin, "--check-types", script}) as child.Result
+  assert(r ~= nil, "check-types run should complete")
+  assert(not r.ok, "a raw integer fd in Options must fail the type check")
+  local diag = r.stdout .. r.stderr
+  assert(diag:find("stdout", 1, true),
+    "diagnostic should name the offending field, got: " .. diag)
+end
+test_options_reject_raw_int_fd()

--- a/lib/cosmic/child/io.tl
+++ b/lib/cosmic/child/io.tl
@@ -7,6 +7,7 @@
 --- a shared PumpState so a `wait(timeout_ms)` that expires can be resumed by a
 --- later call, and the partial output collected so far is never lost.
 local unix = require("cosmo.unix")
+local cfd = require("cosmic.fd")
 local poll = require("cosmic.poll")
 local errno = require("cosmic.errno")
 local time = require("cosmic.time")
@@ -32,6 +33,45 @@ local record PumpState
   out: {string}
   err_out: {string}
   io_err: string
+end
+
+--- Raw descriptors resolved from the public spawn Options. The public
+--- surface speaks fd.Handle (api-review-2, #602); everything below this
+--- boundary speaks raw descriptors.
+local record Stdio
+  stdin_data: string
+  stdin_fd: number
+  stdout_fd: number
+  stderr_fd: number
+end
+
+--- Resolve the caller's stdio options to raw descriptors, once, at the
+--- boundary. A string stdin passes through as pump data; a Handle
+--- contributes its descriptor. A closed Handle is a caller bug surfaced
+--- here, not a confusing EBADF from deep inside the spawn plumbing.
+--- @param stdin string | cfd.Handle | nil string to pipe, or the child's fd 0
+--- @param stdout cfd.Handle | nil the child's fd 1
+--- @param stderr cfd.Handle | nil the child's fd 2
+--- @return Stdio | nil resolved descriptors
+--- @return string error message on a closed Handle
+local function resolve_stdio(stdin?: string | cfd.Handle, stdout?: cfd.Handle,
+    stderr?: cfd.Handle): Stdio | nil, string
+  local s: Stdio = {}
+  if stdin is string then
+    s.stdin_data = stdin
+  elseif stdin ~= nil then
+    s.stdin_fd = (stdin as cfd.Handle):fd()
+    if s.stdin_fd < 0 then return nil, "spawn: stdin handle is closed" end
+  end
+  if stdout then
+    s.stdout_fd = stdout:fd()
+    if s.stdout_fd < 0 then return nil, "spawn: stdout handle is closed" end
+  end
+  if stderr then
+    s.stderr_fd = stderr:fd()
+    if s.stderr_fd < 0 then return nil, "spawn: stderr handle is closed" end
+  end
+  return s
 end
 
 -- Current monotonic time in milliseconds. Used only for relative deadline
@@ -157,13 +197,17 @@ end
 
 local record ChildIoModule
   PumpState: PumpState
+  Stdio: Stdio
   pump: function(state: PumpState, deadline_ms: number): boolean
   now_ms: function(): number
+  resolve_stdio: function(stdin?: string | cfd.Handle, stdout?: cfd.Handle,
+  stderr?: cfd.Handle): Stdio | nil, string
 end
 
 local M: ChildIoModule = {
   pump = pump,
   now_ms = now_ms,
+  resolve_stdio = resolve_stdio,
 }
 
 return M

--- a/lib/cosmic/doc/guide_test.tl
+++ b/lib/cosmic/doc/guide_test.tl
@@ -97,7 +97,7 @@ test_guide_make()
 
 local function test_guide_unknown()
   local r = spawn.run(
-    {cosmic, "--docs", "guide.nonexistent"}, {env = clean_env(), stderr = 1}
+    {cosmic, "--docs", "guide.nonexistent"}, {env = clean_env()}
   ) as spawn.Result
   local ok, code = r.ok, r.code
   assert(not ok, "cosmic --docs guide.nonexistent should fail")

--- a/lib/cosmic/poll_test.tl
+++ b/lib/cosmic/poll_test.tl
@@ -175,7 +175,7 @@ local function test_poll_with_child_pipes()
   local pp0, perr = cfd.pipe()
   assert(pp0 ~= nil, "pipe creation failed: " .. tostring(perr))
   local pp = pp0 as cfd.Pipe
-  local handle, err = child.spawn({"echo", "hello"}, {stdout = pp.writer:fd()})
+  local handle, err = child.spawn({"echo", "hello"}, {stdout = pp.writer})
   assert(handle ~= nil, "spawn failed: " .. tostring(err))
   local h = handle as child.Handle
   pp.writer:close()

--- a/lib/cosmic/script_test.tl
+++ b/lib/cosmic/script_test.tl
@@ -58,10 +58,10 @@ local x: number = "wrong type"
 print(x)
 ]])
 
-  -- stderr = 1 merges stderr into stdout so we can capture the error message
-  local h3 = spawn.spawn({cosmic, script}, {stderr = 1})
+  -- the type-error diagnostic lands on stderr
+  local h3 = spawn.spawn({cosmic, script})
   local __r3 = (h3 as spawn.Handle):wait() as spawn.Result
-  local ok, out = __r3.ok, __r3.stdout
+  local ok, out = __r3.ok, __r3.stderr
   assert(not ok, "cosmic should fail on .tl file with type error")
   assert((out as string):find("type_error.tl"), "error should reference the file name")
 end
@@ -178,9 +178,9 @@ print("shebang=" .. x)
   local verify = fs.read(script) as string
   assert(verify:find("shebang="), "script file should contain shebang test code, got: " .. verify:sub(1, 100))
 
-  local h10 = spawn.spawn({cosmic, script}, {stderr = 1})
+  local h10 = spawn.spawn({cosmic, script})
   local __r10 = (h10 as spawn.Handle):wait() as spawn.Result
-  local ok, out = __r10.ok, __r10.stdout
+  local ok, out = __r10.ok, __r10.stdout .. __r10.stderr
   assert(ok, "cosmic should execute .tl file with shebang, got: " .. tostring(out))
   assert((out as string):find("shebang=777"), "output should contain expected result, got: " .. tostring(out))
 end


### PR DESCRIPTION
Closes #602 (and its duplicate #592) — item 5 (B5) of the pre-stable breaking wave (#604 / #594). The public-record-type slice of #493: raw integer fds leave `child.Options` before the stable cut freezes the shape; the rest of #493 stays backlog.

## API

- `Options.stdin: string | fd.Handle` — a string is piped to the child's stdin (unchanged); a Handle becomes the child's fd 0.
- `Options.stdout / stderr: fd.Handle` — the raw `integer` forms are **removed**. A Handle becomes the child's fd 1/2 and the corresponding `Result` field is then `""`.
- spawn does not take ownership of a Handle: the child gets its own copy of the descriptor, so callers close their end when done (the existing `Example_run_pipe` pattern, now passing `pp.writer` instead of `pp.writer:fd()`). A raw fd from outside the fd module enters via `fd.wrap()`.
- Handles resolve to raw descriptors once, at the boundary, in the new `childio.resolve_stdio` (moved to `child/io.tl` to keep `init.tl` under the 500-line cap). A **closed** Handle fails from `spawn()` itself with `"spawn: <stream> handle is closed"` instead of a confusing EBADF from deep inside the plumbing.
- Everything below the boundary (pump state, `child.fast`'s dup2 dance) still speaks raw fds — internals, unchanged.

## Tests (per the issue's TDD list)

- Handle-typed stdout and stderr through `fd.pipe()` ends, Handle-typed stdin from a filled pipe read end, and a file Handle from `fd.open` as stdout — each asserting the redirected stream bypasses `Result` capture.
- Closed-Handle error surfaced from `spawn()`.
- Type-level contract: a script passing `{stdout = 5}` fails `--check-types` with a diagnostic naming the field — Options mentions no bare integer fds.

## Knock-ons

The old `{stderr = 1}` idiom (merge stderr into the captured stdout via the child's already-wired fd 1) had in-repo users in `check_test`, `binary_test`, `script_test`, and `doc/guide_test`. Since `run`/`wait` capture stderr separately, those tests now assert on `Result.stderr` directly (check_test's `check_run` returns `stdout..stderr` so hint diagnostics stay visible); no raw-int replacement was needed. `poll_test` and the child example pass the pipe-writer Handle itself. `testrun`/`benchmark` pass no raw fds — no changes there.

## Gates

- `bin/make ci` green: format 260, teal 260, test 120, example 21, lint 328, coverage ratchet ok.
- `bin/make perf-compare` against a fresh main baseline on the same machine: `35 scenarios: 0 regression, 0 faster, 35 ok, 0 noise, 0 new, 0 missing, 0 error`. The spawn scenario:
  ```
  child_spawn_true                  1.33 ms ->      1.44 ms     +8.2%  (noise  ±10.0%)  ok
  embed_run_startup                 1.83 ms ->      1.74 ms     -4.9%  (noise  ±10.0%)  ok
  startup_run_lua                   5.64 ms ->      5.34 ms     -5.3%  (noise  ±13.7%)  ok
  ```
  The posix_spawn fast path is untouched; the diff adds one `resolve_stdio` call (a small table) per spawn, µs-scale against a ms-scale scenario, within the noise-aware gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RS1KNSrfeGyduK4J6GdPf4

---
_Generated by [Claude Code](https://claude.ai/code/session_01RS1KNSrfeGyduK4J6GdPf4)_