### PR TITLE
build: unify style/lint twin checks into cosmic.cli.style (redesign 1/3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ $(o)/coverage-summary.txt: $(coverage_got) | $(cosmic_bin)
 ## Rewrite the committed cast-ratchet pin from current per-file `as` counts
 casts-baseline: .PLEDGE = stdio rpath wpath cpath proc exec
 casts-baseline: .UNVEIL = rx:$(o)/bootstrap r:lib r:3p rwcx:$(o) rwc:lib/build
-casts-baseline: $(build_lint) | $(bootstrap_cosmic)
+casts-baseline: $(build_lint) $(lint_style_lua) | $(bootstrap_cosmic)
 	@$(linter) --write-casts-baseline $(shell git ls-files '*.tl')
 
 .PHONY: coverage-baseline
@@ -317,7 +317,7 @@ lint: $(o)/lint-summary.txt
 $(o)/lint-summary.txt: $(all_linted) | $(build_reporter)
 	@$(reporter) --dir $(o) $(patsubst %,%.got,$(basename $(all_linted))) | tee $@
 
-$(o)/%.lint.ok: % $(build_lint) lib/build/casts.txt | $(bootstrap_cosmic)
+$(o)/%.lint.ok: % $(build_lint) $(lint_style_lua) lib/build/casts.txt | $(bootstrap_cosmic)
 	@mkdir -p $(@D)
 	-@$(linter) $< > $(basename $@).out 2> $(basename $@).err; STATUS=$$?; echo $$STATUS > $(basename $@).got; cp $(basename $@).got $@
 

--- a/Makefile
+++ b/Makefile
@@ -103,15 +103,12 @@ fetched: $(all_fetched)
 # the host's CA store for these fetches so the build works on stock runners
 # and behind TLS-intercepting proxies alike. An operator-supplied
 # SSL_CERT_FILE bundle is unveiled so the sandboxed fetch can read it.
-# The fetch/stage scripts run under the pinned bootstrap binary but are
-# compiled from THIS tree and written against THIS tree's cosmic.* APIs,
-# which they load through the exported LUA_PATH. Without the compiled
-# stdlib as a prerequisite, a cold parallel build can run them while
-# o/lib/cosmic/*.lua is still compiling; require() then falls back to the
-# bootstrap's embedded (older-API) stdlib mid-build — observed as
-# "attempt to call a nil value (field 'fetch')" when the embedded fetch
-# predates the Fetch->fetch rename. Unfiltered on purpose: an only= run
-# must not shrink the closure.
+# Fetch/stage scripts run under the pinned bootstrap but are written
+# against THIS tree's cosmic.* APIs (resolved via the exported LUA_PATH).
+# Without the compiled stdlib as a prerequisite, a cold parallel build
+# could run them mid-compile and require() fell back to the bootstrap's
+# embedded older-API stdlib ("attempt to call a nil value (field
+# 'fetch')"). Unfiltered on purpose: only= must not shrink the closure.
 stdlib_lua := $(patsubst %.tl,$(o)/%.lua,$(filter lib/cosmic/%,$(foreach x,$(modules),$($(x)_tl))))
 
 $(o)/%/.fetched: export SSL_USE_SYSTEM_CERTS = 1

--- a/Makefile
+++ b/Makefile
@@ -103,10 +103,21 @@ fetched: $(all_fetched)
 # the host's CA store for these fetches so the build works on stock runners
 # and behind TLS-intercepting proxies alike. An operator-supplied
 # SSL_CERT_FILE bundle is unveiled so the sandboxed fetch can read it.
+# The fetch/stage scripts run under the pinned bootstrap binary but are
+# compiled from THIS tree and written against THIS tree's cosmic.* APIs,
+# which they load through the exported LUA_PATH. Without the compiled
+# stdlib as a prerequisite, a cold parallel build can run them while
+# o/lib/cosmic/*.lua is still compiling; require() then falls back to the
+# bootstrap's embedded (older-API) stdlib mid-build — observed as
+# "attempt to call a nil value (field 'fetch')" when the embedded fetch
+# predates the Fetch->fetch rename. Unfiltered on purpose: an only= run
+# must not shrink the closure.
+stdlib_lua := $(patsubst %.tl,$(o)/%.lua,$(filter lib/cosmic/%,$(foreach x,$(modules),$($(x)_tl))))
+
 $(o)/%/.fetched: export SSL_USE_SYSTEM_CERTS = 1
 $(o)/%/.fetched: .PLEDGE = stdio rpath wpath cpath inet dns
 $(o)/%/.fetched: .UNVEIL = rx:$(o)/bootstrap r:3p rwc:$(o) r:/etc/resolv.conf r:/etc/ssl $(if $(SSL_CERT_FILE),r:$(SSL_CERT_FILE))
-$(o)/%/.fetched: $(o)/%/.versioned $(build_files) | $(bootstrap_cosmic)
+$(o)/%/.fetched: $(o)/%/.versioned $(build_files) $(stdlib_lua) | $(bootstrap_cosmic)
 	@$(bootstrap_cosmic) -- $(build_fetch) $$(readlink $<) $(platform) $@
 
 # versions get staged: o/module/.staged -> o/staged/module/<ver>-<sha>
@@ -116,7 +127,7 @@ all_staged := $(patsubst %/.fetched,%/.staged,$(all_fetched))
 staged: $(all_staged)
 $(o)/%/.staged: .PLEDGE = stdio rpath wpath cpath proc exec
 $(o)/%/.staged: .UNVEIL = rx:$(o)/bootstrap r:3p rwc:$(o) rx:/usr/bin
-$(o)/%/.staged: $(o)/%/.fetched $(build_files)
+$(o)/%/.staged: $(o)/%/.fetched $(build_files) $(stdlib_lua)
 	@$(bootstrap_cosmic) -- $(build_stage) $$(readlink $(o)/$*/.versioned) $(platform) $< $@
 
 all_tests := $(call filter-only,$(foreach x,$(modules),$($(x)_tests)))

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -10,7 +10,11 @@ build_files := $(build_fetch) $(build_stage) $(build_portable) $(build_reporter)
 build_tests := $(wildcard lib/build/*_test.tl)
 
 reporter := $(bootstrap_cosmic) -- $(build_reporter)
-linter := $(bootstrap_cosmic) -- $(build_lint)
+# lint.lua delegates its shared checks to cosmic.cli.style; LUA_PATH points
+# at this tree's freshly compiled modules (the doc/index.tl pattern) so the
+# delegation runs THIS tree's style code, not the bootstrap's embedded copy.
+lint_style_lua := $(o)/lib/cosmic/cli/style.lua
+linter := LUA_PATH="$(o)/lib/?.lua;$(o)/lib/?/init.lua;;" $(bootstrap_cosmic) -- $(build_lint)
 
 # reporter_test needs cosmic binary (in the plain and coverage test lanes)
 $(o)/lib/build/reporter_test.tl.test.got $(o)/coverage/lib/build/reporter_test.tl.test.got: $$(cosmic_bin)

--- a/lib/build/lint.tl
+++ b/lib/build/lint.tl
@@ -1,18 +1,18 @@
 #!/usr/bin/env lua
 
+-- The shared checks (file-length, column-length, call-after-define,
+-- lint_file) live in cosmic.cli.style — ONE implementation for both
+-- `bin/make lint` and `cosmic --check-style`. The build invokes this
+-- linter under the pinned bootstrap binary with LUA_PATH pointing at
+-- this tree's freshly compiled modules (the doc/index.tl pattern), so
+-- the delegation always runs THIS tree's style code, not the
+-- bootstrap's embedded copy. This file adds only the build-side
+-- checks: the cast ratchet and the cosmo-require rule.
 local proc = require("cosmic.proc")
+local style = require("cosmic.cli.style")
 local tl = require("tl")
 
-local record Diagnostic
-  file: string
-  line: integer
-  col: integer
-  rule: string
-  message: string
-end
-
-local DEFAULT_FILE_LINES < const > = 500
-local DEFAULT_COLUMN_WIDTH < const > = 90
+local type Diagnostic = style.Diagnostic
 
 local function count_lines(path: string): integer
   local f = io.open(path, "r")
@@ -30,19 +30,6 @@ local function count_lines(path: string): integer
     return 0
   end
   return n
-end
-
-local function check_file_length(file: string, n: integer, limit: integer): {Diagnostic}
-  if n > limit then
-    return {{
-        file = file,
-        line = limit + 1,
-        col = 1,
-        rule = "file-length",
-        message = string.format("%s has %d lines (limit: %d)", file, n, limit),
-      }}
-  end
-  return {}
 end
 
 -- Cast ratchet: per-file `as` cast counts, pinned by lib/build/casts.txt
@@ -114,100 +101,7 @@ local function check_cast_ratchet(file: string, content: string, base: {string: 
   return {}
 end
 
-local function check_column_length(file: string, lines: {string}, limit: integer): {Diagnostic}
-  local diagnostics: {Diagnostic} = {}
-  for i, line in ipairs(lines) do
-    if #line > limit then
-      table.insert(diagnostics, {
-          file = file,
-          line = i,
-          col = limit + 1,
-          rule = "column-length",
-          message = string.format("%s:%d has %d columns (limit: %d)", file, i, #line, limit),
-        })
-    end
-  end
-  return diagnostics
-end
 
---- Check that top-level `local function NAME(` is immediately called as `NAME()` on
---- the next non-blank line after its closing `end`. Heuristic: track depth of
---- `function`/`end` keywords; when depth returns to 0, check the next line.
-local function check_call_after_define(file: string, lines: {string}): {Diagnostic}
-  local diagnostics: {Diagnostic} = {}
-  local i = 1
-  while i <= #lines do
-    local line = lines[i]
-    -- Match top-level local function definition
-    local fname = line:match("^local function%s+([%w_]+)%s*%(")
-    if fname then
-      local def_line = i
-      -- Track end depth to find the closing end
-      local depth = 1
-      i = i + 1
-      while i <= #lines and depth > 0 do
-        local l = lines[i]
-        -- Count keywords that open a new block scope
-        for _ in l:gmatch("%f[%w_]function%f[^%w_]") do
-          depth = depth + 1
-        end
-        for _ in l:gmatch("%f[%w_]if%f[^%w_]") do
-          depth = depth + 1
-        end
-        for _ in l:gmatch("%f[%w_]for%f[^%w_]") do
-          depth = depth + 1
-        end
-        for _ in l:gmatch("%f[%w_]while%f[^%w_]") do
-          depth = depth + 1
-        end
-        for _ in l:gmatch("%f[%w_]repeat%f[^%w_]") do
-          depth = depth + 1
-        end
-        -- Count standalone `do` (not the `do` terminating a for/while header,
-        -- which is already counted above via for/while). A `do` is standalone
-        -- when the same line contains no `for` or `while` keyword.
-        if l:match("%f[%w_]do%f[^%w_]") and
-        not l:match("%f[%w_]for%f[^%w_]") and
-        not l:match("%f[%w_]while%f[^%w_]") then
-          depth = depth + 1
-        end
-        -- `until` closes a repeat block without an `end`
-        for _ in l:gmatch("%f[%w_]until%f[^%w_]") do
-          depth = depth - 1
-        end
-        -- Count end keywords
-        for _ in l:gmatch("%f[%w_]end%f[^%w_]") do
-          depth = depth - 1
-        end
-        i = i + 1
-      end
-      -- i is now one past the closing end line; skip blank lines
-      while i <= #lines and lines[i]:match("^%s*$") do
-        i = i + 1
-      end
-      if i <= #lines then
-        local call_line = lines[i]
-        -- Accept NAME() or NAME(...) as a valid call
-        if not call_line:match("^" .. fname .. "%s*%(") then
-          table.insert(diagnostics, {
-              file = file,
-              line = def_line,
-              col = 1,
-              rule = "call-after-define",
-              message = string.format(
-                "function '%s' must be called immediately after its definition "
-                .. "(test/example files call each test_* function right after defining it)",
-                fname
-              ),
-            })
-        end
-      end
-    else
-      i = i + 1
-    end
-  end
-  return diagnostics
-end
 
 --- Tests and examples must use cosmic.* wrappers, never raw cosmo.* bindings
 --- (AGENTS.md "cosmo vs cosmic"). These files are the enumerated exceptions
@@ -274,54 +168,6 @@ local function is_exempt(path: string): boolean
   return path:match("%.d%.tl$") ~= nil
 end
 
-local function lint_file(path: string): {Diagnostic}
-  if is_exempt(path) then
-    return {}
-  end
-
-  local diagnostics: {Diagnostic} = {}
-
-  local f = io.open(path, "r")
-  if not f then
-    return diagnostics
-  end
-  local content = f:read("*a")
-  f:close()
-  if not content or content == "" then
-    return diagnostics
-  end
-
-  local lines: {string} = {}
-  for line in (content .. "\n"):gmatch("([^\n]*)\n") do
-    lines[#lines + 1] = line
-  end
-
-  local n = #lines
-  -- A trailing newline produces an empty last element; adjust count
-  if n > 0 and lines[n] == "" then
-    n = n - 1
-  end
-
-  local file_diags = check_file_length(path, n, DEFAULT_FILE_LINES)
-  for _, d in ipairs(file_diags) do
-    table.insert(diagnostics, d)
-  end
-
-  -- Column-length and assert-order checks apply to Teal source files only
-  if path:match("%.tl$") then
-    local col_diags = check_column_length(path, lines, DEFAULT_COLUMN_WIDTH)
-    for _, d in ipairs(col_diags) do
-      table.insert(diagnostics, d)
-    end
-
-    local order_diags = check_call_after_define(path, lines)
-    for _, d in ipairs(order_diags) do
-      table.insert(diagnostics, d)
-    end
-  end
-
-  return diagnostics
-end
 
 local function write_casts_baseline(files: {string}): integer
   local entries: {string} = {}
@@ -369,10 +215,10 @@ local function main(...: string): integer
     -- The standalone lint binary enforces file-length (run on all tracked
     -- files), the cast ratchet (.tl files), and cosmo-require
     -- (tests/examples). Column-length and assert-order are enforced via
-    -- --check-style on .tl files.
+    -- --check-style on .tl files (same cosmic.cli.style implementation).
     if not is_exempt(file) then
       local n = count_lines(file)
-      local diags = check_file_length(file, n, DEFAULT_FILE_LINES)
+      local diags = style.check_file_length(file, n, style.DEFAULT_FILE_LINES)
       for _, d in ipairs(diags) do
         table.insert(all_diagnostics, d)
       end
@@ -416,16 +262,18 @@ if proc.is_main() then
 end
 
 return {
-  Diagnostic = Diagnostic,
-  DEFAULT_FILE_LINES = DEFAULT_FILE_LINES,
-  DEFAULT_COLUMN_WIDTH = DEFAULT_COLUMN_WIDTH,
+  Diagnostic = style.Diagnostic,
+  DEFAULT_FILE_LINES = style.DEFAULT_FILE_LINES,
+  DEFAULT_COLUMN_WIDTH = style.DEFAULT_COLUMN_WIDTH,
   count_lines = count_lines,
-  check_file_length = check_file_length,
-  check_column_length = check_column_length,
-  check_call_after_define = check_call_after_define,
+  -- shared checks: the same function objects cosmic --check-style uses
+  check_file_length = style.check_file_length,
+  check_column_length = style.check_column_length,
+  check_call_after_define = style.check_call_after_define,
+  lint_file = style.lint_file,
+  -- build-side checks
   check_cosmo_require = check_cosmo_require,
   count_casts = count_casts,
   check_cast_ratchet = check_cast_ratchet,
-  lint_file = lint_file,
   main = main,
 }

--- a/lib/build/lint_test.tl
+++ b/lib/build/lint_test.tl
@@ -290,26 +290,40 @@ local function test_cosmo_require_honors_allowlist()
 end
 test_cosmo_require_honors_allowlist()
 
--- Parity: cosmic --check-style (lib/cosmic/cli/style.tl) carries twin
--- implementations of the checks below; audit §5.2 caught them drifting
--- once (fixed in #658). This corpus runs both twins over the same
--- inputs and fails on any diagnostic mismatch, so the next divergence
--- is caught at CI time instead of landing silently (#661).
+-- The shared checks are ONE implementation now: lint.tl delegates to
+-- cosmic.cli.style (#661), so `bin/make lint` and `cosmic --check-style`
+-- literally share function objects — asserted below. The corpus that
+-- used to compare the twins now pins expected diagnostics for every
+-- construct that has fooled a depth tracker before (audit §5.2, #658).
 local style = require("cosmic.cli.style")
 
-local record ParityCase
+local function test_shared_checks_are_delegated()
+  assert(lint.check_file_length == style.check_file_length,
+    "lint must delegate check_file_length to cosmic.cli.style")
+  assert(lint.check_column_length == style.check_column_length,
+    "lint must delegate check_column_length to cosmic.cli.style")
+  assert(lint.check_call_after_define == style.check_call_after_define,
+    "lint must delegate check_call_after_define to cosmic.cli.style")
+  assert(lint.lint_file == style.lint_file,
+    "lint must delegate lint_file to cosmic.cli.style")
+end
+test_shared_checks_are_delegated()
+
+local record CorpusCase
   name: string
   lines: {string}
+  want: string
 end
 
-local parity_cases: {ParityCase} = {
-  {name = "ok_simple", lines = {
+local corpus_cases: {CorpusCase} = {
+  {name = "ok_simple", want = "", lines = {
       "local function foo()",
       "  return 1",
       "end",
       "foo()",
     }},
-  {name = "missing_call_two_defs", lines = {
+  {name = "missing_call_two_defs",
+    want = "call-after-define@1,call-after-define@4", lines = {
       "local function foo()",
       "  return 1",
       "end",
@@ -319,7 +333,7 @@ local parity_cases: {ParityCase} = {
       "foo()",
       "bar()",
     }},
-  {name = "ok_block_scopes", lines = {
+  {name = "ok_block_scopes", want = "", lines = {
       "local function foo()",
       "  if true then",
       "    local x = 1",
@@ -341,7 +355,7 @@ local parity_cases: {ParityCase} = {
       "end",
       "foo()",
     }},
-  {name = "missing_call_block_scopes", lines = {
+  {name = "missing_call_block_scopes", want = "call-after-define@1", lines = {
       "local function foo()",
       "  if true then",
       "    local x = 1",
@@ -349,7 +363,7 @@ local parity_cases: {ParityCase} = {
       "end",
       "local other = 1",
     }},
-  {name = "ok_nested_functions", lines = {
+  {name = "ok_nested_functions", want = "", lines = {
       "local function foo()",
       "  local function helper()",
       "    return 1",
@@ -358,7 +372,7 @@ local parity_cases: {ParityCase} = {
       "end",
       "foo()",
     }},
-  {name = "ok_anonymous_function_arg", lines = {
+  {name = "ok_anonymous_function_arg", want = "", lines = {
       "local function foo()",
       "  local out = map({1}, function(n: number): number",
       "      return n * n",
@@ -367,7 +381,8 @@ local parity_cases: {ParityCase} = {
       "end",
       "foo()",
     }},
-  {name = "comment_between_define_and_call", lines = {
+  {name = "comment_between_define_and_call",
+    want = "call-after-define@1", lines = {
       "local function foo()",
       "  return 1",
       "end",
@@ -384,37 +399,25 @@ local function diag_signature(diags: {lint.Diagnostic}): string
   return table.concat(parts, ",")
 end
 
-local function style_diag_signature(diags: {style.Diagnostic}): string
-  local parts: {string} = {}
-  for _, d in ipairs(diags) do
-    parts[#parts + 1] = d.rule .. "@" .. tostring(d.line)
-  end
-  return table.concat(parts, ",")
-end
-
-local function test_call_after_define_parity_with_style()
-  for _, case in ipairs(parity_cases) do
-    local from_lint = diag_signature(lint.check_call_after_define("case.tl", case.lines))
-    local from_style = style_diag_signature(style.check_call_after_define("case.tl", case.lines))
-    assert(from_lint == from_style,
-      case.name .. ": twins disagree: lint=[" .. from_lint .. "] style=[" .. from_style .. "]")
+local function test_call_after_define_corpus()
+  for _, case in ipairs(corpus_cases) do
+    local got = diag_signature(lint.check_call_after_define("case.tl", case.lines))
+    assert(got == case.want,
+      case.name .. ": want [" .. case.want .. "] got [" .. got .. "]")
   end
 end
-test_call_after_define_parity_with_style()
+test_call_after_define_corpus()
 
-local function test_column_length_parity_with_style()
+local function test_column_length_expectations()
   local lines = {string.rep("x", 90), string.rep("y", 91), "short", string.rep("z", 200)}
-  local from_lint = diag_signature(lint.check_column_length("case.tl", lines, 90))
-  local from_style = style_diag_signature(style.check_column_length("case.tl", lines, 90))
-  assert(from_lint == from_style,
-    "column-length twins disagree: lint=[" .. from_lint .. "] style=[" .. from_style .. "]")
+  local got = diag_signature(lint.check_column_length("case.tl", lines, 90))
+  assert(got == "column-length@2,column-length@4",
+    "column-length: got [" .. got .. "]")
 end
-test_column_length_parity_with_style()
+test_column_length_expectations()
 
-local function test_file_length_parity_with_style()
-  local from_lint = diag_signature(lint.check_file_length("case.tl", 501, 500))
-  local from_style = style_diag_signature(style.check_file_length("case.tl", 501, 500))
-  assert(from_lint == from_style and from_lint ~= "",
-    "file-length twins disagree: lint=[" .. from_lint .. "] style=[" .. from_style .. "]")
+local function test_file_length_expectations()
+  local got = diag_signature(lint.check_file_length("case.tl", 501, 500))
+  assert(got == "file-length@501", "file-length: got [" .. got .. "]")
 end
-test_file_length_parity_with_style()
+test_file_length_expectations()


### PR DESCRIPTION
First of the three approved redesign pieces: replace drift *detection* between the twin check implementations with drift *impossibility* — one implementation.

- `lib/build/lint.tl` now requires `cosmic.cli.style` for the shared checks (`check_file_length`, `check_column_length`, `check_call_after_define`, `lint_file`) and re-exports the same function objects; it keeps only its build-side checks (cast ratchet, cosmo-require). **~200 lines of duplicated logic deleted.** (The duplicated column/order checks were already dead code for the lint binary's main path — only `lint_test` called them.)
- The linter runs under the pinned bootstrap binary, so `cook.mk` now invokes it with `LUA_PATH` pointing at this tree's freshly compiled modules — the established `doc/index.tl` pattern — and the lint/casts-baseline rules depend on the compiled `style.lua`. Verified empirically: poisoning `o/lib/cosmic/cli/style.lua` with an `error()` marker made the bootstrap-run linter fail with that marker (LUA_PATH wins over the embedded copy), and restoring it made lint pass again.
- `lint_test`'s parity corpus (from #663) is upgraded: a delegation-identity assertion (`lint.check_* == style.check_*` — the strongest possible "parity") plus explicit expected-diagnostic pins for every corpus case, which tests actual behavior rather than merely twin agreement.

## Bonus: this PR's enforce-lane CI failure exposed a latent cold-build race on main

The first push lost a race that has been a flake-bomb all along: `build-fetch`/`build-stage` run under the pinned bootstrap but are written against **this tree's** `cosmic.*` APIs, resolved through the globally exported `LUA_PATH`. On a cold parallel build they could execute while `o/lib/cosmic/*.lua` was still compiling, and `require("cosmic.fetch")` fell back to the bootstrap's **embedded** stdlib — whose fetch module predates the `Fetch`→`fetch` rename, hence `attempt to call a nil value (field 'fetch')`. My lint change merely re-timed compile scheduling enough to lose the race on CI (verified: the 2026-07-06 bootstrap's embedded `cosmic.fetch` exports only `Fetch/stream/has_stream/unix_proxy`; a clean-clone local repro of the enforce lane passes/fails on timing).

Fix (second commit): `.fetched`/`.staged` rules now depend on the compiled cosmic stdlib (`stdlib_lua`, unfiltered so `only=` can't shrink the closure), making the version-mixed state unreachable. Verified via dry-run that touching a stdlib `.tl` now forces its compile before any fetch.

Verified: `bin/make lint` green over all 360 files through the delegated path, `teal` 290, `format` 290, full `bin/make test` 135/135, `casts-baseline` reproduces the committed pins, `bin/make staged` green with the new prerequisites.

Next up: redesign 2/3 (tlconfig/teal.tl config parity test) and 3/3 (generate `tl.d.tl` from the staged `tl.tl`, superseding #665's probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDeDS118gqmixRXvGEoZRC