### PR TITLE
3p: bump cosmos to 2026.07.18-1c5cfce40 (Mbed TLS 3.6 cutover, fixed)

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "98c5a286d897ebfa00e5259a2da38cec1ffb53a5c07d5bad93c364b822b7282e"}},
+  platforms = {["*"] = {sha = "c7b22179a5f7199689d590dbf73537d85a22cb5ce4a8d724091ffdcbd55119f1"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.13-89007e6eb"
+  version = "2026.07.18-34ab43699"
 }

--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "c7b22179a5f7199689d590dbf73537d85a22cb5ce4a8d724091ffdcbd55119f1"}},
+  platforms = {["*"] = {sha = "309dcbbc28bd33055aa41f0275671c19d134d22bef8b0e3d01a6bf3c4791f089"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.18-34ab43699"
+  version = "2026.07.18-1c5cfce40"
 }


### PR DESCRIPTION
Bumps the cosmos pin across the Mbed TLS 3.6 cutover, landing on `2026.07.18-1c5cfce40` — the release containing the regression fixes in whilp/cosmopolitan#190. **No longer blocked; expected green.**

## History

The first pin attempt (`2026.07.18-34ab43699`, the raw cutover from whilp/cosmopolitan#182/#183) failed this branch's regression sweep with two C-layer breaks, despite the cutover's "no binding contract changes" claim:

- **`hash_test` red**: `GetCryptoHash` lost case-insensitive algorithm names (3.6 matches exact uppercase; the 2.26 fork used `strcasecmp`), and `blake2b256` vanished entirely (3.6 has no BLAKE2b) — every `cosmic.hash` `digest()`/`hmac()` call errored with `unknown hash type`. Only `hash.sha256()`/`hmac_sha256()` survived (dedicated `Sha256` binding / uppercase literal), which is why upstream's own SHA-256 gates missed it.
- **`perf-compare` red**: `hash_sha256_1mb` +46.3% (2.78 → 4.07 ms), `hash_sha256_small` +26.9% — the fork's SHA-NI/AVX2 kernels weren't wired into pristine 3.6.

whilp/cosmopolitan#190 (merged) restored both, and pushed the gate down: `tool/lua/test_crypto_hash.lua` now pins the full `GetCryptoHash` contract (known-answer vectors in both cases, HMAC, blake2b256, error shape) in cosmopolitan's own CI, so a break like this fails upstream before a release is cut instead of here at pin time.

## Verification on the final pin

- `bin/make regen-types` — byte-for-byte no-op (`definitions.lua` unchanged across all three pins); `test only=gentype` passes
- `bin/make ci` — green, including `hash_test`
- `bin/make perf-compare` against a fresh same-machine old-pin (`2026.07.13-89007e6eb`) baseline:
```
hash_sha256_1mb    2.64 ms -> 2.66 ms   +0.6%  ok
hash_sha256_small  698.7 ns -> 748.5 ns +7.1%  ok (within noise)
35 scenarios: 0 regression, 3 faster, 32 ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xat3KY6vn4jpoTEoRxgUN8