### PR TITLE
build: add --compile-strict; compile in-tree .tl from the checked AST

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,11 @@ $(o)/%: %
 	@mkdir -p $(@D)
 	@$(cp) $< $@
 
-# compile .tl files to .lua (extension changes)
-$(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files)
+# compile .tl to .lua; flag from cook.mk's probe (strict-capable ->
+# hermetic LUA_PATH=";;", pre-flag -> tree LUA_PATH self-healing, #666).
+$(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files) $(compile_flag_stamp)
 	@mkdir -p $(@D)
-	@$(bootstrap_cosmic) $(include_dir_flags) --compile $< > $@.tmp
+	@f=$$(cat $(compile_flag_stamp)); if [ "$$f" = "--compile-strict" ]; then export LUA_PATH=";;"; fi; $(bootstrap_cosmic) $(include_dir_flags) $$f $< > $@.tmp
 	@if cmp -s $@.tmp $@ 2>/dev/null; then rm $@.tmp; else mv $@.tmp $@; fi
 
 # tl files: modules declare _tl, derive compiled .lua outputs

--- a/cook.mk
+++ b/cook.mk
@@ -23,3 +23,19 @@ $(bootstrap_cosmic):
 	@echo "$(bootstrap_sha256)  $@" | sha256sum -c - || { rm -f $@; echo "bootstrap cosmic checksum verification failed" >&2; exit 1; }
 	chmod +x $@
 	@ln -sf cosmic $(@D)/lua
+
+# Strict-compile capability probe: newer bootstraps ship --compile-strict
+# (strict type check, then generate from that same checked AST, so nothing
+# ships that did not typecheck); the pinned bootstrap may predate the flag.
+# Probe once and use the best flag it supports — after a bootstrap pin bump
+# (or CI's stage1 refresh) in-tree compiles become strict automatically.
+compile_flag_stamp := $(o)/bootstrap/compile-flag
+$(compile_flag_stamp): $(bootstrap_files)
+	@mkdir -p $(@D)
+	@printf 'print("probe")\n' > $@.probe.tl
+	@if LUA_PATH=";;" $(bootstrap_cosmic) --compile-strict $@.probe.tl >/dev/null 2>&1; then \
+		echo --compile-strict > $@; \
+	else \
+		echo --compile > $@; \
+	fi
+	@rm -f $@.probe.tl

