### PR TITLE
fetch: verbs, json/form/multipart/query options, Result:json, download (#501)

### DIFF
--- a/lib/cosmic/fetch/extras.tl
+++ b/lib/cosmic/fetch/extras.tl
@@ -1,0 +1,403 @@
+--- Internal helpers for cosmic.fetch: URL/header validation, request
+--- body building (query/json/form/multipart), the verb helpers, and
+--- download. Lives in its own file so fetch/init.tl stays under the
+--- 500-line cap; init wires everything together.
+local url_mod = require("cosmic.url")
+local json_mod = require("cosmic.json")
+local codec = require("cosmic.codec")
+local rand = require("cosmic.rand")
+local fd = require("cosmic.fd")
+local fs = require("cosmic.fs")
+
+--- One part of a multipart/form-data request body.
+local record Part
+  --- Form field name (required).
+  name: string
+  --- Field or file content (required; "" is a valid empty value).
+  value: string
+  --- File name; its presence makes this a file part.
+  filename: string
+  --- Part content type (optional; files default to
+  --- application/octet-stream, plain fields carry none).
+  content_type: string
+end
+
+local function validate_url(url: string): string
+  if url == "" then
+    return "empty URL"
+  end
+  local scheme = url:match("^([a-zA-Z][a-zA-Z0-9+%-.]*)://")
+  if not scheme then
+    return "unsupported URL scheme: (none)"
+  end
+  scheme = scheme:lower()
+  if scheme ~= "http" and scheme ~= "https" then
+    return "unsupported URL scheme: " .. scheme
+  end
+  return nil
+end
+
+-- True when s carries a CR, LF, or NUL. One character-class scan instead
+-- of three separate plain-text searches over the same string.
+local function has_forbidden_byte(s: string): boolean
+  return s:find("[\r\n\0]") ~= nil
+end
+
+--- Reject header names or values that carry a CR, LF, or NUL. HTTP headers
+--- are CRLF-delimited, so an embedded CR/LF in a name or value smuggles
+--- additional header lines (or a body) past cosmo.Fetch — a request-splitting
+--- / header-injection vector (audit §2.3). The error names the offending
+--- header but never echoes the raw control bytes back.
+--- @param headers {string: string} request headers, or nil
+--- @return string? error message, or nil when every header is safe
+local function validate_headers(headers: {string: string}): string
+  if not headers then
+    return nil
+  end
+  for name, value in pairs(headers) do
+    if name == "" then
+      return "invalid header name: must not be empty"
+    end
+    if has_forbidden_byte(name) then
+      return "invalid header name: must not contain CR, LF, or NUL"
+    end
+    if value ~= nil and has_forbidden_byte(value) then
+      return "invalid value for header '" .. name .. "': must not contain CR, LF, or NUL"
+    end
+  end
+  return nil
+end
+
+--- Build a unix domain socket proxy URL from a socket path.
+--- @param path string Absolute path to the unix domain socket
+--- @return string | nil proxy URL in unix:// format
+--- @return string? Error message if path is invalid
+local function unix_proxy(path: string): string | nil, string
+  if not path or path == "" then
+    return nil, "empty socket path"
+  end
+  if path:sub(1, 1) ~= "/" then
+    return nil, "socket path must be absolute"
+  end
+  if path:match("/%.%./") or path:match("/%.%.$") or path:match("/%./") or path:match("/%.$") then
+    return nil, "socket path must not contain . or .. segments"
+  end
+  -- unix(7) sockaddr_un sun_path is typically 108 bytes
+  if #path >= 108 then
+    return nil, "socket path too long"
+  end
+  return "unix://" .. path
+end
+
+--- Percent-encode params as k=v pairs joined with "&", keys sorted so
+--- the encoding is deterministic. Spaces become %20 (not "+").
+local function encode_pairs(params: {string: string}): string
+  local keys: {string} = {}
+  for k in pairs(params) do
+    table.insert(keys, k)
+  end
+  table.sort(keys)
+  local out: {string} = {}
+  for _, k in ipairs(keys) do
+    table.insert(out, url_mod.encode(k) .. "=" .. url_mod.encode(params[k]))
+  end
+  return table.concat(out, "&")
+end
+
+--- Append query params to a URL, honoring an existing query string.
+local function append_query(url: string, params: {string: string}): string
+  local qs = encode_pairs(params)
+  if qs == "" then
+    return url
+  end
+  if url:find("?", 1, true) then
+    return url .. "&" .. qs
+  end
+  return url .. "?" .. qs
+end
+
+-- Multipart names and filenames are embedded in a quoted string inside
+-- Content-Disposition; quotes and CR/LF would corrupt the framing.
+local function bad_token(s: string): boolean
+  return s:find('["\r\n]') ~= nil
+end
+
+--- Encode parts as a multipart/form-data body with a random boundary
+--- (96 random bits, so a body containing it is not a practical concern).
+--- @return string | nil The encoded body, or nil on error
+--- @return string The content type carrying the boundary (error message when body is nil)
+local function encode_multipart(parts: {Part}): string | nil, string
+  if #parts == 0 then
+    return nil, "multipart: no parts"
+  end
+  local raw, rerr = rand.bytes(12)
+  if not raw then
+    return nil, rerr
+  end
+  local boundary = "cosmic" .. codec.encode_hex(raw as string)
+  local out: {string} = {}
+  for _, part in ipairs(parts) do
+    if not part.name or part.name == "" then
+      return nil, "multipart: part missing name"
+    end
+    if bad_token(part.name) or (part.filename and bad_token(part.filename)) then
+      return nil, "multipart: name/filename must not contain quotes, CR, or LF"
+    end
+    if part.value == nil then
+      return nil, "multipart: part '" .. part.name .. "' missing value"
+    end
+    local head = "--" .. boundary .. "\r\nContent-Disposition: form-data; name=\"" .. part.name .. "\""
+    if part.filename then
+      head = head .. "; filename=\"" .. part.filename .. "\""
+    end
+    local ctype = part.content_type
+    if not ctype and part.filename then
+      ctype = "application/octet-stream"
+    end
+    if ctype then
+      head = head .. "\r\nContent-Type: " .. ctype
+    end
+    table.insert(out, head .. "\r\n\r\n" .. part.value .. "\r\n")
+  end
+  table.insert(out, "--" .. boundary .. "--\r\n")
+  return table.concat(out), "multipart/form-data; boundary=" .. boundary
+end
+
+-- Mirror of the Options fields prepare touches (Teal records are
+-- nominal; the boundary crosses through `any`, like cosmic.sqlite's
+-- helper modules).
+local record Opts
+  method: string
+  body: string
+  headers: {string: string}
+  query: {string: string}
+  json: any
+  form: {string: string}
+  multipart: {Part}
+end
+
+local function set_default_content_type(o: Opts, ctype: string)
+  if o.headers then
+    for k in pairs(o.headers) do
+      if k:lower() == "content-type" then
+        return
+      end
+    end
+  else
+    o.headers = {}
+  end
+  o.headers["Content-Type"] = ctype
+end
+
+--- Expand the declarative request options (query/json/form/multipart)
+--- into a concrete URL and body. Returns the (possibly rewritten) URL,
+--- the (possibly copied) options, and an error message. The caller's
+--- options table is never mutated; a body-producing option defaults the
+--- method to POST when none is set.
+--- @param url string The request URL
+--- @param opts_any any The fetch Options, or nil
+--- @return string The URL with query params appended
+--- @return any The prepared options
+--- @return string? Error message on invalid or conflicting options
+local function prepare(url: string, opts_any: any): string, any, string
+  if opts_any == nil then
+    return url, nil, nil
+  end
+  local opts = opts_any as Opts
+  local sources = 0
+  if opts.body then sources = sources + 1 end
+  if opts.json ~= nil then sources = sources + 1 end
+  if opts.form then sources = sources + 1 end
+  if opts.multipart then sources = sources + 1 end
+  if sources > 1 then
+    return url, nil, "at most one of body, json, form, multipart may be set"
+  end
+  if sources == 0 and not opts.query then
+    return url, opts_any, nil
+  end
+
+  -- Shallow copy (headers too) so no caller table is mutated.
+  local o: {string: any} = {}
+  for k, v in pairs(opts_any as {string: any}) do
+    o[k] = v
+  end
+  local prepared = o as Opts
+  if opts.headers then
+    local h: {string: string} = {}
+    for k, v in pairs(opts.headers) do
+      h[k] = v
+    end
+    prepared.headers = h
+  end
+
+  if opts.query then
+    url = append_query(url, opts.query)
+    prepared.query = nil
+  end
+  if opts.json ~= nil then
+    local body, jerr = json_mod.encode(opts.json)
+    if not body then
+      return url, nil, "json body: " .. tostring(jerr)
+    end
+    prepared.json = nil
+    prepared.body = body
+    set_default_content_type(prepared, "application/json")
+  elseif opts.form then
+    prepared.form = nil
+    prepared.body = encode_pairs(opts.form)
+    set_default_content_type(prepared, "application/x-www-form-urlencoded")
+  elseif opts.multipart then
+    local body, ctype_or_err = encode_multipart(opts.multipart)
+    if not body then
+      return url, nil, ctype_or_err
+    end
+    prepared.multipart = nil
+    prepared.body = body
+    set_default_content_type(prepared, ctype_or_err)
+  end
+  if prepared.body and not prepared.method then
+    prepared.method = "POST"
+  end
+  return url, o, nil
+end
+
+-- Mirrors of the stream result surface download consumes.
+local record Reader
+  read: function(self: Reader): string | nil, string
+  close: function(self: Reader): boolean
+end
+
+local record StreamRes
+  ok: boolean
+  status: integer
+  headers: {string: string}
+  raw_headers: {string: {string}}
+  url: string
+  error: string
+  reader: Reader
+end
+
+--- The verb helpers and download, built around init's fetch/stream so
+--- no require cycle forms. wrap attaches init's result metatable
+--- (is_success/json) to download's synthesized results.
+local record Made
+  get: function(string, any): any
+  post: function(string, any): any
+  put: function(string, any): any
+  delete: function(string, any): any
+  download: function(string, string, any): any
+end
+
+local function verb(fetch_fn: function(string, any): any, method: string): function(string, any): any
+  return function(url: string, opts_any: any): any
+    local o: {string: any} = {}
+    if opts_any then
+      for k, v in pairs(opts_any as {string: any}) do
+        o[k] = v
+      end
+    end
+    o["method"] = method
+    return fetch_fn(url, o)
+  end
+end
+
+local function make(fetch_fn: function(string, any): any,
+    stream_fn: function(string, any): any,
+    wrap: function(any): any): Made
+  local made: Made = {
+    get = verb(fetch_fn, "GET"),
+    post = verb(fetch_fn, "POST"),
+    put = verb(fetch_fn, "PUT"),
+    delete = verb(fetch_fn, "DELETE"),
+  }
+
+  made.download = function(url: string, path: string, opts_any: any): any
+    local res_any = stream_fn(url, opts_any)
+    local res = res_any as StreamRes
+    if not res.ok then
+      return res_any
+    end
+    local out: {string: any} = {
+      ok = true, status = res.status, headers = res.headers,
+      raw_headers = res.raw_headers, url = res.url, body = "",
+    }
+    local function fail_with(err: string): any
+      res.reader:close()
+      out["ok"] = false
+      out["error"] = err
+      return wrap(out)
+    end
+    if not (res.status >= 200 and res.status < 300) then
+      -- Nothing is written for a non-2xx response; drain a bounded
+      -- diagnostic body instead so callers can see the error page.
+      local parts: {string} = {}
+      local total = 0
+      while total < 65536 do
+        local chunk = res.reader:read()
+        if not chunk then break end
+        table.insert(parts, chunk)
+        total = total + #chunk
+      end
+      res.reader:close()
+      out["body"] = table.concat(parts)
+      return wrap(out)
+    end
+    local handle, oerr = fd.open(path, fd.O_WRONLY | fd.O_CREAT | fd.O_TRUNC, tonumber("644", 8))
+    if not handle then
+      return fail_with("download: " .. tostring(oerr))
+    end
+    local h = handle as fd.Handle
+    while true do
+      local chunk, rerr = res.reader:read()
+      if rerr then
+        h:close()
+        fs.unlink(path)
+        return fail_with("download: " .. rerr)
+      end
+      if not chunk then break end
+      local c = chunk as string
+      local off = 0
+      while off < #c do
+        local n, werr = h:write(c:sub(off + 1))
+        if not n then
+          h:close()
+          fs.unlink(path)
+          return fail_with("download: write: " .. tostring(werr))
+        end
+        off = off + math.floor(n)
+      end
+    end
+    res.reader:close()
+    local cok, cerr = h:close()
+    if not cok then
+      fs.unlink(path)
+      out["ok"] = false
+      out["error"] = "download: close: " .. tostring(cerr)
+    end
+    return wrap(out)
+  end
+
+  return made
+end
+
+local record ExtrasModule
+  type Part = Part
+  type Made = Made
+  validate_url: function(url: string): string
+  validate_headers: function(headers: {string: string}): string
+  unix_proxy: function(path: string): string | nil, string
+  prepare: function(url: string, opts_any: any): string, any, string
+  make: function(fetch_fn: function(string, any): any,
+  stream_fn: function(string, any): any,
+  wrap: function(any): any): Made
+end
+
+local M: ExtrasModule = {
+  validate_url = validate_url,
+  validate_headers = validate_headers,
+  unix_proxy = unix_proxy,
+  prepare = prepare,
+  make = make,
+}
+
+return M

--- a/lib/cosmic/fetch/init.tl
+++ b/lib/cosmic/fetch/init.tl
@@ -4,8 +4,16 @@
 
 local cosmo = require("cosmo")
 local fetch_headers = require("cosmic.fetch.headers")
+local fetch_extras = require("cosmic.fetch.extras")
+local json_mod = require("cosmic.json")
 local stream = require("cosmic.stream")
 local time = require("cosmic.time")
+
+local validate_url = fetch_extras.validate_url
+local validate_headers = fetch_extras.validate_headers
+
+--- One part of a multipart/form-data request body (see Options.multipart).
+local type Part = fetch_extras.Part
 
 --- Machine-readable failure category, from the C fetch error channel.
 --- nil on wrapper-side validation failures (bad URL, bad header).
@@ -37,14 +45,27 @@ local record Result
   error_kind: ErrorKind
   --- True when ok and status is 2xx.
   is_success: function(self: Result): boolean
+  --- Decode the response body as JSON (nil + error on bad JSON).
+  json: function(self: Result): any, string
 end
 
 --- Options for fetch requests.
 local record Options
-  --- HTTP method (default "GET").
+  --- HTTP method (default "GET"; "POST" when json/form/multipart/body
+  --- is set and no method is given).
   method: string
   --- Request body to send (for POST, PUT, PATCH).
   body: string
+  --- Query parameters appended to the URL, percent-encoded, keys sorted.
+  query: {string: string}
+  --- JSON request body: encoded with cosmic.json, Content-Type set to
+  --- application/json unless the caller supplied one. At most one of
+  --- body/json/form/multipart may be set.
+  json: any
+  --- Form request body (application/x-www-form-urlencoded, keys sorted).
+  form: {string: string}
+  --- multipart/form-data request body parts (random boundary).
+  multipart: {Part}
   --- HTTP headers to send with the request.
   headers: {string: string}
   --- Follow 3xx redirects (default true).
@@ -112,54 +133,17 @@ local result_mt = {
       return self.ok and self.status ~= nil
       and self.status >= 200 and self.status < 300
     end,
+    json = function(self: Result): any, string
+      if not self.body or self.body == "" then
+        return nil, "empty body"
+      end
+      return json_mod.decode(self.body)
+    end,
   },
 }
 
