### PR TITLE
flags: add cosmic.flags declarative arg-parsing battery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,7 @@ all modules are under `lib/cosmic/` and imported as `cosmic.*`:
 | envd | load environment variables from embedded env.d directory |
 | example | example runner with `Example_*` functions |
 | fetch | HTTP client with retry support |
+| flags | declarative command-line flag parsing with generated --help |
 | format | Teal/Lua code formatter |
 | fs | filesystem: paths, stat, walk, read/write, mkdir, symlink, tmp |
 | fuzzy | fuzzy string matching (Levenshtein distance) |

--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -74,6 +74,8 @@
 2	lib/cosmic/fetch/retry_test.tl
 2	lib/cosmic/fetch/stream_test.tl
 3	lib/cosmic/fetch/verbs_test.tl
+1	lib/cosmic/flags.tl
+1	lib/cosmic/flags_test.tl
 8	lib/cosmic/format/init.tl
 12	lib/cosmic/fs/dir_test.tl
 1	lib/cosmic/fs/file.tl

--- a/lib/cosmic/flags.tl
+++ b/lib/cosmic/flags.tl
@@ -1,0 +1,321 @@
+--- Declarative command-line flag parsing.
+--- Describe a program's options once as data — names, value
+--- placeholders, defaults, help text — and get parsing, validation,
+--- and rendered --help from the one spec. Built over cosmic.getopt,
+--- which supplies the underlying short/long option grammar; reach for
+--- getopt directly when you need its lower-level control.
+---
+--- Example usage:
+---   local flags = require("cosmic.flags")
+---   local spec: flags.Spec = {
+---     name = "greet",
+---     summary = "Greet people from the command line",
+---     usage = "[options] <name...>",
+---     options = {
+---       {long = "verbose", short = "v", help = "print more detail"},
+---       {long = "output", short = "o", arg = "FILE",
+---        help = "write to FILE", default = "-"},
+---     },
+---   }
+---   local parsed, err = flags.parse(spec, arg)
+---   if not parsed then
+---     io.stderr:write(err .. "\n")
+---   elseif parsed.help then
+---     print(flags.help(spec))
+---   else
+---     local out = parsed.values["output"]
+---     local loud = parsed.flags["verbose"]
+---   end
+---
+--- An option with an `arg` placeholder takes a required value;
+--- without one it is a boolean flag. --help/-h is recognized
+--- automatically (and --version when the spec carries a version)
+--- unless the spec claims those names itself; parse never prints or
+--- exits — it reports help/version requests as fields on the result
+--- and the caller decides what to do.
+---
+--- Reserved name: flags.command(spec): subcommand dispatch is
+--- reserved for a post-stable battery. Do not reuse this name.
+local getopt = require("cosmic.getopt")
+
+--- One option declaration.
+local record Option
+  --- Long name, without dashes (e.g. "output" for --output). Required.
+  long: string
+  --- Optional single-letter short alias, without the dash.
+  short: string
+  --- Value placeholder shown in help (e.g. "FILE"). Its presence
+  --- makes the option take a required value; absent means boolean.
+  arg: string
+  --- One-line description shown in help.
+  help: string
+  --- Default value, applied when the option is absent (valued only).
+  default: string
+  --- Reject the command line when the option is absent (valued only).
+  required: boolean
+end
+
+--- A program's declared interface.
+local record Spec
+  --- Program name, used in error messages and help (default "program").
+  name: string
+  --- One-line description shown in help.
+  summary: string
+  --- Usage tail shown after the name (default "[options]").
+  usage: string
+  --- Version string; when set, --version is recognized automatically.
+  version: string
+  --- The declared options, in help-display order.
+  options: {Option}
+end
+
+--- A successful parse.
+local record Parsed
+  --- Boolean options by long name; every declared flag is present
+  --- (false when absent), so lookups never need a nil check.
+  flags: {string: boolean}
+  --- Valued options by long name, with defaults applied.
+  values: {string: string}
+  --- Positional (non-option) arguments, in order.
+  args: {string}
+  --- True when --help / -h was given.
+  help: boolean
+  --- True when --version was given (specs with a version only).
+  version: boolean
+end
+
+local function prog(spec: Spec): string
+  return spec.name or "program"
+end
+
+--- Validate a spec and index its options. Returns long-name and
+--- short-letter lookup maps, or nil and a message naming the defect.
+local function index_options(spec: Spec): {string: Option}, {string: Option}, string
+  local by_long: {string: Option} = {}
+  local by_short: {string: Option} = {}
+  for _, opt in ipairs(spec.options or {}) do
+    if not opt.long or #opt.long == 0 then
+      return nil, nil, prog(spec) .. ": invalid spec: option without a long name"
+    end
+    if by_long[opt.long] then
+      return nil, nil, prog(spec) .. ": invalid spec: duplicate option --" .. opt.long
+    end
+    by_long[opt.long] = opt
+    if opt.short then
+      if #opt.short ~= 1 then
+        return nil, nil, prog(spec) .. ": invalid spec: short alias must be one letter: "
+        .. opt.short
+      end
+      if by_short[opt.short] then
+        return nil, nil, prog(spec) .. ": invalid spec: duplicate short option -" .. opt.short
+      end
+      by_short[opt.short] = opt
+    end
+    if not opt.arg and (opt.default or opt.required) then
+      return nil, nil, prog(spec) .. ": invalid spec: --" .. opt.long
+      .. " is boolean; default/required need an arg placeholder"
+    end
+    if opt.default and opt.required then
+      return nil, nil, prog(spec) .. ": invalid spec: --" .. opt.long
+      .. " cannot be both required and defaulted"
+    end
+  end
+  return by_long, by_short
+end
+
+--- The options parse actually recognizes: the declared ones plus the
+--- automatic help/version entries when their names are free.
+local function effective_options(spec: Spec, by_long: {string: Option},
+    by_short: {string: Option}): {Option}
+  local opts: {Option} = {}
+  for _, opt in ipairs(spec.options or {}) do
+    opts[#opts + 1] = opt
+  end
+  if not by_long["help"] then
+    local short: string = nil
+    if not by_short["h"] then
+      short = "h"
+    end
+    opts[#opts + 1] = {long = "help", short = short, help = "show this help"}
+  end
+  if spec.version and not by_long["version"] then
+    opts[#opts + 1] = {long = "version", help = "show version"}
+  end
+  return opts
+end
+
+--- Parse a command-line argument vector against a spec.
+--- Never prints and never exits: --help/--version requests come back
+--- as fields on Parsed, and any problem — invalid spec, unknown
+--- option, missing value, missing required option — is nil plus a
+--- one-line message prefixed with the program name. Repeated valued
+--- options keep the last occurrence.
+--- @param spec Spec The declared interface
+--- @param argv {string} The argument list (typically the global arg)
+--- @return Parsed | nil The parse result, or nil on any error
+--- @return string? Error message when the spec or command line is invalid
+local function parse(spec: Spec, argv: {string}): Parsed | nil, string
+  local by_long, by_short, spec_err = index_options(spec)
+  if not by_long then
+    return nil, spec_err
+  end
+  local opts = effective_options(spec, by_long, by_short)
+
+  local optstring = ""
+  local longopts: {getopt.LongOpt} = {}
+  local lookup: {string: Option} = {}
+  for _, opt in ipairs(opts) do
+    local has_arg = "none"
+    if opt.arg then
+      has_arg = "required"
+    end
+    if opt.short then
+      optstring = optstring .. opt.short
+      if opt.arg then
+        optstring = optstring .. ":"
+      end
+      -- getopt reports an aliased long option as its short letter
+      lookup[opt.short] = opt
+    end
+    lookup[opt.long] = opt
+    longopts[#longopts + 1] = {name = opt.long, has_arg = has_arg, short = opt.short}
+  end
+
+  local r0, gerr = getopt.parse(argv, optstring, longopts)
+  if not r0 then
+    return nil, prog(spec) .. ": " .. tostring(gerr)
+  end
+  local r = r0 as getopt.Result
+
+  if r.unknown[1] then
+    return nil, prog(spec) .. ": unknown option: " .. r.unknown[1] .. " (try --help)"
+  end
+  if r.missing[1] then
+    -- getopt names a missing aliased option by its short letter;
+    -- report the long name, which is what the spec declares.
+    local missing_opt = lookup[r.missing[1]]
+    local name = missing_opt and missing_opt.long or r.missing[1]
+    return nil, prog(spec) .. ": option requires a value: --" .. name
+  end
+
+  local parsed: Parsed = {
+    flags = {},
+    values = {},
+    args = r.args,
+    help = false,
+    version = false,
+  }
+  for _, opt in ipairs(opts) do
+    if opt.arg then
+      if opt.default then
+        parsed.values[opt.long] = opt.default
+      end
+    else
+      parsed.flags[opt.long] = false
+    end
+  end
+
+  for _, o in ipairs(r.opts) do
+    local opt = lookup[o.opt]
+    if opt then
+      if opt.arg then
+        parsed.values[opt.long] = o.arg
+      else
+        parsed.flags[opt.long] = true
+      end
+    end
+  end
+
+  parsed.help = parsed.flags["help"] or false
+  parsed.version = parsed.flags["version"] or false
+
+  -- A help or version request short-circuits required-option
+  -- enforcement: `prog --help` must always work.
+  if not parsed.help and not parsed.version then
+    for _, opt in ipairs(opts) do
+      if opt.required and parsed.values[opt.long] == nil then
+        return nil, prog(spec) .. ": missing required option: --" .. opt.long
+        .. " (try --help)"
+      end
+    end
+  end
+  return parsed
+end
+
+--- Render help text for a spec: a usage line, the summary, and one
+--- aligned row per option (including the automatic help/version
+--- entries), with defaults and required markers noted. Returns the
+--- text without a trailing newline; printing is the caller's job.
+--- @param spec Spec The declared interface
+--- @return string The rendered help text
+local function help(spec: Spec): string
+  local by_long, by_short = index_options(spec)
+  local opts: {Option}
+  if by_long then
+    opts = effective_options(spec, by_long, by_short)
+  else
+    -- Invalid specs still render their declared options so the
+    -- defect is visible next to the parse error.
+    opts = spec.options or {}
+  end
+
+  local lines: {string} = {
+    "usage: " .. prog(spec) .. " " .. (spec.usage or "[options]"),
+  }
+  if spec.summary then
+    lines[#lines + 1] = ""
+    lines[#lines + 1] = spec.summary
+  end
+
+  local lefts: {string} = {}
+  local width = 0
+  for i, opt in ipairs(opts) do
+    local left: string
+    if opt.short then
+      left = "-" .. opt.short .. ", --" .. opt.long
+    else
+      left = "    --" .. opt.long
+    end
+    if opt.arg then
+      left = left .. " " .. opt.arg
+    end
+    lefts[i] = left
+    if #left > width then
+      width = #left
+    end
+  end
+
+  lines[#lines + 1] = ""
+  lines[#lines + 1] = "options:"
+  for i, opt in ipairs(opts) do
+    local row = "  " .. lefts[i] .. string.rep(" ", width - #lefts[i])
+    local desc = opt.help or ""
+    if opt.default then
+      desc = desc .. " (default: " .. opt.default .. ")"
+    end
+    if opt.required then
+      desc = desc .. " (required)"
+    end
+    if #desc > 0 then
+      row = row .. "  " .. desc
+    end
+    lines[#lines + 1] = row
+  end
+  return table.concat(lines, "\n")
+end
+
+local record FlagsModule
+  type Option = Option
+  type Spec = Spec
+  type Parsed = Parsed
+
+  parse: function(spec: Spec, argv: {string}): Parsed | nil, string
+  help: function(spec: Spec): string
+end
+
+local M: FlagsModule = {
+  parse = parse,
+  help = help,
+}
+
+return M

--- a/lib/cosmic/flags_example.tl
+++ b/lib/cosmic/flags_example.tl
@@ -1,0 +1,69 @@
+--- Examples for the cosmic.flags module.
+--- Demonstrates declaring a program's options once and getting
+--- parsing, error messages, and rendered help from the one spec.
+
+-- Example_parse demonstrates the common flow: declare a spec, parse
+-- argv, and read flags (booleans), values (with defaults applied),
+-- and positional args from the result.
+local function Example_parse()
+  local flags = require("cosmic.flags")
+  local spec: flags.Spec = {
+    name = "greet",
+    options = {
+      {long = "verbose", short = "v", help = "print more detail"},
+      {long = "output", short = "o", arg = "FILE",
+        help = "write to FILE", default = "-"},
+    },
+  }
+  local parsed = flags.parse(spec, {"-v", "alice"})
+  if parsed is flags.Parsed then
+    print(parsed.flags["verbose"], parsed.values["output"], parsed.args[1])
+  end
+  -- Output:
+  -- true	-	alice
+end
+
+-- Example_errors demonstrates that parse never prints or exits: bad
+-- command lines come back as nil plus a one-line message.
+local function Example_errors()
+  local flags = require("cosmic.flags")
+  local spec: flags.Spec = {
+    name = "greet",
+    options = {{long = "count", arg = "N", help = "repeat", required = true}},
+  }
+  local _, err = flags.parse(spec, {"--nope"})
+  print(err)
+  local _, err2 = flags.parse(spec, {})
+  print(err2)
+  -- Output:
+  -- greet: unknown option: --nope (try --help)
+  -- greet: missing required option: --count (try --help)
+end
+
+-- Example_help demonstrates the rendered help text, including the
+-- automatic --help entry and default/required annotations.
+local function Example_help()
+  local flags = require("cosmic.flags")
+  local spec: flags.Spec = {
+    name = "greet",
+    summary = "Greet people",
+    usage = "[options] <name>",
+    options = {
+      {long = "verbose", short = "v", help = "print more detail"},
+      {long = "count", arg = "N", help = "repeat N times", default = "1"},
+    },
+  }
+  print(flags.help(spec))
+  -- Output:
+  -- usage: greet [options] <name>
+  --
+  -- Greet people
+  --
+  -- options:
+  --   -v, --verbose  print more detail
+  --       --count N  repeat N times (default: 1)
+  --   -h, --help     show this help
+end
+
+-- Suppress unused warnings for examples
+local _ = {Example_parse, Example_errors, Example_help}

--- a/lib/cosmic/flags_test.tl
+++ b/lib/cosmic/flags_test.tl
@@ -1,0 +1,152 @@
+--- Tests for cosmic.flags.
+local flags = require("cosmic.flags")
+
+local spec: flags.Spec = {
+  name = "greet",
+  summary = "Greet people from the command line",
+  version = "1.2.3",
+  usage = "[options] <name...>",
+  options = {
+    {long = "verbose", short = "v", help = "print more detail"},
+    {long = "output", short = "o", arg = "FILE", help = "write to FILE", default = "-"},
+    {long = "count", arg = "N", help = "repeat N times", required = true},
+  },
+}
+
+-- Parse a command line that must succeed.
+local function must(s: flags.Spec, argv: {string}): flags.Parsed
+  local parsed, err = flags.parse(s, argv)
+  assert(parsed, "unexpected parse error: " .. tostring(err))
+  return parsed as flags.Parsed
+end
+
+local function test_short_and_long_forms()
+  local p = must(spec, {"-v", "--output", "out.txt", "--count", "3", "alice", "bob"})
+  assert(p.flags["verbose"] == true)
+  assert(p.values["output"] == "out.txt")
+  assert(p.values["count"] == "3")
+  assert(#p.args == 2 and p.args[1] == "alice" and p.args[2] == "bob")
+  assert(p.help == false and p.version == false)
+end
+
+local function test_defaults_and_absent_flags()
+  local p = must(spec, {"--count", "1"})
+  assert(p.values["output"] == "-", "default not applied")
+  assert(p.flags["verbose"] == false, "absent flag should be false, not nil")
+  assert(#p.args == 0)
+end
+
+local function test_repeated_valued_option_keeps_last()
+  local p = must(spec, {"--count", "1", "-o", "a", "-o", "b"})
+  assert(p.values["output"] == "b", "got: " .. p.values["output"])
+end
+
+local function test_missing_required_option()
+  local p, err = flags.parse(spec, {"-v"})
+  assert(not p, "expected failure")
+  assert(err and err:find("greet: missing required option: --count", 1, true),
+    "got: " .. tostring(err))
+end
+
+local function test_unknown_option()
+  local p, err = flags.parse(spec, {"--count", "1", "--nope"})
+  assert(not p, "expected failure")
+  assert(err and err:find("greet: unknown option: --nope", 1, true),
+    "got: " .. tostring(err))
+end
+
+local function test_missing_value()
+  local p, err = flags.parse(spec, {"--output"})
+  assert(not p, "expected failure")
+  assert(err and err:find("greet: option requires a value: --output", 1, true),
+    "got: " .. tostring(err))
+end
+
+local function test_auto_help()
+  -- --help must work even though the required --count is absent.
+  local p = must(spec, {"--help"})
+  assert(p.help == true)
+  local p2 = must(spec, {"-h"})
+  assert(p2.help == true)
+end
+
+local function test_auto_version()
+  local p = must(spec, {"--version"})
+  assert(p.version == true)
+  local unversioned: flags.Spec = {name = "x", options = {}}
+  local p2, err = flags.parse(unversioned, {"--version"})
+  assert(not p2, "expected --version to be unknown without spec.version")
+  assert(err and err:find("unknown option", 1, true), "got: " .. tostring(err))
+end
+
+local function test_spec_claims_help_name()
+  local custom: flags.Spec = {
+    name = "x",
+    options = {{long = "help", short = "H", arg = "TOPIC", help = "topic help"}},
+  }
+  local p = must(custom, {"--help", "parsing"})
+  assert(p.values["help"] == "parsing")
+  assert(p.help == false, "user-claimed valued --help must not read as a help request")
+end
+
+local function test_invalid_specs()
+  local cases: {{flags.Spec, string}} = {
+    {{name = "x", options = {{long = "a"}, {long = "a"}}}, "duplicate option --a"},
+    {{name = "x", options = {{long = "a", short = "z"}, {long = "b", short = "z"}}},
+      "duplicate short option -z"},
+    {{name = "x", options = {{long = "a", short = "ab"}}}, "one letter"},
+    {{name = "x", options = {{long = "a", default = "d"}}}, "boolean"},
+    {{name = "x", options = {{long = "a", arg = "V", default = "d", required = true}}},
+      "required and defaulted"},
+    {{name = "x", options = {{long = ""}}}, "without a long name"},
+  }
+  for i, case in ipairs(cases) do
+    local p, err = flags.parse(case[1], {})
+    assert(not p, "case " .. tostring(i) .. " unexpectedly parsed")
+    assert(err and err:find(case[2], 1, true),
+      "case " .. tostring(i) .. " got: " .. tostring(err))
+  end
+end
+
+local function test_help_rendering()
+  local text = flags.help(spec)
+  assert(text:find("usage: greet [options] <name...>", 1, true), text)
+  assert(text:find("Greet people from the command line", 1, true), text)
+  assert(text:find("-v, --verbose", 1, true), text)
+  assert(text:find("-o, --output FILE", 1, true), text)
+  assert(text:find("write to FILE (default: -)", 1, true), text)
+  assert(text:find("--count N", 1, true), text)
+  assert(text:find("repeat N times (required)", 1, true), text)
+  assert(text:find("-h, --help", 1, true), text)
+  assert(text:find("--version", 1, true), text)
+  assert(not text:find("\n$"), "trailing newline")
+end
+
+local function test_help_rows_align()
+  local text = flags.help(spec)
+  local verbose_col: number = nil
+  local output_col: number = nil
+  for line in text:gmatch("[^\n]+") do
+    if line:find("print more detail", 1, true) then
+      verbose_col = line:find("print more detail", 1, true)
+    end
+    if line:find("write to FILE", 1, true) then
+      output_col = line:find("write to FILE", 1, true)
+    end
+  end
+  assert(verbose_col and output_col, "option rows missing from help output")
+  assert(verbose_col == output_col, "descriptions are not column-aligned")
+end
+
+test_short_and_long_forms()
+test_defaults_and_absent_flags()
+test_repeated_valued_option_keeps_last()
+test_missing_required_option()
+test_unknown_option()
+test_missing_value()
+test_auto_help()
+test_auto_version()
+test_spec_claims_help_name()
+test_invalid_specs()
+test_help_rendering()
+test_help_rows_align()

--- a/lib/cosmic/public.tl
+++ b/lib/cosmic/public.tl
@@ -35,6 +35,7 @@ local public: {string} = {
   "example",
   "fd",
   "fetch",
+  "flags",
   "format",
   "fs",
   "fuzzy",


### PR DESCRIPTION
PR 4 of the Wave-2 battery series from #500 — the item listed there as `cosmic.cli`, shipped as **`cosmic.flags`** per the naming decision (owner-confirmed): `cli` is the recorded internal name of the binary's dispatcher directory (#557), so the battery takes a collision-free name and the internal `cli/` stays untouched.

## What's here

- **`lib/cosmic/flags.tl`** — declare a program's interface once as data, get parsing + validation + rendered help from the one spec, built over `cosmic.getopt`:
  - `Option` record: `long` (required key), `short` alias, `arg` placeholder (presence = takes a required value, absence = boolean flag), `default`, `required`, `help`
  - `parse(spec, argv)` **never prints and never exits** — `--help`/`-h` (automatic unless the spec claims the name) and `--version` (when the spec carries a version) come back as fields on `Parsed`, and a help/version request short-circuits required-option enforcement so `prog --help` always works
  - errors are one-line and program-prefixed (`greet: unknown option: --nope (try --help)`), and always name options by their declared long form — including the case where getopt reports a missing value by the short alias
  - spec validation catches duplicate long/short names, multi-letter shorts, boolean+default/required, and required+default contradictions
  - `Parsed.flags` is pre-populated `false` for every declared boolean, so lookups never nil-check; repeated valued options keep the last occurrence
  - `help(spec)` renders usage, summary, and column-aligned option rows with `(default: …)`/`(required)` annotations
  - `flags.command` (subcommand dispatch) reserved by name for a post-stable battery
- **`flags_test.tl`** — 12 tests: short/long forms, defaults, last-wins, all four error classes, auto help/version, a spec that claims `--help` itself, six invalid-spec cases, help rendering and column alignment
- **`flags_example.tl`** — 3 runnable `Example_*` functions including the full rendered help text
- `public.tl` + CLAUDE.md module-table entries; cast pins (1 in the module at the sanctioned `getopt.Result` boundary, 1 in tests)

## Verification

- `bin/make ci` green end-to-end locally (format, teal, test, example, lint, coverage ratchet), exit 0
- `flags.tl` coverage 98.6% (140/142; the two uncovered lines are the getopt-binding-error passthrough and the invalid-spec help fallback)

## Series plan (issue #500)

1. #647 — `cosmic.log` ✅ merged
2. #648 — `cosmic.table` ✅ merged
3. #649 — `cosmic.ansi` ✅ merged
4. **this PR** — `cosmic.flags`

That completes the pure-Teal Wave-2 items from #500 that are actionable today (remaining checklist entries: `httpd` is gated on redbean's HTTP C wrap, `tls` on whilp/cosmopolitan#143, `csv`/`toml`/tar are P2 follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dtDAf7nZRaxmnerATvRVm

---
_Generated by [Claude Code](https://claude.ai/code/session_019dtDAf7nZRaxmnerATvRVm)_