### PR TITLE
docs: fix fs record doc comments and docindex example drop (#509)

### DIFF
--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -47,6 +47,7 @@
 4	lib/cosmic/doc/examples_query_test.tl
 28	lib/cosmic/doc/guide_test.tl
 6	lib/cosmic/doc/index.tl
+6	lib/cosmic/doc/index_test.tl
 28	lib/cosmic/doc/init.tl
 3	lib/cosmic/doc/public_test.tl
 7	lib/cosmic/doc/query.tl

--- a/lib/cosmic/doc/index.tl
+++ b/lib/cosmic/doc/index.tl
@@ -108,6 +108,11 @@ local function generate(files: {string}): string | nil, string
           table.insert(mod_table.examples as {any}, ex)
         end
       end
+    else
+      -- No source module with this name (e.g. deploy_example.tl):
+      -- register the example doc itself under the base name so its
+      -- examples stay addressable instead of being silently dropped.
+      modules[base_name] = example_doc
     end
   end
 

--- a/lib/cosmic/doc/index_test.tl
+++ b/lib/cosmic/doc/index_test.tl
@@ -1,0 +1,87 @@
+#!/usr/bin/env cosmic
+-- test cosmic.doc.index generation
+
+local fs = require("cosmic.fs")
+local env = require("cosmic.env")
+local codec = require("cosmic.codec")
+local index = require("cosmic.doc.index")
+
+local tmpdir = env.get("TEST_TMPDIR")
+assert(tmpdir, "TEST_TMPDIR must be set")
+
+local function write_temp(name: string, content: string): string
+  local filepath = fs.join(tmpdir, name)
+  assert(fs.write(filepath, content))
+  return filepath
+end
+
+local widget_path = write_temp("widget.tl", [[
+--- Widget module.
+local function frob(): number
+  return 1
+end
+return { frob = frob }
+]])
+
+local widget_example_path = write_temp("widget_example.tl", [[
+--- Examples for widgets.
+local function Example_frob()
+  print("frob")
+  -- Output:
+  -- frob
+end
+return {}
+]])
+
+local orphan_example_path = write_temp("orphan_example.tl", [[
+--- Examples for a topic with no source module.
+local function Example_orphan()
+  print("orphan")
+  -- Output:
+  -- orphan
+end
+return {}
+]])
+
+local function generate_modules(files: {string}): {string: any}
+  local encoded, err = index.generate(files)
+  assert(encoded, "generate failed: " .. tostring(err))
+  local data, derr = codec.decode_lua_unsafe(encoded as string)
+  assert(data, "index should decode: " .. tostring(derr))
+  return (data as {string: any}).modules as {string: any}
+end
+
+local function find_module(modules: {string: any}, suffix: string): {string: any}
+  for name, mod in pairs(modules) do
+    if name:match("%." .. suffix .. "$") or name == suffix then
+      return mod as {string: any}
+    end
+  end
+  return nil
+end
+
+-- Examples merge into their source module.
+local function test_examples_merge_into_module()
+  local modules = generate_modules({widget_path, widget_example_path})
+  local mod = find_module(modules, "widget")
+  assert(mod, "widget module should be indexed")
+  local examples = mod.examples as {any}
+  assert(examples and #examples == 1,
+    "widget_example should merge into the widget module")
+  assert(find_module(modules, "widget_example") == nil,
+    "the _example shard should not be its own module entry")
+end
+test_examples_merge_into_module()
+
+-- An example file with no matching source module is registered under
+-- its base name instead of being silently dropped (deploy_example.tl
+-- is the in-tree case).
+local function test_orphan_example_registered()
+  local modules = generate_modules({widget_path, orphan_example_path})
+  local mod = find_module(modules, "orphan")
+  assert(mod, "orphan example file should be indexed under its base name")
+  local examples = mod.examples as {any}
+  assert(examples and #examples == 1,
+    "orphan examples should be addressable, not dropped")
+end
+test_orphan_example_registered()

--- a/lib/cosmic/fs/init.tl
+++ b/lib/cosmic/fs/init.tl
@@ -299,29 +299,31 @@ local record FsModule
   statfs: function(path: string): Statfs | nil, string
   fstatfs: function(fd: number): Statfs | nil, string
 
-  -- Flush all filesystem buffers to disk, system-wide (sync(2)).
-  -- Per-file flushing is Handle:sync()/Handle:datasync() in cosmic.fd.
+  --- Flush all filesystem buffers to disk, system-wide (sync(2)).
+  --- Per-file flushing is Handle:sync()/Handle:datasync() in cosmic.fd.
   sync: function()
 
   -- Device number utilities
   major: function(dev: number): number
   minor: function(dev: number): number
 
-  -- Directory walking.
-  -- walk visitor signature: visitor(path, name, st, ctx): nil | "skip" | "stop"
-  --   path = full path to the entry (e.g. "dir/sub/file.txt") — do NOT join with name.
-  --   name = basename of the entry (e.g. "file.txt").
-  --   st   = WalkStat (import: local types = require("cosmic.fs.types"); types.WalkStat).
-  -- Returning "skip" does not descend into the entry (dirs only); "stop"
-  -- ends the walk now; returning nothing continues.
-  -- Root open failure returns nil, err; subtree failures return the first
-  -- error alongside the results.
+  --- Walk a directory tree depth-first, calling the visitor per entry.
+  --- Visitor signature: visitor(path, name, st, ctx): nil | "skip" | "stop"
+  ---   path = full path to the entry (e.g. "dir/sub/file.txt") — do NOT join with name.
+  ---   name = basename of the entry (e.g. "file.txt").
+  ---   st   = WalkStat (import: local types = require("cosmic.fs.types"); types.WalkStat).
+  --- Returning "skip" does not descend into the entry (dirs only); "stop"
+  --- ends the walk now; returning nothing continues.
+  --- Root open failure returns nil, err; subtree failures return the first
+  --- error alongside the results.
   walk: function<T>(dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string
-  -- glob expands a pattern without recursing; components ("src/*.lua")
-  -- are each globs, and matches of every entry type are returned sorted.
+  --- Expand a glob pattern without recursing; components ("src/*.lua")
+  --- are each globs, and matches of every entry type are returned sorted.
   glob: function(dir: string, pattern: string): {string} | nil, string
-  -- collect's pattern is ALWAYS a glob; collect_matching takes a Lua pattern.
+  --- Recursively collect files under dir whose names match a glob
+  --- pattern (collect's pattern is ALWAYS a glob).
   collect: function(dir: string, pattern: string): {string} | nil, string
+  --- Recursively collect files under dir whose names match a Lua pattern.
   collect_matching: function(dir: string, lua_pattern: string): {string} | nil, string
   collect_all: function(dir: string): {string: FileInfo} | nil, string
   files: function(dir: string, pattern?: string): FileIter | nil, string, any, any


### PR DESCRIPTION
Two docindex slices of #509 (audit §6.3):

- **`fs/init.tl`**: the `walk` visitor doc (and `glob`, `collect`, `collect_matching`, `sync`) used plain `--` comments, which the doc parser ignores. Converted to `---` doc comments so they surface in the doc index; `collect_matching` gained a one-liner it never had.
- **`doc/index.tl`**: example files with no matching source module were silently dropped from the index — `deploy_example.tl` is the in-tree case the issue calls out. The example doc is now registered under its base name, so `cosmic --examples deploy` works (verified against the rebuilt binary; it renders the shebang/script-args/install/embed examples). Modules synthesized this way still go through the normal `cosmic.public` visibility marking.
- New `lib/cosmic/doc/index_test.tl` covers both paths: examples merging into their source module, and orphan example files staying addressable. Cast-ratchet pin added for the new test file.

Not addressed here (still open in #509): doc-index keying for re-exports (`--docs cosmic.fs.walk` resolves to the internal `fs.walk` shard rather than the public `fs` re-export), the 28 missing example files, and tutorials/guides.

Verified: `bin/make ci` green (format + teal + test + example + lint + coverage ratchet), including the new `index_test.tl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDeDS118gqmixRXvGEoZRC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDeDS118gqmixRXvGEoZRC)_