### PR TITLE
sqlite: shed Raw* mirrors for the generated lsqlite3 types

### DIFF
--- a/lib/build/build-stage.tl
+++ b/lib/build/build-stage.tl
@@ -155,236 +155,236 @@ end
 
 local type ExtractFn = function(string, string, number): boolean, string
 
-  local function extract_and_install(
-      extract_fn: ExtractFn,
-      archive: string,
-      stage_dir: string,
-      strip: number,
-      strip_prefix: string
-    ): boolean, string
-    local temp_dir = fs.mkdtemp(fs.join(fs.dirname(stage_dir), ".stage_XXXXXX"))
-    local ok, err = extract_fn(archive, temp_dir, strip)
-    if ok then
-      ok, err = install_files(temp_dir, stage_dir, strip_prefix)
-    end
-    fs.rmrf(temp_dir)
-    return ok, err
+local function extract_and_install(
+    extract_fn: ExtractFn,
+    archive: string,
+    stage_dir: string,
+    strip: number,
+    strip_prefix: string
+  ): boolean, string
+  local temp_dir = fs.mkdtemp(fs.join(fs.dirname(stage_dir), ".stage_XXXXXX"))
+  local ok, err = extract_fn(archive, temp_dir, strip)
+  if ok then
+    ok, err = install_files(temp_dir, stage_dir, strip_prefix)
   end
+  fs.rmrf(temp_dir)
+  return ok, err
+end
 
-  --- Validate a relative path component for use within the stage directory.
-  --- Rejects empty paths, absolute paths (leading /), and paths containing
-  --- `..` components. Returns an error string on failure, nil on success.
-  local function validate_stage_path(p: string): string
-    if not p or p == "" then
-      return "path must not be empty"
-    end
-    if p:sub(1, 1) == "/" then
-      return "path must not be absolute: " .. p
-    end
-    for component in (p .. "/"):gmatch("([^/]*)/") do
-      if component == ".." then
-        return "path must not contain '..': " .. p
-      end
-    end
-    return nil
+--- Validate a relative path component for use within the stage directory.
+--- Rejects empty paths, absolute paths (leading /), and paths containing
+--- `..` components. Returns an error string on failure, nil on success.
+local function validate_stage_path(p: string): string
+  if not p or p == "" then
+    return "path must not be empty"
   end
-
-  --- Validate a symlink target: must be relative and contain no `..` components.
-  local function validate_link_target(target: string): string
-    if not target or target == "" then
-      return "symlink target must not be empty"
-    end
-    if target:sub(1, 1) == "/" then
-      return "symlink target must not be absolute: " .. target
-    end
-    for component in (target .. "/"):gmatch("([^/]*)/") do
-      if component == ".." then
-        return "symlink target must not contain '..': " .. target
-      end
-    end
-    return nil
+  if p:sub(1, 1) == "/" then
+    return "path must not be absolute: " .. p
   end
-
-  local function apply_install(stage_dir: string, install: {string: string}): boolean, string
-    for src, dst in pairs(install) do
-      local src_err = validate_stage_path(src)
-      if src_err then
-        return nil, "install src invalid: " .. src_err
-      end
-      local dst_err = validate_stage_path(dst)
-      if dst_err then
-        return nil, "install dst invalid: " .. dst_err
-      end
-      local src_path = fs.join(stage_dir, src)
-      local dst_path = fs.join(stage_dir, dst)
-      fs.makedirs(fs.dirname(dst_path))
-      local ok, err = fs.rename(src_path, dst_path)
-      if not ok then
-        return nil, string.format("install %s -> %s failed: %s", src, dst, err or "unknown error")
-      end
+  for component in (p .. "/"):gmatch("([^/]*)/") do
+    if component == ".." then
+      return "path must not contain '..': " .. p
     end
-    return true
   end
+  return nil
+end
 
-  local function apply_remove(stage_dir: string, remove: {string}): boolean, string
-    for _, file in ipairs(remove) do
-      local file_err = validate_stage_path(file)
-      if file_err then
-        return nil, "remove path invalid: " .. file_err
-      end
-      local file_path = fs.join(stage_dir, file)
-      fs.rmrf(file_path)
-    end
-    return true
+--- Validate a symlink target: must be relative and contain no `..` components.
+local function validate_link_target(target: string): string
+  if not target or target == "" then
+    return "symlink target must not be empty"
   end
-
-  local function apply_links(stage_dir: string, links: {string: string}): boolean, string
-    for link, target in pairs(links) do
-      local link_err = validate_stage_path(link)
-      if link_err then
-        return nil, "link path invalid: " .. link_err
-      end
-      local target_err = validate_link_target(target)
-      if target_err then
-        return nil, "link target invalid: " .. target_err
-      end
-      local link_path = fs.join(stage_dir, link)
-      fs.makedirs(fs.dirname(link_path))
-      fs.rmrf(link_path)
-      local ok, err = fs.symlink(target, link_path)
-      if not ok then
-        return nil, string.format("link %s -> %s failed: %s", link, target, err or "unknown error")
-      end
-    end
-    return true
+  if target:sub(1, 1) == "/" then
+    return "symlink target must not be absolute: " .. target
   end
-
-  local function find_archive(fetch_dir: string, format: string): string, string
-    if format == "binary" or format == "gz" then
-      return fs.join(fetch_dir, "binary")
+  for component in (target .. "/"):gmatch("([^/]*)/") do
+    if component == ".." then
+      return "symlink target must not contain '..': " .. target
     end
