### PR TITLE
gentype: render literal-union aliases as Teal enums, scalar aliases as types

### DIFF
--- a/lib/types/cook.mk
+++ b/lib/types/cook.mk
@@ -3,6 +3,6 @@ modules += types
 # binary via cosmos) and the committed lib/types/cosmo/*.d.tl, so it runs as a
 # normal test under $(cosmic_bin). It guards the generator against drift, e.g.
 # the errno-return contract in unix.d.tl (see test_errno_drift_unix).
-types_tests := lib/types/gentype_test.tl
+types_tests := lib/types/gentype_test.tl lib/types/gentype_alias_test.tl
 # types_deps is intentionally not set - types_files are source files (.d.tl),
 # not built outputs. The regen-types target uses bootstrap_cosmic directly.

--- a/lib/types/gentype.tl
+++ b/lib/types/gentype.tl
@@ -9,7 +9,6 @@ local gt = require("types.gentype_types")
 local Param = gt.Param
 local Return = gt.Return
 local FuncDecl = gt.FuncDecl
-local Constant = gt.Constant
 local Field = gt.Field
 local ClassDecl = gt.ClassDecl
 local ModuleDecl = gt.ModuleDecl
@@ -17,9 +16,13 @@ local ModuleDecl = gt.ModuleDecl
 local record GentypeRender
   generate_dtl: function(module: ModuleDecl): string
   convert_type: function(t: string): string
-  extract_module_content: function(source: string, module_name: string): string
 end
 local render = require("types.gentype_render") as GentypeRender
+
+local record GentypeExtract
+  extract_module_content: function(source: string, module_name: string): string
+end
+local extract = require("types.gentype_extract") as GentypeExtract
 
 local record GentypeParse
   parse_annotations: function(raw_lines: {string}): {string}, {Param}, {Return}, boolean, string, {Field}, boolean, string
@@ -126,12 +129,12 @@ end
 
 --- Parse a module from definitions.lua source.
 local function parse_module(source: string, module_name: string): ModuleDecl
