### PR TITLE
test: parity corpus between lint.tl and cli/style.tl twins (#661)

### DIFF
--- a/lib/build/lint_test.tl
+++ b/lib/build/lint_test.tl
@@ -289,3 +289,132 @@ local function test_cosmo_require_honors_allowlist()
   assert(#diags == 0, "allowlisted files must not be flagged")
 end
 test_cosmo_require_honors_allowlist()
+
+-- Parity: cosmic --check-style (lib/cosmic/cli/style.tl) carries twin
+-- implementations of the checks below; audit §5.2 caught them drifting
+-- once (fixed in #658). This corpus runs both twins over the same
+-- inputs and fails on any diagnostic mismatch, so the next divergence
+-- is caught at CI time instead of landing silently (#661).
+local style = require("cosmic.cli.style")
+
+local record ParityCase
+  name: string
+  lines: {string}
+end
+
+local parity_cases: {ParityCase} = {
+  {name = "ok_simple", lines = {
+      "local function foo()",
+      "  return 1",
+      "end",
+      "foo()",
+    }},
+  {name = "missing_call_two_defs", lines = {
+      "local function foo()",
+      "  return 1",
+      "end",
+      "local function bar()",
+      "  return 2",
+      "end",
+      "foo()",
+      "bar()",
+    }},
+  {name = "ok_block_scopes", lines = {
+      "local function foo()",
+      "  if true then",
+      "    local x = 1",
+      "  end",
+      "  for i = 1, 2 do",
+      "    local y = i",
+      "  end",
+      "  while false do",
+      "    local z = 3",
+      "  end",
+      "  do",
+      "    local w = 4",
+      "  end",
+      "  local n = 2",
+      "  repeat",
+      "    n = n - 1",
+      "  until n == 0",
+      "  return 1",
+      "end",
+      "foo()",
+    }},
+  {name = "missing_call_block_scopes", lines = {
+      "local function foo()",
+      "  if true then",
+      "    local x = 1",
+      "  end",
+      "end",
+      "local other = 1",
+    }},
+  {name = "ok_nested_functions", lines = {
+      "local function foo()",
+      "  local function helper()",
+      "    return 1",
+      "  end",
+      "  return helper()",
+      "end",
+      "foo()",
+    }},
+  {name = "ok_anonymous_function_arg", lines = {
+      "local function foo()",
+      "  local out = map({1}, function(n: number): number",
+      "      return n * n",
+      "    end)",
+      "  return out",
+      "end",
+      "foo()",
+    }},
+  {name = "comment_between_define_and_call", lines = {
+      "local function foo()",
+      "  return 1",
+      "end",
+      "-- a comment is not a call",
+      "foo()",
+    }},
+}
+
+local function diag_signature(diags: {lint.Diagnostic}): string
+  local parts: {string} = {}
+  for _, d in ipairs(diags) do
+    parts[#parts + 1] = d.rule .. "@" .. tostring(d.line)
+  end
+  return table.concat(parts, ",")
+end
+
+local function style_diag_signature(diags: {style.Diagnostic}): string
+  local parts: {string} = {}
+  for _, d in ipairs(diags) do
+    parts[#parts + 1] = d.rule .. "@" .. tostring(d.line)
+  end
+  return table.concat(parts, ",")
+end
+
+local function test_call_after_define_parity_with_style()
+  for _, case in ipairs(parity_cases) do
+    local from_lint = diag_signature(lint.check_call_after_define("case.tl", case.lines))
+    local from_style = style_diag_signature(style.check_call_after_define("case.tl", case.lines))
+    assert(from_lint == from_style,
+      case.name .. ": twins disagree: lint=[" .. from_lint .. "] style=[" .. from_style .. "]")
+  end
+end
+test_call_after_define_parity_with_style()
+
+local function test_column_length_parity_with_style()
+  local lines = {string.rep("x", 90), string.rep("y", 91), "short", string.rep("z", 200)}
+  local from_lint = diag_signature(lint.check_column_length("case.tl", lines, 90))
+  local from_style = style_diag_signature(style.check_column_length("case.tl", lines, 90))
+  assert(from_lint == from_style,
+    "column-length twins disagree: lint=[" .. from_lint .. "] style=[" .. from_style .. "]")
+end
+test_column_length_parity_with_style()
+
+local function test_file_length_parity_with_style()
+  local from_lint = diag_signature(lint.check_file_length("case.tl", 501, 500))
+  local from_style = style_diag_signature(style.check_file_length("case.tl", 501, 500))
+  assert(from_lint == from_style and from_lint ~= "",
+    "file-length twins disagree: lint=[" .. from_lint .. "] style=[" .. from_style .. "]")
+end
+test_file_length_parity_with_style()


### PR DESCRIPTION
Closes #661.

#658 fixed the `check_call_after_define` drift between `lib/build/lint.tl` and `lib/cosmic/cli/style.tl` but not the mechanism — the twins are still duplicate code and could diverge again silently. This lands option 2 from the issue: a parity corpus in `lint_test.tl` that runs **both** implementations of `check_call_after_define`, `check_column_length`, and `check_file_length` over the same inputs and fails on any mismatch in `rule@line` diagnostic signatures.

The corpus covers every construct that has fooled a depth tracker before: block scopes (`if`/`for`/`while`/standalone `do`/`repeat…until`), nested and anonymous functions, multiple defs with out-of-order calls, and the comment-between-define-and-call case. The block-scope cases are exactly the historical drift — pre-#658 they would have failed this test.

Why detection instead of prevention (issue option 1): the build linter runs under the pinned bootstrap binary, so a shared module would have to load across the bootstrap boundary; the corpus gives the same protection without that constraint. If a shared module lands later, the corpus keeps working as a regression net.

Verified: `bin/make test only=lint` and `only=style` green, `teal` 290, `format` 290, `lint` 360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDeDS118gqmixRXvGEoZRC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDeDS118gqmixRXvGEoZRC)_