-    local extension: string = nil
-    if format == "zip" then
-      extension = ".zip"
-    elseif format == "tar.gz" then
-      extension = ".tar.gz"
-    end
-    local dir0, dir_err = fs.opendir(fetch_dir)
-    if not dir0 then
-      return nil, "failed to open " .. fetch_dir .. ": " .. (dir_err or "unknown error")
-    end
-    local dir = dir0 as fs_types.Dir
-    while true do
-      local name = dir:read()
-      if not name then break end
-      if name ~= "." and name ~= ".." then
-        if not extension or name:sub(-#extension) == extension then
-          return fs.join(fetch_dir, name)
-        end
-      end
-    end
-    return nil, "no archive found in " .. fetch_dir
   end
+  return nil
+end
 
-  local function main(version_file: string, platform: string, input: string, output: string): boolean, string
-    if not version_file or not platform or not input or not output then
-      return nil, "usage: stage.lua <version_file> <platform> <input.fetched> <output.staged>"
+local function apply_install(stage_dir: string, install: {string: string}): boolean, string
+  for src, dst in pairs(install) do
+    local src_err = validate_stage_path(src)
+    if src_err then
+      return nil, "install src invalid: " .. src_err
     end
-
-    local stage_o = os.getenv("STAGE_O")
-    if not stage_o then
-      return nil, "STAGE_O env var required"
+    local dst_err = validate_stage_path(dst)
+    if dst_err then
+      return nil, "install dst invalid: " .. dst_err
     end
-
-    local load_ok, spec = pcall(dofile, version_file) as(boolean, VersionSpec)
-    if not load_ok then
-      return nil, "failed to load " .. version_file .. ": " .. tostring(spec)
-    end
-
-    local plat = spec.platforms[platform] or spec.platforms["*"]
-    if not plat then
-      return nil, "unknown platform: " .. platform
-    end
-
-    local format = spec.format or plat.format or "binary"
-    local strip = spec.strip_components or 1
-
-    -- derive module name from output path: o/<module>/.staged
-    local output_dir = fs.dirname(output)
-    local module_name = fs.basename(output_dir)
-
-    -- input is now a directory; find the archive inside
-    local archive, err = find_archive(input, format)
-    if not archive then
-      return nil, err
-    end
-
-    local version_sha = spec.version .. "-" .. plat.sha
-
-    local stage_dir = fs.join(stage_o, module_name, version_sha)
-    local ok_mk, err_mk = fs.makedirs(stage_dir)
-    if not ok_mk then
-      return nil, "makedirs failed for " .. stage_dir .. ": " .. tostring(err_mk)
-    end
-
-    local ok: boolean
-    if format == "zip" then
-      ok, err = extract_and_install(extract_zip, archive, stage_dir, strip, spec.strip_prefix)
-    elseif format == "tar.gz" then
-      ok, err = extract_and_install(extract_targz, archive, stage_dir, strip, spec.strip_prefix)
-    elseif format == "binary" then
-      ok, err = copy_binary(archive, stage_dir, module_name)
-    elseif format == "gz" then
-      ok, err = extract_gz(archive, stage_dir, module_name)
-    else
-      return nil, "unknown format: " .. format
-    end
-
+    local src_path = fs.join(stage_dir, src)
+    local dst_path = fs.join(stage_dir, dst)
+    fs.makedirs(fs.dirname(dst_path))
+    local ok, err = fs.rename(src_path, dst_path)
     if not ok then
-      return nil, err
+      return nil, string.format("install %s -> %s failed: %s", src, dst, err or "unknown error")
     end
-
-    -- apply post-extraction transforms from version.lua
-    if spec.remove then
-      ok, err = apply_remove(stage_dir, spec.remove)
-      if not ok then return nil, err end
-    end
-    if spec.install then
-      ok, err = apply_install(stage_dir, spec.install)
-      if not ok then return nil, err end
-    end
-    if spec.links then
-      ok, err = apply_links(stage_dir, spec.links)
-      if not ok then return nil, err end
-    end
-
-    -- format: STAGE  module @ version-sha_prefix
-    local sha_prefix = plat.sha:sub(1, 7)
-    io.stderr:write(string.format("□ STAGE  %s @ %s-%s\n", module_name, spec.version, sha_prefix))
-
-    -- create symlink: output -> staged/<module>/<version-sha>
-    -- output is o/<module>/.staged, staged is o/staged/<module>/<ver>-<sha>
-    fs.rmrf(output)
-    fs.makedirs(output_dir)
-    local stage_o_basename = fs.basename(stage_o)
-    local rel_path = "../" .. stage_o_basename .. "/" .. module_name .. "/" .. version_sha
-    local ok_symlink, symlink_err = fs.symlink(rel_path, output)
-    if not ok_symlink then
-      return nil, "failed to symlink: " .. rel_path .. " -> " .. output .. ": " .. (symlink_err or "unknown error")
-    end
-
-    return true
   end
+  return true
+end
 
-  if proc.is_main() then
-    local ok, err = main(arg[1], arg[2], arg[3], arg[4])
+local function apply_remove(stage_dir: string, remove: {string}): boolean, string
+  for _, file in ipairs(remove) do
+    local file_err = validate_stage_path(file)
+    if file_err then
+      return nil, "remove path invalid: " .. file_err
+    end
+    local file_path = fs.join(stage_dir, file)
+    fs.rmrf(file_path)
+  end
+  return true
+end
+
+local function apply_links(stage_dir: string, links: {string: string}): boolean, string
+  for link, target in pairs(links) do
+    local link_err = validate_stage_path(link)
+    if link_err then
+      return nil, "link path invalid: " .. link_err
+    end
+    local target_err = validate_link_target(target)
+    if target_err then
+      return nil, "link target invalid: " .. target_err
+    end
+    local link_path = fs.join(stage_dir, link)
+    fs.makedirs(fs.dirname(link_path))
+    fs.rmrf(link_path)
+    local ok, err = fs.symlink(target, link_path)
     if not ok then
-      io.stderr:write("error: " .. tostring(err) .. "\n")
-      os.exit(1)
+      return nil, string.format("link %s -> %s failed: %s", link, target, err or "unknown error")
     end
   end
+  return true
+end
 
-  return {
-    validate_stage_path = validate_stage_path,
-    validate_link_target = validate_link_target,
-  }
+local function find_archive(fetch_dir: string, format: string): string, string
+  if format == "binary" or format == "gz" then
+    return fs.join(fetch_dir, "binary")
+  end
+  local extension: string = nil
+  if format == "zip" then
+    extension = ".zip"
+  elseif format == "tar.gz" then
+    extension = ".tar.gz"
+  end
+  local dir0, dir_err = fs.opendir(fetch_dir)
+  if not dir0 then
+    return nil, "failed to open " .. fetch_dir .. ": " .. (dir_err or "unknown error")
+  end
+  local dir = dir0 as fs_types.Dir
+  while true do
+    local name = dir:read()
+    if not name then break end
+    if name ~= "." and name ~= ".." then
+      if not extension or name:sub(-#extension) == extension then
+        return fs.join(fetch_dir, name)
+      end
+    end
+  end
+  return nil, "no archive found in " .. fetch_dir
+end
+
+local function main(version_file: string, platform: string, input: string, output: string): boolean, string
+  if not version_file or not platform or not input or not output then
+    return nil, "usage: stage.lua <version_file> <platform> <input.fetched> <output.staged>"
+  end
+
+  local stage_o = os.getenv("STAGE_O")
+  if not stage_o then
+    return nil, "STAGE_O env var required"
+  end
+
+  local load_ok, spec = pcall(dofile, version_file) as(boolean, VersionSpec)
+  if not load_ok then
+    return nil, "failed to load " .. version_file .. ": " .. tostring(spec)
+  end
+
+  local plat = spec.platforms[platform] or spec.platforms["*"]
+  if not plat then
+    return nil, "unknown platform: " .. platform
+  end
+
+  local format = spec.format or plat.format or "binary"
+  local strip = spec.strip_components or 1
+
+  -- derive module name from output path: o/<module>/.staged
+  local output_dir = fs.dirname(output)
+  local module_name = fs.basename(output_dir)
+
+  -- input is now a directory; find the archive inside
+  local archive, err = find_archive(input, format)
+  if not archive then
+    return nil, err
+  end
+
+  local version_sha = spec.version .. "-" .. plat.sha
+
+  local stage_dir = fs.join(stage_o, module_name, version_sha)
+  local ok_mk, err_mk = fs.makedirs(stage_dir)
+  if not ok_mk then
+    return nil, "makedirs failed for " .. stage_dir .. ": " .. tostring(err_mk)
+  end
+
+  local ok: boolean
+  if format == "zip" then
+    ok, err = extract_and_install(extract_zip, archive, stage_dir, strip, spec.strip_prefix)
+  elseif format == "tar.gz" then
+    ok, err = extract_and_install(extract_targz, archive, stage_dir, strip, spec.strip_prefix)
+  elseif format == "binary" then
+    ok, err = copy_binary(archive, stage_dir, module_name)
+  elseif format == "gz" then
+    ok, err = extract_gz(archive, stage_dir, module_name)
+  else
+    return nil, "unknown format: " .. format
+  end
+
+  if not ok then
+    return nil, err
+  end
+
+  -- apply post-extraction transforms from version.lua
+  if spec.remove then
+    ok, err = apply_remove(stage_dir, spec.remove)
+    if not ok then return nil, err end
+  end
+  if spec.install then
+    ok, err = apply_install(stage_dir, spec.install)
+    if not ok then return nil, err end
+  end
+  if spec.links then
+    ok, err = apply_links(stage_dir, spec.links)
+    if not ok then return nil, err end
+  end
+
+  -- format: STAGE  module @ version-sha_prefix
+  local sha_prefix = plat.sha:sub(1, 7)
+  io.stderr:write(string.format("□ STAGE  %s @ %s-%s\n", module_name, spec.version, sha_prefix))
+
+  -- create symlink: output -> staged/<module>/<version-sha>
+  -- output is o/<module>/.staged, staged is o/staged/<module>/<ver>-<sha>
+  fs.rmrf(output)
+  fs.makedirs(output_dir)
+  local stage_o_basename = fs.basename(stage_o)
+  local rel_path = "../" .. stage_o_basename .. "/" .. module_name .. "/" .. version_sha
+  local ok_symlink, symlink_err = fs.symlink(rel_path, output)
+  if not ok_symlink then
+    return nil, "failed to symlink: " .. rel_path .. " -> " .. output .. ": " .. (symlink_err or "unknown error")
+  end
+
+  return true
+end
+
+if proc.is_main() then
+  local ok, err = main(arg[1], arg[2], arg[3], arg[4])
+  if not ok then
+    io.stderr:write("error: " .. tostring(err) .. "\n")
+    os.exit(1)
+  end
+end
+
+return {
+  validate_stage_path = validate_stage_path,
+  validate_link_target = validate_link_target,
+}

--- a/lib/cosmic/format/rules.tl
+++ b/lib/cosmic/format/rules.tl
@@ -179,7 +179,7 @@ local function is_function_block_opener(line_items: {Item}, func_idx: integer): 
   local second = line_items[2]
   if first and (first.tk == "type"
     or ((first.tk == "local" or first.tk == "global")
-    and second and second.tk == "type")) then
+      and second and second.tk == "type")) then
     return false
   end
   local paren_depth = 0

