### PR TITLE
table: add cosmic.table deep-ops and list-transform battery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,6 +293,7 @@ all modules are under `lib/cosmic/` and imported as `cosmic.*`:
 | string | trim, split, capitalize, starts_with, etc. |
 | sys | OS/architecture detection, sysconf (nproc, page size), uname |
 | syslog | system logging |
+| table | deep copy/merge/equality and map/filter/reduce for tables |
 | teal | Teal compilation and type checking |
 | testrun | test execution and reporting |
 | time | timestamps, sleep, clock, datetime |

--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -178,6 +178,8 @@
 2	lib/cosmic/string_test.tl
 3	lib/cosmic/sys.tl
 4	lib/cosmic/sys_test.tl
+5	lib/cosmic/table_example.tl
+8	lib/cosmic/table_test.tl
 3	lib/cosmic/teal.tl
 8	lib/cosmic/testrun.tl
 26	lib/cosmic/time.tl

--- a/lib/cosmic/public.tl
+++ b/lib/cosmic/public.tl
@@ -14,6 +14,9 @@
 --- remaining stdlib-colliding names, recorded so this never re-opens:
 --- `string` collides but the entrenched `str` binding convention avoids
 --- the shadow and the module is a strict superset-by-addition — keep;
+--- `table` (added by #500's battery wave) collides likewise, the `tbl`
+--- binding convention avoids the shadow, and its surface (deep_*,
+--- map/filter/reduce) is disjoint from the stdlib's — keep;
 --- `require` is already internal; `env`, `time`, and the rest carry no
 --- Lua global collision — keep.
 local public: {string} = {
@@ -57,6 +60,7 @@ local public: {string} = {
   "string",
   "sys",
   "syslog",
+  "table",
   "teal",
   "testrun",
   "time",

--- a/lib/cosmic/table.tl
+++ b/lib/cosmic/table.tl
@@ -1,0 +1,189 @@
+--- Table utilities.
+--- Deep operations (copy, merge, structural equality) for nested
+--- tables, and the classic list transforms (map, filter, reduce) with
+--- generic types. All functions are pure: inputs are never mutated,
+--- and the deep operations return results that share no tables with
+--- their arguments. All functions are infallible.
+---
+--- The module name collides with Lua's `table` global; bind it as
+--- `tbl` (the convention used throughout this codebase, like `str`
+--- for cosmic.string) so the stdlib stays reachable.
+---
+--- Example usage:
+---   local tbl = require("cosmic.table")
+---   local copy = tbl.deep_copy(config)
+---   local merged = tbl.deep_merge(defaults, overrides)
+---   local squares = tbl.map({1, 2, 3}, function(n: number): number
+---     return n * n
+---   end)
+---
+--- Deep-operation semantics, frozen here so they never re-open:
+--- deep_copy copies table keys and values recursively and preserves
+--- shared references and cycles within the input; metatables are NOT
+--- copied or attached — the result is plain tables. deep_eq compares
+--- structurally (same key sets, deep-equal values); table-valued keys
+--- are matched by identity, not structure. deep_merge recurses where
+--- both sides hold tables and lets the override win otherwise —
+--- array-like tables therefore merge by index like any other key
+--- (an override list does not truncate a longer base list).
+---
+--- Reserved names: keys, values, contains, invert, and group_by are
+--- reserved for a post-stable battery. Do not reuse these names for
+--- anything else.
+
+--- Recursive copy. seen maps input tables to their copies so shared
+--- references stay shared and cycles terminate.
+local function copy_impl(v: any, seen: {any: any}): any
+  if v is {any: any} then
+    local hit = seen[v]
+    if hit ~= nil then
+      return hit
+    end
+    local out: {any: any} = {}
+    seen[v] = out
+    for k, val in pairs(v) do
+      out[copy_impl(k, seen)] = copy_impl(val, seen)
+    end
+    return out
+  end
+  return v
+end
+
+--- Deep-copy a value. Tables are copied recursively (keys included);
+--- shared references and cycles in the input are preserved in the
+--- copy. Metatables are not copied: the result is plain tables.
+--- Non-table values are returned as-is.
+--- @param value any The value to copy
+--- @return any A copy sharing no tables with the input
+local function deep_copy(value: any): any
+  return copy_impl(value, {})
+end
+
+--- Structural equality. seen maps visited a-tables to the b-table
+--- they are being compared against, so cyclic inputs terminate: a
+--- pair already under comparison is assumed equal.
+local function eq_impl(a: any, b: any, seen: {any: any}): boolean
+  if a == b then
+    return true
+  end
+  if a is {any: any} and b is {any: any} then
+    if seen[a] == b then
+      return true
+    end
+    seen[a] = b
+    local count = 0
+    for k, av in pairs(a) do
+      count = count + 1
+      if not eq_impl(av, b[k], seen) then
+        return false
+      end
+    end
+    for _ in pairs(b) do
+      count = count - 1
+    end
+    return count == 0
+  end
+  return false
+end
+
+--- Compare two values for deep structural equality: equal scalars, or
+--- tables with the same key sets and deep-equal values. Table-valued
+--- keys are matched by identity, not structurally. Handles cyclic
+--- inputs without looping.
+--- @param a any First value
+--- @param b any Second value
+--- @return boolean True when a and b are structurally equal
+local function deep_eq(a: any, b: any): boolean
+  return eq_impl(a, b, {})
+end
+
+local function merge_impl(base: {any: any}, override: {any: any}): {any: any}
+  local out: {any: any} = {}
+  for k, v in pairs(base) do
+    out[k] = copy_impl(v, {})
+  end
+  for k, v in pairs(override) do
+    local prev = out[k]
+    if prev is {any: any} and v is {any: any} then
+      out[k] = merge_impl(prev, v)
+    else
+      out[k] = copy_impl(v, {})
+    end
+  end
+  return out
+end
+
+--- Recursively merge two tables into a new one. Where both sides
+--- hold tables the merge recurses; otherwise the override value wins.
+--- Neither input is mutated and the result shares no tables with
+--- either. Array-like tables merge by index like any other key: an
+--- override list replaces base elements position by position but does
+--- not truncate a longer base list.
+--- @param base {any:any} The base table (defaults)
+--- @param override {any:any} The overriding table (wins on conflict)
+--- @return {any:any} A new deeply-merged table
+local function deep_merge(base: {any: any}, override: {any: any}): {any: any}
+  return merge_impl(base, override)
+end
+
+--- Transform each element of a list, returning a new list of the
+--- results in the same order. The input is not mutated.
+--- @param list {T} The input list
+--- @param fn function(T): U Transform applied to each element
+--- @return {U} A new list of transformed elements
+local function map<T, U>(list: {T}, fn: function(T): U): {U}
+  local out: {U} = {}
+  for i, v in ipairs(list) do
+    out[i] = fn(v)
+  end
+  return out
+end
+
+--- Keep the elements of a list for which the predicate returns true,
+--- preserving order. The input is not mutated.
+--- @param list {T} The input list
+--- @param fn function(T): boolean Predicate deciding which elements stay
+--- @return {T} A new list of the elements that passed
+local function filter<T>(list: {T}, fn: function(T): boolean): {T}
+  local out: {T} = {}
+  for _, v in ipairs(list) do
+    if fn(v) then
+      out[#out + 1] = v
+    end
+  end
+  return out
+end
+
+--- Fold a list into a single value, left to right, starting from
+--- init. An empty list returns init unchanged.
+--- @param list {T} The input list
+--- @param fn function(A, T): A Combiner of the accumulator and each element
+--- @param init A The initial accumulator value
+--- @return A The final accumulator
+local function reduce<T, A>(list: {T}, fn: function(A, T): A, init: A): A
+  local acc = init
+  for _, v in ipairs(list) do
+    acc = fn(acc, v)
+  end
+  return acc
+end
+
+local record TableModule
+  deep_copy: function(value: any): any
+  deep_eq: function(a: any, b: any): boolean
+  deep_merge: function(base: {any: any}, override: {any: any}): {any: any}
+  map: function<T, U>(list: {T}, fn: function(T): U): {U}
+  filter: function<T>(list: {T}, fn: function(T): boolean): {T}
+  reduce: function<T, A>(list: {T}, fn: function(A, T): A, init: A): A
+end
+
+local M: TableModule = {
+  deep_copy = deep_copy,
+  deep_eq = deep_eq,
+  deep_merge = deep_merge,
+  map = map,
+  filter = filter,
+  reduce = reduce,
+}
+
+return M

--- a/lib/cosmic/table_example.tl
+++ b/lib/cosmic/table_example.tl
@@ -1,0 +1,57 @@
+--- Examples for the cosmic.table module.
+--- Demonstrates deep copy/merge/equality and the map/filter/reduce
+--- list transforms. Bind the module as `tbl` so Lua's `table` global
+--- stays reachable.
+
+-- Example_deep_merge demonstrates layering overrides onto defaults:
+-- nested tables merge recursively, scalars are replaced.
+local function Example_deep_merge()
+  local tbl = require("cosmic.table")
+  local defaults: {string: any} = {
+    host = "localhost",
+    limits = {mem = 64, cpu = 1},
+  }
+  local overrides: {string: any} = {
+    limits = {mem = 128},
+    debug = true,
+  }
+  local config = tbl.deep_merge(defaults, overrides)
+  print((config.limits as {string: any}).mem,
+    (config.limits as {string: any}).cpu, config.debug)
+  -- Output:
+  -- 128	1	true
+end
+
+-- Example_deep_copy demonstrates that copies are fully independent:
+-- mutating the copy leaves the original untouched.
+local function Example_deep_copy()
+  local tbl = require("cosmic.table")
+  local original: {string: any} = {settings = {theme = "dark"}}
+  local copy = tbl.deep_copy(original) as {string: any}
+  local copy_settings = copy.settings as {string: any}
+  copy_settings.theme = "light"
+  print((original.settings as {string: any}).theme)
+  -- Output:
+  -- dark
+end
+
+-- Example_map_filter_reduce demonstrates chaining the list
+-- transforms: square the numbers, keep the even squares, sum them.
+local function Example_map_filter_reduce()
+  local tbl = require("cosmic.table")
+  local squares = tbl.map({1, 2, 3, 4}, function(n: number): number
+      return n * n
+    end)
+  local even = tbl.filter(squares, function(n: number): boolean
+      return n % 2 == 0
+    end)
+  local sum = tbl.reduce(even, function(acc: number, n: number): number
+      return acc + n
+    end, 0)
+  print(sum)
+  -- Output:
+  -- 20
+end
+
+-- Suppress unused warnings for examples
+local _ = {Example_deep_merge, Example_deep_copy, Example_map_filter_reduce}

--- a/lib/cosmic/table_test.tl
+++ b/lib/cosmic/table_test.tl
@@ -1,0 +1,192 @@
+--- Tests for cosmic.table.
+local tbl = require("cosmic.table")
+
+-- deep_copy
+
+local function test_deep_copy_is_independent()
+  local orig: {string: any} = {a = 1, nested = {b = {2, 3}}}
+  local copy = tbl.deep_copy(orig) as {string: any}
+  assert(tbl.deep_eq(orig, copy), "copy differs from original")
+  local copy_nested = copy.nested as {string: any}
+  copy_nested.b = "mutated"
+  assert(tbl.deep_eq((orig.nested as {string: any}).b, {2, 3}),
+    "mutating the copy leaked into the original")
+end
+
+local function test_deep_copy_passes_scalars_through()
+  assert(tbl.deep_copy(42) == 42)
+  assert(tbl.deep_copy("s") == "s")
+  assert(tbl.deep_copy(nil) == nil)
+  assert(tbl.deep_copy(true) == true)
+end
+
+local function test_deep_copy_preserves_cycles()
+  local orig: {string: any} = {name = "root"}
+  orig.self = orig
+  local copy = tbl.deep_copy(orig) as {string: any}
+  assert(copy.self == copy, "cycle not preserved")
+  assert(copy ~= orig, "copy is the original")
+  assert(copy.name == "root")
+end
+
+local function test_deep_copy_preserves_shared_references()
+  local shared: {number} = {1}
+  local orig: {string: any} = {x = shared, y = shared}
+  local copy = tbl.deep_copy(orig) as {string: any}
+  assert(copy.x == copy.y, "shared reference duplicated")
+  assert(copy.x ~= shared, "shared table not copied")
+end
+
+local function test_deep_copy_copies_table_keys()
+  local key: {string: string} = {id = "k"}
+  local orig: {any: any} = {[key] = "v"}
+  local copy = tbl.deep_copy(orig) as {any: any}
+  assert(copy[key] == nil, "table key was not copied")
+  local found = false
+  for k, v in pairs(copy) do
+    assert(tbl.deep_eq(k, key), "copied key differs")
+    assert(v == "v")
+    found = true
+  end
+  assert(found, "copied table is empty")
+end
+
+-- deep_eq
+
+local function test_deep_eq_nested()
+  assert(tbl.deep_eq({a = {1, {2}}, b = "x"}, {a = {1, {2}}, b = "x"}))
+  assert(not tbl.deep_eq({a = {1, {2}}}, {a = {1, {3}}}))
+end
+
+local function test_deep_eq_key_sets_must_match()
+  assert(not tbl.deep_eq({a = 1}, {a = 1, b = 2}), "extra key in b")
+  assert(not tbl.deep_eq({a = 1, b = 2}, {a = 1}), "extra key in a")
+  assert(tbl.deep_eq({}, {}), "empty tables differ")
+end
+
+local function test_deep_eq_scalars_and_mixed()
+  assert(tbl.deep_eq(1, 1))
+  assert(not tbl.deep_eq(1, "1"))
+  assert(not tbl.deep_eq({1}, 1))
+  assert(not tbl.deep_eq(nil, {}))
+end
+
+local function test_deep_eq_handles_cycles()
+  local a: {string: any} = {v = 1}
+  a.self = a
+  local b: {string: any} = {v = 1}
+  b.self = b
+  assert(tbl.deep_eq(a, b), "equal cyclic tables compared unequal")
+  local c: {string: any} = {v = 2}
+  c.self = c
+  assert(not tbl.deep_eq(a, c), "unequal cyclic tables compared equal")
+end
+
+-- deep_merge
+
+local function test_deep_merge_recurses_and_overrides()
+  local base: {string: any} = {
+    host = "localhost",
+    limits = {mem = 64, cpu = 1},
+  }
+  local override: {string: any} = {
+    limits = {mem = 128},
+    debug = true,
+  }
+  local merged = tbl.deep_merge(base, override)
+  assert(tbl.deep_eq(merged, {
+        host = "localhost",
+        limits = {mem = 128, cpu = 1},
+        debug = true,
+      }), "unexpected merge result")
+end
+
+local function test_deep_merge_override_wins_on_type_conflict()
+  local merged = tbl.deep_merge({a = {nested = true}}, {a = "flat"})
+  assert(tbl.deep_eq(merged, {a = "flat"}))
+  local merged2 = tbl.deep_merge({a = "flat"}, {a = {nested = true}})
+  assert(tbl.deep_eq(merged2, {a = {nested = true}}))
+end
+
+local function test_deep_merge_mutates_neither_input()
+  local base: {string: any} = {limits = {mem = 64}}
+  local override: {string: any} = {limits = {cpu = 2}}
+  local merged = tbl.deep_merge(base, override)
+  assert(tbl.deep_eq(base, {limits = {mem = 64}}), "base mutated")
+  assert(tbl.deep_eq(override, {limits = {cpu = 2}}), "override mutated")
+  local merged_limits = merged.limits as {string: any}
+  merged_limits.mem = 999
+  assert((base.limits as {string: any}).mem == 64,
+    "merge result shares tables with base")
+end
+
+local function test_deep_merge_arrays_merge_by_index()
+  local merged = tbl.deep_merge({list = {1, 2, 3}}, {list = {9}})
+  assert(tbl.deep_eq(merged, {list = {9, 2, 3}}),
+    "documented by-index array semantics changed")
+end
+
+-- map / filter / reduce
+
+local function test_map()
+  local out = tbl.map({1, 2, 3}, function(n: number): number
+      return n * n
+    end)
+  assert(tbl.deep_eq(out, {1, 4, 9}))
+  local strs = tbl.map({1, 2}, function(n: number): string
+      return "#" .. tostring(n)
+    end)
+  assert(tbl.deep_eq(strs, {"#1", "#2"}))
+end
+
+local function test_filter()
+  local out = tbl.filter({1, 2, 3, 4, 5}, function(n: number): boolean
+      return n % 2 == 0
+    end)
+  assert(tbl.deep_eq(out, {2, 4}))
+end
+
+local function test_reduce()
+  local sum = tbl.reduce({1, 2, 3, 4}, function(acc: number, n: number): number
+      return acc + n
+    end, 0)
+  assert(sum == 10, "got: " .. tostring(sum))
+  local joined = tbl.reduce({"a", "b"}, function(acc: string, s: string): string
+      return acc .. s
+    end, "")
+  assert(joined == "ab", "got: " .. joined)
+end
+
+local function test_map_filter_reduce_empty_list()
+  assert(tbl.deep_eq(tbl.map({}, function(n: number): number return n end), {}))
+  assert(tbl.deep_eq(tbl.filter({}, function(_: number): boolean return true end), {}))
+  local acc = tbl.reduce({}, function(a: number, n: number): number return a + n end, 7)
+  assert(acc == 7, "reduce of empty list changed init")
+end
+
+local function test_inputs_not_mutated_by_list_transforms()
+  local input = {3, 1, 2}
+  tbl.map(input, function(n: number): number return -n end)
+  tbl.filter(input, function(n: number): boolean return n > 1 end)
+  tbl.reduce(input, function(a: number, n: number): number return a + n end, 0)
+  assert(tbl.deep_eq(input, {3, 1, 2}), "a transform mutated its input")
+end
+
+test_deep_copy_is_independent()
+test_deep_copy_passes_scalars_through()
+test_deep_copy_preserves_cycles()
+test_deep_copy_preserves_shared_references()
+test_deep_copy_copies_table_keys()
+test_deep_eq_nested()
+test_deep_eq_key_sets_must_match()
+test_deep_eq_scalars_and_mixed()
+test_deep_eq_handles_cycles()
+test_deep_merge_recurses_and_overrides()
+test_deep_merge_override_wins_on_type_conflict()
+test_deep_merge_mutates_neither_input()
+test_deep_merge_arrays_merge_by_index()
+test_map()
+test_filter()
+test_reduce()
+test_map_filter_reduce_empty_list()
+test_inputs_not_mutated_by_list_transforms()


### PR DESCRIPTION
PR 2 of the Wave-2 battery series from #500 (`cosmic.table`, P2). Follows #647 (`cosmic.log`).

## What's here

- **`lib/cosmic/table.tl`** — pure table utilities, all infallible, inputs never mutated:
  - `deep_copy` — recursive copy of keys and values; shared references and cycles in the input are preserved in the copy; metatables are NOT copied (result is plain tables, documented)
  - `deep_eq` — structural equality (same key sets, deep-equal values) with cycle handling; table-valued keys match by identity, documented
  - `deep_merge` — recurses where both sides hold tables, override wins otherwise; result shares no tables with either input; array-like tables merge by index (an override list does not truncate a longer base list — documented, tested)
  - `map` / `filter` / `reduce` — generic (`function<T, U>`…) list transforms following the `check.eq<T>` precedent
  - `keys`/`values`/`contains`/`invert`/`group_by` reserved by name for a post-stable battery
- **Naming decision, recorded in `public.tl`**: the module name collides with Lua's `table` global. This extends the recorded `cosmic.string` precedent — the entrenched `tbl` binding convention avoids the shadow and the module's surface (deep_*, map/filter/reduce) is disjoint from the stdlib's.
- **`table_test.tl`** — 18 tests: copy independence, cycle/shared-reference preservation, table-key copying, structural equality edge cases (key-set mismatch, mixed types, cycles), merge semantics (recursion, type-conflict override, non-mutation, by-index arrays), transforms incl. empty lists and input non-mutation
- **`table_example.tl`** — 3 runnable `Example_*` functions
- `public.tl` + CLAUDE.md module-table entries; cast-ratchet pins for the test/example files (the module itself has zero casts)

## Verification

- `bin/make ci` green end-to-end locally (format, teal, test, example, lint, coverage ratchet), exit 0
- `table.tl` coverage 100% (75/75)

## Series plan (issue #500)

1. #647 — `cosmic.log` ✅ merged
2. **this PR** — `cosmic.table`
3. `cosmic.cli` — declarative arg parsing over getopt
4. `cosmic.ansi` — terminal styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dtDAf7nZRaxmnerATvRVm

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtDAf7nZRaxmnerATvRVm)_