### PR TITLE
sqlite: add db:query_value and db:savepoint (#501)

### DIFF
--- a/lib/cosmic/sqlite/extras.tl
+++ b/lib/cosmic/sqlite/extras.tl
@@ -1,0 +1,89 @@
+--- Internal helper for cosmic.sqlite: the query_value and savepoint
+--- conveniences attached onto a Database. Lives in its own file so
+--- cosmic/sqlite/init.tl stays under the 500-line cap.
+
+-- Mirrors of cosmic.sqlite's records (Teal records are nominal, so the
+-- boundary crosses through `any`; same convention as cosmic.sqlite.params).
+local record Values
+  metamethod __call: function(self: Values): any ...
+  err: function(self: Values): string
+end
+
+local record Stmt
+  bind: function(self: Stmt, ...: any): boolean, string
+  values: function(self: Stmt): Values
+  close: function(self: Stmt)
+end
+
+local record Db
+  prepare: function(self: Db, sql: string): Stmt | nil, string
+  exec: function(self: Db, sql: string, ...: any): boolean, string
+  query_value: function(self: Db, sql: string, ...: any): any, string
+  savepoint: function(self: Db, fn: function(any)): boolean, string
+end
+
+--- Attach query_value and savepoint to a Database under construction.
+--- The handle is typed `any` so cosmic.sqlite's nominal Database record
+--- doesn't need to be duplicated here.
+--- @param db_any any The Database being built by make_database
+local function attach(db_any: any)
+  local db = db_any as Db
+
+  --- Return the first column of the first row, for scalar lookups like
+  --- COUNT(*) or a single-value SELECT. Returns nil with no error both
+  --- when no row matches and when the value is SQL NULL; use query_one
+  --- when that distinction matters.
+  function db:query_value(sql: string, ...: any): any, string
+    local stmt, err = self:prepare(sql)
+    if not stmt then
+      return nil, "query failed: " .. (err or "unknown error")
+    end
+    local st = stmt as Stmt
+    local ok, bind_err = st:bind(...)
+    if not ok then
+      st:close()
+      return nil, "bind failed: " .. (bind_err or "unknown error")
+    end
+    local vals = st:values()
+    local v = vals()
+    st:close()
+    local step_err = vals:err()
+    if step_err then
+      return nil, step_err
+    end
+    return v
+  end
+
+  -- Savepoint names only have to be unique among currently-active
+  -- savepoints; a monotonic counter per database over-satisfies that.
+  local sp_counter = 0
+
+  --- Execute fn within a savepoint — a nestable transaction. SAVEPOINT
+  --- before fn; RELEASE if fn returns cleanly; ROLLBACK TO (then RELEASE)
+  --- if fn raises or signals failure the library way — a returned `false`,
+  --- or `nil` plus an error (nothing returned still releases). Inside a
+  --- transaction only the savepoint's own changes are rolled back; at the
+  --- top level a savepoint behaves like its own transaction.
+  function db:savepoint(fn: function(any)): boolean, string
+    sp_counter = sp_counter + 1
+    local name = "cosmic_sp_" .. sp_counter
+    local ok, err = self:exec("SAVEPOINT " .. name)
+    if not ok then
+      return false, err or "savepoint failed"
+    end
+    local success, result, result_err = pcall(fn, self) as(boolean, any, any)
+    if not success then
+      self:exec("ROLLBACK TO " .. name)
+      self:exec("RELEASE " .. name)
+      return false, (result as string) or "savepoint failed"
+    end
+    if result == false or (result == nil and result_err ~= nil) then
+      self:exec("ROLLBACK TO " .. name)
+      self:exec("RELEASE " .. name)
+      return false, (result_err as string) or "savepoint rolled back"
+    end
+    return self:exec("RELEASE " .. name)
+  end
+end
+
+return {attach = attach}

