### PR TITLE
test: extend visible-skip convention to quicksand suite (#503)

### DIFF
--- a/lib/cosmic/quicksand/caps_test.tl
+++ b/lib/cosmic/quicksand/caps_test.tl
@@ -22,7 +22,10 @@ test_module_exports()
 -- constants; CAP_LAST_CAP (a bound, not a capability) is deliberately
 -- excluded from NAMES.
 local function test_names_resolve()
-  if not caps.supported() then return end
+  if not caps.supported() then
+    check.skip("capabilities unsupported on this host")
+    return
+  end
   assert(#caps.NAMES > 0, "NAMES should be non-empty")
   for _, name in ipairs(caps.NAMES) do
     local n, err = caps.number_of(name)
@@ -47,7 +50,10 @@ test_number_of_unknown()
 
 -- mask sets bit N (1 << number) per name; unknown names error; empty is 0.
 local function test_mask()
-  if not caps.supported() then return end
+  if not caps.supported() then
+    check.skip("capabilities unsupported on this host")
+    return
+  end
   assert(caps.mask({}) == 0, "empty mask should be 0")
   local chown = caps.number_of("CAP_CHOWN")
   local m = caps.mask({"CAP_CHOWN"})
@@ -63,7 +69,10 @@ test_mask()
 -- bounding_read is non-destructive: it returns a boolean (or a graceful
 -- nil + error under an outer sandbox), never throws.
 local function test_bounding_read()
-  if not caps.supported() then return end
+  if not caps.supported() then
+    check.skip("capabilities unsupported on this host")
+    return
+  end
   local present, err = caps.bounding_read("CAP_CHOWN")
   assert(present ~= nil or type(err) == "string",
     "bounding_read should return a boolean or nil+err")
@@ -100,7 +109,10 @@ local CHILD_DROP = table.concat({
 
 local function test_drop_bounding_child()
   local c = quicksand.capabilities()
-  if not c.linux or not test_bin then return end
+  if not c.linux or not test_bin then
+    check.skip("caps drop child: non-Linux host or no TEST_BIN")
+    return
+  end
   local cosmic = fs.join(test_bin, "cosmic")
   local h = spawn.spawn({cosmic, "-e", CHILD_DROP})
   local __r1 = (h as spawn.Handle):wait() as spawn.Result
@@ -116,6 +128,11 @@ local function test_drop_bounding_child()
     "expected dropped or skipped, got: " .. s)
   assert(not s:find("bad:"),
     "drop must leave the capability absent from the bounding set: " .. s)
+  if s:find("skipped") then
+    check.skip("caps drop: " .. s:gsub("%s+$", ""))
+  else
+    check.enforced("caps bounding drop")
+  end
 end
 test_drop_bounding_child()
 

--- a/lib/cosmic/quicksand/netns_test.tl
+++ b/lib/cosmic/quicksand/netns_test.tl
@@ -1,6 +1,7 @@
 #!/usr/bin/env cosmic
 local netns = require("cosmic.quicksand.netns")
 local quicksand = require("cosmic.quicksand")
+local check = require("cosmic.check")
 local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
 
@@ -37,6 +38,7 @@ test_open_self()
 local function test_unshare_subprocess()
   local c = quicksand.capabilities()
   if not (c.linux and c.net_ns and (c.user_ns or c.cap_net_admin)) then
+    check.skip("netns unshare: namespaces unavailable on this host")
     return
   end
   local script = fs.join(tmpdir, "unshare.lua")
@@ -65,10 +67,16 @@ io.write("ok\n")
   local ok, out = __r1.ok, __r1.stdout
   -- An outer seccomp/pledge filter may SIGSYS the subprocess on unshare.
   -- Accept signal death as a skip.
-  if not ok then return end
+  if not ok then
+    check.skip("netns unshare child died before reporting (outer sandbox)")
+    return
+  end
   local s = out as string
   assert(s:find("ok") or s:find("skipped"),
     "expected ok or skipped, got: " .. s)
+  if s:find("skipped") then
+    check.skip("netns unshare: " .. s:gsub("%s+$", ""))
+  end
 end
 test_unshare_subprocess()
 
@@ -79,6 +87,7 @@ local function test_get_flags_loopback()
   local flags, err = netns.get_flags("lo")
   if not flags then
     assert(type(err) == "string", "get_flags must explain its failure")
+    check.skip("get_flags lo denied on this host: " .. err)
     return
   end
   assert(math.type(flags) == "integer", "flags should be an integer")

--- a/lib/cosmic/quicksand/proc_test.tl
+++ b/lib/cosmic/quicksand/proc_test.tl
@@ -1,6 +1,7 @@
 #!/usr/bin/env cosmic
 local proc = require("cosmic.quicksand.proc")
 local quicksand = require("cosmic.quicksand")
+local check = require("cosmic.check")
 local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
 
@@ -24,7 +25,10 @@ test_module_exports()
 -- environment permits the write.
 local function test_setup_userns_maps_returns_error_outside_userns()
   local c = quicksand.capabilities()
-  if not c.linux then return end
+  if not c.linux then
+    check.skip("userns maps: non-Linux host")
+    return
+  end
   local script = fs.join(tmpdir, "userns_maps.lua")
   fs.write(script, [[
 local proc = require("cosmic.quicksand.proc")
@@ -39,10 +43,16 @@ end
   local h = spawn.spawn({cosmic, script})
   local __r1 = (h as spawn.Handle):wait() as spawn.Result
   local ok, out = __r1.ok, __r1.stdout
-  if not ok then return end
+  if not ok then
+    check.skip("userns maps child died before reporting (outer sandbox)")
+    return
+  end
   local s = out as string
   assert(s:find("ok") or s:find("skipped"),
     "expected ok or skipped, got: " .. s)
+  if s:find("skipped") then
+    check.skip("userns maps: " .. s:gsub("%s+$", ""))
+  end
 end
 test_setup_userns_maps_returns_error_outside_userns()
 
@@ -65,7 +75,10 @@ test_drop_privs_nil_is_noop()
 -- effects on file descriptors — run in subprocesses.
 local function test_no_new_privs_subprocess()
   local c = quicksand.capabilities()
-  if not c.linux then return end
+  if not c.linux then
+    check.skip("no_new_privs: non-Linux host")
+    return
+  end
   local script = fs.join(tmpdir, "nnp.lua")
   fs.write(script, [[
 local proc = require("cosmic.quicksand.proc")
@@ -82,16 +95,25 @@ io.write("ok\n")
   local ok, out = __r2.ok, __r2.stdout
   -- An outer seccomp/pledge filter may SIGSYS the subprocess on prctl.
   -- Accept signal death as a skip.
-  if not ok then return end
+  if not ok then
+    check.skip("no_new_privs child died before reporting (outer sandbox)")
+    return
+  end
   local s = out as string
   assert(s:find("ok") or s:find("skipped"),
     "expected ok or skipped, got: " .. s)
+  if s:find("skipped") then
+    check.skip("no_new_privs: " .. s:gsub("%s+$", ""))
+  end
 end
 test_no_new_privs_subprocess()
 
 local function test_barrier_signal_wait()
   local c = quicksand.capabilities()
-  if not c.linux then return end
+  if not c.linux then
+    check.skip("barrier: non-Linux host")
+    return
+  end
   local script = fs.join(tmpdir, "barrier.lua")
   fs.write(script, [[
 local unix = require("cosmo.unix")
@@ -120,9 +142,15 @@ io.write("done\n")
   local __r3 = (h as spawn.Handle):wait() as spawn.Result
   local ok, out = __r3.ok, __r3.stdout
   -- Signal death under an outer sandbox counts as skip.
-  if not ok then return end
+  if not ok then
+    check.skip("barrier child died before reporting (outer sandbox)")
+    return
+  end
   local s = out as string
   assert(s:find("done") or s:find("skipped"),
     "expected done or skipped, got: " .. s)
+  if s:find("skipped") then
+    check.skip("barrier: " .. s:gsub("%s+$", ""))
+  end
 end
 test_barrier_signal_wait()

--- a/lib/cosmic/quicksand/proxy_test.tl
+++ b/lib/cosmic/quicksand/proxy_test.tl
@@ -1,6 +1,7 @@
 #!/usr/bin/env cosmic
 local proxy = require("cosmic.quicksand.proxy")
 local quicksand = require("cosmic.quicksand")
+local check = require("cosmic.check")
 local net = require("cosmic.net")
 
 -- quicksand's bind_ip option is a raw integer (C-boundary internals);
@@ -50,7 +51,10 @@ test_start_rejects_invalid_rules_pre_fork()
 -- the proxy plumbing is Linux-only.
 local function test_start_stop_lifecycle()
   local c = quicksand.capabilities()
-  if not c.linux then return end
+  if not c.linux then
+    check.skip("quicksand proxy is Linux-only")
+    return
+  end
 
   local handle, err = proxy.start({
       bind_ip = LOOPBACK,
@@ -88,7 +92,10 @@ test_start_stop_lifecycle()
 -- gets 403 back, for both plain-HTTP and CONNECT.
 local function test_deny_unknown_host()
   local c = quicksand.capabilities()
-  if not c.linux then return end
+  if not c.linux then
+    check.skip("quicksand proxy is Linux-only")
+    return
+  end
 
   local handle = assert(proxy.start({
         bind_ip = LOOPBACK,
@@ -111,6 +118,7 @@ local function test_deny_unknown_host()
     "expected 403 from CONNECT deny, got: " .. resp)
 
   handle:stop()
+  check.enforced("proxy deny-by-default")
 end
 test_deny_unknown_host()
 
@@ -118,7 +126,10 @@ test_deny_unknown_host()
 -- origin-form targets get 400; chunked request bodies get 411.
 local function test_malformed_and_chunked_requests()
   local c = quicksand.capabilities()
-  if not c.linux then return end
+  if not c.linux then
+    check.skip("quicksand proxy is Linux-only")
+    return
+  end
 
   local handle = assert(proxy.start({
         bind_ip = LOOPBACK,
@@ -153,7 +164,10 @@ test_malformed_and_chunked_requests()
 -- allowlist alone must not be enough to reach loopback or RFC1918.
 local function test_allowed_private_upstream_gets_502()
   local c = quicksand.capabilities()
-  if not c.linux then return end
+  if not c.linux then
+    check.skip("quicksand proxy is Linux-only")
+    return
+  end
 
   local handle = assert(proxy.start({
         bind_ip = LOOPBACK,
@@ -172,6 +186,7 @@ local function test_allowed_private_upstream_gets_502()
     "expected 502 for private upstream, got: " .. resp)
 
   handle:stop()
+  check.enforced("proxy SSRF guard")
 end
 test_allowed_private_upstream_gets_502()
 
@@ -179,7 +194,10 @@ test_allowed_private_upstream_gets_502()
 -- with SIGSTOP) is SIGKILL'd after the timeout and still reaped.
 local function test_stop_escalates_to_sigkill()
   local c = quicksand.capabilities()
-  if not c.linux then return end
+  if not c.linux then
+    check.skip("quicksand proxy is Linux-only")
+    return
+  end
   local signal = require("cosmic.signal")
 
   local handle = assert(proxy.start({


### PR DESCRIPTION
Closes #503 (audit §5.1, remaining slice).

The quicksand namespace/box tests could silently degrade to no-ops when the environment blocks them — a bare `return` on a capability guard, child death under an outer sandbox, or a child-reported "skipped" all looked identical to a real pass. This applies the `check.skip`/`check.enforced` convention (already used by the pledge/landlock/unveil primitives, `init_test`, and `box/run_test`) to the rest of the suite:

- **`netns_test`**: visible skips for missing namespace capabilities, unshare-child death, denied `SIOCGIFFLAGS` on `lo`, and child-reported skips.
- **`proxy_test`**: the five silent Linux-only guards now announce themselves; `enforce-ran` markers added to the two enforcement-proving tests (deny-by-default → 403, SSRF guard → 502) so a future enforce-lane inclusion gets tripwire coverage for free.
- **`proc_test`**: visible skips for the non-Linux guards and the userns-maps / no_new_privs / barrier subprocess paths (child death and child-reported skips).
- **`caps_test`**: visible skips for the `caps.supported()` guards; `enforce-ran` marker when the bounding-set drop genuinely executes.

No test logic changed — every previously-silent return is now an announced skip, and nothing new can fail on a host where the old code passed (the `strict` escalation flag is not used here since these tests are not in the enforce lane).

Verified on this host: `bin/make teal`/`format`/`lint` green, `bin/make test only=quicksand` 13/13 passed, and the `.err` streams show the markers working — `enforce-ran: proxy deny-by-default`, `enforce-ran: proxy SSRF guard`, `enforce-ran: caps bounding drop`, plus one genuine gap now visible: `enforce-skip: userns maps: skipped: uid_map write: EPERM`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDeDS118gqmixRXvGEoZRC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDeDS118gqmixRXvGEoZRC)_