### PR TITLE
hash: digest/hmac with algo enum; codec: crc32/crc32c (#601)

### DIFF
--- a/lib/cosmic/codec.tl
+++ b/lib/cosmic/codec.tl
@@ -1,5 +1,8 @@
 --- Encoding and decoding utilities for various formats.
---- Provides hex and Lua serialization codecs with consistent error handling.
+--- Provides hex, base64, base32, Latin-1, and Lua serialization codecs
+--- with consistent error handling, plus CRC-32 checksums (checksums are
+--- encoding-adjacent error detection, not crypto — see cosmic.hash for
+--- digests).
 local cosmo = require("cosmo")
 
 --- Encode a string as hexadecimal.
@@ -121,6 +124,28 @@ local function decode_base32(str: string): string | nil, string
   return result
 end
 
+--- Compute the CRC-32 checksum of data (ISO 3309 / "Phil Katz" CRC,
+--- as used by zip, zlib, and gzip; the same value zip.Stat reports).
+--- Checksums are error-detection codes, not cryptographic digests —
+--- for those, see cosmic.hash.digest.
+--- Pass a previous result as initial to checksum a stream
+--- incrementally: crc32(b, crc32(a)) == crc32(a .. b).
+--- @param data string The data to checksum
+--- @param initial integer? Checksum to continue from (default 0)
+--- @return integer The CRC-32 checksum as an unsigned 32-bit integer
+local function crc32(data: string, initial?: integer): integer
+  return cosmo.Crc32(initial or 0, data) as integer
+end
+
+--- Compute the CRC-32C (Castagnoli) checksum of data, the variant
+--- used by iSCSI, ext4, and LevelDB. Same contract as crc32.
+--- @param data string The data to checksum
+--- @param initial integer? Checksum to continue from (default 0)
+--- @return integer The CRC-32C checksum as an unsigned 32-bit integer
+local function crc32c(data: string, initial?: integer): integer
+  return cosmo.Crc32c(initial or 0, data) as integer
+end
+
 --- Encode a UTF-8 string as Latin-1 (ISO-8859-1).
 --- Characters outside the Latin-1 range will cause an error.
 --- @param str string The UTF-8 string to encode
@@ -152,6 +177,8 @@ local record CodecModule
   decode_base64: function(str: string): string | nil, string
   encode_base32: function(data: string): string
   decode_base32: function(str: string): string | nil, string
+  crc32: function(data: string, initial?: integer): integer
+  crc32c: function(data: string, initial?: integer): integer
   encode_latin1: function(str: string): string | nil, string
   decode_latin1: function(data: string): string
 end
@@ -165,6 +192,8 @@ local M: CodecModule = {
   decode_base64 = decode_base64,
   encode_base32 = encode_base32,
   decode_base32 = decode_base32,
+  crc32 = crc32,
+  crc32c = crc32c,
   encode_latin1 = encode_latin1,
   decode_latin1 = decode_latin1,
 }

--- a/lib/cosmic/codec_test.tl
+++ b/lib/cosmic/codec_test.tl
@@ -344,3 +344,45 @@ local function test_latin1_roundtrip()
   assert(decoded == original, "roundtrip mismatch: got '" .. decoded .. "'")
 end
 test_latin1_roundtrip()
+
+-- CRC-32 checksum tests (issue #601)
+
+local function test_crc32_check_vector()
+  -- The standard CRC-32 check value: crc32("123456789") = 0xCBF43926
+  local result = codec.crc32("123456789")
+  assert(result == 0xCBF43926,
+    "crc32 check vector mismatch: " .. string.format("%x", result))
+end
+test_crc32_check_vector()
+
+local function test_crc32c_check_vector()
+  -- The standard CRC-32C (Castagnoli) check value: 0xE3069283
+  local result = codec.crc32c("123456789")
+  assert(result == 0xE3069283,
+    "crc32c check vector mismatch: " .. string.format("%x", result))
+end
+test_crc32c_check_vector()
+
+local function test_crc32_empty()
+  assert(codec.crc32("") == 0, "crc32 of empty string should be 0")
+  assert(codec.crc32c("") == 0, "crc32c of empty string should be 0")
+end
+test_crc32_empty()
+
+local function test_crc32_incremental()
+  local whole = codec.crc32("hello world")
+  local partial = codec.crc32(" world", codec.crc32("hello"))
+  assert(whole == partial, "incremental crc32 should match whole-input crc32")
+  local whole_c = codec.crc32c("hello world")
+  local partial_c = codec.crc32c(" world", codec.crc32c("hello"))
+  assert(whole_c == partial_c, "incremental crc32c should match whole-input crc32c")
+end
+test_crc32_incremental()
+
+local function test_crc32_unsigned_range()
+  -- Values are unsigned 32-bit integers, never negative.
+  local result = codec.crc32("\xff\xff\xff\xff")
+  assert(result >= 0 and result <= 0xFFFFFFFF,
+    "crc32 should be an unsigned 32-bit value, got " .. tostring(result))
+end
+test_crc32_unsigned_range()

--- a/lib/cosmic/hash.tl
+++ b/lib/cosmic/hash.tl
@@ -1,16 +1,50 @@
 --- Hash utilities.
---- Wraps cosmo.Sha256 and cosmo.argon2 for digest and password hashing.
+--- Wraps cosmo.GetCryptoHash and cosmo.argon2 for digest, HMAC, and
+--- password hashing.
 ---
 --- Example usage:
 ---   local hash = require("cosmic.hash")
 ---   local digest = hash.sha256_hex("hello")
+---   local d = hash.digest("sha512", "hello")
+---   local tag = hash.hmac("sha256", "secret", "message")
 ---   local encoded = hash.password("password123")
 ---   local valid = hash.verify_password(encoded, "password123")
 ---
---- For random bytes, use cosmic.rand.bytes(n).
+--- Digest and HMAC functions return raw bytes; hex-encode with
+--- cosmic.codec.encode_hex if needed. For CRC-32 checksums, see
+--- cosmic.codec.crc32. For random bytes, use cosmic.rand.bytes(n).
+---
+--- Reserved name: hash.new(algo): Hasher — a streaming digest object
+--- API (update/final) is reserved for a post-stable battery. Do not
+--- reuse this name for anything else.
 local cosmo = require("cosmo")
 local argon2 = require("cosmo.argon2")
 local codec = require("cosmic.codec")
+
+--- Digest algorithms accepted by digest and hmac.
+local enum Algo
+  "sha256"
+  "sha512"
+  "sha384"
+  "sha224"
+  "sha1"
+  "md5"
+  "blake2b256"
+end
+
+-- The exact algorithm set frozen at the stable cut. The C binding
+-- resolves names case-insensitively and knows a few extra legacy
+-- digests (MD2, MD4), so this wrapper-side check is load-bearing:
+-- it keeps the runtime surface identical to the Algo enum.
+local valid_algos: {string: boolean} = {
+  sha256 = true,
+  sha512 = true,
+  sha384 = true,
+  sha224 = true,
+  sha1 = true,
+  md5 = true,
+  blake2b256 = true,
+}
 
 --- Options for password hashing with Argon2.
 --- All fields are optional and have sensible defaults.
@@ -52,6 +86,51 @@ local function sha256_hex(data: string): string
   -- cosmo.EncodeHex (which encode_hex delegates to) already emits
   -- lowercase hex, so :lower() here was a dead full-string scan.
   return codec.encode_hex(cosmo.Sha256(data))
+end
+
+--- Compute a message digest of data with the given algorithm.
+--- Returns raw bytes; hex-encode with cosmic.codec.encode_hex if
+--- needed. For the common case, sha256 / sha256_hex are equivalent
+--- conveniences. MD5 and SHA-1 are provided for interoperability with
+--- existing formats only — do not use them for new security purposes.
+--- @param algo Algo The digest algorithm
+--- @param data string The data to hash
+--- @return string | nil The digest as raw bytes, or nil on error
+--- @return string? Error message if the algorithm is unknown
+local function digest(algo: Algo, data: string): string | nil, string
+  if not valid_algos[algo] then
+    return nil, "unknown hash algorithm: " .. tostring(algo)
+  end
+  local d, err = cosmo.GetCryptoHash(algo, data)
+  if not d then
+    return nil, err as string
+  end
+  return d
+end
+
+--- Compute an HMAC (RFC 2104) of data with a secret key using the
+--- given digest algorithm. Returns raw bytes; hex-encode with
+--- cosmic.codec.encode_hex if needed. Compare MACs with
+--- constant_time_equal, not ==. The key must be non-empty: the C
+--- binding treats an empty key as "no key" and would silently compute
+--- a plain digest instead of an HMAC.
+--- @param algo Algo The digest algorithm
+--- @param key string The secret key (must be non-empty)
+--- @param data string The message to authenticate
+--- @return string | nil The HMAC tag as raw bytes, or nil on error
+--- @return string? Error message if the algorithm is unknown or the key is empty
+local function hmac(algo: Algo, key: string, data: string): string | nil, string
+  if not valid_algos[algo] then
+    return nil, "unknown hash algorithm: " .. tostring(algo)
+  end
+  if #key == 0 then
+    return nil, "hmac: key must be non-empty"
+  end
+  local d, err = cosmo.GetCryptoHash(algo, data, key)
+  if not d then
+    return nil, err as string
+  end
+  return d
 end
 
 --- Compute HMAC-SHA256 of data with a secret key (RFC 2104).
@@ -133,8 +212,11 @@ local function verify_password(encoded: string, pwd: string): boolean, string
 end
 
 local record HashModule
+  type Algo = Algo
   type HashOptions = HashOptions
 
+  digest: function(algo: Algo, data: string): string | nil, string
+  hmac: function(algo: Algo, key: string, data: string): string | nil, string
   sha256: function(data: string): string
   sha256_hex: function(data: string): string
   hmac_sha256: function(key: string, data: string): string
@@ -144,6 +226,8 @@ local record HashModule
 end
 
 local M: HashModule = {
+  digest = digest,
+  hmac = hmac,
   sha256 = sha256,
   sha256_hex = sha256_hex,
   hmac_sha256 = hmac_sha256,

--- a/lib/cosmic/hash_test.tl
+++ b/lib/cosmic/hash_test.tl
@@ -165,6 +165,112 @@ local function test_hmac_sha256_rfc4231_case2()
 end
 test_hmac_sha256_rfc4231_case2()
 
+-- digest (issue #601): NIST FIPS 180 / RFC 1321 / RFC 7693 "abc" vectors
+
+local function test_digest_known_answers()
+  local vectors: {hash.Algo: string} = {
+    sha256 = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    sha512 = "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a"
+    .. "2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f",
+    sha384 = "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed"
+    .. "8086072ba1e7cc2358baeca134c825a7",
+    sha224 = "23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7",
+    sha1 = "a9993e364706816aba3e25717850c26c9cd0d89d",
+    md5 = "900150983cd24fb0d6963f7d28e17f72",
+    blake2b256 = "bddd813c634239723171ef3fee98579b94964e3bb1cb3e427262c8c068d52319",
+  }
+  for algo, expected in pairs(vectors) do
+    local d, err = hash.digest(algo, "abc")
+    assert(d, "digest(" .. algo .. ") should succeed: " .. tostring(err))
+    local hex = codec.encode_hex(d)
+    assert(hex == expected, "digest(" .. algo .. ", 'abc') mismatch: " .. hex)
+  end
+end
+test_digest_known_answers()
+
+local function test_digest_raw_bytes_length()
+  local lengths: {hash.Algo: number} = {
+    sha256 = 32, sha512 = 64, sha384 = 48, sha224 = 28,
+    sha1 = 20, md5 = 16, blake2b256 = 32,
+  }
+  for algo, len in pairs(lengths) do
+    local d = hash.digest(algo, "")
+    assert(d and #d == len,
+      "digest(" .. algo .. ") should return " .. len .. " raw bytes")
+  end
+end
+test_digest_raw_bytes_length()
+
+local function test_digest_matches_sha256_convenience()
+  local d = hash.digest("sha256", "hello")
+  assert(d == hash.sha256("hello"), "digest('sha256') should match sha256()")
+end
+test_digest_matches_sha256_convenience()
+
+local function test_digest_unknown_algo()
+  local d, err = hash.digest("md4" as hash.Algo, "abc")
+  assert(d == nil, "digest should return nil for unknown algorithm")
+  assert(err and err:match("unknown hash algorithm"),
+    "error should name the problem, got: " .. tostring(err))
+end
+test_digest_unknown_algo()
+
+-- hmac (issue #601): RFC 4231 test vectors
+
+local function test_hmac_rfc4231_case2_sha256()
+  local tag, err = hash.hmac("sha256", "Jefe", "what do ya want for nothing?")
+  assert(tag, "hmac should succeed: " .. tostring(err))
+  local hex = codec.encode_hex(tag)
+  assert(hex == "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843",
+    "RFC 4231 case 2 (sha256) mismatch: " .. hex)
+end
+test_hmac_rfc4231_case2_sha256()
+
+local function test_hmac_rfc4231_case2_sha512()
+  local tag, err = hash.hmac("sha512", "Jefe", "what do ya want for nothing?")
+  assert(tag, "hmac should succeed: " .. tostring(err))
+  local hex = codec.encode_hex(tag)
+  assert(hex == "164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea250554"
+    .. "9758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737",
+    "RFC 4231 case 2 (sha512) mismatch: " .. hex)
+end
+test_hmac_rfc4231_case2_sha512()
+
+local function test_hmac_rfc2202_case1_sha1()
+  -- RFC 2202 section 3 case 1
+  local tag = hash.hmac("sha1", string.rep("\x0b", 20), "Hi There")
+  assert(tag, "hmac sha1 should succeed")
+  local hex = codec.encode_hex(tag as string)
+  assert(hex == "b617318655057264e28bc0b6fb378c8ef146be00",
+    "RFC 2202 case 1 (sha1) mismatch: " .. hex)
+end
+test_hmac_rfc2202_case1_sha1()
+
+local function test_hmac_matches_hmac_sha256_convenience()
+  local tag = hash.hmac("sha256", "key", "message")
+  assert(tag == hash.hmac_sha256("key", "message"),
+    "hmac('sha256') should match hmac_sha256()")
+end
+test_hmac_matches_hmac_sha256_convenience()
+
+local function test_hmac_unknown_algo()
+  local tag, err = hash.hmac("md4" as hash.Algo, "key", "data")
+  assert(tag == nil, "hmac should return nil for unknown algorithm")
+  assert(err and err:match("unknown hash algorithm"),
+    "error should name the problem, got: " .. tostring(err))
+end
+test_hmac_unknown_algo()
+
+local function test_hmac_empty_key_rejected()
+  -- The C binding treats an empty key as "no key" and silently computes
+  -- a plain digest; the wrapper must refuse rather than return a
+  -- non-HMAC value.
+  local tag, err = hash.hmac("sha256", "", "data")
+  assert(tag == nil, "hmac should return nil for empty key")
+  assert(err and err:match("key"), "error should mention the key, got: " .. tostring(err))
+end
+test_hmac_empty_key_rejected()
+
 -- Constant-time comparison
 
 local function test_constant_time_equal()


### PR DESCRIPTION
Implements #601 (B4 in the #604 pre-stable wave): settle the digest/HMAC algorithm shape before the stable cut, and land CRC-32 in codec where checksums belong.

## hash

- **`hash.digest(algo, data)`** and **`hash.hmac(algo, key, data)`** over the mbedTLS digest family already bound in `cosmo.GetCryptoHash`, typed with an `Algo` enum: `"sha256" | "sha512" | "sha384" | "sha224" | "sha1" | "md5" | "blake2b256"`. Raw bytes out; callers hex via `codec.encode_hex`. This stops the per-algorithm combinatorial explosion (`sha512`, `sha512_hex`, `hmac_sha512`, …) before #502 fills out the family.
- A wrapper-side algorithm check keeps the runtime surface identical to the enum — the C binding resolves names case-insensitively and also knows legacy digests (MD2/MD4) that are deliberately not part of the frozen contract. Unknown algo returns `nil, err`.
- **`hash.hmac` rejects empty keys**: the C binding treats an empty key as "no key" and would silently compute a plain digest instead of an HMAC — returning a non-MAC from an HMAC function is a footgun, so the wrapper refuses with `nil, err`.
- **`hash.new(algo): Hasher` is reserved** in the module header for the post-stable streaming digest battery, per the issue.
- `sha256` / `sha256_hex` / `hmac_sha256` stay unchanged as the blessed conveniences.

## codec

- **`codec.crc32(data, initial?)`** and **`codec.crc32c(data, initial?)`**: checksums are encoding-adjacent error detection, not crypto — consistent with the `crc32` field `zip.Stat` already exposes. `initial` enables incremental checksumming (`crc32(b, crc32(a)) == crc32(a .. b)`); both return unsigned 32-bit integers.

## Tests (red → green per the issue's TDD)

- Known-answer digest vectors (FIPS 180 / RFC 1321 / RFC 7693 `"abc"`) for all seven algorithms, plus raw-byte length checks and equivalence with the `sha256` convenience.
- HMAC vectors: RFC 4231 case 2 for SHA-256 and SHA-512, RFC 2202 case 1 for SHA-1, equivalence with `hmac_sha256`.
- `nil, err` for unknown algorithms (digest and hmac) and for empty HMAC keys.
- CRC: standard check values (`crc32("123456789") == 0xCBF43926`, `crc32c == 0xE3069283`), empty-string zero, incremental equivalence, unsigned range.

No upstream cosmopolitan change or release-pin bump needed — `GetCryptoHash`, `Crc32`, and `Crc32c` are all in the pinned binary (verified against it directly).

Gates: `bin/make ci` green (format + teal + test + example + lint + coverage ratchet).

Closes #601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9qfnqpEW2rhSseaLPRf6c

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9qfnqpEW2rhSseaLPRf6c)_