### PR TITLE
cosmos: bump pin to 2026.07.13-e6040de22, regen types, adopt new enums

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "c4e9ac143cb15b05a31a42fab90694415ae71b6e4c1b940adcab569dcf96acd5"}},
+  platforms = {["*"] = {sha = "e310863816dff2630f6e90a1b7c4ed51a7b82bd9e7fdb5603f7b9308a2e43dad"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.09-b208ca89f"
+  version = "2026.07.13-e6040de22"
 }

--- a/lib/cosmic/hash.tl
+++ b/lib/cosmic/hash.tl
@@ -177,7 +177,7 @@ local function password(pwd: string, options?: HashOptions): string | nil, strin
         config.variant = options.variant
       else
         return nil, "invalid variant: " .. tostring(options.variant)
-          .. " (expected argon2id, argon2i, or argon2d)"
+        .. " (expected argon2id, argon2i, or argon2d)"
       end
     end
   end

--- a/lib/cosmic/hash.tl
+++ b/lib/cosmic/hash.tl
@@ -58,17 +58,8 @@ local record HashOptions
   --- Output hash length in bytes (default: 32)
   hash_len: number
   --- Variant: "argon2id" (default), "argon2i", or "argon2d"
-  variant: string
+  variant: argon2.Variant
 end
-
--- Variant names accepted by the argon2 binding. An unknown variant
--- string makes the binding raise (programmer error), so the wrapper
--- validates here and returns nil, err instead.
-local valid_variants: {string: boolean} = {
-  argon2id = true,
-  argon2i = true,
-  argon2d = true,
-}
 
 --- Compute SHA-256 hash of data.
 --- Returns raw bytes (32 bytes).
@@ -178,10 +169,15 @@ local function password(pwd: string, options?: HashOptions): string | nil, strin
     if options.parallelism then config.parallelism = options.parallelism end
     if options.hash_len then config.hash_len = options.hash_len end
     if options.variant then
-      if valid_variants[options.variant] then
+      -- The generated argon2.Variant enum checks literals statically;
+      -- runtime strings smuggled in through casts still get nil, err
+      -- rather than the binding's raise (never throw from library code).
+      if options.variant == "argon2id" or options.variant == "argon2i"
+      or options.variant == "argon2d" then
         config.variant = options.variant
       else
-        return nil, "invalid variant: " .. options.variant .. " (expected argon2id, argon2i, or argon2d)"
+        return nil, "invalid variant: " .. tostring(options.variant)
+          .. " (expected argon2id, argon2i, or argon2d)"
       end
     end
   end

--- a/lib/cosmic/hash_test.tl
+++ b/lib/cosmic/hash_test.tl
@@ -116,7 +116,10 @@ end
 test_password_unicode()
 
 local function test_password_invalid_variant()
-  local encoded, err = hash.password("password", {variant = "invalid"})
+  -- the Variant enum rejects this literal statically; cast to keep
+  -- exercising the wrapper's runtime nil, err guard for smuggled strings
+  local bad = {variant = "invalid"} as hash.HashOptions
+  local encoded, err = hash.password("password", bad)
   assert(encoded == nil, "password should fail with invalid variant")
   assert(err and err:match("invalid variant"), "error should mention invalid variant")
 end

--- a/lib/cosmic/sys.tl
+++ b/lib/cosmic/sys.tl
@@ -32,6 +32,7 @@ local enum HostOs
   "openbsd"
   "netbsd"
   "metal"
+  "unknown"
 end
 
 -- Cosmopolitan's GetHostOs() returns tokens that do not all match the names
@@ -58,10 +59,12 @@ end
 
 --- Get the operating system name.
 --- Returns one of: "linux", "macos", "windows", "freebsd", "openbsd",
---- "netbsd", "metal".
+--- "netbsd", "metal" — or "unknown" if the C layer recognizes none
+--- (GetHostOs returns nil then; unreachable on shipped fat-binary
+--- targets, but the type admits it honestly).
 --- @return HostOs The operating system name
 local function host_os(): HostOs
-  return normalize_host_os(cosmo.GetHostOs())
+  return normalize_host_os(cosmo.GetHostOs() or "unknown")
 end
 
 --- Get the CPU architecture (instruction set architecture).

--- a/lib/types/cosmo.d.tl
+++ b/lib/types/cosmo.d.tl
@@ -2,6 +2,8 @@
 -- GENERATED from cosmopolitan's definitions.lua by lib/types/gentype.tl.
 -- Do not edit by hand. Regenerate with: bin/make regen-types
 
+local unix = require("cosmo.unix")
+
 --- represented as the data structure `{{"a", "b"}, {"c"}, ...}`
 local record Url
   --- e.g. `"http"`
@@ -102,6 +104,42 @@ local record StreamReader
   close: function(self: StreamReader)
 end
 
+--- Machine-readable failure kind returned by `Fetch` / `FetchStream`.
+--- Every `LuaFetchError` call site in `tool/net/lfetch.c` uses one of
+--- these values; extend this alias when adding a new kind there.
+local enum FetchErrorKind
+  "blocked"
+  "connect"
+  "dns"
+  "protocol"
+  "proxy"
+  "timeout"
+end
+
+--- Network category names emitted by `CategorizeIp`, in the order
+--- `net/http/getipcategoryname.c` tests them.
+local enum IpCategory
+  "MULTICAST"
+  "LOOPBACK"
+  "PRIVATE"
+  "TESTNET"
+  "AFRINIC"
+  "LACNIC"
+  "APNIC"
+  "ARIN"
+  "RIPE"
+  "DOD"
+  "AT&T"
+  "APPLE"
+  "FORD"
+  "COGENT"
+  "PRUDENTIAL"
+  "USPS"
+  "COMCAST"
+  "FUTURE"
+  "ANONYMOUS"
+end
+
 local record cosmo
   type Url = Url
   type EncoderOptions = EncoderOptions
@@ -110,6 +148,8 @@ local record cosmo
   type FetchOptions = FetchOptions
   type BarfOptions = BarfOptions
   type StreamReader = StreamReader
+  type FetchErrorKind = FetchErrorKind
+  type IpCategory = IpCategory
 
   --- Writes all data to file the easy way.
   --- This function writes to the local file system. By default it truncates
@@ -120,8 +160,8 @@ local record cosmo
   ---     assert(Barf('x.txt', 'abc123'))
   ---     assert(Barf('x.txt', 'XX', {offset = 3}))
   ---     assert(assert(Slurp('x.txt', 1, 6)) == 'abXX23')
-  Barf: function(filename: string, data: string, options?: BarfOptions): boolean | nil, string | nil, number | nil
-  CategorizeIp: function(ip: number): string
+  Barf: function(filename: string, data: string, options?: BarfOptions): boolean | nil, string | nil, unix.Errno | nil
+  CategorizeIp: function(ip: number): IpCategory
   --- Computes Phil Katz CRC-32 used by zip/zlib/gzip/etc.
   Crc32: function(initial: number, data: string): number
   --- Computes 32-bit Castagnoli Cyclic Redundancy Check.
@@ -454,7 +494,7 @@ local record cosmo
   --- (malformed request or response), `"too_large"` (response exceeded
   --- `maxresponse`), or `"blocked"` (refused by SSRF protection or the
   --- HTTPS-to-HTTP downgrade guard).
-  Fetch: function(url: string, body?: string | FetchOptions): number | nil, {string: string}, string, string, string | nil, string | nil
+  Fetch: function(url: string, body?: string | FetchOptions): number | nil, {string: string}, string, string, string | nil, FetchErrorKind | nil
   --- Sends an HTTP/HTTPS request and returns a streaming reader for the response body.
   --- Useful for Server-Sent Events (SSE), large downloads, or processing data incrementally.
   --- Accepts the same options table as `Fetch()`, including `timeout`, `maxresponse`,
@@ -469,7 +509,7 @@ local record cosmo
   --- redirects. On failure, returns `nil`, a descriptive error message,
   --- and a machine-readable failure kind with the same values as
   --- `Fetch()`.
-  FetchStream: function(url: string, options?: FetchOptions): number | nil, {string: string}, StreamReader, string, string | nil, string | nil
+  FetchStream: function(url: string, options?: FetchOptions): number | nil, {string: string}, StreamReader, string, string | nil, FetchErrorKind | nil
   --- Converts UNIX timestamp to an RFC1123 string that looks like this:
   --- `Mon, 29 Mar 2021 15:37:13 GMT`. See `formathttpdatetime.c`.
   FormatHttpDateTime: function(seconds: number): string
@@ -482,8 +522,9 @@ local record cosmo
   --- - `"X86_64"` for Intel and AMD systems
   --- - `"AARCH64"` for ARM64, M1, and Raspberry Pi systems
   --- - `"POWERPC64"` for OpenPOWER Raptor Computing Systems
+  --- - `"S390X"` for IBM System/390 systems
   GetHostIsa: function(): string
-  GetHostOs: function(): string
+  GetHostOs: function(): string | nil
   GetHttpReason: function(code: number): string
   --- This is useful for fixed-width formatting. For example, CJK characters
   --- typically take up two cells. This function takes into consideration combining
@@ -646,7 +687,7 @@ local record cosmo
   --- This function is uninterruptible so `unix.EINTR` errors will be ignored. This
   --- should only be a concern if you've installed signal handlers. Use the UNIX API
   --- if you need to react to it.
-  Slurp: function(filename: string, i?: number, j?: number): string | nil, string | nil, number | nil
+  Slurp: function(filename: string, i?: number, j?: number): string | nil, string | nil, unix.Errno | nil
   --- Formats a timestamp using strftime(3) format specifiers.
   --- Common format specifiers:
   --- - `%Y` four-digit year

--- a/lib/types/cosmo/argon2.d.tl
+++ b/lib/types/cosmo/argon2.d.tl
@@ -12,11 +12,20 @@ local record Config
   --- the number of desired bytes in hash output, which defaults to 32.
   hash_len: number
   --- the Argon2 variant: `"argon2id"` blend of other two methods [default], `"argon2i"` maximize resistance to side-channel attacks, or `"argon2d"` maximize resistance to gpu cracking attacks
-  variant: string
+  variant: Variant
+end
+
+--- Argon2 variant names accepted by `argon2.hash_encoded` (validated
+--- by the strcmp chain in `tool/net/largon2.c`).
+local enum Variant
+  "argon2id"
+  "argon2i"
+  "argon2d"
 end
 
 local record argon2
   type Config = Config
+  type Variant = Variant
 
   --- Hashes password.
   --- This is consistent with the README of the reference implementation:

--- a/lib/types/cosmo/lsqlite3.d.tl
+++ b/lib/types/cosmo/lsqlite3.d.tl
@@ -133,9 +133,9 @@ local record Database
   db_filename: function(self: Database, name: string): string | nil
   --- Deserializes data from a string which was created by `db:serialize`.
   deserialize: function(self: Database, s: string)
-  errcode: function(self: Database): number
+  errcode: function(self: Database): ResultCode
   errmsg: function(self: Database): string
-  exec: function(self: Database, sql: string, func?: (function(udata: any, cols: number, values: {string}, names: {string}): number), udata?: any)
+  exec: function(self: Database, sql: string, func?: (function(udata: any, cols: number, values: {string}, names: {string}): number), udata?: any): ResultCode
   --- This function causes any pending database operation to abort and return at
   --- the next opportunity.
   interrupt: function(self: Database)
@@ -233,7 +233,7 @@ local record Database
   ---     2       22
   ---     3       33
   urows: function(self: Database, sql: string): function, VM
-  wal_checkpoint: function(self: Database, mode?: number, name?: string): number | nil, number, number | nil
+  wal_checkpoint: function(self: Database, mode?: number, name?: string): number | nil, number, ResultCode | nil
   wal_hook: function(self: Database, func?: (function(udata: any, db: Database, name: string, page_count: number): number), udata?: any)
 end
 
@@ -265,7 +265,7 @@ local record Statement
   --- integer) then there might be gaps in the numbering and the value returned by
   --- this interface is the index of the statement parameter with the largest index
   --- value.
