### PR TITLE
test: close §5.3 happy-path-only gaps (fs, sqlite, rand, hash, json, zip) and rewrite tautological tests

### DIFF
--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -58,6 +58,7 @@
 38	lib/cosmic/embed_test.tl
 1	lib/cosmic/envd.tl
 3	lib/cosmic/envd_example.tl
+1	lib/cosmic/envd_test.tl
 4	lib/cosmic/errno.tl
 1	lib/cosmic/example.tl
 1	lib/cosmic/example_coverage_test.tl
@@ -84,7 +85,7 @@
 1	lib/cosmic/fs/init_example.tl
 19	lib/cosmic/fs/init_test.tl
 4	lib/cosmic/fs/ops.tl
-6	lib/cosmic/fs/ops_test.tl
+11	lib/cosmic/fs/ops_test.tl
 2	lib/cosmic/fs/path.tl
 9	lib/cosmic/fs/path_test.tl
 21	lib/cosmic/fs/traps_test.tl
@@ -96,13 +97,13 @@
 10	lib/cosmic/getopt.tl
 16	lib/cosmic/getopt_test.tl
 3	lib/cosmic/hash.tl
-4	lib/cosmic/hash_test.tl
+6	lib/cosmic/hash_test.tl
 13	lib/cosmic/include_dir_test.tl
 3	lib/cosmic/init.tl
 9	lib/cosmic/ip.tl
 15	lib/cosmic/ip_test.tl
 2	lib/cosmic/json.tl
-12	lib/cosmic/json_test.tl
+23	lib/cosmic/json_test.tl
 24	lib/cosmic/landlock.tl
 1	lib/cosmic/landlock_example.tl
 6	lib/cosmic/landlock_test.tl
@@ -147,7 +148,7 @@
 1	lib/cosmic/quicksand/proxy_example.tl
 7	lib/cosmic/quicksand/proxy_test.tl
 4	lib/cosmic/rand.tl
-6	lib/cosmic/rand_test.tl
+7	lib/cosmic/rand_test.tl
 10	lib/cosmic/re.tl
 10	lib/cosmic/re_ops_test.tl
 15	lib/cosmic/re_test.tl
@@ -160,10 +161,10 @@
 18	lib/cosmic/shm_test.tl
 7	lib/cosmic/signal.tl
 11	lib/cosmic/skill_test.tl
-49	lib/cosmic/sqlite/advanced_test.tl
+51	lib/cosmic/sqlite/advanced_test.tl
 5	lib/cosmic/sqlite/bind.tl
 17	lib/cosmic/sqlite/close_test.tl
-21	lib/cosmic/sqlite/data_test.tl
+26	lib/cosmic/sqlite/data_test.tl
 5	lib/cosmic/sqlite/extras.tl
 6	lib/cosmic/sqlite/extras_test.tl
 19	lib/cosmic/sqlite/init.tl
@@ -180,6 +181,7 @@
 2	lib/cosmic/string_test.tl
 3	lib/cosmic/sys.tl
 4	lib/cosmic/sys_test.tl
+1	lib/cosmic/syslog_test.tl
 5	lib/cosmic/table_example.tl
 8	lib/cosmic/table_test.tl
 3	lib/cosmic/teal.tl
@@ -188,7 +190,7 @@
 4	lib/cosmic/time_test.tl
 8	lib/cosmic/tl_loader_test.tl
 6	lib/cosmic/tty.tl
-6	lib/cosmic/tty_test.tl
+16	lib/cosmic/tty_test.tl
 4	lib/cosmic/unveil.tl
 1	lib/cosmic/unveil_example.tl
 3	lib/cosmic/unveil_test.tl
@@ -196,7 +198,7 @@
 14	lib/cosmic/url_test.tl
 7	lib/cosmic/version_test.tl
 8	lib/cosmic/zip.tl
-38	lib/cosmic/zip_test.tl
+44	lib/cosmic/zip_test.tl
 7	lib/docs/publish.tl
 2	lib/docs/publish_test.tl
 2	lib/perf/bench/child_bench.tl

--- a/lib/cosmic/envd.tl
+++ b/lib/cosmic/envd.tl
@@ -205,6 +205,9 @@ local function load_envd(): LoadResult
 end
 
 local record EnvdModule
+  --- Result of a load()/load_dir() call (count, source, errors).
+  type LoadResult = LoadResult
+
   load: function(): LoadResult
   load_dir: function(dir: string): LoadResult
   parse: function(content: string, ctx?: {string: string}): {string: string}

--- a/lib/cosmic/envd_test.tl
+++ b/lib/cosmic/envd_test.tl
@@ -350,25 +350,49 @@ test_load_dir_crlf_file()
 
 -- FIX 3b: COSMIC_DEBUG='' (empty string) must NOT enable debug mode.
 -- Only a non-empty COSMIC_DEBUG value should enable debug output.
+-- Rewritten for issue #505: capture the debug channel (envd writes via
+-- io.stderr) instead of asserting a count that passes either way.
+local function load_dir_capturing_stderr(dir: string): envd.LoadResult, string
+  local capture_path = fs.join(tmpdir, "envd_debug_capture")
+  local real_stderr = io.stderr
+  io.stderr = assert(io.open(capture_path, "w"))
+  local result = envd.load_dir(dir)
+  io.stderr:close()
+  io.stderr = real_stderr
+  return result, fs.read(capture_path) as string
+end
+
 local function test_cosmic_debug_empty_not_enabled()
-  -- When COSMIC_DEBUG is set to empty string, load_dir should NOT print debug.
-  -- We can't easily capture stderr, but we can verify that setting COSMIC_DEBUG=""
-  -- does NOT cause any side-effects that only happen in debug mode.
-  -- The observable behavior: with COSMIC_DEBUG="" the function should still work
-  -- normally (count==1), and the result should be the same as with no debug.
   local dir = make_envd("debug_empty")
   fs.write(fs.join(dir, "vars"), "COSMIC_ENVD_DEBUG_TEST=value\n")
   env.unset("COSMIC_ENVD_DEBUG_TEST")
 
-  -- Set COSMIC_DEBUG to empty string
   env.set("COSMIC_DEBUG", "")