-local function validate_url(url: string): string
-  if url == "" then
-    return "empty URL"
-  end
-  local scheme = url:match("^([a-zA-Z][a-zA-Z0-9+%-.]*)://")
-  if not scheme then
-    return "unsupported URL scheme: (none)"
-  end
-  scheme = scheme:lower()
-  if scheme ~= "http" and scheme ~= "https" then
-    return "unsupported URL scheme: " .. scheme
-  end
-  return nil
-end
-
--- True when s carries a CR, LF, or NUL. One character-class scan instead
--- of three separate plain-text searches over the same string.
-local function has_forbidden_byte(s: string): boolean
-  return s:find("[\r\n\0]") ~= nil
-end
-
---- Reject header names or values that carry a CR, LF, or NUL. HTTP headers
---- are CRLF-delimited, so an embedded CR/LF in a name or value smuggles
---- additional header lines (or a body) past cosmo.Fetch — a request-splitting
---- / header-injection vector (audit §2.3). The error names the offending
---- header but never echoes the raw control bytes back.
---- @param headers {string: string} request headers, or nil
---- @return string? error message, or nil when every header is safe
-local function validate_headers(headers: {string: string}): string
-  if not headers then
-    return nil
-  end
-  for name, value in pairs(headers) do
-    if name == "" then
-      return "invalid header name: must not be empty"
-    end
-    if has_forbidden_byte(name) then
-      return "invalid header name: must not contain CR, LF, or NUL"
-    end
-    if value ~= nil and has_forbidden_byte(value) then
-      return "invalid value for header '" .. name .. "': must not contain CR, LF, or NUL"
-    end
-  end
-  return nil
-end
+-- validate_url/validate_headers and the request-body builders live in
+-- cosmic.fetch.extras (this file is at the 500-line cap).
 
 --- Project the transport-relevant Options fields onto a fresh typed
 --- cosmo.FetchOptions, shallow-copying headers so no attempt can observe