--- a/lib/cosmic/sqlite/extras_test.tl
+++ b/lib/cosmic/sqlite/extras_test.tl
@@ -1,0 +1,162 @@
+#!/usr/bin/env cosmic
+local sqlite = require("cosmic.sqlite")
+
+local function open_db(): sqlite.Database
+  local db, err = sqlite.open(":memory:")
+  assert(db ~= nil, "open failed: " .. tostring(err))
+  local d = db as sqlite.Database
+  assert(d:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, score REAL)"))
+  assert(d:exec("INSERT INTO t (name, score) VALUES ('alice', 1.5), ('bob', 2.5)"))
+  return d
+end
+
+-- query_value tests
+
+local function test_query_value_count()
+  local db = open_db()
+  local n, err = db:query_value("SELECT COUNT(*) FROM t")
+  assert(n == 2, "expected 2, got " .. tostring(n) .. " (" .. tostring(err) .. ")")
+  db:close()
+end
+test_query_value_count()
+
+local function test_query_value_with_params()
+  local db = open_db()
+  local name = db:query_value("SELECT name FROM t WHERE id = ?", 2)
+  assert(name == "bob", "expected bob, got " .. tostring(name))
+  local score = db:query_value("SELECT score FROM t WHERE name = ?", "alice")
+  assert(score == 1.5, "expected 1.5, got " .. tostring(score))
+  db:close()
+end
+test_query_value_with_params()
+
+local function test_query_value_first_column_first_row()
+  local db = open_db()
+  local v = db:query_value("SELECT name, score FROM t ORDER BY id")
+  assert(v == "alice", "expected first column of first row, got " .. tostring(v))
+  db:close()
+end
+test_query_value_first_column_first_row()
+
+local function test_query_value_no_rows()
+  local db = open_db()
+  local v, err = db:query_value("SELECT name FROM t WHERE id = ?", 999)
+  assert(v == nil, "expected nil for no rows")
+  assert(err == nil, "expected no error for no rows, got " .. tostring(err))
+  db:close()
+end
+test_query_value_no_rows()
+
+local function test_query_value_null()
+  local db = open_db()
+  assert(db:exec("INSERT INTO t (name, score) VALUES (NULL, 9.0)"))
+  local v, err = db:query_value("SELECT name FROM t WHERE score = 9.0")
+  assert(v == nil and err == nil, "expected nil, no error for SQL NULL")
+  db:close()
+end
+test_query_value_null()
+
+local function test_query_value_bad_sql()
+  local db = open_db()
+  local v, err = db:query_value("SELECT nope FROM missing")
+  assert(v == nil, "expected nil for bad SQL")
+  assert(err ~= nil, "expected an error message")
+  db:close()
+end
+test_query_value_bad_sql()
+
+local function test_query_value_closed_db()
+  local db = open_db()
+  db:close()
+  local v, err = db:query_value("SELECT 1")
+  assert(v == nil and err ~= nil, "expected failure on closed database")
+end
+test_query_value_closed_db()
+
+-- savepoint tests
+
+local function count(db: sqlite.Database): number
+  return db:query_value("SELECT COUNT(*) FROM t") as number
+end
+
+local function test_savepoint_commit()
+  local db = open_db()
+  local ok, err = db:savepoint(function(d: sqlite.Database)
+      assert(d:exec("INSERT INTO t (name) VALUES ('carol')"))
+    end)
+  assert(ok, "savepoint failed: " .. tostring(err))
+  assert(count(db) == 3, "expected insert to persist")
+  db:close()
+end
+test_savepoint_commit()
+
+local function test_savepoint_rollback_on_error()
+  local db = open_db()
+  local ok, err = db:savepoint(function(d: sqlite.Database)
+      assert(d:exec("INSERT INTO t (name) VALUES ('carol')"))
+      error("boom")
+    end)
+  assert(not ok, "expected savepoint to fail")
+  assert(err and err:find("boom", 1, true), "expected raised error surfaced, got " .. tostring(err))
+  assert(count(db) == 2, "expected insert rolled back")
+  db:close()
+end
+test_savepoint_rollback_on_error()
+
+local function test_savepoint_rollback_on_false()
+  local db = open_db()
+  local ok = db:savepoint(function(d: sqlite.Database): boolean
+      assert(d:exec("INSERT INTO t (name) VALUES ('carol')"))
+      return false
+    end as function(sqlite.Database))
+  assert(not ok, "expected savepoint to fail on returned false")
+  assert(count(db) == 2, "expected insert rolled back")
+  db:close()
+end
+test_savepoint_rollback_on_false()
+
+local function test_savepoint_rollback_on_nil_err()
+  local db = open_db()
+  local ok, err = db:savepoint(function(d: sqlite.Database): any, string
+      assert(d:exec("INSERT INTO t (name) VALUES ('carol')"))
+      return nil, "signaled failure"
+    end as function(sqlite.Database))
+  assert(not ok, "expected savepoint to fail on nil+err")
+  assert(err == "signaled failure", "expected error message, got " .. tostring(err))
+  assert(count(db) == 2, "expected insert rolled back")
+  db:close()
+end
+test_savepoint_rollback_on_nil_err()
+
+local function test_savepoint_nested_inner_rollback()
+  local db = open_db()
+  local ok, err = db:savepoint(function(d: sqlite.Database)
+      assert(d:exec("INSERT INTO t (name) VALUES ('outer')"))
+      local inner_ok = d:savepoint(function(d2: sqlite.Database): boolean
+          assert(d2:exec("INSERT INTO t (name) VALUES ('inner')"))
+          return false
+        end as function(sqlite.Database))
+      assert(not inner_ok, "expected inner savepoint to roll back")
+    end)
+  assert(ok, "outer savepoint failed: " .. tostring(err))
+  assert(count(db) == 3, "expected outer insert kept, inner rolled back")
+  assert(db:query_value("SELECT COUNT(*) FROM t WHERE name = 'inner'") == 0,
+    "expected inner insert gone")
+  db:close()
+end
+test_savepoint_nested_inner_rollback()
+
+local function test_savepoint_inside_transaction()
+  local db = open_db()
+  local ok, err = db:transaction(function(d: sqlite.Database)
+      assert(d:exec("INSERT INTO t (name) VALUES ('tx')"))
+      d:savepoint(function(d2: sqlite.Database): boolean
+          assert(d2:exec("INSERT INTO t (name) VALUES ('sp')"))
+          return false
+        end as function(sqlite.Database))
+    end)
+  assert(ok, "transaction failed: " .. tostring(err))
+  assert(count(db) == 3, "expected transaction insert kept, savepoint rolled back")
+  db:close()
+end
+test_savepoint_inside_transaction()