-  bind_parameter_count: function(self: Statement): any
+  bind_parameter_count: function(self: Statement): number
   --- Statement parameters of the form `":AAA"` or `"@AAA"` or `"$VVV"` have a name
   --- which is the string `":AAA"` or `"@AAA"` or `"$VVV"`. In other words, the
   --- initial `":"` or `"$"` or `"@"` is included as part of the name. Parameters of
@@ -278,35 +278,35 @@ local record Statement
   columns: function(self: Statement): number
   --- This function frees the prepared statement.
   finalize: function(self: Statement): number
-  get_name: function(self: Statement, n: any): any
-  get_named_types: function(self: Statement): table
+  get_name: function(self: Statement, n: number): string
+  get_named_types: function(self: Statement): {string}
   --- Alias for `lsqlite3.Statement:get_named_types()`.
-  type: function(self: Statement): table
-  get_named_values: function(self: Statement): table
+  type: function(self: Statement): {string}
+  get_named_values: function(self: Statement): {string | number | nil}
   --- Alias for `lsqlite3.Statement:get_named_values()`.
-  data: function(self: Statement): table
+  data: function(self: Statement): {string | number | nil}
   get_names: function(self: Statement): {string}
   --- Alias for `lsqlite3.Statement:get_names()`.
   inames: function(self: Statement): {string}
-  get_type: function(self: Statement, n: any): any
-  get_types: function(self: Statement): {any}
+  get_type: function(self: Statement, n: number): string | nil
+  get_types: function(self: Statement): {string}
   --- Alias for `lsqlite3.Statement:get_types()`.
-  itypes: function(self: Statement): {any}
-  get_unames: function(self: Statement): {any}
-  get_utypes: function(self: Statement): {any}
-  get_uvalues: function(self: Statement): {any}
-  get_value: function(self: Statement, n: any): any
-  get_values: function(self: Statement): {any}
+  itypes: function(self: Statement): {string}
+  get_unames: function(self: Statement): string...
+  get_utypes: function(self: Statement): string...
+  get_uvalues: function(self: Statement): string | number | nil
+  get_value: function(self: Statement, n: number): string | number | nil
+  get_values: function(self: Statement): {string | number | nil}
   --- Alias for `lsqlite3.Statement:get_values()`.
-  idata: function(self: Statement): {any}
+  idata: function(self: Statement): {string | number | nil}
   isopen: function(self: Statement): boolean
-  nrows: function(self: Statement): function
+  nrows: function(self: Statement): function(self: VM): {string: string | number}
   --- Returns `true` if the prepared statement makes no direct changes to
   --- the content of the database file, `false` otherwise.
   readonly: function(self: Statement): boolean
   --- This function resets the SQL statement, so that it is ready to be re-executed. Any statement variables that had values bound to them using the `stmt:bind*()` functions retain their values.
-  reset: function(self: Statement)
-  rows: function(self: Statement): function
+  reset: function(self: Statement): ResultCode
+  rows: function(self: Statement): function(self: VM): {string | number | nil}
   --- This function must be called to evaluate the (next iteration of the) prepared statement.
   --- - `lsqlite3.BUSY`: the engine was unable to acquire the locks needed.
   ---   If the statement is a COMMIT or occurs outside of an explicit transaction,
@@ -327,11 +327,11 @@ local record Statement
   --- - `lsqlite3.MISUSE`: the function was called inappropriately, perhaps because
   ---    the statement has already been finalized or a previous call to `stmt:step()`
   ---    has returned `lsqlite3.ERROR` or `lsqlite3.DONE`.
-  step: function(self: Statement): number
+  step: function(self: Statement): ResultCode
   --- Each iteration returns the values for the current row. This is the prepared
   --- statement equivalent of `db:urows()`.
-  urows: function(self: Statement): function
-  last_insert_rowid: function(self: Statement): any
+  urows: function(self: Statement): function(self: VM): any...
+  last_insert_rowid: function(self: Statement): number
 end
 
 local record VM
@@ -353,7 +353,7 @@ local record VM
   get_names: function(self: VM): {string}
   --- Alias for `lsqlite3.VM:get_names()`.
   inames: function(self: VM): {string}
-  get_type: function(self: VM, index: number): string
+  get_type: function(self: VM, index: number): string | nil
   get_types: function(self: VM): {string}
   --- Alias for `lsqlite3.VM:get_types()`.
   itypes: function(self: VM): {string}
@@ -370,17 +370,28 @@ local record VM
   --- Returns `true` if the prepared statement makes no direct changes to
   --- the content of the database file, `false` otherwise.
   readonly: function(self: VM): boolean
-  reset: function(self: VM): number
+  reset: function(self: VM): ResultCode
   rows: function(self: VM, sql: string): function(self: VM): {string | number | nil}
-  step: function(self: VM): number
+  step: function(self: VM): ResultCode
   urows: function(self: VM, sql: string): function(self: VM): any...
 end
