### PR TITLE
ansi: add cosmic.ansi terminal styling battery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,7 @@ all modules are under `lib/cosmic/` and imported as `cosmic.*`:
 
 | module | description |
 |--------|-------------|
+| ansi | ANSI terminal styling: colors, attributes, strip, NO_COLOR-aware gating |
 | benchmark | benchmark runner with `Benchmark_*` functions |
 | child | child process spawning with I/O control |
 | codec | hex encoding/decoding, Lua serialization |

--- a/lib/cosmic/ansi.tl
+++ b/lib/cosmic/ansi.tl
@@ -1,0 +1,263 @@
+--- ANSI terminal styling.
+--- Wraps text in SGR escape sequences for colors and attributes, with
+--- helpers to strip styling and to decide whether a stream should be
+--- colored at all. All styling functions are pure and infallible:
+--- they return the wrapped string and never inspect the terminal —
+--- gate output with enabled() at the call site.
+---
+--- Example usage:
+---   local ansi = require("cosmic.ansi")
+---   if ansi.enabled(1) then
+---     print(ansi.bold(ansi.red("error:")) .. " something broke")
+---   end
+---
+--- Styles close with their specific off-code (39 for foreground, 49
+--- for background, 24 for underline, ...) rather than a full reset,
+--- so wrapped styles compose: bold(red("x")) renders bold red.
+--- Caveat: bold and dim share off-code 22, so nesting one inside the
+--- other ends both at the inner close.
+---
+--- Reserved names: rgb / color256 (24-bit and 256-color output),
+--- cursor (movement/erase sequences), and hyperlink (OSC 8) are
+--- reserved for a post-stable battery. Do not reuse these names.
+local env = require("cosmic.env")
+local tty = require("cosmic.tty")
+
+local ESC < const > = string.char(27)
+local CSI < const > = ESC .. "["
+
+--- Foreground and background color names. The bright_* variants use
+--- the high-intensity SGR range (90-97 / 100-107).
+local enum Color
+  "black"
+  "red"
+  "green"
+  "yellow"
+  "blue"
+  "magenta"
+  "cyan"
+  "white"
+  "bright_black"
+  "bright_red"
+  "bright_green"
+  "bright_yellow"
+  "bright_blue"
+  "bright_magenta"
+  "bright_cyan"
+  "bright_white"
+end
+
+--- Text attributes.
+local enum Attr
+  "bold"
+  "dim"
+  "italic"
+  "underline"
+  "reverse"
+  "strikethrough"
+end
+
+-- SGR foreground codes; backgrounds are these plus 10. Total over
+-- Color so the checker proves every name has a code.
+local fg_code < total >: {Color: number} = {
+  black = 30,
+  red = 31,
+  green = 32,
+  yellow = 33,
+  blue = 34,
+  magenta = 35,
+  cyan = 36,
+  white = 37,
+  bright_black = 90,
+  bright_red = 91,
+  bright_green = 92,
+  bright_yellow = 93,
+  bright_blue = 94,
+  bright_magenta = 95,
+  bright_cyan = 96,
+  bright_white = 97,
+}
+
+local attr_open < total >: {Attr: number} = {
+  bold = 1,
+  dim = 2,
+  italic = 3,
+  underline = 4,
+  reverse = 7,
+  strikethrough = 9,
+}
+
+local attr_close < total >: {Attr: number} = {
+  bold = 22,
+  dim = 22,
+  italic = 23,
+  underline = 24,
+  reverse = 27,
+  strikethrough = 29,
+}
+
+local function wrap(text: string, open: number, close: number): string
+  return CSI .. tostring(open) .. "m" .. text .. CSI .. tostring(close) .. "m"
+end
+
+--- Color text's foreground. Closes with code 39 (default foreground)
+--- so surrounding styles survive.
+--- @param text string The text to style
+--- @param c Color The foreground color
+--- @return string The wrapped text
+local function color(text: string, c: Color): string
+  return wrap(text, fg_code[c], 39)
+end
+
+--- Color text's background. Closes with code 49 (default background).
+--- @param text string The text to style
+--- @param c Color The background color
+--- @return string The wrapped text
+local function bg(text: string, c: Color): string
+  return wrap(text, fg_code[c] + 10, 49)
+end
+
+--- Apply a text attribute. Closes with the attribute's own off-code
+--- (see the module header for the bold/dim caveat).
+--- @param text string The text to style
+--- @param a Attr The attribute to apply
+--- @return string The wrapped text
+local function attr(text: string, a: Attr): string
+  return wrap(text, attr_open[a], attr_close[a])
+end
+
+--- Style text red. Shorthand for color(text, "red").
+--- @param text string The text to style
+--- @return string The wrapped text
+local function red(text: string): string
+  return color(text, "red")
+end
+
+--- Style text green. Shorthand for color(text, "green").
+--- @param text string The text to style
+--- @return string The wrapped text
+local function green(text: string): string
+  return color(text, "green")
+end
+
+--- Style text yellow. Shorthand for color(text, "yellow").
+--- @param text string The text to style
+--- @return string The wrapped text
+local function yellow(text: string): string
+  return color(text, "yellow")
+end
+
+--- Style text blue. Shorthand for color(text, "blue").
+--- @param text string The text to style
+--- @return string The wrapped text
+local function blue(text: string): string
+  return color(text, "blue")
+end
+
+--- Style text magenta. Shorthand for color(text, "magenta").
+--- @param text string The text to style
+--- @return string The wrapped text
+local function magenta(text: string): string
+  return color(text, "magenta")
+end
+
+--- Style text cyan. Shorthand for color(text, "cyan").
+--- @param text string The text to style
+--- @return string The wrapped text
+local function cyan(text: string): string
+  return color(text, "cyan")
+end
+
+--- Make text bold. Shorthand for attr(text, "bold").
+--- @param text string The text to style
+--- @return string The wrapped text
+local function bold(text: string): string
+  return attr(text, "bold")
+end
+
+--- Make text dim. Shorthand for attr(text, "dim").
+--- @param text string The text to style
+--- @return string The wrapped text
+local function dim(text: string): string
+  return attr(text, "dim")
+end
+
+--- Underline text. Shorthand for attr(text, "underline").
+--- @param text string The text to style
+--- @return string The wrapped text
+local function underline(text: string): string
+  return attr(text, "underline")
+end
+
+--- Remove all SGR escape sequences from text, returning the plain
+--- string. Only styling sequences (CSI ... m) are removed; other
+--- escape sequences pass through untouched.
+--- @param text string The possibly-styled text
+--- @return string The text with SGR sequences removed
+local function strip(text: string): string
+  return (text:gsub(CSI .. "[0-9;]*m", ""))
+end
+
+--- Decide whether styled output is appropriate for a stream, honoring
+--- the NO_COLOR convention (https://no-color.org: set to any value,
+--- including empty, disables color), TERM=dumb, and whether the fd is
+--- a terminal.
+--- @param fd number? File descriptor to check (default 1, stdout)
+--- @return boolean True when it is reasonable to emit styled output
+local function enabled(fd?: number): boolean
+  if env.get("NO_COLOR") ~= nil then
+    return false
+  end
+  if env.get("TERM") == "dumb" then
+    return false
+  end
+  return tty.isatty(fd or 1)
+end
+
+local record AnsiModule
+  type Color = Color
+  type Attr = Attr
+
+  --- Full reset sequence (SGR 0), for manual composition.
+  reset: string
+
+  color: function(text: string, c: Color): string
+  bg: function(text: string, c: Color): string
+  attr: function(text: string, a: Attr): string
+
+  red: function(text: string): string
+  green: function(text: string): string
+  yellow: function(text: string): string
+  blue: function(text: string): string
+  magenta: function(text: string): string
+  cyan: function(text: string): string
+  bold: function(text: string): string
+  dim: function(text: string): string
+  underline: function(text: string): string
+
+  strip: function(text: string): string
+  enabled: function(fd?: number): boolean
+end
+
+local M: AnsiModule = {
+  reset = CSI .. "0m",
+
+  color = color,
+  bg = bg,
+  attr = attr,
+
+  red = red,
+  green = green,
+  yellow = yellow,
+  blue = blue,
+  magenta = magenta,
+  cyan = cyan,
+  bold = bold,
+  dim = dim,
+  underline = underline,
+
+  strip = strip,
+  enabled = enabled,
+}
+
+return M