-  local content = render.extract_module_content(source, module_name)
+  local content = extract.extract_module_content(source, module_name)
   if not content then return nil end
 
   local module: ModuleDecl = {
     name = module_name, description = {},
-    functions = {}, classes = {}, constants = {},
+    functions = {}, classes = {}, constants = {}, aliases = {},
   }
 
   -- Keep empty lines: a blank line terminates an annotation block (e.g. a
@@ -148,7 +151,23 @@ local function parse_module(source: string, module_name: string): ModuleDecl
   while i <= #lines do
     local line = lines[i]
 
-    if line:match("^%s*%-%-%-") or line:match("^%-%-%-") then
+    local aname, arest = line:match("^%-%-%-@alias%s+([%w_%.]+)%s+(.+)$")
+    if aname then
+      -- Only module-prefixed aliases become named types; bare legacy
+      -- aliases (uint32, JsonValue, ...) stay hardcoded conversions in
+      -- gentype_render.TYPE_ALIASES.
+      if aname:match("%.") then
+        local adesc = parse_annotations(anno_lines)
+        table.insert(module.aliases, {
+            name = aname:match("%.([%w_]+)$"),
+            module = module_name,
+            alias_type = arest:match("^(%S+)"),
+            description = adesc,
+          })
+      end
+      anno_lines = {}
+      i = i + 1
+    elseif line:match("^%s*%-%-%-") or line:match("^%-%-%-") then
       if line:match("^%-%-%-@class%s+") and in_class_block and #anno_lines > 0 then
         process_class_block(anno_lines, module_name, module.classes)
         anno_lines = {}

--- a/lib/types/gentype_alias_test.tl
+++ b/lib/types/gentype_alias_test.tl
@@ -1,0 +1,47 @@
+#!/usr/bin/env cosmic
+--- Tests for gentype's ---@alias handling (Teal enum / type alias emission).
+--- Split from gentype_test.tl to respect the 500-line file cap.
+
+local gentype = require("types.gentype")
+
+-- A module-prefixed `---@alias` whose right-hand side is a union of string
+-- literals renders as a real Teal enum, is re-exported on the module record,
+-- and references to it collapse to the bare enum name. A scalar alias renders
+-- as a transparent `type` alias. Bare (unprefixed) legacy aliases like uint32
+-- stay hardcoded conversions and must not be emitted.
+local function test_alias_enum_and_scalar()
+  local source = [==[
+zip = {}
+
+---@alias uint32 integer Unsigned 32-bit integer
+
+--- Archive open modes.
+---@alias zip.OpenMode "r"|"w"|"a"
+
+--- Kernel-reported errno group.
+---@alias zip.Errno integer
+
+--- Opens an archive.
+---@param path string
+---@param mode? zip.OpenMode Open mode
+---@return boolean ok
+function zip.open(path, mode) end
+]==]
+  local dtl = gentype.generate_dtl(gentype.parse_module(source, "zip"))
+  assert(dtl:match("local enum OpenMode\n  \"r\"\n  \"w\"\n  \"a\"\nend"),
+    "literal-union alias should render as a Teal enum:\n" .. dtl)
+  assert(dtl:match("--- Archive open modes%.\nlocal enum OpenMode"),
+    "alias description should precede the enum:\n" .. dtl)
+  assert(dtl:match("local type Errno = number"),
+    "scalar alias should render as a transparent type alias:\n" .. dtl)
+  assert(dtl:match("  type OpenMode = OpenMode"),
+    "enum should be re-exported on the module record:\n" .. dtl)
+  assert(dtl:match("open: function%(path: string, mode%?: OpenMode%)"),
+    "module-local alias reference should collapse to the bare name:\n" .. dtl)
+  assert(not dtl:match("uint32"),
+    "bare legacy aliases must not be emitted:\n" .. dtl)
+  print("test_alias_enum_and_scalar: PASS")
+end
+test_alias_enum_and_scalar()
+
+print("\nAll tests passed!")

--- a/lib/types/gentype_extract.tl
+++ b/lib/types/gentype_extract.tl
@@ -1,0 +1,90 @@
+--- Extraction of one module's annotation content from definitions.lua.
+--- Split from gentype_render.tl to respect the 500-line file cap.
+
+--- Extract a module's content from definitions.lua.
+--- Selects, line-based: (1) the `<mod> = { ... }` table section, with brace
+--- depth counted only outside comments (a stray `}` in a doc comment must not
+--- terminate the table early); (2) every annotation block followed by a
+--- `function <mod>.<name>(` or `function <mod>.<Class>:<method>(` declaration,
+--- wherever it appears in the file; (3) every standalone `---@class <mod>.*`
+--- data-class block. Blocks belonging to other modules never leak in, so no
+--- boundary heuristics are needed.
+local function extract_module_content(source: string, module_name: string): string
+  local lines: {string} = {}
+  for line in (source .. "\n"):gmatch("([^\n]*)\n") do
+    table.insert(lines, line)
+  end
+
+  -- 1) module table section
+  local start_idx: integer = nil
+  for idx, line in ipairs(lines) do
+    if line:match("^" .. module_name .. "%s*=%s*{") then
+      start_idx = idx
+      break
+    end
+  end
+  if not start_idx then return nil end
+
+  local out: {string} = {}
+  local depth = 0
+  local table_end = start_idx
+  for idx = start_idx, #lines do
+    local code = lines[idx]:gsub("%-%-.*$", "")
+    for brace in code:gmatch("[{}]") do
+      depth = depth + (brace == "{" and 1 or -1)
+    end
+    table.insert(out, lines[idx])
+    table_end = idx
+    if depth <= 0 then break end
+  end
+
+  -- 2) + 3) annotation blocks and declarations for this module
+  local fn_pattern = "^function%s+" .. module_name .. "%."
+  local class_pattern = "^%-%-%-@class%s+" .. module_name .. "%."
+  local alias_pattern = "^%-%-%-@alias%s+" .. module_name .. "%."
+  local pending: {string} = {}
+  local function flush_standalone_class()
+    local is_class = false
+    for _, a in ipairs(pending) do
+      if a:match(class_pattern) or a:match(alias_pattern) then
+        is_class = true
+        break
+      end
+    end
+    if is_class then
+      for _, a in ipairs(pending) do table.insert(out, a) end
+      table.insert(out, "")
+    end
+    pending = {}
+  end
+
+  for idx = 1, #lines do
+    if idx >= start_idx and idx <= table_end then
+      pending = {}
+    else
+      local line = lines[idx]
+      if line:match("^%-%-%-") then
+        table.insert(pending, line)
+      elseif line:match(fn_pattern) then
+        for _, a in ipairs(pending) do table.insert(out, a) end
+        table.insert(out, line)
+        pending = {}
+      else
+        flush_standalone_class()
+      end
+    end
+  end
+  flush_standalone_class()
+
+  return table.concat(out, "\n")
+end
+
+local record GentypeExtractModule
+  extract_module_content: function(source: string, module_name: string): string
+end
+
+local M: GentypeExtractModule = {
+  extract_module_content = extract_module_content,
+}
+
+return M

