### PR TITLE
cli: reconcile style.tl check_call_after_define with lint.tl (#504)

### DIFF
--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -24,7 +24,7 @@
 5	lib/cosmic/cli/main.tl
 2	lib/cosmic/cli/main_handlers.tl
 1	lib/cosmic/cli/script_cache.tl
-8	lib/cosmic/cli/style_test.tl
+12	lib/cosmic/cli/style_test.tl
 1	lib/cosmic/cli/welcome.tl
 11	lib/cosmic/cli/welcome_test.tl
 9	lib/cosmic/codec.tl

--- a/lib/cosmic/cli/style.tl
+++ b/lib/cosmic/cli/style.tl
@@ -61,9 +61,33 @@ local function check_call_after_define(file: string, lines: {string}): {Diagnost
       i = i + 1
       while i <= #lines and depth > 0 do
         local l = lines[i]
-        -- Count function keywords that open a new scope
+        -- Count keywords that open a new block scope
         for _ in l:gmatch("%f[%w_]function%f[^%w_]") do
           depth = depth + 1
+        end
+        for _ in l:gmatch("%f[%w_]if%f[^%w_]") do
+          depth = depth + 1
+        end
+        for _ in l:gmatch("%f[%w_]for%f[^%w_]") do
+          depth = depth + 1
+        end
+        for _ in l:gmatch("%f[%w_]while%f[^%w_]") do
+          depth = depth + 1
+        end
+        for _ in l:gmatch("%f[%w_]repeat%f[^%w_]") do
+          depth = depth + 1
+        end
+        -- Count standalone `do` (not the `do` terminating a for/while header,
+        -- which is already counted above via for/while). A `do` is standalone
+        -- when the same line contains no `for` or `while` keyword.
+        if l:match("%f[%w_]do%f[^%w_]") and
+        not l:match("%f[%w_]for%f[^%w_]") and
+        not l:match("%f[%w_]while%f[^%w_]") then
+          depth = depth + 1
+        end
+        -- `until` closes a repeat block without an `end`
+        for _ in l:gmatch("%f[%w_]until%f[^%w_]") do
+          depth = depth - 1
         end
         -- Count end keywords
         for _ in l:gmatch("%f[%w_]end%f[^%w_]") do
@@ -85,7 +109,8 @@ local function check_call_after_define(file: string, lines: {string}): {Diagnost
               col = 1,
               rule = "call-after-define",
               message = string.format(
-                "function '%s' must be called immediately after its definition (test/example files call each test_* function right after defining it)",
+                "function '%s' must be called immediately after its definition "
+                .. "(test/example files call each test_* function right after defining it)",
                 fname
               ),
             })

--- a/lib/cosmic/cli/style_test.tl
+++ b/lib/cosmic/cli/style_test.tl
@@ -63,6 +63,53 @@ bar()
 end
 test_style_call_after_define()
 
+-- A function body containing if/for/do blocks must not fool the
+-- closing-end detection (audit §5.2: style.tl had drifted from its
+-- tested twin lib/build/lint.tl, which counts all block openers).
+-- Exercised through the CLI so bin/make lint and cosmic --check-style
+-- are proven to agree on the same input.
+local function test_style_block_scopes_in_body()
+  local input = write_temp("style_blocks.tl", [[
+local function foo()
+  if true then
+    local x = 1
+  end
+  for i = 1, 2 do
+    local y = i
+  end
+  do
+    local z = 3
+  end
+  return 1
+end
+foo()
+]])
+
+  local h = spawn.spawn({cosmic, "--check-style", input})
+  local __r5 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, _ = __r5.ok, __r5.stdout
+  assert(ok, "block scopes inside a body must not trip call-after-define")
+end
+test_style_block_scopes_in_body()
+
+-- The same block-heavy body with the call missing must still fail.
+local function test_style_block_scopes_missing_call()
+  local input = write_temp("style_blocks_bad.tl", [[
+local function foo()
+  if true then
+    local x = 1
+  end
+end
+local other = 1
+]])
+
+  local h = spawn.spawn({cosmic, "--check-style", input})
+  local __r6 = (h as spawn.Handle):wait() as spawn.Result
+  local ok, _ = __r6.ok, __r6.stdout
+  assert(not ok, "missing call must still fail with block scopes in the body")
+end
+test_style_block_scopes_missing_call()
+
 -- Missing file: should fail
 local function test_style_missing_file()
   local h = spawn.spawn({cosmic, "--check-style", "/nonexistent/file.tl"})


### PR DESCRIPTION
Part of #504 (audit §5.2): the `style.tl`-vs-`lint.tl` drift slice.

`lib/build/lint.tl`'s `check_call_after_define` counts every block opener (`if`/`for`/`while`/`repeat`/standalone `do`, with `until` as a closer) while tracking a top-level function's closing `end`; `lib/cosmic/cli/style.tl`'s twin only counted `function` keywords. Any function body containing a block made `cosmic --check-style` see the body close early and check the wrong "next line" — so `bin/make lint` and `cosmic --check-style` disagreed on the same input.

- Ported lint.tl's depth logic verbatim into style.tl (plus its wrapped diagnostic message), eliminating the behavioral drift.
- Added CLI-driven tests to `style_test.tl`: a block-heavy body must pass `--check-style`, and the same body with the call missing must still fail. Verified the pass-case **fails against the old style.tl** (reverted the fix, test errored; restored, test passed).
- Cast-ratchet pin for `style_test.tl` raised 8→12 for the two standard subprocess-result casts in each new test.

Remaining in #504 (not this PR): tests for `become_init`/`fork_pidns`, tty/getpass/termios, the format gate, `--make`/`run.tl`, `docs_lookup`, and `--examples`.

Verified: `bin/make teal`/`format`/`lint` green; `bin/make test only=style` and `only=lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDeDS118gqmixRXvGEoZRC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDeDS118gqmixRXvGEoZRC)_