### PR TITLE
3p: bump cosmos to 2026.07.18-feb77961c (sqlite 3.40.0 → 3.53.3)

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "309dcbbc28bd33055aa41f0275671c19d134d22bef8b0e3d01a6bf3c4791f089"}},
+  platforms = {["*"] = {sha = "c46ddd491c254a3c05cc7aa9237c2c88f71bb7fc1b6f876ad7e5072abe63ae2f"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.18-1c5cfce40"
+  version = "2026.07.18-feb77961c"
 }


### PR DESCRIPTION
Picks up the whilp/cosmopolitan release built from the sqlite amalgamation migration (whilp/cosmopolitan#191) and version bump (whilp/cosmopolitan#192): sqlite moves **3.40.0 → 3.53.3**, ~3.7 years of query planner, JSON, FTS, and fuzzing fixes. Closes out the cosmic side of whilp/cosmopolitan#189.

## What changed

- `3p/cosmos/version.lua`: version `2026.07.18-1c5cfce40` → `2026.07.18-feb77961c`, sha256 updated (verified against the downloaded artifact; the release binary reports `sqlite_version()` = 3.53.3)
- `bin/make regen-types` produced **zero changes** — lsqlite3 uses stable public API only, so the generated `cosmo.*` type surface is byte-identical

## Gates

- `bin/make test only=gentype`: PASS
- `bin/make ci` (format + teal + test + example + lint + coverage ratchet): **PASS**, all green
- `bin/make perf-compare` vs the previous pin, sqlite scenarios lead the wins and match the C-layer A/B from whilp/cosmopolitan#192:

```
sqlite_insert_delete_tx         352.52 µs ->    316.26 µs    -10.3%  (noise  ±10.0%)  faster
sqlite_point_query                9.03 µs ->      8.57 µs     -5.1%  (noise  ±14.3%)  ok
sqlite_scan_aggregate           137.29 µs ->    121.72 µs    -11.3%  (noise  ±22.1%)  ok
startup_run_lua                   5.96 ms ->      5.24 ms    -12.0%  (noise  ±13.2%)  ok
```

## Known measurement artifact (disclosed, not hidden)

The pin-vs-pin `perf-compare` gate flagged regressions on scenarios that share no code with sqlite. I chased each one with interleaved ABAB runs of the two wrapped release binaries:

- `json_decode_large`, `hash_sha256_small`: **not real** — equal within noise when interleaved (old 1.15/1.17ms vs new 1.20/1.17ms; 559/562ns vs 746±45%/561ns — one noisy outlier drove the flag)
- `codec_hex_roundtrip_64k`: **reproducible on the release pair** (~154µs → ~170–203µs across 4 interleaved rounds in both orders), yet the same scenario measured 11% *faster* in both controlled single-arch local A/Bs on the cosmopolitan side (preprocessed→amalgamation, and 3.40→3.53). The hex codec path is untouched by these commits. Conclusion: fat-binary code-layout shift from sqlite's text growth (`lua` grew 6.26 → 6.63 MB), not a code regression. Layout luck will reshuffle on any future release; if it matters, candidates for a `perf`-labeled follow-up in whilp/cosmopolitan are function alignment for hot `lfuncs` paths or restoring size optimization on the sqlite amalgamation TU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrKEwNF6De2jJ3NsG56RDi

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrKEwNF6De2jJ3NsG56RDi)_