+
+--- SQLite result/status code (the OK/ERROR/BUSY/DONE/ROW/... family
+--- of lsqlite3.* integer constants; see the SC() table in
+--- tool/net/lsqlite3.c).
+local type ResultCode = number
+
+--- Bitmask of lsqlite3.OPEN_* flags accepted by `lsqlite3.open` (see
+--- https://www.sqlite.org/c3ref/open.html).
+local type OpenFlag = number
 
 local record lsqlite3
   type Context = Context
   type Database = Database
   type Statement = Statement
   type VM = VM
+  type ResultCode = ResultCode
+  type OpenFlag = OpenFlag
 
   --- The `lsqlite3.OK` result code means that the operation was successful
   --- and that there were no errors. Most other result codes indicate an
@@ -691,11 +702,11 @@ local record lsqlite3
   --- Since `0.9.4`, there is a second optional `flags` argument to `lsqlite3.open`.
   --- See https://www.sqlite.org/c3ref/open.html for an explanation of these flags and options.
   ---     local db = lsqlite3.open('foo.db', lsqlite3.OPEN_READWRITE + lsqlite3.OPEN_CREATE + lsqlite3.OPEN_SHAREDCACHE)
-  open: function(filename: string, flags?: number): Database | nil, number | nil, string | nil
+  open: function(filename: string, flags?: OpenFlag): Database | nil, ResultCode | nil, string | nil
   --- Opens an SQLite database in memory and returns its handle as userdata. In case
   --- of an error, the function returns `nil`, an error code and an error message.
   --- (In-memory databases are volatile as they are never stored on disk.)
-  open_memory: function(): Database | nil, number | nil, string | nil
+  open_memory: function(): Database | nil, ResultCode | nil, string | nil
   lversion: function(): string
   version: function(): string
   --- Sets global SQLite3 library configuration options.

--- a/lib/types/cosmo/re.d.tl
+++ b/lib/types/cosmo/re.d.tl
@@ -14,11 +14,22 @@ local record Regex
   --- - `re.NOTBOL`
   --- - `re.NOTEOL`
   --- This has an O(𝑛) cost.
-  search: function(self: Regex, str: string, flags?: number): string | nil, {string}, string | nil
+  search: function(self: Regex, str: string, flags?: SearchFlag): string | nil, {string}, string | nil
 end
+
+--- Bitmask of compilation flags accepted by `re.compile` and
+--- `re.search` (`re.BASIC`, `re.ICASE`, `re.NEWLINE`, `re.NOSUB`;
+--- masked in `tool/net/lre.c`).
+local type CompileFlag = number
+
+--- Bitmask of search-time flags accepted by `re.search` and
+--- `re.Regex:search` (`re.NOTBOL`, `re.NOTEOL`).
+local type SearchFlag = number
 
 local record re
   type Regex = Regex
+  type CompileFlag = CompileFlag
+  type SearchFlag = SearchFlag
 
   --- No match
   NOMATCH: number
@@ -91,7 +102,7 @@ local record re
   --- - `re.NOTEOL`
   --- This has exponential complexity. Please use `re.compile()` to compile your regular expressions once from `/.init.lua`. This API exists for convenience. This isn't recommended for prod.
   --- This uses POSIX extended syntax by default.
-  search: function(regex: string, text: string, flags?: number): string | nil, {string}, string | nil
+  search: function(regex: string, text: string, flags?: CompileFlag | SearchFlag): string | nil, {string}, string | nil
   --- Compiles regular expression.
   --- - `re.BASIC`
   --- - `re.ICASE`
@@ -102,7 +113,7 @@ local record re
   --- If regex is an untrusted user value, then `unix.setrlimit` should be
   --- used to impose cpu and memory quotas for security.
   --- This uses POSIX extended syntax by default.
-  compile: function(regex: string, flags?: number): Regex | nil, string | nil
+  compile: function(regex: string, flags?: CompileFlag): Regex | nil, string | nil
 end
 
 return re

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -2,6 +2,22 @@
 -- GENERATED from cosmopolitan's definitions.lua by lib/types/gentype.tl.
 -- Do not edit by hand. Regenerate with: bin/make regen-types
 
+--- Fields reported by uname(2).
+local record Uname
+  ---
+  sysname: string
+  ---
+  nodename: string
+  ---
+  release: string
+  ---
+  version: string
+  ---
+  machine: string
+  ---
+  domainname: string
+end
+
 local record Termios
   --- Input mode flags (e.g. `unix.BRKINT`, `unix.ICRNL`).
   iflag: number
@@ -129,7 +145,7 @@ local record Memory
   --- `EAGAIN` is raised if, upon entry, the word at `word_index` had a
   --- different value than what's specified at `expect`.
   --- `ETIMEDOUT` is raised when the absolute deadline expires.
-  wait: function(self: Memory, word_index: number, expect: number, abs_deadline?: number, nanos?: number): number | nil, string | nil, number | nil
+  wait: function(self: Memory, word_index: number, expect: number, abs_deadline?: number, nanos?: number): number | nil, string | nil, Errno | nil
   --- Wakes other processes waiting on word.
   --- This method may be used to signal or broadcast to waiters. The
   --- `count` specifies the number of processes that should be woken,
@@ -145,7 +161,7 @@ local record Dir
   --- Closes directory stream object and associated its file descriptor.
   --- This is called automatically by the garbage collector.
   --- This may be called multiple times.
-  close: function(self: Dir): boolean | nil, string | nil, number | nil
+  close: function(self: Dir): boolean | nil, string | nil, Errno | nil
   --- Reads entry from directory stream.
   --- Returns `nil` if there are no more entries.
   --- On error, `nil` will be returned and `errno` will be non-nil.
@@ -162,8 +178,8 @@ local record Dir
   --- `unix.Dir` objects may be used as a for loop iterator.
   read: function(self: Dir): string | nil, number, number, number
   --- Returns `EOPNOTSUPP` if using a `/zip/...` path or if using Windows NT.
-  fd: function(self: Dir): number | nil, string | nil, number | nil
-  tell: function(self: Dir): number | nil, string | nil, number | nil
+  fd: function(self: Dir): number | nil, string | nil, Errno | nil
+  tell: function(self: Dir): number | nil, string | nil, Errno | nil
   --- Resets stream back to beginning.
   rewind: function(self: Dir)
 end
@@ -354,13 +370,28 @@ local record Sigset
   __tostring: function(self: Sigset): string
 end
 
+--- The numeric errno value carried as the third return of every
+--- fallible unix.* call (see LuaUnixSysretErrno in
+--- third_party/lua/lunix.c): always one of the exported E* constants
+--- (unix.EINTR, unix.ENOENT, ...). An alias rather than a checked
+--- enum: Teal enums are string-only.
+local type Errno = number
+
+--- An `unix.F_*` command constant selecting the operation performed by
+--- `unix.fcntl` (`unix.F_GETFD`, `unix.F_SETFD`, `unix.F_GETFL`,
+--- `unix.F_SETFL`, `unix.F_SETLK`, `unix.F_SETLKW`, `unix.F_GETLK`, ...).
+local type FcntlCmd = number
+
 local record unix
+  type Uname = Uname
   type Termios = Termios
   type Memory = Memory
   type Dir = Dir
   type Rusage = Rusage
   type Stat = Stat
   type Statfs = Statfs
+  type Errno = Errno
+  type FcntlCmd = FcntlCmd
 
   --- @type integer
   AF_INET: number
@@ -1438,7 +1469,7 @@ local record unix
   --- Returns `ENOTDIR` if `path` contained a directory component that
   --- wasn't a directory
   --- .
-  open: function(path: string, flags: number, mode?: number, dirfd?: number): number | nil, string | nil, number | nil
+  open: function(path: string, flags: number, mode?: number, dirfd?: number): number | nil, string | nil, Errno | nil
   --- Closes file descriptor.
   --- This function should never be called twice for the same file
   --- descriptor, regardless of whether or not an error happened. The file
@@ -1454,14 +1485,14 @@ local record unix
   --- Returns `EBADF` if `fd` wasn't valid.
   --- Returns `EINTR` possibly maybe.
   --- Returns `EIO` if an i/o error occurred.
-  close: function(fd: number): boolean | nil, string | nil, number | nil
+  close: function(fd: number): boolean | nil, string | nil, Errno | nil
   --- Reads from file descriptor.
   --- This function returns empty string on end of file. The exception is
   --- if `bufsiz` is zero, in which case an empty returned string means
   --- the file descriptor works.
-  read: function(fd: number, bufsiz?: number, offset?: number): string | nil, string | nil, number | nil
+  read: function(fd: number, bufsiz?: number, offset?: number): string | nil, string | nil, Errno | nil
   --- Writes to file descriptor.
-  write: function(fd: number, data: string, offset?: number): number | nil, string | nil, number | nil
+  write: function(fd: number, data: string, offset?: number): number | nil, string | nil, Errno | nil
   --- Invokes `_Exit(exitcode)` on the process. This will immediately
   --- halt the current process. Memory will be freed. File descriptors
   --- will be closed. Any open connections it owns will be reset. This
@@ -1484,19 +1515,19 @@ local record unix
   --- Sets environment variable.
   --- This wraps the C `setenv()` function to allow Lua scripts to set
   --- environment variables.
-  setenv: function(name: string, value: string, overwrite?: boolean): boolean | nil, string | nil, number | nil
+  setenv: function(name: string, value: string, overwrite?: boolean): boolean | nil, string | nil, Errno | nil
   --- Unsets environment variable.
   --- This wraps the C `unsetenv()` function to allow Lua scripts to remove
   --- environment variables.
-  unsetenv: function(name: string): boolean | nil, string | nil, number | nil
+  unsetenv: function(name: string): boolean | nil, string | nil, Errno | nil
   --- Clears all environment variables.
   --- This wraps the C `clearenv()` function to allow Lua scripts to remove
   --- all environment variables at once.
-  clearenv: function(): boolean | nil, string | nil, number | nil
+  clearenv: function(): boolean | nil, string | nil, Errno | nil
   --- Gets login name of current user.
   --- This wraps the C `getlogin()` function to retrieve the login name
   --- associated with the current session.
-  getlogin: function(): string | nil, string | nil, number | nil
+  getlogin: function(): string | nil, string | nil, Errno | nil
   --- Creates a new process mitosis style.
   --- This system call returns twice. The parent process gets the nonzero
   --- pid. The child gets zero.
@@ -1552,7 +1583,7 @@ local record unix
   --- Hence it should come as no surprise that `fork()` would go slower on
   --- operating systems that have more security features. So depending on
   --- your use case, you can choose the operating system that suits you.
-  fork: function(): number | nil, string | nil, number | nil
+  fork: function(): number | nil, string | nil, Errno | nil
   --- Performs `$PATH` lookup of executable.
   ---     unix = require 'unix'
   ---     prog = assert(unix.commandv('ls'))
@@ -1565,7 +1596,7 @@ local record unix
   --- they can be discovered like they would on UNIX. If you want to find
   --- a program like notepad on the $PATH using this function, then you
   --- need to specify "notepad.exe" so it includes the extension.
-  commandv: function(prog: string): string | nil, string | nil, number | nil
+  commandv: function(prog: string): string | nil, string | nil, Errno | nil
   --- Exits current process, replacing it with a new instance of the
   --- specified program. `prog` needs to be an absolute path, see
   --- commandv(). `env` defaults to to the current `environ`. Here's
@@ -1589,20 +1620,20 @@ local record unix
   --- This function never returns on success.
   --- `EAGAIN` is returned if you've enforced a max number of
   --- processes using `setrlimit(RLIMIT_NPROC)`.
-  execve: function(prog: string, args: {string}, env: {string}): nil, string | nil, number | nil
+  execve: function(prog: string, args: {string}, env: {string}): nil, string | nil, Errno | nil
   --- Executes program with PATH search.
   --- Unlike `execve()`, this function searches for `prog` in the
   --- directories listed in the `PATH` environment variable.
   --- If `argv` is not provided, it defaults to `{prog}`.
   --- This function never returns on success.
-  execvp: function(prog: string, argv?: {string}): nil, string | nil, number | nil
+  execvp: function(prog: string, argv?: {string}): nil, string | nil, Errno | nil
   --- Executes program with PATH search and custom environment.
   --- Like `execvp()` but also allows specifying a custom environment.
   --- `envp` is a string list table where each string is typically
   --- in the form `"KEY=value"`. If not specified, inherits the
   --- current environment.
   --- This function never returns on success.
-  execvpe: function(prog: string, argv: {string}, envp?: {string}): nil, string | nil, number | nil
+  execvpe: function(prog: string, argv: {string}, envp?: {string}): nil, string | nil, Errno | nil
   --- Executes program from file descriptor.
   --- This allows executing a program that has already been opened,
   --- which can be useful for executing programs that have been
@@ -1613,7 +1644,7 @@ local record unix
   --- `envp` is the environment. If not specified, inherits the
   --- current environment.
   --- This function never returns on success.
-  fexecve: function(fd: number, argv: {string}, envp?: {string}): nil, string | nil, number | nil
+  fexecve: function(fd: number, argv: {string}, envp?: {string}): nil, string | nil, Errno | nil
   --- Spawns a new process.
   --- Unlike `fork()` + `execve()`, this uses `posix_spawn()` which
   --- can be more efficient on some platforms.
@@ -1622,12 +1653,12 @@ local record unix
   --- `envp` is the environment. If not specified, inherits the
   --- current environment.
   --- Returns the child process id on success.
-  spawn: function(prog: string, argv: {string}, envp?: {string}): number | nil, string | nil, number | nil
+  spawn: function(prog: string, argv: {string}, envp?: {string}): number | nil, string | nil, Errno | nil
   --- Spawns a new process with PATH search.
   --- Like `spawn()` but searches for `prog` in the directories
   --- listed in the `PATH` environment variable.
   --- Returns the child process id on success.
-  spawnp: function(prog: string, argv: {string}, envp?: {string}): number | nil, string | nil, number | nil
+  spawnp: function(prog: string, argv: {string}, envp?: {string}): number | nil, string | nil, Errno | nil
   --- Duplicates file descriptor.
   --- `newfd` may be specified to choose a specific number for the new
   --- file descriptor. If it's already open, then the preexisting one will
@@ -1642,7 +1673,7 @@ local record unix
   --- Will ensure that, in the rare event standard output or standard
   --- error are closed, you won't accidentally duplicate standard input to
   --- those numbers.
-  dup: function(oldfd: number, newfd?: number, flags?: number, lowest?: number): number | nil, string | nil, number | nil
+  dup: function(oldfd: number, newfd?: number, flags?: number, lowest?: number): number | nil, string | nil, Errno | nil
   --- Creates fifo which enables communication between processes.
   --- - `O_CLOEXEC`: Automatically close file descriptor upon execve()
   --- - `O_NONBLOCK`: Request `EAGAIN` be raised rather than blocking
@@ -1681,7 +1712,7 @@ local record unix
   ---        assert(unix.close(reader))
   ---        assert(unix.wait())
   ---     end
-  pipe: function(flags?: number): number | nil, number, string | nil, number | nil
+  pipe: function(flags?: number): number | nil, number, string | nil, Errno | nil
   --- Waits for subprocess to terminate.
   --- `pid` defaults to `-1` which means any child process. Setting
   --- `pid` to `0` is equivalent to `-getpid()`. If `pid < -1` then
@@ -1715,7 +1746,7 @@ local record unix
   ---           break
   ---        end
   ---     end
-  wait: function(pid?: number, options?: number): number | nil, number, Rusage, string | nil, number | nil
+  wait: function(pid?: number, options?: number): number | nil, number, Rusage, string | nil, Errno | nil
   --- Returns `true` if process exited cleanly.
   WIFEXITED: function(wstatus: number): boolean
   --- Returns code passed to exit() assuming `WIFEXITED(wstatus)` is true.
@@ -1749,20 +1780,20 @@ local record unix
   --- standard, which are `SIGINT` and `SIGQUIT`. All other signals on the
   --- Windows platform that are sent to another process via kill() will be
   --- treated like `SIGKILL`.
-  kill: function(pid: number, sig: number): boolean | nil, string | nil, number | nil
+  kill: function(pid: number, sig: number): boolean | nil, string | nil, Errno | nil
   --- Sends signal to process group.
   --- This is similar to `kill()` but sends the signal to all processes
   --- in the specified process group.
   --- `pgrp` is the process group id. If 0, sends to the calling process's
   --- process group.
   --- `sig` can be any signal value (e.g., `SIGTERM`, `SIGKILL`, etc.).
-  killpg: function(pgrp: number, sig: number): boolean | nil, string | nil, number | nil
+  killpg: function(pgrp: number, sig: number): boolean | nil, string | nil, Errno | nil
   --- Triggers signal in current process.
   --- This is pretty much the same as `kill(getpid(), sig)`.
-  raise: function(sig: number): number | nil, string | nil, number | nil
+  raise: function(sig: number): number | nil, string | nil, Errno | nil
   --- Checks if effective user of current process has permission to access file.
   --- - `AT_SYMLINK_NOFOLLOW`: do not follow symbolic links.
-  access: function(path: string, how: number, flags?: number, dirfd?: number): boolean | nil, string | nil, number | nil
+  access: function(path: string, how: number, flags?: number, dirfd?: number): boolean | nil, string | nil, Errno | nil
   --- Makes directory.
   --- `path` is the path of the directory you wish to create.
   --- `mode` is octal permission bits, e.g. `0755`.
@@ -1776,14 +1807,14 @@ local record unix
   --- Fails with `EACCES` if the parent directory doesn't grant write
   --- permission to the current user.
   --- Fails with `ENAMETOOLONG` if the path is too long.
-  mkdir: function(path: string, mode?: number, dirfd?: number): boolean | nil, string | nil, number | nil
+  mkdir: function(path: string, mode?: number, dirfd?: number): boolean | nil, string | nil, Errno | nil
   --- Unlike mkdir() this convenience wrapper will automatically create
   --- parent parent directories as needed. If the directory already exists
   --- then, unlike mkdir() which returns EEXIST, the makedirs() function
   --- will return success.
   --- `path` is the path of the directory you wish to create.
   --- `mode` is octal permission bits, e.g. `0755`.
-  makedirs: function(path: string, mode?: number): boolean | nil, string | nil, number | nil
+  makedirs: function(path: string, mode?: number): boolean | nil, string | nil, Errno | nil
   --- Creates a temporary directory with a unique name.
   --- `template` must end with "XXXXXX" which will be replaced with random
   --- characters to create a unique directory name.
@@ -1791,7 +1822,7 @@ local record unix
   --- Example:
   ---     local tmpdir = unix.mkdtemp("/tmp/myapp_XXXXXX")
   ---     -- tmpdir is now something like "/tmp/myapp_a3b2c1"
-  mkdtemp: function(template: string): string | nil, string | nil, number | nil
+  mkdtemp: function(template: string): string | nil, string | nil, Errno | nil
   --- Creates a temporary file with a unique name.
   --- `template` must end with "XXXXXX" which will be replaced with random
   --- characters to create a unique filename.
@@ -1802,26 +1833,26 @@ local record unix
   ---     unix.write(fd, "hello")
   ---     unix.close(fd)
   ---     unix.unlink(path)
-  mkstemp: function(template: string): number | nil, string, string | nil, number | nil
+  mkstemp: function(template: string): number | nil, string, string | nil, Errno | nil
   --- Changes current directory to `path`.
-  chdir: function(path: string): boolean | nil, string | nil, number | nil
+  chdir: function(path: string): boolean | nil, string | nil, Errno | nil
   --- Removes file at `path`.
   --- If `path` refers to a symbolic link, the link is removed.
   --- Returns `EISDIR` if `path` refers to a directory. See `rmdir()`.
-  unlink: function(path: string, dirfd?: number): boolean | nil, string | nil, number | nil
+  unlink: function(path: string, dirfd?: number): boolean | nil, string | nil, Errno | nil
   --- Removes empty directory at `path`.
   --- Returns `ENOTDIR` if `path` isn't a directory, or a path component
   --- in `path` exists yet wasn't a directory.
-  rmdir: function(path: string, dirfd?: number): boolean | nil, string | nil, number | nil
+  rmdir: function(path: string, dirfd?: number): boolean | nil, string | nil, Errno | nil
   --- Renames file or directory.
-  rename: function(oldpath: string, newpath: string, olddirfd: number, newdirfd: number): boolean | nil, string | nil, number | nil
+  rename: function(oldpath: string, newpath: string, olddirfd: number, newdirfd: number): boolean | nil, string | nil, Errno | nil
   --- Creates hard link, so your underlying inode has two names.
-  link: function(existingpath: string, newpath: string, flags: number, olddirfd: number, newdirfd: number): boolean | nil, string | nil, number | nil
+  link: function(existingpath: string, newpath: string, flags: number, olddirfd: number, newdirfd: number): boolean | nil, string | nil, Errno | nil
   --- Creates symbolic link.
   --- On Windows NT a symbolic link is called a "reparse point" and can
   --- only be created from an administrator account. Your redbean will
   --- automatically request the appropriate permissions.
-  symlink: function(target: string, linkpath: string, newdirfd?: number): boolean | nil, string | nil, number | nil
+  symlink: function(target: string, linkpath: string, newdirfd?: number): boolean | nil, string | nil, Errno | nil
   --- Reads contents of symbolic link.
   --- Note that broken links are supported on all platforms. A symbolic
   --- link can contain just about anything. It's important to not assume
@@ -1830,10 +1861,10 @@ local record unix
   --- furthermore prefixes `//?/` to WIN32 DOS-style absolute paths,
   --- thereby assisting with simple absolute filename checks in addition
   --- to enabling one to exceed the traditional 260 character limit.
-  readlink: function(path: string, dirfd?: number): string | nil, string | nil, number | nil
+  readlink: function(path: string, dirfd?: number): string | nil, string | nil, Errno | nil
   --- Returns absolute path of filename, with `.` and `..` components
   --- removed, and symlinks will be resolved.
-  realpath: function(path: string): string | nil, string | nil, number | nil
+  realpath: function(path: string): string | nil, string | nil, Errno | nil
   --- Changes access and/or modified timestamps on file.
   --- `path` is a string with the name of the file.
   --- The `asecs` and `ananos` parameters set the access time. If they're
@@ -1855,7 +1886,7 @@ local record unix
   --- - `AT_SYMLINK_NOFOLLOW`: Do not follow symbolic links. This makes it
   --- possible to edit the timestamps on the symbolic link itself,
   --- rather than the file it points to.
-  utimensat: function(path: string, asecs: number, ananos: number, msecs: number, mnanos: number, dirfd?: number, flags?: number): number | nil, string | nil, number | nil
+  utimensat: function(path: string, asecs: number, ananos: number, msecs: number, mnanos: number, dirfd?: number, flags?: number): number | nil, string | nil, Errno | nil
   --- Changes access and/or modified timestamps on file descriptor.
   --- `fd` is the file descriptor of a file opened with `unix.open`.
   --- The `asecs` and `ananos` parameters set the access time. If they're
@@ -1871,25 +1902,25 @@ local record unix
   --- - `unix.UTIME_OMIT`: Do not alter this timestamp.
   --- This system call is currently not available on very old versions of
   --- Linux, e.g. RHEL5.
-  futimens: function(fd: number, asecs: number, ananos: number, msecs: number, mnanos: number): number | nil, string | nil, number | nil
+  futimens: function(fd: number, asecs: number, ananos: number, msecs: number, mnanos: number): number | nil, string | nil, Errno | nil
   --- Changes user and group on file.
   --- Returns `ENOSYS` on Windows NT.
-  chown: function(path: string, uid: number, gid: number, flags?: number, dirfd?: number): boolean | nil, string | nil, number | nil
+  chown: function(path: string, uid: number, gid: number, flags?: number, dirfd?: number): boolean | nil, string | nil, Errno | nil
   --- Changes mode bits on file.
   --- On Windows NT the chmod system call only changes the read-only
   --- status of a file.
-  chmod: function(path: string, mode: number, flags?: number, dirfd?: number): boolean | nil, string | nil, number | nil
+  chmod: function(path: string, mode: number, flags?: number, dirfd?: number): boolean | nil, string | nil, Errno | nil
   --- Returns current working directory.
   --- On Windows NT, this function transliterates `\` to `/` and
   --- furthermore prefixes `//?/` to WIN32 DOS-style absolute paths,
   --- thereby assisting with simple absolute filename checks in addition
   --- to enabling one to exceed the traditional 260 character limit.
-  getcwd: function(): string | nil, string | nil, number | nil
+  getcwd: function(): string | nil, string | nil, Errno | nil
   --- Recursively removes filesystem path.
   --- Like `unix.makedirs()` this function isn't actually a system call but
   --- rather is a Libc convenience wrapper. It's intended to be equivalent
   --- to using the UNIX shell's `rm -rf path` command.
-  rmrf: function(path: string): boolean | nil, string | nil, number | nil
+  rmrf: function(path: string): boolean | nil, string | nil, Errno | nil
   --- Manipulates file descriptor.
   --- `cmd` may be one of:
   --- - `unix.F_GETFD` Returns file descriptor flags.
@@ -1988,21 +2019,21 @@ local record unix
   ---   Returned `pid` is the process id of the current lock owner.
   ---   This function is currently not supported on Windows.
   ---   Returns `EBADF` if `fd` wasn't open.
-  fcntl: function(fd: number, cmd: number, ...: any): any | nil, string | nil, number | nil
+  fcntl: function(fd: number, cmd: FcntlCmd, ...: any): any | nil, string | nil, Errno | nil
   --- Gets session id.
-  getsid: function(pid: number): number | nil, string | nil, number | nil
+  getsid: function(pid: number): number | nil, string | nil, Errno | nil
   --- Gets process group id.
-  getpgrp: function(): number | nil, string | nil, number | nil
+  getpgrp: function(): number | nil, string | nil, Errno | nil
   --- Sets process group id. This is the same as `setpgid(0,0)`.
-  setpgrp: function(): number | nil, string | nil, number | nil
+  setpgrp: function(): number | nil, string | nil, Errno | nil
   --- Sets process group id the modern way.
-  setpgid: function(pid: number, pgid: number): boolean | nil, string | nil, number | nil
+  setpgid: function(pid: number, pgid: number): boolean | nil, string | nil, Errno | nil
   --- Gets process group id the modern way.
-  getpgid: function(pid: number): number | nil, string | nil, number | nil
+  getpgid: function(pid: number): number | nil, string | nil, Errno | nil
   --- Sets session id.
   --- This function can be used to create daemons.
   --- Fails with `ENOSYS` on Windows NT.
-  setsid: function(): number | nil, string | nil, number | nil
+  setsid: function(): number | nil, string | nil, Errno | nil
   --- Daemonizes the current process.
   --- This function performs the standard Unix daemonization steps:
   --- forks, creates a new session, and optionally changes directory
@@ -2013,7 +2044,7 @@ local record unix
   --- `/dev/null`. Defaults to false (will redirect to `/dev/null`).
   --- This is a convenience wrapper that combines `fork()`, `setsid()`,
   --- and related operations.
-  daemon: function(nochdir?: boolean, noclose?: boolean): boolean | nil, string | nil, number | nil
+  daemon: function(nochdir?: boolean, noclose?: boolean): boolean | nil, string | nil, Errno | nil
   --- Gets real user id.
   --- On Windows this system call is polyfilled by running `GetUserNameW()`
   --- through Knuth's multiplicative hash.
@@ -2036,7 +2067,7 @@ local record unix
   getegid: function(): number
   --- Changes root directory.
   --- Returns `ENOSYS` on Windows NT.
-  chroot: function(path: string): boolean | nil, string | nil, number | nil
+  chroot: function(path: string): boolean | nil, string | nil, Errno | nil
   --- Sets user id.
   --- One use case for this function is dropping root privileges. Should
   --- you ever choose to run redbean as root and decide not to use the
@@ -2056,24 +2087,24 @@ local record unix
   --- system manual about the subtleties of changing user id in a way that
   --- isn't restorable.
   --- Returns `ENOSYS` on Windows NT if `uid` isn't `getuid()`.
-  setuid: function(uid: number): boolean | nil, string | nil, number | nil
+  setuid: function(uid: number): boolean | nil, string | nil, Errno | nil
   --- Sets user id for file system ops.
-  setfsuid: function(uid: number): boolean | nil, string | nil, number | nil
+  setfsuid: function(uid: number): boolean | nil, string | nil, Errno | nil
   --- Sets group id for file system ops.
-  setfsgid: function(gid: number): boolean | nil, string | nil, number | nil
+  setfsgid: function(gid: number): boolean | nil, string | nil, Errno | nil
   --- Sets group id.
   --- Returns `ENOSYS` on Windows NT if `gid` isn't `getgid()`.
-  setgid: function(gid: number): boolean | nil, string | nil, number | nil
+  setgid: function(gid: number): boolean | nil, string | nil, Errno | nil
   --- Sets real, effective, and saved user ids.
   --- If any of the above parameters are -1, then it's a no-op.
   --- Returns `ENOSYS` on Windows NT.
   --- Returns `ENOSYS` on Macintosh and NetBSD if `saved` isn't -1.
-  setresuid: function(real: number, effective: number, saved: number): boolean | nil, string | nil, number | nil
+  setresuid: function(real: number, effective: number, saved: number): boolean | nil, string | nil, Errno | nil
   --- Sets real, effective, and saved group ids.
   --- If any of the above parameters are -1, then it's a no-op.
   --- Returns `ENOSYS` on Windows NT.
   --- Returns `ENOSYS` on Macintosh and NetBSD if `saved` isn't -1.
-  setresgid: function(real: number, effective: number, saved: number): boolean | nil, string | nil, number | nil
+  setresgid: function(real: number, effective: number, saved: number): boolean | nil, string | nil, Errno | nil
   --- Sets file permission mask and returns the old one.
   --- This is used to remove bits from the `mode` parameter of functions
   --- like open() and mkdir(). The masks typically used are 027 and 022.
@@ -2092,12 +2123,12 @@ local record unix
   ---     unix.sysconf(unix.SC_PAGESIZE)          -- mmap() page size
   ---     unix.sysconf(unix.SC_CLK_TCK)           -- clock ticks per second
   --- Returns `nil` with an `EINVAL` errno when `name` isn't recognized.
-  sysconf: function(name: number): number | nil, string | nil, number | nil
+  sysconf: function(name: number): number | nil, string | nil, Errno | nil
   --- Returns identity of the current operating system.
   --- Example:
   ---     local u = assert(unix.uname())
   ---     print(u.sysname, u.release, u.machine)
-  uname: function(): any, string | nil, number | nil
+  uname: function(): Uname | nil, string | nil, Errno | nil
   --- Generates a log message, which will be distributed by syslogd.
   --- `priority` is a bitmask containing the facility value and the level
   --- value. If no facility value is ORed into priority, then the default
@@ -2176,32 +2207,32 @@ local record unix
   --- Returns `EINVAL` if clock isn't supported on platform.
   --- This function only fails if `clock` is invalid.
   --- This function goes fastest on Linux and Windows.
-  clock_gettime: function(clock?: number): number | nil, number, string | nil, number | nil
+  clock_gettime: function(clock?: number): number | nil, number, string | nil, Errno | nil
   --- Sleeps with nanosecond precision.
   --- Returns `EINTR` if a signal was received while waiting.
-  nanosleep: function(seconds: number, nanos?: number): number | nil, number, string | nil, number | nil
+  nanosleep: function(seconds: number, nanos?: number): number | nil, number, string | nil, Errno | nil
   --- These functions are used to make programs slower by asking the
   --- operating system to flush data to the physical medium.
   sync: function()
   --- These functions are used to make programs slower by asking the
   --- operating system to flush data to the physical medium.
-  fsync: function(fd: number): boolean | nil, string | nil, number | nil
+  fsync: function(fd: number): boolean | nil, string | nil, Errno | nil
   --- These functions are used to make programs slower by asking the
   --- operating system to flush data to the physical medium.
-  fdatasync: function(fd: number): boolean | nil, string | nil, number | nil
+  fdatasync: function(fd: number): boolean | nil, string | nil, Errno | nil
   --- Seeks to file position.
   --- `whence` can be one of:
   --- - `SEEK_SET`: Sets the file position to `offset` [default]
   --- - `SEEK_CUR`: Sets the file position to `position + offset`
   --- - `SEEK_END`: Sets the file position to `filesize + offset`
   --- Returns the new position relative to the start of the file.
-  lseek: function(fd: number, offset: number, whence?: number): number | nil, string | nil, number | nil
+  lseek: function(fd: number, offset: number, whence?: number): number | nil, string | nil, Errno | nil
   --- Reduces or extends underlying physical medium of file.
   --- If file was originally larger, content >length is lost.
-  truncate: function(path: string, length?: number): boolean | nil, string | nil, number | nil
+  truncate: function(path: string, length?: number): boolean | nil, string | nil, Errno | nil
   --- Reduces or extends underlying physical medium of open file.
   --- If file was originally larger, content >length is lost.
-  ftruncate: function(fd: number, length?: number): boolean | nil, string | nil, number | nil
+  ftruncate: function(fd: number, length?: number): boolean | nil, string | nil, Errno | nil
   --- - `AF_INET`: Creates Internet Protocol Version 4 (IPv4) socket.
   --- - `AF_UNIX`: Creates local UNIX domain socket. On the New Technology
   --- this requires Windows 10 and only works with `SOCK_STREAM`.
@@ -2219,7 +2250,7 @@ local record unix
   --- - `IPPROTO_RAW`
   --- - `IPPROTO_IP`
   --- - `IPPROTO_ICMP`
-  socket: function(family?: number, type?: number, protocol?: number): number | nil, string | nil, number | nil
+  socket: function(family?: number, type?: number, protocol?: number): number | nil, string | nil, Errno | nil
   --- Creates bidirectional pipe.
   --- - `SOCK_STREAM`
   --- - `SOCK_DGRAM`
@@ -2227,7 +2258,7 @@ local record unix
   --- You may bitwise OR any of the following into `type`:
   --- - `SOCK_CLOEXEC`
   --- - `SOCK_NONBLOCK`
-  socketpair: function(family?: number, type?: number, protocol?: number): number | nil, number, string | nil, number | nil
+  socketpair: function(family?: number, type?: number, protocol?: number): number | nil, number, string | nil, Errno | nil
   ---  Binds socket.
   ---  `ip` and `port` are in host endian order. For example, if you
   ---  wanted to listen on `1.2.3.4:31337` you could do any of these
@@ -2249,9 +2280,9 @@ local record unix
   ---      end
   ---  Further note that calling `unix.bind(sock)` is equivalent to not
   ---  calling bind() at all, since the above behavior is the default.
-  bind: function(fd: number, ip?: number, port?: number): boolean | nil, string | nil, number | nil
+  bind: function(fd: number, ip?: number, port?: number): boolean | nil, string | nil, Errno | nil
   --- Returns list of network adapter addresses.
-  siocgifconf: function(): any, string | nil, number | nil
+  siocgifconf: function(): any, string | nil, Errno | nil
   --- Tunes networking parameters.
   --- `level` and `optname` may be one of the following pairs. The ellipses
   --- type signature above changes depending on which options are used.
@@ -2339,7 +2370,7 @@ local record unix
   --- earlier on the listening socket. This is Linux-only. You can use the
   --- `OnServerListen` hook to enable SYN saving in your Redbean. When the
   --- `TCP_SAVE_SYN` option isn't used, this may return empty string.
-  getsockopt: function(fd: number, level: number, optname: number): number | nil, string | nil, number | nil
+  getsockopt: function(fd: number, level: number, optname: number): number | nil, string | nil, Errno | nil
   --- Tunes networking parameters.
   --- `level` and `optname` may be one of the following pairs. The ellipses
   --- type signature above changes depending on which options are used.
@@ -2427,7 +2458,7 @@ local record unix
   --- earlier on the listening socket. This is Linux-only. You can use the
   --- `OnServerListen` hook to enable SYN saving in your Redbean. When the
   --- `TCP_SAVE_SYN` option isn't used, this may return empty string.
-  setsockopt: function(fd: number, level: number, optname: number, value: boolean | number): boolean | nil, string | nil, number | nil
+  setsockopt: function(fd: number, level: number, optname: number, value: boolean | number): boolean | nil, string | nil, Errno | nil
   --- Checks for events on a set of file descriptors.
   --- The table of file descriptors to poll uses sparse integer keys. Any
   --- pairs with non-integer keys will be ignored. Pairs with negative
@@ -2449,61 +2480,61 @@ local record unix
   --- - `POLLNVAL` (revents): Invalid request.
   --- If this is set to -1 then that means block as long as it takes until there's an
   --- event or an interrupt. If the timeout expires, an empty table is returned.
-  poll: function(fds: {number: number}, timeoutms?: number): {number: number} | nil, string | nil, number | nil
+  poll: function(fds: {number: number}, timeoutms?: number): {number: number} | nil, string | nil, Errno | nil
   --- Returns hostname of system.
-  gethostname: function(): string | nil, string | nil, number | nil
+  gethostname: function(): string | nil, string | nil, Errno | nil
   --- Sets hostname of system.
   --- Requires CAP_SYS_ADMIN on Linux (or root on BSDs); returns `EPERM`
   --- otherwise. Not supported on Windows, where it returns `ENOSYS`.
-  sethostname: function(name: string): boolean | nil, string | nil, number | nil
+  sethostname: function(name: string): boolean | nil, string | nil, Errno | nil
   --- Begins listening for incoming connections on a socket.
-  listen: function(fd: number, backlog?: number): boolean | nil, string | nil, number | nil
+  listen: function(fd: number, backlog?: number): boolean | nil, string | nil, Errno | nil
   --- Accepts new client socket descriptor for a listening tcp socket.
   --- `flags` may have any combination (using bitwise OR) of:
   --- - `SOCK_CLOEXEC`
   --- - `SOCK_NONBLOCK`
-  accept: function(serverfd: number, flags?: number): number | nil, number, number, string | nil, number | nil
+  accept: function(serverfd: number, flags?: number): number | nil, number, number, string | nil, Errno | nil
   ---  Connects a TCP socket to a remote host.
   ---  With TCP this is a blocking operation. For a UDP socket it simply
   ---  remembers the intended address so that `send()` or `write()` may be used
   ---  rather than `sendto()`.
-  connect: function(fd: number, ip: number, port: number): boolean | nil, string | nil, number | nil
+  connect: function(fd: number, ip: number, port: number): boolean | nil, string | nil, Errno | nil
   --- Retrieves the local address of a socket.
-  getsockname: function(fd: number): number | nil, number, string | nil, number | nil
+  getsockname: function(fd: number): number | nil, number, string | nil, Errno | nil
   --- Retrieves the remote address of a socket.
   --- This operation will either fail on `AF_UNIX` sockets or return an
   --- empty string.
-  getpeername: function(fd: number): number | nil, number, string | nil, number | nil
+  getpeername: function(fd: number): number | nil, number, string | nil, Errno | nil
   --- - `MSG_WAITALL`
   --- - `MSG_DONTROUTE`
   --- - `MSG_PEEK`
   --- - `MSG_OOB`
-  recv: function(fd: number, bufsiz?: number, flags?: number): string | nil, string | nil, number | nil
+  recv: function(fd: number, bufsiz?: number, flags?: number): string | nil, string | nil, Errno | nil
   --- - `MSG_WAITALL`
   --- - `MSG_DONTROUTE`
   --- - `MSG_PEEK`
   --- - `MSG_OOB`
-  recvfrom: function(fd: number, bufsiz?: number, flags?: number): string | nil, number, number, string | nil, number | nil
+  recvfrom: function(fd: number, bufsiz?: number, flags?: number): string | nil, number, number, string | nil, Errno | nil
   --- This is the same as `write` except it has a `flags` argument
   --- that's intended for sockets.
   --- - `MSG_NOSIGNAL`: Don't SIGPIPE on EOF
   --- - `MSG_OOB`: Send stream data through out of bound channel
   --- - `MSG_DONTROUTE`: Don't go through gateway (for diagnostics)
   --- - `MSG_MORE`: Manual corking to belay nodelay (0 on non-Linux)
-  send: function(fd: number, data: string, flags?: number, offset?: number): number | nil, string | nil, number | nil
+  send: function(fd: number, data: string, flags?: number, offset?: number): number | nil, string | nil, Errno | nil
   --- This is useful for sending messages over UDP sockets to specific
   --- addresses.
   --- - `MSG_OOB`
   --- - `MSG_DONTROUTE`
   --- - `MSG_NOSIGNAL`
-  sendto: function(fd: number, data: string, ip: number, port: number, flags?: number): number | nil, string | nil, number | nil
+  sendto: function(fd: number, data: string, ip: number, port: number, flags?: number): number | nil, string | nil, Errno | nil
   --- Partially closes socket.
   --- - `SHUT_RD`: sends a tcp half close for reading
   --- - `SHUT_WR`: sends a tcp half close for writing
   --- - `SHUT_RDWR`
   --- This system call currently has issues on Macintosh, so portable code
   --- should log rather than assert failures reported by `shutdown()`.
-  shutdown: function(fd: number, how: number): boolean | nil, string | nil, number | nil
+  shutdown: function(fd: number, how: number): boolean | nil, string | nil, Errno | nil
   --- Manipulates bitset of signals blocked by process.
   --- - `SIG_BLOCK`: applies `mask` to set of blocked signals using bitwise OR
   --- - `SIG_UNBLOCK`: removes bits in `mask` from set of blocked signals
@@ -2515,7 +2546,7 @@ local record unix
   ---   oldmask = assert(unix.sigprocmask(unix.SIG_BLOCK, newmask))
   ---   -- do something...
   ---   assert(unix.sigprocmask(unix.SIG_SETMASK, oldmask))
-  sigprocmask: function(how: number, newmask: Sigset): Sigset | nil, string | nil, number | nil
+  sigprocmask: function(how: number, newmask: Sigset): Sigset | nil, string | nil, Errno | nil
   --- - `unix.SIGINT`
   --- - `unix.SIGQUIT`
   --- - `unix.SIGTERM`
@@ -2582,13 +2613,13 @@ local record unix
   --- handlers (e.g. `unix.SIG_IGN`, `unix.SIG_DFL`, or a raw function pointer)
   --- are installed directly and are not deferred.
   --- It's a good idea to not do too much work in a signal handler.
-  sigaction: function(sig: number, handler?: function | number, flags?: number, mask?: Sigset): function | number | nil, number, Sigset, string | nil, number | nil
+  sigaction: function(sig: number, handler?: function | number, flags?: number, mask?: Sigset): function | number | nil, number, Sigset, string | nil, Errno | nil
   --- Waits for signal to be delivered.
   --- The signal mask is temporarily replaced with `mask` during this system call.
-  sigsuspend: function(mask?: Sigset): nil, string | nil, number | nil
+  sigsuspend: function(mask?: Sigset): nil, string | nil, Errno | nil
   --- Returns the set of signals pending delivery to the calling process
   --- that are currently blocked.
-  sigpending: function(): Sigset | nil, string | nil, number | nil
+  sigpending: function(): Sigset | nil, string | nil, Errno | nil
   --- Causes `SIGALRM` signals to be generated at some point(s) in the
   --- future. The `which` parameter should be `ITIMER_REAL`.
   --- Here's an example of how to create a 400 ms interval timer:
@@ -2604,7 +2635,7 @@ local record unix
   --- Here's how you'd do a single-shot timeout in 1 second:
   ---     unix.sigaction(unix.SIGALRM, MyOnSigAlrm, unix.SA_RESETHAND)
   ---     unix.setitimer(unix.ITIMER_REAL, 0, 0, 1, 0)
-  setitimer: function(which: number, intervalsec: number, intervalns: number, valuesec: number, valuens: number): number | nil, number, number, number, string | nil, number | nil
+  setitimer: function(which: number, intervalsec: number, intervalns: number, valuesec: number, valuens: number): number | nil, number, number, number, string | nil, Errno | nil
   --- Turns platform-specific `sig` code into its symbolic name.
   --- For example:
   ---     >: unix.strsignal(9)
@@ -2634,9 +2665,9 @@ local record unix
   --- If a limit isn't supported by the host platform, it'll be set to
   --- 127. On most platforms these limits are enforced by the kernel and
   --- as such are inherited by subprocesses.
-  setrlimit: function(resource: number, soft: number, hard?: number): boolean | nil, string | nil, number | nil
+  setrlimit: function(resource: number, soft: number, hard?: number): boolean | nil, string | nil, Errno | nil
   --- Returns information about resource limits for current process.
-  getrlimit: function(resource: number): number | nil, number, string | nil, number | nil
+  getrlimit: function(resource: number): number | nil, number, string | nil, Errno | nil
   --- Adjusts the nice value (scheduling priority) of the calling process.
   --- The nice value ranges from -20 (highest priority) to 19 (lowest priority).
   --- Only privileged processes can lower the nice value (increase priority).
@@ -2644,7 +2675,7 @@ local record unix
   --- priority, negative values increase it.
   --- Returns the new nice value on success. Note that -1 is a valid return
   --- value, so errors must be detected by checking the second return value.
-  nice: function(inc: number): number | nil, string | nil, number | nil
+  nice: function(inc: number): number | nil, string | nil, Errno | nil
   --- Lowers the calling process to the lowest scheduling priority.
   --- On Linux this additionally requests the idle scheduling policy and a
   --- best-effort idle i/o priority. This function does not fail.
@@ -2657,7 +2688,7 @@ local record unix
   --- Returns the priority value (nice value) which ranges from -20 to 19.
   --- Note that -1 is a valid return value, so errors must be detected by
   --- checking the second return value.
-  getpriority: function(which: number, who: number): number | nil, string | nil, number | nil
+  getpriority: function(which: number, who: number): number | nil, string | nil, Errno | nil
   --- Sets the scheduling priority of a process, process group, or user.
   --- `which` specifies what `who` refers to:
   --- - `PRIO_PROCESS`: `who` is a process id (0 = calling process)
@@ -2666,7 +2697,7 @@ local record unix
   --- `prio` is the new priority value (nice value), ranging from -20
   --- (highest priority) to 19 (lowest priority). Only privileged processes
   --- can set negative priority values.
-  setpriority: function(which: number, who: number, prio: number): boolean | nil, string | nil, number | nil
+  setpriority: function(which: number, who: number, prio: number): boolean | nil, string | nil, Errno | nil
   --- Returns information about resource usage for current process, e.g.
   ---     >: unix.getrusage()
   ---     {utime={0, 53644000}, maxrss=44896, minflt=545, oublock=24, nvcsw=9}
@@ -2674,7 +2705,7 @@ local record unix
   --- - `RUSAGE_THREAD`: current thread
   --- - `RUSAGE_CHILDREN`: not supported on Windows NT
   --- - `RUSAGE_BOTH`: not supported on non-Linux
-  getrusage: function(who?: number): Rusage | nil, string | nil, number | nil
+  getrusage: function(who?: number): Rusage | nil, string | nil, Errno | nil
   --- Restrict system operations.
   --- This can be used to sandbox your redbean workers. It allows finer
   --- customization compared to the `-S` flag.
@@ -2797,7 +2828,7 @@ local record unix
   ---   means that the `unix.WTERMSIG()` on your killed processes will
   ---   always be `unix.SIGABRT` on both Linux and OpenBSD. Otherwise,
   ---   Linux prefers to raise `unix.SIGSYS`.
-  pledge: function(promises?: string, execpromises?: string, mode?: number): boolean | nil, string | nil, number | nil
+  pledge: function(promises?: string, execpromises?: string, mode?: number): boolean | nil, string | nil, Errno | nil
   --- Restricts filesystem operations, e.g.
   ---    unix.unveil(".", "r");     -- current dir + children visible
   ---    unix.unveil("/etc", "r");  -- make /etc readable too
@@ -2840,9 +2871,9 @@ local record unix
   ---   corresponding to the pledge promises "exec" and "execnative".
   --- - `c` allows `path` to be created and removed, corresponding to
   ---   the pledge promise "cpath".
-  unveil: function(path: string, permissions: string): boolean | nil, string | nil, number | nil
+  unveil: function(path: string, permissions: string): boolean | nil, string | nil, Errno | nil
   --- Breaks down UNIX timestamp into Zulu Time numbers.
-  gmtime: function(unixts: number): number | nil, number, number, number, number, number, number, number, number, number, string, string | nil, number | nil
+  gmtime: function(unixts: number): number | nil, number, number, number, number, number, number, number, number, number, string, string | nil, Errno | nil
   --- Breaks down UNIX timestamp into local time numbers, e.g.
   ---     >: unix.localtime(unix.clock_gettime())
   ---     2022    4       28      2       14      22      -25200  4       117     1       "PDT"
@@ -2868,10 +2899,10 @@ local record unix
   --- can simply copy it inside your redbean. The same is also the case
   --- for future updates to the database, which can be swapped out when
   --- needed, without having to recompile.
-  localtime: function(unixts: number): number | nil, number, number, number, number, number, number, number, number, number, string, string | nil, number | nil
+  localtime: function(unixts: number): number | nil, number, number, number, number, number, number, number, number, number, string, string | nil, Errno | nil
   --- Gets information about file or directory.
   --- - `AT_SYMLINK_NOFOLLOW`: do not follow symbolic links.
-  stat: function(path: string, flags?: number, dirfd?: number): Stat | nil, string | nil, number | nil
+  stat: function(path: string, flags?: number, dirfd?: number): Stat | nil, string | nil, Errno | nil
   --- Tests if file mode represents a directory.
   S_ISDIR: function(mode: number): boolean
   --- Tests if file mode represents a regular file.
@@ -2896,7 +2927,7 @@ local record unix
   ---     st = assert(unix.fstat(fd))
   ---     Log(kLogInfo, 'hello.txt is %d bytes in size' % {st:size()})
   ---     unix.close(fd)
-  fstat: function(fd: number): Stat | nil, string | nil, number | nil
+  fstat: function(fd: number): Stat | nil, string | nil, Errno | nil
   --- Opens directory for listing its contents.
   --- For example, to print a simple directory listing:
   ---     Write('<ul>\r\n')
@@ -2906,19 +2937,19 @@ local record unix
   ---         end
   ---     end
   ---     Write('</ul>\r\n')
-  opendir: function(path: string): Dir | nil, string | nil, number | nil
+  opendir: function(path: string): Dir | nil, string | nil, Errno | nil
   --- Opens directory for listing its contents, via an fd.
   --- The returned `unix.Dir` takes ownership of the file descriptor
   --- and will close it automatically when garbage collected.
-  fdopendir: function(fd: number): Dir | nil, string | nil, number | nil
+  fdopendir: function(fd: number): Dir | nil, string | nil, Errno | nil
   --- Returns true if file descriptor is a teletypewriter. Otherwise nil
   --- with an Errno object holding one of the following values:
   --- - `ENOTTY` if `fd` is valid but not a teletypewriter
   --- - `EBADF` if `fd` isn't a valid file descriptor.
   --- - `EPERM` if pledge() is used without `tty` in lenient mode
   --- No other error numbers are possible.
-  isatty: function(fd: number): boolean | nil, string | nil, number | nil
-  tiocgwinsz: function(fd: number): number | nil, number, string | nil, number | nil
+  isatty: function(fd: number): boolean | nil, string | nil, Errno | nil
+  tiocgwinsz: function(fd: number): number | nil, number, string | nil, Errno | nil
   --- Gets terminal attributes.
   --- Returns a termios table containing the terminal I/O settings for the
   --- specified file descriptor. The table contains these fields:
@@ -2937,7 +2968,7 @@ local record unix
   ---     local password = io.read()
   ---     tio.lflag = old_lflag
   ---     unix.tcsetattr(0, unix.TCSANOW, tio)
-  tcgetattr: function(fd: number): Termios | nil, string | nil, number | nil
+  tcgetattr: function(fd: number): Termios | nil, string | nil, Errno | nil
   --- Sets terminal attributes.
   --- Modifies the terminal I/O settings for the specified file descriptor
   --- using the provided termios table. The `action` parameter controls when
@@ -2948,7 +2979,7 @@ local record unix
   ---   input is discarded
   --- The termios table should contain the same fields as returned by
   --- `unix.tcgetattr()`. Missing fields default to zero.
-  tcsetattr: function(fd: number, action: number, termios: Termios): boolean | nil, string | nil, number | nil
+  tcsetattr: function(fd: number, action: number, termios: Termios): boolean | nil, string | nil, Errno | nil
   --- Returns file descriptor of open anonymous file.
   --- This creates a secure temporary file inside `$TMPDIR`. If it isn't
   --- defined, then `/tmp` is used on UNIX and GetTempPath() is used on
@@ -2959,59 +2990,59 @@ local record unix
   --- On the New Technology, temporary files created by this function
   --- should have better performance, because `kNtFileAttributeTemporary`
   --- asks the kernel to more aggressively cache and reduce i/o ops.
-  tmpfd: function(): number | nil, string | nil, number | nil
+  tmpfd: function(): number | nil, string | nil, Errno | nil
   --- Relinquishes scheduled quantum.
   sched_yield: function()
   --- Disassociates parts of the caller's execution context, placing it
   --- into fresh namespace(s) specified by `flags` (bitwise OR of
   --- `unix.CLONE_NEW*` constants). Linux-only; returns ENOSYS elsewhere.
-  unshare: function(flags: number): boolean | nil, string | nil, number | nil
+  unshare: function(flags: number): boolean | nil, string | nil, Errno | nil
   --- Reassociates the calling thread with the namespace referenced by
   --- `fd` (typically from `/proc/<pid>/ns/*`). `nstype`, if nonzero,
   --- must match a `unix.CLONE_NEW*` constant and asserts the kind of
   --- namespace. Linux-only; returns ENOSYS elsewhere.
-  setns: function(fd: number, nstype?: number): boolean | nil, string | nil, number | nil
+  setns: function(fd: number, nstype?: number): boolean | nil, string | nil, Errno | nil
   --- Mounts a filesystem. `flags` is a bitwise OR of `unix.MS_*`
   --- constants; `data` is a filesystem-specific options string.
-  mount: function(source?: string, target?: string, fstype?: string, flags?: number, data?: string): boolean | nil, string | nil, number | nil
+  mount: function(source?: string, target?: string, fstype?: string, flags?: number, data?: string): boolean | nil, string | nil, Errno | nil
   --- Unmounts a filesystem. On Linux this is the `umount2` syscall.
   --- `flags` may include `unix.MNT_FORCE`, `unix.MNT_DETACH`,
   --- `unix.MNT_EXPIRE`, `unix.UMOUNT_NOFOLLOW`.
-  unmount: function(target: string, flags?: number): boolean | nil, string | nil, number | nil
+  unmount: function(target: string, flags?: number): boolean | nil, string | nil, Errno | nil
   --- Moves the root filesystem of the current mount namespace to
   --- `put_old` and makes `new_root` the new root. Usually paired with
   --- `chdir("/")` in the child. Requires a private mount namespace.
-  pivot_root: function(new_root: string, put_old: string): boolean | nil, string | nil, number | nil
+  pivot_root: function(new_root: string, put_old: string): boolean | nil, string | nil, Errno | nil
   --- Performs an operation on the calling process. `option` is one of
   --- the `unix.PR_*` constants; remaining arguments are option-specific.
   --- Returns the integer result (0 for most setters).
-  prctl: function(option: number, arg2?: number, arg3?: number, arg4?: number, arg5?: number): number | nil, string | nil, number | nil
+  prctl: function(option: number, arg2?: number, arg3?: number, arg4?: number, arg5?: number): number | nil, string | nil, Errno | nil
   --- Returns the calling thread's (or `pid`'s) capability sets as
   --- 64-bit bitmasks. Each bit position N corresponds to `unix.CAP_*`
   --- constant N. Linux-only.