--- a/lib/types/gentype_render.tl
+++ b/lib/types/gentype_render.tl
@@ -4,8 +4,6 @@ local gt = require("types.gentype_types")
 local Param = gt.Param
 local Return = gt.Return
 local FuncDecl = gt.FuncDecl
-local Constant = gt.Constant
-local ClassDecl = gt.ClassDecl
 local ModuleDecl = gt.ModuleDecl
 
 -- The module currently being rendered. A dotted type reference whose prefix
@@ -242,6 +240,21 @@ local function format_description(desc: {string}, indent: string): {string}
   return result
 end
 
+--- Split an alias right-hand side into enum members when it is a union
+--- of two or more string literals; nil otherwise.
+local function alias_enum_members(t: string): {string}
+  if not t or not t:match("|") then return nil end
+  local members: {string} = {}
+  for part in t:gmatch("[^|]+") do
+    part = part:match("^%s*(.-)%s*$")
+    local lit = part:match('^"(.*)"$') or part:match("^'(.*)'$")
+    if not lit then return nil end
+    table.insert(members, lit)
+  end
+  if #members < 2 then return nil end
+  return members
+end
+
 --- Collect foreign module prefixes referenced from the module's types
 --- (e.g. `unix.Errno` inside cosmo), so requires can be emitted for them.
 local function foreign_modules(module: ModuleDecl): {string}
@@ -267,6 +280,7 @@ local function foreign_modules(module: ModuleDecl): {string}
     for _, f in ipairs(cls.fields) do scan(f.field_type) end
   end
   for _, c in ipairs(module.constants) do scan(c.const_type) end
+  for _, al in ipairs(module.aliases or {}) do scan(al.alias_type) end
   local result: {string} = {}
   for prefix in pairs(seen) do table.insert(result, prefix) end
   table.sort(result)
@@ -336,6 +350,25 @@ local function generate_dtl(module: ModuleDecl): string
     end
   end
 
+  -- Named aliases: a literal-string union becomes a real Teal enum
+  -- (checked at call sites); anything else a transparent type alias.
+  for _, al in ipairs(module.aliases or {}) do
+    for _, line in ipairs(format_description(al.description, "")) do
+      table.insert(out, line)
+    end
+    local members = alias_enum_members(al.alias_type)
+    if members then
+      table.insert(out, "local enum " .. al.name)
+      for _, m in ipairs(members) do
+        table.insert(out, "  \"" .. m .. "\"")
+      end
+      table.insert(out, "end")
+    else
+      table.insert(out, "local type " .. al.name .. " = " .. convert_type(al.alias_type))
+    end
+    table.insert(out, "")
+  end
+
   table.insert(out, "local record " .. module.name)
 
   -- Export each class type on the module record so consumers can name it
@@ -349,6 +382,14 @@ local function generate_dtl(module: ModuleDecl): string
   for _, cls in ipairs(module.classes) do
     if not taken[cls.name] then
       table.insert(out, "  type " .. cls.name .. " = " .. cls.name)
+      taken[cls.name] = true
+      aliased = aliased + 1
+    end
+  end
+  for _, al in ipairs(module.aliases or {}) do
+    if not taken[al.name] then
+      table.insert(out, "  type " .. al.name .. " = " .. al.name)
+      taken[al.name] = true
       aliased = aliased + 1
     end
   end
@@ -390,93 +431,14 @@ local function generate_dtl(module: ModuleDecl): string
   return table.concat(out, "\n")
 end
 