@@ -261,6 +245,14 @@ end
 --- @param opts Options optional fetch options (retry, headers, redirects, ...)
 --- @return Result fetch result with ok, status, headers, body, url, or error
 local function Fetch(url: string, opts?: Options): Result
+  -- Expand query/json/form/multipart first: prepare may set the method
+  -- (body options default to POST), which the retry policy inspects.
+  local purl, popts, perr = fetch_extras.prepare(url, opts)
+  if perr then
+    return fail(perr, nil)
+  end
+  url = purl
+  opts = popts as Options
   local max_attempts = (opts and opts.max_attempts) or 1
   local base_delay = (opts and opts.base_delay) or 0.5
   local max_delay = (opts and opts.max_delay) or 30
@@ -413,6 +405,12 @@ end
 --- @param opts Options optional fetch options
 --- @return StreamResult with reader for incremental body access
 local function stream(url: string, opts?: Options): StreamResult
+  local purl, popts, perr = fetch_extras.prepare(url, opts)
+  if perr then
+    return stream_fail(perr, nil)
+  end
+  url = purl
+  opts = popts as Options
   local verr = validate_url(url)
   if verr then
     return stream_fail(verr, nil)
@@ -438,44 +436,50 @@ local function stream(url: string, opts?: Options): StreamResult
     } as StreamResult, result_mt) as StreamResult
 end
 