--- a/lib/cosmic/format/rules.tl
+++ b/lib/cosmic/format/rules.tl
@@ -171,6 +171,17 @@ end
 --- Determine if a `function` keyword is a block-opening function definition
 --- vs a function TYPE annotation.
 local function is_function_block_opener(line_items: {Item}, func_idx: integer): boolean
+  -- `type X = function(...)` (optionally local/global-prefixed) declares a
+  -- function TYPE alias: no body follows, so it never opens a block.
+  -- Without this, everything after such an alias is indented into a
+  -- phantom function body that no `end` ever closes.
+  local first = line_items[1]
+  local second = line_items[2]
+  if first and (first.tk == "type"
+    or ((first.tk == "local" or first.tk == "global")
+    and second and second.tk == "type")) then
+    return false
+  end
   local paren_depth = 0
   for i = func_idx - 1, 1, -1 do
     local item = line_items[i]

--- a/lib/cosmic/fs/walk.tl
+++ b/lib/cosmic/fs/walk.tl
@@ -337,123 +337,123 @@ end
 --- Iterator over file paths, as returned by files().
 local type FileIter = function(): string
 
-  --- Iterate over files matching a pattern.
-  --- Returns an iterator that yields file paths. The fourth return value
-  --- is a to-be-closed guard: a plain `for f in fs.files(dir) do ... end`
-  --- loop adopts it as the loop's closing value (Lua 5.4), so directory
-  --- handles are closed even when the loop exits early via break/error.
-  --- If the root directory cannot be opened, returns nil plus the error —
-  --- iterate the checked value: `for f in assert(fs.files(dir)) as fs.FileIter do`
-  --- (assert passes all four returns through, keeping the closing guard;
-  --- the cast only narrows the type, it does not drop return values).
-  --- @param dir string The directory to search
-  --- @param pattern string Glob pattern (*.lua) - defaults to all files (*)
-  --- @return function | nil Iterator yielding file paths, or nil if the root could not be opened
-  --- @return string Error if the root directory could not be opened
-  --- @return nil Unused (generic-for control slot)
-  --- @return any Closing guard that releases open directory handles
-  local function files(dir: string, pattern?: string): FileIter | nil, string, any, any
-    pattern = pattern or "*"
+--- Iterate over files matching a pattern.
+--- Returns an iterator that yields file paths. The fourth return value
+--- is a to-be-closed guard: a plain `for f in fs.files(dir) do ... end`
+--- loop adopts it as the loop's closing value (Lua 5.4), so directory
+--- handles are closed even when the loop exits early via break/error.
+--- If the root directory cannot be opened, returns nil plus the error —
+--- iterate the checked value: `for f in assert(fs.files(dir)) as fs.FileIter do`
+--- (assert passes all four returns through, keeping the closing guard;
+--- the cast only narrows the type, it does not drop return values).
+--- @param dir string The directory to search
+--- @param pattern string Glob pattern (*.lua) - defaults to all files (*)
+--- @return function | nil Iterator yielding file paths, or nil if the root could not be opened
+--- @return string Error if the root directory could not be opened
+--- @return nil Unused (generic-for control slot)
+--- @return any Closing guard that releases open directory handles
+local function files(dir: string, pattern?: string): FileIter | nil, string, any, any
+  pattern = pattern or "*"
 
-    -- The pattern is always a glob (see collect); no heuristics.
-    local lua_pattern = glob_to_pattern(pattern)
+  -- The pattern is always a glob (see collect); no heuristics.
+  local lua_pattern = glob_to_pattern(pattern)
 
-    -- Stack of (dir, handle) for depth-first traversal
-    local stack: {{string, WalkDirHandle}} = {}
-    local handle, oerr = unix.opendir(dir)
-    if not handle then
-      return nil, errstr(oerr, "opendir: " .. dir)
+  -- Stack of (dir, handle) for depth-first traversal
+  local stack: {{string, WalkDirHandle}} = {}
+  local handle, oerr = unix.opendir(dir)
+  if not handle then
+    return nil, errstr(oerr, "opendir: " .. dir)
+  end
+  table.insert(stack, {dir, handle as WalkDirHandle})
+
+  local function close_all()
+    for i = #stack, 1, -1 do
+      stack[i][2]:close()
+      stack[i] = nil
     end
-    table.insert(stack, {dir, handle as WalkDirHandle})
+  end
+  local guard = setmetatable({}, {__close = close_all, __gc = close_all})
 
