### PR TITLE
types: first generic function and Socket stream-interface adoption

### DIFF
--- a/lib/cosmic/net/io_test.tl
+++ b/lib/cosmic/net/io_test.tl
@@ -207,3 +207,21 @@ local function test_set_timeout_closed_socket()
   b:close()
 end
 test_set_timeout_closed_socket()
+
+-- Socket implements the stream interfaces: a socket can be handed to
+-- any consumer of stream.Reader / stream.Writer (e.g. cosmic.sse).
+local function test_socket_is_stream()
+  local stream = require("cosmic.stream")
+  local a, b = pair()
+  local w: stream.Writer = a
+  local r: stream.Reader = b
+  local n, werr = w:write("via stream")
+  assert(n == 10, "write failed: " .. tostring(werr))
+  local chunk, rerr = r:read()
+  assert(chunk == "via stream", "read failed: " .. tostring(rerr))
+  a:close()
+  local eof = r:read()
+  assert(eof == nil, "expected bare nil at end of stream")
+  b:close()
+end
+test_socket_is_stream()

--- a/lib/cosmic/net/socket.tl
+++ b/lib/cosmic/net/socket.tl
@@ -29,7 +29,9 @@ end
 --- Socket handle for network I/O.
 --- Sockets are BLOCKING by default: recv and accept wait until data or a
 --- connection arrives. Supports Lua 5.4's to-be-closed via __close.
-local record Socket
+local stream = require("cosmic.stream")
+
+local record Socket is stream.Reader, stream.Writer
   --- The underlying file descriptor.
   fd: number
   --- Close the socket.
@@ -40,6 +42,8 @@ local record Socket
   shutdown: function(self: Socket, how?: number): boolean, string
   --- Send data; returns bytes sent, or nil + error.
   send: function(self: Socket, data: string, flags?: number): number | nil, string
+  --- stream.Writer: alias for send (bytes written, or nil + error).
+  write: function(self: Socket, data: string): number | nil, string
   --- Send all of data, retrying partial writes until done.
   --- Returns false + error if any write fails; bytes already sent
   --- before the failure stay sent.
@@ -53,6 +57,9 @@ local record Socket
   --- nil + error message on failure. bufsiz must be positive when
   --- given (default 65536).
   recv: function(self: Socket, bufsiz?: number, flags?: number): string | nil, string
+  --- stream.Reader: alias for recv (chunk; bare nil at end of stream;
+  --- nil + error on failure).
+  read: function(self: Socket, n?: number): string | nil, string
   --- Receive exactly n bytes from a stream socket, blocking until they
   --- arrive. Returns nil + error if the peer closes the connection
   --- first (bytes read before the close are discarded).
@@ -190,6 +197,12 @@ local function make_socket(fd: number): Socket
     end
     return data
   end
+
+  -- The stream.Reader/Writer contract is exactly recv/send's: recv
+  -- returns bare nil at end of stream (api-review-2, #589) and send
+  -- returns bytes written. Alias rather than wrap.
+  sock.read = sock.recv
+  sock.write = sock.send
 
   function sock:recv_exact(n: number, flags?: number): string | nil, string
     local parts: {string} = {}

--- a/lib/cosmic/quicksand/box/merge.tl
+++ b/lib/cosmic/quicksand/box/merge.tl
@@ -60,8 +60,8 @@ local function concat_unique(a: {any}, b: {any}): {any}
   return out
 end
 
-local function merge_map(a: {any: any}, b: {any: any}): {any: any}
-  local out: {any: any} = {}
+local function merge_map<K, V>(a: {K: V}, b: {K: V}): {K: V}
+  local out: {K: V} = {}
   if a then for k, v in pairs(a) do out[k] = v end end
   if b then for k, v in pairs(b) do out[k] = v end end
   return out


### PR DESCRIPTION
Fixes #631 (phase A of the type-system audit, tracked in #632). **Stacked on #634** — base is that branch (it needs #634's formatter support for generic type-parameter lists); GitHub retargets to main when #634 merges.

**First generic function.** `merge_map<K, V>(a: {K: V}, b: {K: V}): {K: V}` in `quicksand/box/merge.tl` replaces three `{any: any}` annotations with a checked signature — establishing the generics pattern the library previously had zero of (generic *function types* existed in `fs.walk`; this is the first generic function definition).

**Socket joins the stream interfaces.** `net.Socket` now declares `is stream.Reader, stream.Writer`. Its `recv`/`send` already satisfy the stream contract exactly — `recv` returns bare nil at end of stream (api-review-2, #589) and `send` returns bytes written — so `read`/`write` are direct aliases, not wrappers. A socket can now be handed to any `stream.Reader`/`Writer` consumer (`cosmic.sse`, generic pumps); a typed interface-assignment test in `net/io_test.tl` pins the subtyping and the EOF contract. `fd.Handle`, `fetch.Reader`, and `child.Handle` already declared the interfaces, so this closes the set.

## Verification

`bin/make ci` green (format + teal + test + example + lint + coverage), including the new `test_socket_is_stream`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p