---- Build a unix domain socket proxy URL from a socket path.
---- @param path string Absolute path to the unix domain socket
---- @return string | nil proxy URL in unix:// format
---- @return string? Error message if path is invalid
-local function unix_proxy(path: string): string | nil, string
-  if not path or path == "" then
-    return nil, "empty socket path"
-  end
-  if path:sub(1, 1) ~= "/" then
-    return nil, "socket path must be absolute"
-  end
-  if path:match("/%.%./") or path:match("/%.%.$") or path:match("/%./") or path:match("/%.$") then
-    return nil, "socket path must not contain . or .. segments"
-  end
-  -- unix(7) sockaddr_un sun_path is typically 108 bytes
-  if #path >= 108 then
-    return nil, "socket path too long"
-  end
-  return "unix://" .. path
-end
+-- The verb helpers and download are built in cosmic.fetch.extras around
+-- this file's fetch/stream; wrap hands them the result metatable so
+-- download's synthesized results answer is_success()/json() too.
+local made = fetch_extras.make(
+  Fetch as(function(string, any): any),
+    stream as(function(string, any): any),
+      function(t: any): any
+        return setmetatable(t as {string: any}, result_mt)
+      end)
 
-local record FetchModule
-  fetch: function(url: string, opts?: Options): Result
-  stream: function(url: string, opts?: Options): StreamResult
-  unix_proxy: function(path: string): string | nil, string
-  type ErrorKind = ErrorKind
-  --- Type aliases, not runtime values — the old `Result: Result`
-  --- field spelling declared phantom fields that were nil at runtime.
-  type Options = Options
-  type Result = Result
-  type Reader = Reader
-  type StreamResult = StreamResult
-end
+    local record FetchModule
+      fetch: function(url: string, opts?: Options): Result
+      --- GET/POST/PUT/DELETE conveniences: fetch with the method forced.
+      get: function(url: string, opts?: Options): Result
+      post: function(url: string, opts?: Options): Result
+      put: function(url: string, opts?: Options): Result
+      delete: function(url: string, opts?: Options): Result
+      --- Stream a URL to a file. The file is written only for a 2xx
+      --- response (created/truncated, then removed again on a mid-stream
+      --- failure); a non-2xx response returns its status with a bounded
+      --- diagnostic body and writes nothing. The result carries body = ""
+      --- on success.
+      download: function(url: string, path: string, opts?: Options): Result
+      stream: function(url: string, opts?: Options): StreamResult
+      unix_proxy: function(path: string): string | nil, string
+      type ErrorKind = ErrorKind
+      --- Type aliases, not runtime values — the old `Result: Result`
+      --- field spelling declared phantom fields that were nil at runtime.
+      type Options = Options
+      type Part = Part
+      type Result = Result
+      type Reader = Reader
+      type StreamResult = StreamResult
+    end
 