-  capget: function(pid?: number): number | nil, number, number, string | nil, number | nil
+  capget: function(pid?: number): number | nil, number, number, string | nil, Errno | nil
   --- Sets the calling thread's (or `pid`'s) capability sets. Each
   --- argument is a 64-bit bitmask of `1 << unix.CAP_*` bits. Linux-only.
-  capset: function(effective: number, permitted: number, inheritable: number, pid?: number): boolean | nil, string | nil, number | nil
+  capset: function(effective: number, permitted: number, inheritable: number, pid?: number): boolean | nil, string | nil, Errno | nil
   --- Generic device control. When `arg` is nil or absent, the ioctl is
   --- invoked with a null pointer. When `arg` is an integer, it's passed
   --- by value. When `arg` is a string, a mutable copy of the same size
   --- is passed to the kernel and the (possibly-modified) buffer of the
   --- same length is returned.
-  ioctl: function(fd: number, request: number, arg?: number | string): boolean | string | nil, string | nil, number | nil
+  ioctl: function(fd: number, request: number, arg?: number | string): boolean | string | nil, string | nil, Errno | nil
   --- Landlock: create ruleset. With no args, returns the kernel's
   --- supported ABI version. With `handled_access_fs`, creates a new
   --- ruleset file descriptor that handles the given access categories
   --- (bitwise OR of `unix.LANDLOCK_ACCESS_FS_*`). Linux 5.13+.
