### PR TITLE
fs: add home and expanduser (#501)

### DIFF
--- a/lib/cosmic/fs/home_test.tl
+++ b/lib/cosmic/fs/home_test.tl
@@ -1,0 +1,93 @@
+#!/usr/bin/env cosmic
+local fs = require("cosmic.fs")
+local env = require("cosmic.env")
+
+local saved_home = env.get("HOME")
+local saved_profile = env.get("USERPROFILE")
+
+local function restore()
+  if saved_home then
+    env.set("HOME", saved_home)
+  else
+    env.unset("HOME")
+  end
+  if saved_profile then
+    env.set("USERPROFILE", saved_profile)
+  else
+    env.unset("USERPROFILE")
+  end
+end
+
+-- home tests
+
+local function test_home_from_env()
+  env.set("HOME", "/home/tester")
+  local dir, err = fs.home()
+  assert(dir == "/home/tester", "expected /home/tester, got " .. tostring(dir) .. " (" .. tostring(err) .. ")")
+  restore()
+end
+test_home_from_env()
+
+local function test_home_userprofile_fallback()
+  env.unset("HOME")
+  env.set("USERPROFILE", "/users/tester")
+  local dir = fs.home()
+  assert(dir == "/users/tester", "expected USERPROFILE fallback, got " .. tostring(dir))
+  restore()
+end
+test_home_userprofile_fallback()
+
+local function test_home_unset()
+  env.unset("HOME")
+  env.unset("USERPROFILE")
+  local dir, err = fs.home()
+  assert(dir == nil, "expected nil when no home is set")
+  assert(err ~= nil, "expected an error message")
+  restore()
+end
+test_home_unset()
+
+-- expanduser tests
+
+local function test_expanduser_bare_tilde()
+  env.set("HOME", "/home/tester")
+  assert(fs.expanduser("~") == "/home/tester", "expected bare ~ expanded")
+  restore()
+end
+test_expanduser_bare_tilde()
+
+local function test_expanduser_tilde_slash()
+  env.set("HOME", "/home/tester")
+  assert(fs.expanduser("~/docs/x.txt") == "/home/tester/docs/x.txt",
+    "expected ~/ expanded, got " .. fs.expanduser("~/docs/x.txt"))
+  restore()
+end
+test_expanduser_tilde_slash()
+
+local function test_expanduser_trailing_slash_home()
+  env.set("HOME", "/home/tester/")
+  local p = fs.expanduser("~/docs")
+  assert(p == "/home/tester/docs", "expected joined path without double slash, got " .. p)
+  restore()
+end
+test_expanduser_trailing_slash_home()
+
+local function test_expanduser_untouched_forms()
+  env.set("HOME", "/home/tester")
+  assert(fs.expanduser("/abs/path") == "/abs/path", "absolute path must be unchanged")
+  assert(fs.expanduser("rel/path") == "rel/path", "relative path must be unchanged")
+  assert(fs.expanduser("~other/docs") == "~other/docs", "~user form must be unchanged")
+  assert(fs.expanduser("mid~dle") == "mid~dle", "interior ~ must be unchanged")
+  assert(fs.expanduser("") == "", "empty path must be unchanged")
+  restore()
+end
+test_expanduser_untouched_forms()
+
+local function test_expanduser_no_home()
+  env.unset("HOME")
+  env.unset("USERPROFILE")
+  assert(fs.expanduser("~/docs") == "~/docs", "expected unchanged path when no home is set")
+  assert(fs.expanduser("~") == "~", "expected bare ~ unchanged when no home is set")
+  restore()
+end
+test_expanduser_no_home()

--- a/lib/cosmic/fs/init.tl
+++ b/lib/cosmic/fs/init.tl
@@ -228,6 +228,10 @@ local record FsModule
   dirname: function(str: string): string
   basename: function(str: string): string
   join: function(...: string): string
+  --- Current user's home directory (nil + error when unset).
+  home: function(): string | nil, string
+  --- Expand a leading "~" or "~/" to the home directory.
+  expanduser: function(p: string): string
   exists: function(path: string): boolean
   isfile: function(path: string): boolean
   isdir: function(path: string): boolean
@@ -335,6 +339,8 @@ local M: FsModule = {
   dirname = fs_path.dirname,
   basename = fs_path.basename,
   join = fs_path.join,
+  home = fs_path.home,
+  expanduser = fs_path.expanduser,
   exists = fs_path.exists,
   isfile = fs_path.isfile,
   isdir = fs_path.isdir,

--- a/lib/cosmic/fs/path.tl
+++ b/lib/cosmic/fs/path.tl
@@ -290,10 +290,44 @@ local function ext(p: string): string
   return extension
 end
 
+--- Return the current user's home directory.
+--- Uses $HOME, falling back to $USERPROFILE (Windows).
+--- @return string | nil The home directory, or nil when unknown
+--- @return string? Error message when no home directory is set
+local function home(): string | nil, string
+  local dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+  if not dir or dir == "" then
+    return nil, "home: HOME is not set"
+  end
+  return dir
+end
+
+--- Expand a leading "~" in a path to the user's home directory.
+--- Only bare "~" and "~/..." are expanded; "~user/..." forms and
+--- paths without the prefix are returned unchanged, as is any path
+--- when no home directory can be determined.
+--- @param p string The path to expand
+--- @return string The expanded path
+local function expanduser(p: string): string
+  if p ~= "~" and p:sub(1, 2) ~= "~/" then
+    return p
+  end
+  local dir = home()
+  if not dir then
+    return p
+  end
+  if p == "~" then
+    return dir
+  end
+  return cosmo_path.join(dir, p:sub(3))
+end
+
 local record FsPathModule
   dirname: function(str: string): string
   basename: function(str: string): string
   join: function(...: string): string
+  home: function(): string | nil, string
+  expanduser: function(p: string): string
   exists: function(path: string): boolean
   isfile: function(path: string): boolean
   isdir: function(path: string): boolean
@@ -309,6 +343,8 @@ local M: FsPathModule = {
   dirname = dirname,
   basename = basename,
   join = join,
+  home = home,
+  expanduser = expanduser,
   exists = exists,
   isfile = isfile,
   isdir = isdir,


### PR DESCRIPTION
Part of #501 (§4.2 umbrella) — the last unblocked pieces of the **fs (P1)** item (`copy`/`copytree`/`move`/`touch`/`write_atomic` landed earlier).

## What's added

Two functions in `cosmic.fs` (implemented in `fs/path.tl`, re-exported from `fs/init.tl` like the other path helpers):

- **`fs.home()`** — the current user's home directory from `$HOME`, falling back to `$USERPROFILE` for Windows. Fallible (`string | nil, string`) since neither may be set.
- **`fs.expanduser(p)`** — expands a leading `~` or `~/` to the home directory (joined via `cosmo.path.join`, so a trailing slash on `$HOME` doesn't double up). Deliberately conservative and infallible: `~user/...` forms, interior `~`, and paths with no home set are returned unchanged, matching Python's expanduser behavior.

## Tests

New `fs/home_test.tl` (kept separate — `path_test.tl` is at 455 lines, close to the 500-line cap): HOME/USERPROFILE resolution, unset-env failure, bare-`~` and `~/` expansion, trailing-slash HOME, and the full set of untouched forms. Env vars are saved and restored around each test.

`bin/make ci` passes locally.

Branch note: separate PRs for the remaining #501 items were requested; this one uses the derived branch `claude/cosmic-501-gtma65-fs` so they can be open simultaneously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi)_