### PR TITLE
fs: non-recursive glob and walk max_depth (#501)

### DIFF
--- a/lib/cosmic/fs/glob_test.tl
+++ b/lib/cosmic/fs/glob_test.tl
@@ -1,0 +1,130 @@
+#!/usr/bin/env cosmic
+local fs = require("cosmic.fs")
+local types = require("cosmic.fs.types")
+local type WalkStat = types.WalkStat
+
+local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
+
+-- Layout:
+--   root/a.lua  root/b.lua  root/c.txt  root/.hidden.lua
+--   root/src/x.lua  root/src/y.txt
+--   root/src/deep/z.lua
+local root = fs.join(TEST_TMPDIR, "glob_root")
+assert(fs.makedirs(fs.join(root, "src", "deep")))
+for _, p in ipairs({"a.lua", "b.lua", "c.txt", ".hidden.lua", "src/x.lua", "src/y.txt", "src/deep/z.lua"}) do
+  assert(fs.write(fs.join(root, p), "-- " .. p))
+end
+
+local function names(paths: {string}): {string}
+  local out: {string} = {}
+  for i, p in ipairs(paths) do
+    out[i] = fs.relpath(p, root)
+  end
+  return out
+end
+
+-- glob tests
+
+local function test_glob_single_level_not_recursive()
+  local paths = assert(fs.glob(root, "*.lua")) as {string}
+  local rel = names(paths)
+  assert(#rel == 3, "expected 3 top-level .lua files, got " .. #rel)
+  assert(rel[1] == ".hidden.lua" and rel[2] == "a.lua" and rel[3] == "b.lua",
+    "expected sorted dotfile-inclusive matches, got " .. table.concat(rel, ","))
+end
+test_glob_single_level_not_recursive()
+
+local function test_glob_path_components()
+  local paths = assert(fs.glob(root, "src/*.lua")) as {string}
+  local rel = names(paths)
+  assert(#rel == 1 and rel[1] == "src/x.lua", "expected src/x.lua, got " .. table.concat(rel, ","))
+end
+test_glob_path_components()
+
+local function test_glob_component_wildcard_dir()
+  local paths = assert(fs.glob(root, "*/deep/*.lua")) as {string}
+  local rel = names(paths)
+  assert(#rel == 1 and rel[1] == "src/deep/z.lua", "expected src/deep/z.lua")
+end
+test_glob_component_wildcard_dir()
+
+local function test_glob_matches_directories_too()
+  local paths = assert(fs.glob(root, "s?c")) as {string}
+  local rel = names(paths)
+  assert(#rel == 1 and rel[1] == "src", "expected the src directory itself")
+end
+test_glob_matches_directories_too()
+
+local function test_glob_literal_component()
+  local paths = assert(fs.glob(root, "a.lua")) as {string}
+  assert(#paths == 1, "expected exact-name match")
+end
+test_glob_literal_component()
+
+local function test_glob_no_match_and_missing_dirs()
+  assert(#(assert(fs.glob(root, "*.nope")) as {string}) == 0, "expected no matches")
+  assert(#(assert(fs.glob(root, "missing/*.lua")) as {string}) == 0,
+    "expected no matches through a missing directory")
+end
+test_glob_no_match_and_missing_dirs()
+
+local function test_glob_root_failure()
+  local paths, err = fs.glob(fs.join(root, "nonexistent"), "*.lua")
+  assert(paths == nil and err ~= nil, "expected nil, err for missing root")
+end
+test_glob_root_failure()
+
+local function test_glob_invalid_patterns()
+  local paths, err = fs.glob(root, "/etc/*")
+  assert(paths == nil and err ~= nil, "expected absolute pattern rejected")
+  paths, err = fs.glob(root, "")
+  assert(paths == nil and err ~= nil, "expected empty pattern rejected")
+end
+test_glob_invalid_patterns()
+
+-- walk max_depth tests
+
+local function collect_depth(max_depth: integer): {string}
+  local seen: {string} = {}
+  assert(fs.walk(root, function(path: string, _name: string, _st: WalkStat, acc: {string})
+        table.insert(acc, fs.relpath(path, root))
+      end, seen, {max_depth = max_depth}))
+  table.sort(seen)
+  return seen
+end
+
+local function has(list: {string}, want: string): boolean
+  for _, v in ipairs(list) do
+    if v == want then
+      return true
+    end
+  end
+  return false
+end
+
+local function test_walk_max_depth_one()
+  local seen = collect_depth(1)
+  assert(has(seen, "a.lua") and has(seen, "src"), "expected top-level entries")
+  assert(not has(seen, "src/x.lua"), "expected no descent at max_depth=1")
+end
+test_walk_max_depth_one()
+
+local function test_walk_max_depth_two()
+  local seen = collect_depth(2)
+  assert(has(seen, "src/x.lua") and has(seen, "src/deep"), "expected depth-2 entries")
+  assert(not has(seen, "src/deep/z.lua"), "expected no depth-3 entries")
+end
+test_walk_max_depth_two()
+
+local function test_walk_unlimited_by_default()
+  local seen: {string} = {}
+  assert(fs.walk(root, function(path: string, _name: string, _st: WalkStat, acc: {string})
+        table.insert(acc, fs.relpath(path, root))
+      end, seen))
+  assert(has(seen, "src/deep/z.lua"), "expected full depth without opts")
+  local zero = collect_depth(0)
+  assert(has(zero, "src/deep/z.lua"), "expected max_depth=0 to mean unlimited")
+end
+test_walk_unlimited_by_default()
+
+fs.rmrf(root)

--- a/lib/cosmic/fs/init.tl
+++ b/lib/cosmic/fs/init.tl
@@ -216,6 +216,9 @@ local type FileIter = fs_walk.FileIter
 --- Visitor verdict for walk(): nil continues, "skip" prunes, "stop" ends the walk.
 local type WalkAction = fs_walk.WalkAction
 
+--- Options for walk() (max_depth).
+local type WalkOptions = fs_walk.WalkOptions
+
 --- Module interface
 local record FsModule
   --- Iterator over file paths, as returned by files().
@@ -223,6 +226,9 @@ local record FsModule
 
   --- Visitor verdict for walk(): nil continues, "skip" prunes, "stop" ends the walk.
   type WalkAction = WalkAction
+
+  --- Options for walk() (max_depth; entries directly in dir are depth 1).
+  type WalkOptions = WalkOptions
 
   -- Path manipulation
   dirname: function(str: string): string
@@ -310,7 +316,10 @@ local record FsModule
   -- ends the walk now; returning nothing continues.
   -- Root open failure returns nil, err; subtree failures return the first
   -- error alongside the results.
-  walk: function < T > (dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T): T | nil, string
+  walk: function < T > (dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string
+  -- glob expands a pattern without recursing; components ("src/*.lua")
+  -- are each globs, and matches of every entry type are returned sorted.
+  glob: function(dir: string, pattern: string): {string} | nil, string
   -- collect's pattern is ALWAYS a glob; collect_matching takes a Lua pattern.
   collect: function(dir: string, pattern: string): {string} | nil, string
   collect_matching: function(dir: string, lua_pattern: string): {string} | nil, string
@@ -409,6 +418,7 @@ local M: FsModule = {
 
   -- Directory walking
   walk = fs_walk.walk,
+  glob = fs_walk.glob,
   collect = fs_walk.collect,
   collect_matching = fs_walk.collect_matching,
   collect_all = fs_walk.collect_all,

--- a/lib/cosmic/fs/walk.tl
+++ b/lib/cosmic/fs/walk.tl
@@ -25,15 +25,25 @@ local enum WalkAction
   "stop"
 end
 
+--- Options for walk().
+local record WalkOptions
+  --- Maximum directory depth to visit: entries directly in dir are at
+  --- depth 1, entries one level down at depth 2, and so on. The walk
+  --- never descends into directories at the maximum depth. nil (or 0)
+  --- means unlimited.
+  max_depth: integer
+end
+
 local walk_tree: function < T > (string,
-function(string, string, WalkStat, T): (WalkAction ...), T, {string}): boolean
+function(string, string, WalkStat, T): (WalkAction ...), T, {string}, integer, integer): boolean
 
 --- Shared per-directory loop. Consumes (and closes) an already-open
 --- handle, records the first subtree error in errbox[1], and returns
---- true when a visitor asked to stop the walk.
+--- true when a visitor asked to stop the walk. Entries visited here are
+--- at depth; max_depth of 0 means unlimited.
 local function walk_entries < T > (dir: string, h: WalkDirHandle,
     visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx: T,
-    errbox: {string}): boolean
+    errbox: {string}, depth: integer, max_depth: integer): boolean
   while true do
     local entry = h:read()
     if not entry then break end
@@ -48,8 +58,9 @@ local function walk_entries < T > (dir: string, h: WalkDirHandle,
           h:close()
           return true
         end
-        if action ~= "skip" and unix.S_ISDIR((st as unix.Stat):mode()) then
-          if walk_tree(full_path, visitor, ctx, errbox) then
+        if action ~= "skip" and unix.S_ISDIR((st as unix.Stat):mode())
+        and (max_depth == 0 or depth < max_depth) then
+          if walk_tree(full_path, visitor, ctx, errbox, depth + 1, max_depth) then
             h:close()
             return true
           end
@@ -67,7 +78,7 @@ end
 --- in errbox[1] rather than swallowed or fatal.
 walk_tree = function < T > (dir: string,
     visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx: T,
-    errbox: {string}): boolean
+    errbox: {string}, depth: integer, max_depth: integer): boolean
   local handle, oerr = unix.opendir(dir)
   if not handle then
     if not errbox[1] then
@@ -75,7 +86,7 @@ walk_tree = function < T > (dir: string,
     end
     return false
   end
-  return walk_entries(dir, handle as WalkDirHandle, visitor, ctx, errbox)
+  return walk_entries(dir, handle as WalkDirHandle, visitor, ctx, errbox, depth, max_depth)
 end
 
 --- Walk a directory tree, calling visitor for each entry.
@@ -107,16 +118,21 @@ end
 --- @param dir string The directory to walk
 --- @param visitor function Called for each entry: function(path, name, st, ctx): nil|"skip"|"stop"
 --- @param ctx T Optional context passed to every visitor call
+--- @param opts WalkOptions? max_depth limits how deep the walk descends
 --- @return T | nil The context object, or nil if the root could not be opened
 --- @return string First error encountered, if any
-local function walk < T > (dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T): T | nil, string
+local function walk < T > (dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string
   ctx = ctx or {} as T
+  local max_depth = 0
+  if opts and opts.max_depth then
+    max_depth = opts.max_depth
+  end
   local handle, oerr = unix.opendir(dir)
   if not handle then
     return nil, errstr(oerr, "opendir: " .. dir)
   end
   local errbox: {string} = {}
-  walk_entries(dir, handle as WalkDirHandle, visitor, ctx, errbox)
+  walk_entries(dir, handle as WalkDirHandle, visitor, ctx, errbox, 1, max_depth)
   return ctx, errbox[1]
 end
 
@@ -165,6 +181,78 @@ end
 --- @return string First error encountered, if any
 local function collect(dir: string, pattern: string): {string} | nil, string
   return collect_by_pattern(dir, glob_to_pattern(pattern))
+end
+
+--- List entries in one directory whose name matches a glob component.
+--- Appends matching paths (any entry type) to out; returns an error
+--- string on opendir failure, nil otherwise.
+local function glob_level(dir: string, lua_pattern: string, out: {string}): string
+  local handle, oerr = unix.opendir(dir)
+  if not handle then
+    return errstr(oerr, "opendir: " .. dir)
+  end
+  local h = handle as WalkDirHandle
+  while true do
+    local entry = h:read()
+    if not entry then break end
+    if entry ~= "." and entry ~= ".." and entry:match(lua_pattern) then
+      table.insert(out, cosmo_path.join(dir, entry))
+    end
+  end
+  h:close()
+end
+
+--- Expand a glob pattern against a directory, WITHOUT recursing:
+--- unlike collect(), only the levels named by the pattern are read.
+--- The pattern may span path components ("src/*.lua", "*/init.tl");
+--- each component is a glob (`*` any run, `?` one char, both never
+--- crossing a "/"), other characters match literally, and there is no
+--- `**`. Unlike a shell, `*` also matches names starting with a dot.
+--- Matches of every entry type (files, dirs, symlinks) are returned,
+--- sorted. If dir itself cannot be opened, returns nil plus the error;
+--- an unreadable directory at a deeper level does not stop expansion,
+--- and the first such error is returned alongside the results.
+--- @param dir string The directory the pattern is relative to
+--- @param pattern string Glob pattern, optionally with "/" components
+--- @return {string} | nil Sorted matching paths, or nil if dir failed
+--- @return string First error encountered, if any
+local function glob(dir: string, pattern: string): {string} | nil, string
+  if pattern:sub(1, 1) == "/" then
+    return nil, "glob: pattern must be relative to dir: " .. pattern
+  end
+  local comps: {string} = {}
+  for comp in pattern:gmatch("[^/]+") do
+    table.insert(comps, comp)
+  end
+  if #comps == 0 then
+    return nil, "glob: empty pattern"
+  end
+  local current: {string} = {dir}
+  local first_err: string = nil
+  for i, comp in ipairs(comps) do
+    local lua_pattern = glob_to_pattern(comp)
+    local next_level: {string} = {}
+    for j, d in ipairs(current) do
+      -- Below the first level only descend through directories; a file
+      -- matching an intermediate component cannot contain entries.
+      if i == 1 or cosmo_path.isdir(d) then
+        local gerr = glob_level(d, lua_pattern, next_level)
+        if gerr then
+          -- The root directory failing is fatal; deeper failures are
+          -- recorded (first one wins) and expansion continues.
+          if i == 1 and j == 1 then
+            return nil, gerr
+          end
+          if not first_err then
+            first_err = gerr
+          end
+        end
+      end
+    end
+    current = next_level
+  end
+  table.sort(current)
+  return current, first_err
 end
 
 --- Collect file paths whose basename matches a Lua pattern (%.lua$).
@@ -345,10 +433,14 @@ local type FileIter = function(): string
     --- Visitor verdict: nil continues, "skip" prunes, "stop" ends the walk.
     type WalkAction = WalkAction
 
+    --- Options for walk() (max_depth).
+    type WalkOptions = WalkOptions
+
     --- Walk dir tree. visitor(path, name, st, ctx): path is the FULL path; name is the basename.
     --- Do NOT join path and name — path is already complete.
     --- The visitor may return "skip" (don't descend) or "stop" (end the walk).
-    walk: function < T > (dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T): T | nil, string
+    walk: function < T > (dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string
+    glob: function(dir: string, pattern: string): {string} | nil, string
     collect: function(dir: string, pattern: string): {string} | nil, string
     collect_matching: function(dir: string, lua_pattern: string): {string} | nil, string
     collect_all: function(dir: string): {string: FileInfo} | nil, string
@@ -357,6 +449,7 @@ local type FileIter = function(): string
 
   local M: FsWalkModule = {
     walk = walk,
+    glob = glob,
     collect = collect,
     collect_matching = collect_matching,
     collect_all = collect_all,


### PR DESCRIPTION
Part of #501 (§4.2 umbrella) — addresses the audit's remaining fs notes: "glob basename-only/always-recursive" and "walk depth/prune" (pruning already existed via the `"skip"` visitor verdict; this adds the depth half).

## What's added

**`fs.glob(dir, pattern)`** — expands a glob **without recursing**; only the levels named by the pattern are read (unlike `collect`, which always walks the whole tree and matches basenames). The pattern may span path components (`"src/*.lua"`, `"*/init.tl"`); each component uses the same strict glob rules as `collect` (`*` any run, `?` one char, everything else literal, wildcards never cross `/`, no `**`). Matches of every entry type are returned sorted. Divergence from a shell, documented: `*` also matches dotfiles. Root open failure is `nil, err`; deeper unreadable directories record the first error alongside results, matching `collect`'s convention. Absolute or empty patterns are rejected.

**`walk(dir, visitor, ctx?, opts?)`** — gains an optional `WalkOptions` record with `max_depth`: entries directly in `dir` are depth 1, and the walk never descends into directories at the maximum depth. `nil`/`0` mean unlimited, so all existing three-argument callers are untouched (verified: `collect`/`collect_by_pattern` still call it bare).

## Tests

New `fs/glob_test.tl` over a small fixture tree: non-recursion (top-level `*.lua` doesn't see `src/x.lua`), path components, wildcard directory components, directory matches, literal components, dotfile inclusion, sorted output, missing-dir/no-match empties, root failure, invalid patterns; plus `max_depth` 1/2 boundaries and unlimited-by-default/`0` semantics.

`bin/make ci` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi)_