--- a/lib/cosmic/cli/args.tl
+++ b/lib/cosmic/cli/args.tl
@@ -12,6 +12,7 @@ local longopts: {getopt.LongOpt} = {
   {name = "version", has_arg = "none", short = "v"},
   {name = "help", has_arg = "none", short = "h"},
   {name = "compile", has_arg = "required"},
+  {name = "compile-strict", has_arg = "required"},
   {name = "format", has_arg = "required"},
   {name = "fix", has_arg = "required"},
   {name = "check-format", has_arg = "required"},

--- a/lib/cosmic/cli/main.tl
+++ b/lib/cosmic/cli/main.tl
@@ -3,17 +3,11 @@
 
 global warn: function(...: any)
 
--- Install a lazy searcher at the end of package.searchers instead of
--- eagerly require("tl")-ing the ~15k-line Teal compiler on every startup,
--- including runs that never touch a .tl file. It loads the real compiler
--- and replaces itself on first invocation, i.e. the first require() that
--- the default Lua searcher can't resolve.
---
--- The end position (not position 2, where tl.loader() itself inserts)
--- ensures the default Lua file searcher runs first, so pre-compiled .lua
--- modules are found before falling back to compiling .tl source. Without
--- this, setting TL_PATH causes ~330ms startup overhead from recompiling
--- cosmic modules. See: https://github.com/whilp/cosmic/issues/377
+-- Lazy searcher at the END of package.searchers: the ~15k-line Teal
+-- compiler loads only on the first require() the default searchers can't
+-- resolve, and the end position (not 2, where tl.loader() inserts) lets
+-- the default Lua searcher find pre-compiled .lua first — without it,
+-- setting TL_PATH costs ~330ms recompiling cosmic modules (#377).
 if package.searchers then
   local function lazy_tl_searcher(module_name: string): any, any
     local tl = require("tl")
@@ -45,6 +39,7 @@ local record Options
   script: string
   script_args: {integer: string}
   compile: string
+  compile_strict: string
   format: string
   fix: string
   check_format: string
@@ -81,6 +76,7 @@ local function parse_args(): Options
     script = nil,
     script_args = {},
     compile = nil,
+    compile_strict = nil,
     format = nil,
     fix = nil,
     check_format = nil,
@@ -249,6 +245,9 @@ local function parse_args(): Options
     elseif opt == "compile" then
       opts.compile = optarg
       return opts
+    elseif opt == "compile-strict" then
+      opts.compile_strict = optarg
+      return opts
     elseif opt == "format" then
       opts.format = optarg
       return opts
@@ -366,6 +365,7 @@ local function main(): integer, string
     end
   end
   if opts.compile then return handlers.handle_compile(opts.compile, opts.output, opts.write_if_changed, opts.include_dirs) end
+  if opts.compile_strict then return handlers.handle_compile(opts.compile_strict, opts.output, opts.write_if_changed, opts.include_dirs, true) end
   if opts.format then return handlers.handle_format(opts.format, opts.output, opts.write_if_changed) end
   if opts.fix then return handlers.handle_format(opts.fix, opts.fix, true) end
   if opts.check_format then return handlers.handle_check_format(opts.check_format) end

--- a/lib/cosmic/cli/main_handlers.tl
+++ b/lib/cosmic/cli/main_handlers.tl
@@ -132,11 +132,11 @@ local function write_output(content: string, output: string, write_if_changed: b
   return 0
 end
 
---- Handle --compile flag.
-local function handle_compile(file: string, output?: string, write_if_changed?: boolean, include_dirs?: {string}): integer, string
+--- Handle --compile / --compile-strict flags.
+local function handle_compile(file: string, output?: string, write_if_changed?: boolean, include_dirs?: {string}, strict?: boolean): integer, string
   local span = instrument.begin("compile", file)
   local teal = require("cosmic.teal")
-  local result = teal.compile(file, {include_dirs = include_dirs})
+  local result = teal.compile(file, {include_dirs = include_dirs, strict = strict})
   local exit_code: integer
   local err_msg: string
   if result.ok then
@@ -457,7 +457,7 @@ local record HandlersModule
   load_script_file: function(script_path: string): function(...: any): any ... | nil, string
   run_docs: function(query: string): DocsRunResult
   handle_version: function(): integer
-  handle_compile: function(file: string, output?: string, write_if_changed?: boolean, include_dirs?: {string}): integer, string
+  handle_compile: function(file: string, output?: string, write_if_changed?: boolean, include_dirs?: {string}, strict?: boolean): integer, string
   handle_format: function(file: string, output?: string, write_if_changed?: boolean): integer, string
   handle_check_format: function(file: string): integer
   handle_check_types: function(file: string, include_dirs?: {string}): integer

--- a/lib/cosmic/teal.tl
+++ b/lib/cosmic/teal.tl
@@ -1,6 +1,9 @@
 --- Teal compilation and type-checking.
---- --compile uses lax mode for permissive compilation.
---- --check uses strict mode for thorough type checking.
+--- --compile uses lax mode for permissive compilation (the gradual-typing
+--- on-ramp for plain-Lua scripts); --compile-strict type-checks strictly
+--- (warnings fail, matching --check-types) and generates from the same
+--- checked AST — the build uses it for in-tree sources so nothing ships
+--- that did not typecheck. --check-types uses strict mode.
 
 local tl = require("tl")
 
@@ -15,10 +18,13 @@ local record Issue
 end
 
 --- Options for compiling Teal to Lua.
+--- strict type-checks strictly before generating (warnings fail too,
+--- matching check's default) and emits code from that same checked AST.
 local record CompileOptions
   include_dirs: {string}
   gen_target: string
   gen_compat: string
+  strict: boolean
 end
 
 --- Options for type-checking Teal files.
@@ -227,6 +233,29 @@ local function collect_errors(result: TlResult, input_path: string): {Issue}
   return errors
 end
 
+--- Collect warnings from a tl result as Issue records.
+--- @param result TlResult The result from tl.process_string
+--- @param input_path string Path to the source file for error reporting
+--- @return {Issue} List of warning issues
+local function collect_warnings(result: TlResult, input_path: string): {Issue}
+  local warnings: {Issue} = {}
+  if result.warnings then
+    for _, w in ipairs(result.warnings) do
+      if w.msg then
+        table.insert(warnings, {
+            file = w.filename or input_path,
+            line = w.y or 0,
+            column = w.x or 0,
+            message = w.msg,
+            severity = "warning",
+            tag = w.tag,
+          })
+      end
+    end
+  end
+  return warnings
+end
+
 --- Merge caller-provided include directories with defaults.
 --- Caller dirs come first (higher priority), followed by default dirs.
 --- @param extra {string} Additional include directories from caller
@@ -247,20 +276,28 @@ local function merge_include_dirs(extra: {string}): {string}
 end
 
 --- Compile a Teal file to Lua code.
---- Uses lax mode for permissive compilation. Preserves shebang if present.
+--- Lax mode by default (permissive, for user scripts); opts.strict
+--- type-checks strictly first — warnings fail too, matching check's
+--- default — and generates from that same checked AST, so a strict
+--- compile can never ship code the checker rejected. Preserves shebang.
 --- @param input_path string Path to the Teal file to compile
---- @param opts CompileOptions Compilation options (include_dirs, gen_target, gen_compat)
+--- @param opts CompileOptions Compilation options (include_dirs, gen_target, gen_compat, strict)
 --- @return CompileResult Result with ok status, generated Lua code, and any errors
 local function compile(input_path: string, opts: CompileOptions): CompileResult
   opts = opts or {} as CompileOptions
 
   local dirs = merge_include_dirs(opts.include_dirs)
-  local proc = process_file(input_path, dirs, true)
+  local proc = process_file(input_path, dirs, not opts.strict)
   if proc.error then
     return {ok = false, code = nil, errors = {proc.error}}
   end
 
   local errors = collect_errors(proc.tl_result, input_path)
+  if opts.strict then
+    for _, w in ipairs(collect_warnings(proc.tl_result, input_path)) do
+      table.insert(errors, w)
+    end
+  end
   if #errors > 0 then
     return {ok = false, code = nil, errors = errors}
   end
@@ -297,22 +334,7 @@ local function check(input_path: string, opts: CheckOptions): CheckResult
   end
 
   local errors = collect_errors(proc.tl_result, input_path)
-
-  local warnings: {Issue} = {}
-  if proc.tl_result.warnings then
-    for _, w in ipairs(proc.tl_result.warnings) do
-      if w.msg then
-        table.insert(warnings, {
-            file = w.filename or input_path,
-            line = w.y or 0,
-            column = w.x or 0,
-            message = w.msg,
-            severity = "warning",
-            tag = w.tag,
-          })
-      end
-    end
-  end
+  local warnings = collect_warnings(proc.tl_result, input_path)
 
   local ok = #errors == 0 and (not werror or #warnings == 0)
   return {ok = ok, warnings = warnings, errors = errors}

--- a/lib/cosmic/teal_test.tl
+++ b/lib/cosmic/teal_test.tl
@@ -115,6 +115,68 @@ f({})
 end
 test_hint_index_any()
 
+-- The lax/strict contract, previously asserted only by docstring:
+-- --compile (default) is the permissive gradual-typing on-ramp; strict
+-- compile refuses everything --check-types refuses (type errors AND
+-- warnings) and generates from the checked AST.
+local function test_compile_lax_strict_contract()
+  -- Lax forgives UNKNOWNS (the plain-Lua on-ramp), not explicit
+  -- contradictions: an undeclared variable passes lax and fails strict.
+  local unknown = fs.join(tmpdir, "c_unknown.tl")
+  assert(fs.write(unknown, "print(xyzzy)\n"))
+  assert(teal.compile(unknown).ok,
+    "default compile is lax: unknown variables must not stop codegen")
+  local strict = teal.compile(unknown, {strict = true})
+  assert(not strict.ok, "strict compile must reject unknown variables")
+  assert(#strict.errors > 0 and strict.errors[1].severity == "error")
+  assert(not teal.check(unknown).ok, "check must reject what strict compile rejects")
+
+  -- An explicitly annotated contradiction fails both ways: lax still
+  -- checks what you declared.
+  local type_err = fs.join(tmpdir, "c_type_err.tl")
+  assert(fs.write(type_err, "local s: string = 42\nprint(s)\n"))
+  assert(not teal.compile(type_err).ok,
+    "even lax compile rejects an annotated contradiction")
+  assert(not teal.compile(type_err, {strict = true}).ok)
+
+  local warn_only = fs.join(tmpdir, "c_warn.tl")
+  assert(fs.write(warn_only, "local unused = 1\nprint(\"hi\")\n"))
+  assert(teal.compile(warn_only).ok,
+    "default compile must not fail on warnings")
+  local strict_warn = teal.compile(warn_only, {strict = true})
+  assert(not strict_warn.ok, "strict compile must fail on warnings, matching check")
+  assert(strict_warn.errors[1].severity == "warning",
+    "the failure should carry the warning issue")
+end
+test_compile_lax_strict_contract()
+
+-- A clean file must generate identical code both ways (same AST, same
+-- 5.4 target), and 5.4-only syntax must survive the strict path.
+local function test_strict_compile_codegen()
+  local clean = fs.join(tmpdir, "c_clean.tl")
+  assert(fs.write(clean,
+      "local function add(a: integer, b: integer): integer\n"
+      .. "  return a + b\n"
+      .. "end\n"
+      .. "print(add(1, 2))\n"))
+  local lax = teal.compile(clean)
+  local strict = teal.compile(clean, {strict = true})
+  assert(lax.ok and strict.ok, "clean file should compile both ways")
+  assert(lax.code == strict.code,
+    "lax and strict codegen of a clean file must be identical")
+
+  local closer = fs.join(tmpdir, "c_close.tl")
+  assert(fs.write(closer,
+      "local f <close> = assert(io.open(\"/dev/null\", \"r\"))\n"
+      .. "print(f ~= nil)\n"))
+  local sc = teal.compile(closer, {strict = true})
+  assert(sc.ok, "strict compile of <close> should pass: "
+    .. (sc.ok and "" or teal.format_issues(sc.errors)))
+  assert(sc.code:find("<close>", 1, true),
+    "strict compile must keep the 5.4 <close> attribute")
+end
+test_strict_compile_codegen()
+
 local function test_no_hint_for_plain_errors()
   -- A message outside every known trap must produce no hint at all.
   assert(teal.hint_for_message("unknown variable: x") == nil,

--- a/sys/help.md
+++ b/sys/help.md
@@ -4,6 +4,7 @@ Usage: cosmic-lua [options] [script [args]]
 
 Cosmic options:
   --compile <file.tl>           compile Teal file to Lua, lax mode (stdout)
+  --compile-strict <file.tl>    compile with strict type check first; warnings fail
   --include-dir <dir>           add search path for --compile/--check-types (repeatable)
   --format <file>               format Teal or Lua file (stdout)
   --fix <file>                  format Teal or Lua file in place


### PR DESCRIPTION
Closes #670. Teal/types hardening wave (#676), stack 4/9. **Stacked on #679** (merge order: #678 → #679 → this; GitHub retargets on merge).

The build's only `.tl → .lua` rule invoked `--compile`, which is **lax**: the artifact that ships was generated from a different, permissive parse than the one `make teal` validates — the same "two things claiming to be the same" shape #666/#667 eliminated for lint twins and tlconfig.

- **`cosmic.teal`**: `CompileOptions.strict` type-checks strictly first (warnings fail too, matching `check`'s `werror` default) and generates from **that same checked AST** — a strict compile can never ship code the checker rejected. `check()` now shares the new `collect_warnings` helper.
- **CLI**: `--compile-strict <file.tl>` as its own early-returning option, so there's no flag-ordering footgun with `--compile`. `--compile` stays lax — that's the gradual-typing on-ramp for plain-Lua scripts.
- **Makefile**: the compile rule consults a one-time capability probe (`o/bootstrap/compile-flag`). A bootstrap that knows `--compile-strict` compiles the tree strictly; the pinned 2026-07-06 bootstrap predates the flag and keeps today's lax behavior (with `make teal` still gating strictness in CI). After the next bootstrap pin bump — or CI's `stage1` refresh — in-tree compiles become strict automatically, no further change needed.
- **`teal_test.tl`** pins the lax/strict contract that was previously docstring-only, with two empirical findings recorded: lax forgives *unknowns* (undeclared variables), not explicitly annotated contradictions — those fail both ways; and a clean file generates byte-identical code lax vs strict, with `<close>` surviving the strict path at the 5.4 target.

Verified: `bin/make ci` green twice — once under the pinned (lax) bootstrap, and again after `bin/make stage1` refreshed the bootstrap, where the probe flips to `--compile-strict` and the **entire tree strict-compiles clean**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3)_