--- a/lib/cosmic/ansi_example.tl
+++ b/lib/cosmic/ansi_example.tl
@@ -1,0 +1,46 @@
+--- Examples for the cosmic.ansi module.
+--- Demonstrates styling text, gating on terminal support, and
+--- stripping styles. Examples print stripped or boolean results so
+--- their output stays deterministic across terminals.
+
+-- Example_style demonstrates wrapping text in colors and attributes.
+-- Styles close with their specific off-codes, so nesting composes.
+local function Example_style()
+  local ansi = require("cosmic.ansi")
+  local styled = ansi.bold(ansi.red("error:") .. " disk full")
+  -- print the plain text; the styled string carries the SGR codes
+  print(ansi.strip(styled))
+  print(#styled > #ansi.strip(styled))
+  -- Output:
+  -- error: disk full
+  -- true
+end
+
+-- Example_enabled demonstrates gating styled output on the stream:
+-- NO_COLOR (set to anything, even empty) always wins.
+local function Example_enabled()
+  local ansi = require("cosmic.ansi")
+  local env = require("cosmic.env")
+  env.set("NO_COLOR", "1")
+  local message = "hello"
+  if ansi.enabled(1) then
+    message = ansi.green(message)
+  end
+  print(message)
+  env.unset("NO_COLOR")
+  -- Output:
+  -- hello
+end
+
+-- Example_strip demonstrates removing styling, e.g. before writing
+-- terminal output to a log file.
+local function Example_strip()
+  local ansi = require("cosmic.ansi")
+  local line = ansi.dim("2026-01-01") .. " " .. ansi.yellow("warn") .. " low disk"
+  print(ansi.strip(line))
+  -- Output:
+  -- 2026-01-01 warn low disk
+end
+
+-- Suppress unused warnings for examples
+local _ = {Example_style, Example_enabled, Example_strip}

--- a/lib/cosmic/ansi_test.tl
+++ b/lib/cosmic/ansi_test.tl
@@ -1,0 +1,114 @@
+--- Tests for cosmic.ansi.
+local ansi = require("cosmic.ansi")
+local env = require("cosmic.env")
+
+local ESC = string.char(27)
+
+local function test_color_wraps_with_fg_close()
+  assert(ansi.red("x") == ESC .. "[31mx" .. ESC .. "[39m",
+    "got: " .. ansi.red("x"):gsub(ESC, "\\e"))
+  assert(ansi.color("x", "bright_cyan") == ESC .. "[96mx" .. ESC .. "[39m")
+end
+
+local function test_bg_wraps_with_bg_close()
+  assert(ansi.bg("x", "red") == ESC .. "[41mx" .. ESC .. "[49m")
+  assert(ansi.bg("x", "bright_white") == ESC .. "[107mx" .. ESC .. "[49m")
+end
+
+local function test_attr_uses_specific_off_codes()
+  assert(ansi.bold("x") == ESC .. "[1mx" .. ESC .. "[22m")
+  assert(ansi.underline("x") == ESC .. "[4mx" .. ESC .. "[24m")
+  assert(ansi.attr("x", "strikethrough") == ESC .. "[9mx" .. ESC .. "[29m")
+end
+
+local function test_styles_compose_when_nested()
+  -- The inner color close (39) must not end the outer bold, so the
+  -- trailing text after the nested section stays bold.
+  local nested = ansi.bold(ansi.red("err") .. " detail")
+  assert(nested == ESC .. "[1m" .. ESC .. "[31merr" .. ESC .. "[39m"
+    .. " detail" .. ESC .. "[22m",
+    "got: " .. nested:gsub(ESC, "\\e"))
+end
+
+local function test_convenience_functions_match_generic_forms()
+  assert(ansi.green("x") == ansi.color("x", "green"))
+  assert(ansi.yellow("x") == ansi.color("x", "yellow"))
+  assert(ansi.blue("x") == ansi.color("x", "blue"))
+  assert(ansi.magenta("x") == ansi.color("x", "magenta"))
+  assert(ansi.cyan("x") == ansi.color("x", "cyan"))
+  assert(ansi.dim("x") == ansi.attr("x", "dim"))
+end
+
+local function test_strip_removes_all_sgr()
+  local styled = ansi.bold(ansi.bg(ansi.red("a"), "blue") .. "b") .. "c"
+  assert(ansi.strip(styled) == "abc", "got: " .. ansi.strip(styled))
+  assert(ansi.strip("plain") == "plain")
+  assert(ansi.strip(ansi.reset) == "")
+  -- multi-parameter sequences are SGR too
+  assert(ansi.strip(ESC .. "[1;31mx" .. ESC .. "[0m") == "x")
+end
+
+local function test_strip_leaves_non_sgr_escapes()
+  local cursor_up = ESC .. "[2A"
+  assert(ansi.strip(cursor_up .. "x") == cursor_up .. "x")
+end
+
+local function test_reset_constant()
+  assert(ansi.reset == ESC .. "[0m")
+end
+
+local function test_enabled_honors_no_color()
+  local saved = env.get("NO_COLOR")
+  assert(env.set("NO_COLOR", "1"))
+  assert(ansi.enabled(1) == false, "NO_COLOR should disable color")
+  assert(ansi.enabled() == false)
+  if saved then
+    env.set("NO_COLOR", saved)
+  else
+    env.unset("NO_COLOR")
+  end
+end
+
+local function test_enabled_honors_dumb_term()
+  local saved_no_color = env.get("NO_COLOR")
+  local saved_term = env.get("TERM")
+  env.unset("NO_COLOR")
+  assert(env.set("TERM", "dumb"))
+  assert(ansi.enabled(1) == false, "TERM=dumb should disable color")
+  if saved_term then
+    env.set("TERM", saved_term)
+  else
+    env.unset("TERM")
+  end
+  if saved_no_color then
+    env.set("NO_COLOR", saved_no_color)
+  end
+end
+
+local function test_enabled_requires_a_tty()
+  -- Under the test runner stdout is a pipe, so with the env vetoes
+  -- cleared the tty check decides — and must say false.
+  local saved_no_color = env.get("NO_COLOR")
+  local saved_term = env.get("TERM")
+  env.unset("NO_COLOR")
+  env.unset("TERM")
+  assert(ansi.enabled(1) == false, "pipe misdetected as tty")
+  if saved_term then
+    env.set("TERM", saved_term)
+  end
+  if saved_no_color then
+    env.set("NO_COLOR", saved_no_color)
+  end
+end
+
+test_color_wraps_with_fg_close()
+test_bg_wraps_with_bg_close()
+test_attr_uses_specific_off_codes()
+test_styles_compose_when_nested()
+test_convenience_functions_match_generic_forms()
+test_strip_removes_all_sgr()
+test_strip_leaves_non_sgr_escapes()
+test_reset_constant()
+test_enabled_honors_no_color()
+test_enabled_honors_dumb_term()
+test_enabled_requires_a_tty()

--- a/lib/cosmic/public.tl
+++ b/lib/cosmic/public.tl
@@ -20,6 +20,7 @@
 --- `require` is already internal; `env`, `time`, and the rest carry no
 --- Lua global collision — keep.
 local public: {string} = {
+  "ansi",
   "benchmark",
   "check",
   "child",


### PR DESCRIPTION
PR 3 of the Wave-2 battery series from #500 (`cosmic.ansi`, P2). Follows #647 (`cosmic.log`) and #648 (`cosmic.table`).

## What's here

- **`lib/cosmic/ansi.tl`** — pure SGR styling, all infallible:
  - typed `Color` (8 classic + 8 bright) and `Attr` enums with `< total >` code maps
  - `color`/`bg`/`attr` generic wraps plus convenience functions for the classic six colors and `bold`/`dim`/`underline`
  - **composition by design**: styles close with their specific off-code (39 foreground, 49 background, 24 underline, …) instead of a full reset, so `bold(red("err") .. " detail")` keeps the trailing text bold — verified byte-exactly in tests. The one caveat (bold/dim share off-code 22) is documented in the header
  - `strip()` removes SGR sequences only (non-SGR escapes like cursor movement pass through, tested)
  - `enabled(fd?)` gates styling on the [NO_COLOR](https://no-color.org) convention (any value, even empty, disables), `TERM=dumb`, and `isatty`
  - `rgb`/`color256`/`cursor`/`hyperlink` reserved by name for a post-stable battery
- **`ansi_test.tl`** — 11 tests: exact escape bytes for fg/bg/attrs, nested composition, strip edge cases, and all three `enabled` vetoes (with env save/restore)
- **`ansi_example.tl`** — 3 runnable `Example_*` functions with terminal-independent output
- `public.tl` + CLAUDE.md module-table entries; zero `as` casts anywhere in the new files

## Verification

- `bin/make ci` green end-to-end locally (format, teal, test, example, lint, coverage ratchet), exit 0
- `ansi.tl` coverage 100% (86/86)

## Series plan (issue #500)

1. #647 — `cosmic.log` ✅ merged
2. #648 — `cosmic.table` ✅ merged
3. **this PR** — `cosmic.ansi`
4. `cosmic.cli` — needs a naming decision first: `cli` is recorded as an *internal* top-level name in `public.tl` (#557, the binary's dispatcher directory), so the declarative arg-parsing battery either takes a different public name (`flags`? `args`?) or the internal `cli/` directory moves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dtDAf7nZRaxmnerATvRVm

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtDAf7nZRaxmnerATvRVm)_