### PR TITLE
types: declare metamethod __close on closable records; fix tl.generate target (#660)

### DIFF
--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -61,7 +61,6 @@
 3	lib/cosmic/envd_example.tl
 1	lib/cosmic/envd_test.tl
 4	lib/cosmic/errno.tl
-1	lib/cosmic/example.tl
 1	lib/cosmic/example_coverage_test.tl
 7	lib/cosmic/example_test.tl
 3	lib/cosmic/fd.tl

--- a/lib/cosmic/child/init.tl
+++ b/lib/cosmic/child/init.tl
@@ -33,6 +33,7 @@ end
 --- Handle for a spawned process.
 --- Fields prefixed `_` are internal bookkeeping; use the methods.
 local record Handle is stream.Reader
+  metamethod __close: function(self: Handle)
   pid: integer
 
   -- internal state (do not touch)

--- a/lib/cosmic/example.tl
+++ b/lib/cosmic/example.tl
@@ -216,10 +216,10 @@ local function run_example(example: Example, _file_path: string): ExampleResult
     return result
   end
 
-  local lua_code = tl.generate(tl_result.ast, {
-      gen_target = "5.4",
-      gen_compat = "off",
-    } as {string: any})
+  -- tl.generate's second argument is the target STRING, not an options
+  -- table; passing a table silently fell back to the default (non-5.4)
+  -- target, which rejects 5.4-only features like <close> attributes.
+  local lua_code = tl.generate(tl_result.ast, "5.4")
 
   if not lua_code then
     result.error = "compile error: code generation failed"

--- a/lib/cosmic/fd.tl
+++ b/lib/cosmic/fd.tl
@@ -25,6 +25,7 @@ local stream = require("cosmic.stream")
 --- nil at end of file, write returns bytes written or nil + error.
 --- Supports Lua 5.4's to-be-closed via __close metamethod.
 local record Handle is stream.Reader, stream.Writer
+  metamethod __close: function(self: Handle)
   close: function(self: Handle): boolean, string
   closed: function(self: Handle): boolean
   fd: function(self: Handle): number
@@ -186,6 +187,7 @@ end
 --- Pipe for inter-process communication.
 --- Supports Lua 5.4's to-be-closed via __close metamethod.
 local record Pipe
+  metamethod __close: function(self: Pipe)
   reader: Handle
   writer: Handle
   close: function(self: Pipe): boolean

--- a/lib/cosmic/fd_example.tl
+++ b/lib/cosmic/fd_example.tl
@@ -5,18 +5,19 @@
 --- beneath it.
 
 -- Example_open_write_read demonstrates opening with flags (mode 420
--- is 0644), writing, seeking back, and reading.
+-- is 0644), writing, seeking back, and reading. The <close>
+-- attribute releases the descriptor on scope exit (Lua 5.4
+-- to-be-closed).
 local function Example_open_write_read()
   local fd = require("cosmic.fd")
   local fs = require("cosmic.fs")
   local dir = fs.mkdtemp("/tmp/fd_example_XXXXXX")
   local path = fs.join(dir, "note.txt")
 
-  local h = assert(fd.open(path, fd.O_RDWR | fd.O_CREAT, 420)) as fd.Handle
+  local h < close > = assert(fd.open(path, fd.O_RDWR | fd.O_CREAT, 420)) as fd.Handle
   print(h:write("hello fd"))
   h:seek(0, fd.SEEK_SET)
   print(h:read(5))
-  h:close()
   fs.rmrf(dir)
   -- Output:
   -- 8
@@ -33,10 +34,9 @@ local function Example_positional()
   local path = fs.join(dir, "data.txt")
   fs.write(path, "abcdef")
 
-  local h = assert(fd.open(path, fd.O_RDONLY)) as fd.Handle
+  local h < close > = assert(fd.open(path, fd.O_RDONLY)) as fd.Handle
   print(h:read(3, 2))
   print(h:read(2))
-  h:close()
   fs.rmrf(dir)
   -- Output:
   -- cde
@@ -47,10 +47,9 @@ end
 -- writer end come back from the reader end in order.
 local function Example_pipe()
   local fd = require("cosmic.fd")
-  local p = assert(fd.pipe()) as fd.Pipe
+  local p < close > = assert(fd.pipe()) as fd.Pipe
   p.writer:write("ping")
   print(p.reader:read(4))
-  p:close()
   -- Output:
   -- ping
 end

--- a/lib/cosmic/fd_test.tl
+++ b/lib/cosmic/fd_test.tl
@@ -359,7 +359,9 @@ local function test_close_metamethod_exists()
   assert(mt, "handle should have metatable")
   assert(mt.__close, "handle metatable should have __close")
 
-  mt.__close(f)
+  do
+    local _ < close > = f
+  end
   assert(f:closed(), "handle should be closed after __close")
 
   os.remove(filepath)
@@ -372,7 +374,9 @@ local function test_pipe_close_metamethod_exists()
   assert(mt, "pipe should have metatable")
   assert(mt.__close, "pipe metatable should have __close")
 
-  mt.__close(p)
+  do
+    local _ < close > = p
+  end
   assert(p:closed(), "pipe should be closed after __close")
 end
 test_pipe_close_metamethod_exists()

--- a/lib/cosmic/fetch/init.tl
+++ b/lib/cosmic/fetch/init.tl
@@ -102,8 +102,8 @@ end
 --- Conforms to the stream contract (cosmic.stream): read returns the
 --- next chunk, bare nil at end of stream, or nil + error on failure.
 --- Chunk sizes are transport-determined; read takes no size argument.
