### PR TITLE
fs: relpath base param is optional in the inner signature too (#501)

### DIFF
--- a/lib/cosmic/fs/path.tl
+++ b/lib/cosmic/fs/path.tl
@@ -155,9 +155,9 @@ end
 --- Make path relative to another path (defaults to cwd).
 --- Pure string manipulation - does not access the filesystem.
 --- @param p string The path to make relative
---- @param base string The base path (defaults to cwd)
+--- @param base string? The base path (defaults to cwd)
 --- @return string The relative path
-local function relpath(p: string, base: string): string
+local function relpath(p: string, base?: string): string
   -- Get absolute versions of both paths. When both p and the implicit
   -- base need cwd (relative p, no explicit base), fetch it once instead
   -- of once per abspath() call.


### PR DESCRIPTION
Part of #501 (§4.2 umbrella) — resolves the audit's "reconcile `relpath` base optional-vs-required (`fs.tl:270` vs `fs_path.tl:136`)" note.

The public surface in `fs/init.tl` already declared `base?: string` optional and the implementation already handled a nil base (defaulting to cwd); only `fs/path.tl`'s local function signature still typed `base` as required. This makes the inner signature and its doc comment match the public contract. Signature-only; no behavior change.

`bin/make ci` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi)_