-  landlock_create_ruleset: function(handled_access_fs?: number, flags?: number): number | nil, string | nil, number | nil
+  landlock_create_ruleset: function(handled_access_fs?: number, flags?: number): number | nil, string | nil, Errno | nil
   --- Landlock: add a PATH_BENEATH rule granting `allowed` access to the
   --- subtree rooted at `parent_fd` (opened with `unix.O_PATH`). `allowed`
   --- must be a subset of the ruleset's handled set.
-  landlock_add_rule: function(ruleset_fd: number, parent_fd: number, allowed: number, flags?: number): boolean | nil, string | nil, number | nil
+  landlock_add_rule: function(ruleset_fd: number, parent_fd: number, allowed: number, flags?: number): boolean | nil, string | nil, Errno | nil
   --- Landlock: apply the ruleset to the current thread (and its future
   --- children). Caller must set `PR_SET_NO_NEW_PRIVS` first or hold
   --- `CAP_SYS_ADMIN`. The restriction is irrevocable.
-  landlock_restrict_self: function(ruleset_fd: number, flags?: number): boolean | nil, string | nil, number | nil
+  landlock_restrict_self: function(ruleset_fd: number, flags?: number): boolean | nil, string | nil, Errno | nil
   --- Creates interprocess shared memory mapping.
   --- This function allocates special memory that'll be inherited across
   --- fork in a shared way. By default all memory in Redbean is "private"
