### PR TITLE
proxy: cap request-body size; strict Content-Length parsing (#497)

### DIFF
--- a/lib/cosmic/quicksand/box/run.tl
+++ b/lib/cosmic/quicksand/box/run.tl
@@ -201,6 +201,7 @@ local function supervisor(
         upstream_ns_fd = parent_netns_fd,
         log_level = net.log_level or "quiet",
         resolve_timeout_ms = net.resolve_timeout_ms,
+        max_body_bytes = net.max_body_bytes,
       })
     if not h then
       die("proxy.start: " .. tostring(perr))

--- a/lib/cosmic/quicksand/proxy/http.tl
+++ b/lib/cosmic/quicksand/proxy/http.tl
@@ -24,6 +24,10 @@ local LENGTH_REQUIRED < const > = "HTTP/1.1 411 Length Required\r\n"
 .. "Content-Length: 0\r\n"
 .. "Connection: close\r\n\r\n"
 
+local PAYLOAD_TOO_LARGE < const > = "HTTP/1.1 413 Payload Too Large\r\n"
+.. "Content-Length: 0\r\n"
+.. "Connection: close\r\n\r\n"
+
 local UPSTREAM_FAIL < const > = "HTTP/1.1 502 Bad Gateway\r\n"
 .. "Content-Length: 0\r\n"
 .. "Connection: close\r\n\r\n"
@@ -135,11 +139,20 @@ local function header_get(headers: {Header}, lower_name: string): string | nil
   return nil
 end
 
---- Content-Length from a parsed header list; 0 if absent.
-local function content_length(headers: {Header}): integer
+--- Content-Length from a parsed header list: 0 when absent, nil when
+--- present but not a plain digit string (RFC 7230: 1*DIGIT) or too
+--- large for an integer — callers treat nil as a malformed request.
+--- tonumber() leniency here would accept hex, exponents, and
+--- negatives, letting a client name an absurd or nonsensical body
+--- size that read_body would then try to buffer.
+local function content_length(headers: {Header}): integer | nil
   local v = header_get(headers, "content-length")
   if not v then return 0 end