---- Supports Lua 5.4's to-be-closed via __close metamethod.
 local record Reader is stream_mod.Reader
+  metamethod __close: function(self: Reader)
   read: function(self: Reader): string | nil, string
   close: function(self: Reader): boolean
   closed: function(self: Reader): boolean

--- a/lib/cosmic/fs/types.tl
+++ b/lib/cosmic/fs/types.tl
@@ -80,6 +80,7 @@ local record fs_types
   --- Handle for reading directory entries.
   --- Supports automatic cleanup with `<close>` attribute.
   record Dir
+    metamethod __close: function(self: Dir)
     --- Reads next directory entry. Returns nil when done. The second
     --- return is the dirent d_type (fs.DT_DIR / DT_REG / DT_LNK / ... /
     --- DT_UNKNOWN where the filesystem does not expose it), so callers

--- a/lib/cosmic/net/init_test.tl
+++ b/lib/cosmic/net/init_test.tl
@@ -339,13 +339,17 @@ local function test_socket_has_close_metamethod()
   assert(mt.__close ~= nil, "expected socket metatable to have __close")
   assert(type(mt.__close) == "function", "expected __close to be a function")
 
-  -- Test that __close calls close()
+  -- Test that __close calls close(): leaving a <close> scope closes it
   assert(sock:closed() == false, "expected socket to not be closed")
-  mt.__close(sock)
+  do
+    local _ < close > = sock
+  end
   assert(sock:closed() == true, "expected socket to be closed after __close")
 
   -- __close should be idempotent (via close())
-  mt.__close(sock)
+  do
+    local _ < close > = sock
+  end
   assert(sock:closed() == true, "expected socket to remain closed")
 end
 test_socket_has_close_metamethod()

--- a/lib/cosmic/net/socket.tl
+++ b/lib/cosmic/net/socket.tl
@@ -32,6 +32,7 @@ end
 local stream = require("cosmic.stream")
 
 local record Socket is stream.Reader, stream.Writer
+  metamethod __close: function(self: Socket)
   --- The underlying file descriptor.
   fd: number
   --- Close the socket.

--- a/lib/cosmic/teal.tl
+++ b/lib/cosmic/teal.tl
@@ -252,11 +252,11 @@ local function compile(input_path: string, opts: CompileOptions): CompileResult
     return {ok = false, code = nil, errors = errors}
   end
 
-  local gen_opts: {string: any} = {
-    gen_target = opts.gen_target or "5.4",
-    gen_compat = opts.gen_compat or "off",
-  }
-  local lua_code = tl.generate(proc.tl_result.ast, gen_opts)
+  -- tl.generate's second argument is the target STRING; passing an
+  -- options table silently fell back to tl's default (non-5.4) target,
+  -- which rejects 5.4-only syntax like <close> attributes. gen_compat
+  -- is an env-level default (set in make_env), not a generate option.
+  local lua_code = tl.generate(proc.tl_result.ast, opts.gen_target or "5.4")
 
   if proc.shebang then
     lua_code = proc.shebang .. lua_code

--- a/lib/types/tl.d.tl
+++ b/lib/types/tl.d.tl
@@ -44,7 +44,9 @@ local record tl
   lex: function(string, string): {Token}, {Error}
   parse_program: function({Token}, {Error}, string, string): any, {string}
   process_string: function(string, boolean, any, string): Result, string
-  generate: function(any, {string: any}): string
+  -- second argument is the generation TARGET string ("5.4"), not an
+  -- options table; returns nil plus an error on codegen failure
+  generate: function(any, string): string, string
 end
 
 return tl


### PR DESCRIPTION
Closes #660 — and fixes a deeper latent bug the work exposed.

## `__close` declarations

Every record that installs a runtime `__close` via `setmetatable` now declares it, so `local h <close> = …` type-checks: `fd.Handle`, `fd.Pipe`, `net.Socket`, `child.Handle`, `fetch.Reader`, and fs `Dir` (sqlite's `Rows` already did this). The fd examples now demonstrate the idiomatic `< close >` form, and the fd/net metamethod tests exercise real `<close>` scopes instead of calling `mt.__close(x)` directly (which the checker rightly flags as invoking a method as a function once the metamethod is declared).

## The latent bug: `tl.generate` never got the 5.4 target

Converting the examples surfaced a codegen failure — `attempt to emit a <close> attribute for a non 5.4 target` — that traced to a wrong signature in the handcrafted `lib/types/tl.d.tl`:

```teal
generate: function(any, {string: any}): string   -- wrong: 2nd arg is the TARGET STRING
```

Both `cosmic.teal.compile` (the main `--compile` path) and the example runner passed `{gen_target = "5.4", gen_compat = "off"}` as that argument, so **the 5.4 target silently never applied anywhere** — tl fell back to its non-5.4 default, which happens to emit runnable code for everything the tree used so far but rejects 5.4-only syntax like `<close>` attributes. Fixed the declaration (`function(any, string): string, string`) and both call sites; `gen_compat` is an env-level default already set in `make_env`, not a generate option, so its table entry was doing nothing.

Bookkeeping: `fetch/init.tl` trimmed one now-redundant "supports __close" comment line to stay at the 500-line cap (the declaration is the documentation now); `example.tl`'s cast pin dropped with the bogus options-table cast.

Verified: `teal` 290, `format` 290, `lint` 360, `example` 30/30 (fd examples now using `< close >`), targeted test lanes for fd/net/fetch/child/fs all green; full local `bin/make ci` running as a final check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDeDS118gqmixRXvGEoZRC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDeDS118gqmixRXvGEoZRC)_