-local M: FetchModule = {
-  fetch = Fetch,
-  stream = stream,
-  unix_proxy = unix_proxy,
-}
+    local M: FetchModule = {
+      fetch = Fetch,
+      get = made.get as(function(string, Options): Result),
+        post = made.post as(function(string, Options): Result),
+          put = made.put as(function(string, Options): Result),
+            delete = made.delete as(function(string, Options): Result),
+              download = made.download as(function(string, string, Options): Result),
+                stream = stream,
+                unix_proxy = fetch_extras.unix_proxy,
+              }
 
-return M
+              return M

--- a/lib/cosmic/fetch/verbs_test.tl
+++ b/lib/cosmic/fetch/verbs_test.tl
@@ -1,0 +1,249 @@
+#!/usr/bin/env cosmic
+--- Verb helpers, request-body building, and download, tested against
+--- forked loopback echo servers (same pattern as init_test.tl): the
+--- server answers with the raw request, so method lines, headers, and
+--- bodies can be asserted from the response body.
+local fetch = require("cosmic.fetch")
+local fs = require("cosmic.fs")
+local net = require("cosmic.net")
+local proc = require("cosmic.proc")
+
+local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
+
+--- Read one HTTP request (head plus Content-Length body) from a connection.
+local function read_request(conn: net.Socket): string
+  local buf = ""
+  while true do
+    local head_end = buf:find("\r\n\r\n", 1, true)
+    if head_end then
+      local cl = buf:match("[Cc]ontent%-[Ll]ength:%s*(%d+)")
+      local want = head_end + 3 + ((cl and math.tointeger(tonumber(cl))) or 0)
+      if #buf >= want then
+        return buf
+      end
+    end
+    local data = conn:recv(4096)
+    if not data or #data == 0 then
+      return buf
+    end
+    buf = buf .. data
+  end
+end
+
+--- Fork a loopback HTTP server that answers #responses requests in order,
+--- then exits. A response of "echo" answers 200 with the raw request as
+--- the body.
+--- @return integer port, integer child pid (caller must proc.wait it)
+local function serve(responses: {string}): integer, number
+  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  assert(srv ~= nil, "listen_tcp failed")
+  local s = srv as net.Socket
+  local pid = proc.fork()
+  if pid == 0 then
+    for _, resp in ipairs(responses) do
+      local conn = s:accept()
+      if conn then
+        local c = conn as net.Socket
+        local req = read_request(c)
+        if resp == "echo" then
+          c:send("HTTP/1.1 200 OK\r\nContent-Length: " .. #req
+            .. "\r\nConnection: close\r\n\r\n" .. req)
+        elseif #resp > 0 then
+          c:send(resp)
+        end
+        c:close()
+      end
+    end
+    os.exit(0)
+  end
+  s:close()
+  return math.tointeger(port), pid
+end
+
+--- Run one echoed request and return the raw request the server saw.
+local function echo_request(run: function(string): fetch.Result): string
+  local port, pid = serve({"echo"})
+  local r = run("http://127.0.0.1:" .. port)
+  proc.wait(math.tointeger(pid))
+  assert(r.ok, "request failed: " .. tostring(r.error))
+  assert(r:is_success(), "expected 2xx, got " .. tostring(r.status))
+  return r.body
+end
+
+-- verb tests
+
+local function test_verbs_set_method()
+  local req = echo_request(function(base: string): fetch.Result
+      return fetch.get(base .. "/x", {allow_private = true})
+    end)
+  assert(req:find("^GET /x HTTP/1") ~= nil, "expected GET line, got: " .. req:sub(1, 40))
+
+  req = echo_request(function(base: string): fetch.Result
+      return fetch.post(base .. "/x", {allow_private = true, body = "hi"})
+    end)
+  assert(req:find("^POST /x HTTP/1") ~= nil, "expected POST line")
+  assert(req:find("\r\n\r\nhi$") ~= nil, "expected body 'hi'")
+
+  req = echo_request(function(base: string): fetch.Result
+      return fetch.put(base .. "/x", {allow_private = true, body = "data"})
+    end)
+  assert(req:find("^PUT /x HTTP/1") ~= nil, "expected PUT line")
+
+  req = echo_request(function(base: string): fetch.Result
+      return fetch.delete(base .. "/x", {allow_private = true})
+    end)
+  assert(req:find("^DELETE /x HTTP/1") ~= nil, "expected DELETE line")
+end
+test_verbs_set_method()
+
+-- query tests
+
+local function test_query_appended_sorted_and_encoded()
+  local req = echo_request(function(base: string): fetch.Result
+      return fetch.get(base .. "/s", {allow_private = true, query = {q = "hello world", a = "1"}})
+    end)
+  assert(req:find("GET /s?a=1&q=hello%20world HTTP", 1, true) ~= nil,
+    "expected sorted, percent-encoded query, got: " .. req:sub(1, 60))
+end
+test_query_appended_sorted_and_encoded()
+
+local function test_query_appends_to_existing()
+  local req = echo_request(function(base: string): fetch.Result
+      return fetch.get(base .. "/s?x=1", {allow_private = true, query = {y = "2"}})
+    end)
+  assert(req:find("GET /s?x=1&y=2 HTTP", 1, true) ~= nil, "expected & continuation")
+end
+test_query_appends_to_existing()
+
+-- json body tests
+
+local function test_json_body_and_default_post()
+  local req = echo_request(function(base: string): fetch.Result
+      -- No method and no verb helper: a json body must default to POST.
+      return fetch.fetch(base .. "/j", {allow_private = true, json = {n = 7}})
+    end)
+  assert(req:find("^POST /j HTTP/1") ~= nil, "expected POST default for json body")
+  assert(req:lower():find("content-type: application/json", 1, true) ~= nil,
+    "expected json content type")
+  assert(req:find('{"n":7}', 1, true) ~= nil, "expected encoded json body")
+end
+test_json_body_and_default_post()
+
+local function test_json_respects_caller_content_type()
+  local req = echo_request(function(base: string): fetch.Result
+      return fetch.post(base .. "/j", {
+          allow_private = true,
+          json = {n = 1},
+          headers = {["content-type"] = "application/vnd.api+json"},
+        })
+    end)
+  assert(req:lower():find("content-type: application/vnd.api+json", 1, true) ~= nil,
+    "expected caller content type kept")
+  assert(req:lower():find("content-type: application/json\r\n", 1, true) == nil,
+    "expected no second content type")
+end
+test_json_respects_caller_content_type()
+
+-- form body tests
+
+local function test_form_body()
+  local req = echo_request(function(base: string): fetch.Result
+      return fetch.post(base .. "/f", {allow_private = true, form = {b = "two words", a = "1"}})
+    end)
+  assert(req:lower():find("content-type: application/x-www-form-urlencoded", 1, true) ~= nil,
+    "expected form content type")
+  assert(req:find("\r\n\r\na=1&b=two%20words", 1, true) ~= nil, "expected sorted encoded form body")
+end
+test_form_body()
+
+-- multipart tests
+
+local function test_multipart_body()
+  local req = echo_request(function(base: string): fetch.Result
+      return fetch.post(base .. "/m", {
+          allow_private = true,
+          multipart = {
+            {name = "field", value = "plain"},
+            {name = "up", value = "file-bytes", filename = "a.txt", content_type = "text/plain"},
+          },
+        })
+    end)
+  local boundary = req:match("multipart/form%-data; boundary=(%w+)")
+  assert(boundary, "expected multipart content type with boundary")
+  assert(req:find('Content-Disposition: form-data; name="field"\r\n\r\nplain\r\n', 1, true) ~= nil,
+    "expected plain field part")
+  assert(req:find('name="up"; filename="a.txt"\r\nContent-Type: text/plain\r\n\r\nfile-bytes\r\n', 1, true) ~= nil,
+    "expected file part with content type")
+  assert(req:find("--" .. boundary .. "--", 1, true) ~= nil, "expected closing boundary")
+end
+test_multipart_body()
+
+-- option validation tests
+
+local function test_conflicting_body_options()
+  local r = fetch.post("http://127.0.0.1:1/x", {json = {a = 1}, form = {b = "2"}})
+  assert(not r.ok, "expected conflicting body options to fail")
+  assert(r.error and r.error:find("at most one", 1, true), "expected conflict error, got: " .. tostring(r.error))
+end
+test_conflicting_body_options()
+
+local function test_multipart_validation()
+  local r = fetch.post("http://127.0.0.1:1/x", {multipart = {{name = 'bad"name', value = "v"}}})
+  assert(not r.ok and r.error ~= nil, "expected bad multipart name rejected")
+end
+test_multipart_validation()
+
+-- Result:json() tests
+
+local function test_result_json()
+  local port, pid = serve({"HTTP/1.1 200 OK\r\nContent-Length: 15\r\nConnection: close\r\n\r\n{\"answer\": 42}\n"})
+  local r = fetch.get("http://127.0.0.1:" .. port, {allow_private = true})
+  proc.wait(math.tointeger(pid))
+  assert(r.ok, "request failed: " .. tostring(r.error))
+  local v = r:json()
+  assert((v as {string: any}).answer == 42, "expected decoded json body")
+end
+test_result_json()
+
+local function test_result_json_bad_body()
+  local port, pid = serve({"HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\nnot-json"})
+  local r = fetch.get("http://127.0.0.1:" .. port, {allow_private = true})
+  proc.wait(math.tointeger(pid))
+  local v, err = r:json()
+  assert(v == nil and err ~= nil, "expected decode failure for bad json")
+end
+test_result_json_bad_body()
+
+-- download tests
+
+local function test_download_success()
+  local path = fs.join(TEST_TMPDIR, "dl.bin")
+  local port, pid = serve({"HTTP/1.1 200 OK\r\nContent-Length: 12\r\nConnection: close\r\n\r\nfile-content"})
+  local r = fetch.download("http://127.0.0.1:" .. port, path, {allow_private = true})
+  proc.wait(math.tointeger(pid))
+  assert(r.ok and r:is_success(), "download failed: " .. tostring(r.error))
+  assert(r.body == "", "expected empty body on download success")
+  assert(fs.read(path) == "file-content", "expected file written")
+  fs.unlink(path)
+end
+test_download_success()
+
+local function test_download_non_2xx_writes_nothing()
+  local path = fs.join(TEST_TMPDIR, "dl404.bin")
+  local port, pid = serve({"HTTP/1.1 404 Not Found\r\nContent-Length: 9\r\nConnection: close\r\n\r\nnot found"})
+  local r = fetch.download("http://127.0.0.1:" .. port, path, {allow_private = true})
+  proc.wait(math.tointeger(pid))
+  assert(r.ok, "expected transport success")
+  assert(not r:is_success() and r.status == 404, "expected 404 result")
+  assert(r.body == "not found", "expected diagnostic body, got: " .. tostring(r.body))
+  assert(not fs.exists(path), "expected no file for non-2xx")
+end
+test_download_non_2xx_writes_nothing()
+
+local function test_download_transport_failure()
+  local path = fs.join(TEST_TMPDIR, "dlfail.bin")
+  local r = fetch.download("http://127.0.0.1:1", path, {allow_private = true, timeout = 2})
+  assert(not r.ok and r.error ~= nil, "expected connect failure")
+  assert(not fs.exists(path), "expected no file on transport failure")
+end
+test_download_transport_failure()


