### PR TITLE
types: tighten quicksand proxy rules, fetch prepare, format rules, shm

### DIFF
--- a/lib/cosmic/cli/main.tl
+++ b/lib/cosmic/cli/main.tl
@@ -35,7 +35,7 @@ local help = require("cosmic.cli.help")
 local handlers = require("cosmic.cli.main_handlers")
 
 -- Parsed options record
-local record Opts
+local record Options
   execute: {string}
   load: {string}
   interactive: boolean
@@ -70,8 +70,8 @@ local record Opts
 end
 
 -- Parse arguments using cosmo.getopt iterator API
-local function parse_args(): Opts
-  local opts: Opts = {
+local function parse_args(): Options
+  local opts: Options = {
     execute = {},
     load = {},
     interactive = false,

--- a/lib/cosmic/fetch/extras.tl
+++ b/lib/cosmic/fetch/extras.tl
@@ -163,10 +163,12 @@ local function encode_multipart(parts: {Part}): string | nil, string
   return table.concat(out), "multipart/form-data; boundary=" .. boundary
 end
 
--- Mirror of the Options fields prepare touches (Teal records are
--- nominal; the boundary crosses through `any`, like cosmic.sqlite's
--- helper modules).
-local record Opts
+-- Internal mirror of the fetch.Options fields prepare touches. The
+-- full Options record lives in fetch/init.tl (its should_retry
+-- callback references Result, and extras cannot require init back);
+-- prepare is generic over the caller's record so the module boundary
+-- itself stays fully typed.
+local record PrepareOptions
   method: string
   body: string
   headers: {string: string}
@@ -176,7 +178,7 @@ local record Opts
   multipart: {Part}
 end
 
-local function set_default_content_type(o: Opts, ctype: string)
+local function set_default_content_type(o: PrepareOptions, ctype: string)
   if o.headers then
     for k in pairs(o.headers) do
       if k:lower() == "content-type" then
@@ -195,15 +197,15 @@ end
 --- options table is never mutated; a body-producing option defaults the
 --- method to POST when none is set.
 --- @param url string The request URL
---- @param opts_any any The fetch Options, or nil
+--- @param opts_in T The fetch Options record, or nil
 --- @return string The URL with query params appended
---- @return any The prepared options
+--- @return T The prepared options
 --- @return string? Error message on invalid or conflicting options
-local function prepare(url: string, opts_any: any): string, any, string
-  if opts_any == nil then
+local function prepare<T>(url: string, opts_in: T): string, T, string
+  if opts_in == nil then
     return url, nil, nil
   end
-  local opts = opts_any as Opts
+  local opts = opts_in as PrepareOptions
   local sources = 0
   if opts.body then sources = sources + 1 end
   if opts.json ~= nil then sources = sources + 1 end
@@ -213,15 +215,15 @@ local function prepare(url: string, opts_any: any): string, any, string
     return url, nil, "at most one of body, json, form, multipart may be set"
   end
   if sources == 0 and not opts.query then
-    return url, opts_any, nil
+    return url, opts_in, nil
   end
 
   -- Shallow copy (headers too) so no caller table is mutated.
   local o: {string: any} = {}
-  for k, v in pairs(opts_any as {string: any}) do
+  for k, v in pairs(opts_in as {string: any}) do
     o[k] = v
   end
-  local prepared = o as Opts
+  local prepared = o as PrepareOptions
   if opts.headers then
     local h: {string: string} = {}
     for k, v in pairs(opts.headers) do
@@ -258,7 +260,7 @@ local function prepare(url: string, opts_any: any): string, any, string
   if prepared.body and not prepared.method then
     prepared.method = "POST"
   end
-  return url, o, nil
+  return url, o as T, nil
 end
 
 -- Mirrors of the stream result surface download consumes.
@@ -386,7 +388,7 @@ local record ExtrasModule
   validate_url: function(url: string): string
   validate_headers: function(headers: {string: string}): string
   unix_proxy: function(path: string): string | nil, string
-  prepare: function(url: string, opts_any: any): string, any, string
+  prepare: function<T>(url: string, opts_in: T): string, T, string
   make: function(fetch_fn: function(string, any): any,
   stream_fn: function(string, any): any,
   wrap: function(any): any): Made

--- a/lib/cosmic/fetch/init.tl
+++ b/lib/cosmic/fetch/init.tl
@@ -252,7 +252,7 @@ local function Fetch(url: string, opts?: Options): Result
     return fail(perr, nil)
   end
   url = purl
-  opts = popts as Options
+  opts = popts
   local max_attempts = (opts and opts.max_attempts) or 1
   local base_delay = (opts and opts.base_delay) or 0.5
   local max_delay = (opts and opts.max_delay) or 30
@@ -410,7 +410,7 @@ local function stream(url: string, opts?: Options): StreamResult
     return stream_fail(perr, nil)
   end
   url = purl
-  opts = popts as Options
+  opts = popts
   local verr = validate_url(url)
   if verr then
     return stream_fail(verr, nil)

--- a/lib/cosmic/format/init.tl
+++ b/lib/cosmic/format/init.tl
@@ -5,12 +5,7 @@
 
 local tl = require("tl")
 
-local record FormatRules
-  is_long_comment: function(tk: string): boolean
-  needs_space: function(prev_prev: any, prev: any, cur: any, next_item: any): boolean
-  compute_indent_change: function(line_items: {any}): integer, integer
-end
-local rules = require("cosmic.format.rules") as FormatRules
+local rules = require("cosmic.format.rules")
 
 --- A formatting issue (syntax error preventing formatting).
 local record Issue
@@ -29,12 +24,43 @@ local record FormatResult
 end
 
 -- An item in the output stream: either a token or a comment.
-local record Item
-  y: integer -- source line
-  x: integer -- source column
-  tk: string -- text
-  kind: string -- token kind (or "comment" for comments)
+local record Item is rules.Item
+  -- y/x/tk/kind come from the rules.Item interface.
   _newlines: integer -- cached newline count for multiline tokens
+  _tight_before: boolean -- render with no space before (type-param lists)
+end
+
+--- Mark type-parameter lists (`function<T>(`, `function name<K, V>(`) so
+--- the spacing pass renders them tightly; needs_space alone cannot tell
+--- `f<T>(` from a `<` comparison in its four-token window.
+local function mark_type_params(items: {Item})
+  for i, item in ipairs(items) do
+    if item.kind == "keyword" and item.tk == "function" then
+      local j = i + 1
+      if items[j] and items[j].kind == "identifier" then j = j + 1 end
+      if items[j] and items[j].tk == "<" then
+        local k = j + 1
+        local depth = 1
+        while items[k] and depth > 0 do
+          if items[k].tk == "<" then
+            depth = depth + 1
+          elseif items[k].tk == ">" then
+            depth = depth - 1
+          end
+          k = k + 1
+        end
+        if depth == 0 and items[k] and items[k].tk == "(" then
+          for m = j, k do
+            local it = items[m]
+            if m == j or it.tk == ">" or m == k
+            or (items[m - 1] and items[m - 1].tk == "<") then
+              it._tight_before = true
+            end
+          end
+        end
+      end
+    end
+  end
 end
 
 --- Count newlines in a string using plain find (faster than gmatch for counting).
@@ -223,13 +249,15 @@ local function format(input: string, filename: string): FormatResult
       out[#out + 1] = "\n"
     end
 
-    local pre_change, post_change = rules.compute_indent_change(line.items as {any})
+    local pre_change, post_change = rules.compute_indent_change(line.items)
 
     indent = math.max(0, indent + pre_change)
 
     if indent > 0 then
       out[#out + 1] = string.rep(indent_str, indent)
     end
+
+    mark_type_params(line.items)
 
     local prev_prev_item: Item = nil
     local prev_item: Item = nil
@@ -239,7 +267,8 @@ local function format(input: string, filename: string): FormatResult
         if item_idx < #line.items then
           next_item = line.items[item_idx + 1]
         end
-        if rules.needs_space(prev_prev_item as any, prev_item as any, item as any, next_item as any) then
+        if not item._tight_before
+        and rules.needs_space(prev_prev_item, prev_item, item, next_item) then
           out[#out + 1] = " "
         end
       end

--- a/lib/cosmic/format/rules.tl
+++ b/lib/cosmic/format/rules.tl
@@ -2,7 +2,9 @@
 --- Contains lookup tables, token classifiers, and indent computation.
 
 -- An item in the output stream: either a token or a comment.
-local record Item
+-- An interface so the formatter's richer Item record (which caches
+-- newline counts) subtypes it and the rule functions stay fully typed.
+local interface Item
   y: integer
   x: integer
   tk: string
@@ -297,14 +299,15 @@ local function compute_indent_change(line_items: {Item}): integer, integer
 end
 
 local record FormatRulesModule
+  type Item = Item
   is_long_comment: function(tk: string): boolean
-  needs_space: function(prev_prev: any, prev: any, cur: any, next_item: any): boolean
-  compute_indent_change: function(line_items: {any}): integer, integer
+  needs_space: function(prev_prev: Item, prev: Item, cur: Item, next_item: Item): boolean
+  compute_indent_change: function(line_items: {Item}): integer, integer
 end
 
 local M: FormatRulesModule = {}
 M.is_long_comment = is_long_comment
-M.needs_space = needs_space as function(any, any, any, any): boolean
-M.compute_indent_change = compute_indent_change as function({any}): integer, integer
+M.needs_space = needs_space
+M.compute_indent_change = compute_indent_change
 
 return M

--- a/lib/cosmic/fs/init.tl
+++ b/lib/cosmic/fs/init.tl
@@ -316,7 +316,7 @@ local record FsModule
   -- ends the walk now; returning nothing continues.
   -- Root open failure returns nil, err; subtree failures return the first
   -- error alongside the results.
-  walk: function < T > (dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string
+  walk: function<T>(dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string
   -- glob expands a pattern without recursing; components ("src/*.lua")
   -- are each globs, and matches of every entry type are returned sorted.
   glob: function(dir: string, pattern: string): {string} | nil, string

--- a/lib/cosmic/fs/walk.tl
+++ b/lib/cosmic/fs/walk.tl
@@ -34,14 +34,14 @@ local record WalkOptions
   max_depth: integer
 end
 
-local walk_tree: function < T > (string,
+local walk_tree: function<T>(string,
 function(string, string, WalkStat, T): (WalkAction ...), T, {string}, integer, integer): boolean
 
 --- Shared per-directory loop. Consumes (and closes) an already-open
 --- handle, records the first subtree error in errbox[1], and returns
 --- true when a visitor asked to stop the walk. Entries visited here are
 --- at depth; max_depth of 0 means unlimited.
-local function walk_entries < T > (dir: string, h: WalkDirHandle,
+local function walk_entries<T>(dir: string, h: WalkDirHandle,
     visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx: T,
     errbox: {string}, depth: integer, max_depth: integer): boolean
   while true do
@@ -76,7 +76,7 @@ end
 
 --- Recursive walk helper. An opendir failure below the root is recorded
 --- in errbox[1] rather than swallowed or fatal.
-walk_tree = function < T > (dir: string,
+walk_tree = function<T>(dir: string,
     visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx: T,
     errbox: {string}, depth: integer, max_depth: integer): boolean
   local handle, oerr = unix.opendir(dir)
@@ -121,7 +121,7 @@ end
 --- @param opts WalkOptions? max_depth limits how deep the walk descends
 --- @return T | nil The context object, or nil if the root could not be opened
 --- @return string First error encountered, if any
-local function walk < T > (dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string
+local function walk<T>(dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string
   ctx = ctx or {} as T
   local max_depth = 0
   if opts and opts.max_depth then
@@ -439,7 +439,7 @@ local type FileIter = function(): string
     --- Walk dir tree. visitor(path, name, st, ctx): path is the FULL path; name is the basename.
     --- Do NOT join path and name — path is already complete.
     --- The visitor may return "skip" (don't descend) or "stop" (end the walk).
-    walk: function < T > (dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string
+    walk: function<T>(dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string
     glob: function(dir: string, pattern: string): {string} | nil, string
     collect: function(dir: string, pattern: string): {string} | nil, string
     collect_matching: function(dir: string, lua_pattern: string): {string} | nil, string

--- a/lib/cosmic/quicksand/box/run.tl
+++ b/lib/cosmic/quicksand/box/run.tl
@@ -194,10 +194,9 @@ local function supervisor(
     local h, perr = proxy.start({
         bind_ip = cosmo.ParseIp("127.0.0.1") as integer,
         bind_port = 0,
-        -- Box's typed NetRule and the proxy's runtime-validated
-        -- ProxyRule are distinct records with the same wire shape;
-        -- proxy.start's rules.validate is the checker of record here.
-        allowed_hosts = net.allow as {string: proxy.ProxyRule},
+        -- NetRule and ProxyRule are the same nominal record now;
+        -- proxy.start's rules.validate still runtime-checks raw config.
+        allowed_hosts = net.allow,
         upstream_ns_fd = parent_netns_fd,
         log_level = net.log_level or "quiet",
         resolve_timeout_ms = net.resolve_timeout_ms,

--- a/lib/cosmic/quicksand/proxy/rules.tl
+++ b/lib/cosmic/quicksand/proxy/rules.tl
@@ -17,19 +17,26 @@
 --- typo'd rule silently degrading to pass-through would strip auth
 --- from an otherwise-authenticated egress path.
 local cosmo = require("cosmo")
+local qtypes = require("cosmic.quicksand.types")
+
+--- The typed allowlist rule: one nominal record for the whole
+--- quicksand family (cosmic.quicksand.types.NetRule, re-exported by
+--- the proxy modules as ProxyRule). validate()/validate_rule() still
+--- accept raw untyped config; everything after index() is typed.
+local type ProxyRule = qtypes.NetRule
 
 --- One wildcard ("*.suffix") allowlist entry. `port` nil = any port.
 local record SuffixEntry
   suffix: string
   port: integer
-  rule: any
+  rule: ProxyRule
 end
 
 --- Fast lookup structure built from an allowlist by index().
 --- exact[host][port] and exact[host]["*"] hold exact-host rules;
 --- suffix is walked in insertion order for "*.suffix" patterns.
 local record Index
-  exact: {string: {any: any}}
+  exact: {string: {any: ProxyRule}}
   suffix: {SuffixEntry}
 end
 
@@ -134,9 +141,15 @@ end
 --- Build a lookup Index from an allowlist table. Wildcard entries
 --- are stored with a leading "." and matched at the tail of the
 --- candidate host, in insertion order.
-local function index(allowed_hosts: {string: any}): Index
+local function index(allowed_hosts: {string: ProxyRule}): Index
   local idx: Index = {exact = {}, suffix = {}}
   for k, rule in pairs(allowed_hosts or {}) do
+    -- Raw config reaches here through casts and may carry `true` for
+    -- pass-through (validate() accepts it); normalize to an empty rule
+    -- so nothing downstream ever indexes a boolean.
+    if type(rule) ~= "table" then
+      rule = {} as ProxyRule
+    end
     local wild = k:match("^%*%.(.+)$")
     if wild then
       local h, p = parse_rule(wild)
@@ -158,7 +171,7 @@ end
 --- Look up a (host, port) pair. Returns the rule value on a hit, or
 --- nil. Exact-host matches win over suffix patterns; suffix patterns
 --- return the first hit in insertion order.
-local function match(idx: Index, host: string, port: integer): any
+local function match(idx: Index, host: string, port: integer): ProxyRule | nil
   host = host:lower()
   local entry = idx.exact[host]
   if entry then
@@ -176,30 +189,33 @@ end
 
 --- Build the auth header a rule injects on plain-HTTP requests.
 --- Returns (name, value), or nil for pass-through rules.
-local function auth_header(rule: any): string | nil, string
-  if not (rule is table) then return nil end
-  local r = rule as {string: any}
-  local t = r["type"]
+local function auth_header(rule: ProxyRule): string | nil, string
+  -- Raw config can still smuggle `true` through casts; stay defensive
+  -- rather than index a boolean at runtime.
+  if rule == nil or type(rule) ~= "table" then return nil end
+  local t = rule.type
   if t == "bearer" then
-    return "Authorization", "Bearer " .. tostring(r["token"])
+    return "Authorization", "Bearer " .. tostring(rule.token)
   elseif t == "basic" then
     local enc = cosmo.EncodeBase64(
-      tostring(r["username"]) .. ":" .. tostring(r["password"]))
+      tostring(rule.username) .. ":" .. tostring(rule.password))
     return "Authorization", "Basic " .. enc
   elseif t == "header" then
-    return r["header_name"] as string, r["header_value"] as string
+    return rule.header_name, rule.header_value
   end
   return nil
 end
 
 local record RulesModule
+  type ProxyRule = ProxyRule
+  type Index = Index
   parse_rule: function(key: string): string, integer
   validate_key: function(key: string): string
   validate_rule: function(key: string, rule: any): string
   validate: function(allowed_hosts: {string: any}): boolean, string
-  index: function(allowed_hosts: {string: any}): Index
-  match: function(idx: Index, host: string, port: integer): any
-  auth_header: function(rule: any): string | nil, string
+  index: function(allowed_hosts: {string: ProxyRule}): Index
+  match: function(idx: Index, host: string, port: integer): ProxyRule | nil
+  auth_header: function(rule: ProxyRule): string | nil, string
 end
 
 local M: RulesModule = {

--- a/lib/cosmic/quicksand/proxy/rules_test.tl
+++ b/lib/cosmic/quicksand/proxy/rules_test.tl
@@ -127,6 +127,7 @@ local function test_auth_header()
     })
   assert(n == "x-k" and v == "s", "custom header")
   assert(rules.auth_header({}) == nil, "pass-through injects nothing")
-  assert(rules.auth_header(true) == nil, "true injects nothing")
+  -- raw config can smuggle `true` past the types; auth_header must not index it
+  assert(rules.auth_header(true as rules.ProxyRule) == nil, "true injects nothing")
 end
 test_auth_header()

--- a/lib/cosmic/quicksand/proxy/serve.tl
+++ b/lib/cosmic/quicksand/proxy/serve.tl
@@ -10,6 +10,9 @@
 local unix = require("cosmo.unix")
 local cosmo = require("cosmo")
 local rules = require("cosmic.quicksand.proxy.rules")
+local qtypes = require("cosmic.quicksand.types")
+
+local type ProxyRule = qtypes.NetRule
 local http = require("cosmic.quicksand.proxy.http")
 local updial = require("cosmic.quicksand.proxy.dial")
 local errno = require("cosmic.errno")
@@ -39,15 +42,9 @@ local record ServeModule
 
   --- A single allowlist rule. `type` nil means pass-through
   --- (allowed, no header injection). Fields not relevant to the
-  --- chosen type are ignored.
-  record ProxyRule
-    type: string -- "bearer" | "basic" | "header" | nil
-    token: string -- bearer
-    username: string -- basic
-    password: string -- basic
-    header_name: string -- header
-    header_value: string -- header
-  end
+  --- chosen type are ignored. This is cosmic.quicksand.types.NetRule:
+  --- one nominal record for the whole quicksand family.
+  type ProxyRule = ProxyRule
 
   --- Options for start() / new().
   record ProxyOptions
@@ -55,8 +52,8 @@ local record ServeModule
     bind_port: integer -- default 3128; 0 = ephemeral
     allowed_hosts: {string: ProxyRule}
     upstream_ns_fd: integer -- netns fd to dial in; nil = current ns
-    log_level: string -- "quiet" | "info" | "debug" (default "info")
-    log_format: string -- "text" | "json"            (default "text")
+    log_level: qtypes.LogLevel -- default "info"
+    log_format: qtypes.LogFormat -- default "text"
     log_file: string -- path; default stderr
     accept_backlog: integer -- default 32
     resolve_timeout_ms: integer -- per-dial DNS deadline in ms;
@@ -147,7 +144,7 @@ local function new(opts: ServeModule.ProxyOptions): Server | nil, string
   opts = opts or {}
   local logger, lerr = make_logger(opts)
   if not logger then return nil, lerr end
-  local idx = rules.index((opts.allowed_hosts or {}) as {string: any})
+  local idx = rules.index(opts.allowed_hosts or {})
   local bind_ip: integer = opts.bind_ip or cosmo.ParseIp("127.0.0.1") as integer
   local bind_port: integer = opts.bind_port or 3128
   local backlog: integer = opts.accept_backlog or 32
@@ -273,7 +270,7 @@ local function new(opts: ServeModule.ProxyOptions): Server | nil, string
       refuse(client_fd, http.UPSTREAM_FAIL)
       return
     end
-    local injn, injv = rules.auth_header(rule)
+    local injn, injv = rules.auth_header(rule as ProxyRule)
     local host_hdr = host
     if (scheme == "http" and port ~= 80)
     or (scheme == "https" and port ~= 443) then

--- a/lib/cosmic/quicksand/types.tl
+++ b/lib/cosmic/quicksand/types.tl
@@ -21,6 +21,12 @@ local enum LogLevel
   "debug"
 end
 
+--- Proxy log line encoding.
+local enum LogFormat
+  "text"
+  "json"
+end
+
 --- A single allowlist rule for `net.allow`. Mirrors
 --- cosmic.quicksand.proxy.ProxyRule (whose looser runtime schema is
 --- validated by proxy.start) — empty table = pass-through.
@@ -100,6 +106,7 @@ end
 local record TypesModule
   type NetRuleType = NetRuleType
   type LogLevel = LogLevel
+  type LogFormat = LogFormat
   type NetRule = NetRule
   type NetOptions = NetOptions
   type FsOpts = FsOpts

--- a/lib/cosmic/shm.tl
+++ b/lib/cosmic/shm.tl
@@ -137,13 +137,12 @@ local function wrap(raw: unix.Memory, size: number): Memory
   end
 
   -- Shared body for the atomic read-modify-write word operations.
-  local function atomic(op: string, fn: any, word_index: number, value: number): number | nil, string
+  local function atomic(op: string, fn: function(unix.Memory, number, number): number, word_index: number, value: number): number | nil, string
     local range_err = check_word(word_index, size, op)
     if range_err then
       return nil, range_err
     end
-    local call = fn as function(unix.Memory, number, number): number
-    local ok, res = pcall(call, raw, word_index, value)
+    local ok, res = pcall(fn, raw, word_index, value)
     if not ok then
       return nil, thrown(op, res)
     end


### PR DESCRIPTION
Fixes #630 (phase A of the type-system audit, tracked in #632).

Each change is a place where a known record or closed set crossed a module boundary as `any`:

**quicksand.** `ProxyRule` is now one nominal record for the whole family — it *is* `cosmic.quicksand.types.NetRule`, re-exported by `proxy`/`proxy.serve` under the old name, so `box/run` drops its `NetRule → ProxyRule` cast. `rules.index/match/auth_header` are fully typed (`match` returns `ProxyRule | nil`; `validate`/`validate_rule` still take raw untrusted config, which is genuinely `any`), and `index` normalizes a smuggled `true` to an empty rule so nothing downstream ever indexes a boolean. `ProxyOptions.log_level`/`log_format` use the `LogLevel`/`LogFormat` enums (`LogFormat` is new in `quicksand.types`); with `ProxyRule.type` now the `NetRuleType` enum, the bearer/basic/header dispatch is checker-verified.

**fetch.** `extras.prepare` is generic over the caller's options record (`prepare<T>`), so `fetch/init` passes `Options` straight through with no casts on either side. The internal field mirror is renamed `PrepareOptions` and its reason for existing is documented (it cannot require init back — `Result` lives there).

**format.** `rules.Item` is an interface that the formatter's richer `Item` record implements — `needs_space`/`compute_indent_change` are fully typed and the four `as any` casts on the render hot path are gone. The formatter also learns type-parameter lists: `function<T>(` renders tightly instead of `function < T > (` (a line-level pre-pass marks them; `needs_space`'s four-token window can't distinguish `f<T>(` from a `<` comparison). `fs/walk`/`fs/init` are reformatted to the new canonical spelling — this also unblocks the generics work in #631.

**shm.** `atomic()` takes the real callback type (`function(unix.Memory, number, number): number`) instead of `fn: any`.

**cli.** The options record is named `Options` per convention.

**Deliberate non-change:** `quicksand.probe(fn: any)` stays — its callers pass heterogeneous C-binding signatures (`unix.pledge`, `unix.unveil`), so typing the param would just move the one internal cast to every call site.

## Verification

`bin/make ci` green (format + teal + test + example + lint + coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p)_