### PR TITLE
types: total maps for enum-keyed dispatch

### DIFF
--- a/lib/cosmic/fetch/init.tl
+++ b/lib/cosmic/fetch/init.tl
@@ -179,9 +179,8 @@ local function to_fetch_options(opts?: Options): cosmo.FetchOptions
   return fo
 end
 
--- kind is the raw failure kind from cosmo.Fetch (its dual-shape third
--- return is statically string); fetch's ErrorKind is a superset
--- (adds "tls"/"too_large"), so the enum conversion is a checked cast.
+-- kind is cosmo.Fetch's dual-shape third return (statically string);
+-- fetch's ErrorKind is a superset, so the enum conversion is a cast.
 local function fail(err: any, kind: string): Result
   return setmetatable({
       ok = false,
@@ -219,7 +218,18 @@ end
 local IDEMPOTENT: {string: boolean} = {
   GET = true, HEAD = true, OPTIONS = true, PUT = true, DELETE = true, TRACE = true,
 }
-local RETRYABLE_KIND: {string: boolean} = {dns = true, connect = true, timeout = true}
+-- <total>: every ErrorKind must take an explicit retry-or-not position;
+-- adding a kind without deciding is a compile error.
+local RETRYABLE_KIND < total >: {ErrorKind: boolean} = {
+  dns = true,
+  connect = true,
+  tls = false,
+  timeout = true,
+  proxy = false,
+  protocol = false,
+  too_large = false,
+  blocked = false,
+}
 local RETRYABLE_STATUS: {integer: boolean} = {[429] = true, [502] = true, [503] = true, [504] = true}
 
 --- Default retry policy: transport blips (dns/connect/timeout) and

--- a/lib/cosmic/hash.tl
+++ b/lib/cosmic/hash.tl
@@ -36,7 +36,7 @@ end
 -- resolves names case-insensitively and knows a few extra legacy
 -- digests (MD2, MD4), so this wrapper-side check is load-bearing:
 -- it keeps the runtime surface identical to the Algo enum.
-local valid_algos: {string: boolean} = {
+local valid_algos < total >: {Algo: boolean} = {
   sha256 = true,
   sha512 = true,
   sha384 = true,

--- a/lib/cosmic/quicksand/proxy/serve.tl
+++ b/lib/cosmic/quicksand/proxy/serve.tl
@@ -67,7 +67,9 @@ local record ServeModule
   new: function(opts: ProxyOptions): Server | nil, string
 end
 
-local LEVELS: {string: integer} = {quiet = 0, info = 1, debug = 2}
+-- <total>: adding a LogLevel member without deciding its threshold is a
+-- compile error, not a silent fallthrough to the `or 1` default.
+local LEVELS < total >: {qtypes.LogLevel: integer} = {quiet = 0, info = 1, debug = 2}
 
 local function ts(): string
   local s, ns = unix.clock_gettime(unix.CLOCK_REALTIME)


### PR DESCRIPTION
Second of the four Teal-feature adoption PRs (audit tracker #632 follow-ups).

`<total>` (Teal 0.24) makes an enum-keyed map declare a value for **every** member — verified to fail compilation naming the missing key. Growing an enum without deciding each dispatch site becomes a compile error instead of a silent fallthrough:

- **`quicksand.proxy` `LEVELS`** → `{LogLevel: integer} <total>`: a new log level must pick its verbosity threshold (previously fell through to the `or 1` default).
- **`fetch` `RETRYABLE_KIND`** → `{ErrorKind: boolean} <total>`: every failure kind takes an explicit retry-or-not position — `tls`/`proxy`/`protocol`/`too_large`/`blocked` are now explicit `false` where they were implicit absences.
- **`hash` `valid_algos`** → `{Algo: boolean} <total>`: this map's entire purpose (per its own comment) is staying identical to the `Algo` enum; the checker now enforces that instead of asking maintainers to remember.

No runtime behavior changes — every entry's value is what the old lookup already produced.

## Verification

`bin/make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p)_