@@ -3070,9 +3101,9 @@ local record unix
   --- Extracts the minor device number from a device id such as `Stat:rdev()`.
   minor: function(rdev: number): number
   --- Gets filesystem statistics for the filesystem that contains `path`.
-  statfs: function(path: string): Statfs | nil, string | nil, number | nil
+  statfs: function(path: string): Statfs | nil, string | nil, Errno | nil
   --- Gets filesystem statistics via an open file descriptor.
-  fstatfs: function(fd: number): Statfs | nil, string | nil, number | nil
+  fstatfs: function(fd: number): Statfs | nil, string | nil, Errno | nil
   --- Signal set for blocking, unblocking, and waiting on signals.
   --- Used with `unix.sigprocmask()`, `unix.sigaction()`, and `unix.sigsuspend()`.
   --- The unix.Sigset class defines a mutable bitset that may currently

--- a/lib/types/cosmo/zip.d.tl
+++ b/lib/types/cosmo/zip.d.tl
@@ -37,7 +37,7 @@ end
 
 local record AddOptions
   --- Compression method: `"store"` or `"deflate"`
-  method: string
+  method: CompressionMethod
   --- Modification time as Unix timestamp
   mtime: number
   --- Unix file mode (default 0644)
@@ -83,6 +83,21 @@ local record Appender
   close: function(self: Appender)
 end
 
