### PR TITLE
teal: extend config parity to the Makefile include dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,10 +147,10 @@ export NO_COLOR := 1
 $(o)/%.tl.test.got: .PLEDGE = stdio rpath wpath cpath proc exec
 $(o)/%.tl.test.got: .UNVEIL = rx:$(o)/bootstrap r:lib r:3p rwcx:$(o) rwc:$(TMP) rx:/usr rx:/proc r:/etc r:/dev/null
 
-# teal_config_test reads tlconfig.lua (outside the default test unveil)
+# teal_config_test reads tlconfig.lua and the Makefile (outside the test unveil)
 tlconfig_tests := $(o)/lib/cosmic/teal_config_test.tl.test.got \
   $(o)/coverage/lib/cosmic/teal_config_test.tl.test.got
-$(tlconfig_tests): .UNVEIL = rx:$(o)/bootstrap r:lib r:3p rwcx:$(o) rwc:$(TMP) rx:/usr rx:/proc r:/etc r:/dev/null r:tlconfig.lua
+$(tlconfig_tests): .UNVEIL = rx:$(o)/bootstrap r:lib r:3p rwcx:$(o) rwc:$(TMP) rx:/usr rx:/proc r:/etc r:/dev/null r:tlconfig.lua r:Makefile
 
 # Namespace-exercising tests need to call unshare(CLONE_NEWUSER|NEWNET|...)
 # and write /proc/self/{uid,gid}_map. No pledge promise covers unshare,

--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -189,7 +189,7 @@
 5	lib/cosmic/table_example.tl
 8	lib/cosmic/table_test.tl
 3	lib/cosmic/teal.tl
-2	lib/cosmic/teal_config_test.tl
+3	lib/cosmic/teal_config_test.tl
 8	lib/cosmic/testrun.tl
 26	lib/cosmic/time.tl
 4	lib/cosmic/time_test.tl

--- a/lib/cosmic/teal.tl
+++ b/lib/cosmic/teal.tl
@@ -48,6 +48,12 @@ end
 local DEFAULT_GEN_TARGET < const > = "5.4"
 local DEFAULT_GEN_COMPAT < const > = "off"
 
+--- Extra include dirs the repo build passes via --include-dir
+--- (Makefile INCLUDE_DIRS). The Makefile default and tlconfig.lua both
+--- mirror this list; teal_config_test.tl fails if either drifts, so the
+--- build, the checker, and the editor resolve types identically.
+local MAKEFILE_INCLUDE_DIRS < const >: {string} = {"lib"}
+
 --- Get default include directories for cosmic type definitions.
 --- Returns paths to bundled and local type definition directories.
 --- @return {string} List of default include directory paths
@@ -390,6 +396,7 @@ end
 local record TealModule
   DEFAULT_GEN_TARGET: string
   DEFAULT_GEN_COMPAT: string
+  MAKEFILE_INCLUDE_DIRS: {string}
   compile: function(input_path: string, opts?: CompileOptions): CompileResult
   check: function(input_path: string, opts?: CheckOptions): CheckResult
   format_issues: function(issues: {Issue}): string
@@ -401,6 +408,7 @@ end
 local M: TealModule = {
   DEFAULT_GEN_TARGET = DEFAULT_GEN_TARGET,
   DEFAULT_GEN_COMPAT = DEFAULT_GEN_COMPAT,
+  MAKEFILE_INCLUDE_DIRS = MAKEFILE_INCLUDE_DIRS,
   compile = compile,
   check = check,
   format_issues = format_issues,

--- a/lib/cosmic/teal_config_test.tl
+++ b/lib/cosmic/teal_config_test.tl
@@ -1,9 +1,11 @@
 #!/usr/bin/env cosmic
--- tlconfig.lua (editor/LSP tooling) mirrors the checker options compiled
--- into cosmic.teal; this test replaces the old "keep the two in sync by
--- hand" comment with enforcement. The test's Makefile target grants
--- r:tlconfig.lua — the repo root is outside the default test unveil.
+-- tlconfig.lua (editor/LSP tooling) and the Makefile's INCLUDE_DIRS both
+-- mirror the checker options compiled into cosmic.teal; this test replaces
+-- the old "keep the two in sync by hand" comment with enforcement. The
+-- test's Makefile target grants r:tlconfig.lua and r:Makefile — the repo
+-- root is outside the default test unveil.
 
+local fs = require("cosmic.fs")
 local teal = require("cosmic.teal")
 
 local function test_tlconfig_matches_teal_defaults()
@@ -22,15 +24,65 @@ local function test_tlconfig_matches_teal_defaults()
     .. teal.DEFAULT_GEN_COMPAT .. ")")
 
   -- Every editor include dir must be one the compiled-in checker also
