### PR TITLE
teal: canary tests for hint_for_message error patterns

### DIFF
--- a/lib/cosmic/teal_test.tl
+++ b/lib/cosmic/teal_test.tl
@@ -1,0 +1,125 @@
+#!/usr/bin/env cosmic
+-- Canary tests for teal.hint_for_message: each hint pattern is provoked
+-- through the real check path with the pinned tl, so a tl version bump
+-- that rewords an error message fails here instead of silently killing
+-- the hint. Same philosophy as the 5.4 codegen canary in 3p/tl/tl_test.tl.
+
+local fs = require("cosmic.fs")
+local teal = require("cosmic.teal")
+
+local tmpdir = os.getenv("TEST_TMPDIR")
+
+-- Check a snippet and return the first error message that has a hint,
+-- plus that hint, asserting the check failed at all.
+local function first_hinted_error(name: string, source: string): string, string
+  local path = fs.join(tmpdir, name)
+  local ok, werr = fs.write(path, source)
+  assert(ok, "write " .. name .. ": " .. tostring(werr))
+  local result = teal.check(path)
+  assert(not result.ok, name .. ": snippet should fail the strict check")
+  assert(#result.errors > 0, name .. ": snippet should produce errors")
+  for _, issue in ipairs(result.errors) do
+    local hint = teal.hint_for_message(issue.message)
+    if hint then
+      return issue.message, hint
+    end
+  end
+  local msgs: {string} = {}
+  for _, issue in ipairs(result.errors) do
+    msgs[#msgs + 1] = issue.message
+  end
+  error(name .. ": no error message matched a hint; got:\n  "
+    .. table.concat(msgs, "\n  "))
+end
+
+local function test_hint_number_expected_integer()
+  local msg, hint = first_hinted_error("h_integer.tl", [[
+local s = "abc"
+local n: number = 2.5
+print(s:sub(1, n))
+]])
+  assert(msg:find("got number, expected integer", 1, true), "wrong error: " .. msg)
+  assert(hint:find("math.tointeger", 1, true), "wrong hint: " .. hint)
+end
+test_hint_number_expected_integer()
+
+local function test_hint_nil_union_not_narrowed()
+  -- tl 0.24.8 accepts a plain `T | nil` where `T` is expected (nil is a
+  -- member of every type), so the two-member case never errors; a union
+  -- with a second non-nil member is what actually produces
+  -- "got ... | nil, expected ...".
+  local msg, hint = first_hinted_error("h_union.tl", [[
+local function f(): string | integer | nil
+  return nil
+end
+local function g(s: string): string
+  return s
+end
+print(g(f()))
+]])
+  assert(msg:find("| nil", 1, true) and msg:find("expected", 1, true),
+    "wrong error: " .. msg)
+  assert(hint:find("narrow first", 1, true), "wrong hint: " .. hint)
+end
+test_hint_nil_union_not_narrowed()
+
+local function test_hint_excess_return_values()
+  local msg, hint = first_hinted_error("h_excess.tl", [[
+local function f(): string
+  return "a", "b"
+end
+print(f())
+]])
+  assert(msg:find("excess return values", 1, true), "wrong error: " .. msg)
+  assert(hint:find("capture multiple returns", 1, true), "wrong hint: " .. hint)
+end
+test_hint_excess_return_values()
+
+local function test_hint_ipairs_on_any()
+  local msg, hint = first_hinted_error("h_ipairs.tl", [[
+local function f(v: any)
+  for _, x in ipairs(v) do
+    print(x)
+  end
+end
+f({})
+]])
+  assert(msg:find("attempting ipairs", 1, true), "wrong error: " .. msg)
+  assert(hint:find("as {any}", 1, true), "wrong hint: " .. hint)
+end
+test_hint_ipairs_on_any()
+
+local function test_hint_concat_any()
+  local msg, hint = first_hinted_error("h_concat.tl", [[
+local function f(v: any): string
+  return "x" .. v
+end
+print(f(1))
+]])
+  assert(msg:find("cannot use operator", 1, true)
+    and msg:find("<any type>", 1, true), "wrong error: " .. msg)
+  assert(hint:find("as string", 1, true), "wrong hint: " .. hint)
+end
+test_hint_concat_any()
+
+local function test_hint_index_any()
+  local msg, hint = first_hinted_error("h_index.tl", [[
+local function f(v: any)
+  print(v.x)
+end
+f({})
+]])
+  assert(msg:find("cannot index", 1, true)
+    and msg:find("<any type>", 1, true), "wrong error: " .. msg)
+  assert(hint:find("as {string: any}", 1, true), "wrong hint: " .. hint)
+end
+test_hint_index_any()
+
+local function test_no_hint_for_plain_errors()
+  -- A message outside every known trap must produce no hint at all.
+  assert(teal.hint_for_message("unknown variable: x") == nil,
+    "plain error should have no hint")
+  assert(teal.hint_for_message("syntax error, expected 'end'") == nil,
+    "syntax error should have no hint")
+end
+test_no_hint_for_plain_errors()


### PR DESCRIPTION
Closes #672. First of the teal/types hardening wave (#676), stack 1/9.

`teal.hint_for_message` string-matches six tl error phrasings ("got number, expected integer", "| nil … expected", "excess return values", ipairs/concat/index on `<any type>`). A tl version bump that rewords any of them silently kills the corresponding hint — no test noticed. This adds `lib/cosmic/teal_test.tl`: each pattern is provoked through the real `teal.check` path with the pinned tl, and the canary asserts the hint fires. On a tl bump that rewords an error, the canary fails and the pattern gets updated deliberately instead of rotting. Same philosophy as the 5.4 codegen canary in `3p/tl/tl_test.tl`.

Empirical findings baked into the canaries (worth knowing):

- tl 0.24.8 accepts a plain `T | nil` where `T` is expected — nil is a member of every type — so the "| nil … expected" message only arises from unions with a second non-nil member. The canary uses `string | integer | nil`. (The common two-member case people assume triggers this hint… doesn't.)
- A local annotated `any` but initialized from a literal gets the literal's inferred type in the message (`nil`, not `<any type>`), so the `<any type>` canaries route values through function parameters.
- A negative test pins that plain errors ("unknown variable", syntax errors) produce no hint.

Verified: `bin/make ci` green (format + teal + test incl. new canaries + example + lint + coverage ratchet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3)_