-    local function close_all()
-      for i = #stack, 1, -1 do
-        stack[i][2]:close()
-        stack[i] = nil
-      end
-    end
-    local guard = setmetatable({}, {__close = close_all, __gc = close_all})
+  local iter = function(): string
+    -- anchor the guard as an upvalue: a caller that keeps only the
+    -- iterator (dropping the fourth return) must not let the guard's
+    -- __gc close these handles while the iterator is still running
+    local _ = guard
+    while #stack > 0 do
+      local current = stack[#stack]
+      local current_dir = current[1]
+      local current_handle = current[2]
 
-    local iter = function(): string
-      -- anchor the guard as an upvalue: a caller that keeps only the
-      -- iterator (dropping the fourth return) must not let the guard's
-      -- __gc close these handles while the iterator is still running
-      local _ = guard
-      while #stack > 0 do
-        local current = stack[#stack]
-        local current_dir = current[1]
-        local current_handle = current[2]
-
-        local entry, kind = current_handle:read()
-        if not entry then
-          current_handle:close()
-          table.remove(stack)
-        elseif entry ~= "." and entry ~= ".." then
-          local full_path = cosmo_path.join(current_dir, entry)
-          if kind == unix.DT_DIR then
-            -- d_type never follows symlinks, so this is a real directory
-            -- (a symlinked dir reports DT_LNK), and skips a stat(2) call.
-            local subhandle = unix.opendir(full_path)
-            if subhandle then
-              table.insert(stack, {full_path, subhandle as WalkDirHandle})
-            end
-          elseif kind ~= unix.DT_UNKNOWN then
-            -- Definitely not a directory: files() never needs stat data,
-            -- only the path, so just check the pattern without stat(2).
-            if entry:match(lua_pattern) then
-              return full_path
-            end
-          else
-            -- Filesystem doesn't expose d_type; fall back to a real stat,
-            -- using AT_SYMLINK_NOFOLLOW so a symlinked dir reports
-            -- S_ISLNK, not S_ISDIR, preserving the same cycle prevention.
-            local st = unix.stat(full_path, unix.AT_SYMLINK_NOFOLLOW)
-            if st then
-              if unix.S_ISDIR((st as unix.Stat):mode()) then
-                local subhandle = unix.opendir(full_path)
-                if subhandle then
-                  table.insert(stack, {full_path, subhandle as WalkDirHandle})
-                end
-              elseif entry:match(lua_pattern) then
-                return full_path
+      local entry, kind = current_handle:read()
+      if not entry then
+        current_handle:close()
+        table.remove(stack)
+      elseif entry ~= "." and entry ~= ".." then
+        local full_path = cosmo_path.join(current_dir, entry)
+        if kind == unix.DT_DIR then
+          -- d_type never follows symlinks, so this is a real directory
+          -- (a symlinked dir reports DT_LNK), and skips a stat(2) call.
+          local subhandle = unix.opendir(full_path)
+          if subhandle then
+            table.insert(stack, {full_path, subhandle as WalkDirHandle})
+          end
+        elseif kind ~= unix.DT_UNKNOWN then
+          -- Definitely not a directory: files() never needs stat data,
+          -- only the path, so just check the pattern without stat(2).
+          if entry:match(lua_pattern) then
+            return full_path
+          end
+        else
+          -- Filesystem doesn't expose d_type; fall back to a real stat,
+          -- using AT_SYMLINK_NOFOLLOW so a symlinked dir reports
+          -- S_ISLNK, not S_ISDIR, preserving the same cycle prevention.
+          local st = unix.stat(full_path, unix.AT_SYMLINK_NOFOLLOW)
+          if st then
+            if unix.S_ISDIR((st as unix.Stat):mode()) then
+              local subhandle = unix.opendir(full_path)
+              if subhandle then
+                table.insert(stack, {full_path, subhandle as WalkDirHandle})
               end
+            elseif entry:match(lua_pattern) then
+              return full_path
             end
           end
         end
       end
-      return nil
     end
-    return iter, nil, nil, guard
+    return nil
   end
+  return iter, nil, nil, guard
+end
 
-  local record FsWalkModule
-    --- Iterator over file paths, as returned by files().
-    type FileIter = FileIter
+local record FsWalkModule
+  --- Iterator over file paths, as returned by files().
+  type FileIter = FileIter
 
-    --- Visitor verdict: nil continues, "skip" prunes, "stop" ends the walk.
-    type WalkAction = WalkAction
+  --- Visitor verdict: nil continues, "skip" prunes, "stop" ends the walk.
+  type WalkAction = WalkAction
 
-    --- Options for walk() (max_depth).
-    type WalkOptions = WalkOptions
+  --- Options for walk() (max_depth).
+  type WalkOptions = WalkOptions
 
-    --- Walk dir tree. visitor(path, name, st, ctx): path is the FULL path; name is the basename.
-    --- Do NOT join path and name — path is already complete.
-    --- The visitor may return "skip" (don't descend) or "stop" (end the walk).
-    walk: function<T>(dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string
-    glob: function(dir: string, pattern: string): {string} | nil, string
-    collect: function(dir: string, pattern: string): {string} | nil, string
-    collect_matching: function(dir: string, lua_pattern: string): {string} | nil, string
-    collect_all: function(dir: string): {string: FileInfo} | nil, string
-    files: function(dir: string, pattern?: string): FileIter | nil, string, any, any
-  end
+  --- Walk dir tree. visitor(path, name, st, ctx): path is the FULL path; name is the basename.
+  --- Do NOT join path and name — path is already complete.
+  --- The visitor may return "skip" (don't descend) or "stop" (end the walk).
+  walk: function<T>(dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string
+  glob: function(dir: string, pattern: string): {string} | nil, string
+  collect: function(dir: string, pattern: string): {string} | nil, string
+  collect_matching: function(dir: string, lua_pattern: string): {string} | nil, string
+  collect_all: function(dir: string): {string: FileInfo} | nil, string
+  files: function(dir: string, pattern?: string): FileIter | nil, string, any, any
+end
 
-  local M: FsWalkModule = {
-    walk = walk,
-    glob = glob,
-    collect = collect,
-    collect_matching = collect_matching,
-    collect_all = collect_all,
-    files = files,
-  }
+local M: FsWalkModule = {
+  walk = walk,
+  glob = glob,
+  collect = collect,
+  collect_matching = collect_matching,
+  collect_all = collect_all,
+  files = files,
+}
 
-  return M
+return M

--- a/lib/cosmic/re.tl
+++ b/lib/cosmic/re.tl
@@ -223,82 +223,82 @@ end
 --- text and its capture groups; a nil return keeps the match unchanged.
 local type Repl = string | function(string, {string}): string
 
-  --- Replace every non-overlapping match of pattern in text.
-  --- Patterns that can match the empty string are rejected.
-  --- @param pattern string The regex pattern to match
-  --- @param text string The text to operate on
-  --- @param repl Repl A literal replacement string, or function(match, caps)
-  --- @param flags number? Optional compile flags: BASIC, ICASE, NEWLINE
-  --- @return string | nil The result, or nil on error
-  --- @return string? Error message on a bad pattern or engine failure
-  local function gsub(pattern: string, text: string, repl: Repl, flags?: number): string | nil, string
-    local regex, cerr = compile_for_iter(pattern, flags)
-    if not regex then
-      return nil, cerr
-    end
-    local spans, err = all_matches(regex as Regex, text)
-    if not spans then
-      return nil, err
-    end
-    local out: {string} = {}
-    local pos = 1
-    for _, sp in ipairs(spans as {Span}) do
-      out[#out + 1] = text:sub(pos, sp.s - 1)
-      if repl is string then
-        out[#out + 1] = repl
+--- Replace every non-overlapping match of pattern in text.
+--- Patterns that can match the empty string are rejected.
+--- @param pattern string The regex pattern to match
+--- @param text string The text to operate on
+--- @param repl Repl A literal replacement string, or function(match, caps)
+--- @param flags number? Optional compile flags: BASIC, ICASE, NEWLINE
+--- @return string | nil The result, or nil on error
+--- @return string? Error message on a bad pattern or engine failure
+local function gsub(pattern: string, text: string, repl: Repl, flags?: number): string | nil, string
+  local regex, cerr = compile_for_iter(pattern, flags)
+  if not regex then
+    return nil, cerr
+  end
+  local spans, err = all_matches(regex as Regex, text)
+  if not spans then
+    return nil, err
+  end
+  local out: {string} = {}
+  local pos = 1
+  for _, sp in ipairs(spans as {Span}) do
+    out[#out + 1] = text:sub(pos, sp.s - 1)
+    if repl is string then
+      out[#out + 1] = repl
+    else
+      local r = repl(sp.m, sp.caps)
+      if r is string then
+        out[#out + 1] = r
       else
-        local r = repl(sp.m, sp.caps)
-        if r is string then
-          out[#out + 1] = r
-        else
-          out[#out + 1] = sp.m
-        end
+        out[#out + 1] = sp.m
       end
-      pos = sp.e + 1
     end
-    out[#out + 1] = text:sub(pos)
-    return table.concat(out)
+    pos = sp.e + 1
   end
+  out[#out + 1] = text:sub(pos)
+  return table.concat(out)
+end
 
-  local record ReModule
-    -- Exported so callers can name/cast the fallible compile result.
-    type Regex = Regex
-    type Repl = Repl
+local record ReModule
+  -- Exported so callers can name/cast the fallible compile result.
+  type Regex = Regex
+  type Repl = Repl
 
-    -- Functions
-    compile: function(pattern: string, flags?: number): Regex | nil, string
-    search: function(pattern: string, text: string, flags?: number): string | nil, {string} | nil, string | nil
-    test: function(pattern: string, text: string, flags?: number): boolean, string
-    findall: function(pattern: string, text: string, flags?: number): {string} | nil, string
-    split: function(pattern: string, text: string, flags?: number): {string} | nil, string
-    gsub: function(pattern: string, text: string, repl: Repl, flags?: number): string | nil, string
+  -- Functions
+  compile: function(pattern: string, flags?: number): Regex | nil, string
+  search: function(pattern: string, text: string, flags?: number): string | nil, {string} | nil, string | nil
+  test: function(pattern: string, text: string, flags?: number): boolean, string
+  findall: function(pattern: string, text: string, flags?: number): {string} | nil, string
+  split: function(pattern: string, text: string, flags?: number): {string} | nil, string
+  gsub: function(pattern: string, text: string, repl: Repl, flags?: number): string | nil, string
 
-    -- Compile flags
-    BASIC: number -- Use basic (obsolete) regex syntax instead of extended
-    ICASE: number -- Case-insensitive matching
-    NEWLINE: number -- Treat newline as special (affects ^ and $)
-    NOSUB: number -- Report only success/failure, not match position
+  -- Compile flags
+  BASIC: number -- Use basic (obsolete) regex syntax instead of extended
+  ICASE: number -- Case-insensitive matching
+  NEWLINE: number -- Treat newline as special (affects ^ and $)
+  NOSUB: number -- Report only success/failure, not match position
 
-    -- Search flags
-    NOTBOL: number -- First character is not at beginning of line
-    NOTEOL: number -- Last character is not at end of line
-  end
+  -- Search flags
+  NOTBOL: number -- First character is not at beginning of line
+  NOTEOL: number -- Last character is not at end of line
+end
 
-  local M: ReModule = {
-    compile = compile,
-    search = search,
-    test = test,
-    findall = findall,
-    split = split,
-    gsub = gsub,
+local M: ReModule = {
+  compile = compile,
+  search = search,
+  test = test,
+  findall = findall,
+  split = split,
+  gsub = gsub,
 
-    -- Expose flags from cosmo.re
-    BASIC = re.BASIC,
-    ICASE = re.ICASE,
-    NEWLINE = re.NEWLINE,
-    NOSUB = re.NOSUB,
-    NOTBOL = re.NOTBOL,
-    NOTEOL = re.NOTEOL,
-  }
+  -- Expose flags from cosmo.re
+  BASIC = re.BASIC,
+  ICASE = re.ICASE,
+  NEWLINE = re.NEWLINE,
+  NOSUB = re.NOSUB,
+  NOTBOL = re.NOTBOL,
+  NOTEOL = re.NOTEOL,
+}
 
-  return M
+return M

--- a/lib/cosmic/sqlite/bind.tl
+++ b/lib/cosmic/sqlite/bind.tl
@@ -5,15 +5,12 @@
 --- affinity everywhere instead of defaulting to TEXT.
 --- Lives in its own file so cosmic/sqlite.tl stays under the 500-line cap.
 
+local lsqlite3 = require("cosmo.lsqlite3")
+
 --- Marker wrapper produced by `cosmic.sqlite.blob()`. Bind loops detect it
 --- by metatable identity and bind `data` via `bind_blob` instead of `bind`.
 local record Blob
   data: string
-end
-
-local record RawStatement
-  bind: function(self: RawStatement, n: number, value?: any): number
-  bind_blob: function(self: RawStatement, n: number, blob: string): number
 end
 
 -- Identity marker: getmetatable(v) == blob_mt is the only blob test, so a
@@ -35,27 +32,26 @@ local function is_blob(v: any): boolean
 end
 
 --- Bind one positional parameter, routing blob() wrappers to bind_blob.
---- The raw statement is typed `any` so callers don't need a
---- nominally-identical RawStatement type (same convention as
---- sqlite_stmt_cache and sqlite_row_iter).
---- @param raw_stmt_any any The prepared statement to bind into
+--- @param raw_stmt lsqlite3.Statement The prepared statement to bind into
 --- @param i integer 1-based parameter index
 --- @param v any The value (or blob() wrapper) to bind
 --- @return number The sqlite result code from the bind call
-local function bind_at(raw_stmt_any: any, i: integer, v: any): number
-  local raw_stmt = raw_stmt_any as RawStatement
+local function bind_at(raw_stmt: lsqlite3.Statement, i: integer, v: any): number
   if getmetatable(v) == blob_mt as any then
     return raw_stmt:bind_blob(i, (v as Blob).data)
   end
-  return raw_stmt:bind(i, v)
+  return raw_stmt:bind(i, v as string | number | boolean)
 end
 
 local record M
   type Blob = Blob
+  --- Statement release callback shared by stmt_cache (producer) and
+  --- row_iter (consumer) so the two sides name one nominal type.
+  type OnClose = function(lsqlite3.Statement)
 
   blob: function(data: string): Blob
   is_blob: function(v: any): boolean
-  bind_at: function(raw_stmt_any: any, i: integer, v: any): number
+  bind_at: function(raw_stmt: lsqlite3.Statement, i: integer, v: any): number
 end
 
 local mod: M = {

--- a/lib/cosmic/sqlite/init.tl
+++ b/lib/cosmic/sqlite/init.tl
@@ -24,41 +24,9 @@ local bind_mod = require("cosmic.sqlite.bind")
 local params_mod = require("cosmic.sqlite.params")
 local extras_mod = require("cosmic.sqlite.extras")
 
--- Raw lsqlite3 types (0-indexed, requires manual cleanup)
-local record RawStatement
-  bind_values: function(self: RawStatement, ...: any): number
-  bind: function(self: RawStatement, n: number, value?: any): number
-  bind_blob: function(self: RawStatement, n: number, blob: string): number
-  bind_names: function(self: RawStatement, params: {string: any}): number
-  bind_parameter_count: function(self: RawStatement): number
-  step: function(self: RawStatement): number
-  reset: function(self: RawStatement)
-  finalize: function(self: RawStatement): number
-  get_value: function(self: RawStatement, n: number): any
-  columns: function(self: RawStatement): number
-  get_name: function(self: RawStatement, n: number): string
-end
-
-local record RawDatabase
-  close: function(self: RawDatabase): number
-  exec: function(self: RawDatabase, sql: string): number
-  prepare: function(self: RawDatabase, sql: string): RawStatement, number, string
-  busy_timeout: function(self: RawDatabase, milliseconds: number)
-  last_insert_rowid: function(self: RawDatabase): number
-  changes: function(self: RawDatabase): number
-  errmsg: function(self: RawDatabase): string
-end
-
-local record RawSqlite3
-  OK: number
-  ROW: number
-  DONE: number
-  SCHEMA: number
-  OPEN_READONLY: number
-  open: function(filename: string, flags?: number): RawDatabase, number, string
-end
-
-local sqlite3 = lsqlite3 as RawSqlite3
+-- The raw lsqlite3 surface is fully typed since the 2026.07.13 pin;
+-- the wrapper uses the generated types directly (no Raw* mirrors).
+local sqlite3 = lsqlite3
 
 --- Callable row iterator with an out-of-band error channel. Use it in a
 --- `for row in ... do` loop, then call `:err()` afterward to detect a step
@@ -119,7 +87,7 @@ local record Database
   close: function(self: Database)
 end
 
-local function make_statement(raw_stmt: RawStatement, raw_db: RawDatabase): Statement
+local function make_statement(raw_stmt: lsqlite3.Statement, raw_db: lsqlite3.Database): Statement
   local stmt: Statement = {}
   local closed = false
 
@@ -267,22 +235,22 @@ local function make_statement(raw_stmt: RawStatement, raw_db: RawDatabase): Stat
     }) as Statement
 end
 
-local function make_database(raw_db: RawDatabase): Database
+local function make_database(raw_db: lsqlite3.Database): Database
   local db: Database = {}
   local closed = false
 
   -- Reuses prepared statements for db:exec (see cosmic.sqlite.stmt_cache).
-  local stmt_cache = stmt_cache_mod.new(raw_db as any, sqlite3.OK, sqlite3.DONE, sqlite3.ROW, sqlite3.SCHEMA)
+  local stmt_cache = stmt_cache_mod.new(raw_db, sqlite3.OK, sqlite3.DONE, sqlite3.ROW, sqlite3.SCHEMA)
 
   function db:prepare(sql: string): Statement | nil, string
     if closed then
       return nil, "database is closed"
     end
-    local raw_stmt, errcode, errmsg = raw_db:prepare(sql)
+    local raw_stmt = raw_db:prepare(sql)
     if not raw_stmt then
-      return nil, errmsg or ("error code " .. tostring(errcode))
+      return nil, raw_db:errmsg()
     end
-    return make_statement(raw_stmt, raw_db)
+    return make_statement(raw_stmt as lsqlite3.Statement, raw_db)
   end
 
   function db:query(sql: string, ...: any): Rows | nil, string
@@ -296,7 +264,7 @@ local function make_database(raw_db: RawDatabase): Database
     -- Hot path: skip the full Statement object and its per-call closures;
     -- bind and iterate the raw statement directly (see cosmic.sqlite.row_iter).
     local iter, bind_err = row_iter.query(
-      raw_stmt as any, raw_db as any, on_close as any,
+      raw_stmt, raw_db, on_close,
       sqlite3.OK, sqlite3.ROW, sqlite3.DONE, ...)
     if not iter then
       return nil, bind_err
@@ -430,9 +398,9 @@ end
 --- @return Database | nil Database handle with __close support
 --- @return string Error message on failure
 local function open(filename: string, opts?: OpenOptions): Database | nil, string
-  local raw_db: RawDatabase
-  local errcode: number
-  local errmsg: string
+  local raw_db: lsqlite3.Database | nil
+  local errcode: number | nil
+  local errmsg: string | nil
   if opts and opts.read_only then
     raw_db, errcode, errmsg = sqlite3.open(filename, sqlite3.OPEN_READONLY)
   else
@@ -441,12 +409,14 @@ local function open(filename: string, opts?: OpenOptions): Database | nil, strin
   if not raw_db then
     return nil, errmsg or ("error code " .. tostring(errcode))
   end
+  -- records don't flow-narrow; cast once after the guard
+  local dbh = raw_db as lsqlite3.Database
   local timeout_ms = 5000
   if opts and opts.busy_timeout_ms ~= nil then
     timeout_ms = opts.busy_timeout_ms
   end
-  raw_db:busy_timeout(timeout_ms)
-  return make_database(raw_db)
+  dbh:busy_timeout(timeout_ms)
+  return make_database(dbh)
 end
 
 local record sqlite

--- a/lib/cosmic/sqlite/row_iter.tl
+++ b/lib/cosmic/sqlite/row_iter.tl
@@ -6,20 +6,7 @@
 --- Lives in its own file so cosmic/sqlite.tl stays under the 500-line cap.
 
 local bind_mod = require("cosmic.sqlite.bind")
-
-local record RawStatement
-  bind: function(self: RawStatement, n: number, value?: any): number
-  step: function(self: RawStatement): number
-  reset: function(self: RawStatement)
-  finalize: function(self: RawStatement): number
-  get_value: function(self: RawStatement, n: number): any
-  columns: function(self: RawStatement): number
-  get_name: function(self: RawStatement, n: number): string
-end
-
-local record RawDatabase
-  errmsg: function(self: RawDatabase): string
-end
+local lsqlite3 = require("cosmo.lsqlite3")
 
 -- Callable row iterator: `for row in iter do ... end`, then `iter:err()`
 -- surfaces a post-drain step error. Same shape as cosmic.sqlite's Rows.
@@ -35,114 +22,106 @@ end
 
 -- on_close mirrors stmt_cache:checkout — non-nil returns the shared cached
 -- slot when iteration ends; nil means a throwaway statement to finalize.
-local type OnClose = function(RawStatement)
+local type OnClose = bind_mod.OnClose
 
-  --- Build the row iterator over an already-reset+bound raw statement.
-  --- Raw handles are typed `any` so callers don't need nominally-identical
-  --- record types (same convention as sqlite_stmt_cache).
-  --- @param raw_stmt_any any The prepared, bound statement to step
-  --- @param raw_db_any any The owning database (for errmsg)
-  --- @param on_close_any any Release callback, or nil to finalize
-  --- @param row_code number sqlite3.ROW
-  --- @param done_code number sqlite3.DONE
-  --- @return Rows The callable row iterator
-  local function make(raw_stmt_any: any, raw_db_any: any, on_close_any: any, row_code: number, done_code: number): Rows
-    local raw_stmt = raw_stmt_any as RawStatement
-    local raw_db = raw_db_any as RawDatabase
-    local on_close = on_close_any as OnClose
-    local step_err: string
-    local col_count = raw_stmt:columns()
-    local col_names: {integer: string}
-    local first_call = true
-    local done = false
+--- Build the row iterator over an already-reset+bound raw statement.
+--- @param raw_stmt lsqlite3.Statement The prepared, bound statement to step
+--- @param raw_db lsqlite3.Database The owning database (for errmsg)
+--- @param on_close OnClose Release callback, or nil to finalize
+--- @param row_code number sqlite3.ROW
+--- @param done_code number sqlite3.DONE
+--- @return Rows The callable row iterator
+local function make(raw_stmt: lsqlite3.Statement, raw_db: lsqlite3.Database, on_close: OnClose, row_code: number, done_code: number): Rows
+  local step_err: string
+  local col_count = raw_stmt:columns()
+  local col_names: {integer: string}
+  local first_call = true
+  local done = false
 
-    -- Release exactly once: return the shared cached slot, or finalize a
-    -- throwaway. Reached from drain, from close/<close>, and from __gc.
-    local function release()
-      if done then
-        return
-      end
-      done = true
+  -- Release exactly once: return the shared cached slot, or finalize a
+  -- throwaway. Reached from drain, from close/<close>, and from __gc.
+  local function release()
+    if done then
+      return
+    end
+    done = true
+    if on_close then
+      on_close(raw_stmt)
+    else
+      local _ = raw_stmt:finalize()
+    end
+  end
+
+  local iter = setmetatable({} as Rows, {
+      __call = function(_: Rows): {string: any}
+        if done then
+          return nil
+        end
+        local rc = raw_stmt:step()
+        if rc == row_code then
+          -- Column names require step to have run first; resolve once.
+          if first_call then
+            first_call = false
+            col_names = {}
+            for idx = 0, col_count - 1 do
+              col_names[(idx + 1) as integer] = raw_stmt:get_name(idx)
+            end
+          end
+          local row: {string: any} = {}
+          for idx = 0, col_count - 1 do
+            row[col_names[(idx + 1) as integer]] = raw_stmt:get_value(idx)
+          end
+          return row
+        end
+        -- Anything but a clean SQLITE_DONE is a real error to surface.
+        if rc ~= done_code then
+          step_err = raw_db:errmsg()
+        end
+        release()
+        return nil
+      end,
+      __close = function(_: Rows)
+        release()
+      end,
+      __gc = function(_: Rows)
+        release()
+      end,
+    })
+  iter.err = function(_: Rows): string return step_err end
+  iter.close = function(_: Rows)
+    release()
+  end
+  return iter
+end
+
+--- Reset + positional-bind a raw statement, then return its row iterator.
+--- Resets first (even with no args) so a reused cached statement is cleared.
+--- On a bind failure the statement is released and (nil, message) returned.
+--- @param raw_stmt lsqlite3.Statement The checked-out statement
+--- @param raw_db lsqlite3.Database The owning database (for errmsg)
+--- @param on_close OnClose Release callback, or nil to finalize
+--- @param ok_code number sqlite3.OK
+--- @param row_code number sqlite3.ROW
+--- @param done_code number sqlite3.DONE
+--- @param ... any Positional bind parameters
+--- @return Rows | nil The row iterator, or nil on bind failure
+--- @return string Error message when binding failed
+local function query(raw_stmt: lsqlite3.Statement, raw_db: lsqlite3.Database, on_close: OnClose, ok_code: number, row_code: number, done_code: number, ...: any): Rows | nil, string
+  raw_stmt:reset()
+  local n = select("#", ...) as integer
+  for i = 1, n do
+    local rc = bind_mod.bind_at(raw_stmt, i, (select(i, ...)))
+    if rc ~= ok_code then
+      local bind_err = raw_db:errmsg()
       if on_close then
         on_close(raw_stmt)
       else
         local _ = raw_stmt:finalize()
       end
+      return nil, "bind failed: " .. (bind_err or "unknown error")
     end
-
-    local iter = setmetatable({} as Rows, {
-        __call = function(_: Rows): {string: any}
-          if done then
-            return nil
-          end
-          local rc = raw_stmt:step()
-          if rc == row_code then
-            -- Column names require step to have run first; resolve once.
-            if first_call then
-              first_call = false
-              col_names = {}
-              for idx = 0, col_count - 1 do
-                col_names[(idx + 1) as integer] = raw_stmt:get_name(idx)
-              end
-            end
-            local row: {string: any} = {}
-            for idx = 0, col_count - 1 do
-              row[col_names[(idx + 1) as integer]] = raw_stmt:get_value(idx)
-            end
-            return row
-          end
-          -- Anything but a clean SQLITE_DONE is a real error to surface.
-          if rc ~= done_code then
-            step_err = raw_db:errmsg()
-          end
-          release()
-          return nil
-        end,
-        __close = function(_: Rows)
-          release()
-        end,
-        __gc = function(_: Rows)
-          release()
-        end,
-      })
-    iter.err = function(_: Rows): string return step_err end
-    iter.close = function(_: Rows)
-      release()
-    end
-    return iter
   end
+  return make(raw_stmt, raw_db, on_close, row_code, done_code)
+end
 
-  --- Reset + positional-bind a raw statement, then return its row iterator.
-  --- Resets first (even with no args) so a reused cached statement is cleared.
-  --- On a bind failure the statement is released and (nil, message) returned.
-  --- @param raw_stmt_any any The checked-out statement
-  --- @param raw_db_any any The owning database (for errmsg)
-  --- @param on_close_any any Release callback, or nil to finalize
-  --- @param ok_code number sqlite3.OK
-  --- @param row_code number sqlite3.ROW
-  --- @param done_code number sqlite3.DONE
-  --- @param ... any Positional bind parameters
-  --- @return Rows | nil The row iterator, or nil on bind failure
-  --- @return string Error message when binding failed
-  local function query(raw_stmt_any: any, raw_db_any: any, on_close_any: any, ok_code: number, row_code: number, done_code: number, ...: any): Rows | nil, string
-    local raw_stmt = raw_stmt_any as RawStatement
-    local raw_db = raw_db_any as RawDatabase
-    local on_close = on_close_any as OnClose
-    raw_stmt:reset()
-    local n = select("#", ...) as integer
-    for i = 1, n do
-      local rc = bind_mod.bind_at(raw_stmt, i, (select(i, ...)))
-      if rc ~= ok_code then
-        local bind_err = raw_db:errmsg()
-        if on_close then
-          on_close(raw_stmt)
-        else
-          local _ = raw_stmt:finalize()
-        end
-        return nil, "bind failed: " .. (bind_err or "unknown error")
-      end
-    end
-    return make(raw_stmt, raw_db, on_close, row_code, done_code)
-  end
-
-  return {make = make, query = query}
+return {make = make, query = query}

--- a/lib/cosmic/sqlite/stmt_cache.tl
+++ b/lib/cosmic/sqlite/stmt_cache.tl
@@ -4,137 +4,128 @@
 --- and finalizing a fresh one every time.
 
 local bind_mod = require("cosmic.sqlite.bind")
+local lsqlite3 = require("cosmo.lsqlite3")
 
-local record RawStatement
-  bind: function(self: RawStatement, n: number, value?: any): number
-  step: function(self: RawStatement): number
-  reset: function(self: RawStatement)
-  finalize: function(self: RawStatement): number
+-- Named alias (shared through cosmic.sqlite.bind) so a function-typed
+-- return value never appears as an inline literal in a multi-return
+-- signature: that trips a bootstrap-compiler formatter bug.
+local type OnClose = bind_mod.OnClose
+
+local record StmtCache
+  exec: function(self: StmtCache, sql: string, args: {integer: any}, n: integer): boolean, string
+  checkout: function(self: StmtCache, sql: string): lsqlite3.Statement | nil, OnClose, string
+  close_all: function(self: StmtCache)
 end
 
-local record RawDatabase
-  prepare: function(self: RawDatabase, sql: string): RawStatement, number, string
-  errmsg: function(self: RawDatabase): string
-end
+--- Create a statement cache bound to a raw database handle.
+--- @param raw_db lsqlite3.Database The database to prepare against
+--- @param ok_code number lsqlite3.OK
+--- @param done_code number lsqlite3.DONE
+--- @param row_code number lsqlite3.ROW
+--- @param schema_code number lsqlite3.SCHEMA
+--- @return StmtCache
+local function new(raw_db: lsqlite3.Database, ok_code: number, done_code: number, row_code: number, schema_code: number): StmtCache
+  local cache: {string: lsqlite3.Statement} = {}
+  -- Separate from `cache`: a query's statement stays alive for the life
+  -- of its Rows iterator (unlike exec's synchronous prepare-bind-step),
+  -- so it needs its own pool plus a checked-out flag per SQL text.
+  local query_cache: {string: lsqlite3.Statement} = {}
+  local checked_out: {string: boolean} = {}
+  local self: StmtCache = {}
 
--- Named alias so a function-typed return value never appears as an inline
--- literal in a multi-return signature: writing that out inline trips a
--- bootstrap-compiler formatter bug (mis-indents everything after it).
-local type OnClose = function(RawStatement)
-
-  local record StmtCache
-    exec: function(self: StmtCache, sql: string, args: {integer: any}, n: integer): boolean, string
-    checkout: function(self: StmtCache, sql: string): RawStatement | nil, OnClose, string
-    close_all: function(self: StmtCache)
+  local function get(sql: string): lsqlite3.Statement, string
+    local cached = cache[sql]
+    if cached then
+      return cached
+    end
+    local raw_stmt = raw_db:prepare(sql)
+    if not raw_stmt then
+      return nil, raw_db:errmsg()
+    end
+    local stmt = raw_stmt as lsqlite3.Statement
+    cache[sql] = stmt
+    return stmt
   end
 
-  --- Create a statement cache bound to a raw database handle.
-  --- @param raw_db_any any The lsqlite3 database handle to prepare against
-  --- (typed `any` so callers don't need a nominally-identical RawDatabase type)
-  --- @param ok_code number lsqlite3.OK
-  --- @param done_code number lsqlite3.DONE
-  --- @param row_code number lsqlite3.ROW
-  --- @param schema_code number lsqlite3.SCHEMA
-  --- @return StmtCache
-  local function new(raw_db_any: any, ok_code: number, done_code: number, row_code: number, schema_code: number): StmtCache
-    local raw_db = raw_db_any as RawDatabase
-    local cache: {string: RawStatement} = {}
-    -- Separate from `cache`: a query's statement stays alive for the life
-    -- of its Rows iterator (unlike exec's synchronous prepare-bind-step),
-    -- so it needs its own pool plus a checked-out flag per SQL text.
-    local query_cache: {string: RawStatement} = {}
-    local checked_out: {string: boolean} = {}
-    local self: StmtCache = {}
-
-    local function get(sql: string): RawStatement, string
-      local cached = cache[sql]
-      if cached then
-        return cached
-      end
-      local raw_stmt, errcode, errmsg = raw_db:prepare(sql)
-      if not raw_stmt then
-        return nil, errmsg or ("error code " .. tostring(errcode))
-      end
-      cache[sql] = raw_stmt
-      return raw_stmt
-    end
-
-    local function bind_and_step(raw_stmt: RawStatement, args: {integer: any}, n: integer): number
-      raw_stmt:reset()
-      for i = 1, n do
-        local rc = bind_mod.bind_at(raw_stmt, i, args[i])
-        if rc ~= ok_code then
-          return rc
-        end
-      end
-      return raw_stmt:step()
-    end
-
-    --- Finalize every cached statement, e.g. when the owning database closes.
-    self.close_all = function(_: StmtCache)
-      for sql, raw_stmt in pairs(cache) do
-        local _ = raw_stmt:finalize()
-        cache[sql] = nil
-      end
-      for sql, raw_stmt in pairs(query_cache) do
-        local _ = raw_stmt:finalize()
-        query_cache[sql] = nil
+  local function bind_and_step(raw_stmt: lsqlite3.Statement, args: {integer: any}, n: integer): number
+    raw_stmt:reset()
+    for i = 1, n do
+      local rc = bind_mod.bind_at(raw_stmt, i, args[i])
+      if rc ~= ok_code then
+        return rc
       end
     end
+    return raw_stmt:step()
+  end
 
-    --- Check out a statement for db:query, preparing and caching one if this
-    --- SQL text hasn't been queried yet. Returns (statement, on_close):
-    --- on_close is non-nil when the statement is the shared cached one —
-    --- the caller must call it (instead of finalizing) when its Rows
-    --- iterator finishes, to return the slot. When the cached slot for
-    --- this SQL is already checked out by an unfinished query
-    --- (nested/interleaved queries for the same SQL text), a fresh
-    --- throwaway statement is prepared instead and on_close is nil — the
-    --- caller finalizes it itself, same as an uncached prepare.
-    function self:checkout(sql: string): RawStatement | nil, OnClose, string
-      local cached = query_cache[sql]
-      if cached and not checked_out[sql] then
-        checked_out[sql] = true
-        return cached, function(_: RawStatement) checked_out[sql] = nil end
-      end
-      local raw_stmt, errcode, errmsg = raw_db:prepare(sql)
-      if not raw_stmt then
-        return nil, nil, errmsg or ("error code " .. tostring(errcode))
-      end
-      if not cached then
-        query_cache[sql] = raw_stmt
-        checked_out[sql] = true
-        return raw_stmt, function(_: RawStatement) checked_out[sql] = nil end
-      end
-      return raw_stmt, nil
+  --- Finalize every cached statement, e.g. when the owning database closes.
+  self.close_all = function(_: StmtCache)
+    for sql, raw_stmt in pairs(cache) do
+      local _ = raw_stmt:finalize()
+      cache[sql] = nil
     end
+    for sql, raw_stmt in pairs(query_cache) do
+      local _ = raw_stmt:finalize()
+      query_cache[sql] = nil
+    end
+  end
 
-    --- Execute a parameterized statement once, reusing (or preparing and
-    --- caching) the statement for `sql`. On SQLITE_SCHEMA, drops the stale
-    --- statement and retries once (sqlite3 already retries internally
-    --- before surfacing SCHEMA, so a second failure is a real error).
-    function self:exec(sql: string, args: {integer: any}, n: integer): boolean, string
-      local raw_stmt, err = get(sql)
+  --- Check out a statement for db:query, preparing and caching one if this
+  --- SQL text hasn't been queried yet. Returns (statement, on_close):
+  --- on_close is non-nil when the statement is the shared cached one —
+  --- the caller must call it (instead of finalizing) when its Rows
+  --- iterator finishes, to return the slot. When the cached slot for
+  --- this SQL is already checked out by an unfinished query
+  --- (nested/interleaved queries for the same SQL text), a fresh
+  --- throwaway statement is prepared instead and on_close is nil — the
+  --- caller finalizes it itself, same as an uncached prepare.
+  function self:checkout(sql: string): lsqlite3.Statement | nil, OnClose, string
+    local cached = query_cache[sql]
+    if cached and not checked_out[sql] then
+      checked_out[sql] = true
+      return cached, function(_: lsqlite3.Statement) checked_out[sql] = nil end
+    end
+    local raw_stmt = raw_db:prepare(sql)
+    if not raw_stmt then
+      return nil, nil, raw_db:errmsg()
+    end
+    -- prepare is Statement | nil once the pin carries the honest
+    -- annotation; records don't flow-narrow, so cast after the guard.
+    local stmt = raw_stmt as lsqlite3.Statement
+    if not cached then
+      query_cache[sql] = stmt
+      checked_out[sql] = true
+      return stmt, function(_: lsqlite3.Statement) checked_out[sql] = nil end
+    end
+    return stmt, nil
+  end
+
+  --- Execute a parameterized statement once, reusing (or preparing and
+  --- caching) the statement for `sql`. On SQLITE_SCHEMA, drops the stale
+  --- statement and retries once (sqlite3 already retries internally
+  --- before surfacing SCHEMA, so a second failure is a real error).
+  function self:exec(sql: string, args: {integer: any}, n: integer): boolean, string
+    local raw_stmt, err = get(sql)
+    if not raw_stmt then
+      return false, err
+    end
+    local rc = bind_and_step(raw_stmt, args, n)
+    if rc == schema_code then
+      cache[sql] = nil
+      local _ = raw_stmt:finalize()
+      raw_stmt, err = get(sql)
       if not raw_stmt then
         return false, err
       end
-      local rc = bind_and_step(raw_stmt, args, n)
-      if rc == schema_code then
-        cache[sql] = nil
-        local _ = raw_stmt:finalize()
-        raw_stmt, err = get(sql)
-        if not raw_stmt then
-          return false, err
-        end
-        rc = bind_and_step(raw_stmt, args, n)
-      end
-      if rc ~= done_code and rc ~= row_code then
-        return false, raw_db:errmsg()
-      end
-      return true
+      rc = bind_and_step(raw_stmt, args, n)
     end
-
-    return self
+    if rc ~= done_code and rc ~= row_code then
+      return false, raw_db:errmsg()
+    end
+    return true
   end
 
-  return {new = new}
+  return self
+end
+
+return {new = new}


### PR DESCRIPTION
Fixes #638 (spun out of #637; audit tracker #632).

Since the 2026.07.13 pin, `lsqlite3.Statement`/`Database` are fully typed, so the nominal mirror records and `any`-boundaries in `cosmic.sqlite`'s helpers can go:

- **`init`/`bind`/`row_iter`/`stmt_cache` use the generated types directly.** Every `raw_*_any: any` parameter is typed, the `as Raw*` casts are gone, and `init.tl` drops all three mirror records (26 references). The only `as any` left in the module is `bind.tl`'s metatable-identity blob test. (`params.tl` is untouched — its mirrors are of cosmic's *own* records, a different boundary.)
- **`OnClose` lives once** in `cosmic.sqlite.bind`, shared by producer (`stmt_cache`) and consumer (`row_iter`) — previously two nominally-distinct aliases that only type-checked because everything crossed through `any`.
- **Real error messages for prepare failures.** The mirror declared a third `errmsg` return that `db_prepare` never produces (C returns `nil, errcode`), so failures degraded to `"error code N"`. Failures now report `db:errmsg()`. The annotation is fixed upstream in whilp/cosmopolitan#181, and the call shape here is already compatible with that honest `Statement | nil` signature — the next pin bump needs no further sqlite changes.
- **Formatter bug fix (found by this refactor):** `is_function_block_opener` treated a `type X = function(...)` alias as a function-literal block opener, silently forcing a phantom extra indent level on everything after it — the long-standing "bootstrap-compiler formatter bug" noted in `stmt_cache`. Fixed with a statement-head `type` guard; `fs/walk.tl` and `lib/build/build-stage.tl` are reformatted to the corrected canonical style (whitespace-only — verified the add/remove line multisets differ only by the intended sqlite changes).

## Verification

`bin/make ci` green (format + teal + test + example + lint + coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p)_