### PR TITLE
test: 5.4 codegen canary; audit handcrafted tl.d.tl signatures

### DIFF
--- a/3p/tl/tl_test.tl
+++ b/3p/tl/tl_test.tl
@@ -21,3 +21,20 @@ local function test_parse_simple()
   assert(result.syntax_errors == nil or #result.syntax_errors == 0, "should have no syntax errors")
 end
 test_parse_simple()
+
+-- Canary for the 5.4 codegen target: tl.generate's second argument is
+-- the target STRING — an options table was once passed here instead,
+-- silently regressing every compile to the non-5.4 default, which
+-- rejects 5.4-only syntax like <close> attributes (#660/#662). This
+-- fails if the target ever stops being honored.
+local function test_generate_emits_close_attribute()
+  local result = tl.process_string(
+    "local x <close> = setmetatable({}, {__close = function() end})\n",
+    true, nil, "close_canary.tl")
+  assert(result.syntax_errors == nil or #result.syntax_errors == 0,
+    "canary snippet should parse")
+  local code = tl.generate(result.ast, "5.4")
+  assert(code and code:find("<close>", 1, true),
+    "5.4 target must emit the <close> attribute")
+end
+test_generate_emits_close_attribute()

--- a/lib/cosmic/example.tl
+++ b/lib/cosmic/example.tl
@@ -202,14 +202,12 @@ local function run_example(example: Example, _file_path: string): ExampleResult
   -- Compile through Teal first to handle type annotations
   local teal_source = example.body
 
-  -- Initialize Teal environment and process the source
-  local env = tl.init_env(true) -- lax mode
-  local tl_result, proc_err = tl.process_string(teal_source, true, env, "@" .. example.name)
-
-  if not tl_result then
-    result.error = "process error: " .. (proc_err or "unknown")
-    return result
-  end
+  -- Initialize Teal environment (lax, compat off, 5.4 target — same
+  -- settings cosmic.teal's make_env uses) and process the source.
+  -- process_string always returns a Result; failures land in its
+  -- syntax_errors field, not a second return.
+  local env = tl.init_env(true, "off", "5.4")
+  local tl_result = tl.process_string(teal_source, true, env, "@" .. example.name)
 
   if tl_result.syntax_errors and #tl_result.syntax_errors > 0 then
     result.error = "syntax error: " .. tl_result.syntax_errors[1].msg

--- a/lib/cosmic/teal.tl
+++ b/lib/cosmic/teal.tl
@@ -143,7 +143,9 @@ local function process_file(input_path: string, include_dirs: {string}, lax: boo
         gen_compat = "off",
       },
     })
-  local ok, result_or_err, proc_err = pcall(tl.process_string, input, false, env, input_path)
+  -- process_string returns exactly one value (a Result); errors land in
+  -- its syntax_errors/type_errors fields or arrive here as a throw.
+  local ok, result_or_err = pcall(tl.process_string, input, false, env, input_path)
 
   tl.path = saved_tl_path
 
@@ -166,7 +168,7 @@ local function process_file(input_path: string, include_dirs: {string}, lax: boo
         file = input_path,
         line = 0,
         column = 0,
-        message = proc_err or "processing failed",
+        message = "processing failed",
         severity = "error",
       },
     }

--- a/lib/types/tl.d.tl
+++ b/lib/types/tl.d.tl
@@ -39,11 +39,14 @@ local record tl
   path: string
   loader: function()
   warning_kinds: {string: boolean}
-  init_env: function(boolean): any
+  -- positional args: lax?, gen_compat? ("off"|...), gen_target? ("5.4"|...)
+  init_env: function(? boolean, ? string, ? string): any, string
   new_env: function(EnvOptions): any, string
   lex: function(string, string): {Token}, {Error}
   parse_program: function({Token}, {Error}, string, string): any, {string}
-  process_string: function(string, boolean, any, string): Result, string
+  -- always returns a Result; parse/check failures land in its
+  -- syntax_errors/type_errors fields, never in a second return
+  process_string: function(string, boolean, any, string): Result
   -- second argument is the generation TARGET string ("5.4"), not an
   -- options table; returns nil plus an error on codegen failure
   generate: function(any, string): string, string


### PR DESCRIPTION
Follow-up to #662's `tl.generate` target fix, answering "what should we do about the 5.4 codegen": make the guarantee deliberate, and finish auditing the handcrafted `tl.d.tl` against the staged tl 0.24.8 source (the self-hosted `tl.tl` is the ground truth).

- **Canary**: `3p/tl/tl_test.tl` now generates a `<close>` snippet at the `"5.4"` target and asserts the attribute survives in the emitted Lua. Until now the only protection against a target regression was `fd_test`/`fd_example` *happening* to use `<close>` — a later refactor of those files would have silently removed the net.
- **Audit findings, fixed**: two more misdeclarations in `tl.d.tl` beyond the `generate` one:
  - `init_env` actually takes positional `(lax?, gen_compat?, gen_target?)` — declared as one-arg, which is why the example runner had no way to set target/compat on its env.
  - `process_string` returns exactly one `Result`; the declared second error return **does not exist** upstream, so every caller's error slot was permanently nil. Dropped it, removed `example.tl`'s dead process-error branch, and dropped the phantom `proc_err` from `teal.tl`'s pcall site (real failures land in the Result's `syntax_errors`/`type_errors` or arrive as a throw the pcall already handles).
  - `loader`/`new_env`/`parse_program`/`generate` check out against upstream; `lex` is assigned dynamically upstream and its declared shape matches observed behavior.
- **Env alignment**: the example runner now builds its env as `init_env(true, "off", "5.4")` — the same compat/target settings `cosmic.teal`'s `make_env` uses — so the two compile pipelines can no longer differ on compat.

Also verified post-#662 state on main: rebuilt output now carries the attributes (`box/run.lua` has 5 `<const>`, `fd_test.lua` has 2 `<close>`), and the script cache is keyed by content + cosmic build version, so old-target cached entries can't survive an upgrade.

Verified: full `bin/make test` 135/135 (canary included), `teal` 290, `format` 290, `lint` 360, `example` 30/30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDeDS118gqmixRXvGEoZRC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDeDS118gqmixRXvGEoZRC)_