### PR TITLE
coverage: is-narrowing for the AST walker; teach is-dispatch for json

### DIFF
--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -39,7 +39,7 @@
 10	lib/cosmic/coverage/init.tl
 1	lib/cosmic/coverage/init_example.tl
 8	lib/cosmic/coverage/init_test.tl
-15	lib/cosmic/coverage/lines.tl
+11	lib/cosmic/coverage/lines.tl
 1	lib/cosmic/coverage/lines_test.tl
 5	lib/cosmic/coverage/report.tl
 9	lib/cosmic/coverage/report_test.tl

--- a/lib/cosmic/coverage/lines.tl
+++ b/lib/cosmic/coverage/lines.tl
@@ -73,21 +73,20 @@ local function walk(node: {any: any}, seen: {any: boolean}, out: {integer: boole
   seen[node] = true
   if node["kind"] == "statements" then
     for _, child in ipairs(node as {any}) do
-      if type(child) == "table" then
-        mark_statement(child as {any: any}, out)
+      if child is {any: any} then
+        mark_statement(child, out)
       end
     end
   end
   for _, v in pairs(node) do
-    if type(v) == "table" then
-      local t = v as {any: any}
-      if t["kind"] then
-        walk(t, seen, out)
+    if v is {any: any} then
+      if v["kind"] then
+        walk(v, seen, out)
       else
         -- kindless container (e.g. the if_blocks array): walk node elements
         for _, e in ipairs(v as {any}) do
-          if type(e) == "table" and (e as {any: any})["kind"] then
-            walk(e as {any: any}, seen, out)
+          if e is {any: any} and e["kind"] then
+            walk(e, seen, out)
           end
         end
       end

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -38,20 +38,28 @@ local data = json.decode(input)
 for _, item in ipairs(data) do  -- error: attempting ipairs on something that's not an array: <any type>
 ```
 
-**right:**
+**right — `is` when the shape is uncertain** (narrows in the positive
+branch, compiles to one `type()` check, and untrusted input that isn't
+the expected shape takes the other branch instead of misbehaving later):
 ```teal
-local data = json.decode(input) as {any}         -- cast to array
-for _, raw in ipairs(data) do
-  local item = raw as {string: any}              -- cast each element
-  print(item["name"] as string)
+local data = json.decode(input)
+if data is {any} then
+  for _, raw in ipairs(data) do
+    if raw is {string: any} then
+      print(raw["name"] as string)
+    end
+  end
 end
 ```
 
-for nested maps use chained casts:
+**right — `as` when the shape is trusted** (a schema you control):
 ```teal
 local obj = json.decode(input) as {string: any}
 local tags = obj["tags"] as {string}
 ```
+
+new casts count against the cast ratchet (`lib/build/casts.txt`); prefer
+the `is` form where the code branches anyway.
 
 ## 3. `arg` elements are `string | nil`
 


### PR DESCRIPTION
Third of the four Teal-feature adoption PRs (audit tracker #632 follow-ups).

The original plan was `where`-discriminated unions in the doc module, but the survey showed the doc records live in separate typed lists — there's no tagged union to discriminate, and inventing one would be worse. The genuine fit for `is`-dispatch is dynamic-value traversal:

- **`coverage/lines.tl`** — the Teal AST walker's `type(v) == "table"` checks each dragged a cast behind them; `v is {any: any}` is the *same* runtime test with the narrowing done by the checker. Four casts gone (15 → 11, pinned by the freshly-live cast ratchet from #641 — this PR is its first locked-in improvement).
- **`skills/cosmic/gotchas.md`** — the "traversing `any` from json.decode" gotcha now teaches both shapes: `is` when the input shape is untrusted (a wrong shape takes the other branch instead of misbehaving later), `as` when the schema is yours, with a pointer to the ratchet.

No runtime behavior changes — `is {any: any}` compiles to exactly the `type() == "table"` test it replaces.

## Verification

`bin/make ci` green, including the ratchet at the new lower pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p)_