### PR TITLE
teal: treat warnings as errors in --check-types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ bin/
 - **doc comments**: `---` prefix with `@param` and `@return` tags
 - **naming**: `snake_case` for functions and variables. `PascalCase` for record types and record constructors (e.g. `signal.Sigset()`); options records are named `Options` (or `<Thing>Options` when a module has several).
 - **formatting**: 2-space indent, LF line endings, enforced by `cosmic --check-format`
+- **warnings are errors**: `--check-types` fails on any Teal warning (unused, shadowing, unreachable branch). mark deliberately-unused values with a leading underscore (`local _out`, `_self: Poller`).
 - **file length**: all `.tl` files must be ≤500 lines. no exceptions. enforced by `bin/make lint`. `.d.tl` type declaration files are exempt (they describe C binding interfaces and cannot be split due to Teal's record system).
 - **imports**: prefer `cosmic.*` modules over raw `cosmo.*` C bindings. `cosmo.*` is only for library internals implementing wrappers.
 - **tests**: `*_test.tl` files alongside source, run via `make test`

--- a/lib/build/reporter_test.tl
+++ b/lib/build/reporter_test.tl
@@ -52,7 +52,7 @@ local function test_single_checker_mode()
   write_test_result(fs.join(test_dir, "test1.test"), 0, "all good\n", "")
   write_test_result(fs.join(test_dir, "test2.test"), 1, "", "assertion failed\n")
 
-  local code, stdout, stderr = run_reporter(
+  local code, stdout, _stderr = run_reporter(
     "--dir", test_dir,
     fs.join(test_dir, "test1.test.got"),
     fs.join(test_dir, "test2.test.got")
@@ -74,7 +74,7 @@ local function test_all_passing()
   write_test_result(fs.join(test_dir, "test1.test"), 0, "ok\n", "")
   write_test_result(fs.join(test_dir, "test2.test"), 0, "ok\n", "")
 
-  local code, stdout, stderr = run_reporter(
+  local code, stdout, _stderr = run_reporter(
     "--dir", test_dir,
     fs.join(test_dir, "test1.test.got"),
     fs.join(test_dir, "test2.test.got")
@@ -93,7 +93,7 @@ local function test_directory_stripping()
 
   write_test_result(fs.join(test_dir, "subdir", "file.test"), 0, "ok\n", "")
 
-  local code, stdout, stderr = run_reporter(
+  local code, stdout, _stderr = run_reporter(
     "--dir", test_dir,
     fs.join(test_dir, "subdir", "file.test.got")
   )
@@ -106,7 +106,7 @@ test_directory_stripping()
 
 -- test missing --dir flag
 local function test_missing_dir_flag()
-  local code, stdout, stderr = run_reporter("file.test.got")
+  local code, _stdout, stderr = run_reporter("file.test.got")
 
   assert(code == 1, "expected exit code 1")
   assert(stderr:match("%-%-dir is required"), "expected error about --dir")
@@ -115,7 +115,7 @@ test_missing_dir_flag()
 
 -- test no files specified
 local function test_no_files()
-  local code, stdout, stderr = run_reporter("--dir", tmpdir)
+  local code, _stdout, stderr = run_reporter("--dir", tmpdir)
 
   assert(code == 1, "expected exit code 1")
   assert(stderr:match("usage:"), "expected usage error")
@@ -129,7 +129,7 @@ local function test_message_from_stderr()
 
   write_test_result(fs.join(test_dir, "fail.test"), 1, "", "first line error\nsecond line\n")
 
-  local code, stdout, stderr = run_reporter(
+  local code, stdout, _stderr = run_reporter(
     "--dir", test_dir,
     fs.join(test_dir, "fail.test.got")
   )

--- a/lib/cosmic/check_test.tl
+++ b/lib/cosmic/check_test.tl
@@ -32,7 +32,7 @@ local y: string = "hello"
 print(x, y)
 ]])
 
-  local ok, out = check_run({cosmic, "--check-types", input})
+  local ok, _out = check_run({cosmic, "--check-types", input})
   assert(ok, "cosmic --check-types should succeed on valid file")
 end
 test_check_valid()
@@ -43,7 +43,7 @@ local function test_check_type_error()
 local x: number = "not a number"
 ]])
 
-  local ok, out = check_run({cosmic, "--check-types", input})
+  local ok, _out = check_run({cosmic, "--check-types", input})
   assert(not ok, "cosmic --check-types should fail on type error")
 end
 test_check_type_error()
@@ -54,26 +54,38 @@ local function test_check_undefined_variable()
 local x: number = undefined_var
 ]])
 
-  local ok, out = check_run({cosmic, "--check-types", input})
+  local ok, _out = check_run({cosmic, "--check-types", input})
   assert(not ok, "cosmic --check-types should fail on undefined variable")
 end
 test_check_undefined_variable()
 
--- Test check reports warnings (but succeeds)
-local function test_check_warnings()
+-- Test check treats warnings as errors: an unused local must fail the check.
+local function test_check_warnings_fail()
   local input = write_temp("warnings.tl", [[
 local x: number = 42
--- x is unused, should generate warning but not fail
+-- x is unused: warnings are errors, so this must fail
+]])
+
+  local ok, _out = check_run({cosmic, "--check-types", input})
+  assert(not ok, "cosmic --check-types must fail on warnings")
+end
+test_check_warnings_fail()
+
+-- Test the sanctioned suppression: a leading underscore marks a value as
+-- deliberately unused, so the same file with _x passes.
+local function test_check_underscore_suppresses_unused()
+  local input = write_temp("warnings_ok.tl", [[
+local _x: number = 42
 ]])
 
   local ok, out = check_run({cosmic, "--check-types", input})
-  assert(ok, "cosmic --check-types should succeed with only warnings")
+  assert(ok, "leading-underscore locals must not warn: " .. tostring(out))
 end
-test_check_warnings()
+test_check_underscore_suppresses_unused()
 
 -- Test check on missing file
 local function test_check_missing_file()
-  local ok, out = check_run({cosmic, "--check-types", "/nonexistent/file.tl"})
+  local ok, _out = check_run({cosmic, "--check-types", "/nonexistent/file.tl"})
   assert(not ok, "cosmic --check-types should fail on missing file")
 end
 test_check_missing_file()
@@ -86,7 +98,7 @@ local result: string = fs.join("a", "b")
 print(result)
 ]])
 
-  local ok, out = check_run({cosmic, "--check-types", input})
+  local ok, _out = check_run({cosmic, "--check-types", input})
   assert(ok, "check with cosmic types should succeed")
 end
 test_check_with_cosmic_types()

--- a/lib/cosmic/child/init_example.tl
+++ b/lib/cosmic/child/init_example.tl
@@ -97,4 +97,12 @@ local function Example_run_pipe()
   -- exit:	0
 end
 
-return {}
+-- Suppress unused warnings for examples
+local _ = {
+  Example_run,
+  Example_run_stdin,
+  Example_run_exit_code,
+  Example_kill,
+  Example_wait_timeout,
+  Example_run_pipe,
+}

--- a/lib/cosmic/cli/main.tl
+++ b/lib/cosmic/cli/main.tl
@@ -463,8 +463,8 @@ local function main(): integer, string
     end
     local run_chunk = chunk as function(...: any): any ...
     local args: {string} = {}
