### PR TITLE
net: add Socket sendall, recv_exact, readline, set_timeout (#501)

### DIFF
--- a/lib/cosmic/net/io_test.tl
+++ b/lib/cosmic/net/io_test.tl
@@ -1,0 +1,209 @@
+#!/usr/bin/env cosmic
+local net = require("cosmic.net")
+
+local function pair(): net.Socket, net.Socket
+  local a, b, err = net.socketpair()
+  assert(a ~= nil and b ~= nil, "socketpair failed: " .. tostring(err))
+  return a as net.Socket, b
+end
+
+-- sendall tests
+
+local function test_sendall_basic()
+  local a, b = pair()
+  local ok, err = a:sendall("hello world")
+  assert(ok, "sendall failed: " .. tostring(err))
+  local data = b:recv()
+  assert(data == "hello world", "expected payload, got: " .. tostring(data))
+  a:close()
+  b:close()
+end
+test_sendall_basic()
+
+local function test_sendall_empty()
+  local a, b = pair()
+  local ok, err = a:sendall("")
+  assert(ok, "sendall of empty string failed: " .. tostring(err))
+  a:close()
+  b:close()
+end
+test_sendall_empty()
+
+local function test_sendall_large()
+  local a, b = pair()
+  local payload = string.rep("x", 64 * 1024)
+  local ok, err = a:sendall(payload)
+  assert(ok, "sendall failed: " .. tostring(err))
+  local data, rerr = b:recv_exact(#payload)
+  assert(data == payload, "expected 64KiB round-trip: " .. tostring(rerr))
+  a:close()
+  b:close()
+end
+test_sendall_large()
+
+local function test_sendall_closed_socket()
+  local a, b = pair()
+  a:close()
+  local ok, err = a:sendall("data")
+  assert(not ok, "expected sendall on closed socket to fail")
+  assert(err ~= nil, "expected an error message")
+  b:close()
+end
+test_sendall_closed_socket()
+
+-- recv_exact tests
+
+local function test_recv_exact_across_sends()
+  local a, b = pair()
+  assert(a:sendall("hello"))
+  assert(a:sendall("world"))
+  local data, err = b:recv_exact(10)
+  assert(data == "helloworld", "expected coalesced read: " .. tostring(err))
+  a:close()
+  b:close()
+end
+test_recv_exact_across_sends()
+
+local function test_recv_exact_leaves_rest()
+  local a, b = pair()
+  assert(a:sendall("abcdef"))
+  local head = b:recv_exact(3)
+  assert(head == "abc", "expected first 3 bytes, got: " .. tostring(head))
+  local rest = b:recv_exact(3)
+  assert(rest == "def", "expected remaining bytes, got: " .. tostring(rest))
+  a:close()
+  b:close()
+end
+test_recv_exact_leaves_rest()
+
+local function test_recv_exact_zero()
+  local a, b = pair()
+  local data, err = b:recv_exact(0)
+  assert(data == "", "expected empty string for n=0: " .. tostring(err))
+  a:close()
+  b:close()
+end
+test_recv_exact_zero()
+
+local function test_recv_exact_early_close()
+  local a, b = pair()
+  assert(a:sendall("abc"))
+  a:shutdown()
+  local data, err = b:recv_exact(5)
+  assert(data == nil, "expected failure on short stream")
+  assert(err and err:find("3 of 5", 1, true), "expected byte counts in error, got: " .. tostring(err))
+  a:close()
+  b:close()
+end
+test_recv_exact_early_close()
+
+-- readline tests
+
+local function test_readline_basic()
+  local a, b = pair()
+  assert(a:sendall("alpha\nbeta\r\ngamma"))
+  a:shutdown()
+  assert(b:readline() == "alpha", "expected first line")
+  assert(b:readline() == "beta", "expected CRLF stripped")
+  assert(b:readline() == "gamma", "expected final unterminated line")
+  local eof, err = b:readline()
+  assert(eof == nil and err == nil, "expected bare nil at end of stream, got: " .. tostring(err))
+  a:close()
+  b:close()
+end
+test_readline_basic()
+
+local function test_readline_empty_line()
+  local a, b = pair()
+  assert(a:sendall("first\n\nsecond\n"))
+  a:shutdown()
+  assert(b:readline() == "first", "expected first line")
+  assert(b:readline() == "", "expected empty line preserved")
+  assert(b:readline() == "second", "expected second line")
+  assert(b:readline() == nil, "expected end of stream")
+  a:close()
+  b:close()
+end
+test_readline_empty_line()
+
+local function test_readline_leaves_rest_for_recv()
+  local a, b = pair()
+  assert(a:sendall("line\nbinary-tail"))
+  a:shutdown()
+  assert(b:readline() == "line", "expected line")
+  local rest = b:recv_exact(11)
+  assert(rest == "binary-tail", "expected bytes after newline untouched, got: " .. tostring(rest))
+  a:close()
+  b:close()
+end
+test_readline_leaves_rest_for_recv()
+
+local function test_readline_max()
+  local a, b = pair()
+  assert(a:sendall("abcdef\n"))
+  local head = b:readline(3)
+  assert(head == "abc", "expected max-bounded read, got: " .. tostring(head))
+  local rest = b:readline()
+  assert(rest == "def", "expected remainder as next line, got: " .. tostring(rest))
+  a:close()
+  b:close()
+end
+test_readline_max()
+
+local function test_readline_long_line_multiple_chunks()
+  local a, b = pair()
+  local long = string.rep("z", 10000)
+  assert(a:sendall(long .. "\nnext\n"))
+  local line = b:readline()
+  assert(line == long, "expected 10k line reassembled")
+  assert(b:readline() == "next", "expected following line")
+  a:close()
+  b:close()
+end
+test_readline_long_line_multiple_chunks()
+
+-- set_timeout tests
+
+local function test_set_timeout_recv_times_out()
+  local a, b = pair()
+  local ok, serr = b:set_timeout(50)
+  assert(ok, "set_timeout failed: " .. tostring(serr))
+  local data, err = b:recv()
+  assert(data == nil, "expected recv to time out")
+  assert(err ~= nil, "expected a timeout error, not end of stream")
+  a:close()
+  b:close()
+end
+test_set_timeout_recv_times_out()
+
+local function test_set_timeout_clear_restores_blocking()
+  local a, b = pair()
+  assert(b:set_timeout(50))
+  assert(b:set_timeout())
+  assert(a:sendall("ping"))
+  local data = b:recv()
+  assert(data == "ping", "expected recv to work after clearing timeout")
+  a:close()
+  b:close()
+end
+test_set_timeout_clear_restores_blocking()
+
+local function test_set_timeout_readline_times_out()
+  local a, b = pair()
+  assert(b:set_timeout(50))
+  assert(a:sendall("partial-without-newline"))
+  local line, err = b:readline()
+  assert(line == nil and err ~= nil, "expected readline to time out on missing newline")
+  a:close()
+  b:close()
+end
+test_set_timeout_readline_times_out()
+
+local function test_set_timeout_closed_socket()
+  local a, b = pair()
+  a:close()
+  local ok, err = a:set_timeout(100)
+  assert(not ok and err ~= nil, "expected set_timeout on closed socket to fail")
+  b:close()
+end
+test_set_timeout_closed_socket()

--- a/lib/cosmic/net/socket.tl
+++ b/lib/cosmic/net/socket.tl
@@ -40,6 +40,10 @@ local record Socket
   shutdown: function(self: Socket, how?: number): boolean, string
   --- Send data; returns bytes sent, or nil + error.
   send: function(self: Socket, data: string, flags?: number): number | nil, string
+  --- Send all of data, retrying partial writes until done.
+  --- Returns false + error if any write fails; bytes already sent
+  --- before the failure stay sent.
+  sendall: function(self: Socket, data: string, flags?: number): boolean, string
   --- Send a datagram to addr:port; returns bytes sent, or nil + error.
   sendto: function(self: Socket, data: string, addr: Address, port: number, flags?: number): number | nil, string
   --- Receive up to bufsiz bytes (blocks until data arrives).
@@ -49,6 +53,17 @@ local record Socket
   --- nil + error message on failure. bufsiz must be positive when
   --- given (default 65536).
   recv: function(self: Socket, bufsiz?: number, flags?: number): string | nil, string
+  --- Receive exactly n bytes from a stream socket, blocking until they
+  --- arrive. Returns nil + error if the peer closes the connection
+  --- first (bytes read before the close are discarded).
+  recv_exact: function(self: Socket, n: number, flags?: number): string | nil, string
+  --- Read one line from a stream socket, blocking until a "\n" arrives.
+  --- The trailing "\n" (and a "\r" before it) is consumed but not
+  --- returned. At end of stream a final unterminated line is returned
+  --- as-is; after that (or on an empty stream) returns bare nil, matching
+  --- the stream contract. With max set, returns at most max bytes even
+  --- if no newline was seen (the rest stays readable), like fgets.
+  readline: function(self: Socket, max?: number): string | nil, string
   --- Receive a datagram; returns data, sender Addr, sender port.
   recvfrom: function(self: Socket, bufsiz?: number, flags?: number): string | nil, ip.Addr, number, string
   --- Local address as (Addr, port); use after bind for the real port.
@@ -74,6 +89,10 @@ local record Socket
   setsockopt: function(self: Socket, level: number, optname: number, value: number | boolean): boolean, string
   --- Switch O_NONBLOCK on (default) or off for this socket.
   set_nonblocking: function(self: Socket, enable?: boolean): boolean, string
+  --- Set a timeout in milliseconds for blocking sends and receives
+  --- (SO_RCVTIMEO + SO_SNDTIMEO). Timed-out operations fail with an
+  --- EAGAIN error. nil or 0 clears the timeout (block forever).
+  set_timeout: function(self: Socket, ms?: number): boolean, string
 end
 
 --- Create a socket handle from a file descriptor.
@@ -126,6 +145,18 @@ local function make_socket(fd: number): Socket
     return n
   end
 
+  function sock:sendall(data: string, flags?: number): boolean, string
+    local off: integer = 0
+    while off < #data do
+      local n, err = self:send(data:sub(off + 1), flags)
+      if not n then
+        return false, err
+      end
+      off = off + math.floor(n)
+    end
+    return true
+  end
+
   function sock:sendto(data: string, addr: Address, port: number, flags?: number): number | nil, string
     if not self.fd then return nil, "socket closed" end
     local raw, aerr = resolve_addr(addr)
@@ -158,6 +189,75 @@ local function make_socket(fd: number): Socket
       end
     end
     return data
+  end
+
+  function sock:recv_exact(n: number, flags?: number): string | nil, string
+    local parts: {string} = {}
+    local got = 0
+    while got < n do
+      local chunk, err = self:recv(n - got, flags)
+      if not chunk then
+        if err then
+          return nil, err
+        end
+        return nil, "recv_exact: connection closed after " .. got .. " of " .. n .. " bytes"
+      end
+      parts[#parts + 1] = chunk
+      got = got + #chunk
+    end
+    return table.concat(parts)
+  end
+
+  function sock:readline(max?: number): string | nil, string
+    if not self.fd then return nil, "socket closed" end
+    local parts: {string} = {}
+    local total = 0
+    local saw_newline = false
+    while true do
+      -- Peek without consuming, then consume exactly through the newline,
+      -- so bytes past the line stay readable by recv/recv_exact.
+      local data, err = unix.recv(self.fd, 4096, unix.MSG_PEEK)
+      if not data then
+        return nil, errstr(err, "readline")
+      end
+      local d = data as string
+      if d == "" then
+        -- End of stream: hand back a final unterminated line if any.
+        if total == 0 then
+          return nil
+        end
+        break
+      end
+      local nl = string.find(d, "\n", 1, true)
+      local take: integer = nl or #d
+      if max and total + take > max then
+        take = math.floor(max - total)
+        nl = nil
+      end
+      if take > 0 then
+        local chunk, cerr = self:recv_exact(take)
+        if not chunk then
+          return nil, cerr
+        end
+        parts[#parts + 1] = chunk
+        total = total + take
+      end
+      if nl then
+        saw_newline = true
+        break
+      end
+      if max and total >= max then
+        break
+      end
+    end
+    local line = table.concat(parts)
+    if saw_newline then
+      line = line:sub(1, -2)
+      if line:sub(-1) == "\r" then
+        line = line:sub(1, -2)
+      end
+    end
+    return line
   end
 
   function sock:recvfrom(bufsiz?: number, flags?: number): string | nil, ip.Addr, number, string
@@ -282,6 +382,25 @@ local function make_socket(fd: number): Socket
     local ok, serr = unix.fcntl(self.fd, unix.F_SETFL, want)
     if not ok then
       return false, errstr(serr, "set_nonblocking")
+    end
+    return true
+  end
+
+  function sock:set_timeout(ms?: number): boolean, string
+    if not self.fd then return false, "socket closed" end
+    ms = ms or 0
+    local secs = math.floor(ms / 1000)
+    local nanos = math.floor((ms % 1000) * 1000000)
+    -- The declared setsockopt signature takes one value; SO_RCVTIMEO and
+    -- SO_SNDTIMEO take (secs, nanos), so cast around it like bind_unix.
+    local sso = unix.setsockopt as function(number, number, number, number, number): (boolean, any)
+    local ok, err = sso(self.fd, unix.SOL_SOCKET, unix.SO_RCVTIMEO, secs, nanos)
+    if not ok then
+      return false, errstr(err, "set_timeout")
+    end
+    ok, err = sso(self.fd, unix.SOL_SOCKET, unix.SO_SNDTIMEO, secs, nanos)
+    if not ok then
+      return false, errstr(err, "set_timeout")
     end
     return true
   end


### PR DESCRIPTION
Part of #501 (§4.2 umbrella) — fills the stream-I/O half of the **net (P1)** item. `dial` already landed (#588); IPv6 remains blocked on upstream U5 (whilp/cosmopolitan#144).

## What's added

Four new methods on `cosmic.net` Socket:

- **`sendall(data, flags?)`** — loops `send` until every byte is written; `boolean, string`. Bytes sent before a failure stay sent (documented).
- **`recv_exact(n, flags?)`** — blocks until exactly n bytes arrive; returns `nil, err` with byte counts if the peer closes early. `n=0` returns `""`.
- **`readline(max?)`** — reads one line from a stream socket. Implementation peeks with `MSG_PEEK` and then consumes exactly through the newline, so bytes past the line stay readable by `recv`/`recv_exact` — no hidden user-space buffer on the socket. Strips the trailing `\n` (and a `\r` before it). A final unterminated line is returned as-is at EOF; after that, bare `nil` per the stream contract. `max` bounds the read fgets-style: at most max bytes are returned and the remainder stays readable.
- **`set_timeout(ms?)`** — applies `SO_RCVTIMEO` + `SO_SNDTIMEO` in milliseconds; timed-out operations fail with an EAGAIN error (distinguishable from bare-nil EOF). `nil`/`0` clears back to blocking.

No changes to existing method contracts.

## Tests

New `lib/cosmic/net/io_test.tl` over `socketpair`: 64 KiB `sendall` round-trip, `recv_exact` coalescing/short-stream error/zero-byte, `readline` for LF and CRLF, empty lines, a 10k-byte line spanning multiple peek windows, binary bytes after the newline staying readable, `max` bounding, and `set_timeout` expiry (for both `recv` and `readline`), clearing, and closed-socket failure.

`bin/make ci` passes: format + teal (264), test (124), example (21), lint (331), coverage ratchet.

## Remaining in #501

fs `expanduser`/`home`, sqlite `query_value`/savepoints, re `gsub`/`findall`/`split`, codec base64url, ip CIDR, rand `float`/`choice`/`shuffle`/`token`; net IPv6 blocked on U5, fs `touch` upstream dep landed earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi)_