-  local result = envd.load_dir(dir)
+  local result, captured = load_dir_capturing_stderr(dir)
   env.unset("COSMIC_DEBUG")
 
   assert(result.count == 1, "expected 1 with empty COSMIC_DEBUG, got " .. tostring(result.count))
+  assert(not captured:match("%[envd%]"),
+    "COSMIC_DEBUG='' must not emit debug output, got: " .. captured)
   env.unset("COSMIC_ENVD_DEBUG_TEST")
 end
 test_cosmic_debug_empty_not_enabled()
+
+local function test_cosmic_debug_nonempty_emits_debug()
+  local dir = make_envd("debug_on")
+  fs.write(fs.join(dir, "vars"), "COSMIC_ENVD_DEBUG_TEST2=value\n")
+  env.unset("COSMIC_ENVD_DEBUG_TEST2")
+
+  env.set("COSMIC_DEBUG", "1")
+  local result, captured = load_dir_capturing_stderr(dir)
+  env.unset("COSMIC_DEBUG")
+
+  assert(result.count == 1, "expected 1 with COSMIC_DEBUG=1, got " .. tostring(result.count))
+  assert(captured:match("%[envd%] set COSMIC_ENVD_DEBUG_TEST2"),
+    "COSMIC_DEBUG=1 must log each set variable, got: " .. captured)
+  env.unset("COSMIC_ENVD_DEBUG_TEST2")
+end
+test_cosmic_debug_nonempty_emits_debug()
 
 -- LoadResult.errors (issue #529, review item 39): per-file read failures
 -- are collected instead of being visible only under COSMIC_DEBUG.

--- a/lib/cosmic/fs/ops_test.tl
+++ b/lib/cosmic/fs/ops_test.tl
@@ -176,6 +176,86 @@ local function test_tmpfile_success_contract()
 end
 test_tmpfile_success_contract()
 
+-- utimensat/futimens (issue #505): exact timestamp semantics, not just
+-- "touch moved mtime forward".
+
+local function test_utimensat_sets_exact_times()
+  local test_dir = setup()
+  local p = fs.join(test_dir, "stamped")
+  touch(p, "x")
+
+  local ok, err = fs.utimensat(p, 1234567890, 500000000, 987654321, 250000000)
+  assert(ok, "utimensat should succeed: " .. (err or ""))
+
+  local st = fs.stat(p)
+  assert(st, "stat should succeed")
+  local a_s, a_ns = (st as fs_types.Stat):atim()
+  local m_s, m_ns = (st as fs_types.Stat):mtim()
+  assert(a_s == 1234567890 and a_ns == 500000000,
+    "atime should be exactly what was set, got " .. a_s .. "." .. a_ns)
+  assert(m_s == 987654321 and m_ns == 250000000,
+    "mtime should be exactly what was set, got " .. m_s .. "." .. m_ns)
+
+  teardown(test_dir)
+end
+test_utimensat_sets_exact_times()
+
+local function test_utimensat_missing_path()
+  local test_dir = setup()
+  local ok, err = fs.utimensat(fs.join(test_dir, "absent"), 1, 0, 1, 0)
+  assert(not ok, "utimensat on a missing path should fail")
+  assert(err and err:match("ENOENT"), "error should name ENOENT: " .. (err or ""))
+  teardown(test_dir)
+end
+test_utimensat_missing_path()
+
+local function test_futimens_sets_exact_times()
+  local test_dir = setup()
+  local p = fs.join(test_dir, "fstamped")
+  touch(p, "x")
+
+  local h, herr = cfd.open(p, 0)
+  assert(h, "open should succeed: " .. tostring(herr))
+  local hh = h as cfd.Handle
+  local ok, err = fs.futimens(hh:fd(), 111, 0, 222, 0)
+  assert(ok, "futimens should succeed: " .. (err or ""))
+
+  local st = fs.fstat(hh:fd())
+  assert(st, "fstat should succeed")
+  local a_s, a_ns = (st as fs_types.Stat):atim()
+  local m_s, m_ns = (st as fs_types.Stat):mtim()
+  assert(a_s == 111 and a_ns == 0,
+    "atime should be 111.0, got " .. a_s .. "." .. a_ns)
+  assert(m_s == 222 and m_ns == 0,
+    "mtime should be 222.0, got " .. m_s .. "." .. m_ns)
+  hh:close()
+
+  teardown(test_dir)
+end
+test_futimens_sets_exact_times()
+
+local function test_futimens_bad_fd()
+  local ok, err = fs.futimens(9999, 1, 0, 1, 0)
+  assert(not ok, "futimens on a bad fd should fail")
+  assert(err and err:match("EBADF"), "error should name EBADF: " .. (err or ""))
+end
+test_futimens_bad_fd()
+
+-- rmrf failure path (issue #505): a path whose parent component is a
+-- regular file fails with ENOTDIR regardless of privileges.
+
+local function test_rmrf_failure_reports_error()
+  local test_dir = setup()
+  local blocker = fs.join(test_dir, "afile")
+  touch(blocker, "x")
+  local ok, err = fs.rmrf(fs.join(blocker, "child"))
+  assert(not ok, "rmrf through a file component should fail")
+  assert(err and err:match("ENOTDIR"), "error should name ENOTDIR: " .. (err or ""))
+  assert(fs.isfile(blocker), "the blocking file must be untouched")
+  teardown(test_dir)
+end
+test_rmrf_failure_reports_error()
+
 local function test_tmpfile_failure_contract()
   -- The second return is always the path (nil on failure); the error is
   -- always in the third slot.

--- a/lib/cosmic/fs/path_test.tl
+++ b/lib/cosmic/fs/path_test.tl
@@ -46,6 +46,39 @@ local function test_join_basic()
 end
 test_join_basic()
 
+-- join semantics (issue #505): pin the documented edge cases so a change
+-- in the underlying C binding surfaces as a failure, not silent drift.
+
+local function test_join_absolute_later_arg_resets()
+  assert(fs.join("a", "/abs") == "/abs",
+    "an absolute later component must reset the result")
+end
+test_join_absolute_later_arg_resets()
+
+local function test_join_empty_components_skipped()
+  assert(fs.join("a", "", "b") == "a/b", "empty middle component is skipped")
+  assert(fs.join("", "b") == "b", "empty first component is skipped")
+end
+test_join_empty_components_skipped()
+
+local function test_join_no_doubled_separator()
+  assert(fs.join("a/", "b") == "a/b",
+    "a trailing slash on the left must not double the separator")
+end
+test_join_no_doubled_separator()
+
+local function test_join_single_component()
+  assert(fs.join("a") == "a", "a single component joins to itself")
+end
+test_join_single_component()
+
+local function test_join_does_not_normalize()
+  -- join concatenates; it does not resolve ".." (that is normalize's job).
+  assert(fs.join("a", "..", "b") == "a/../b",
+    "join must not collapse '..' segments")
+end
+test_join_does_not_normalize()
+
 local function test_join_multiple()
   local result = fs.join("/usr", "local", "bin")
   assert(result == "/usr/local/bin", "expected '/usr/local/bin', got '" .. result .. "'")

--- a/lib/cosmic/fs/walk_test.tl
+++ b/lib/cosmic/fs/walk_test.tl
@@ -2,6 +2,7 @@
 --- Tests for fs_walk module (symlink cycle safety)
 local fs_walk = require("cosmic.fs.walk")
 local fs = require("cosmic.fs")
+local user = require("cosmic.user")
 local type FileIter = fs_walk.FileIter
 local type WalkAction = fs_walk.WalkAction
 
@@ -157,6 +158,37 @@ local function test_files_missing_root_errors()
     "files error should name ENOENT: " .. tostring(err))
 end
 test_files_missing_root_errors()
+
+-- Error propagation: an unreadable subdirectory does not stop the walk,
+-- but the error is surfaced alongside the context (issue #505) — a
+-- partial walk must never be mistaken for a complete one.
+
+local function test_walk_permission_denied_subdir_reports_error()
+  if user.geteuid() == 0 then
+    return -- root bypasses permission checks; nothing to observe
+  end
+  local base = mksubdir("walk_denied")
+  local open_dir = fs.join(base, "open")
+  local locked = fs.join(base, "locked")
+  fs.makedirs(open_dir)
+  fs.makedirs(locked)
+  write_file(fs.join(open_dir, "seen.txt"), "x")
+  write_file(fs.join(locked, "hidden.txt"), "x")
+  assert(fs.chmod(locked, 0))
+
+  local visited: {string: boolean} = {}
+  local ctx, err = fs_walk.walk(base, function(_p: string, name: string,
+        _st: any, c: {string: boolean})
+      c[name] = true
+    end, visited)
+  assert(fs.chmod(locked, tonumber("755", 8)))
+
+  assert(ctx ~= nil, "a denied subdir must not abort the walk")
+  assert(visited["seen.txt"], "readable entries must still be visited")
+  assert(err and err:match("EACCES"),
+    "walk must surface the denied subdir as EACCES: " .. tostring(err))
+end
+test_walk_permission_denied_subdir_reports_error()
 
 -- #558b: visitor return protocol — "skip" prunes a subtree, "stop" ends
 -- the walk. Visitors that return nothing keep today's behavior.

--- a/lib/cosmic/hash_test.tl
+++ b/lib/cosmic/hash_test.tl
@@ -30,6 +30,25 @@ local function test_sha256_empty_string()
 end
 test_sha256_empty_string()
 
+-- NIST FIPS 180-4 vectors (issue #505): the canonical empty and "abc"
+-- inputs, asserted byte-for-byte, not just by length.
+
+local function test_sha256_nist_empty_vector()
+  local digest = hash.sha256_hex("")
+  local expected = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  assert(digest == expected,
+    "sha256('') should match the NIST vector, got " .. digest)
+end
+test_sha256_nist_empty_vector()
+
+local function test_sha256_nist_abc_vector()
+  local digest = hash.sha256_hex("abc")
+  local expected = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+  assert(digest == expected,
+    "sha256('abc') should match the NIST vector, got " .. digest)
+end
+test_sha256_nist_abc_vector()
+
 local function test_sha256_hex_returns_64_chars()
   local digest = hash.sha256_hex("hello")
   assert(#digest == 64, "sha256_hex should return 64 characters, got " .. #digest)
@@ -114,6 +133,37 @@ local function test_password_unicode()
   assert(valid == true, "verify_password should verify unicode password")
 end
 test_password_unicode()
+
+-- argon2i / argon2d variants (issue #505): happy-path round trips, not
+-- just the invalid-variant guard below.
+
+local function test_password_argon2i_roundtrip()
+  local encoded, err = hash.password("pw-i", {
+      variant = "argon2i", m_cost = 2048, t_cost = 1, parallelism = 1,
+    })
+  assert(encoded, "argon2i password should succeed: " .. tostring(err))
+  assert(string.match(encoded as string, "^%$argon2i%$"),
+    "encoded string should carry the argon2i tag, got: " .. tostring(encoded))
+  assert(hash.verify_password(encoded, "pw-i") == true,
+    "argon2i verify should accept the right password")
+  assert(hash.verify_password(encoded, "wrong") == false,
+    "argon2i verify should reject a wrong password")
+end
+test_password_argon2i_roundtrip()
+
+local function test_password_argon2d_roundtrip()
+  local encoded, err = hash.password("pw-d", {
+      variant = "argon2d", m_cost = 2048, t_cost = 1, parallelism = 1,
+    })
+  assert(encoded, "argon2d password should succeed: " .. tostring(err))
+  assert(string.match(encoded as string, "^%$argon2d%$"),
+    "encoded string should carry the argon2d tag, got: " .. tostring(encoded))
+  assert(hash.verify_password(encoded, "pw-d") == true,
+    "argon2d verify should accept the right password")
+  assert(hash.verify_password(encoded, "wrong") == false,
+    "argon2d verify should reject a wrong password")
+end
+test_password_argon2d_roundtrip()
 
 local function test_password_invalid_variant()
   -- the Variant enum rejects this literal statically; cast to keep

--- a/lib/cosmic/json_test.tl
+++ b/lib/cosmic/json_test.tl
@@ -155,6 +155,83 @@ local function test_nan_inf_encoding()
 end
 test_nan_inf_encoding()
 
+-- Precision, nesting, \uXXXX escapes, and NUL bytes (issue #505).
+
+local function test_integer_precision_roundtrip()
+  -- 2^53 + 1 is not representable as a double; it survives only if the
+  -- encoder and decoder keep 64-bit integers as integers.
+  local n = 9007199254740993
+  local encoded = json.encode(n)
+  assert(encoded == "9007199254740993",
+    "integer must encode without float rounding, got: " .. tostring(encoded))
+  local decoded = json.decode(encoded as string)
+  assert(decoded as integer == n, "integer must round-trip exactly")
+  assert(math.type(decoded as number) == "integer",
+    "decoded integer should stay an integer")
+end
+test_integer_precision_roundtrip()
+
+local function test_float_precision_roundtrip()
+  for _, f in ipairs({0.1, 3.141592653589793, 1e308, -2.5e-10}) do
+    local decoded = json.decode(json.encode(f) as string)
+    assert(decoded as number == f,
+      "float should round-trip bit-exactly: " .. tostring(f)
+      .. " -> " .. tostring(decoded))
+  end
+end
+test_float_precision_roundtrip()
+
+local function test_decode_unicode_escapes()
+  assert(json.decode('"\\u0041"') as string == "A", "\\u0041 should decode to A")
+  assert(json.decode('"\\u00e9"') as string == "\xc3\xa9",
+    "\\u00e9 should decode to UTF-8 e-acute")
+  -- Surrogate pair: U+1F600 (emoji) is 4 UTF-8 bytes.
+  local emoji = json.decode('"\\uD83D\\uDE00"') as string
+  assert(emoji == "\xf0\x9f\x98\x80",
+    "surrogate pair should decode to 4-byte UTF-8, got " .. tostring(emoji))
+end
+test_decode_unicode_escapes()
+
+local function test_nul_byte_roundtrip()
+  local decoded = json.decode('"\\u0000"') as string
+  assert(#decoded == 1 and decoded == "\0",
+    "\\u0000 should decode to a 1-byte NUL string")
+  local encoded = json.encode("\0")
+  assert(encoded == '"\\u0000"',
+    "an embedded NUL should encode as \\u0000, got: " .. tostring(encoded))
+  local rt = json.decode(json.encode("a\0b") as string) as string
+  assert(rt == "a\0b" and #rt == 3, "NUL inside a string must round-trip")
+end
+test_nul_byte_roundtrip()
+
+local function test_decode_depth_limit()
+  -- 63 nested arrays decode; 64 exceed the C decoder's depth limit and
+  -- must fail with a clean error, never crash or recurse unbounded.
+  local ok63 = string.rep("[", 63) .. "1" .. string.rep("]", 63)
+  assert(json.decode(ok63) ~= nil, "63 nesting levels should decode")
+  local deep = string.rep("[", 64) .. "1" .. string.rep("]", 64)
+  local decoded, err = json.decode(deep)
+  assert(decoded == nil, "64 nesting levels should be rejected")
+  assert(err and err:match("depth"),
+    "error should name the depth limit, got: " .. tostring(err))
+end
+test_decode_depth_limit()
+
+local function test_encode_default_depth_limit()
+  -- Without an explicit maxdepth, a very deep table still fails cleanly.
+  local t: {any} = {1}
+  local root = t
+  for _ = 1, 200 do
+    local inner: {any} = {1}
+    t[1] = inner
+    t = inner
+  end
+  local encoded, err = json.encode(root)
+  assert(encoded == nil, "encoding a 200-deep table should fail")
+  assert(err ~= nil, "deep-table failure should carry an error message")
+end
+test_encode_default_depth_limit()
+
 local function test_empty_array_roundtrip()
   -- Decoded arrays carry the shared array marker, so [] survives a
   -- round-trip instead of collapsing into {}.

--- a/lib/cosmic/quicksand/caps_test.tl
+++ b/lib/cosmic/quicksand/caps_test.tl
@@ -1,6 +1,7 @@
 #!/usr/bin/env cosmic
 local caps = require("cosmic.quicksand.caps")
 local quicksand = require("cosmic.quicksand")
+local check = require("cosmic.check")
 local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
 
@@ -104,7 +105,12 @@ local function test_drop_bounding_child()
   local h = spawn.spawn({cosmic, "-e", CHILD_DROP})
   local __r1 = (h as spawn.Handle):wait() as spawn.Result
   local ok, out = __r1.ok, __r1.stdout
-  if not ok then return end
+  if not ok then
+    -- An outer seccomp/pledge filter can kill the child before it can
+    -- report; a silent return here would hide that from the skip report.
+    check.skip("caps drop child died before reporting (outer sandbox)")
+    return
+  end
   local s = out as string
   assert(s:find("dropped") or s:find("skipped"),
     "expected dropped or skipped, got: " .. s)

--- a/lib/cosmic/quicksand/init_test.tl
+++ b/lib/cosmic/quicksand/init_test.tl
@@ -53,17 +53,16 @@ local function test_user_ns_agrees_with_scratch_probe()
 end
 test_user_ns_agrees_with_scratch_probe()
 
-local function test_is_supported_returns_boolean()
-  local v = quicksand.is_supported()
-  assert(type(v) == "boolean", "is_supported() should return a boolean, got " .. type(v))
-end
-test_is_supported_returns_boolean()
-
+-- is_supported (issue #505): pinned to the capability report it is
+-- derived from (which the shape test above proves is all booleans),
+-- and stable across calls — not just "returns a boolean".
 local function test_is_supported_matches_capabilities()
   local c = quicksand.capabilities()
   local expected = c.linux and c.net_ns and c.mount_ns
   assert(quicksand.is_supported() == expected,
     "is_supported() must agree with capabilities().linux/net_ns/mount_ns")
+  assert(quicksand.is_supported() == expected,
+    "is_supported() must be deterministic across calls")
 end
 test_is_supported_matches_capabilities()
 

--- a/lib/cosmic/rand_test.tl
+++ b/lib/cosmic/rand_test.tl
@@ -24,6 +24,26 @@ local function test_bytes_various_sizes()
 end
 test_bytes_various_sizes()
 
+local function test_bytes_statistical_sanity()
+  -- 4096 draws should touch nearly all 256 byte values: the chance a
+  -- given value is absent is (255/256)^4096 ~ 1e-7, so requiring 250
+  -- distinct values can only fail on a broken (constant/low-entropy)
+  -- generator, not on bad luck.
+  local b = assert(rand.bytes(4096)) as string
+  local seen: {integer: boolean} = {}
+  local distinct = 0
+  for i = 1, #b do
+    local v = string.byte(b, i)
+    if not seen[v] then
+      seen[v] = true
+      distinct = distinct + 1
+    end
+  end
+  assert(distinct >= 250,
+    "4096 random bytes should cover >=250 distinct values, got " .. distinct)
+end
+test_bytes_statistical_sanity()
+
 -- Fast pseudo-random tests (non-cryptographic).
 
 local function test_rand64()

--- a/lib/cosmic/sqlite/advanced_test.tl
+++ b/lib/cosmic/sqlite/advanced_test.tl
@@ -298,6 +298,29 @@ local function test_transaction_commits_on_no_return()
 end
 test_transaction_commits_on_no_return()
 
+local function test_nested_transaction_fails_inner_only()
+  -- BEGIN does not nest in SQLite (issue #505): an inner db:transaction
+  -- must fail with SQLite's own message, while the outer transaction and
+  -- its writes survive. Nesting is what savepoint() is for.
+  local db = sqlite.open(":memory:") as sqlite.Database
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+
+  local ok, err = db:transaction(function(d: sqlite.Database)
+      local inner_ok, inner_err = d:transaction(function(_d2: sqlite.Database)
+        end)
+      assert(not inner_ok, "an inner transaction must fail")
+      assert(inner_err and inner_err:match("within a transaction"),
+        "inner error should name the nesting problem, got: " .. tostring(inner_err))
+      d:exec("INSERT INTO t (name) VALUES (?)", "outer-survives")
+    end)
+  assert(ok, "the outer transaction must still commit: " .. tostring(err))
+
+  local row = db:query_one("SELECT COUNT(*) AS c FROM t") as {string: any}
+  assert(row.c == 1, "the outer write must commit, got " .. tostring(row.c))
+  db:close()
+end
+test_nested_transaction_fails_inner_only()
+
 -- Named parameters
 
 local function test_bind_named()

--- a/lib/cosmic/sqlite/data_test.tl
+++ b/lib/cosmic/sqlite/data_test.tl
@@ -130,3 +130,57 @@ local function test_read_only_missing_file_fails()
   assert(err, "should return an error message")
 end
 test_read_only_missing_file_fails()
+
+-- constraint violations (issue #505): exec must return false plus the
+-- constraint's own message, never throw or silently succeed.
+
+local function test_unique_constraint_violation()
+  local db = sqlite.open(":memory:") as sqlite.Database
+  db:exec("CREATE TABLE t (u TEXT UNIQUE)")
+  assert(db:exec("INSERT INTO t (u) VALUES (?)", "dup"))
+  local ok, err = db:exec("INSERT INTO t (u) VALUES (?)", "dup")
+  assert(not ok, "duplicate insert should fail")
+  assert(err and err:match("UNIQUE constraint failed"),
+    "error should name the UNIQUE constraint, got: " .. tostring(err))
+  local row = db:query_one("SELECT COUNT(*) AS c FROM t") as {string: any}
+  assert(row.c == 1, "the failed insert must not add a row")
+  db:close()
+end
+test_unique_constraint_violation()
+
+local function test_not_null_constraint_violation()
+  local db = sqlite.open(":memory:") as sqlite.Database
+  db:exec("CREATE TABLE t (n TEXT NOT NULL)")
+  local ok, err = db:exec("INSERT INTO t (n) VALUES (?)", nil)
+  assert(not ok, "NULL insert into NOT NULL column should fail")
+  assert(err and err:match("NOT NULL constraint failed"),
+    "error should name the NOT NULL constraint, got: " .. tostring(err))
+  db:close()
+end
+test_not_null_constraint_violation()
+
+-- SQLITE_BUSY (issue #505): real lock contention between two connections
+-- to the same file, not just the busy_timeout PRAGMA readback above.
+
+local function test_busy_second_connection_write_blocked()
+  local path = fs.join(TEST_TMPDIR, "busy_test.db")
+  local a = sqlite.open(path) as sqlite.Database
+  a:exec("CREATE TABLE k (v TEXT)")
+  -- busy_timeout_ms=0: fail immediately instead of stalling the test.
+  local b = sqlite.open(path, {busy_timeout_ms = 0}) as sqlite.Database
+
+  assert(a:exec("BEGIN IMMEDIATE"))
+  assert(a:exec("INSERT INTO k (v) VALUES (?)", "held"))
+
+  local ok, err = b:exec("INSERT INTO k (v) VALUES (?)", "blocked")
+  assert(not ok, "write while another connection holds the lock should fail")
+  assert(err and err:match("locked"),
+    "error should report the lock, got: " .. tostring(err))
+
+  assert(a:exec("COMMIT"))
+  local ok2, err2 = b:exec("INSERT INTO k (v) VALUES (?)", "after")
+  assert(ok2, "write after the lock is released should succeed: " .. tostring(err2))
+  a:close()
+  b:close()
+end
+test_busy_second_connection_write_blocked()

--- a/lib/cosmic/syslog_test.tl
+++ b/lib/cosmic/syslog_test.tl
@@ -1,71 +1,40 @@
 #!/usr/bin/env cosmic
 local syslog = require("cosmic.syslog")
 
--- Test that priority constants are defined
-local function test_constants()
-  assert(syslog.LOG_EMERG ~= nil, "LOG_EMERG should be defined")
-  assert(syslog.LOG_ALERT ~= nil, "LOG_ALERT should be defined")
-  assert(syslog.LOG_CRIT ~= nil, "LOG_CRIT should be defined")
-  assert(syslog.LOG_ERR ~= nil, "LOG_ERR should be defined")
-  assert(syslog.LOG_WARNING ~= nil, "LOG_WARNING should be defined")
-  assert(syslog.LOG_NOTICE ~= nil, "LOG_NOTICE should be defined")
-  assert(syslog.LOG_INFO ~= nil, "LOG_INFO should be defined")
-  assert(syslog.LOG_DEBUG ~= nil, "LOG_DEBUG should be defined")
-
-  -- Check that priorities have expected ordering (lower = more severe)
-  assert(syslog.LOG_EMERG < syslog.LOG_DEBUG, "LOG_EMERG should be lower than LOG_DEBUG")
-  assert(syslog.LOG_ERR < syslog.LOG_WARNING, "LOG_ERR should be lower than LOG_WARNING")
-  assert(syslog.LOG_WARNING < syslog.LOG_INFO, "LOG_WARNING should be lower than LOG_INFO")
+-- Priority constants are the wire protocol: RFC 5424 fixes their numeric
+-- values (issue #505 — pinned exactly, not just "defined and ordered").
+local function test_constants_rfc5424_values()
+  assert(syslog.LOG_EMERG == 0, "LOG_EMERG must be 0, got " .. tostring(syslog.LOG_EMERG))
+  assert(syslog.LOG_ALERT == 1, "LOG_ALERT must be 1, got " .. tostring(syslog.LOG_ALERT))
+  assert(syslog.LOG_CRIT == 2, "LOG_CRIT must be 2, got " .. tostring(syslog.LOG_CRIT))
+  assert(syslog.LOG_ERR == 3, "LOG_ERR must be 3, got " .. tostring(syslog.LOG_ERR))
+  assert(syslog.LOG_WARNING == 4, "LOG_WARNING must be 4, got " .. tostring(syslog.LOG_WARNING))
+  assert(syslog.LOG_NOTICE == 5, "LOG_NOTICE must be 5, got " .. tostring(syslog.LOG_NOTICE))
+  assert(syslog.LOG_INFO == 6, "LOG_INFO must be 6, got " .. tostring(syslog.LOG_INFO))
+  assert(syslog.LOG_DEBUG == 7, "LOG_DEBUG must be 7, got " .. tostring(syslog.LOG_DEBUG))
 end
-test_constants()
+test_constants_rfc5424_values()
 
--- Test that functions exist and are callable
--- Note: actual syslog delivery may fail in containerized environments
--- where /dev/log doesn't exist, but the functions should not error
-local function test_write_functions_exist()
-  assert(type(syslog.write) == "function", "write should be a function")
-  assert(type(syslog.emerg) == "function", "emerg should be a function")
-  assert(type(syslog.alert) == "function", "alert should be a function")
-  assert(type(syslog.crit) == "function", "crit should be a function")
-  assert(type(syslog.err) == "function", "err should be a function")
-  assert(type(syslog.warning) == "function", "warning should be a function")
-  assert(type(syslog.notice) == "function", "notice should be a function")
-  assert(type(syslog.info) == "function", "info should be a function")
-  assert(type(syslog.debug) == "function", "debug should be a function")
-end
-test_write_functions_exist()
-
--- Test calling every priority-level convenience function completes without error
-local function test_write_calls()
-  syslog.write(syslog.LOG_INFO, "cosmic.syslog test: write()")
-  syslog.emerg("cosmic.syslog test: emerg()")
-  syslog.alert("cosmic.syslog test: alert()")
-  syslog.crit("cosmic.syslog test: crit()")
-  syslog.err("cosmic.syslog test: err()")
-  syslog.warning("cosmic.syslog test: warning()")
-  syslog.notice("cosmic.syslog test: notice()")
-  syslog.info("cosmic.syslog test: info()")
-  syslog.debug("cosmic.syslog test: debug()")
-end
-test_write_calls()
-
--- Test that write dispatches to each priority constant without error
-local function test_write_all_priorities()
-  local priorities = {
-    syslog.LOG_EMERG,
-    syslog.LOG_ALERT,
-    syslog.LOG_CRIT,
-    syslog.LOG_ERR,
-    syslog.LOG_WARNING,
-    syslog.LOG_NOTICE,
-    syslog.LOG_INFO,
-    syslog.LOG_DEBUG,
+-- Delivery is unobservable here (containers usually lack /dev/log), so
+-- the only falsifiable in-process contract beyond the constant values is
+-- "never throws": a broken binding or bad argument handling would raise.
+local function test_write_smoke_never_throws()
+  local calls: {function()} = {
+    function() syslog.write(syslog.LOG_INFO, "cosmic.syslog test: write()") end,
+    function() syslog.emerg("cosmic.syslog test: emerg()") end,
+    function() syslog.alert("cosmic.syslog test: alert()") end,
+    function() syslog.crit("cosmic.syslog test: crit()") end,
+    function() syslog.err("cosmic.syslog test: err()") end,
+    function() syslog.warning("cosmic.syslog test: warning()") end,
+    function() syslog.notice("cosmic.syslog test: notice()") end,
+    function() syslog.info("cosmic.syslog test: info()") end,
+    function() syslog.debug("cosmic.syslog test: debug()") end,
   }
-  for _, prio in ipairs(priorities) do
-    assert(type(prio) == "number", "priority should be a number")
-    syslog.write(prio, "test priority " .. tostring(prio))
+  for i, call in ipairs(calls) do
+    local ok, thrown = pcall(call as function(): any)
+    assert(ok, "syslog call " .. i .. " must not throw: " .. tostring(thrown))
   end
 end
-test_write_all_priorities()
+test_write_smoke_never_throws()
 
 print("All syslog tests passed")

--- a/lib/cosmic/tty_test.tl
+++ b/lib/cosmic/tty_test.tl
@@ -1,4 +1,7 @@
 #!/usr/bin/env cosmic
+local cfd = require("cosmic.fd")
+local fs = require("cosmic.fs")
+local spawn = require("cosmic.child")
 local tty = require("cosmic.tty")
 
 -- Test module exports
@@ -12,53 +15,45 @@ local function test_module_exports()
 end
 test_module_exports()
 
--- Test isatty with standard file descriptors
--- Note: In test environments, stdin/stdout/stderr are typically not ttys
+-- isatty (issue #505): assert real verdicts on fds whose tty-ness is
+-- known, instead of only checking the return type.
 
-local function test_isatty_returns_boolean()
-  local result = tty.isatty(0)
-  assert(type(result) == "boolean", "isatty should return boolean, got " .. type(result))
+local function test_isatty_regular_file_is_false()
+  local test_file = fs.join(os.getenv("TEST_TMPDIR") as string, "not_a_tty")
+  fs.write(test_file, "x")
+  local h = cfd.open(test_file, cfd.O_RDONLY)
+  assert(h, "should open the scratch file")
+  local hh = h as cfd.Handle
+  assert(tty.isatty(hh:fd()) == false, "a regular file fd is not a tty")
+  hh:close()
 end
-test_isatty_returns_boolean()
+test_isatty_regular_file_is_false()
 
-local function test_isatty_stdin()
-  local result = tty.isatty(0)
-  -- In test environment, stdin is typically not a tty (piped)
-  assert(type(result) == "boolean", "isatty(0) should return boolean")
+local function test_isatty_bad_fd_is_false()
+  assert(tty.isatty(999) == false, "an unopened fd is not a tty")
 end
-test_isatty_stdin()
+test_isatty_bad_fd_is_false()
 
-local function test_isatty_stdout()
-  local result = tty.isatty(1)
-  assert(type(result) == "boolean", "isatty(1) should return boolean")
+local function test_isatty_pty_master_is_true()
+  -- A pty master is the one fd guaranteed to BE a tty. /dev/ptmx exists
+  -- on Linux; elsewhere this case is exercised wherever the device exists.
+  if not fs.exists("/dev/ptmx") then
+    return
+  end
+  local h, err = cfd.open("/dev/ptmx", cfd.O_RDWR)
+  assert(h, "opening /dev/ptmx should succeed: " .. tostring(err))
+  local hh = h as cfd.Handle
+  assert(tty.isatty(hh:fd()) == true, "a pty master must report as a tty")
+  hh:close()
 end
-test_isatty_stdout()
+test_isatty_pty_master_is_true()
 
-local function test_isatty_stderr()
-  local result = tty.isatty(2)
-  assert(type(result) == "boolean", "isatty(2) should return boolean")
+local function test_convenience_functions_agree_with_isatty()
+  assert(tty.stdin_isatty() == tty.isatty(0), "stdin_isatty must equal isatty(0)")
+  assert(tty.stdout_isatty() == tty.isatty(1), "stdout_isatty must equal isatty(1)")
+  assert(tty.stderr_isatty() == tty.isatty(2), "stderr_isatty must equal isatty(2)")
 end
-test_isatty_stderr()
-
--- Test convenience functions
-
-local function test_stdin_isatty()
-  local result = tty.stdin_isatty()
-  assert(type(result) == "boolean", "stdin_isatty should return boolean")
-end
-test_stdin_isatty()
-
-local function test_stdout_isatty()
-  local result = tty.stdout_isatty()
-  assert(type(result) == "boolean", "stdout_isatty should return boolean")
-end
-test_stdout_isatty()
-
-local function test_stderr_isatty()
-  local result = tty.stderr_isatty()
-  assert(type(result) == "boolean", "stderr_isatty should return boolean")
-end
-test_stderr_isatty()
+test_convenience_functions_agree_with_isatty()
 
 -- Test winsize function
 
@@ -173,37 +168,42 @@ local function test_noecho_non_tty()
 end
 test_noecho_non_tty()
 
--- Test getpass function
+-- getpass (issue #505): exercised end-to-end in a subprocess with a
+-- piped (non-tty) stdin, instead of only checking the export exists.
 
-local function test_getpass_exported()
-  assert(tty.getpass ~= nil, "getpass function should be exported")
-  assert(type(tty.getpass) == "function", "getpass should be a function")
+local getpass_script = fs.join(os.getenv("TEST_TMPDIR") as string, "getpass_child.lua")
+fs.write(getpass_script, [[
+local tty = require("cosmic.tty")
+local line, err = tty.getpass("pw: ")
+if line == nil then
+  io.write("ERR:" .. tostring(err))
+else
+  io.write("GOT:" .. line)
 end
-test_getpass_exported()
+]])
+local cosmic_bin = fs.join(os.getenv("TEST_BIN") as string, "cosmic")
+
+local function test_getpass_non_tty_reads_one_line()
+  local h = spawn.spawn({cosmic_bin, getpass_script}, {stdin = "sekrit\nsecond\n"})
+  assert(h, "getpass child should spawn")
+  local r = (h as spawn.Handle):wait() as spawn.Result
+  assert(r.ok, "getpass child should exit 0: " .. tostring(r.stderr))
+  assert(r.stdout == "GOT:sekrit",
+    "getpass should return exactly the first stdin line, got: " .. tostring(r.stdout))
+  assert((r.stderr as string):match("^pw: "),
+    "the prompt must go to stderr, got: " .. tostring(r.stderr))
+end
+test_getpass_non_tty_reads_one_line()
 
 local function test_getpass_non_tty_eof()
-  -- When stdin is not a tty and is at EOF, getpass should return nil, "EOF"
-  if not tty.isatty(0) then
-    -- stdin in test env is closed/at EOF or piped with no data
-    -- We can't easily test the EOF path without modifying stdin,
-    -- but we can verify the function is callable without panicking.
-    -- The non-tty path reads from stdin; if stdin has data it returns a line.
-    -- Skip actual invocation since it would consume stdin unexpectedly.
-    io.stderr:write("SKIP: test_getpass_non_tty_eof (cannot safely consume stdin in test)\n")
-  end
+  local h = spawn.spawn({cosmic_bin, getpass_script}, {stdin = ""})
+  assert(h, "getpass child should spawn")
+  local r = (h as spawn.Handle):wait() as spawn.Result
+  assert(r.ok, "getpass child should exit 0: " .. tostring(r.stderr))
+  assert(r.stdout == "ERR:EOF",
+    "getpass at stdin EOF should return nil, 'EOF', got: " .. tostring(r.stdout))
 end
 test_getpass_non_tty_eof()
-
-local function test_getpass_tty_only()
-  -- When stdin is a tty, getpass would prompt interactively — skip in test env.
-  if tty.isatty(0) then
-    io.stderr:write("SKIP: test_getpass_tty_only (stdin is a tty, interactive test not supported)\n")
-  else
-    -- Non-tty: function exists and has correct signature, already tested above.
-    assert(tty.getpass ~= nil, "getpass exported")
-  end
-end
-test_getpass_tty_only()
 
 -- make_raw: pure raw-mode computation, unit-testable without a tty
 -- (issue #529, review item 35).

--- a/lib/cosmic/zip_test.tl
+++ b/lib/cosmic/zip_test.tl
@@ -165,6 +165,57 @@ local function test_appender()
 end
 test_appender()
 
+-- Appender:remove (issue #505): previously wholly untested.
+
+local function test_appender_remove()
+  local p = zip_path("remove_test.zip")
+  local w = zip.writer(p) as zip.Writer
+  w:add("gone.txt", "delete me")
+  w:add("kept.txt", "keep me")
+  w:close()
+
+  local a, err = zip.appender(p)
+  assert(a, "should open for appending: " .. tostring(err))
+  local appender = a as zip.Appender
+  local ok, remove_err = appender:remove("gone.txt")
+  assert(ok, "remove of an existing entry should succeed: " .. tostring(remove_err))
+  appender:close()
+
+  local r = zip.reader(p) as zip.Reader
+  local files = r:list()
+  assert(#files == 1, "archive should have 1 entry after remove, got " .. #files)
+  assert(files[1].name == "kept.txt",
+    "the surviving entry should be kept.txt, got " .. tostring(files[1].name))
+  local kept = r:read("kept.txt")
+  assert(kept == "keep me", "surviving entry content must be intact")
+  local gone, read_err = r:read("gone.txt")
+  assert(gone == nil, "the removed entry must not be readable")
+  assert(read_err and read_err:match("not found"),
+    "reading a removed entry should say not found, got: " .. tostring(read_err))
+  r:close()
+end
+test_appender_remove()
+
+local function test_appender_remove_missing_entry()
+  local p = zip_path("remove_missing_test.zip")
+  local w = zip.writer(p) as zip.Writer
+  w:add("only.txt", "here")
+  w:close()
+
+  local appender = zip.appender(p) as zip.Appender
+  local ok, err = appender:remove("no-such-entry.txt")
+  assert(ok == nil, "remove of a missing entry should fail")
+  assert(err and err:match("not found"),
+    "error should say the entry was not found, got: " .. tostring(err))
+  appender:close()
+
+  -- The archive is untouched by the failed remove.
+  local r = zip.reader(p) as zip.Reader
+  assert(r:read("only.txt") == "here", "existing entry must survive a failed remove")
+  r:close()
+end
+test_appender_remove_missing_entry()
+
 -- In-memory reading with from()
 
 local function test_from_memory()


### PR DESCRIPTION
Closes #505 (audit finding §5.3, umbrella).

Several items enumerated in the audit were already closed by later PRs (getopt error paths, rand int/choice/shuffle distribution tests, digest "abc" vectors, sqlite use-after-close/BLOB-NUL/savepoints, walk missing-root errors, box run-shape tests). This PR closes the remaining gaps and rewrites the still-tautological tests. Every pinned behavior was verified against the real binary before being asserted.

## New error-path / edge-case tests

- **fs**: `utimensat`/`futimens` exact-timestamp semantics (set → stat back both `atim`/`mtim` with nanoseconds) plus ENOENT/EBADF failure paths; `rmrf` failure path (ENOTDIR through a file component — fails even as root); `walk` surfaces a permission-denied subdirectory as `ctx + EACCES error` instead of a silently partial walk (guarded on non-root, verified with `setpriv`); `join` semantics pinned (absolute later arg resets, empty components skipped, no separator doubling, no `..` normalization).
- **sqlite**: UNIQUE and NOT NULL constraint violations return `false` + the constraint's message and don't add rows; real two-connection `SQLITE_BUSY` contention on a file database (`busy_timeout_ms=0` writer fails with "database is locked" while the lock is held, succeeds after COMMIT); nested `db:transaction` fails inner-only ("cannot start a transaction within a transaction") while the outer transaction commits.
- **hash**: NIST FIPS 180-4 empty-string and "abc" SHA-256 vectors asserted byte-for-byte; `argon2i`/`argon2d` happy-path round trips (encoded tag + verify accept/reject).
- **json**: 64-bit integer precision (2^53+1 round-trips as integer), bit-exact float round trips, `\uXXXX` escapes including surrogate pairs, NUL byte round trip (`` ⇄ embedded NUL), decode depth limit (63 ok / 64 clean error) and default encode depth failure.
- **zip**: `Appender:remove` — removing an existing entry (survivors intact, removed entry unreadable) and a missing entry (`nil, "entry not found"`, archive untouched).
- **rand**: `bytes()` statistical sanity (4096 draws must cover ≥250 distinct byte values; false-positive probability ~0).

## Tautological tests rewritten to be falsifiable

- **tty**: the six type-only `isatty` tests replaced with real verdicts — regular-file fd and unopened fd are `false`, a `/dev/ptmx` pty master is `true`, convenience functions must agree with `isatty(0/1/2)`; the two getpass skip-only tests replaced with end-to-end subprocess tests (piped stdin returns exactly the first line with the prompt on stderr; empty stdin returns `nil, "EOF"`).
- **syslog**: constants pinned to their RFC 5424 wire values (0–7) instead of "defined and ordered"; blind write calls wrapped in `pcall` + assert so a throwing binding fails the test (delivery itself is unobservable in containers without /dev/log).
- **envd**: the `COSMIC_DEBUG=""` test now captures the debug channel (envd writes via `io.stderr`) and asserts no `[envd]` output, plus a companion test asserting `COSMIC_DEBUG=1` does emit per-variable debug lines; previously it asserted a count that passed either way. `envd` now exports its `LoadResult` type for the test helper.
- **quicksand**: the type-only `is_supported` test folded into the capabilities-agreement test (which also asserts determinism); the caps drop-child test's silent `return` on child death is now a named `check.skip`.

Cast-ratchet pins in `lib/build/casts.txt` raised for the new test code.

## Verification

- `bin/make ci` passes (format + teal + test + example + lint + coverage): 284 teal checks, 134 test files, 354 lint checks, all green.
- The walk-EACCES path was additionally verified as an unprivileged user via `setpriv --reuid=nobody` since the development container runs as root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgJ3zykwYPKPh7eKAAH8rj

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgJ3zykwYPKPh7eKAAH8rj)_