### PR TITLE
ip: add CIDR blocks (#501)

### DIFF
--- a/lib/cosmic/ip.tl
+++ b/lib/cosmic/ip.tl
@@ -171,18 +171,146 @@ local function lookup(hostname: string): Addr | nil, string
   return make_addr(raw)
 end
 
+--- A parsed IPv4 CIDR block (e.g. "10.0.0.0/8"). Compares by value
+--- and formats with tostring(). Construct with cidr().
+local record Cidr
+  _n: integer
+  _bits: integer
+  --- Prefix length (0-32).
+  bits: function(Cidr): integer
+  --- First address of the block (the network address).
+  --- @return Addr The network address
+  network: function(Cidr): Addr
+  --- The netmask (e.g. 255.255.255.0 for /24).
+  --- @return Addr The netmask
+  netmask: function(Cidr): Addr
+  --- Last address of the block (the broadcast address).
+  --- @return Addr The broadcast address
+  broadcast: function(Cidr): Addr
+  --- Number of addresses in the block (including network/broadcast).
+  --- @return number The block size
+  size: function(Cidr): number
+  --- Check whether the block contains an address.
+  --- @param a Addr | string The address (typed or dotted quad)
+  --- @return boolean True when contained; false (plus an error
+  --- message) when a string address does not parse
+  contains: function(Cidr, Addr | string): boolean, string
+  --- Format as "addr/bits" (same as tostring()).
+  --- @return string The CIDR notation
+  format: function(Cidr): string
+end
+
+--- Netmask integer for a prefix length (0 -> 0, 24 -> 0xFFFFFF00).
+local function cidr_mask(bits: integer): integer
+  if bits == 0 then
+    return 0
+  end
+  return (~ ((1 << (32 - bits)) - 1)) & 0xFFFFFFFF
+end
+
+local function cidr_bits(self: Cidr): integer
+  return self._bits
+end
+
+local function cidr_network(self: Cidr): Addr
+  return make_addr(self._n)
+end
+
+local function cidr_netmask(self: Cidr): Addr
+  return make_addr(cidr_mask(self._bits))
+end
+
+local function cidr_broadcast(self: Cidr): Addr
+  return make_addr(self._n | (~ cidr_mask(self._bits) & 0xFFFFFFFF))
+end
+
+local function cidr_size(self: Cidr): number
+  return 1 << (32 - self._bits)
+end
+
+local function cidr_contains(self: Cidr, a: Addr | string): boolean, string
+  local n: integer
+  if a is string then
+    local parsed, err = parse(a)
+    if not parsed then
+      return false, err
+    end
+    n = math.tointeger((parsed as Addr):int())
+  else
+    n = math.tointeger((a as Addr):int())
+  end
+  return (n & cidr_mask(self._bits)) == self._n
+end
+
+local function cidr_format(self: Cidr): string
+  return cosmo.FormatIp(self._n) .. "/" .. self._bits
+end
+
+local Cidr_mt: metatable < Cidr > = {
+  __index = {
+    bits = cidr_bits,
+    network = cidr_network,
+    netmask = cidr_netmask,
+    broadcast = cidr_broadcast,
+    size = cidr_size,
+    contains = cidr_contains,
+    format = cidr_format,
+  } as Cidr,
+  __tostring = cidr_format,
+  __eq = function(a: Cidr, b: Cidr): boolean
+    return a._n == b._n and a._bits == b._bits
+  end,
+}
+
+local function make_cidr(n: integer, bits: integer): Cidr
+  return setmetatable({_n = n, _bits = bits} as Cidr, Cidr_mt)
+end
+
+--- Parse an IPv4 CIDR block ("addr/prefix", e.g. "192.168.0.0/16").
+--- The address part follows parse()'s strict dotted-quad rules; the
+--- prefix must be a decimal 0-32 without leading zeros. Host bits set
+--- below the prefix are masked away (like Go's ParseCIDR):
+--- cidr("10.1.2.3/8") is the 10.0.0.0/8 block.
+--- @param str string The CIDR string to parse
+--- @return Cidr | nil The parsed block, or nil on error
+--- @return string Error message if parsing failed
+local function cidr(str: string): Cidr | nil, string
+  local addr_part, bits_part = str:match("^([^/]*)/(%d+)$")
+  if not addr_part then
+    return nil, "invalid CIDR (want addr/prefix): " .. str
+  end
+  local base, err = parse(addr_part)
+  if not base then
+    return nil, err
+  end
+  local bp = bits_part as string
+  if #bp > 2 or (#bp > 1 and bp:sub(1, 1) == "0") then
+    return nil, "invalid CIDR prefix '" .. bp .. "' in: " .. str
+  end
+  local bits = math.tointeger(tonumber(bp))
+  if not bits or bits > 32 then
+    return nil, "invalid CIDR prefix '" .. bp .. "' in: " .. str
+  end
+  local b = bits as integer
+  local n = math.tointeger((base as Addr):int()) & cidr_mask(b)
+  return make_cidr(n, b)
+end
+
 local record IpModule
   Addr: Addr
   type Category = Category
   type Family = Family
+  type Cidr = Cidr
   addr: function(n: number): Addr
   parse: function(str: string): Addr | nil, string
+  cidr: function(str: string): Cidr | nil, string
   lookup: function(hostname: string): Addr | nil, string
 end
 
 local M: IpModule = {
   addr = addr,
   parse = parse,
+  cidr = cidr,
   lookup = lookup,
 }
 

--- a/lib/cosmic/ip_test.tl
+++ b/lib/cosmic/ip_test.tl
@@ -231,3 +231,97 @@ local function test_lookup_returns_addr_with_methods()
   assert(tostring(aa) == "127.0.0.1", "expected tostring '127.0.0.1'")
 end
 test_lookup_returns_addr_with_methods()
+
+-- CIDR tests (#501)
+
+local function test_cidr_parse()
+  local c = assert(ip.cidr("192.168.0.0/16")) as ip.Cidr
+  assert(c:bits() == 16, "expected 16 bits")
+  assert(tostring(c:network()) == "192.168.0.0", "expected network 192.168.0.0")
+  assert(tostring(c) == "192.168.0.0/16", "expected tostring 192.168.0.0/16")
+  assert(c:format() == "192.168.0.0/16", "expected format to match tostring")
+end
+test_cidr_parse()
+
+local function test_cidr_masks_host_bits()
+  local c = assert(ip.cidr("10.1.2.3/8")) as ip.Cidr
+  assert(tostring(c:network()) == "10.0.0.0", "expected host bits masked away")
+  assert(tostring(c) == "10.0.0.0/8", "expected canonical form")
+end
+test_cidr_masks_host_bits()
+
+local function test_cidr_netmask_broadcast_size()
+  local c = assert(ip.cidr("192.168.1.0/24")) as ip.Cidr
+  assert(tostring(c:netmask()) == "255.255.255.0", "expected /24 netmask")
+  assert(tostring(c:broadcast()) == "192.168.1.255", "expected broadcast")
+  assert(c:size() == 256, "expected 256 addresses, got " .. tostring(c:size()))
+
+  local host = assert(ip.cidr("1.2.3.4/32")) as ip.Cidr
+  assert(tostring(host:netmask()) == "255.255.255.255", "expected /32 netmask")
+  assert(tostring(host:broadcast()) == "1.2.3.4", "expected /32 broadcast = itself")
+  assert(host:size() == 1, "expected single address")
+
+  local all = assert(ip.cidr("0.0.0.0/0")) as ip.Cidr
+  assert(tostring(all:netmask()) == "0.0.0.0", "expected /0 netmask")
+  assert(tostring(all:broadcast()) == "255.255.255.255", "expected /0 broadcast")
+  assert(all:size() == 4294967296, "expected 2^32 addresses")
+end
+test_cidr_netmask_broadcast_size()
+
+local function test_cidr_contains()
+  local c = assert(ip.cidr("192.168.1.0/24")) as ip.Cidr
+  assert(c:contains("192.168.1.1"), "expected member")
+  assert(c:contains("192.168.1.0"), "expected network address contained")
+  assert(c:contains("192.168.1.255"), "expected broadcast address contained")
+  assert(not c:contains("192.168.2.1"), "expected non-member")
+  assert(not c:contains("10.0.0.1"), "expected non-member")
+
+  local a = assert(ip.parse("192.168.1.42"))
+  assert(c:contains(a), "expected typed Addr accepted")
+
+  local all = assert(ip.cidr("0.0.0.0/0")) as ip.Cidr
+  assert(all:contains("8.8.8.8"), "expected /0 to contain everything")
+
+  local host = assert(ip.cidr("1.2.3.4/32")) as ip.Cidr
+  assert(host:contains("1.2.3.4"), "expected /32 to contain itself")
+  assert(not host:contains("1.2.3.5"), "expected /32 to exclude neighbors")
+end
+test_cidr_contains()
+
+local function test_cidr_contains_bad_string()
+  local c = assert(ip.cidr("10.0.0.0/8")) as ip.Cidr
+  local ok, err = c:contains("not-an-ip")
+  assert(ok == false, "expected false for unparseable address")
+  assert(err ~= nil, "expected an error message")
+end
+test_cidr_contains_bad_string()
+
+local function test_cidr_equality()
+  local a = assert(ip.cidr("10.0.0.0/8")) as ip.Cidr
+  local b = assert(ip.cidr("10.9.9.9/8")) as ip.Cidr
+  local c = assert(ip.cidr("10.0.0.0/9")) as ip.Cidr
+  assert(a == b, "expected same masked block to compare equal")
+  assert(a ~= c, "expected different prefix to differ")
+end
+test_cidr_equality()
+
+local function test_cidr_invalid()
+  local cases = {
+    "10.0.0.0", -- no prefix
+    "10.0.0.0/", -- empty prefix
+    "10.0.0.0/33", -- prefix out of range
+    "10.0.0.0/08", -- leading zero
+    "10.0.0.0/-1", -- negative
+    "10.0.0/8", -- bad address
+    "300.0.0.0/8", -- bad octet
+    "10.0.0.0/8/8", -- double slash
+    "::1/128", -- IPv6
+    "", -- empty
+  }
+  for _, s in ipairs(cases) do
+    local c, err = ip.cidr(s)
+    assert(c == nil, "expected failure for '" .. s .. "'")
+    assert(err ~= nil, "expected error message for '" .. s .. "'")
+  end
+end
+test_cidr_invalid()


### PR DESCRIPTION
Part of #501 (§4.2 umbrella) — completes the **ip CIDR** P2 item.

## What's added

`ip.cidr(str)` parses `"addr/prefix"` (e.g. `"192.168.0.0/16"`) into a typed `Cidr` value, following the module's `Addr` conventions exactly: shared-metatable methods, value equality, `tostring()` formatting, and strict parsing (the address part uses `parse()`'s dotted-quad rules; the prefix must be decimal 0–32 with no leading zeros).

`Cidr` methods:
- `contains(addr)` — membership test accepting a typed `Addr` or a dotted-quad string (`false, err` when the string doesn't parse);
- `network()` / `netmask()` / `broadcast()` — returned as typed `Addr`s;
- `bits()` / `size()` / `format()`.

Host bits below the prefix are masked away on parse, like Go's `ParseCIDR`: `cidr("10.1.2.3/8")` is the `10.0.0.0/8` block (documented).

IPv4-only, matching the module; IPv6 remains blocked on upstream whilp/cosmopolitan#144 and extends `Cidr` as a value later, not the API.

## Tests

Appended to `ip_test.tl`: parse/canonicalization, host-bit masking, netmask/broadcast/size for /24, /32, and /0, membership including network/broadcast edges and both input forms, value equality across differently-spelled blocks, and ten invalid-input rejections (missing/empty/oversized/leading-zero prefixes, bad octets, IPv6, double slash).

`bin/make ci` passes locally.

Branch note: separate PRs for the remaining #501 items were requested; this one uses the derived branch `claude/cosmic-501-gtma65-ip` so they can be open simultaneously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi)_