### PR TITLE
check: eq/ne are generic over the compared type

### DIFF
--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -11,7 +11,7 @@
 11	lib/cosmic/benchmark_test.tl
 25	lib/cosmic/binary_test.tl
 3	lib/cosmic/check.tl
-2	lib/cosmic/check_assertions_test.tl
+3	lib/cosmic/check_assertions_test.tl
 2	lib/cosmic/check_test.tl
 11	lib/cosmic/child/init.tl
 9	lib/cosmic/child/init_example.tl

--- a/lib/cosmic/check.tl
+++ b/lib/cosmic/check.tl
@@ -46,10 +46,13 @@ end
 --- Assert deep equality between actual and expected.
 --- Uses deep comparison for tables, == for all other types.
 --- Throws with a formatted message when the assertion fails.
---- @param actual any The value produced by the code under test
---- @param expected any The value it should equal
+--- Generic over the compared type: comparing values of different types
+--- (a Stat against a string, a number against a boolean) fails at
+--- check time instead of always-unequal at runtime.
+--- @param actual T The value produced by the code under test
+--- @param expected T The value it should equal
 --- @param label string? Optional label prepended to the failure message
-local function eq(actual: any, expected: any, label?: string)
+local function eq<T>(actual: T, expected: T, label?: string)
   if deep_eq(actual, expected) then
     return
   end
@@ -64,10 +67,10 @@ end
 --- Assert that actual and expected are NOT equal.
 --- Uses deep comparison for tables, == for all other types.
 --- Throws with a formatted message when the assertion fails.
---- @param actual any The value produced by the code under test
---- @param expected any The value it should not equal
+--- @param actual T The value produced by the code under test
+--- @param expected T The value it should not equal
 --- @param label string? Optional label prepended to the failure message
-local function ne(actual: any, expected: any, label?: string)
+local function ne<T>(actual: T, expected: T, label?: string)
   if not deep_eq(actual, expected) then
     return
   end
@@ -152,8 +155,8 @@ local function enforced(label: string)
 end
 
 local record CheckModule
-  eq: function(actual: any, expected: any, label?: string)
-  ne: function(actual: any, expected: any, label?: string)
+  eq: function<T>(actual: T, expected: T, label?: string)
+  ne: function<T>(actual: T, expected: T, label?: string)
   ok: function(value: any, label?: string)
   err: function(value: any, e: string, label?: string)
   enforcing: function(): boolean

--- a/lib/cosmic/check_assertions_test.tl
+++ b/lib/cosmic/check_assertions_test.tl
@@ -110,7 +110,9 @@ end
 test_ne_strings()
 
 local function test_ne_different_types()
-  check.ne(1, "1")
+  -- eq/ne are generic, so a cross-type comparison is normally a
+  -- check-time error; cast to keep exercising the runtime behavior.
+  check.ne(1 as any, "1")
   check.ne(nil, false)
 end
 test_ne_different_types()


### PR DESCRIPTION
Last of the four Teal-feature adoption PRs (audit tracker #632 follow-ups).

`check.eq<T>(actual: T, expected: T)` / `check.ne<T>` make a cross-type comparison — a `Stat` against a string, a number against a boolean — a **check-time** error instead of an assertion that can only ever fail (or for `ne`, vacuously pass) at runtime. No runtime change: the implementations still deep-compare.

Every existing call site across the 7 consuming test files type-checked unchanged except one: `test_ne_different_types` deliberately compares `1` against `"1"` to pin the runtime behavior — it keeps doing so through an explicit `1 as any` cast, with the cast ratchet pin raised for that file (2 → 3), which is precisely the deliberate-exception workflow #641 prescribes.

On bounded generics (`<T is Interface>`): surveyed, verified working, and left unadopted for now — no existing signature genuinely benefits (the stream helpers that would want them don't exist yet). Worth reaching for when such helpers appear, not worth inventing API to showcase.

## Verification

`bin/make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4cfGeopNPLwryRisNUc6p)_