-  return (tonumber(v) or 0) as integer
+  local digits = string.match(v, "^(%d+)%s*$")
+  if not digits then return nil end
+  local n = math.tointeger(tonumber(digits))
+  if not n then return nil end
+  return n
 end
 
 --- Hop-by-hop headers per RFC 7230 6.1, plus content-length (always
@@ -249,6 +262,7 @@ local record HttpModule
   DENY: string
   BAD_REQUEST: string
   LENGTH_REQUIRED: string
+  PAYLOAD_TOO_LARGE: string
   UPSTREAM_FAIL: string
   read_headers: function(fd: integer, max: integer): string | nil, string
   send_all: function(fd: integer, data: string): boolean, string
@@ -258,7 +272,7 @@ local record HttpModule
   parse_absolute_uri: function(t: string): string | nil, string, integer, string
   parse_headers: function(block: string): {Header}
   header_get: function(headers: {Header}, lower_name: string): string | nil
-  content_length: function(headers: {Header}): integer
+  content_length: function(headers: {Header}): integer | nil
   rebuild_request: function(spec: ForwardSpec): string
   pump: function(a: integer, b: integer)
 end
@@ -267,6 +281,7 @@ local M: HttpModule = {
   DENY = DENY,
   BAD_REQUEST = BAD_REQUEST,
   LENGTH_REQUIRED = LENGTH_REQUIRED,
+  PAYLOAD_TOO_LARGE = PAYLOAD_TOO_LARGE,
   UPSTREAM_FAIL = UPSTREAM_FAIL,
   read_headers = read_headers,
   send_all = send_all,

--- a/lib/cosmic/quicksand/proxy/http_test.tl
+++ b/lib/cosmic/quicksand/proxy/http_test.tl
@@ -50,6 +50,29 @@ local function test_headers_and_content_length()
 end
 test_headers_and_content_length()
 
+-- Content-Length is 1*DIGIT (RFC 7230). tonumber() leniency would let a
+-- client name a hex, exponent, or negative body size; anything but a
+-- plain digit string must read as malformed (nil), not silently as 0 —
+-- a "0" misread desyncs the connection with the body still unread.
+local function test_content_length_strict()
+  local function cl(v: string): integer | nil
+    local block = "POST / HTTP/1.1\r\nContent-Length: " .. v .. "\r\n\r\n"
+    return http.content_length(http.parse_headers(block))
+  end
+  assert(cl("0") == 0, "zero parses")
+  assert(cl("5") == 5, "digits parse")
+  assert(cl("007") == 7, "leading zeros parse")
+  assert(cl("banana") == nil, "garbage is malformed")
+  assert(cl("-5") == nil, "negative is malformed")
+  assert(cl("1e3") == nil, "exponent is malformed")
+  assert(cl("0x10") == nil, "hex is malformed")
+  assert(cl("4 4") == nil, "embedded space is malformed")
+  assert(cl("5.0") == nil, "float is malformed")
+  assert(cl("99999999999999999999999999") == nil,
+    "integer overflow is malformed")
+end
+test_content_length_strict()
+
 local function test_rebuild_request_injects_and_strips()
   local block = "POST http://a.example.com/p HTTP/1.1\r\n"
   .. "Host: a.example.com\r\nContent-Length: 5\r\nX-Foo: bar\r\n"

--- a/lib/cosmic/quicksand/proxy/serve.tl
+++ b/lib/cosmic/quicksand/proxy/serve.tl
@@ -57,6 +57,9 @@ local record ServeModule
     accept_backlog: integer -- default 32
     resolve_timeout_ms: integer -- per-dial DNS deadline in ms;
     -- nil = 5000, <= 0 disables the deadline entirely
+    max_body_bytes: integer -- request-body cap in bytes; a larger
+    -- Content-Length is refused with 413 before any body byte is
+    -- buffered. nil = 64 MiB, <= 0 disables the cap
     on_log: function({string: any}) -- overrides the default sink
   end
 
@@ -151,6 +154,12 @@ local function new(opts: ServeModule.ProxyOptions): Server | nil, string
   elseif opts.resolve_timeout_ms > 0 then
     resolve_timeout_ms = opts.resolve_timeout_ms
   end
+  local max_body_bytes: integer
+  if opts.max_body_bytes == nil then
+    max_body_bytes = 64 * 1024 * 1024
+  elseif opts.max_body_bytes > 0 then
+    max_body_bytes = opts.max_body_bytes
+  end
   local listen_fd: integer
 
   -- Reply with a canned response and close the client socket.
@@ -225,8 +234,24 @@ local function new(opts: ServeModule.ProxyOptions): Server | nil, string
       refuse(client_fd, http.DENY)
       return
     end
-    -- Read the request body (Content-Length only).
+    -- Read the request body (Content-Length only). A malformed
+    -- Content-Length is a 400; an over-cap one is refused with 413
+    -- before a single body byte is read, so a client inside the box
+    -- cannot make this worker buffer an attacker-chosen amount of
+    -- memory (#497).
     local clen = http.content_length(parsed)
+    if not clen then
+      logger.warn("bad_content_length",
+        {method = method, host = host, path = path})
+      refuse(client_fd, http.BAD_REQUEST)
+      return
+    end
+    if max_body_bytes and clen > max_body_bytes then
+      logger.warn("body_too_large", {method = method, host = host,
+          path = path, content_length = clen, max = max_body_bytes})
+      refuse(client_fd, http.PAYLOAD_TOO_LARGE)
+      return
+    end
     local body: string
     if clen > 0 then
       local b = http.read_body(client_fd, clen, leftover)

--- a/lib/cosmic/quicksand/proxy/serve_test.tl
+++ b/lib/cosmic/quicksand/proxy/serve_test.tl
@@ -1,0 +1,111 @@
+#!/usr/bin/env cosmic
+--- End-to-end tests for the proxy's request-body limits (#497): a
+--- Content-Length over max_body_bytes is refused with 413 and a
+--- malformed one with 400, in both cases before a single body byte is
+--- read or buffered. Every request here is refused before the upstream
+--- dial, so the tests need only loopback sockets, no DNS or egress.
+local serve = require("cosmic.quicksand.proxy.serve")
+local net = require("cosmic.net")
+
+-- serve's Server record is module-local; declare a structural twin for
+-- the methods this test drives (casts are the codebase's escape hatch
+-- for un-exported record types).
+local record Srv
+  port: function(): integer
+  listen: function(): integer | nil, string
+  accept: function(): integer | nil, string
+  handle: function(client_fd: integer)
+end
+
+--- Start a proxy on an ephemeral loopback port with a tiny body cap
+--- and one allowed pass-through host.
+local function start_proxy(max_body: integer): Srv
+  local srv = serve.new({
+      bind_port = 0,
+      allowed_hosts = {["a.example.com"] = {}},
+      log_level = "quiet",
+      max_body_bytes = max_body,
+      resolve_timeout_ms = 200,
+    }) as Srv
+  assert(srv, "serve.new failed")
+  assert(srv.listen(), "listen failed")
+  return srv
+end
+
+--- Send one raw request, run one in-process handle() pass, and return
+--- the full response. handle() closes the server-side fd; recv drains
+--- until EOF (nil per the stream contract).
+local function roundtrip(srv: Srv, request: string): string
+  local sock = net.connect_tcp("127.0.0.1", srv.port()) as net.Socket
+  assert(sock, "connect failed")
+  assert(sock:send(request))
+  local fd = srv.accept() as integer
+  assert(fd, "accept failed")
+  srv.handle(fd)
+  local parts: {string} = {}
+  while true do
+    local chunk = sock:recv(4096)
+    if not chunk then break end
+    table.insert(parts, chunk as string)
+  end
+  sock:close()
+  return table.concat(parts)
+end
+
+-- A Content-Length beyond the cap is refused with 413 without reading
+-- the body: the client never sends one, so anything but an immediate
+-- refusal would deadlock this single-threaded test.
+local function test_over_cap_body_refused_with_413()
+  local srv = start_proxy(1024)
+  local resp = roundtrip(srv,
+    "POST http://a.example.com/upload HTTP/1.1\r\n"
+    .. "Host: a.example.com\r\n"
+    .. "Content-Length: 4096\r\n\r\n")
+  assert(resp:find("^HTTP/1%.1 413 "),
+    "over-cap body should get 413, got: " .. resp:sub(1, 40))
+end
+test_over_cap_body_refused_with_413()
+
+-- A malformed Content-Length is a 400, not a silent 0: misreading it
+-- as 0 would forward the request with the body still unread on the
+-- socket.
+local function test_malformed_content_length_refused_with_400()
+  local srv = start_proxy(1024)
+  local resp = roundtrip(srv,
+    "POST http://a.example.com/upload HTTP/1.1\r\n"
+    .. "Host: a.example.com\r\n"
+    .. "Content-Length: banana\r\n\r\n")
+  assert(resp:find("^HTTP/1%.1 400 "),
+    "malformed content-length should get 400, got: " .. resp:sub(1, 40))
+end
+test_malformed_content_length_refused_with_400()
+
+-- Boundary control: a body of exactly max_body_bytes passes the cap
+-- check (the later upstream dial fails in this sandbox, so the
+-- observable is only "anything but 413/400").
+local function test_at_cap_body_passes_the_cap_check()
+  local srv = start_proxy(16)
+  local body = string.rep("x", 16)
+  local resp = roundtrip(srv,
+    "POST http://a.example.com/upload HTTP/1.1\r\n"
+    .. "Host: a.example.com\r\n"
+    .. "Content-Length: 16\r\n\r\n" .. body)
+  assert(not resp:find("^HTTP/1%.1 413 "),
+    "at-cap body must not be refused with 413, got: " .. resp:sub(1, 40))
+  assert(not resp:find("^HTTP/1%.1 400 "),
+    "at-cap body must not be refused with 400, got: " .. resp:sub(1, 40))
+end
+test_at_cap_body_passes_the_cap_check()
+
+-- Denied hosts are refused before the body checks ever run, so an
+-- oversized claim against a non-allowlisted host stays a plain 403.
+local function test_deny_precedes_body_checks()
+  local srv = start_proxy(1024)
+  local resp = roundtrip(srv,
+    "POST http://evil.example.com/ HTTP/1.1\r\n"
+    .. "Host: evil.example.com\r\n"
+    .. "Content-Length: 4096\r\n\r\n")
+  assert(resp:find("^HTTP/1%.1 403 "),
+    "denied host should get 403, got: " .. resp:sub(1, 40))
+end
+test_deny_precedes_body_checks()

--- a/lib/cosmic/quicksand/types.tl
+++ b/lib/cosmic/quicksand/types.tl
@@ -38,6 +38,8 @@ local record NetOptions
   allow: {string: NetRule}
   log_level: LogLevel
   resolve_timeout_ms: integer -- per-dial DNS budget; <=0 opts out
+  max_body_bytes: integer -- proxy request-body cap; larger
+  -- Content-Lengths get 413. nil = 64 MiB, <=0 disables
 end
 
 --- The filesystem policy is cosmic.sandbox's Fs schema (ro/rw/exec


### PR DESCRIPTION
Closes #497 — the remaining live half of the allocation-DoS finding. The egress proxy read the client's `Content-Length` with `tonumber()` and buffered exactly that many bytes in `read_body`: a client inside the box could name an attacker-chosen allocation, and hex/exponent/negative values parsed "successfully" into nonsense sizes.

## Changes

- **Strict `Content-Length` parsing** (`http.content_length`): RFC 7230 `1*DIGIT` only. Absent = `0`; anything non-digit or overflowing integer range = `nil`, which `serve` turns into a **400**. The old `tonumber() or 0` path silently read garbage as 0 and forwarded the request with the body still unread on the socket.
- **`ProxyOptions.max_body_bytes`**: request-body cap, default **64 MiB** (matching the tree-wide `Inflate` cap), `<= 0` disables. An over-cap `Content-Length` is refused with a new canned **413 Payload Too Large** *before a single body byte is read or buffered*. Deny (403) still precedes the body checks, so denied hosts learn nothing new.
- **Box passthrough**: `NetOptions.max_body_bytes` threads to `proxy.start`, mirroring `resolve_timeout_ms`.

## Tests

- `http_test`: strict-parse table — hex, exponent, negative, float, embedded space, and integer-overflow values all read as malformed; digits and leading zeros parse.
- **New `serve_test`** (first end-to-end test of the serve layer): drives a real loopback server through `listen`/`accept`/`handle` with a raw client socket, no DNS or egress needed —
  - over-cap `Content-Length` → 413, verified body-blind: the client never sends the body, so anything but an immediate refusal deadlocks the single-threaded test;
  - malformed `Content-Length` → 400;
  - at-cap boundary passes the check (refutes off-by-one);
  - denied host with an oversized claim stays a plain 403.

## Note on the other half of #497

The `compress.inflate` size-prefix concern is already resolved: the distrusted 4-byte prefix format was deleted in #606, and `decompress()` takes `max_output` with a 64 MiB default enforced by the binding. Verified in the current tree before writing this.

Gates: `bin/make ci` green (format + teal + test + example + lint + coverage ratchet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9qfnqpEW2rhSseaLPRf6c

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9qfnqpEW2rhSseaLPRf6c)_