### PR TITLE
export module record types, delete structural twins (serve, sqlite, fetch, zip consumers) (#614)

### DIFF
--- a/lib/cosmic/embed_advanced_test.tl
+++ b/lib/cosmic/embed_advanced_test.tl
@@ -11,31 +11,6 @@ local embed = require("cosmic.embed")
 local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
--- Local declaration of Reader interface for type casting
-local record Entry
-  name: string
-  size: number
-  mode: number
-end
-
-local record Reader
-  list: function(self: Reader): {Entry}
-  read: function(self: Reader, name: string): string | nil, string | nil
-  stat: function(self: Reader, name: string): Stat | nil
-  close: function(self: Reader)
-end
-
--- Stat record for file metadata
-local record Stat
-  mode: number
-end
-
--- Writer interface for crafting test archives
-local record Writer
-  add: function(self: Writer, name: string, content: string): boolean, string
-  close: function(self: Writer)
-end
-
 local function write_temp(name: string, content: string): string
   local filepath = fs.join(tmpdir, name)
   local dir = fs.dirname(filepath)
@@ -75,7 +50,7 @@ local function test_extract_embed_roundtrip()
 
   -- Read original main.lua from the zip
   local orig_data = fs.read(cosmic)
-  local orig_reader = zip.from(orig_data) as Reader
+  local orig_reader = zip.from(orig_data) as zip.Reader
   local orig_main = orig_reader:read("main.lua")
   assert(orig_main, "original should have main.lua")
   orig_reader:close()
@@ -92,7 +67,7 @@ local function test_extract_embed_roundtrip()
 
   -- Read main.lua from the re-embedded binary
   local new_data = fs.read(output)
-  local new_reader = zip.from(new_data) as Reader
+  local new_reader = zip.from(new_data) as zip.Reader
   local new_main = new_reader:read("main.lua")
   assert(new_main == orig_main, "roundtripped main.lua should match original")
   new_reader:close()
@@ -128,7 +103,7 @@ test_extract_modify_embed()
 local function test_embed_overwrites_cleanly()
   -- Read original zip file list
   local orig_data = fs.read(cosmic)
-  local orig_reader = zip.from(orig_data) as Reader
+  local orig_reader = zip.from(orig_data) as zip.Reader
   local orig_files: {string: boolean} = {}
   for _, entry in ipairs(orig_reader:list()) do
     -- Skip directory entries
@@ -150,7 +125,7 @@ local function test_embed_overwrites_cleanly()
 
   -- The new zip should have main.lua with the new content
   local new_data = fs.read(output)
-  local new_reader = zip.from(new_data) as Reader
+  local new_reader = zip.from(new_data) as zip.Reader
   local new_main = new_reader:read("main.lua")
   assert(new_main == 'print("new")\n', "main.lua should have new content: " .. tostring(new_main))
 
@@ -192,7 +167,7 @@ local function test_embed_preserves_file_modes()
   local data = fs.read(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
-  local reader = reader_maybe as Reader
+  local reader = reader_maybe as zip.Reader
 
   local script_stat = reader:stat("run.sh")
   local config_stat = reader:stat("config.txt")
@@ -203,9 +178,9 @@ local function test_embed_preserves_file_modes()
   assert(secret_stat, "secret.key should exist in zip")
 
   -- Check permission bits (mask with 0777 to get just permission bits)
-  local script_mode = (script_stat as Stat).mode & tonumber("777", 8)
-  local config_mode = (config_stat as Stat).mode & tonumber("777", 8)
-  local secret_mode = (secret_stat as Stat).mode & tonumber("777", 8)
+  local script_mode = (script_stat as zip.Stat).mode & tonumber("777", 8)
+  local config_mode = (config_stat as zip.Stat).mode & tonumber("777", 8)
+  local secret_mode = (secret_stat as zip.Stat).mode & tonumber("777", 8)
 
   assert(script_mode == tonumber("755", 8),
     "run.sh should have mode 755, got " .. string.format("%o", script_mode))
@@ -318,7 +293,7 @@ local function test_extract_rejects_path_traversal()
   -- byte-patch it to a traversal name (no offsets change, so the zip stays
   -- valid). "XX/escaped.txt" -> "../escaped.txt".
   local safe = fs.join(tmpdir, "patched.zip")
-  local w = zip.writer(safe) as Writer
+  local w = zip.writer(safe) as zip.Writer
   assert(w, "should open zip for writing")
   w:add("XX/escaped.txt", "pwned")
   w:close()
@@ -352,7 +327,7 @@ local function test_embed_symlink_loop_terminates()
   assert(result.ok, "embed of dir with symlink loop should succeed: " .. (result.message or ""))
   -- Only real.txt should be embedded, not any path through the loop
   local data = fs.read(fs.join(tmpdir, "cosmic-symlinkloop"))
-  local reader = zip.from(data) as Reader
+  local reader = zip.from(data) as zip.Reader
   local files = reader:list()
   for _, f in ipairs(files) do
     assert(not f.name:match("loop"), "embedded zip should not contain loop path: " .. f.name)
@@ -377,7 +352,7 @@ local function test_embed_symlink_to_outside_file_skipped()
   assert(result.ok, "embed should succeed even with outside symlink: " .. (result.message or ""))
   -- "leaked.txt" (the symlink) must not appear in the zip
   local data = fs.read(fs.join(tmpdir, "cosmic-symlinkoutside"))
-  local reader = zip.from(data) as Reader
+  local reader = zip.from(data) as zip.Reader
   local files = reader:list()
   for _, f in ipairs(files) do
     assert(not f.name:match("leaked"), "symlink to outside file should not be embedded: " .. f.name)

--- a/lib/cosmic/embed_env_test.tl
+++ b/lib/cosmic/embed_env_test.tl
@@ -9,19 +9,6 @@ local zip = require("cosmic.zip")
 local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
--- Local declaration of Reader interface for type casting
-local record Reader
-  list: function(self: Reader): {string}
-  read: function(self: Reader, name: string): string | nil, string | nil
-  stat: function(self: Reader, name: string): Stat | nil
-  close: function(self: Reader)
-end
-
--- Stat record for file metadata
-local record Stat
-  mode: number
-end
-
 local function write_temp(name: string, content: string): string
   local filepath = fs.join(tmpdir, name)
   local dir = fs.dirname(filepath)
@@ -58,7 +45,7 @@ local function test_embed_via_env()
   local data = fs.read(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
-  local reader = reader_maybe as Reader
+  local reader = reader_maybe as zip.Reader
 
   local expected_name = input:gsub("^/+", "")
   local content = reader:read(expected_name)
@@ -112,7 +99,7 @@ local function test_cli_priority_over_env()
   local data = fs.read(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
-  local reader = reader_maybe as Reader
+  local reader = reader_maybe as zip.Reader
 
   -- CLI file should be present
   local cli_name = cli_input:gsub("^/+", "")

--- a/lib/cosmic/embed_test.tl
+++ b/lib/cosmic/embed_test.tl
@@ -9,28 +9,6 @@ local zip = require("cosmic.zip")
 local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
--- Local declaration of Reader interface for type casting
-local record Entry
-  name: string
-  size: number
-  mode: number
-end
-
-local record Reader
-  list: function(self: Reader): {Entry}
-  read: function(self: Reader, name: string): string | nil, string | nil
-  stat: function(self: Reader, name: string): Stat | nil
-  close: function(self: Reader)
-end
-
--- Stat record for file metadata
-local record Stat
-  mode: number
-  method: number
-  size: number
-  compressed_size: number
-end
-
 local function write_temp(name: string, content: string): string
   local filepath = fs.join(tmpdir, name)
   local dir = fs.dirname(filepath)
@@ -59,7 +37,7 @@ local function test_embed_single_file()
   local data = fs.read(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
-  local reader = reader_maybe as Reader
+  local reader = reader_maybe as zip.Reader
   local files = reader:list()
 
   local found = false
@@ -92,7 +70,7 @@ local function test_embed_multiple_files()
   local data = fs.read(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
-  local reader = reader_maybe as Reader
+  local reader = reader_maybe as zip.Reader
 
   local name1 = file1:gsub("^/+", "")
   local name2 = file2:gsub("^/+", "")
@@ -142,7 +120,7 @@ local function test_embed_lua_file()
   local data = fs.read(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
-  local reader = reader_maybe as Reader
+  local reader = reader_maybe as zip.Reader
   local name = modfile:gsub("^/+", "")
   local content = reader:read(name)
   assert(content == [[return { value = 42 }]], "lua content should be preserved")
@@ -164,7 +142,7 @@ local function test_embed_binary_file()
   local data = fs.read(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
-  local reader = reader_maybe as Reader
+  local reader = reader_maybe as zip.Reader
   local name = input:gsub("^/+", "")
   local content = reader:read(name)
   assert(content == binary, "binary content should be preserved exactly")
@@ -190,7 +168,7 @@ local function test_embed_directory()
   local data = fs.read(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
-  local reader = reader_maybe as Reader
+  local reader = reader_maybe as zip.Reader
 
   local c1 = reader:read("main.lua")
   assert(c1 == 'print("hello")\n', "main.lua should be at zip root: " .. tostring(c1))
@@ -221,7 +199,7 @@ local function test_embed_nested_directory()
   local data = fs.read(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
-  local reader = reader_maybe as Reader
+  local reader = reader_maybe as zip.Reader
 
   assert(reader:read("top.txt") == "top", "top-level file")
   assert(reader:read("a/mid.txt") == "mid", "mid-level file")
@@ -246,7 +224,7 @@ local function test_embed_mixed()
   local data = fs.read(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
-  local reader = reader_maybe as Reader
+  local reader = reader_maybe as zip.Reader
 
   local c1 = reader:read("main.lua")
   assert(c1 == 'print("mixed")\n', "directory file should be present")
@@ -291,12 +269,12 @@ local function test_embed_uses_deflate()
   local data = fs.read(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
-  local reader = reader_maybe as Reader
+  local reader = reader_maybe as zip.Reader
 
   local name = input:gsub("^/+", "")
   local st = reader:stat(name)
   assert(st ~= nil, "stat should return metadata for embedded file")
-  local stat = st as Stat
+  local stat = st as zip.Stat
   assert(stat.method == 8,
     "embedded file should use deflate (method=8), got: " .. tostring(stat.method))
   assert(stat.compressed_size < stat.size,
@@ -322,12 +300,12 @@ local function test_embed_stores_lua()
   local data = fs.read(output)
   local reader_maybe = zip.from(data)
   assert(reader_maybe, "failed to open zip from data")
-  local reader = reader_maybe as Reader
+  local reader = reader_maybe as zip.Reader
 
   local name = input:gsub("^/+", "")
   local st = reader:stat(name)
   assert(st ~= nil, "stat should return metadata for embedded file")
-  local stat = st as Stat
+  local stat = st as zip.Stat
   assert(stat.method == 0,
     "embedded .lua should be stored (method=0), got: " .. tostring(stat.method))
   assert(stat.compressed_size == stat.size,

--- a/lib/cosmic/fetch/init.tl
+++ b/lib/cosmic/fetch/init.tl
@@ -464,10 +464,12 @@ local record FetchModule
   stream: function(url: string, opts?: Options): StreamResult
   unix_proxy: function(path: string): string | nil, string
   type ErrorKind = ErrorKind
-  Options: Options
-  Result: Result
-  Reader: Reader
-  StreamResult: StreamResult
+  --- Type aliases, not runtime values — the old `Result: Result`
+  --- field spelling declared phantom fields that were nil at runtime.
+  type Options = Options
+  type Result = Result
+  type Reader = Reader
+  type StreamResult = StreamResult
 end
 
 local M: FetchModule = {

--- a/lib/cosmic/quicksand/proxy/serve.tl
+++ b/lib/cosmic/quicksand/proxy/serve.tl
@@ -33,6 +33,10 @@ local record Server
 end
 
 local record ServeModule
+  --- The Server record new() returns, exported so callers (tests
+  --- included) can name it instead of casting to structural twins.
+  type Server = Server
+
   --- A single allowlist rule. `type` nil means pass-through
   --- (allowed, no header injection). Fields not relevant to the
   --- chosen type are ignored.

--- a/lib/cosmic/quicksand/proxy/serve_test.tl
+++ b/lib/cosmic/quicksand/proxy/serve_test.tl
@@ -7,26 +7,16 @@
 local serve = require("cosmic.quicksand.proxy.serve")
 local net = require("cosmic.net")
 
--- serve's Server record is module-local; declare a structural twin for
--- the methods this test drives (casts are the codebase's escape hatch
--- for un-exported record types).
-local record Srv
-  port: function(): integer
-  listen: function(): integer | nil, string
-  accept: function(): integer | nil, string
-  handle: function(client_fd: integer)
-end
-
 --- Start a proxy on an ephemeral loopback port with a tiny body cap
 --- and one allowed pass-through host.
-local function start_proxy(max_body: integer): Srv
+local function start_proxy(max_body: integer): serve.Server
   local srv = serve.new({
       bind_port = 0,
       allowed_hosts = {["a.example.com"] = {}},
       log_level = "quiet",
       max_body_bytes = max_body,
       resolve_timeout_ms = 200,
-    }) as Srv
+    }) as serve.Server
   assert(srv, "serve.new failed")
   assert(srv.listen(), "listen failed")
   return srv
@@ -35,7 +25,7 @@ end
 --- Send one raw request, run one in-process handle() pass, and return
 --- the full response. handle() closes the server-side fd; recv drains
 --- until EOF (nil per the stream contract).
-local function roundtrip(srv: Srv, request: string): string
+local function roundtrip(srv: serve.Server, request: string): string
   local sock = net.connect_tcp("127.0.0.1", srv.port()) as net.Socket
   assert(sock, "connect failed")
   assert(sock:send(request))

--- a/lib/cosmic/sqlite/advanced_test.tl
+++ b/lib/cosmic/sqlite/advanced_test.tl
@@ -3,13 +3,6 @@
 
 local sqlite = require("cosmic.sqlite")
 
--- The module's Rows iterator record is not exported; mirror its shape here so
--- the fallible `db:query* -> Rows | nil` results can be cast for iteration.
-local record Rows
-  metamethod __call: function(self: Rows): {string: any}
-  err: function(self: Rows): string
-end
-
 -- Nil handling in bind
 
 local function test_exec_trailing_nils()
@@ -20,7 +13,7 @@ local function test_exec_trailing_nils()
   local ok, err = db:exec("INSERT INTO t (a, b, c) VALUES (?, ?, ?)", "hello", nil, nil)
   assert(ok, "exec with trailing nils should succeed: " .. tostring(err))
 
-  for row in db:query("SELECT * FROM t") as Rows do
+  for row in db:query("SELECT * FROM t") as sqlite.Rows do
     assert(row.a == "hello", "a should be 'hello', got: " .. tostring(row.a))
     assert(row.b == nil, "b should be nil")
     assert(row.c == nil, "c should be nil")
@@ -36,7 +29,7 @@ local function test_exec_middle_nils()
   local ok, err = db:exec("INSERT INTO t (a, b, c) VALUES (?, ?, ?)", nil, "middle", nil)
   assert(ok, "exec with middle nils should succeed: " .. tostring(err))
 
-  for row in db:query("SELECT * FROM t") as Rows do
+  for row in db:query("SELECT * FROM t") as sqlite.Rows do
     assert(row.a == nil, "a should be nil")
     assert(row.b == "middle", "b should be 'middle'")
     assert(row.c == nil, "c should be nil")
@@ -55,7 +48,7 @@ local function test_bind_trailing_nils()
   stmt:exec()
   stmt:close()
 
-  for row in db:query("SELECT * FROM t") as Rows do
+  for row in db:query("SELECT * FROM t") as sqlite.Rows do
     assert(row.a == "first", "a should be 'first'")
     assert(row.b == 42, "b should be 42")
     assert(row.c == nil, "c should be nil")
@@ -77,7 +70,7 @@ local function test_bind_list()
   stmt:exec()
   stmt:close()
 
-  for row in db:query("SELECT * FROM t") as Rows do
+  for row in db:query("SELECT * FROM t") as sqlite.Rows do
     assert(row.a == "hello", "a should be 'hello'")
     assert(row.b == nil, "b should be nil")
     assert(row.c == "world", "c should be 'world'")
@@ -98,7 +91,7 @@ local function test_exec_list()
     values)
   assert(ok, "exec_list should succeed: " .. tostring(err))
 
-  for row in db:query("SELECT * FROM t") as Rows do
+  for row in db:query("SELECT * FROM t") as sqlite.Rows do
     assert(row.a == "one", "a should be 'one'")
     assert(row.b == nil, "b should be nil")
     assert(row.c == nil, "c should be nil")
@@ -118,7 +111,7 @@ local function test_exec_list_all_nils()
     values)
   assert(ok, "exec_list with all nils should succeed: " .. tostring(err))
 
-  for row in db:query("SELECT * FROM t") as Rows do
+  for row in db:query("SELECT * FROM t") as sqlite.Rows do
     assert(row.a == nil, "a should be nil")
     assert(row.b == nil, "b should be nil")
   end
@@ -135,7 +128,7 @@ local function test_query_list()
 
   local values = {"x"}
   local rows = {}
-  for row in db:query_list("SELECT * FROM t WHERE a = ?", values) as Rows do
+  for row in db:query_list("SELECT * FROM t WHERE a = ?", values) as sqlite.Rows do
     table.insert(rows, row)
   end
   assert(#rows == 1, "should get 1 row")
@@ -192,7 +185,7 @@ local function test_transaction_commit()
   assert(ok, "transaction should succeed: " .. tostring(err))
 
   local count = 0
-  for _ in db:query("SELECT * FROM t") as Rows do
+  for _ in db:query("SELECT * FROM t") as sqlite.Rows do
     count = count + 1
   end
   assert(count == 1, "should have 1 row after committed transaction")
@@ -212,7 +205,7 @@ local function test_transaction_rollback_on_error()
   assert(err and err:match("something went wrong"), "should include error message")
 
   local count = 0
-  for _ in db:query("SELECT * FROM t") as Rows do
+  for _ in db:query("SELECT * FROM t") as sqlite.Rows do
     count = count + 1
   end
   assert(count == 0, "should have 0 rows after rollback")
@@ -232,7 +225,7 @@ local function test_transaction_multiple_ops()
   assert(ok, "transaction should succeed")
 
   local count = 0
-  for _ in db:query("SELECT * FROM t") as Rows do
+  for _ in db:query("SELECT * FROM t") as sqlite.Rows do
     count = count + 1
   end
   assert(count == 3, "should have 3 rows")
@@ -256,7 +249,7 @@ local function test_transaction_rollback_on_false()
   assert(err == "boom", "should surface the body error, got " .. tostring(err))
 
   local count = 0
-  for _ in db:query("SELECT * FROM t") as Rows do
+  for _ in db:query("SELECT * FROM t") as sqlite.Rows do
     count = count + 1
   end
   assert(count == 0, "row must roll back when body returns false, got " .. tostring(count))
@@ -278,7 +271,7 @@ local function test_transaction_rollback_on_nil_err()
   assert(err == "nope", "should surface the body error, got " .. tostring(err))
 
   local count = 0
-  for _ in db:query("SELECT * FROM t") as Rows do
+  for _ in db:query("SELECT * FROM t") as sqlite.Rows do
     count = count + 1
   end
   assert(count == 0, "row must roll back when body returns nil, err, got " .. tostring(count))
@@ -297,7 +290,7 @@ local function test_transaction_commits_on_no_return()
   assert(ok, "should commit when body returns nothing: " .. tostring(err))
 
   local count = 0
-  for _ in db:query("SELECT * FROM t") as Rows do
+  for _ in db:query("SELECT * FROM t") as sqlite.Rows do
     count = count + 1
   end
   assert(count == 1, "row must commit when body returns nothing, got " .. tostring(count))
@@ -317,7 +310,7 @@ local function test_bind_named()
   stmt:exec()
   stmt:close()
 
-  for row in db:query("SELECT * FROM t") as Rows do
+  for row in db:query("SELECT * FROM t") as sqlite.Rows do
     assert(row.a == "hello", "a should be 'hello'")
     assert(row.b == nil, "b should be nil (unbound)")
     assert(row.c == "world", "c should be 'world'")
@@ -335,7 +328,7 @@ local function test_exec_named()
     {a = "one", b = 42})
   assert(ok, "exec_named should succeed: " .. tostring(err))
 
-  for row in db:query("SELECT * FROM t") as Rows do
+  for row in db:query("SELECT * FROM t") as sqlite.Rows do
     assert(row.a == "one", "a should be 'one'")
     assert(row.b == 42, "b should be 42")
     assert(row.c == nil, "c should be nil")
@@ -352,7 +345,7 @@ local function test_exec_named_all_nil()
     "INSERT INTO t (a, b) VALUES (:a, :b)", {})
   assert(ok, "exec_named with empty params should succeed: " .. tostring(err))
 
-  for row in db:query("SELECT * FROM t") as Rows do
+  for row in db:query("SELECT * FROM t") as sqlite.Rows do
     assert(row.a == nil, "a should be nil")
     assert(row.b == nil, "b should be nil")
   end
@@ -368,7 +361,7 @@ local function test_query_named()
   local names: {string} = {}
   for row in db:query_named(
     "SELECT * FROM t WHERE city = :city ORDER BY id",
-    {city = "NYC"}) as Rows do
+    {city = "NYC"}) as sqlite.Rows do
     table.insert(names, row.name as string)
   end
   assert(#names == 2, "should get 2 rows")
@@ -389,8 +382,8 @@ local function test_same_sql_nested_query_reentrant()
   db:exec("INSERT INTO t (name) VALUES ('a'), ('b'), ('c')")
 
   local pairs_seen: {string} = {}
-  for outer in db:query("SELECT * FROM t ORDER BY id") as Rows do
-    for inner in db:query("SELECT * FROM t ORDER BY id") as Rows do
+  for outer in db:query("SELECT * FROM t ORDER BY id") as sqlite.Rows do
+    for inner in db:query("SELECT * FROM t ORDER BY id") as sqlite.Rows do
       table.insert(pairs_seen, (outer.name as string) .. (inner.name as string))
     end
   end

--- a/lib/cosmic/sqlite/close_test.tl
+++ b/lib/cosmic/sqlite/close_test.tl
@@ -6,15 +6,6 @@
 
 local sqlite = require("cosmic.sqlite")
 
--- Mirror of cosmic.sqlite's Rows iterator record (not exported; Teal
--- records are nominal, so the boundary crosses through a cast).
-local record Rows
-  metamethod __call: function(self: Rows): {string: any}
-  metamethod __close: function(self: Rows)
-  err: function(self: Rows): string
-  close: function(self: Rows)
-end
-
 -- Abandoned query iterators: close(), <close>, and GC release the statement
 
 local function test_query_close_releases_early()
@@ -22,7 +13,7 @@ local function test_query_close_releases_early()
   db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
   db:exec("INSERT INTO t (name) VALUES ('a'), ('b'), ('c')")
 
-  local rows = db:query("SELECT * FROM t ORDER BY id") as Rows
+  local rows = db:query("SELECT * FROM t ORDER BY id") as sqlite.Rows
   local first = rows()
   assert(first and first.name == "a", "should get first row")
   rows:close()
@@ -31,7 +22,7 @@ local function test_query_close_releases_early()
 
   -- The cached statement slot must be usable again for the same SQL.
   local n = 0
-  for _ in db:query("SELECT * FROM t ORDER BY id") as Rows do
+  for _ in db:query("SELECT * FROM t ORDER BY id") as sqlite.Rows do
     n = n + 1
   end
   assert(n == 3, "re-query after close should see all rows, got: " .. tostring(n))
@@ -44,11 +35,11 @@ local function test_query_close_idempotent()
   db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY)")
   db:exec("INSERT INTO t DEFAULT VALUES")
 
-  local rows = db:query("SELECT * FROM t") as Rows
+  local rows = db:query("SELECT * FROM t") as sqlite.Rows
   rows:close()
   rows:close()
 
-  local drained = db:query("SELECT * FROM t") as Rows
+  local drained = db:query("SELECT * FROM t") as sqlite.Rows
   while drained() ~= nil do end
   drained:close()
   db:close()
@@ -63,7 +54,7 @@ local function test_query_to_be_closed_scope()
   -- The repo build compiles Teal targeting 5.3 syntax, so exercise the
   -- __close metamethod directly instead of a `local rows <close> = ...`
   -- declaration (which works in user scripts running on the 5.4 runtime).
-  local rows = db:query("SELECT * FROM t ORDER BY id") as Rows
+  local rows = db:query("SELECT * FROM t ORDER BY id") as sqlite.Rows
   local first = rows()
   assert(first and first.name == "a", "should get first row")
   local mt = getmetatable(rows as any) as {string: any}
@@ -73,7 +64,7 @@ local function test_query_to_be_closed_scope()
   assert(rows() == nil, "__close must release the iterator")
 
   local n = 0
-  for _ in db:query("SELECT * FROM t ORDER BY id") as Rows do
+  for _ in db:query("SELECT * FROM t ORDER BY id") as sqlite.Rows do
     n = n + 1
   end
   assert(n == 2, "re-query after <close> should see all rows, got: " .. tostring(n))
@@ -87,7 +78,7 @@ local function test_query_abandoned_iterator_collected()
   db:exec("INSERT INTO t DEFAULT VALUES")
 
   do
-    local rows = db:query("SELECT * FROM t") as Rows
+    local rows = db:query("SELECT * FROM t") as sqlite.Rows
     assert(rows() ~= nil, "should get a row")
     -- Abandon without close: the GC backstop must release the statement.
   end
@@ -95,7 +86,7 @@ local function test_query_abandoned_iterator_collected()
   collectgarbage("collect")
 
   local n = 0
-  for _ in db:query("SELECT * FROM t") as Rows do
+  for _ in db:query("SELECT * FROM t") as sqlite.Rows do
     n = n + 1
   end
   assert(n == 1, "query after GC of abandoned iterator should work")
@@ -108,7 +99,7 @@ local function test_query_list_close_early()
   db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
   db:exec("INSERT INTO t (name) VALUES ('a'), ('b')")
 
-  local rows = db:query_list("SELECT * FROM t WHERE name != ? ORDER BY id", {"z"}) as Rows
+  local rows = db:query_list("SELECT * FROM t WHERE name != ? ORDER BY id", {"z"}) as sqlite.Rows
   local first = rows()
   assert(first and first.name == "a", "should get first row")
   rows:close()

--- a/lib/cosmic/sqlite/data_test.tl
+++ b/lib/cosmic/sqlite/data_test.tl
@@ -7,13 +7,6 @@ local sqlite = require("cosmic.sqlite")
 
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
 
--- The module's Rows iterator record is not exported; mirror its shape here so
--- the fallible `db:query* -> Rows | nil` results can be cast for iteration.
-local record Rows
-  metamethod __call: function(self: Rows): {string: any}
-  err: function(self: Rows): string
-end
-
 -- Blob binding
 
 local function test_blob_bind_affinity()
@@ -45,7 +38,7 @@ local function test_blob_in_query_params()
   -- db:query binds through the hot-path row iterator; make sure the blob
   -- marker is honored there too.
   local db = sqlite.open(":memory:") as sqlite.Database
-  local iter = db:query("SELECT typeof(?) AS ty", sqlite.blob("abc")) as Rows
+  local iter = db:query("SELECT typeof(?) AS ty", sqlite.blob("abc")) as sqlite.Rows
   assert(iter, "query should succeed")
   local row = iter()
   assert(row and row.ty == "blob", "query param should bind as blob")
@@ -67,7 +60,7 @@ local function test_blob_bind_and_bind_list()
   ok, err = db:exec_list("INSERT INTO t (a, b) VALUES (?, ?)", {sqlite.blob("p"), "q"})
   assert(ok, "exec_list with blob should succeed: " .. tostring(err))
 
-  local iter = db:query("SELECT typeof(a) AS ta, typeof(b) AS tb FROM t") as Rows
+  local iter = db:query("SELECT typeof(a) AS ta, typeof(b) AS tb FROM t") as sqlite.Rows
   local n = 0
   for row in iter do
     n = n + 1

--- a/lib/cosmic/sqlite/init.tl
+++ b/lib/cosmic/sqlite/init.tl
@@ -443,12 +443,17 @@ end
 local record sqlite
   type Blob = bind_mod.Blob
   type OpenOptions = OpenOptions
+  --- Exported so callers can name the handles open() and its methods
+  --- return; these are type aliases, not runtime values (the old
+  --- `Database: Database` field spelling declared phantom fields that
+  --- were nil at runtime).
+  type Database = Database
+  type Statement = Statement
+  type Rows = Rows
+  type Values = Values
 
   open: function(filename: string, opts?: OpenOptions): Database | nil, string
   blob: function(data: string): bind_mod.Blob
-  Database: Database
-  Statement: Statement
-  Rows: Rows
 end
 
 local M: sqlite = {

--- a/lib/cosmic/sqlite/init_example.tl
+++ b/lib/cosmic/sqlite/init_example.tl
@@ -1,13 +1,6 @@
 --- Examples for the cosmic.sqlite module.
 --- Demonstrates database operations, prepared statements, and queries.
 
--- The module's Rows iterator record is not exported; mirror its shape here so
--- the fallible `db:query -> Rows | nil` results can be cast for iteration.
-local record Rows
-  metamethod __call: function(self: Rows): {string: any}
-  err: function(self: Rows): string
-end
-
 -- Example_open_file demonstrates database file path resolution
 local function Example_open_file()
   local sqlite = require("cosmic.sqlite")
@@ -38,7 +31,7 @@ local function Example_open()
   local db = sqlite.open(":memory:") as sqlite.Database
   db:exec("CREATE TABLE kv (k TEXT PRIMARY KEY, v TEXT)")
   db:exec("INSERT INTO kv (k, v) VALUES ('hello', 'world')")
-  for row in db:query("SELECT * FROM kv") as Rows do
+  for row in db:query("SELECT * FROM kv") as sqlite.Rows do
     print(row.k, row.v)
   end
   db:close()
@@ -60,7 +53,7 @@ local function Example_prepared()
   stmt:exec()
   stmt:close()
 
-  for row in db:query("SELECT * FROM users ORDER BY id") as Rows do
+  for row in db:query("SELECT * FROM users ORDER BY id") as sqlite.Rows do
     print(row.id, row.name)
   end
   db:close()
@@ -78,7 +71,7 @@ local function Example_query_params()
     db:exec("INSERT INTO nums (n) VALUES (" .. i .. ")")
   end
 
-  for row in db:query("SELECT * FROM nums WHERE n > ?", 2) as Rows do
+  for row in db:query("SELECT * FROM nums WHERE n > ?", 2) as sqlite.Rows do
     print(row.n)
   end
   db:close()
@@ -98,7 +91,7 @@ local function Example_exec_params()
   db:exec("INSERT INTO cities (name, pop) VALUES (?, ?)", "Delhi", 16787941)
   db:exec("INSERT INTO cities (name, pop) VALUES (?, ?)", "Shanghai", 24870895)
 
-  for row in db:query("SELECT * FROM cities ORDER BY pop DESC") as Rows do
+  for row in db:query("SELECT * FROM cities ORDER BY pop DESC") as sqlite.Rows do
     print(row.name, row.pop)
   end
   db:close()
@@ -118,7 +111,7 @@ local function Example_query_like()
   db:exec("INSERT INTO files (path) VALUES (?)", "src/util.tl")
   db:exec("INSERT INTO files (path) VALUES (?)", "docs/readme.md")
 
-  for row in db:query("SELECT path FROM files WHERE path LIKE ?", "%src%") as Rows do
+  for row in db:query("SELECT path FROM files WHERE path LIKE ?", "%src%") as sqlite.Rows do
     print(row.path)
   end
   db:close()


### PR DESCRIPTION
Closes #614, widened to every case a sweep for the same pattern found: modules whose returned record types callers can't name, worked around with local structural twins and unchecked casts that drift silently.

## serve (the original #614)

- `ServeModule` exports `type Server = Server`; `serve_test.tl` drops its twin and is now type-checked against the real record.

## sqlite (worst case: six mirrors)

- `Rows` (and `Values`) join `Database`/`Statement` as exported types. The module record spelled the existing ones as **value fields** (`Database: Database`) — which tl accepts in type positions but which declared phantom fields that are `nil` at runtime; all are now proper `type X = X` aliases.
- The `Rows` twins mirrored in `data_test`, `advanced_test`, `close_test`, and `init_example` are deleted; casts name `sqlite.Rows`.
- Out of scope: the shard-internal mirrors in `params.tl`/`row_iter.tl` are the deliberate any-boundary convention between directory-module shards — that's audit #491 territory.

## fetch (same gap, pre-emptive)

- `Options`/`Result`/`Reader`/`StreamResult` get the same field-spelling → type-alias conversion, so the first caller who wants a typed signature over fetch results doesn't have to twin them.

## embed tests (export existed, twins stale)

- `zip` has exported `Reader`/`Entry`/`Stat`/`Writer` for some time, but `embed_test`, `embed_advanced_test`, and `embed_env_test` still carried weaker local twins — one twin `Stat` was down to a single field, and one twin `Reader` claimed `list()` returns `{string}` when the real record returns `{Entry}`. Twins deleted; casts now name the real zip types.

Net **−83 lines**. All internal/type-level — no runtime behavior change, no `definitions.lua`/type-regen impact. Everything the twins previously hid from the checker now checks against the real records.

Gates: `bin/make ci` green (format + teal + test + example + lint + coverage ratchet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9qfnqpEW2rhSseaLPRf6c