### PR TITLE
string: add contains, count, replace, lines, partition, fields, pad, dedent, indent, truncate, shell_quote (#501)

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -18,7 +18,7 @@ local sqlite = require("cosmic.sqlite")
 | `cosmic.fd` | file descriptor I/O: open/wrap handles, pipes |
 | `cosmic.stream` | the stream contract: Reader/Writer interfaces |
 | `cosmic.fs` | filesystem paths, stat, walk, mkdir, temp files |
-| `cosmic.string` | trim, split, capitalize, starts_with |
+| `cosmic.string` | trim, split, replace, contains, fields, lines, pad, dedent, truncate, shell_quote |
 | `cosmic.env` | environment variable get/set/unset/list |
 | `cosmic.envd` | load environment variables from an embedded env.d directory |
 | `cosmic.errno` | errno names, numbers, and error-string helpers |

--- a/lib/cosmic/string.tl
+++ b/lib/cosmic/string.tl
@@ -1,5 +1,7 @@
 --- String utilities.
---- Common string manipulation functions for trimming, splitting, and case conversion.
+--- Common string manipulation functions for trimming, splitting, searching,
+--- padding, and quoting. All functions are infallible and treat their
+--- arguments as plain text (no Lua patterns).
 ---
 --- Example usage:
 ---   local str = require("cosmic.string")
@@ -7,6 +9,9 @@
 ---   str.trim("  hello  ")             -- "hello"
 ---   str.split("a,b,c", ",")           -- {"a", "b", "c"}
 ---   str.starts_with("hello", "he")    -- true
+---   str.contains("hello", "ell")      -- true
+---   str.replace("a-b-c", "-", "+")    -- "a+b+c"
+---   str.fields("  a  b  ")            -- {"a", "b"}
 
 --- Capitalize the first character of a string.
 --- Converts the first character to uppercase, leaving the rest unchanged.
@@ -91,6 +96,270 @@ local function ends_with(s: string, suffix: string): boolean
   return suffix == "" or s:sub(-#suffix) == suffix
 end
 
+--- Check if a string contains a substring.
+--- Plain-text search; the substring is not a Lua pattern.
+--- The empty substring is contained in every string.
+--- @param s string The string to search
+--- @param sub string The substring to look for
+--- @return boolean True if s contains sub
+local function contains(s: string, sub: string): boolean
+  if sub == "" then
+    return true
+  end
+  return s:find(sub, 1, true) ~= nil
+end
+
+--- Count non-overlapping occurrences of a substring.
+--- Plain-text search; the substring is not a Lua pattern.
+--- The empty substring counts as zero occurrences.
+--- @param s string The string to search
+--- @param sub string The substring to count
+--- @return integer Number of non-overlapping occurrences
+local function count(s: string, sub: string): integer
+  if sub == "" then
+    return 0
+  end
+  local n = 0
+  local pos = 1
+  while true do
+    local found = s:find(sub, pos, true)
+    if not found then
+      return n
+    end
+    n = n + 1
+    pos = found + #sub
+  end
+end
+
+--- Replace occurrences of a substring with plain text.
+--- Both old and new are treated literally (no Lua patterns, unlike
+--- string.gsub). Replaces all occurrences unless max is given.
+--- An empty old string returns s unchanged.
+--- @param s string The string to operate on
+--- @param old string The substring to replace
+--- @param new string The replacement text
+--- @param max integer? Maximum number of replacements (default unlimited)
+--- @return string The string with replacements applied
+local function replace(s: string, old: string, new: string, max?: integer): string
+  if old == "" or max == 0 then
+    return s
+  end
+  local parts: {string} = {}
+  local n = 0
+  local done = 0
+  local pos = 1
+  while true do
+    local found = s:find(old, pos, true)
+    if not found or (max and done >= max) then
+      n = n + 1
+      parts[n] = s:sub(pos)
+      break
+    end
+    n = n + 1
+    parts[n] = s:sub(pos, found - 1)
+    n = n + 1
+    parts[n] = new
+    done = done + 1
+    pos = found + #old
+  end
+  return table.concat(parts)
+end
+
+--- Split a string into lines.
+--- Lines are separated by "\n"; a trailing "\r" on each line (from
+--- "\r\n" endings) is removed. A final trailing newline does not
+--- produce an extra empty line. The empty string yields no lines.
+--- @param s string The string to split
+--- @return {string} Array of lines without their line endings
+local function lines(s: string): {string}
+  local result: {string} = {}
+  if s == "" then
+    return result
+  end
+  if s:sub(-1) == "\n" then
+    s = s:sub(1, -2)
+  end
+  local n = 0
+  for line in (s .. "\n"):gmatch("(.-)\n") do
+    if line:sub(-1) == "\r" then
+      line = line:sub(1, -2)
+    end
+    n = n + 1
+    result[n] = line
+  end
+  return result
+end
+
+--- Split the string at the first occurrence of a separator.
+--- Plain-text search. If the separator is not found (or is empty),
+--- returns the whole string followed by two empty strings.
+--- @param s string The string to partition
+--- @param sep string The separator to split at
+--- @return string The part before the separator (or all of s)
+--- @return string The separator if found, otherwise ""
+--- @return string The part after the separator, otherwise ""
+local function partition(s: string, sep: string): string, string, string
+  if sep == "" then
+    return s, "", ""
+  end
+  local found = s:find(sep, 1, true)
+  if not found then
+    return s, "", ""
+  end
+  return s:sub(1, found - 1), sep, s:sub(found + #sep)
+end
+
+--- Split a string around runs of whitespace.
+--- Leading and trailing whitespace is ignored; the result contains
+--- no empty strings. A blank or empty string yields no fields.
+--- @param s string The string to split
+--- @return {string} Array of whitespace-separated fields
+local function fields(s: string): {string}
+  local result: {string} = {}
+  local n = 0
+  for field in s:gmatch("%S+") do
+    n = n + 1
+    result[n] = field
+  end
+  return result
+end
+
+--- Pad a string on the left to a minimum width.
+--- The pad string (default " ") is repeated as needed and truncated
+--- so the result is exactly width characters. Strings already at
+--- least width long are returned unchanged, as is any input when
+--- the pad string is empty.
+--- @param s string The string to pad
+--- @param width integer Minimum width of the result
+--- @param pad string? Padding text (default " ")
+--- @return string The padded string
+local function pad_left(s: string, width: integer, pad?: string): string
+  pad = pad or " "
+  local need = width - #s
+  if need <= 0 or pad == "" then
+    return s
+  end
+  local fill = pad:rep(math.ceil(need / #pad)):sub(1, need)
+  return fill .. s
+end
+
+--- Pad a string on the right to a minimum width.
+--- The pad string (default " ") is repeated as needed and truncated
+--- so the result is exactly width characters. Strings already at
+--- least width long are returned unchanged, as is any input when
+--- the pad string is empty.
+--- @param s string The string to pad
+--- @param width integer Minimum width of the result
+--- @param pad string? Padding text (default " ")
+--- @return string The padded string
+local function pad_right(s: string, width: integer, pad?: string): string
+  pad = pad or " "
+  local need = width - #s
+  if need <= 0 or pad == "" then
+    return s
+  end
+  local fill = pad:rep(math.ceil(need / #pad)):sub(1, need)
+  return s .. fill
+end
+
+--- Remove common leading whitespace from all lines.
+--- The margin is the longest whitespace prefix shared by every
+--- non-blank line; blank (empty or whitespace-only) lines are ignored
+--- when computing it and have the margin stripped where present.
+--- Line endings are preserved.
+--- @param s string The string to dedent
+--- @return string The dedented string
+local function dedent(s: string): string
+  local margin: string | nil = nil
+  for _, line in ipairs(split(s, "\n")) do
+    if line:find("%S") then
+      local prefix: string = line:match("^[ \t]*")
+      if margin == nil then
+        margin = prefix
+      else
+        local m = margin as string
+        local i = 0
+        local limit = math.min(#m, #prefix)
+        while i < limit and prefix:sub(i + 1, i + 1) == string.sub(m, i + 1, i + 1) do
+          i = i + 1
+        end
+        margin = string.sub(m, 1, i)
+      end
+    end
+  end
+  if margin == nil or margin == "" then
+    return s
+  end
+  local m = margin as string
+  local out: {string} = {}
+  for i, line in ipairs(split(s, "\n")) do
+    if line:sub(1, #m) == m then
+      out[i] = line:sub(#m + 1)
+    else
+      out[i] = line
+    end
+  end
+  return table.concat(out, "\n")
+end
+
+--- Prefix each non-blank line of a string.
+--- Blank (empty or whitespace-only) lines are left unchanged.
+--- Line endings are preserved.
+--- @param s string The string to indent
+--- @param prefix string The prefix to add to each non-blank line
+--- @return string The indented string
+local function indent(s: string, prefix: string): string
+  local out: {string} = {}
+  for i, line in ipairs(split(s, "\n")) do
+    if line:find("%S") then
+      out[i] = prefix .. line
+    else
+      out[i] = line
+    end
+  end
+  return table.concat(out, "\n")
+end
+
+--- Truncate a string to a maximum width, appending a suffix when cut.
+--- Widths count bytes, not display characters. Strings at most width
+--- long are returned unchanged. Otherwise the result is exactly width
+--- bytes ending in the suffix (default "..."); if width is too small
+--- to fit the suffix, the string is hard-cut to width without it.
+--- @param s string The string to truncate
+--- @param width integer Maximum width of the result
+--- @param suffix string? Marker appended when truncated (default "...")
+--- @return string The truncated string
+local function truncate(s: string, width: integer, suffix?: string): string
+  if #s <= width then
+    return s
+  end
+  if width <= 0 then
+    return ""
+  end
+  suffix = suffix or "..."
+  local keep = width - #suffix
+  if keep < 1 then
+    return s:sub(1, width)
+  end
+  return s:sub(1, keep) .. suffix
+end
+
+--- Quote a string for use as a single word in a POSIX shell.
+--- Safe strings (alphanumerics and ._-/=:,+@%) are returned unchanged;
+--- everything else is wrapped in single quotes with embedded single
+--- quotes escaped. The empty string quotes to ''.
+--- @param s string The string to quote
+--- @return string The shell-quoted string
+local function shell_quote(s: string): string
+  if s == "" then
+    return "''"
+  end
+  if s:match("^[%w%._%-/=:,+@%%]+$") then
+    return s
+  end
+  return "'" .. (s:gsub("'", "'\\''")) .. "'"
+end
+
 local record StringModule
   capitalize: function(s: string): string
   trim: function(s: string): string
@@ -99,6 +368,18 @@ local record StringModule
   split: function(s: string, sep: string): {string}
   starts_with: function(s: string, prefix: string): boolean
   ends_with: function(s: string, suffix: string): boolean
+  contains: function(s: string, sub: string): boolean
+  count: function(s: string, sub: string): integer
+  replace: function(s: string, old: string, new: string, max?: integer): string
+  lines: function(s: string): {string}
+  partition: function(s: string, sep: string): string, string, string
+  fields: function(s: string): {string}
+  pad_left: function(s: string, width: integer, pad?: string): string
+  pad_right: function(s: string, width: integer, pad?: string): string
+  dedent: function(s: string): string
+  indent: function(s: string, prefix: string): string
+  truncate: function(s: string, width: integer, suffix?: string): string
+  shell_quote: function(s: string): string
 end
 
 local M: StringModule = {
@@ -109,6 +390,18 @@ local M: StringModule = {
   split = split,
   starts_with = starts_with,
   ends_with = ends_with,
+  contains = contains,
+  count = count,
+  replace = replace,
+  lines = lines,
+  partition = partition,
+  fields = fields,
+  pad_left = pad_left,
+  pad_right = pad_right,
+  dedent = dedent,
+  indent = indent,
+  truncate = truncate,
+  shell_quote = shell_quote,
 }
 
 return M

--- a/lib/cosmic/string_format_test.tl
+++ b/lib/cosmic/string_format_test.tl
@@ -1,0 +1,175 @@
+#!/usr/bin/env cosmic
+local str = require("cosmic.string")
+
+-- pad_left tests
+
+local function test_pad_left_basic()
+  assert(str.pad_left("5", 3) == "  5", "expected '  5'")
+  assert(str.pad_left("5", 3, "0") == "005", "expected '005'")
+end
+test_pad_left_basic()
+
+local function test_pad_left_already_wide()
+  assert(str.pad_left("hello", 3) == "hello", "expected unchanged")
+  assert(str.pad_left("abc", 3) == "abc", "expected exact width unchanged")
+end
+test_pad_left_already_wide()
+
+local function test_pad_left_multichar_pad()
+  assert(str.pad_left("x", 6, "ab") == "ababax", "expected 'ababax'")
+  assert(str.pad_left("x", 4, "abc") == "abcx", "expected 'abcx'")
+end
+test_pad_left_multichar_pad()
+
+local function test_pad_left_edges()
+  assert(str.pad_left("", 3) == "   ", "expected three spaces")
+  assert(str.pad_left("x", 0) == "x", "expected zero width unchanged")
+  assert(str.pad_left("x", 5, "") == "x", "expected empty pad unchanged")
+end
+test_pad_left_edges()
+
+-- pad_right tests
+
+local function test_pad_right_basic()
+  assert(str.pad_right("5", 3) == "5  ", "expected '5  '")
+  assert(str.pad_right("5", 3, "0") == "500", "expected '500'")
+end
+test_pad_right_basic()
+
+local function test_pad_right_already_wide()
+  assert(str.pad_right("hello", 3) == "hello", "expected unchanged")
+  assert(str.pad_right("abc", 3) == "abc", "expected exact width unchanged")
+end
+test_pad_right_already_wide()
+
+local function test_pad_right_multichar_pad()
+  assert(str.pad_right("x", 6, "ab") == "xababa", "expected 'xababa'")
+  assert(str.pad_right("x", 4, "abc") == "xabc", "expected 'xabc'")
+end
+test_pad_right_multichar_pad()
+
+local function test_pad_right_edges()
+  assert(str.pad_right("", 3) == "   ", "expected three spaces")
+  assert(str.pad_right("x", 0) == "x", "expected zero width unchanged")
+  assert(str.pad_right("x", 5, "") == "x", "expected empty pad unchanged")
+end
+test_pad_right_edges()
+
+-- dedent tests
+
+local function test_dedent_basic()
+  assert(str.dedent("  a\n  b") == "a\nb", "expected common margin removed")
+  assert(str.dedent("    a\n      b") == "a\n  b", "expected relative indent kept")
+end
+test_dedent_basic()
+
+local function test_dedent_mixed_margins()
+  assert(str.dedent("    a\n  b") == "  a\nb", "expected shortest margin removed")
+  assert(str.dedent("a\n  b") == "a\n  b", "expected no common margin")
+end
+test_dedent_mixed_margins()
+
+local function test_dedent_blank_lines_ignored()
+  assert(str.dedent("  a\n\n  b") == "a\n\nb", "expected blank line ignored for margin")
+  assert(str.dedent("  a\n \n  b") == "a\n \nb", "expected whitespace-only line ignored")
+end
+test_dedent_blank_lines_ignored()
+
+local function test_dedent_tabs()
+  assert(str.dedent("\ta\n\tb") == "a\nb", "expected tab margin removed")
+  assert(str.dedent("\ta\n  b") == "\ta\n  b", "expected tab/space mix unchanged")
+end
+test_dedent_tabs()
+
+local function test_dedent_edges()
+  assert(str.dedent("") == "", "expected empty unchanged")
+  assert(str.dedent("plain") == "plain", "expected unindented unchanged")
+  assert(str.dedent("  only") == "only", "expected single line dedented")
+end
+test_dedent_edges()
+
+-- indent tests
+
+local function test_indent_basic()
+  assert(str.indent("a\nb", "  ") == "  a\n  b", "expected both lines indented")
+  assert(str.indent("a", "> ") == "> a", "expected single line indented")
+end
+test_indent_basic()
+
+local function test_indent_blank_lines_skipped()
+  assert(str.indent("a\n\nb", "  ") == "  a\n\n  b", "expected empty line untouched")
+  assert(str.indent("a\n \nb", "  ") == "  a\n \n  b", "expected blank line untouched")
+end
+test_indent_blank_lines_skipped()
+
+local function test_indent_edges()
+  assert(str.indent("", "  ") == "", "expected empty unchanged")
+  assert(str.indent("a\nb", "") == "a\nb", "expected empty prefix unchanged")
+  assert(str.indent("a\nb\n", "  ") == "  a\n  b\n", "expected trailing newline kept")
+end
+test_indent_edges()
+
+-- truncate tests
+
+local function test_truncate_basic()
+  assert(str.truncate("hello world", 8) == "hello...", "expected 'hello...'")
+  assert(#str.truncate("hello world", 8) == 8, "expected exact width")
+end
+test_truncate_basic()
+
+local function test_truncate_no_cut()
+  assert(str.truncate("hello", 5) == "hello", "expected exact fit unchanged")
+  assert(str.truncate("hi", 10) == "hi", "expected short string unchanged")
+end
+test_truncate_no_cut()
+
+local function test_truncate_custom_suffix()
+  assert(str.truncate("hello world", 6, "~") == "hello~", "expected custom suffix")
+  assert(str.truncate("hello world", 5, "") == "hello", "expected bare cut with empty suffix")
+end
+test_truncate_custom_suffix()
+
+local function test_truncate_tiny_width()
+  assert(str.truncate("hello", 3) == "hel", "expected hard cut when suffix does not fit")
+  assert(str.truncate("hello", 0) == "", "expected empty at width 0")
+end
+test_truncate_tiny_width()
+
+-- shell_quote tests
+
+local function test_shell_quote_safe_unchanged()
+  assert(str.shell_quote("hello") == "hello", "expected safe word unchanged")
+  assert(str.shell_quote("a/b.c-d_e") == "a/b.c-d_e", "expected path unchanged")
+  assert(str.shell_quote("K=V,x:y+z@h%1") == "K=V,x:y+z@h%1", "expected safe symbols unchanged")
+end
+test_shell_quote_safe_unchanged()
+
+local function test_shell_quote_spaces_and_specials()
+  assert(str.shell_quote("hello world") == "'hello world'", "expected quoted")
+  assert(str.shell_quote("a$b") == "'a$b'", "expected $ quoted")
+  assert(str.shell_quote("a;rm -rf") == "'a;rm -rf'", "expected ; quoted")
+  assert(str.shell_quote("a\"b") == "'a\"b'", "expected double quote quoted")
+  assert(str.shell_quote("a*b") == "'a*b'", "expected glob quoted")
+end
+test_shell_quote_spaces_and_specials()
+
+local function test_shell_quote_single_quotes()
+  assert(str.shell_quote("it's") == "'it'\\''s'", "expected embedded quote escaped")
+  assert(str.shell_quote("'") == "''\\'''", "expected lone quote escaped")
+end
+test_shell_quote_single_quotes()
+
+local function test_shell_quote_empty()
+  assert(str.shell_quote("") == "''", "expected empty quoted as ''")
+end
+test_shell_quote_empty()
+
+local function test_shell_quote_roundtrip()
+  local child = require("cosmic.child")
+  local payload = "it's a $test; with \"quotes\" and *globs*"
+  local result, err = child.run({"/bin/sh", "-c", "printf %s " .. str.shell_quote(payload)})
+  assert(result, "sh failed: " .. tostring(err))
+  local out = (result as child.Result).stdout
+  assert(out == payload, "expected round-trip through sh, got: " .. tostring(out))
+end
+test_shell_quote_roundtrip()

--- a/lib/cosmic/string_search_test.tl
+++ b/lib/cosmic/string_search_test.tl
@@ -1,0 +1,185 @@
+#!/usr/bin/env cosmic
+local str = require("cosmic.string")
+
+-- contains tests
+
+local function test_contains_basic()
+  assert(str.contains("hello world", "world"), "expected true")
+  assert(str.contains("hello", "hello"), "expected true for exact match")
+  assert(not str.contains("hello", "xyz"), "expected false")
+end
+test_contains_basic()
+
+local function test_contains_plain_text()
+  assert(str.contains("a.b", "."), "expected literal dot to match")
+  assert(not str.contains("axb", "."), "expected no pattern matching")
+  assert(str.contains("50%", "%"), "expected literal percent to match")
+end
+test_contains_plain_text()
+
+local function test_contains_empty()
+  assert(str.contains("hello", ""), "expected empty substring contained")
+  assert(str.contains("", ""), "expected empty in empty")
+  assert(not str.contains("", "a"), "expected false for empty string")
+end
+test_contains_empty()
+
+-- count tests
+
+local function test_count_basic()
+  assert(str.count("banana", "an") == 2, "expected 2")
+  assert(str.count("banana", "a") == 3, "expected 3")
+  assert(str.count("banana", "x") == 0, "expected 0")
+end
+test_count_basic()
+
+local function test_count_non_overlapping()
+  assert(str.count("aaaa", "aa") == 2, "expected non-overlapping count of 2")
+end
+test_count_non_overlapping()
+
+local function test_count_plain_text()
+  assert(str.count("a.b.c", ".") == 2, "expected literal dots counted")
+  assert(str.count("abc", ".") == 0, "expected no pattern matching")
+end
+test_count_plain_text()
+
+local function test_count_empty()
+  assert(str.count("hello", "") == 0, "expected 0 for empty substring")
+  assert(str.count("", "a") == 0, "expected 0 for empty string")
+end
+test_count_empty()
+
+-- replace tests
+
+local function test_replace_basic()
+  assert(str.replace("a-b-c", "-", "+") == "a+b+c", "expected all replaced")
+  assert(str.replace("hello", "l", "L") == "heLLo", "expected heLLo")
+  assert(str.replace("hello", "x", "y") == "hello", "expected unchanged")
+end
+test_replace_basic()
+
+local function test_replace_plain_text()
+  assert(str.replace("a.b.c", ".", "-") == "a-b-c", "expected literal dots replaced")
+  assert(str.replace("100%", "%", " pct") == "100 pct", "expected literal percent")
+  assert(str.replace("a1b", "1", "%0") == "a%0b", "expected literal replacement text")
+end
+test_replace_plain_text()
+
+local function test_replace_max()
+  assert(str.replace("a-b-c-d", "-", "+", 2) == "a+b+c-d", "expected first 2 replaced")
+  assert(str.replace("a-b-c", "-", "+", 0) == "a-b-c", "expected max=0 unchanged")
+  assert(str.replace("a-b-c", "-", "+", 99) == "a+b+c", "expected large max ok")
+end
+test_replace_max()
+
+local function test_replace_multichar_and_growth()
+  assert(str.replace("ababab", "ab", "xyz") == "xyzxyzxyz", "expected xyzxyzxyz")
+  assert(str.replace("aaa", "aa", "b") == "ba", "expected non-overlapping replace")
+  assert(str.replace("abc", "b", "") == "ac", "expected deletion")
+end
+test_replace_multichar_and_growth()
+
+local function test_replace_empty_old()
+  assert(str.replace("abc", "", "x") == "abc", "expected empty old to be a no-op")
+end
+test_replace_empty_old()
+
+-- lines tests
+
+local function test_lines_basic()
+  local ls = str.lines("a\nb\nc")
+  assert(#ls == 3, "expected 3 lines, got " .. #ls)
+  assert(ls[1] == "a" and ls[2] == "b" and ls[3] == "c", "expected a,b,c")
+end
+test_lines_basic()
+
+local function test_lines_trailing_newline()
+  local ls = str.lines("a\nb\n")
+  assert(#ls == 2, "expected 2 lines, got " .. #ls)
+  assert(ls[1] == "a" and ls[2] == "b", "expected a,b")
+end
+test_lines_trailing_newline()
+
+local function test_lines_crlf()
+  local ls = str.lines("a\r\nb\r\n")
+  assert(#ls == 2, "expected 2 lines, got " .. #ls)
+  assert(ls[1] == "a" and ls[2] == "b", "expected CR stripped")
+end
+test_lines_crlf()
+
+local function test_lines_empty_and_blank()
+  assert(#str.lines("") == 0, "expected no lines for empty string")
+  local ls = str.lines("\n")
+  assert(#ls == 1 and ls[1] == "", "expected one empty line")
+  ls = str.lines("a\n\nb")
+  assert(#ls == 3 and ls[2] == "", "expected inner empty line preserved")
+end
+test_lines_empty_and_blank()
+
+local function test_lines_no_newline()
+  local ls = str.lines("solo")
+  assert(#ls == 1 and ls[1] == "solo", "expected single line")
+end
+test_lines_no_newline()
+
+-- partition tests
+
+local function test_partition_found()
+  local before, sep, after = str.partition("key=value", "=")
+  assert(before == "key", "expected key, got " .. before)
+  assert(sep == "=", "expected =")
+  assert(after == "value", "expected value, got " .. after)
+end
+test_partition_found()
+
+local function test_partition_first_occurrence()
+  local before, sep, after = str.partition("a=b=c", "=")
+  assert(before == "a" and sep == "=" and after == "b=c", "expected split at first =")
+end
+test_partition_first_occurrence()
+
+local function test_partition_not_found()
+  local before, sep, after = str.partition("hello", "=")
+  assert(before == "hello", "expected whole string")
+  assert(sep == "" and after == "", "expected empty sep and after")
+end
+test_partition_not_found()
+
+local function test_partition_edges()
+  local before, sep, after = str.partition("=v", "=")
+  assert(before == "" and sep == "=" and after == "v", "expected empty before")
+  before, sep, after = str.partition("k=", "=")
+  assert(before == "k" and sep == "=" and after == "", "expected empty after")
+  before, sep, after = str.partition("abc", "")
+  assert(before == "abc" and sep == "" and after == "", "expected empty sep no-op")
+end
+test_partition_edges()
+
+local function test_partition_multichar()
+  local before, sep, after = str.partition("a::b::c", "::")
+  assert(before == "a" and sep == "::" and after == "b::c", "expected multichar sep")
+end
+test_partition_multichar()
+
+-- fields tests
+
+local function test_fields_basic()
+  local fs = str.fields("a b c")
+  assert(#fs == 3, "expected 3 fields, got " .. #fs)
+  assert(fs[1] == "a" and fs[2] == "b" and fs[3] == "c", "expected a,b,c")
+end
+test_fields_basic()
+
+local function test_fields_runs_and_edges()
+  local fs = str.fields("  a \t b\n\nc  ")
+  assert(#fs == 3, "expected 3 fields, got " .. #fs)
+  assert(fs[1] == "a" and fs[2] == "b" and fs[3] == "c", "expected a,b,c")
+end
+test_fields_runs_and_edges()
+
+local function test_fields_empty()
+  assert(#str.fields("") == 0, "expected no fields for empty string")
+  assert(#str.fields("  \t\n ") == 0, "expected no fields for blank string")
+end
+test_fields_empty()


### PR DESCRIPTION
Part of #501 (§4.2 umbrella) — completes the **string (P1)** checklist item.

## What's added

Twelve new functions on `cosmic.string`, all infallible and all plain-text (no Lua patterns), matching the module's existing style:

- **search**: `contains`, `count` (non-overlapping), `partition` (split at first occurrence, returns before/sep/after)
- **transform**: `replace` (literal old/new, optional max), `lines` (handles `\n` and `\r\n`, no phantom trailing line), `fields` (whitespace-separated, awk-style)
- **format**: `pad_left`/`pad_right` (repeating pad string, exact width), `dedent` (common leading-whitespace margin, blank lines ignored), `indent` (prefix non-blank lines), `truncate` (byte widths, suffix default `...`, hard-cut when suffix doesn't fit)
- **quoting**: `shell_quote` (POSIX single-quote escaping; safe words pass through unchanged)

Edge-case semantics are documented on each function (empty substring/separator behavior, byte-not-character widths, etc.).

## Tests

Two new test files (kept separate to respect the 500-line cap): `string_search_test.tl` and `string_format_test.tl`, covering plain-text (non-pattern) behavior, empty/edge inputs, CRLF handling, non-overlapping counting, and a `shell_quote` round-trip through `/bin/sh` via `cosmic.child`.

`bin/make ci` passes: format + teal (263), test (123), example (21), lint (329), coverage ratchet.

## Status of the rest of #501

Surveyed while scoping this PR — much of the umbrella has already landed on main: fs `copy`/`copytree`/`move`/`touch`/`write_atomic`, fetch redirects, net `dial`, sqlite `busy_timeout`/open options, json pretty/sorted, codec crc32, rand `int`, zip typed opens + `extract`. Remaining gaps for follow-up PRs: fs `expanduser`/`home`, net `sendall`/`recv_exact`/`readline`/`set_timeout`, sqlite `query_value`/savepoints, re `gsub`/`findall`/`split`, codec base64url, ip CIDR, rand `float`/`choice`/`shuffle`/`token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi)_