### PR TITLE
log: add cosmic.log leveled logging battery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,7 @@ all modules are under `lib/cosmic/` and imported as `cosmic.*`:
 | fd | file descriptor I/O: open/wrap handles, pipes |
 | ip | IP address parsing, formatting, classification |
 | json | JSON encode/decode |
+| log | leveled logging to stderr with key=value fields |
 | net | TCP/UDP/Unix sockets |
 | poll | poll(2) wrapper for I/O multiplexing |
 | proc | current process: pid, exec, resource usage |

--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -104,6 +104,7 @@
 24	lib/cosmic/landlock.tl
 1	lib/cosmic/landlock_example.tl
 6	lib/cosmic/landlock_test.tl
+1	lib/cosmic/log_test.tl
 2	lib/cosmic/make.tl
 29	lib/cosmic/net/connect_test.tl
 10	lib/cosmic/net/init.tl

--- a/lib/cosmic/log.tl
+++ b/lib/cosmic/log.tl
@@ -1,0 +1,208 @@
+--- Leveled logging.
+--- A small structured logger for scripts and services: four severity
+--- levels, a module-wide threshold, and optional key=value fields per
+--- line. Lines go to stderr by default; redirect with set_output (for
+--- tests, or to ship lines elsewhere). For writing to the system log
+--- daemon instead, see cosmic.syslog.
+---
+--- Example usage:
+---   local log = require("cosmic.log")
+---   log.info("server started", {port = 8080})
+---   log.set_level("debug")
+---   log.debug("cache miss", {key = "user:42"})
+---
+--- Line format: `<iso8601-utc> <LEVEL> <message> <key=value ...>` with
+--- fields sorted by key so output is deterministic. Logging is
+--- infallible: emitters return nothing and never throw; a message
+--- below the threshold costs one map lookup and no formatting.
+---
+--- The initial threshold is "info", or the value of the
+--- COSMIC_LOG_LEVEL environment variable when it names a valid level.
+---
+--- Reserved names: log.with(fields): Logger (a child logger carrying
+--- context fields) and log.new(options): Logger (independent logger
+--- instances) are reserved for a post-stable battery. Do not reuse
+--- these names for anything else.
+local env = require("cosmic.env")
+local time = require("cosmic.time")
+
+--- Severity levels accepted by set_level and log, in increasing
+--- order of severity.
+local enum Level
+  "debug"
+  "info"
+  "warn"
+  "error"
+end
+
+-- Numeric severity for threshold comparison. Total over Level so the
+-- checker proves every enum value ranks.
+local severity < total >: {Level: number} = {
+  debug = 1,
+  info = 2,
+  warn = 3,
+  error = 4,
+}
+
+-- Uppercase tags, padded to a fixed width so messages align.
+local tag < total >: {Level: string} = {
+  debug = "DEBUG",
+  info = "INFO ",
+  warn = "WARN ",
+  error = "ERROR",
+}
+
+local current: Level = "info"
+do
+  local initial = env.get("COSMIC_LOG_LEVEL")
+  if initial == "debug" or initial == "info"
+  or initial == "warn" or initial == "error" then
+    current = initial
+  end
+end
+
+local function write_stderr(line: string)
+  io.stderr:write(line .. "\n")
+end
+
+local output: function(line: string) = write_stderr
+
+--- Render one field value for a key=value pair. Strings that contain
+--- whitespace, quotes, or "=" are quoted with %q so lines stay
+--- unambiguous; everything else is tostring'd.
+local function render_value(v: any): string
+  if v is string then
+    if string.find(v, "[%s\"=]") then
+      return string.format("%q", v)
+    end
+    return v
+  end
+  return tostring(v)
+end
+
+--- Format a log line without emitting it. Exposed so custom outputs
+--- and tests can reuse the exact format. The timestamp is the current
+--- UTC time in ISO 8601; fields are rendered sorted by key.
+--- @param level Level The severity level
+--- @param message string The log message
+--- @param fields {string:any}? Optional key=value context fields
+--- @return string The formatted line, without a trailing newline
+local function format(level: Level, message: string, fields?: {string: any}): string
+  local ts = time.format_iso8601((time.now())) or "?"
+  local parts: {string} = {ts, tag[level], message}
+  if fields then
+    local keys: {string} = {}
+    for k in pairs(fields) do
+      keys[#keys + 1] = k
+    end
+    table.sort(keys)
+    for _, k in ipairs(keys) do
+      parts[#parts + 1] = k .. "=" .. render_value(fields[k])
+    end
+  end
+  return table.concat(parts, " ")
+end
+
+--- Log a message at the given level. Suppressed (at the cost of one
+--- table lookup) when the level ranks below the current threshold.
+--- @param level Level The severity level
+--- @param message string The log message
+--- @param fields {string:any}? Optional key=value context fields
+local function log(level: Level, message: string, fields?: {string: any})
+  if severity[level] < severity[current] then
+    return
+  end
+  output(format(level, message, fields))
+end
+
+--- Log a debug message (suppressed unless the threshold is "debug").
+--- @param message string The log message
+--- @param fields {string:any}? Optional key=value context fields
+local function debug_msg(message: string, fields?: {string: any})
+  log("debug", message, fields)
+end
+
+--- Log an informational message.
+--- @param message string The log message
+--- @param fields {string:any}? Optional key=value context fields
+local function info(message: string, fields?: {string: any})
+  log("info", message, fields)
+end
+
+--- Log a warning message.
+--- @param message string The log message
+--- @param fields {string:any}? Optional key=value context fields
+local function warn(message: string, fields?: {string: any})
+  log("warn", message, fields)
+end
+
+--- Log an error message.
+--- @param message string The log message
+--- @param fields {string:any}? Optional key=value context fields
+local function error_msg(message: string, fields?: {string: any})
+  log("error", message, fields)
+end
+
+--- Set the minimum level that gets emitted. The Level enum checks
+--- literals statically; runtime strings smuggled in through casts get
+--- false, err rather than corrupting the threshold (never throw from
+--- library code).
+--- @param level Level The new threshold
+--- @return boolean True when the threshold was set
+--- @return string? Error message when the level is not a valid Level
+local function set_level(level: Level): boolean, string
+  if not severity[level] then
+    return false, "unknown log level: " .. tostring(level)
+    .. " (expected debug, info, warn, or error)"
+  end
+  current = level
+  return true
+end
+
+--- Get the current minimum level.
+--- @return Level The current threshold
+local function level(): Level
+  return current
+end
+
+--- Redirect where formatted lines go. The function receives each line
+--- without a trailing newline. Call with no argument to restore the
+--- default stderr output.
+--- @param out function(line: string)? The new output, or nil for stderr
+local function set_output(out?: function(line: string))
+  if out then
+    output = out
+  else
+    output = write_stderr
+  end
+end
+
+local record LogModule
+  type Level = Level
+
+  log: function(level: Level, message: string, fields?: {string: any})
+  debug: function(message: string, fields?: {string: any})
+  info: function(message: string, fields?: {string: any})
+  warn: function(message: string, fields?: {string: any})
+  error: function(message: string, fields?: {string: any})
+
+  format: function(level: Level, message: string, fields?: {string: any}): string
+  set_level: function(level: Level): boolean, string
+  level: function(): Level
+  set_output: function(out?: function(line: string))
+end
+
+local M: LogModule = {
+  log = log,
+  debug = debug_msg,
+  info = info,
+  warn = warn,
+  error = error_msg,
+
+  format = format,
+  set_level = set_level,
+  level = level,
+  set_output = set_output,
+}
+
+return M

--- a/lib/cosmic/log_example.tl
+++ b/lib/cosmic/log_example.tl
@@ -1,0 +1,48 @@
+--- Examples for the cosmic.log module.
+--- Demonstrates leveled logging with key=value fields, thresholds,
+--- and output redirection. Examples capture lines with set_output so
+--- their printed output is deterministic (real timestamps vary).
+
+-- Example_info demonstrates the most common call: a message plus
+-- key=value context fields, emitted at the default "info" threshold.
+local function Example_info()
+  local log = require("cosmic.log")
+  log.set_output(function(line: string)
+      -- drop the timestamp so the example output is stable
+      print((line:gsub("^%S+ ", "")))
+    end)
+  log.info("server started", {port = 8080, tls = false})
+  log.set_output()
+  -- Output:
+  -- INFO  server started port=8080 tls=false
+end
+
+-- Example_threshold demonstrates level filtering: debug lines are
+-- suppressed until the threshold is lowered with set_level.
+local function Example_threshold()
+  local log = require("cosmic.log")
+  log.set_output(function(line: string)
+      print((line:gsub("^%S+ ", "")))
+    end)
+  log.set_level("info")
+  log.debug("cache miss")
+  log.set_level("debug")
+  log.debug("cache miss", {key = "user:42"})
+  log.set_level("info")
+  log.set_output()
+  -- Output:
+  -- DEBUG cache miss key=user:42
+end
+
+-- Example_format demonstrates formatting a line without emitting it,
+-- for feeding cosmic.log's format into another sink.
+local function Example_format()
+  local log = require("cosmic.log")
+  local line = log.format("warn", "disk almost full", {pct = 93})
+  print((line:gsub("^%S+ ", "")))
+  -- Output:
+  -- WARN  disk almost full pct=93
+end
+
+-- Suppress unused warnings for examples
+local _ = {Example_info, Example_threshold, Example_format}

--- a/lib/cosmic/log_test.tl
+++ b/lib/cosmic/log_test.tl
@@ -1,0 +1,137 @@
+--- Tests for cosmic.log.
+local log = require("cosmic.log")
+
+-- Capture emitted lines instead of writing to stderr. Every test
+-- resets the capture buffer and pins the threshold it needs, so tests
+-- stay independent of COSMIC_LOG_LEVEL in the environment.
+local captured: {string} = {}
+log.set_output(function(line: string)
+    captured[#captured + 1] = line
+  end)
+
+local function reset(level: log.Level)
+  captured = {}
+  assert(log.set_level(level))
+end
+
+local iso_pattern < const > = "^%d%d%d%d%-%d%d%-%d%dT%d%d:%d%d:%d%dZ "
+
+local function test_default_threshold_suppresses_debug()
+  reset("info")
+  log.debug("hidden")
+  log.info("visible")
+  assert(#captured == 1, "expected 1 line, got " .. tostring(#captured))
+  assert(captured[1]:find("visible", 1, true), "got: " .. captured[1])
+end
+
+local function test_line_format()
+  reset("info")
+  log.info("server started")
+  local line = captured[1]
+  assert(line:match(iso_pattern), "no ISO timestamp: " .. line)
+  assert(line:find("INFO  server started", 1, true), "got: " .. line)
+end
+
+local function test_level_tags()
+  reset("debug")
+  log.debug("d")
+  log.info("i")
+  log.warn("w")
+  log.error("e")
+  assert(#captured == 4, "expected 4 lines, got " .. tostring(#captured))
+  assert(captured[1]:find("DEBUG d", 1, true), "got: " .. captured[1])
+  assert(captured[2]:find("INFO  i", 1, true), "got: " .. captured[2])
+  assert(captured[3]:find("WARN  w", 1, true), "got: " .. captured[3])
+  assert(captured[4]:find("ERROR e", 1, true), "got: " .. captured[4])
+end
+
+local function test_error_threshold_suppresses_warn()
+  reset("error")
+  log.debug("hidden")
+  log.info("hidden")
+  log.warn("hidden")
+  log.error("visible")
+  assert(#captured == 1, "expected 1 line, got " .. tostring(#captured))
+  assert(captured[1]:find("ERROR visible", 1, true), "got: " .. captured[1])
+end
+
+local function test_fields_sorted_by_key()
+  reset("info")
+  log.info("req", {zebra = 1, alpha = "ok", middle = true})
+  local line = captured[1]
+  assert(line:find("req alpha=ok middle=true zebra=1", 1, true), "got: " .. line)
+end
+
+local function test_field_values_quoted_when_ambiguous()
+  reset("info")
+  log.info("m", {
+      plain = "bare",
+      spaced = "two words",
+      eq = "k=v",
+      n = 42,
+      b = false,
+    })
+  local line = captured[1]
+  assert(line:find("plain=bare", 1, true), "got: " .. line)
+  assert(line:find('spaced="two words"', 1, true), "got: " .. line)
+  assert(line:find('eq="k=v"', 1, true), "got: " .. line)
+  assert(line:find("n=42", 1, true), "got: " .. line)
+  assert(line:find("b=false", 1, true), "got: " .. line)
+end
+
+local function test_generic_log_function()
+  reset("info")
+  log.log("warn", "generic", {code = 7})
+  assert(#captured == 1, "expected 1 line, got " .. tostring(#captured))
+  assert(captured[1]:find("WARN  generic code=7", 1, true), "got: " .. captured[1])
+end
+
+local function test_level_getter_tracks_set_level()
+  reset("info")
+  assert(log.level() == "info", "got: " .. log.level())
+  assert(log.set_level("warn"))
+  assert(log.level() == "warn", "got: " .. log.level())
+end
+
+local function test_set_level_rejects_runtime_garbage()
+  reset("info")
+  local ok, err = log.set_level("verbose" as log.Level)
+  assert(not ok, "expected rejection")
+  assert(err and err:find("unknown log level: verbose", 1, true),
+    "got: " .. tostring(err))
+  assert(log.level() == "info", "threshold corrupted: " .. log.level())
+end
+
+local function test_format_does_not_emit()
+  reset("info")
+  local line = log.format("error", "standalone", {id = 3})
+  assert(#captured == 0, "format emitted a line")
+  assert(line:match(iso_pattern), "no ISO timestamp: " .. line)
+  assert(line:find("ERROR standalone id=3", 1, true), "got: " .. line)
+end
+
+local function test_set_output_restores_stderr_default()
+  reset("info")
+  -- Restoring the default must not raise; emitting afterwards writes
+  -- to stderr (visible in test output on failure) rather than the
+  -- capture buffer.
+  log.set_output()
+  log.debug("suppressed, goes nowhere")
+  log.set_output(function(line: string)
+      captured[#captured + 1] = line
+    end)
+  log.info("captured again")
+  assert(#captured == 1, "expected 1 line, got " .. tostring(#captured))
+end
+
+test_default_threshold_suppresses_debug()
+test_line_format()
+test_level_tags()
+test_error_threshold_suppresses_warn()
+test_fields_sorted_by_key()
+test_field_values_quoted_when_ambiguous()
+test_generic_log_function()
+test_level_getter_tracks_set_level()
+test_set_level_rejects_runtime_garbage()
+test_format_does_not_emit()
+test_set_output_restores_stderr_default()

--- a/lib/cosmic/public.tl
+++ b/lib/cosmic/public.tl
@@ -40,6 +40,7 @@ local public: {string} = {
   "ip",
   "json",
   "landlock",
+  "log",
   "net",
   "pledge",
   "poll",


### PR DESCRIPTION
First Wave-2 battery from #500 (`cosmic.log`, P1) — the start of a short PR series working through the pure-Teal battery checklist.

## What's here

- **`lib/cosmic/log.tl`** — a small structured logger:
  - four levels (`debug`/`info`/`warn`/`error`) with a module-wide threshold; below-threshold calls cost one map lookup and no formatting
  - line format `<iso8601-utc> <LEVEL> <message> <key=value ...>`, fields sorted by key for deterministic output; string values containing whitespace/quotes/`=` are `%q`-quoted
  - `set_level` validates runtime strings (cast-smuggled garbage gets `false, err`, never a corrupted threshold); initial threshold seeded from `COSMIC_LOG_LEVEL` when valid
  - `format()` exposed separately from emission for custom sinks; `set_output()` redirects lines (tests use this), no-arg call restores stderr
  - `log.with(fields)` / `log.new(options)` reserved by name for a post-stable child-logger battery, per the hash.tl reserved-name convention
- **`log_test.tl`** — 11 tests: threshold filtering at every level, line format, field sorting/quoting, runtime rejection of invalid levels, `format()` non-emission, output restore
- **`log_example.tl`** — 3 runnable `Example_*` functions with deterministic output
- **`public.tl`** manifest entry + CLAUDE.md module-table row

## Verification

- `bin/make ci` green end-to-end (format, teal, test, example, lint, coverage ratchet), exit 0
- `log.tl` coverage 97.3% (72/74; the two missing lines are the env-seed fallback branch and the raw stderr writer)

## Series plan (issue #500)

1. **this PR** — `cosmic.log`
2. `cosmic.table` — deep copy/merge/eq, map/filter/reduce
3. `cosmic.cli` — declarative arg parsing over getopt
4. `cosmic.ansi` — terminal styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dtDAf7nZRaxmnerATvRVm

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtDAf7nZRaxmnerATvRVm)_