### PR TITLE
rand: add float, choice, shuffle, token (#501)

### DIFF
--- a/lib/cosmic/rand.tl
+++ b/lib/cosmic/rand.tl
@@ -74,15 +74,92 @@ local function int(min: integer, max: integer): integer | nil, string
   end
 end
 
+--- Generate a cryptographically secure uniform float in [0, 1).
+--- Uses 53 random bits, so the result has full double precision.
+--- @return number | nil The random float, or nil on failure
+--- @return string? Error message on failure
+local function float(): number | nil, string
+  local v, err = int(0, (1 << 53) - 1)
+  if not v then
+    return nil, err
+  end
+  return v / (1 << 53)
+end
+
+--- Pick one element of a list uniformly at random (crypto-grade).
+--- @param list {any} The list to pick from
+--- @return any The chosen element, or nil on failure or empty list
+--- @return string? Error message on failure or empty list
+local function choice(list: {any}): any, string
+  if #list == 0 then
+    return nil, "rand.choice: empty list"
+  end
+  local i, err = int(1, #list)
+  if not i then
+    return nil, err
+  end
+  return list[i as integer]
+end
+
+--- Shuffle a list in place with an unbiased Fisher-Yates pass
+--- (crypto-grade). Returns the same list for call chaining.
+--- @param list {any} The list to shuffle (mutated in place)
+--- @return {any} | nil The shuffled list, or nil on failure
+--- @return string? Error message on failure
+local function shuffle(list: {any}): {any} | nil, string
+  for i = #list, 2, -1 do
+    local j, err = int(1, i)
+    if not j then
+      return nil, err
+    end
+    local jj = j as integer
+    list[i], list[jj] = list[jj], list[i]
+  end
+  return list
+end
+
+local TOKEN_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+
+--- Generate a random alphanumeric token (crypto-grade, unbiased).
+--- Tokens are URL- and filename-safe. Each character carries ~5.95 bits
+--- of entropy, so the default 32 characters give ~190 bits.
+--- @param len integer? Token length in characters (default 32)
+--- @return string | nil The token, or nil on failure
+--- @return string? Error message on failure
+local function token(len?: integer): string | nil, string
+  len = len or 32
+  if len < 1 then
+    return nil, "rand.token: len must be positive"
+  end
+  local chars: {string} = {}
+  for i = 1, len do
+    local j, err = int(1, #TOKEN_ALPHABET)
+    if not j then
+      return nil, err
+    end
+    local jj = j as integer
+    chars[i] = TOKEN_ALPHABET:sub(jj, jj)
+  end
+  return table.concat(chars)
+end
+
 local record RandModule
   bytes: function(n: number): string | nil, string
   int: function(min: integer, max: integer): integer | nil, string
+  float: function(): number | nil, string
+  choice: function(list: {any}): any, string
+  shuffle: function(list: {any}): {any} | nil, string
+  token: function(len?: integer): string | nil, string
   rand64: function(): number
 end
 
 local M: RandModule = {
   bytes = bytes,
   int = int,
+  float = float,
+  choice = choice,
+  shuffle = shuffle,
+  token = token,
   rand64 = rand64,
 }
 

--- a/lib/cosmic/rand_test.tl
+++ b/lib/cosmic/rand_test.tl
@@ -89,3 +89,119 @@ local function test_int_invalid_args()
   assert(err and err:match("range"), "expected range error, got: " .. tostring(err))
 end
 test_int_invalid_args()
+
+-- float (#501)
+
+local function test_float_range()
+  for _ = 1, 200 do
+    local f = assert(rand.float())
+    assert(f >= 0 and f < 1, "float() out of [0,1): " .. tostring(f))
+    assert(math.type(f) == "float", "float() should return a float")
+  end
+end
+test_float_range()
+
+local function test_float_varies()
+  local a = assert(rand.float())
+  local b = assert(rand.float())
+  assert(a ~= b, "two float() draws should differ")
+end
+test_float_varies()
+
+-- choice (#501)
+
+local function test_choice_picks_member()
+  local list = {"a", "b", "c"}
+  for _ = 1, 50 do
+    local v = assert(rand.choice(list))
+    assert(v == "a" or v == "b" or v == "c", "choice returned non-member: " .. tostring(v))
+  end
+end
+test_choice_picks_member()
+
+local function test_choice_covers_all()
+  local seen: {string: boolean} = {}
+  for _ = 1, 200 do
+    seen[assert(rand.choice({"x", "y", "z"})) as string] = true
+  end
+  assert(seen.x and seen.y and seen.z, "choice never produced some member in 200 draws")
+end
+test_choice_covers_all()
+
+local function test_choice_single_and_empty()
+  assert(rand.choice({42}) == 42, "single-element choice must return it")
+  local v, err = rand.choice({})
+  assert(v == nil and err ~= nil, "empty list should fail with an error")
+end
+test_choice_single_and_empty()
+
+-- shuffle (#501)
+
+local function test_shuffle_permutes()
+  local list = {1, 2, 3, 4, 5, 6, 7, 8}
+  local out = assert(rand.shuffle(list))
+  assert(out == list, "shuffle should return the same list (in place)")
+  assert(#out == 8, "shuffle must preserve length")
+  local seen: {number: boolean} = {}
+  for _, v in ipairs(out) do
+    seen[v as number] = true
+  end
+  for v = 1, 8 do
+    assert(seen[v], "shuffle lost element " .. v)
+  end
+end
+test_shuffle_permutes()
+
+local function test_shuffle_actually_shuffles()
+  -- With 20 elements, 30 identity shuffles in a row is impossible in
+  -- practice (P = (1/20!)^30).
+  local moved = false
+  for _ = 1, 30 do
+    local list: {integer} = {}
+    for i = 1, 20 do
+      list[i] = i
+    end
+    assert(rand.shuffle(list as {any}))
+    for i = 1, 20 do
+      if list[i] ~= i then
+        moved = true
+      end
+    end
+    if moved then
+      break
+    end
+  end
+  assert(moved, "shuffle never changed the order")
+end
+test_shuffle_actually_shuffles()
+
+local function test_shuffle_small()
+  assert(#assert(rand.shuffle({})) == 0, "empty shuffle should be a no-op")
+  local one = assert(rand.shuffle({7})) as {any}
+  assert(#one == 1 and one[1] == 7, "single-element shuffle should be a no-op")
+end
+test_shuffle_small()
+
+-- token (#501)
+
+local function test_token_default()
+  local t = assert(rand.token()) as string
+  assert(#t == 32, "default token length should be 32, got " .. #t)
+  assert(t:match("^[%w]+$"), "token must be alphanumeric, got: " .. t)
+end
+test_token_default()
+
+local function test_token_length_and_uniqueness()
+  local t = assert(rand.token(8))
+  assert(#t == 8, "token(8) length should be 8")
+  local a = assert(rand.token(24))
+  local b = assert(rand.token(24))
+  assert(a ~= b, "two tokens should differ")
+end
+test_token_length_and_uniqueness()
+
+local function test_token_invalid_length()
+  local t, err = rand.token(0)
+  assert(t == nil and err ~= nil, "token(0) should fail")
+end
+test_token_invalid_length()


### PR DESCRIPTION
Part of #501 (§4.2 umbrella) — completes the **rand** P2 item (`int` landed earlier).

## What's added

Four functions on `cosmic.rand`, all crypto-grade and unbiased, built on the existing rejection-sampled `rand.int`:

- **`float()`** — uniform in [0, 1) from 53 random bits (full double precision).
- **`choice(list)`** — uniform element pick; `nil, err` on an empty list.
- **`shuffle(list)`** — in-place Fisher–Yates; returns the same list for chaining.
- **`token(len?)`** — URL- and filename-safe alphanumeric token (default 32 chars ≈ 190 bits of entropy), each character drawn without modulo bias.

All follow the module's existing `value | nil, err` convention since the entropy source can fail.

## Tests

Extended `rand_test.tl`: range/type checks for `float`, membership and full-coverage draws for `choice`, permutation-preservation and does-it-actually-move checks for `shuffle`, plus length/alphabet/uniqueness for `token` and error cases (empty list, `token(0)`).

`bin/make ci` passes locally.

Branch note: separate PRs for the remaining #501 items were requested; this one uses the derived branch `claude/cosmic-501-gtma65-rand` so they can be open simultaneously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi)_