### PR DESCRIPTION
Part of #501 (§4.2 umbrella) — the last work item: the **fetch (P1)** ergonomics cluster (redirects, the `Fetch`→`fetch` rename, and retry classification had already landed).

## What's added

**Verb helpers** — `fetch.get/post/put/delete(url, opts?)`: `fetch` with the method forced (options are shallow-copied, never mutated).

**Declarative request options** on `Options`, expanded by a `prepare` step before the retry loop:
- `query` — appended to the URL, percent-encoded, keys sorted (deterministic).
- `json` — body encoded via `cosmic.json`, `Content-Type: application/json` unless the caller already set one (checked case-insensitively).
- `form` — `application/x-www-form-urlencoded`, sorted keys.
- `multipart` — `{fetch.Part}` list (`name`, `value`, optional `filename`/`content_type`), random 96-bit boundary; names/filenames containing quotes or CR/LF are rejected (they'd corrupt the Content-Disposition framing).

At most one of `body`/`json`/`form`/`multipart` may be set (conflict is an error, not a silent pick), and a body-producing option defaults the method to POST — `prepare` runs before the retry policy reads the method, so idempotency classification sees the real method.

**`Result:json()`** — decodes the response body (nil + error on empty/bad JSON), attached via the existing result metatable so failed results answer it too.

**`fetch.download(url, path, opts?)`** — streams to a file via the existing `stream()`: writes only on 2xx (created/truncated, removed again on mid-stream read/write failure); a non-2xx response writes nothing and returns its status with a bounded (64 KiB) diagnostic body.

## Structure

`init.tl` was at the 500-line cap, so URL/header validation and `unix_proxy` moved verbatim to a new `cosmic.fetch.extras`, which also holds the body builders, verbs, and download (wired through a `make(fetch, stream, wrap)` factory to avoid a require cycle — same mirror-record convention as `cosmic.sqlite`'s helpers). Public contracts are unchanged; `init.tl` ends at 485 lines.

## Tests

New `fetch/verbs_test.tl` (same forked loopback echo-server pattern as `init_test.tl`, so every assertion checks the actual request bytes on the wire): method lines for all four verbs, query encoding/sorting/`?`-vs-`&` continuation, json body + POST default + caller-content-type preservation, form encoding, multipart framing (parts, filename, content type, closing boundary), conflict and multipart-name validation, `Result:json()` good/bad bodies, and download success / non-2xx-writes-nothing / transport-failure cases.

`bin/make ci` passes locally (format + teal + test + example + lint + coverage ratchet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4sza7cpsrMxYnbvFEYZSi)_