---- Extract a module's content from definitions.lua.
---- Selects, line-based: (1) the `<mod> = { ... }` table section, with brace
---- depth counted only outside comments (a stray `}` in a doc comment must not
---- terminate the table early); (2) every annotation block followed by a
---- `function <mod>.<name>(` or `function <mod>.<Class>:<method>(` declaration,
---- wherever it appears in the file; (3) every standalone `---@class <mod>.*`
---- data-class block. Blocks belonging to other modules never leak in, so no
---- boundary heuristics are needed.
-local function extract_module_content(source: string, module_name: string): string
-  local lines: {string} = {}
-  for line in (source .. "\n"):gmatch("([^\n]*)\n") do
-    table.insert(lines, line)
-  end
-
-  -- 1) module table section
-  local start_idx: integer = nil
-  for idx, line in ipairs(lines) do
-    if line:match("^" .. module_name .. "%s*=%s*{") then
-      start_idx = idx
-      break
-    end
-  end
-  if not start_idx then return nil end
-
-  local out: {string} = {}
-  local depth = 0
-  local table_end = start_idx
-  for idx = start_idx, #lines do
-    local code = lines[idx]:gsub("%-%-.*$", "")
-    for brace in code:gmatch("[{}]") do
-      depth = depth + (brace == "{" and 1 or -1)
-    end
-    table.insert(out, lines[idx])
-    table_end = idx
-    if depth <= 0 then break end
-  end
-
-  -- 2) + 3) annotation blocks and declarations for this module
-  local fn_pattern = "^function%s+" .. module_name .. "%."
-  local class_pattern = "^%-%-%-@class%s+" .. module_name .. "%."
-  local pending: {string} = {}
-  local function flush_standalone_class()
-    local is_class = false
-    for _, a in ipairs(pending) do
-      if a:match(class_pattern) then
-        is_class = true
-        break
-      end
-    end
-    if is_class then
-      for _, a in ipairs(pending) do table.insert(out, a) end
-      table.insert(out, "")
-    end
-    pending = {}
-  end
-
-  for idx = 1, #lines do
-    if idx >= start_idx and idx <= table_end then
-      pending = {}
-    else
-      local line = lines[idx]
-      if line:match("^%-%-%-") then
-        table.insert(pending, line)
-      elseif line:match(fn_pattern) then
-        for _, a in ipairs(pending) do table.insert(out, a) end
-        table.insert(out, line)
-        pending = {}
-      else
-        flush_standalone_class()
-      end
-    end
-  end
-  flush_standalone_class()
-
-  return table.concat(out, "\n")
-end
-
 local record GentypeRenderModule
   generate_dtl: function(module: ModuleDecl): string
   convert_type: function(t: string): string
-  extract_module_content: function(source: string, module_name: string): string
 end
 
 local M: GentypeRenderModule = {
   generate_dtl = generate_dtl,
   convert_type = convert_type,
-  extract_module_content = extract_module_content,
 }
 
 return M

--- a/lib/types/gentype_types.tl
+++ b/lib/types/gentype_types.tl
@@ -43,6 +43,15 @@ local record gentype_types
     description: {string}
   end
 
+  -- A named type alias (`---@alias mod.Name <type>`). A literal-string
+  -- union renders as a Teal enum; anything else as a transparent alias.
+  record AliasDecl
+    name: string -- bare name (module prefix stripped)
+    module: string
+    alias_type: string -- raw LuaLS right-hand side
+    description: {string}
+  end
+
   record ClassDecl
     name: string
     module: string
@@ -58,6 +67,7 @@ local record gentype_types
     functions: {FuncDecl}
     classes: {ClassDecl}
     constants: {Constant}
+    aliases: {AliasDecl}
   end
 
 end


### PR DESCRIPTION
Fixes #628 (phase B — the keystone generator work of the type-system audit, tracked in #632).

`definitions.lua` can now declare named type groups (`---@alias mod.Name <rhs>`) and gentype turns them into real Teal types:

- a union of ≥2 string literals becomes a **Teal enum** — closed string sets (fetch error kinds, zip modes, argon2 variants) become checked at call sites once the pin carrying whilp/cosmopolitan#176 lands
- any other right-hand side becomes a transparent `type` alias (`unix.Errno = number`), keeping signatures self-documenting
- aliases are re-exported on the module record exactly like classes (same collision guard), module-local references collapse to the bare name, and cross-module references (`unix.Errno` used from `cosmo.Barf`) resolve through the emitted requires
- `extract_module_content` gains a fourth extraction rule: standalone `---@alias <mod>.<Name>` blocks, with their doc comments
- bare legacy aliases (`uint32`, `JsonValue`, …) stay hardcoded conversions and are never emitted

Mechanical split for the 500-line cap: `extract_module_content` moves to `lib/types/gentype_extract.tl`; the new unit test lives in `lib/types/gentype_alias_test.tl` (registered in `lib/types/cook.mk`).

## Verification

- `bin/make ci` green (includes the byte-for-byte drift test: regen against the **pinned** cosmos is byte-identical, so no committed `.d.tl` changes here)
- Validated against a cosmopolitan checkout carrying the #176 + #177 alias branches via `GENTYPE_DEFS=…` — enums and aliases render as expected (e.g. `local enum FetchErrorKind`, `local type Errno = number`, `step: function(self: Statement): ResultCode`) and all six generated files pass `--check-types`

## Sequencing

This must merge (and be in the bootstrap toolchain's regen path) **before** cosmic bumps to a cosmos release containing whilp/cosmopolitan#176/#177 — without it, regen would emit references to alias types it can't declare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p)_