--- a/lib/cosmic/sqlite/init.tl
+++ b/lib/cosmic/sqlite/init.tl
@@ -22,6 +22,7 @@ local stmt_cache_mod = require("cosmic.sqlite.stmt_cache")
 local row_iter = require("cosmic.sqlite.row_iter")
 local bind_mod = require("cosmic.sqlite.bind")
 local params_mod = require("cosmic.sqlite.params")
+local extras_mod = require("cosmic.sqlite.extras")
 
 -- Raw lsqlite3 types (0-indexed, requires manual cleanup)
 local record RawStatement
@@ -103,10 +104,16 @@ local record Database
   query_list: function(self: Database, sql: string, values: {any}): Rows | nil, string
   query_named: function(self: Database, sql: string, params: {string: any}): Rows | nil, string
   query_one: function(self: Database, sql: string, ...: any): {string: any} | nil, string
+  --- First column of the first row (nil + no error when no row matches
+  --- or the value is SQL NULL); see cosmic.sqlite.extras.
+  query_value: function(self: Database, sql: string, ...: any): any, string
   exec: function(self: Database, sql: string, ...: any): boolean, string
   exec_list: function(self: Database, sql: string, values: {any}): boolean, string
   exec_named: function(self: Database, sql: string, params: {string: any}): boolean, string
   transaction: function(self: Database, fn: function(Database)): boolean, string
+  --- Run fn in a nestable savepoint with transaction's rollback rules;
+  --- see cosmic.sqlite.extras.
+  savepoint: function(self: Database, fn: function(Database)): boolean, string
   last_insert_rowid: function(self: Database): number
   changes: function(self: Database): number
   close: function(self: Database)
@@ -321,8 +328,10 @@ local function make_database(raw_db: RawDatabase): Database
 
   -- exec_list, exec_named, query_list, query_named live in
   -- cosmic.sqlite.params (same prepare/bind/consume shape, split out to
-  -- keep this file under the 500-line cap).
+  -- keep this file under the 500-line cap); query_value and savepoint
+  -- live in cosmic.sqlite.extras for the same reason.
   params_mod.attach(db)
+  extras_mod.attach(db)
 
   --- Return the first row matching a query, or nil if no rows match.
   --- Convenience method for single-row lookups.


### PR DESCRIPTION
Part of #501 (§4.2 umbrella) — completes the **sqlite (P1)** item (`busy_timeout` and open flags landed earlier in #610-era work).

## What's added

Two new methods on `cosmic.sqlite` Database, implemented in a new `cosmic.sqlite.extras` module using the same `attach` pattern as `cosmic.sqlite.params` so `init.tl` stays under the 500-line cap:

- **`db:query_value(sql, ...)`** — first column of the first row, for scalar lookups (`COUNT(*)`, single-value SELECTs). Returns `nil` with no error both when no row matches and when the value is SQL NULL (documented; use `query_one` when that distinction matters). Errors from prepare/bind/step surface as `nil, err`.
- **`db:savepoint(fn)`** — runs fn in a nestable savepoint with exactly `transaction`'s rollback rules: RELEASE if fn returns cleanly; ROLLBACK TO + RELEASE if fn raises, returns `false`, or returns `nil` plus an error. Names come from a per-database monotonic counter, so savepoints nest freely. Inside a transaction only the savepoint's changes roll back; at top level it behaves as its own transaction.

Both are declared with doc comments on the `Database` record so they show up in generated docs and the Teal surface.

## Tests

New `lib/cosmic/sqlite/extras_test.tl`: `query_value` with params, first-column/first-row selection, no-row nil, NULL nil, bad-SQL and closed-db errors; `savepoint` commit, rollback on raise / returned `false` / `nil+err`, nested inner-rollback-outer-commit, and savepoint-inside-transaction.

`bin/make ci` passes: format + teal (266), test (125), example (21), lint (332), coverage ratchet.

## Remaining in #501

fs `expanduser`/`home`, re `gsub`/`findall`/`split`, codec base64url, ip CIDR, rand `float`/`choice`/`shuffle`/`token`; net IPv6 blocked on upstream U5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi)_