### PR TITLE
codec: add base64url encode/decode (#501)

### DIFF
--- a/lib/cosmic/codec.tl
+++ b/lib/cosmic/codec.tl
@@ -93,6 +93,41 @@ local function decode_base64(str: string): string | nil, string
   return cosmo.DecodeBase64(str)
 end
 
+--- Encode binary data as base64url (RFC 4648 section 5).
+--- The URL- and filename-safe variant: "-" and "_" replace "+" and
+--- "/", and no "=" padding is emitted.
+--- @param data string The binary data to encode
+--- @return string The base64url encoded string
+local function encode_base64url(data: string): string
+  local b64 = cosmo.EncodeBase64(data)
+  b64 = string.gsub(b64, "%+", "-")
+  b64 = string.gsub(b64, "/", "_")
+  b64 = string.gsub(b64, "=", "")
+  return b64
+end
+
+--- Decode a base64url string to binary data.
+--- Accepts the URL-safe alphabet ("-" and "_") with or without "="
+--- padding. Standard-alphabet characters ("+", "/") are rejected.
+--- @param str string The base64url string to decode
+--- @return string | nil The decoded binary data, or nil on error
+--- @return string? Error message if decoding failed
+local function decode_base64url(str: string): string | nil, string
+  local content, padding = str:match("^([A-Za-z0-9%-_]*)(%=*)$")
+  if not content then
+    if str:match("[^A-Za-z0-9%-_=]") then
+      return nil, "invalid base64url character"
+    end
+    return nil, "invalid base64url: padding in middle"
+  end
+  if #padding > 2 then
+    return nil, "invalid base64url padding"
+  end
+  local b64 = string.gsub(content as string, "%-", "+")
+  b64 = string.gsub(b64, "_", "/")
+  return cosmo.DecodeBase64(b64)
+end
+
 --- Encode binary data as base32.
 --- Uses lowercase base32 alphabet (0-9a-v excluding i, l, o, u).
 --- @param data string The binary data to encode
@@ -175,6 +210,8 @@ local record CodecModule
   decode_lua_unsafe: function(code: string): any | nil, string
   encode_base64: function(data: string): string
   decode_base64: function(str: string): string | nil, string
+  encode_base64url: function(data: string): string
+  decode_base64url: function(str: string): string | nil, string
   encode_base32: function(data: string): string
   decode_base32: function(str: string): string | nil, string
   crc32: function(data: string, initial?: integer): integer
@@ -190,6 +227,8 @@ local M: CodecModule = {
   decode_lua_unsafe = decode_lua_unsafe,
   encode_base64 = encode_base64,
   decode_base64 = decode_base64,
+  encode_base64url = encode_base64url,
+  decode_base64url = decode_base64url,
   encode_base32 = encode_base32,
   decode_base32 = decode_base32,
   crc32 = crc32,

--- a/lib/cosmic/codec_test.tl
+++ b/lib/cosmic/codec_test.tl
@@ -386,3 +386,67 @@ local function test_crc32_unsigned_range()
     "crc32 should be an unsigned 32-bit value, got " .. tostring(result))
 end
 test_crc32_unsigned_range()
+
+-- base64url tests (#501)
+
+local function test_base64url_roundtrip()
+  local cases = {"", "f", "fo", "foo", "foob", "fooba", "foobar", "hello world"}
+  for _, s in ipairs(cases) do
+    local enc = codec.encode_base64url(s)
+    local dec, err = codec.decode_base64url(enc)
+    assert(dec == s, "round-trip failed for '" .. s .. "': " .. tostring(err))
+  end
+end
+test_base64url_roundtrip()
+
+local function test_base64url_alphabet()
+  -- 0xfb 0xff encodes to "-_8" in base64url ("+/8" in standard base64).
+  local enc = codec.encode_base64url("\xfb\xff")
+  assert(enc == "-_8", "expected '-_8', got '" .. enc .. "'")
+  assert(not enc:find("[+/=]"), "base64url output must not contain +, / or =")
+  local dec = codec.decode_base64url("-_8")
+  assert(dec == "\xfb\xff", "expected 0xfb 0xff back")
+end
+test_base64url_alphabet()
+
+local function test_base64url_no_padding_emitted()
+  -- "f" encodes to "Zg==" in padded base64; base64url emits "Zg".
+  assert(codec.encode_base64url("f") == "Zg", "expected unpadded 'Zg'")
+  assert(codec.encode_base64url("fo") == "Zm8", "expected unpadded 'Zm8'")
+end
+test_base64url_no_padding_emitted()
+
+local function test_base64url_decode_accepts_padding()
+  assert(codec.decode_base64url("Zg==") == "f", "padded input should decode")
+  assert(codec.decode_base64url("Zg") == "f", "unpadded input should decode")
+end
+test_base64url_decode_accepts_padding()
+
+local function test_base64url_rejects_standard_alphabet()
+  local dec, err = codec.decode_base64url("+_8")
+  assert(dec == nil and err ~= nil, "expected '+' to be rejected")
+  dec, err = codec.decode_base64url("a/b")
+  assert(dec == nil and err ~= nil, "expected '/' to be rejected")
+end
+test_base64url_rejects_standard_alphabet()
+
+local function test_base64url_rejects_bad_input()
+  local dec, err = codec.decode_base64url("a b")
+  assert(dec == nil and err ~= nil, "expected space to be rejected")
+  dec, err = codec.decode_base64url("Zg=X")
+  assert(dec == nil and err ~= nil, "expected padding in middle to be rejected")
+  dec, err = codec.decode_base64url("Zg===")
+  assert(dec == nil and err ~= nil, "expected over-long padding to be rejected")
+end
+test_base64url_rejects_bad_input()
+
+local function test_base64url_binary_roundtrip()
+  local all_bytes: {string} = {}
+  for i = 0, 255 do
+    all_bytes[i + 1] = string.char(i)
+  end
+  local blob = table.concat(all_bytes)
+  local dec = codec.decode_base64url(codec.encode_base64url(blob))
+  assert(dec == blob, "all-bytes blob should round-trip")
+end
+test_base64url_binary_roundtrip()


### PR DESCRIPTION
Part of #501 (§4.2 umbrella) — completes the **codec** P2 item (`crc32`/`crc32c` landed earlier in #610).

## What's added

`encode_base64url` / `decode_base64url` on `cosmic.codec`, implementing RFC 4648 §5 (the URL- and filename-safe variant) on top of the existing base64 binding:

- encode emits `-`/`_` and **no padding** (per the JWT/web convention);
- decode is lenient about `=` padding but rejects standard-alphabet characters (`+`, `/`), interior padding, and over-long padding — mirroring `decode_base64`'s validation structure and error style;
- both follow the module's infallible-encode / fallible-decode convention.

## Tests

Appended to `codec_test.tl`: RFC test-vector-style round-trips (`""` through `"foobar"`), an alphabet check (`\xfb\xff` → `-_8`), unpadded output, padded/unpadded decode acceptance, rejection cases, and an all-256-bytes binary round-trip.

`bin/make ci` passes locally.

Branch note: separate PRs for the remaining #501 items were requested; this one uses the derived branch `claude/cosmic-501-gtma65-codec` so they can be open simultaneously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi)_