-    for i = 1, #opts.script_args do
-      args[i] = opts.script_args[i]
+    for i, a in pairs(opts.script_args) do
+      if i >= 1 then args[i] = a end
     end
     local results: {any} = table.pack(xpcall(function()
           run_chunk(table.unpack(args))

--- a/lib/cosmic/compile_test.tl
+++ b/lib/cosmic/compile_test.tl
@@ -37,7 +37,7 @@ if if if
 
   local h2 = spawn.spawn({cosmic, "--compile", input})
   local __r2 = (h2 as spawn.Handle):wait() as spawn.Result
-  local ok, out = __r2.ok, __r2.stdout
+  local ok = __r2.ok
   assert(not ok, "cosmic --compile should fail on syntax error")
 end
 test_compile_syntax_error()
@@ -50,7 +50,7 @@ local x: number = "wrong type"
 
   local h3 = spawn.spawn({cosmic, "--compile", input})
   local __r3 = (h3 as spawn.Handle):wait() as spawn.Result
-  local ok, out = __r3.ok, __r3.stdout
+  local ok = __r3.ok
   assert(not ok, "cosmic --compile should fail on type error")
 end
 test_compile_type_error()
@@ -96,7 +96,7 @@ test_compile_generics()
 local function test_compile_missing_file()
   local h6 = spawn.spawn({cosmic, "--compile", "/nonexistent/file.tl"})
   local __r6 = (h6 as spawn.Handle):wait() as spawn.Result
-  local ok, out = __r6.ok, __r6.stdout
+  local ok = __r6.ok
   assert(not ok, "cosmic --compile should fail on missing file")
 end
 test_compile_missing_file()
@@ -136,7 +136,7 @@ print("read " .. #data .. " bytes")
 
   local h9 = spawn.spawn({cosmic, "--compile", input})
   local __r9 = (h9 as spawn.Handle):wait() as spawn.Result
-  local ok, out = __r9.ok, __r9.stdout
+  local ok = __r9.ok
   assert(ok, "compile with cosmic types should succeed")
 end
 test_compile_with_cosmic_types()

--- a/lib/cosmic/deploy_example.tl
+++ b/lib/cosmic/deploy_example.tl
@@ -130,4 +130,10 @@ local function Example_portable_executable()
   -- portable app
 end
 
-return {}
+-- Suppress unused warnings for examples
+local _ = {
+  Example_shebang,
+  Example_script_args,
+  Example_install_to_path,
+  Example_portable_executable,
+}

--- a/lib/cosmic/doc/init.tl
+++ b/lib/cosmic/doc/init.tl
@@ -4,7 +4,6 @@
 local types = require("cosmic.doc.types")
 local Param = types.Param
 local Return = types.Return
-local FunctionDoc = types.FunctionDoc
 local ModuleDoc = types.ModuleDoc
 
 local doc_render = require("cosmic.doc.render")

--- a/lib/cosmic/doc/init_test.tl
+++ b/lib/cosmic/doc/init_test.tl
@@ -2,10 +2,8 @@
 -- test cosmic.doc module
 
 local fs = require("cosmic.fs")
-local spawn = require("cosmic.child")
 local doc = require("cosmic.doc")
 
-local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 local function write_temp(name: string, content: string): string

--- a/lib/cosmic/doc/render.tl
+++ b/lib/cosmic/doc/render.tl
@@ -5,8 +5,6 @@ local types = require("cosmic.doc.types")
 local Param = types.Param
 local Return = types.Return
 local FunctionDoc = types.FunctionDoc
-local RecordDoc = types.RecordDoc
-local ExampleDoc = types.ExampleDoc
 local ModuleDoc = types.ModuleDoc
 
 --- Extract leading doc comment before a position.

--- a/lib/cosmic/doc/show.tl
+++ b/lib/cosmic/doc/show.tl
@@ -2,8 +2,6 @@
 --- Formats documentation records into human-readable CLI output.
 
 local types = require("cosmic.doc.types")
-local Param = types.Param
-local Return = types.Return
 local FunctionDoc = types.FunctionDoc
 local RecordDoc = types.RecordDoc
 local ExampleDoc = types.ExampleDoc

--- a/lib/cosmic/embed_advanced_test.tl
+++ b/lib/cosmic/embed_advanced_test.tl
@@ -11,16 +11,6 @@ local embed = require("cosmic.embed")
 local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
 
-local function write_temp(name: string, content: string): string
-  local filepath = fs.join(tmpdir, name)
-  local dir = fs.dirname(filepath)
-  if dir ~= tmpdir then
-    fs.makedirs(dir)
-  end
-  fs.write(filepath, content)
-  return filepath
-end
-
 -- Test --extract extracts zip contents
 local function test_extract()
   local extractdir = fs.join(tmpdir, "extracted")

--- a/lib/cosmic/embed_example.tl
+++ b/lib/cosmic/embed_example.tl
@@ -117,4 +117,10 @@ local function Example_embed_from_teal()
   -- hello from teal
 end
 
-return {}
+-- Suppress unused warnings for examples
+local _ = {
+  Example_embed_directory,
+  Example_extract_roundtrip,
+  Example_embed_with_libraries,
+  Example_embed_from_teal,
+}

--- a/lib/cosmic/env_example.tl
+++ b/lib/cosmic/env_example.tl
@@ -64,4 +64,5 @@ local function Example_all()
   -- environment has true variables
 end
 
-return {}
+-- Suppress unused warnings for examples
+local _ = {Example_get, Example_get_missing, Example_set_and_get, Example_unset, Example_all}

--- a/lib/cosmic/envd.tl
+++ b/lib/cosmic/envd.tl
@@ -122,11 +122,11 @@ end
 local function load_dir(dir: string): LoadResult
   local result: LoadResult = {count = 0, source = dir, errors = {}}
   local cosmic_debug_val = env.get("COSMIC_DEBUG")
-  local debug = cosmic_debug_val ~= nil and cosmic_debug_val ~= ""
+  local debug_on = cosmic_debug_val ~= nil and cosmic_debug_val ~= ""
 
   local dh, dh_err = fs.opendir(dir)
   if not dh then
-    if debug then
+    if debug_on then
       io.stderr:write("[envd] skip " .. dir .. ": " .. (dh_err or "not found") .. "\n")
     end
     return result
@@ -158,7 +158,7 @@ local function load_dir(dir: string): LoadResult
       end
     else
       table.insert(result.errors, "envd: " .. (read_err or (name .. ": unreadable")))
-      if debug then
+      if debug_on then
         io.stderr:write("[envd] skip " .. name .. ": " .. (read_err or "unreadable") .. "\n")
       end
     end
@@ -174,7 +174,7 @@ local function load_dir(dir: string): LoadResult
   for _, key in ipairs(keys) do
     local existing = env.get(key)
     if existing then
-      if debug then
+      if debug_on then
         io.stderr:write("[envd] skip " .. key .. " from " .. sources[key] .. ": overridden by environment\n")
       end
     else
@@ -184,13 +184,13 @@ local function load_dir(dir: string): LoadResult
       else
         result.count = result.count + 1
       end
-      if debug then
+      if debug_on then
         io.stderr:write("[envd] set " .. key .. " from " .. sources[key] .. "\n")
       end
     end
   end
 
-  if debug then
+  if debug_on then
     io.stderr:write("[envd] loaded " .. tostring(result.count) .. " variable(s) from " .. dir .. "\n")
   end
 
@@ -200,7 +200,7 @@ end
 --- Load env vars from the embedded /zip/embed/env.d directory.
 --- Call this early in startup, before code that depends on the variables.
 --- @return LoadResult Result with count of variables set and source path
-local function load(): LoadResult
+local function load_envd(): LoadResult
   return load_dir(ENVD_PATH)
 end
 
@@ -212,7 +212,7 @@ local record EnvdModule
 end
 
 local M: EnvdModule = {
-  load = load,
+  load = load_envd,
   load_dir = load_dir,
   parse = parse,
   expand = expand,

--- a/lib/cosmic/envd_example.tl
+++ b/lib/cosmic/envd_example.tl
@@ -98,4 +98,5 @@ local function Example_variable_expansion()
   -- KEEP=
 end
 
-return {}
+-- Suppress unused warnings for examples
+local _ = {Example_load_dir, Example_extract_update_embed, Example_variable_expansion}

--- a/lib/cosmic/example.tl
+++ b/lib/cosmic/example.tl
@@ -181,9 +181,9 @@ end
 --- Run a single example and capture its output.
 --- Executes the example code and compares actual output with expected output.
 --- @param example Example The example to run
---- @param file_path string Path to the source file (for context)
+--- @param _file_path string Path to the source file (unused; kept for call-site context)
 --- @return ExampleResult Result with pass/fail status and output comparison
-local function run_example(example: Example, file_path: string): ExampleResult
+local function run_example(example: Example, _file_path: string): ExampleResult
   local result: ExampleResult = {
     name = example.name,
     passed = false,

--- a/lib/cosmic/fd.tl
+++ b/lib/cosmic/fd.tl
@@ -167,11 +167,11 @@ make_handle = function(fd: number): Handle
   end
 
   --- File control operations. cmd: F_GETFD, F_SETFD, F_GETFL, F_SETFL, F_SETLK, etc.
-  function handle:fcntl(cmd: number, arg?: number): number | nil, string
+  function handle:fcntl(cmd: number, value?: number): number | nil, string
     if not handle_fd then
       return nil, "handle closed"
     end
-    local result, err = unix.fcntl(handle_fd, cmd, arg)
+    local result, err = unix.fcntl(handle_fd, cmd, value)
     if result == nil then
       return nil, errstr(err, "fcntl")
     end

--- a/lib/cosmic/fetch/init.tl
+++ b/lib/cosmic/fetch/init.tl
@@ -6,7 +6,7 @@ local cosmo = require("cosmo")
 local fetch_headers = require("cosmic.fetch.headers")
 local fetch_extras = require("cosmic.fetch.extras")
 local json_mod = require("cosmic.json")
-local stream = require("cosmic.stream")
+local stream_mod = require("cosmic.stream")
 local time = require("cosmic.time")
 
 local validate_url = fetch_extras.validate_url
@@ -103,7 +103,7 @@ end
 --- next chunk, bare nil at end of stream, or nil + error on failure.
 --- Chunk sizes are transport-determined; read takes no size argument.
 --- Supports Lua 5.4's to-be-closed via __close metamethod.
-local record Reader is stream.Reader
+local record Reader is stream_mod.Reader
   read: function(self: Reader): string | nil, string
   close: function(self: Reader): boolean
   closed: function(self: Reader): boolean

--- a/lib/cosmic/fetch/init_example.tl
+++ b/lib/cosmic/fetch/init_example.tl
@@ -103,4 +103,5 @@ local function Example_stream_lines()
   -- gamma
 end
 
-return {}
+-- Suppress unused warnings for examples
+local _ = {Example_get, Example_retry, Example_stream_lines}

--- a/lib/cosmic/format/rules.tl
+++ b/lib/cosmic/format/rules.tl
@@ -115,19 +115,6 @@ local function is_long_comment(tk: string): boolean
   or (tk:sub(1, 3) == "--[" and tk:sub(4, 4) == "=")
 end
 
---- Check if a colon is in method-call position (vs type annotation).
-local function is_method_colon(prev: Item, next_item: Item): boolean
-  if not prev or not next_item then
-    return false
-  end
-  if next_item.kind == "identifier" then
-    if prev.kind == "identifier" or prev.tk == ")" or prev.tk == "]" or prev.kind == "string" then
-      return true
-    end
-  end
-  return false
-end
-
 --- Determine if we need a space between two adjacent items on the same line.
 local function needs_space(prev_prev: Item, prev: Item, cur: Item, next_item: Item): boolean
   if cur.kind == "comment" then

--- a/lib/cosmic/fs/walk_test.tl
+++ b/lib/cosmic/fs/walk_test.tl
@@ -32,7 +32,6 @@ local function test_walk_symlink_cycle_terminates()
   -- Create a symlink cycle: sub/loop -> ..  (points back to base)
   fs.symlink("..", fs.join(subdir, "loop"))
 
-  local count = 0
   local max_depth_seen = 0
   -- walk the base directory; collect all entries to detect infinite loop
   -- (the test harness has a timeout; if we don't hang this is fine)
@@ -106,7 +105,7 @@ local function test_walk_symlink_file_visited()
   fs.symlink("real.txt", fs.join(base, "alias.txt"))
 
   local found: {string: boolean} = {}
-  fs_walk.walk(base, function(full_path: string, entry: string, _st: any, ctx: {string: boolean})
+  fs_walk.walk(base, function(_full_path: string, entry: string, _st: any, ctx: {string: boolean})
       ctx[entry] = true
     end, found)
   -- Both the real file and the symlink to a file should be visited

--- a/lib/cosmic/fuzzy_test.tl
+++ b/lib/cosmic/fuzzy_test.tl
@@ -42,14 +42,14 @@ end
 test_levenshtein_case_sensitive()
 
 local function test_levenshtein_symmetry()
-  -- distance(a,b) must equal distance(b,a) for all pairs
-  local pairs: {{string, string}} = {
+  -- distance(a,b) must equal distance(b,a) for all cases
+  local cases: {{string, string}} = {
     {"kitten", "sitting"},
     {"a", "abcdef"},
     {"short", "a much longer string"},
     {"xyz", ""},
   }
-  for _, p in ipairs(pairs) do
+  for _, p in ipairs(cases) do
     local d1 = fuzzy.levenshtein(p[1], p[2])
     local d2 = fuzzy.levenshtein(p[2], p[1])
     assert(d1 == d2, "levenshtein should be symmetric: '" .. p[1] .. "' <-> '" .. p[2] .. "': " .. tostring(d1) .. " vs " .. tostring(d2))

--- a/lib/cosmic/json_example.tl
+++ b/lib/cosmic/json_example.tl
@@ -23,7 +23,7 @@ end
 -- Example_decode_error demonstrates error handling for invalid JSON
 local function Example_decode_error()
   local json = require("cosmic.json")
-  local result, err = json.decode("{invalid}")
+  local _, err = json.decode("{invalid}")
   if err then
     print("decode error: " .. err)
   end
@@ -34,7 +34,7 @@ end
 -- Example_encode_error demonstrates error handling for unencodable values
 local function Example_encode_error()
   local json = require("cosmic.json")
-  local result, err = json.encode(function() end)
+  local _, err = json.encode(function() end)
   if err then
     print("encode error: " .. err)
   end
@@ -42,4 +42,5 @@ local function Example_encode_error()
   -- encode error: unsupported lua type
 end
 
-return {}
+-- Suppress unused warnings for examples
+local _ = {Example_decode, Example_encode, Example_decode_error, Example_encode_error}

--- a/lib/cosmic/landlock_example.tl
+++ b/lib/cosmic/landlock_example.tl
@@ -52,4 +52,5 @@ assert(ll.restrict{
   local _ = (h as spawn.Handle):wait()
 end
 
-return {}
+-- Suppress unused warnings for examples
+local _ = {Example_available, Example_masks, Example_restrict}

--- a/lib/cosmic/net/connect_test.tl
+++ b/lib/cosmic/net/connect_test.tl
@@ -6,10 +6,10 @@ local ip = require("cosmic.ip")
 local proc = require("cosmic.proc")
 
 local function test_interfaces()
-  local ifaces, err = net.interfaces()
-  assert(ifaces ~= nil, "interfaces() failed: " .. tostring(err))
-  assert(type(ifaces) == "table", "expected table, got " .. type(ifaces))
-  local ifaces = ifaces as {net.Interface}
+  local raw_ifaces, err = net.interfaces()
+  assert(raw_ifaces ~= nil, "interfaces() failed: " .. tostring(err))
+  assert(type(raw_ifaces) == "table", "expected table, got " .. type(raw_ifaces))
+  local ifaces = raw_ifaces as {net.Interface}
 
   -- Should have at least the loopback interface
   local has_loopback = false
@@ -29,9 +29,9 @@ test_interfaces()
 
 local function test_interfaces_format()
   -- Test that we can format interface IPs
-  local ifaces = net.interfaces()
-  if ifaces then
-    local ifaces = ifaces as {net.Interface}
+  local raw_ifaces = net.interfaces()
+  if raw_ifaces then
+    local ifaces = raw_ifaces as {net.Interface}
     for _, iface in ipairs(ifaces) do
       local ip_str = iface.ip:format()
       assert(ip_str:match("^%d+%.%d+%.%d+%.%d+$"), "expected dotted IP format, got " .. ip_str)
@@ -45,9 +45,9 @@ local function test_unix_domain_socket_bind_connect()
   local path = tmpdir .. "/test.sock"
 
   -- Create server socket
-  local server, err = net.socket(net.AF_UNIX, net.SOCK_STREAM, 0)
-  assert(server ~= nil, "unix server socket creation failed: " .. tostring(err))
-  local server = server as net.Socket
+  local raw_server, err = net.socket(net.AF_UNIX, net.SOCK_STREAM, 0)
+  assert(raw_server ~= nil, "unix raw_server socket creation failed: " .. tostring(err))
+  local server = raw_server as net.Socket
 
   -- Bind to path
   local ok, bind_err = server:bind_unix(path)
@@ -60,9 +60,9 @@ local function test_unix_domain_socket_bind_connect()
   -- Fork to create a client
   local pid = proc.fork()
   if pid == 0 then
-    local client = net.socket(net.AF_UNIX, net.SOCK_STREAM, 0)
-    if not client then os.exit(1) end
-    local client = client as net.Socket
+    local raw_client = net.socket(net.AF_UNIX, net.SOCK_STREAM, 0)
+    if not raw_client then os.exit(1) end
+    local client = raw_client as net.Socket
     local connect_ok = client:connect_unix(path)
     if not connect_ok then os.exit(2) end
     local sent = client:send("hello from unix client")
@@ -72,9 +72,9 @@ local function test_unix_domain_socket_bind_connect()
   end
 
   -- Parent: accept connection
-  local client, _, _, accept_err = server:accept()
-  assert(client ~= nil, "accept failed: " .. tostring(accept_err))
-  local client = client as net.Socket
+  local raw_client, _, _, accept_err = server:accept()
+  assert(raw_client ~= nil, "accept failed: " .. tostring(accept_err))
+  local client = raw_client as net.Socket
 
   -- Read data from client
   local data, recv_err = client:recv()
@@ -93,19 +93,19 @@ local function test_listen_unix_connect_unix()
   local path = tmpdir .. "/test.sock"
 
   -- Use module-level listen_unix helper
-  local server, err = net.listen_unix(path)
-  assert(server ~= nil, "listen_unix failed: " .. tostring(err))
-  local server = server as net.Socket
+  local raw_server, err = net.listen_unix(path)
+  assert(raw_server ~= nil, "listen_unix failed: " .. tostring(err))
+  local server = raw_server as net.Socket
 
   -- Fork to create a client using module-level connect_unix helper
   local pid = proc.fork()
   if pid == 0 then
-    local client, cerr = net.connect_unix(path)
-    if not client then
+    local raw_client, cerr = net.connect_unix(path)
+    if not raw_client then
       io.stderr:write("connect_unix failed: " .. tostring(cerr) .. "\n")
       os.exit(1)
     end
-    local client = client as net.Socket
+    local client = raw_client as net.Socket
     local sent = client:send("hello from connect_unix")
     if not sent then os.exit(2) end
     client:close()
@@ -113,9 +113,9 @@ local function test_listen_unix_connect_unix()
   end
 
   -- Parent: accept connection
-  local client, _, _, accept_err = server:accept()
-  assert(client ~= nil, "accept failed: " .. tostring(accept_err))
-  local client = client as net.Socket
+  local raw_client, _, _, accept_err = server:accept()
+  assert(raw_client ~= nil, "accept failed: " .. tostring(accept_err))
+  local client = raw_client as net.Socket
 
   -- Read data from client
   local data, recv_err = client:recv()
@@ -135,9 +135,9 @@ test_listen_unix_connect_unix()
 
 local function test_nb_connect_loopback()
   -- Create a listening socket
-  local server, err = net.socket()
-  assert(server ~= nil, "server socket creation failed: " .. tostring(err))
-  local server = server as net.Socket
+  local raw_server, err = net.socket()
+  assert(raw_server ~= nil, "raw_server socket creation failed: " .. tostring(err))
+  local server = raw_server as net.Socket
 
   local ok, setopt_err = server:setsockopt(net.SOL_SOCKET, net.SO_REUSEADDR, true)
   assert(ok, "setsockopt failed: " .. tostring(setopt_err))
@@ -154,18 +154,18 @@ local function test_nb_connect_loopback()
   -- A plain blocking socket: nb_connect switches it to non-blocking
   -- itself via Socket:set_nonblocking (it used to silently block when
   -- handed a blocking socket).
-  local client, cerr = net.socket()
-  assert(client ~= nil, "client socket creation failed: " .. tostring(cerr))
-  local client = client as net.Socket
+  local raw_client, cerr = net.socket()
+  assert(raw_client ~= nil, "raw_client socket creation failed: " .. tostring(cerr))
+  local client = raw_client as net.Socket
 
   -- nb_connect to the listening server, by dotted-quad string
   ok, err = net.nb_connect(client, "127.0.0.1", server_port, 5000)
   assert(ok, "nb_connect failed: " .. tostring(err))
 
   -- Accept the connection on the server side
-  local accepted, _, _, accept_err = server:accept()
-  assert(accepted ~= nil, "accept failed: " .. tostring(accept_err))
-  local accepted = accepted as net.Socket
+  local raw_accepted, _, _, accept_err = server:accept()
+  assert(raw_accepted ~= nil, "accept failed: " .. tostring(accept_err))
+  local accepted = raw_accepted as net.Socket
 
   -- Verify the connection works by sending data
   local sent, send_err = client:send("nb_hello")
@@ -182,9 +182,9 @@ test_nb_connect_loopback()
 
 local function test_nb_connect_refused()
   -- Create a non-blocking socket and try to connect to a port with no listener
-  local client, err = net.socket(net.AF_INET, net.SOCK_STREAM | net.SOCK_NONBLOCK, 0)
-  assert(client ~= nil, "client socket creation failed: " .. tostring(err))
-  local client = client as net.Socket
+  local raw_client, err = net.socket(net.AF_INET, net.SOCK_STREAM | net.SOCK_NONBLOCK, 0)
+  assert(raw_client ~= nil, "raw_client socket creation failed: " .. tostring(err))
+  local client = raw_client as net.Socket
 
   -- Connect to localhost port 1 — should be refused
   local ok, conn_err = net.nb_connect(client, "127.0.0.1", 1, 2000)
@@ -197,9 +197,9 @@ test_nb_connect_refused()
 
 local function test_connect_tcp()
   -- Create a listening socket
-  local server, err = net.socket()
-  assert(server ~= nil, "server socket creation failed: " .. tostring(err))
-  local server = server as net.Socket
+  local raw_server, err = net.socket()
+  assert(raw_server ~= nil, "raw_server socket creation failed: " .. tostring(err))
+  local server = raw_server as net.Socket
 
   local ok, setopt_err = server:setsockopt(net.SOL_SOCKET, net.SO_REUSEADDR, true)
   assert(ok, "setsockopt failed: " .. tostring(setopt_err))
@@ -216,12 +216,12 @@ local function test_connect_tcp()
   -- Fork to create a client using connect_tcp
   local pid = proc.fork()
   if pid == 0 then
-    local client, cerr = net.connect_tcp("127.0.0.1", server_port)
-    if not client then
+    local raw_client, cerr = net.connect_tcp("127.0.0.1", server_port)
+    if not raw_client then
       io.stderr:write("connect_tcp failed: " .. tostring(cerr) .. "\n")
       os.exit(1)
     end
-    local client = client as net.Socket
+    local client = raw_client as net.Socket
     local sent = client:send("hello from connect_tcp")
     if not sent then os.exit(2) end
     client:close()
@@ -229,9 +229,9 @@ local function test_connect_tcp()
   end
 
   -- Parent: accept connection
-  local client, _, _, accept_err = server:accept()
-  assert(client ~= nil, "accept failed: " .. tostring(accept_err))
-  local client = client as net.Socket
+  local raw_client, _, _, accept_err = server:accept()
+  assert(raw_client ~= nil, "accept failed: " .. tostring(accept_err))
+  local client = raw_client as net.Socket
 
   -- Read data from client
   local data, recv_err = client:recv()
@@ -244,9 +244,9 @@ end
 test_connect_tcp()
 
 local function test_connect_tcp_accepts_string_and_addr()
-  local server, port, lerr = net.listen_tcp("127.0.0.1", 0)
-  assert(server ~= nil, "listen_tcp with string address failed: " .. tostring(lerr))
-  local server = server as net.Socket
+  local raw_server, port, lerr = net.listen_tcp("127.0.0.1", 0)
+  assert(raw_server ~= nil, "listen_tcp with string address failed: " .. tostring(lerr))
+  local server = raw_server as net.Socket
 
   -- connect by dotted-quad string
   local c1, e1 = net.connect_tcp("127.0.0.1", port)
@@ -283,9 +283,9 @@ test_connect_tcp_rejects_bad_addresses()
 
 local function test_connect_error_message()
   -- Connect to a port with no listener — should get a descriptive error, not just "connect failed"
-  local sock, err = net.socket()
-  assert(sock ~= nil, "socket creation failed: " .. tostring(err))
-  local sock = sock as net.Socket
+  local raw_sock, err = net.socket()
+  assert(raw_sock ~= nil, "socket creation failed: " .. tostring(err))
+  local sock = raw_sock as net.Socket
 
   local ok, conn_err = sock:connect("127.0.0.1", 1) -- localhost port 1
   assert(not ok, "expected connect to fail")

--- a/lib/cosmic/net/init_example.tl
+++ b/lib/cosmic/net/init_example.tl
@@ -4,18 +4,18 @@
 -- listen on an OS-assigned port, connect, accept, echo one message back
 local function Example_echo()
   local net = require("cosmic.net")
-  local srv, port, err = net.listen_tcp("127.0.0.1", 0)
-  assert(srv, err)
+  local raw_srv, port, err = net.listen_tcp("127.0.0.1", 0)
+  assert(raw_srv, err)
   assert(port > 0)
-  local srv = srv as net.Socket
+  local srv = raw_srv as net.Socket
 
-  local client, cerr = net.connect_tcp("127.0.0.1", port)
-  assert(client, cerr)
-  local client = client as net.Socket
+  local raw_client, cerr = net.connect_tcp("127.0.0.1", port)
+  assert(raw_client, cerr)
+  local client = raw_client as net.Socket
 
-  local conn, _, _, aerr = srv:accept()
-  assert(conn, aerr)
-  local conn = conn as net.Socket
+  local raw_conn, _, _, aerr = srv:accept()
+  assert(raw_conn, aerr)
+  local conn = raw_conn as net.Socket
 
   client:send("hello")
   local msg = conn:recv()
@@ -34,9 +34,9 @@ end
 -- stream contract (cosmic.stream)
 local function Example_recv_eof()
   local net = require("cosmic.net")
-  local srv, port, err = net.listen_tcp("127.0.0.1", 0)
-  assert(srv, err)
-  local srv = srv as net.Socket
+  local raw_srv, port, err = net.listen_tcp("127.0.0.1", 0)
+  assert(raw_srv, err)
+  local srv = raw_srv as net.Socket
 
   local client = net.connect_tcp("127.0.0.1", port) as net.Socket
   local conn = srv:accept() as net.Socket
@@ -52,4 +52,5 @@ local function Example_recv_eof()
   -- eof
 end
 
-return {}
+-- Suppress unused warnings for examples
+local _ = {Example_echo, Example_recv_eof}

--- a/lib/cosmic/net/init_test.tl
+++ b/lib/cosmic/net/init_test.tl
@@ -1,6 +1,5 @@
 #!/usr/bin/env cosmic
 local net = require("cosmic.net")
-local fs = require("cosmic.fs")
 local ip = require("cosmic.ip")
 local proc = require("cosmic.proc")
 
@@ -21,9 +20,9 @@ end
 test_socket_creation()
 
 local function test_socketpair()
-  local sock1, sock2, err = net.socketpair()
-  assert(sock1 ~= nil and sock2 ~= nil, "socketpair failed: " .. tostring(err))
-  local sock1 = sock1 as net.Socket
+  local raw_sock1, sock2, err = net.socketpair()
+  assert(raw_sock1 ~= nil and sock2 ~= nil, "socketpair failed: " .. tostring(err))
+  local sock1 = raw_sock1 as net.Socket
 
   -- Test sending data between the pair
   local sent, send_err = sock1:send("hello")
@@ -41,9 +40,9 @@ local function test_send_to_closed_peer_returns_error()
   -- Regression: sending to a peer that has closed must return nil, err --
   -- NOT kill the process with SIGPIPE (which surfaces as exit 141, an
   -- unambiguous red before send() ORed in MSG_NOSIGNAL).
-  local a, b, err = net.socketpair()
-  assert(a ~= nil and b ~= nil, "socketpair failed: " .. tostring(err))
-  local a = a as net.Socket
+  local raw_a, b, err = net.socketpair()
+  assert(raw_a ~= nil and b ~= nil, "socketpair failed: " .. tostring(err))
+  local a = raw_a as net.Socket
   b:close()
 
   -- Loop so a kernel that accepts the first write into the buffer before
@@ -61,9 +60,9 @@ end
 test_send_to_closed_peer_returns_error()
 
 local function test_bind_and_getsockname()
-  local sock, err = net.socket()
-  assert(sock ~= nil, "socket creation failed: " .. tostring(err))
-  local sock = sock as net.Socket
+  local raw_sock, err = net.socket()
+  assert(raw_sock ~= nil, "socket creation failed: " .. tostring(err))
+  local sock = raw_sock as net.Socket
 
   -- Bind to ephemeral port on all interfaces
   local ok, bind_err = sock:bind("0.0.0.0", 0)
@@ -80,9 +79,9 @@ test_bind_and_getsockname()
 
 local function test_listen_accept_connect()
   -- Create server socket
-  local server, err = net.socket()
-  assert(server ~= nil, "server socket creation failed: " .. tostring(err))
-  local server = server as net.Socket
+  local raw_server, err = net.socket()
+  assert(raw_server ~= nil, "raw_server socket creation failed: " .. tostring(err))
+  local server = raw_server as net.Socket
 
   local ok, setopt_err = server:setsockopt(net.SOL_SOCKET, net.SO_REUSEADDR, true)
   assert(ok, "setsockopt failed: " .. tostring(setopt_err))
@@ -100,11 +99,11 @@ local function test_listen_accept_connect()
   local pid = proc.fork()
   if pid == 0 then
     -- Child: connect to server
-    local client = net.socket()
-    if not client then
+    local raw_client = net.socket()
+    if not raw_client then
       os.exit(1)
     end
-    local client = client as net.Socket
+    local client = raw_client as net.Socket
     -- Connect to localhost
     local connect_ok = client:connect("127.0.0.1", server_port) -- 127.0.0.1
     if not connect_ok then
@@ -119,13 +118,13 @@ local function test_listen_accept_connect()
   end
 
   -- Parent: accept connection
-  local client, client_ip, client_port, accept_err = server:accept()
-  assert(client ~= nil, "accept failed: " .. tostring(accept_err))
-  assert(client_ip ~= nil, "expected client IP")
+  local raw_client, client_ip, client_port, accept_err = server:accept()
+  assert(raw_client ~= nil, "accept failed: " .. tostring(accept_err))
+  assert(client_ip ~= nil, "expected raw_client IP")
   assert(client_ip.family == "inet", "peer address must be a typed Addr")
   assert(client_ip:is_loopback(), "peer should be loopback, got " .. client_ip:format())
-  assert(client_port ~= nil and client_port > 0, "expected client port")
-  local client = client as net.Socket
+  assert(client_port ~= nil and client_port > 0, "expected raw_client port")
+  local client = raw_client as net.Socket
 
   -- Read data from client
   local data, recv_err = client:recv()
@@ -152,9 +151,9 @@ end
 test_gethostname()
 
 local function test_shutdown()
-  local sock1, sock2, err = net.socketpair()
-  assert(sock1 ~= nil and sock2 ~= nil, "socketpair failed: " .. tostring(err))
-  local sock1 = sock1 as net.Socket
+  local raw_sock1, sock2, err = net.socketpair()
+  assert(raw_sock1 ~= nil and sock2 ~= nil, "socketpair failed: " .. tostring(err))
+  local sock1 = raw_sock1 as net.Socket
 
   -- Shutdown write side of sock1
   local ok, shutdown_err = sock1:shutdown(net.SHUT_WR)
@@ -174,9 +173,9 @@ local function test_poll_readiness()
   -- net.poll was a duplicate of cosmic.poll and is gone; sockets compose
   -- with the Poller directly via their fd.
   local poll = require("cosmic.poll")
-  local sock1, sock2, err = net.socketpair()
-  assert(sock1 ~= nil and sock2 ~= nil, "socketpair failed: " .. tostring(err))
-  local sock1 = sock1 as net.Socket
+  local raw_sock1, sock2, err = net.socketpair()
+  assert(raw_sock1 ~= nil and sock2 ~= nil, "socketpair failed: " .. tostring(err))
+  local sock1 = raw_sock1 as net.Socket
 
   -- Send data on sock1
   sock1:send("hello")
@@ -195,13 +194,13 @@ test_poll_readiness()
 
 local function test_udp_sendto_recvfrom()
   -- Create two UDP sockets
-  local sender, err = net.socket(net.AF_INET, net.SOCK_DGRAM)
-  assert(sender ~= nil, "sender socket creation failed: " .. tostring(err))
-  local sender = sender as net.Socket
+  local raw_sender, err = net.socket(net.AF_INET, net.SOCK_DGRAM)
+  assert(raw_sender ~= nil, "raw_sender socket creation failed: " .. tostring(err))
+  local sender = raw_sender as net.Socket
 
-  local receiver, rerr = net.socket(net.AF_INET, net.SOCK_DGRAM)
-  assert(receiver ~= nil, "receiver socket creation failed: " .. tostring(rerr))
-  local receiver = receiver as net.Socket
+  local raw_receiver, rerr = net.socket(net.AF_INET, net.SOCK_DGRAM)
+  assert(raw_receiver ~= nil, "raw_receiver socket creation failed: " .. tostring(rerr))
+  local receiver = raw_receiver as net.Socket
 
   -- Bind receiver to ephemeral port
   local ok, bind_err = receiver:bind("127.0.0.1", 0)
@@ -228,9 +227,9 @@ end
 test_udp_sendto_recvfrom()
 
 local function test_socket_options()
-  local sock, err = net.socket()
-  assert(sock ~= nil, "socket creation failed: " .. tostring(err))
-  local sock = sock as net.Socket
+  local raw_sock, err = net.socket()
+  assert(raw_sock ~= nil, "socket creation failed: " .. tostring(err))
+  local sock = raw_sock as net.Socket
 
   -- Set TCP_NODELAY
   local ok, setopt_err = sock:setsockopt(net.SOL_TCP, net.TCP_NODELAY, true)
@@ -284,9 +283,9 @@ end
 test_constants_exist()
 
 local function test_socket_closed_method()
-  local sock, err = net.socket()
-  assert(sock ~= nil, "socket creation failed: " .. tostring(err))
-  local sock = sock as net.Socket
+  local raw_sock, err = net.socket()
+  assert(raw_sock ~= nil, "socket creation failed: " .. tostring(err))
+  local sock = raw_sock as net.Socket
 
   -- Socket should not be closed initially
   assert(sock:closed() == false, "expected socket to not be closed initially")
@@ -305,9 +304,9 @@ end
 test_socket_closed_method()
 
 local function test_socket_methods_after_close()
-  local sock, err = net.socket()
-  assert(sock ~= nil, "socket creation failed: " .. tostring(err))
-  local sock = sock as net.Socket
+  local raw_sock, err = net.socket()
+  assert(raw_sock ~= nil, "socket creation failed: " .. tostring(err))
+  local sock = raw_sock as net.Socket
   sock:close()
 
   -- Every operation on a closed socket must return its error shape, never
@@ -316,8 +315,8 @@ local function test_socket_methods_after_close()
   assert(n == nil and serr == "socket closed", "send: " .. tostring(serr))
   local d, rerr = sock:recv()
   assert(d == nil and rerr == "socket closed", "recv: " .. tostring(rerr))
-  local ip, port, gerr = sock:getsockname()
-  assert(ip == nil and port == nil and gerr == "socket closed",
+  local addr, port, gerr = sock:getsockname()
+  assert(addr == nil and port == nil and gerr == "socket closed",
     "getsockname: " .. tostring(gerr))
   local bok, berr = sock:bind()
   assert(bok == false and berr == "socket closed", "bind: " .. tostring(berr))
@@ -330,9 +329,9 @@ test_socket_methods_after_close()
 
 local function test_socket_has_close_metamethod()
   -- Verify socket has __close metamethod for Lua 5.4 to-be-closed support
-  local sock, err = net.socket()
-  assert(sock ~= nil, "socket creation failed: " .. tostring(err))
-  local sock = sock as net.Socket
+  local raw_sock, err = net.socket()
+  assert(raw_sock ~= nil, "socket creation failed: " .. tostring(err))
+  local sock = raw_sock as net.Socket
 
   -- Get the metatable and verify __close exists
   local mt = getmetatable(sock)
@@ -353,9 +352,9 @@ test_socket_has_close_metamethod()
 
 local function test_socketpair_has_close_metamethod()
   -- Verify socketpair sockets also have __close
-  local sock1, sock2, err = net.socketpair()
-  assert(sock1 ~= nil and sock2 ~= nil, "socketpair failed: " .. tostring(err))
-  local sock1 = sock1 as net.Socket
+  local raw_sock1, sock2, err = net.socketpair()
+  assert(raw_sock1 ~= nil and sock2 ~= nil, "socketpair failed: " .. tostring(err))
+  local sock1 = raw_sock1 as net.Socket
 
   local mt1 = getmetatable(sock1)
   local mt2 = getmetatable(sock2)
@@ -369,9 +368,9 @@ test_socketpair_has_close_metamethod()
 
 local function test_accept_socket_has_close_metamethod()
   -- Create server socket
-  local server, err = net.socket()
-  assert(server ~= nil, "server socket creation failed: " .. tostring(err))
-  local server = server as net.Socket
+  local raw_server, err = net.socket()
+  assert(raw_server ~= nil, "raw_server socket creation failed: " .. tostring(err))
+  local server = raw_server as net.Socket
 
   local ok, setopt_err = server:setsockopt(net.SOL_SOCKET, net.SO_REUSEADDR, true)
   assert(ok, "setsockopt failed: " .. tostring(setopt_err))
@@ -386,9 +385,9 @@ local function test_accept_socket_has_close_metamethod()
   -- Fork to create a client
   local pid = proc.fork()
   if pid == 0 then
-    local client = net.socket()
-    if not client then os.exit(1) end
-    local client = client as net.Socket
+    local raw_client = net.socket()
+    if not raw_client then os.exit(1) end
+    local client = raw_client as net.Socket
     local connect_ok = client:connect("127.0.0.1", server_port)
     if not connect_ok then os.exit(2) end
     client:send("test")
@@ -397,9 +396,9 @@ local function test_accept_socket_has_close_metamethod()
   end
 
   -- Accept and verify __close exists on accepted socket
-  local client, _, _, accept_err = server:accept()
-  assert(client ~= nil, "accept failed: " .. tostring(accept_err))
-  local client = client as net.Socket
+  local raw_client, _, _, accept_err = server:accept()
+  assert(raw_client ~= nil, "accept failed: " .. tostring(accept_err))
+  local client = raw_client as net.Socket
 
   local mt = getmetatable(client)
   assert(mt ~= nil and mt.__close ~= nil, "expected accepted socket to have __close")
@@ -415,37 +414,37 @@ test_accept_socket_has_close_metamethod()
 
 local function test_listen_tcp_ephemeral_port()
   -- listen_tcp with port 0 should return a listening socket and a port > 0
-  local srv, port, err = net.listen_tcp("127.0.0.1", 0)
-  assert(srv ~= nil, "listen_tcp failed: " .. tostring(err))
+  local raw_srv, port, err = net.listen_tcp("127.0.0.1", 0)
+  assert(raw_srv ~= nil, "listen_tcp failed: " .. tostring(err))
   assert(port ~= nil and port > 0, "expected non-zero port, got " .. tostring(port))
-  local srv = srv as net.Socket
+  local srv = raw_srv as net.Socket
   srv:close()
 end
 test_listen_tcp_ephemeral_port()
 
 local function test_listen_tcp_connect_to_returned_port()
   -- bind on 127.0.0.1:0, then connect_tcp to the returned port
-  local srv, port, serr = net.listen_tcp("127.0.0.1", 0)
-  assert(srv ~= nil, "listen_tcp failed: " .. tostring(serr))
+  local raw_srv, port, serr = net.listen_tcp("127.0.0.1", 0)
+  assert(raw_srv ~= nil, "listen_tcp failed: " .. tostring(serr))
   assert(port > 0, "expected non-zero port")
-  local srv = srv as net.Socket
+  local srv = raw_srv as net.Socket
 
   -- Fork: child connects and sends, parent accepts and reads
   local pid = proc.fork()
   if pid == 0 then
-    local csock = net.connect_tcp("127.0.0.1", port)
-    if not csock then
+    local raw_csock = net.connect_tcp("127.0.0.1", port)
+    if not raw_csock then
       os.exit(1)
     end
-    local csock = csock as net.Socket
+    local csock = raw_csock as net.Socket
     csock:send("hi")
     csock:close()
     os.exit(0)
   end
 
-  local conn, _, _, aerr = srv:accept()
-  assert(conn ~= nil, "accept failed: " .. tostring(aerr))
-  local conn = conn as net.Socket
+  local raw_conn, _, _, aerr = srv:accept()
+  assert(raw_conn ~= nil, "accept failed: " .. tostring(aerr))
+  local conn = raw_conn as net.Socket
   local data = conn:recv()
   assert(data == "hi", "expected 'hi', got '" .. tostring(data) .. "'")
   conn:close()
@@ -457,10 +456,10 @@ test_listen_tcp_connect_to_returned_port()
 local function test_listen_tcp_double_bind_same_port_fails()
   -- Bind a specific port, then try to bind the same port again without
   -- REUSEPORT; the second listen_tcp should fail.
-  local srv, port, serr = net.listen_tcp("127.0.0.1", 0)
-  assert(srv ~= nil, "first listen_tcp failed: " .. tostring(serr))
+  local raw_srv, port, serr = net.listen_tcp("127.0.0.1", 0)
+  assert(raw_srv ~= nil, "first listen_tcp failed: " .. tostring(serr))
   assert(port > 0, "expected non-zero port")
-  local srv = srv as net.Socket
+  local srv = raw_srv as net.Socket
 
   -- Second bind to the same explicit port should fail (SO_REUSEADDR alone
   -- does not allow two listeners on the same port simultaneously)

--- a/lib/cosmic/pledge_example.tl
+++ b/lib/cosmic/pledge_example.tl
@@ -19,4 +19,5 @@ io.write("stdio only\n")
   -- stdio only
 end
 
-return {}
+-- Suppress unused warnings for examples
+local _ = {Example_apply}

--- a/lib/cosmic/poll.tl
+++ b/lib/cosmic/poll.tl
@@ -93,7 +93,7 @@ local function new(): Poller
 
   local poller: Poller = {}
 
-  poller.add = function(self: Poller, fd: number, events: number)
+  poller.add = function(_self: Poller, fd: number, events: number)
     if fd == nil then
       -- A nil fd is a caller bug (e.g. an unchecked open); registering
       -- nothing would silently turn every wait into a timeout.
@@ -102,23 +102,23 @@ local function new(): Poller
     fds[fd] = events
   end
 
-  poller.remove = function(self: Poller, fd: number)
+  poller.remove = function(_self: Poller, fd: number)
     if fd then
       fds[fd] = nil
       results[fd] = nil
     end
   end
 
-  poller.clear = function(self: Poller)
+  poller.clear = function(_self: Poller)
     fds = {}
     results = {}
   end
 
-  poller.empty = function(self: Poller): boolean
+  poller.empty = function(_self: Poller): boolean
     return next(fds) == nil
   end
 
-  poller.count = function(self: Poller): number
+  poller.count = function(_self: Poller): number
     local n = 0
     for _ in pairs(fds) do
       n = n + 1
@@ -126,7 +126,7 @@ local function new(): Poller
     return n
   end
 
-  poller.poll = function(self: Poller, timeoutms: number): number | nil, string
+  poller.poll = function(_self: Poller, timeoutms: number): number | nil, string
     -- Retry when a signal interrupts the wait: an unretried EINTR otherwise
     -- surfaces as a poll failure, and a caller that loops on it (e.g. a drain
     -- loop waiting on a child that raised SIGCHLD) spins at 100% CPU.
@@ -150,7 +150,7 @@ local function new(): Poller
     return ready
   end
 
-  poller.events = function(self: Poller, fd: number): Events | nil
+  poller.events = function(_self: Poller, fd: number): Events | nil
     local revents = results[fd]
     if revents then
       return make_events(revents)

--- a/lib/cosmic/poll_test.tl
+++ b/lib/cosmic/poll_test.tl
@@ -46,9 +46,9 @@ end
 test_poller_add_remove_raw_fd()
 
 local function test_poll_pipe_readable()
-  local pipe, err = cfd.pipe()
-  assert(pipe ~= nil, "pipe creation failed: " .. tostring(err))
-  local pipe = pipe as cfd.Pipe
+  local raw_pipe, err = cfd.pipe()
+  assert(raw_pipe ~= nil, "raw_pipe creation failed: " .. tostring(err))
+  local pipe = raw_pipe as cfd.Pipe
 
   -- Write to the pipe so it becomes readable
   local n = pipe.writer:write("hello")
@@ -74,9 +74,9 @@ end
 test_poll_pipe_readable()
 
 local function test_poll_pipe_writable()
-  local pipe, err = cfd.pipe()
-  assert(pipe ~= nil, "pipe creation failed: " .. tostring(err))
-  local pipe = pipe as cfd.Pipe
+  local raw_pipe, err = cfd.pipe()
+  assert(raw_pipe ~= nil, "raw_pipe creation failed: " .. tostring(err))
+  local pipe = raw_pipe as cfd.Pipe
 
   local p = poll.new()
   -- Check if writer is writable (should be, since buffer is empty)
@@ -95,13 +95,13 @@ end
 test_poll_pipe_writable()
 
 local function test_poll_multiple_fds()
-  local pipe1, err1 = cfd.pipe()
-  assert(pipe1 ~= nil, "pipe1 creation failed: " .. tostring(err1))
-  local pipe1 = pipe1 as cfd.Pipe
+  local raw_pipe1, err1 = cfd.pipe()
+  assert(raw_pipe1 ~= nil, "raw_pipe1 creation failed: " .. tostring(err1))
+  local pipe1 = raw_pipe1 as cfd.Pipe
 
-  local pipe2, err2 = cfd.pipe()
-  assert(pipe2 ~= nil, "pipe2 creation failed: " .. tostring(err2))
-  local pipe2 = pipe2 as cfd.Pipe
+  local raw_pipe2, err2 = cfd.pipe()
+  assert(raw_pipe2 ~= nil, "raw_pipe2 creation failed: " .. tostring(err2))
+  local pipe2 = raw_pipe2 as cfd.Pipe
 
   -- Write to both pipes
   pipe1.writer:write("hello")
@@ -127,9 +127,9 @@ end
 test_poll_multiple_fds()
 
 local function test_poll_timeout()
-  local pipe, err = cfd.pipe()
-  assert(pipe ~= nil, "pipe creation failed: " .. tostring(err))
-  local pipe = pipe as cfd.Pipe
+  local raw_pipe, err = cfd.pipe()
+  assert(raw_pipe ~= nil, "raw_pipe creation failed: " .. tostring(err))
+  local pipe = raw_pipe as cfd.Pipe
 
   local p = poll.new()
   -- Poll for read on empty pipe - should timeout
@@ -146,9 +146,9 @@ end
 test_poll_timeout()
 
 local function test_poll_with_socket()
-  local sock1, sock2, err = net.socketpair()
-  assert(sock1 ~= nil and sock2 ~= nil, "socketpair failed: " .. tostring(err))
-  local sock1 = sock1 as net.Socket
+  local raw_sock1, sock2, err = net.socketpair()
+  assert(raw_sock1 ~= nil and sock2 ~= nil, "socketpair failed: " .. tostring(err))
+  local sock1 = raw_sock1 as net.Socket
 
   -- Send data on sock1
   sock1:send("hello")
@@ -197,9 +197,9 @@ end
 test_poll_with_child_pipes()
 
 local function test_poll_events_method()
-  local pipe, err = cfd.pipe()
-  assert(pipe ~= nil, "pipe creation failed: " .. tostring(err))
-  local pipe = pipe as cfd.Pipe
+  local raw_pipe, err = cfd.pipe()
+  assert(raw_pipe ~= nil, "raw_pipe creation failed: " .. tostring(err))
+  local pipe = raw_pipe as cfd.Pipe
 
   pipe.writer:write("test")
 
@@ -210,9 +210,9 @@ local function test_poll_events_method()
   assert(ready ~= nil, "poll failed: " .. tostring(poll_err))
   assert(ready == 1, "expected 1 ready fd")
 
-  local events = p:events(pipe.reader:fd())
-  assert(events ~= nil, "events should not be nil for ready fd")
-  local events = events as poll.Events
+  local raw_events = p:events(pipe.reader:fd())
+  assert(raw_events ~= nil, "raw_events should not be nil for ready fd")
+  local events = raw_events as poll.Events
   assert(events.readable, "expected readable")
   assert(events.revents ~= nil, "revents should be set")
 
@@ -224,9 +224,9 @@ end
 test_poll_events_method()
 
 local function test_poll_nonblocking()
-  local pipe, err = cfd.pipe()
-  assert(pipe ~= nil, "pipe creation failed: " .. tostring(err))
-  local pipe = pipe as cfd.Pipe
+  local raw_pipe, err = cfd.pipe()
+  assert(raw_pipe ~= nil, "raw_pipe creation failed: " .. tostring(err))
+  local pipe = raw_pipe as cfd.Pipe
 
   local p = poll.new()
   p:add(pipe.reader:fd(), poll.POLLIN)
@@ -240,9 +240,9 @@ end
 test_poll_nonblocking()
 
 local function test_poll_hangup()
-  local pipe, err = cfd.pipe()
-  assert(pipe ~= nil, "pipe creation failed: " .. tostring(err))
-  local pipe = pipe as cfd.Pipe
+  local raw_pipe, err = cfd.pipe()
+  assert(raw_pipe ~= nil, "raw_pipe creation failed: " .. tostring(err))
+  local pipe = raw_pipe as cfd.Pipe
 
   -- Close the writer to trigger hangup on reader
   pipe.writer:close()

--- a/lib/cosmic/quicksand/box/init_example.tl
+++ b/lib/cosmic/quicksand/box/init_example.tl
@@ -57,4 +57,5 @@ local function Example_run_return_shape()
   -- exclusive
 end
 
-return {}
+-- Suppress unused warnings for examples
+local _ = {Example_new_and_close, Example_merge, Example_run_return_shape}

--- a/lib/cosmic/quicksand/netns_example.tl
+++ b/lib/cosmic/quicksand/netns_example.tl
@@ -6,7 +6,7 @@
 -- which the example also handles.
 local function Example_open_self()
   local netns = require("cosmic.quicksand.netns")
-  local fd, err = netns.open(nil)
+  local fd, _err = netns.open(nil)
   if not fd then
     io.write("no netns\n")
     return
@@ -34,4 +34,5 @@ assert(ns.bring_up("lo"))
   hh:wait()
 end
 
-return {}
+-- Suppress unused warnings for examples
+local _ = {Example_open_self, Example_unshare_in_subprocess}

--- a/lib/cosmic/quicksand/proc_example.tl
+++ b/lib/cosmic/quicksand/proc_example.tl
@@ -35,4 +35,5 @@ assert(proc.no_new_privs())
   hh:wait()
 end
 
-return {}
+-- Suppress unused warnings for examples
+local _ = {Example_default_signals, Example_drop_privs_noop, Example_no_new_privs_subprocess}

--- a/lib/cosmic/quicksand/proxy_example.tl
+++ b/lib/cosmic/quicksand/proxy_example.tl
@@ -31,4 +31,5 @@ local function Example_start_stop()
   h:stop()
 end
 
-return {}
+-- Suppress unused warnings for examples
+local _ = {Example_start_stop}

--- a/lib/cosmic/sandbox_example.tl
+++ b/lib/cosmic/sandbox_example.tl
@@ -32,4 +32,5 @@ io.write("done\n")
   -- done
 end
 
-return {}
+-- Suppress unused warnings for examples
+local _ = {Example_apply}

--- a/lib/cosmic/script_test.tl
+++ b/lib/cosmic/script_test.tl
@@ -75,7 +75,7 @@ if if if
 
   local h4 = spawn.spawn({cosmic, script})
   local __r4 = (h4 as spawn.Handle):wait() as spawn.Result
-  local ok, out = __r4.ok, __r4.stdout
+  local ok = __r4.ok
   assert(not ok, "cosmic should fail on .tl file with syntax error")
 end
 test_teal_syntax_error()

--- a/lib/cosmic/sqlite/init_example.tl
+++ b/lib/cosmic/sqlite/init_example.tl
@@ -120,4 +120,12 @@ local function Example_query_like()
   -- src/util.tl
 end
 
-return {}
+-- Suppress unused warnings for examples
+local _ = {
+  Example_open_file,
+  Example_open,
+  Example_prepared,
+  Example_query_params,
+  Example_exec_params,
+  Example_query_like,
+}

--- a/lib/cosmic/stream_example.tl
+++ b/lib/cosmic/stream_example.tl
@@ -53,4 +53,5 @@ local function Example_writer()
   -- ten bytes!
 end
 
-return {}
+-- Suppress unused warnings for examples
+local _ = {Example_reader, Example_writer}

--- a/lib/cosmic/syslog.tl
+++ b/lib/cosmic/syslog.tl
@@ -72,7 +72,7 @@ end
 
 --- Write a debug message to the system log.
 --- @param message string The message to log
-local function debug(message: string)
+local function debug_msg(message: string)
   unix.syslog(LOG_DEBUG, message)
 end
 
@@ -109,7 +109,7 @@ local M: SyslogModule = {
   warning = warning,
   notice = notice,
   info = info,
-  debug = debug,
+  debug = debug_msg,
 
   -- Priority constants
   LOG_EMERG = LOG_EMERG,

--- a/lib/cosmic/teal.tl
+++ b/lib/cosmic/teal.tl
@@ -11,6 +11,7 @@ local record Issue
   column: integer
   message: string
   severity: string -- "error" or "warning"
+  tag: string -- warning kind ("unused", "redeclaration", ...) when severity is "warning"
 end
 
 --- Options for compiling Teal to Lua.
@@ -21,8 +22,10 @@ local record CompileOptions
 end
 
 --- Options for type-checking Teal files.
+--- Warnings fail the check unless werror is explicitly set to false.
 local record CheckOptions
   include_dirs: {string}
+  werror: boolean
 end
 
 --- Result from compiling a Teal file.
@@ -57,6 +60,7 @@ local record TlError
   filename: string
   y: integer
   x: integer
+  tag: string
 end
 
 --- Result from Teal's process_string function.
@@ -128,7 +132,17 @@ local function process_file(input_path: string, include_dirs: {string}, lax: boo
   path_parts[#path_parts + 1] = package.path
   tl.path = table.concat(path_parts, ";")
 
-  local env = tl.init_env(lax)
+  -- Options-form env construction: feature flags are explicit rather than
+  -- inherited from tl's version-dependent defaults. feat_arity stays "on"
+  -- (0.24 default) so function-arity mismatches are checked in strict mode.
+  local env = tl.new_env({
+      defaults = {
+        feat_lax = lax and "on" or "off",
+        feat_arity = "on",
+        gen_target = "5.4",
+        gen_compat = "off",
+      },
+    })
   local ok, result_or_err, proc_err = pcall(tl.process_string, input, false, env, input_path)
 
   tl.path = saved_tl_path
@@ -253,11 +267,15 @@ end
 
 --- Type-check a Teal file.
 --- Uses strict mode for thorough type checking. Collects errors and warnings.
+--- Warnings fail the check (ok = false) unless opts.werror is explicitly
+--- false: an unused local or shadowed variable is a defect the author must
+--- either fix or deliberately mark (leading underscore), never ignore.
 --- @param input_path string Path to the Teal file to check
---- @param opts CheckOptions Type-checking options (include_dirs)
+--- @param opts CheckOptions Type-checking options (include_dirs, werror)
 --- @return CheckResult Result with ok status, warnings, and errors
 local function check(input_path: string, opts: CheckOptions): CheckResult
   opts = opts or {} as CheckOptions
+  local werror = opts.werror ~= false
 
   local dirs = merge_include_dirs(opts.include_dirs)
   local proc = process_file(input_path, dirs, false)
@@ -277,12 +295,14 @@ local function check(input_path: string, opts: CheckOptions): CheckResult
             column = w.x or 0,
             message = w.msg,
             severity = "warning",
+            tag = w.tag,
           })
       end
     end
   end
 
-  return {ok = #errors == 0, warnings = warnings, errors = errors}
+  local ok = #errors == 0 and (not werror or #warnings == 0)
+  return {ok = ok, warnings = warnings, errors = errors}
 end
 
 --- Format issues for human-readable output.

--- a/lib/cosmic/testrun.tl
+++ b/lib/cosmic/testrun.tl
@@ -315,7 +315,6 @@ end
 --- ```
 local function Example_makefile()
   local testrun = require("cosmic.testrun")
-  local fs = require("cosmic.fs")
   local tmpdir = fs.mkdtemp("/tmp/testrun_example_XXXXXX")
   if not tmpdir then return end
 

--- a/lib/cosmic/time.tl
+++ b/lib/cosmic/time.tl
@@ -26,18 +26,6 @@ local record DateTime
   zone: string -- Timezone name (e.g., "UTC", "PDT")
 end
 
---- Clock identifiers for clock_gettime().
-local record Clock
-  REALTIME: number -- Wall clock, subject to NTP adjustments
-  MONOTONIC: number -- Monotonic clock, not affected by system time changes
-  BOOTTIME: number -- Monotonic clock including suspend time
-  MONOTONIC_RAW: number -- Raw monotonic clock, not adjusted for NTP
-  REALTIME_COARSE: number -- Faster but less precise real time clock
-  MONOTONIC_COARSE: number -- Faster but less precise monotonic clock
-  THREAD_CPUTIME_ID: number -- CPU time for current thread
-  PROCESS_CPUTIME_ID: number -- CPU time for current process
-end
-
 --- Get current time from the specified clock.
 --- Returns seconds since epoch and nanoseconds.
 --- @param clock number? Clock identifier (default: CLOCK_REALTIME)

--- a/lib/cosmic/time_test.tl
+++ b/lib/cosmic/time_test.tl
@@ -14,7 +14,7 @@ end
 test_clock_gettime_default()
 
 local function test_clock_gettime_realtime()
-  local secs, nanos = time.clock_gettime(time.CLOCK_REALTIME)
+  local secs, _nanos = time.clock_gettime(time.CLOCK_REALTIME)
   assert(secs ~= nil, "expected seconds to be non-nil")
   assert(secs > 1700000000, "expected timestamp after 2023")
 end

--- a/lib/cosmic/tl_loader_test.tl
+++ b/lib/cosmic/tl_loader_test.tl
@@ -80,7 +80,6 @@ print("answer=" .. tostring(mymod.answer))
 
   local h2 = spawn.spawn({cosmic, "-e", "package.path='" .. moddir .. "/?.tl;' .. package.path", script})
   local __r2 = (h2 as spawn.Handle):wait() as spawn.Result
-  local ok, out = __r2.ok, __r2.stdout
   -- This may not work exactly this way, but the point is tl_package_loader
   -- should still work for .tl-only modules
   -- For now, just verify the tl_package_loader exists in searchers

--- a/lib/cosmic/tty_test.tl
+++ b/lib/cosmic/tty_test.tl
@@ -88,7 +88,7 @@ local function test_winsize_structure()
     io.stderr:write("SKIP: test_winsize_structure (stdout is not a tty)\n")
     return
   end
-  local ws, err = tty.winsize(1)
+  local ws, _err = tty.winsize(1)
   if ws then
     local w = ws as tty.WinSize
     assert(w.rows ~= nil, "winsize should have rows field")
@@ -139,7 +139,7 @@ local function test_getattr_structure()
     io.stderr:write("SKIP: test_getattr_structure (stdin is not a tty)\n")
     return
   end
-  local termios, err = tty.getattr(0)
+  local termios, _err = tty.getattr(0)
   if termios then
     local t = termios as tty.Termios
     assert(t.iflag ~= nil, "termios should have iflag")

--- a/lib/cosmic/unveil_example.tl
+++ b/lib/cosmic/unveil_example.tl
@@ -28,4 +28,5 @@ io.write("done\n")
   -- done
 end
 
-return {}
+-- Suppress unused warnings for examples
+local _ = {Example_allow}

--- a/lib/types/tl.d.tl
+++ b/lib/types/tl.d.tl
@@ -4,6 +4,7 @@ local record tl
     y: number
     x: number
     msg: string
+    tag: string -- warning kind: "unknown"|"unused"|"unread"|"redeclaration"|"branch"|"hint"
   end
 
   record Result
@@ -21,9 +22,25 @@ local record tl
     comments: {any}
   end
 
+  -- per-env feature/codegen defaults (tl.CheckOptions upstream)
+  record CheckOptions
+    feat_lax: string -- "on"|"off"
+    feat_arity: string -- "on"|"off"
+    gen_compat: string -- "off"|"optional"|"required"
+    gen_target: string -- "5.1"|"5.3"|"5.4"
+    run_internal_compiler_checks: boolean
+  end
+
+  record EnvOptions
+    defaults: CheckOptions
+    predefined_modules: {string}
+  end
+
   path: string
   loader: function()
+  warning_kinds: {string: boolean}
   init_env: function(boolean): any
+  new_env: function(EnvOptions): any, string
   lex: function(string, string): {Token}, {Error}
   parse_program: function({Token}, {Error}, string, string): any, {string}
   process_string: function(string, boolean, any, string): Result, string

--- a/skills/cosmic/checking.md
+++ b/skills/cosmic/checking.md
@@ -10,7 +10,7 @@ cosmic --make . check           # generate Makefile and type-check all files
 make check                      # if you have a saved Makefile
 ```
 
-`--check-types` runs Teal in strict mode. it reports errors and warnings on stderr. exit code 0 means the file passes.
+`--check-types` runs Teal in strict mode. it reports errors and warnings on stderr. exit code 0 means the file passes. warnings are treated as errors: an unused local, shadowed variable, or unreachable branch fails the check. mark a deliberately-unused value with a leading underscore (`local _out`, `_self: Poller`) to suppress the unused warning.
 
 ### Makefile Rules for Type Checking
 

--- a/tlconfig.lua
+++ b/tlconfig.lua
@@ -1,3 +1,6 @@
+-- Editor/LSP tooling config only (teal-language-server, tl CLI). cosmic's own
+-- build and --check-types do NOT read this file: checker options are set in
+-- lib/cosmic/teal.tl (process_file/compile). Keep the two in sync by hand.
 return {
   gen_target = "5.4",
   gen_compat = "off",


### PR DESCRIPTION
Fixes #629 (phase A of the type-system audit, tracked in #632).

## What changed

**The gate.** `teal.check()` now returns `ok=false` when warnings are present, unless the caller passes `werror=false` (`lib/cosmic/teal.tl`). `--check-types` therefore fails on any Teal warning; `check_test.tl` pins both the failure and the sanctioned suppression (leading underscore, which tl exempts from unused warnings).

**The seam.** The Teal env is now built with the options form (`tl.new_env({defaults = {...}})`) instead of the legacy `tl.init_env(lax)` boolean, so `feat_arity = "on"`, `feat_lax`, `gen_target = "5.4"`, and `gen_compat = "off"` are explicit rather than inherited version-dependent defaults. `lib/types/tl.d.tl` models `EnvOptions`/`CheckOptions`/`new_env` and the warning `tag` field (kinds: unused, redeclaration, branch, hint, unknown, unread), which `teal.check` now propagates on each Issue.

**The config.** `tlconfig.lua` is documented as editor/LSP-only — nothing in cosmic reads it; checker options live in `teal.tl`. `CLAUDE.md` and `skills/cosmic/checking.md` document the warnings-are-errors policy.

**The cleanup.** The tree had 164 warnings across 45 files, now zero:
- example files reference their `Example_*` functions in a trailing `local _ = {...}` list (the pattern `fs/init_example.tl` already used)
- the assert-then-cast narrowing sites in net/poll tests rename the raw fallible value (`raw_srv`) instead of shadowing the narrowed name
- deliberately-unused captures get the underscore marker (`_out`, `_err`, `_self`)
- `envd`/`syslog`/`fd`/`fetch`/`testrun`/`fuzzy_test` stop shadowing Lua globals (`load`, `debug`, `arg`, `pairs`) and module imports
- dead code removed: `format/rules.is_method_colon`, `time.Clock` record, `embed_advanced_test.write_temp`
- `cli/main.tl` builds script args without `#` on a `{integer:string}` map keyed at -1/0/1..n

## Verification

`bin/make ci` green (format + teal 271/271 + test + example + lint + coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p)_