### PR TITLE
cli: cosmic-owned runtime .tl searcher replacing tl.loader

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,13 +150,14 @@ or map unions through truthiness (`if not x`). Two sanctioned tools:
   member in its OWN source (see re.tl's Regex) — then `is` compiles to
   the correct `type(x) == "userdata"` test everywhere. Caveats:
   narrowing does NOT survive an early-exit guard (`if not (x is Rec)
-  then return end` does not narrow below); do NOT use `is` with a
-  REQUIRED `cosmo.*` class (the runtime tl loader can lax-recompile a
-  module where the required .d.tl marker doesn't resolve, silently
-  degrading `is` to a table test — keep casts at those boundaries);
-  and `is` is WRONG for mixed-representation records — `fs.Stat` is
-  usually the raw stat userdata but falls back to a plain wrapper
-  table, so neither marker fits; it stays on casts.
+  then return end` does not narrow below); and `is` is WRONG for
+  mixed-representation records — `fs.Stat` is usually the raw stat
+  userdata but falls back to a plain wrapper table, so neither marker
+  fits; it stays on casts. (The old ban on `is` with REQUIRED
+  `cosmo.*` classes is lifted: the cosmic runtime searcher (#669)
+  resolves .d.tl markers through the same include dirs as the
+  checker, so `is` can no longer silently degrade to a table test;
+  existing boundary casts get converted incrementally.)
 - **Cast in linear code and at userdata boundaries**: after an assert or
   early-exit guard, `(x as Rec).field`, `(x as {K:V})[k]`. Scalars
   (`string | nil`) narrow normally, except method-call syntax: use

--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -24,6 +24,7 @@
 5	lib/cosmic/cli/main.tl
 2	lib/cosmic/cli/main_handlers.tl
 1	lib/cosmic/cli/script_cache.tl
+1	lib/cosmic/cli/searcher.tl
 12	lib/cosmic/cli/style_test.tl
 1	lib/cosmic/cli/welcome.tl
 11	lib/cosmic/cli/welcome_test.tl
@@ -188,12 +189,12 @@
 1	lib/cosmic/syslog_test.tl
 5	lib/cosmic/table_example.tl
 8	lib/cosmic/table_test.tl
-3	lib/cosmic/teal.tl
+4	lib/cosmic/teal.tl
 3	lib/cosmic/teal_config_test.tl
 8	lib/cosmic/testrun.tl
 26	lib/cosmic/time.tl
 4	lib/cosmic/time_test.tl
-8	lib/cosmic/tl_loader_test.tl
+14	lib/cosmic/tl_loader_test.tl
 6	lib/cosmic/tty.tl
 16	lib/cosmic/tty_test.tl
 4	lib/cosmic/unveil.tl

--- a/lib/cosmic/benchmark.tl
+++ b/lib/cosmic/benchmark.tl
@@ -172,9 +172,10 @@ local function run_benchmark(benchmark: Benchmark, _file_path: string): Benchmar
     error = nil,
   }
 
-  -- Build a script that returns the benchmark function
+  -- Build a script that returns the benchmark function. No loader
+  -- prelude: the cosmic dispatcher's runtime .tl searcher already
+  -- resolves require statements in benchmark bodies.
   local script = [[
-require("tl").loader()
 return function()
 ]] .. benchmark.body .. [[
 end

--- a/lib/cosmic/cli/main.tl
+++ b/lib/cosmic/cli/main.tl
@@ -3,22 +3,10 @@
 
 global warn: function(...: any)
 
--- Lazy searcher at the END of package.searchers: the ~15k-line Teal
--- compiler loads only on the first require() the default searchers can't
--- resolve, and the end position (not 2, where tl.loader() inserts) lets
--- the default Lua searcher find pre-compiled .lua first — without it,
--- setting TL_PATH costs ~330ms recompiling cosmic modules (#377).
-if package.searchers then
-  local function lazy_tl_searcher(module_name: string): any, any
-    local tl = require("tl")
-    tl.loader()
-    local real = table.remove(package.searchers, 2)
-    package.searchers[#package.searchers] = real
-    local loader_fn, extra = real(module_name)
-    return loader_fn, extra
-  end
-  table.insert(package.searchers, lazy_tl_searcher)
-end
+-- cosmic-owned runtime .tl searcher (#669): resolves and compiles .tl
+-- modules through cosmic.teal, fails the require() on compile errors,
+-- and caches compiled output. See cosmic.cli.searcher for the details.
+require("cosmic.cli.searcher").install()
 if not os.getenv("COSMIC_NO_REQUIRE_HINTS") then
   require("cosmic.require").install()
 end

--- a/lib/cosmic/cli/searcher.tl
+++ b/lib/cosmic/cli/searcher.tl
@@ -1,0 +1,78 @@
+--- cosmic-owned runtime .tl package searcher (#669), replacing
+--- tl.loader(). Three guarantees tl's own loader did not make:
+---
+--- 1. Modules resolve through cosmic.teal's include dirs, so required
+---    .d.tl markers always resolve and `is` narrowing never silently
+---    degrades to a table test against a real userdata handle.
+--- 2. One compile configuration: the same cosmic.teal env as
+---    --compile, instead of tl's own env defaults.
+--- 3. Loud failures: a module that fails to compile fails the
+---    require() with the formatted issues. tl's loader ran tl.check
+---    and generated code without ever looking at the type errors.
+---
+--- Compiled output is cached content-hashed via script_cache, so a
+--- script's .tl require tree compiles once per content+build, not once
+--- per run. Compilation is lax — the same gradual-typing on-ramp as
+--- running a script directly; --check-types remains the strict gate.
+---
+--- install() appends the searcher at the END of package.searchers so
+--- the default Lua file searcher finds pre-compiled .lua modules
+--- first; without this, setting TL_PATH costs ~330ms per run
+--- recompiling cosmic's own modules (#377). Everything here loads
+--- lazily on the first require() the default searchers cannot
+--- resolve, so runs that never touch a .tl file never load the
+--- ~15k-line Teal compiler.
+
+--- The searcher: resolve, compile (or hit the cache), load.
+--- @param module_name string Module name as passed to require()
+--- @return any A loader function, or a string describing the miss
+--- @return any The found filename (loader data)
+local function cosmic_tl_searcher(module_name: string): any, any
+  local teal = require("cosmic.teal")
+  local found = teal.search_module(module_name)
+  if not found then
+    return "no .tl source found for module '" .. module_name .. "'"
+  end
+  local cache = require("cosmic.cli.script_cache")
+  local code = cache.load(found)
+  if not code then
+    local result = teal.compile(found)
+    if not result.ok then
+      error("error loading module '" .. module_name .. "' from '"
+        .. found .. "':\n" .. teal.format_issues(result.errors), 0)
+    end
+    code = result.code
+    cache.store(found, code)
+  end
+  -- compile() preserves shebangs for CLI output, but load() on a
+  -- string does not skip them (only luaL_loadfile does); blank the
+  -- shebang line, keeping line numbers intact.
+  local lua_code = code as string
+  if lua_code:sub(1, 2) == "#!" then
+    lua_code = "--" .. lua_code:sub(3)
+  end
+  local chunk, lerr = load(lua_code, "@" .. found)
+  if not chunk then
+    error("error loading module '" .. module_name .. "': " .. tostring(lerr), 0)
+  end
+  return chunk, found
+end
+
+--- Append the searcher to package.searchers (no-op without searchers).
+local function install()
+  if package.searchers then
+    table.insert(package.searchers, cosmic_tl_searcher)
+  end
+end
+
+local record SearcherModule
+  install: function()
+  searcher: function(module_name: string): any, any
+end
+
+local M: SearcherModule = {
+  install = install,
+  searcher = cosmic_tl_searcher,
+}
+
+return M

--- a/lib/cosmic/doc/gendoc.tl
+++ b/lib/cosmic/doc/gendoc.tl
@@ -2,8 +2,6 @@
 --- Generate markdown documentation from a Teal file.
 --- Usage: cosmic gendoc.tl <file.tl>
 
-require("tl").loader()
-
 local doc = require("cosmic.doc")
 
 local file_path = arg[1]

--- a/lib/cosmic/example.tl
+++ b/lib/cosmic/example.tl
@@ -224,10 +224,9 @@ local function run_example(example: Example, _file_path: string): ExampleResult
     return result
   end
 
-  -- Prepend tl loader for require statements
-  local script = [[
-require("tl").loader()
-]] .. lua_code
+  -- No loader prelude: the cosmic dispatcher's runtime .tl searcher
+  -- already resolves require statements in example bodies.
+  local script = lua_code
 
   -- Execute using load
   local chunk, load_err = load(script, example.name)

--- a/lib/cosmic/sqlite/init.tl
+++ b/lib/cosmic/sqlite/init.tl
@@ -451,10 +451,10 @@ local function open(filename: string, opts?: OpenOptions): Database | nil, strin
   if not raw_db then
     return nil, errmsg or ("error code " .. tostring(errcode))
   end
-  -- records don't flow-narrow; cast once after the guard. (Not `is`:
-  -- the runtime tl loader can lax-recompile this module where the
-  -- required class's userdata marker doesn't resolve, degrading `is`
-  -- to a table test that rejects every real handle.)
+  -- records don't flow-narrow; cast once after the guard. (`is` became
+  -- safe at cosmo.* boundaries once the cosmic runtime searcher (#669)
+  -- guaranteed .d.tl resolution; converting boundary casts like this
+  -- one is #491 follow-up work.)
   local dbh = raw_db as lsqlite3.Database
   local timeout_ms = 5000
   if opts and opts.busy_timeout_ms ~= nil then

--- a/lib/cosmic/teal.tl
+++ b/lib/cosmic/teal.tl
@@ -71,6 +71,31 @@ local function get_default_include_dirs(): {string}
   }
 end
 
+--- Assemble the tl module-search path from TL_PATH + include dirs +
+--- package.path, so tl.search_module finds all required modules
+--- regardless of whether TL_PATH is set. tl.search_module priority:
+--- TL_PATH env > tl.path > package.path. By putting include_dirs in
+--- tl.path (which takes precedence over package.path), they are always
+--- consulted — even when TL_PATH is set. Appending package.path
+--- preserves CWD-relative and system search patterns.
+--- @param include_dirs {string} Directories to search for modules/types
+--- @return string The assembled search path for tl.path
+local function assemble_tl_path(include_dirs: {string}): string
+  local path_parts: {string} = {}
+  local tl_path = os.getenv("TL_PATH")
+  if tl_path then
+    path_parts[#path_parts + 1] = tl_path
+  end
+  for _, dir in ipairs(include_dirs) do
+    path_parts[#path_parts + 1] = dir .. "/?.d.tl"
+    path_parts[#path_parts + 1] = dir .. "/?/init.d.tl"
+    path_parts[#path_parts + 1] = dir .. "/?.tl"
+    path_parts[#path_parts + 1] = dir .. "/?/init.tl"
+  end
+  path_parts[#path_parts + 1] = package.path
+  return table.concat(path_parts, ";")
+end
+
 --- Error from the Teal compiler.
 local record TlError
   msg: string
@@ -128,26 +153,8 @@ local function process_file(input_path: string, include_dirs: {string}, lax: boo
 
   include_dirs = include_dirs or get_default_include_dirs()
 
-  -- Assemble tl.path from TL_PATH env var + include_dirs + package.path so
-  -- tl.search_module finds all required modules regardless of whether TL_PATH
-  -- is set. tl.search_module priority: TL_PATH env > tl.path > package.path.
-  -- By setting tl.path (which takes precedence over package.path), we ensure
-  -- include_dirs are always consulted — even when TL_PATH is set.
-  -- Appending package.path preserves CWD-relative and system search patterns.
   local saved_tl_path = tl.path
-  local path_parts: {string} = {}
-  local tl_path = os.getenv("TL_PATH")
-  if tl_path then
-    path_parts[#path_parts + 1] = tl_path
-  end
-  for _, dir in ipairs(include_dirs) do
-    path_parts[#path_parts + 1] = dir .. "/?.d.tl"
-    path_parts[#path_parts + 1] = dir .. "/?/init.d.tl"
-    path_parts[#path_parts + 1] = dir .. "/?.tl"
-    path_parts[#path_parts + 1] = dir .. "/?/init.tl"
-  end
-  path_parts[#path_parts + 1] = package.path
-  tl.path = table.concat(path_parts, ";")
+  tl.path = assemble_tl_path(include_dirs)
 
   -- Options-form env construction: feature flags are explicit rather than
   -- inherited from tl's version-dependent defaults. feat_arity stays "on"
@@ -273,6 +280,26 @@ local function merge_include_dirs(extra: {string}): {string}
     merged[#merged + 1] = d
   end
   return merged
+end
+
+--- Find the source file for a module name using the same search path
+--- the compiler uses (TL_PATH, include dirs, package.path). Used by the
+--- runtime .tl searcher so require() resolves modules exactly like
+--- --compile/--check-types do.
+--- @param module_name string Module name as passed to require()
+--- @param include_dirs? {string} Extra include dirs (defaults merged in)
+--- @return string|nil Path to the found source, or nil
+local function search_module(module_name: string, include_dirs?: {string}): string | nil
+  local dirs = merge_include_dirs(include_dirs)
+  local saved_tl_path = tl.path
+  tl.path = assemble_tl_path(dirs)
+  local found, fd = tl.search_module(module_name, false)
+  tl.path = saved_tl_path
+  if fd ~= nil then
+    local f = fd as FILE
+    f:close()
+  end
+  return found
 end
 
 --- Compile a Teal file to Lua code.
@@ -420,6 +447,7 @@ local record TealModule
   MAKEFILE_INCLUDE_DIRS: {string}
   compile: function(input_path: string, opts?: CompileOptions): CompileResult
   check: function(input_path: string, opts?: CheckOptions): CheckResult
+  search_module: function(module_name: string, include_dirs?: {string}): string | nil
   format_issues: function(issues: {Issue}): string
   format_issues_with_hints: function(issues: {Issue}): string
   hint_for_message: function(msg: string): string | nil
@@ -432,6 +460,7 @@ local M: TealModule = {
   MAKEFILE_INCLUDE_DIRS = MAKEFILE_INCLUDE_DIRS,
   compile = compile,
   check = check,
+  search_module = search_module,
   format_issues = format_issues,
   format_issues_with_hints = format_issues_with_hints,
   hint_for_message = hint_for_message,

--- a/lib/cosmic/tl_loader_test.tl
+++ b/lib/cosmic/tl_loader_test.tl
@@ -4,6 +4,7 @@
 
 local spawn = require("cosmic.child")
 local fs = require("cosmic.fs")
+local fstypes = require("cosmic.fs.types")
 
 local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
@@ -65,24 +66,33 @@ test_tl_loader_not_at_position_2()
 --- Test that the tl_package_loader is still present (as a later searcher)
 --- so that .tl-only modules can still be loaded.
 local function test_tl_loader_still_available()
-  -- Create a .tl-only module (no .lua version)
+  -- Create a .tl-only module (no .lua version). The type annotation
+  -- makes it invalid as raw Lua, so only the cosmic .tl searcher can
+  -- load it — the default Lua searcher grabbing it would error.
+  -- Resolution goes through TL_PATH (never package.path: the default
+  -- Lua searcher consults package.path FIRST and would loadfile the
+  -- raw .tl as Lua).
   local moddir = fs.join(tmpdir, "tlonly")
   fs.makedirs(moddir)
   fs.write(fs.join(moddir, "mymod.tl"), [[
-return { answer = 42 }
+local answer: integer = 42
+return { answer = answer }
 ]])
 
   local script = write_temp("use_tlonly.tl", [[
--- Add tmpdir to TL_PATH so tl_package_loader can find our .tl module
 local mymod = require("mymod")
 print("answer=" .. tostring(mymod.answer))
 ]])
 
-  local h2 = spawn.spawn({cosmic, "-e", "package.path='" .. moddir .. "/?.tl;' .. package.path", script})
+  local h2 = spawn.spawn({cosmic, script}, {
+      env = {"TL_PATH=" .. moddir .. "/?.tl"},
+    })
   local __r2 = (h2 as spawn.Handle):wait() as spawn.Result
-  -- This may not work exactly this way, but the point is tl_package_loader
-  -- should still work for .tl-only modules
-  -- For now, just verify the tl_package_loader exists in searchers
+  local ok2a, out2a = __r2.ok, __r2.stdout
+  assert(ok2a, ".tl-only require should succeed: " .. tostring(__r2.stderr))
+  assert((out2a as string):find("answer=42", 1, true),
+    ".tl-only module should load and run: " .. tostring(out2a))
+
   local check_script = write_temp("check_tl_exists.lua", [[
 local searchers = package.searchers
 local n = 0
@@ -105,5 +115,64 @@ end
     "tl_package_loader should still be present: " .. tostring(out2))
 end
 test_tl_loader_still_available()
+
+--- A required .tl module that fails to compile must fail the require()
+--- with the compile issues — tl's old loader type-checked and then
+--- generated code anyway, silently running broken modules (#669).
+local function test_require_fails_on_compile_error()
+  local baddir = fs.join(tmpdir, "tlbad")
+  fs.makedirs(baddir)
+  fs.write(fs.join(baddir, "badmod.tl"), [[
+local x: string = 42
+return { x = x }
+]])
+  local script = write_temp("use_bad.tl", [[
+local badmod = require("badmod")
+print("should not get here: " .. tostring(badmod))
+]])
+  local h = spawn.spawn({cosmic, script}, {
+      env = {"TL_PATH=" .. baddir .. "/?.tl"},
+    })
+  local r = (h as spawn.Handle):wait() as spawn.Result
+  assert(not r.ok, "require of a broken .tl module must fail")
+  local err = tostring(r.stderr)
+  assert(err:find("badmod", 1, true) and err:find("got integer", 1, true),
+    "failure should carry the compile issue: " .. err)
+  local out = tostring(r.stdout)
+  assert(not out:find("should not get here", 1, true),
+    "broken module must not run: " .. out)
+end
+test_require_fails_on_compile_error()
+
+--- Required .tl modules go through the content-hash compile cache, so a
+--- script's require tree compiles once per content+build, not per run.
+local function test_require_uses_compile_cache()
+  local gooddir = fs.join(tmpdir, "tlgood")
+  fs.makedirs(gooddir)
+  fs.write(fs.join(gooddir, "goodmod.tl"), [[
+local value: string = "cached"
+return { value = value }
+]])
+  local script = write_temp("use_good.tl", [[
+print("value=" .. require("goodmod").value)
+]])
+  local cachedir = fs.join(tmpdir, "tlcache")
+  local h = spawn.spawn({cosmic, script}, {
+      env = {
+        "TL_PATH=" .. gooddir .. "/?.tl",
+        "COSMIC_TL_CACHE_DIR=" .. cachedir,
+      },
+    })
+  local r = (h as spawn.Handle):wait() as spawn.Result
+  assert(r.ok, "good .tl require should succeed: " .. tostring(r.stderr))
+  assert(tostring(r.stdout):find("value=cached", 1, true))
+  local counted = fs.walk(cachedir, function(_path: string, _name: string, _st: fstypes.WalkStat, acc: {integer})
+      acc[1] = acc[1] + 1
+    end, {0})
+  assert(counted, "cache dir should exist and be walkable")
+  assert((counted as {integer})[1] > 0,
+    "compile cache should hold the required module's output")
+end
+test_require_uses_compile_cache()
 
 print("All tl_loader tests passed!")

--- a/lib/types/gentl.tl
+++ b/lib/types/gentl.tl
@@ -148,6 +148,10 @@ end
 
 local FUNCTIONS: {Entry} = {
   {name = "loader"},
+  {name = "search_module", comment = {
+      "-- returns found filename, an open FILE handle (caller must close",
+      "-- it), and the list of tried path patterns",
+    }},
   {name = "init_env", comment = {
       "-- positional args: lax?, gen_compat? (\"off\"|...), gen_target? (\"5.4\"|...)",
     }},

--- a/lib/types/tl.d.tl
+++ b/lib/types/tl.d.tl
@@ -44,6 +44,9 @@ local record tl
   path: string
   warning_kinds: {string: boolean}
   loader: function()
+  -- returns found filename, an open FILE handle (caller must close
+  -- it), and the list of tried path patterns
+  search_module: function(string, boolean): string, any, {string}
   -- positional args: lax?, gen_compat? ("off"|...), gen_target? ("5.4"|...)
   init_env: function(? boolean, ? boolean | string, ? string, ? {string}): any, string
   new_env: function(? EnvOptions): any, string


### PR DESCRIPTION
Closes #669. Teal/types hardening wave (#676), stack 5/9. **Stacked on #680** (merge order: #679 → #680 → this).

tl's `tl_package_loader` runs `tl.check` and generates code **without ever inspecting the result** — runtime-required `.tl` modules silently bypassed the type checker, and a module recompiled where a required `.d.tl` marker didn't resolve silently degraded `is` narrowing to a table test. That degradation hazard was the documented folklore behind the codebase-wide "no `is` at `cosmo.*` boundaries" rule.

New `cosmic.cli.searcher`, installed by the dispatcher at the END of `package.searchers` (keeping #377's precompiled-`.lua`-first ordering, and still lazy — runs that never touch a `.tl` file never load the compiler):

- **resolves** via new `cosmic.teal.search_module` — the same `TL_PATH` + include dirs + `package.path` assembly the compiler uses, so `.d.tl` markers always resolve and `is` can no longer silently degrade;
- **compiles** with cosmic.teal's one env configuration and **fails the `require()`** with formatted issues on any compile error. Compilation is lax — the same gradual-typing on-ramp as running a script directly (`--check-types` stays the strict gate); note this is deliberately narrower than the issue's "matching --check-types" sketch, so user scripts requiring loosely-typed `.tl` keep working — but it's strictly louder than before, since tl's loader ignored even the errors lax mode reports;
- **caches** compiled output content-hashed via `script_cache` — a script's require tree compiles once per content+build, not per run.

Ride-alongs: `gentl` adds `tl.search_module` to the generated `tl.d.tl` (regen verified byte-identical); the `tl.loader()` preludes in example/benchmark bodies and gendoc are dropped (the dispatcher's searcher covers them); the AGENTS.md `is`-ban caveat is rewritten as lifted, with cast conversion tracked as #491 follow-up; sqlite's defensive comment updated.

`tl_loader_test` grows three behavior tests: a `.tl`-only module **invalid as raw Lua** loads through `TL_PATH`; a module with a type error **fails the require** with the issue in stderr (previously it ran); the require tree lands in the compile cache. Found en route: the old test's `package.path` `?.tl` prepend was actually exercising the *default Lua searcher* loading raw `.tl` as Lua — the new tests route through `TL_PATH` and use modules that cannot parse as Lua, so only the real searcher can pass them.

Verified: `bin/make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3)_