-  -- searches, so the LSP and cosmic --check-types resolve the same types.
-  local defaults: {string: boolean} = {}
+  -- searches (defaults or the Makefile's extra dirs), so the LSP and
+  -- cosmic --check-types resolve the same types.
+  local cfg_dirs = cfg.include_dir as {string}
+  local blessed: {string: boolean} = {}
   for _, d in ipairs(teal.get_default_include_dirs()) do
-    defaults[d] = true
+    blessed[d] = true
   end
-  for _, d in ipairs(cfg.include_dir as {string}) do
-    assert(defaults[d],
+  for _, d in ipairs(teal.MAKEFILE_INCLUDE_DIRS) do
+    blessed[d] = true
+  end
+  for _, d in ipairs(cfg_dirs) do
+    assert(blessed[d],
       "tlconfig include_dir '" .. d
-      .. "' is not in cosmic.teal's default include dirs")
+      .. "' is not in cosmic.teal's default or Makefile include dirs")
+  end
+
+  -- And the editor must cover everything the checker sees locally: every
+  -- repo-relative dir the build/checker searches (Makefile extras plus
+  -- non-/zip defaults) must appear in tlconfig, or the LSP resolves less
+  -- than --check-types does.
+  local editor: {string: boolean} = {}
+  for _, d in ipairs(cfg_dirs) do
+    editor[d] = true
+  end
+  for _, d in ipairs(teal.MAKEFILE_INCLUDE_DIRS) do
+    assert(editor[d],
+      "Makefile include dir '" .. d .. "' is missing from tlconfig.lua")
+  end
+  for _, d in ipairs(teal.get_default_include_dirs()) do
+    if d:sub(1, 5) ~= "/zip/" then
+      assert(editor[d],
+        "checker default include dir '" .. d
+        .. "' is missing from tlconfig.lua")
+    end
   end
 end
 test_tlconfig_matches_teal_defaults()
+
+-- The Makefile's INCLUDE_DIRS default must equal the mirror compiled into
+-- cosmic.teal — the build and the library must agree on what extra dirs
+-- the checker searches, or --check-types behaves differently under
+-- bin/make than standalone.
+local function test_makefile_include_dirs_match_mirror()
+  local raw = fs.read("Makefile")
+  assert(raw, "Makefile should be readable")
+  local content = raw as string
+  local line = content:match("\nINCLUDE_DIRS %?= ([^\n]*)")
+  assert(line, "Makefile should declare 'INCLUDE_DIRS ?= ...'")
+  local dirs: {string} = {}
+  for d in line:gmatch("%S+") do
+    dirs[#dirs + 1] = d
+  end
+  assert(#dirs == #teal.MAKEFILE_INCLUDE_DIRS,
+    "Makefile INCLUDE_DIRS has " .. #dirs .. " entries, cosmic.teal mirror has "
+    .. #teal.MAKEFILE_INCLUDE_DIRS)
+  for i, d in ipairs(teal.MAKEFILE_INCLUDE_DIRS) do
+    assert(dirs[i] == d,
+      "Makefile INCLUDE_DIRS[" .. i .. "] is '" .. tostring(dirs[i])
+      .. "', cosmic.teal mirror says '" .. d .. "'")
+  end
+end
+test_makefile_include_dirs_match_mirror()

--- a/tlconfig.lua
+++ b/tlconfig.lua
@@ -1,11 +1,13 @@
 -- Editor/LSP tooling config only (teal-language-server, tl CLI). cosmic's own
 -- build and --check-types do NOT read this file: checker options are set in
 -- lib/cosmic/teal.tl (process_file/compile). teal_config_test.tl fails if
--- this mirror drifts from cosmic.teal's compiled-in defaults.
+-- this mirror drifts from cosmic.teal's compiled-in defaults or from the
+-- Makefile's INCLUDE_DIRS, so the editor resolves cosmic.* and cosmo.*
+-- exactly like the build does.
 return {
   gen_target = "5.4",
   gen_compat = "off",
-  include_dir = { "lib/types" },
+  include_dir = { "lib", "lib/types" },
   source_dir = ".",
   build_dir = "o/teal",
 }


### PR DESCRIPTION
Closes #671. Teal/types hardening wave (#676), stack 2/9. **Stacked on #677** (base is its branch; GitHub retargets to main when it merges — merge #677 first).

Follow-up to #667 (redesign 2/3): include dirs were still assembled from **three** unsynchronized places — `Makefile:28` (`INCLUDE_DIRS ?= lib`), the compiled-in defaults in `cosmic.teal`, and `tlconfig.lua` — and the parity test only covered tlconfig ⊆ defaults. Two real gaps:

- the Makefile's `lib` was unchecked — nothing would catch it drifting, and the build's effective include set was an implicit union;
- the editor resolved *less* than the checker: `tlconfig.lua` lacked `lib`, so the LSP couldn't resolve `cosmic.*` module sources that `--check-types` sees via `--include-dir lib`.

Changes:

- `cosmic.teal` exports `MAKEFILE_INCLUDE_DIRS` — the mirror of the Makefile's `INCLUDE_DIRS` default, same pattern as #667's `DEFAULT_GEN_TARGET`/`DEFAULT_GEN_COMPAT`.
- `tlconfig.lua` gains `lib`, so the editor searches everything the checker searches locally.
- `teal_config_test.tl` now asserts three-way parity: the Makefile's `INCLUDE_DIRS` line equals the compiled-in mirror (parsed from the Makefile itself; the test's unveil grant gains `r:Makefile`); every tlconfig dir is a checker dir; and every repo-local checker dir (Makefile extras + non-`/zip` defaults) appears in tlconfig.

**Negative verified**: drifting `INCLUDE_DIRS` to `lib extradir` fails with `Makefile INCLUDE_DIRS has 2 entries, cosmic.teal mirror has 1`; restoring passes.

Verified: `bin/make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3)_