### PR TITLE
build: exempt doc index and docs sources from the only= filter (#608)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -394,8 +394,11 @@ regen-types: $(cosmic_bin)
 	@echo "Type definitions regenerated. Verify with: bin/make test only=gentype"
 
 # Documentation generation - render .tl files as markdown
-# Module sources for docs: all _tl files (excludes tests and examples)
-all_module_srcs := $(call filter-only,$(foreach m,$(modules),$($(m)_tl)))
+# Module sources for docs: all _tl files (excludes tests and examples).
+# Deliberately NOT filter-only'd: these feed artifacts (published docs and
+# the doc index embedded in the binary). only= filters which tests and
+# checks run; it must never change what artifacts contain (#608).
+all_module_srcs := $(foreach m,$(modules),$($(m)_tl))
 all_docs := $(patsubst %.tl,$(o)/docs/%.md,$(all_module_srcs))
 
 # Documentation from .d.tl type definition files (cosmo modules)
@@ -419,12 +422,22 @@ $(o)/docs/cosmo/%.md: lib/types/cosmo/%.d.tl $(cosmic_bin) | $(bootstrap_files)
 # Include both module sources and example files for the index
 # LUA_PATH points at the freshly compiled modules so the index generator uses
 # this tree's cosmic.doc code, not the bootstrap's embedded (older) copy
-doc_index_srcs := $(all_module_srcs) $(all_example_srcs) $(dtl_files)
+# Example sources for the index are expanded unfiltered here (unlike
+# all_example_srcs, which only= legitimately filters as test targets):
+# the embedded index must always describe every module (#608)
+doc_index_example_srcs := $(foreach m,$(modules),$($(m)_examples))
+doc_index_srcs := $(all_module_srcs) $(doc_index_example_srcs) $(dtl_files)
 doc_index_lua := $(patsubst %.tl,$(o)/%.lua,$(all_module_srcs))
 doc_index := $(o)/docs/.index.lua
 doc_index_script := lib/cosmic/doc/index.tl
 
-$(doc_index): $(doc_index_srcs) $(doc_index_lua) $(doc_index_script) | $(bootstrap_cosmic)
+# Makefile is a prerequisite so trees whose index was poisoned by a
+# filtered rebuild (the mtime trap in #608: the broken index is newer
+# than every source, and .SECONDARY blocks rebuild-on-delete) self-heal
+# when this fix — or any future Makefile change — arrives; the
+# write-if-changed dance below keeps the binary from re-embedding when
+# the regenerated content is identical
+$(doc_index): $(doc_index_srcs) $(doc_index_lua) $(doc_index_script) Makefile | $(bootstrap_cosmic)
 	@mkdir -p $(@D)
 	@LUA_PATH="$(o)/lib/?.lua;$(o)/lib/?/init.lua;;" $(bootstrap_cosmic) $(doc_index_script) $(doc_index_srcs) > $@.tmp
 	@if cmp -s $@.tmp $@ 2>/dev/null; then rm $@.tmp; else mv $@.tmp $@; fi

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -31,7 +31,14 @@ $(build_make_out)/database.out: Makefile $(wildcard */*.mk) $(wildcard */*/*.mk)
 	@mkdir -p $(@D)
 	@code=0; $(MAKE) -p -n -q >$@.tmp 2>&1 || code=$$?; echo "exit:$$code" >> $@.tmp; mv $@.tmp $@
 
-build_make_outputs := $(build_make_out)/dry-run.out $(build_make_out)/database.out
+# database dump under an only= filter that matches nothing: artifact
+# source lists (doc index, docs) must stay complete while test lists
+# empty out (#608)
+$(build_make_out)/only-database.out: Makefile $(wildcard */*.mk) $(wildcard */*/*.mk)
+	@mkdir -p $(@D)
+	@code=0; $(MAKE) -p -n -q only=__no_such_module__ >$@.tmp 2>&1 || code=$$?; echo "exit:$$code" >> $@.tmp; mv $@.tmp $@
+
+build_make_outputs := $(build_make_out)/dry-run.out $(build_make_out)/database.out $(build_make_out)/only-database.out
 
 # makefile_test consumes the fixtures in both test lanes
 build_makefile_test_got := \

--- a/lib/build/makefile_test.tl
+++ b/lib/build/makefile_test.tl
@@ -43,3 +43,34 @@ local function test_print_database()
   assert(result.output:match("platform"), "expected 'platform' variable in database output")
 end
 test_print_database()
+
+-- test: only= filters test targets but never artifact source lists (#608).
+-- A filter matching nothing must leave the doc-index inputs complete —
+-- a filtered doc_index_srcs regenerates o/docs/.index.lua from a subset
+-- and the broken index gets embedded in the binary.
+local function test_only_filter_exempts_artifact_sources()
+  local result = read_make_output("only-database.out")
+  local out = result.output
+
+  local doc_srcs = out:match("\ndoc_index_srcs := ([^\n]*)")
+  assert(doc_srcs, "expected doc_index_srcs in filtered database output")
+  assert(doc_srcs:find("lib/cosmic/json.tl", 1, true),
+    "doc_index_srcs should keep module sources under only=")
+  assert(doc_srcs:find("lib/cosmic/env_example.tl", 1, true),
+    "doc_index_srcs should keep example sources under only=")
+  assert(doc_srcs:find("lib/types/cosmo/unix.d.tl", 1, true),
+    "doc_index_srcs should keep .d.tl sources under only=")
+
+  local module_srcs = out:match("\nall_module_srcs := ([^\n]*)")
+  assert(module_srcs, "expected all_module_srcs in filtered database output")
+  assert(module_srcs:find("lib/cosmic/json.tl", 1, true),
+    "all_module_srcs (docs inputs) should be exempt from only=")
+
+  -- the filter itself must still work: test lists empty out
+  local tests = out:match("\nall_tests := ([^\n]*)")
+  assert(tests, "expected all_tests in filtered database output")
+  assert(not tests:find("_test.tl", 1, true),
+    "all_tests should be empty under a non-matching only=, got: " ..
+    tests:sub(1, 200))
+end
+test_only_filter_exempts_artifact_sources()


### PR DESCRIPTION
Fixes #608 (and its earlier filing #573): `only=` is a test/check filter, but it was also applied to the source lists that feed the doc index, so any filtered invocation regenerated `o/docs/.index.lua` from just the matching modules and embedded the hollowed-out index into `o/bin/cosmic`. The write-if-changed dance then gave the broken index a fresh mtime, so later unfiltered builds trusted it — and `public_test`, `doc/public_test`, `example_coverage_test`, `--docs`, and the coverage numbers of everything index-driven all misbehaved far from the cause.

(This bug bit this very session: a coverage-ratchet "decline" in `doc/query.tl`/`doc/show.tl` during #610 development was the doc tests running against an index poisoned by `only=hash`/`only=codec` runs.)

## The fix (the issue's preferred option)

- **`all_module_srcs` is no longer `filter-only`'d.** It feeds artifacts — published docs and the embedded doc index — and artifact contents must not depend on which tests you chose to run. The index's example inputs get their own unfiltered expansion (`doc_index_example_srcs`); `all_example_srcs` stays filtered since it drives *test* targets.
- **Self-healing for already-poisoned trees:** `$(doc_index)` now also depends on `Makefile`. The issue's two aggravating factors — the broken index being newer than every source, and `.SECONDARY` blocking rebuild-on-delete — meant a poisoned tree could never repair itself. With this prerequisite, pulling this fix (or any future Makefile change) rebuilds the index once; the existing `cmp` guard keeps the binary from re-embedding when content is identical, so the ongoing cost is nil.

## Regression test

New `only-database.out` fixture dumps the make database under `only=__no_such_module__`; `makefile_test` asserts that `doc_index_srcs`/`all_module_srcs` still contain module, example, and `.d.tl` sources while `all_tests` empties out. **Red on the old Makefile** — the filtered `doc_index_srcs` degenerates to only the `.d.tl` files (verified by running the fixture against `origin/main`'s Makefile) — green now.

## Verification

The issue's repro, on this branch:

```
bin/make build          # index: 123 modules
touch lib/cosmic/codec.tl
bin/make test only=codec
# embedded index: still 123 modules (previously: the codec-matching handful)
```

Gates: `bin/make ci` green (format + teal + test + example + lint + coverage ratchet).

Closes #608. Closes #573.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9qfnqpEW2rhSseaLPRf6c

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9qfnqpEW2rhSseaLPRf6c)_