+--- Archive open modes, validated by the strcmp chain in `LuaZipOpen`
+--- (`tool/net/lzip.c`).
+local enum OpenMode
+  "r"
+  "w"
+  "a"
+end
+
+--- Entry compression methods (`tool/net/lzip.c`); anything else is
+--- rejected with "invalid method".
+local enum CompressionMethod
+  "store"
+  "deflate"
+end
+
 local record zip
   type OpenOptions = OpenOptions
   type Stat = Stat
@@ -91,10 +106,12 @@ local record zip
   type Reader = Reader
   type Writer = Writer
   type Appender = Appender
+  type OpenMode = OpenMode
+  type CompressionMethod = CompressionMethod
 
   --- Opens a ZIP archive for reading, writing, or appending.
   --- The first argument can be a file path string or a file descriptor integer.
-  open: function(path: string | number, mode?: string, options?: OpenOptions): any, string | nil
+  open: function(path: string | number, mode?: OpenMode, options?: OpenOptions): any, string | nil
   --- Opens a ZIP archive from in-memory data for reading.
   from: function(data: string, options?: OpenOptions): Reader | nil, string | nil
   --- Creates a new ZIP archive for writing. This is equivalent to


### PR DESCRIPTION
Phase C closeout of the type-system audit (#632). Bumps the cosmos pin to `2026.07.13-e6040de22` — the release carrying whilp/cosmopolitan#178/#179/#180 — and regenerates types with the new gentype (#635).

**The pin delta is annotation-only**: `git diff b208ca89f..e6040de22` touches exactly `tool/net/definitions.lua` and its ratchet test — zero C changes — so runtime behavior is identical by construction and the usual pin-bump `perf-compare` has nothing to measure.

## What the regen brings (6 generated files)

- **Real Teal enums** from the literal-union aliases: `cosmo.FetchErrorKind`, `cosmo.IpCategory`, `argon2.Variant`, `zip.OpenMode`, `zip.CompressionMethod` — closed string sets now checked at call sites
- **Named integer aliases**: `unix.Errno` on every fallible `unix.*` errno slot (128 signatures, plus cross-module `cosmo.Barf`/`Slurp`), `lsqlite3.ResultCode`/`OpenFlag`, `re.CompileFlag`/`SearchFlag`, `unix.FcntlCmd`
- **`lsqlite3.Statement` fully typed** (matches its VM twin — `get_value(n: number): string | number | nil`, typed iterators, `step(): ResultCode`); `unix.Uname` named record; `GetHostOs(): string | nil`; `GetHostIsa` includes `"S390X"`

## Wrapper adoptions (same change, per the frozen-contract rule)

- **hash**: `HashOptions.variant` is now the generated `argon2.Variant` enum. The hand-maintained `valid_variants` allowlist is gone — literals are checked statically; strings smuggled through casts still get `nil, err` at runtime (never throw). Test updated to cast its deliberate bad literal.
- **sys**: `host_os()` handles the now-admitted `GetHostOs` nil by mapping it to a new `"unknown"` `HostOs` member instead of crashing in `:lower()` — the nil was a pre-existing (unreachable-on-shipped-targets) crash path the honest type exposed.

## Deferred follow-up

Shedding the `Raw*` mirror records in `cosmic.sqlite`'s helper modules (init/bind/row_iter/params) in favor of the now-typed `lsqlite3.Statement`/`Database` is a cross-file refactor, not a pin adaptation — left for its own change.

## Verification

`bin/make ci` (format + teal 272/272 + test incl. gentype byte-for-byte drift + example + lint + coverage) run against the new pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p)_