### PR TITLE
types: adopt generated enums in ip/zip/fetch; bump pin for honest prepare

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "e310863816dff2630f6e90a1b7c4ed51a7b82bd9e7fdb5603f7b9308a2e43dad"}},
+  platforms = {["*"] = {sha = "98c5a286d897ebfa00e5259a2da38cec1ffb53a5c07d5bad93c364b822b7282e"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.13-e6040de22"
+  version = "2026.07.13-89007e6eb"
 }

--- a/lib/cosmic/fetch/init.tl
+++ b/lib/cosmic/fetch/init.tl
@@ -179,7 +179,10 @@ local function to_fetch_options(opts?: Options): cosmo.FetchOptions
   return fo
 end
 
-local function fail(err: any, kind: any): Result
+-- kind is the raw failure kind from cosmo.Fetch (its dual-shape third
+-- return is statically string); fetch's ErrorKind is a superset
+-- (adds "tls"/"too_large"), so the enum conversion is a checked cast.
+local function fail(err: any, kind: string): Result
   return setmetatable({
       ok = false,
       error = tostring(err or "unknown error"),
@@ -388,7 +391,9 @@ local function make_reader(raw_reader: cosmo.StreamReader): Reader
     }) as Reader
 end
 
-local function stream_fail(err: any, kind: any): StreamResult
+-- kind mirrors fail()'s: FetchStream's dual-shape third return is
+-- statically StreamReader (it carries the kind string on failure).
+local function stream_fail(err: any, kind: string | cosmo.StreamReader): StreamResult
   return setmetatable({
       ok = false,
       error = tostring(err or "unknown error"),

--- a/lib/cosmic/ip.tl
+++ b/lib/cosmic/ip.tl
@@ -11,27 +11,7 @@ local cosmo = require("cosmo")
 --- Category of an IPv4 address, as reported by categorize().
 --- LOOPBACK/PRIVATE/TESTNET/MULTICAST are special-use ranges; the rest
 --- name the registry or organization the block is delegated to.
-local enum Category
-  "MULTICAST"
-  "LOOPBACK"
-  "PRIVATE"
-  "TESTNET"
-  "AFRINIC"
-  "LACNIC"
-  "APNIC"
-  "ARIN"
-  "RIPE"
-  "DOD"
-  "AT&T"
-  "APPLE"
-  "FORD"
-  "COGENT"
-  "PRUDENTIAL"
-  "USPS"
-  "COMCAST"
-  "FUTURE"
-  "ANONYMOUS"
-end
+local type Category = cosmo.IpCategory
 
 --- Address family. IPv4 only today; IPv6 (whilp/cosmopolitan#144) adds
 --- "inet6" as a value, leaving every Addr-taking signature unchanged.
@@ -76,7 +56,7 @@ local function addr_format(self: Addr): string
 end
 
 local function addr_categorize(self: Addr): Category
-  return cosmo.CategorizeIp(self._n) as Category
+  return cosmo.CategorizeIp(self._n)
 end
 
 local function addr_is_loopback(self: Addr): boolean

--- a/lib/cosmic/zip.tl
+++ b/lib/cosmic/zip.tl
@@ -19,7 +19,7 @@ end
 --- Options for adding a file to a ZIP archive.
 local record AddOptions
   --- Compression method: "store" (no compression) or "deflate" (compressed).
-  method: string
+  method: zip.CompressionMethod
   --- Modification time as Unix timestamp.
   mtime: number
   --- Unix file mode/permissions (default 0644).

--- a/lib/types/cosmo/lsqlite3.d.tl
+++ b/lib/types/cosmo/lsqlite3.d.tl
@@ -172,7 +172,7 @@ local record Database
   --- used for all further method calls in connection with this specific SQL
   --- statement.
   --- See https://lua.sqlite.org/home/doc/tip/doc/lsqlite3.wiki#methods_for_prepared_statements for details.
-  prepare: function(self: Database, sql: string): Statement
+  prepare: function(self: Database, sql: string): Statement | nil, string | ResultCode
   --- Returns `true` if the database `name` of connection `db` is read-only,
   --- `false` if it is read/write. Returns `nil` plus an error message if
   --- `name` is not the name of a database on connection `db`.


### PR DESCRIPTION
Final cleanup wave of the type-system audit (#632).

## Wrapper adoptions

- **ip**: the wrapper's 19-member `Category` enum duplicated the generated `cosmo.IpCategory` member-for-member. It's now a type re-export (`local type Category = cosmo.IpCategory`), and the `CategorizeIp` result flows through without a cast — the public `ip.Category` name is unchanged.
- **zip**: `AddOptions.method` is `zip.CompressionMethod`, so a typo'd compression method is caught at cosmic call sites instead of a runtime "invalid method".
- **fetch**: `fail()` takes `kind: string` and `stream_fail()` takes `kind: string | cosmo.StreamReader` instead of `any` — the raw kind is the dual-shape third return of `Fetch`/`FetchStream` (statically `string`/`StreamReader`, carrying the kind on failure). `fetch.ErrorKind` deliberately stays its own enum: it's a strict superset of the generated `FetchErrorKind` (adds `"tls"`, `"too_large"`), so the one `as ErrorKind` conversion cast remains and is documented.

## Pin bump

`2026.07.13-89007e6eb` (whilp/cosmopolitan#181, annotation-only delta). The regen changes exactly **one** generated line — `Database:prepare` is now honestly `Statement | nil, string | ResultCode` — and the sqlite wrappers from #639 were already written for that shape, so nothing else moves.

## Verification

`bin/make ci` green (format + teal + test incl. gentype drift vs the new pin + example + lint + coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p)_