### PR TITLE
gentype: stop erasing integer; migrate wrappers to honest integer types

### DIFF
--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -13,7 +13,7 @@
 3	lib/cosmic/check.tl
 3	lib/cosmic/check_assertions_test.tl
 2	lib/cosmic/check_test.tl
-11	lib/cosmic/child/init.tl
+6	lib/cosmic/child/init.tl
 9	lib/cosmic/child/init_example.tl
 48	lib/cosmic/child/init_test.tl
 5	lib/cosmic/child/io.tl
@@ -112,7 +112,7 @@
 6	lib/cosmic/landlock_test.tl
 1	lib/cosmic/log_test.tl
 2	lib/cosmic/make.tl
-29	lib/cosmic/net/connect_test.tl
+28	lib/cosmic/net/connect_test.tl
 10	lib/cosmic/net/init.tl
 7	lib/cosmic/net/init_example.tl
 27	lib/cosmic/net/init_test.tl
@@ -192,11 +192,11 @@
 4	lib/cosmic/teal.tl
 3	lib/cosmic/teal_config_test.tl
 8	lib/cosmic/testrun.tl
-26	lib/cosmic/time.tl
+22	lib/cosmic/time.tl
 4	lib/cosmic/time_test.tl
 14	lib/cosmic/tl_loader_test.tl
-6	lib/cosmic/tty.tl
-16	lib/cosmic/tty_test.tl
+4	lib/cosmic/tty.tl
+12	lib/cosmic/tty_test.tl
 4	lib/cosmic/unveil.tl
 1	lib/cosmic/unveil_example.tl
 3	lib/cosmic/unveil_test.tl

--- a/lib/build/lint.tl
+++ b/lib/build/lint.tl
@@ -101,8 +101,6 @@ local function check_cast_ratchet(file: string, content: string, base: {string: 
   return {}
 end
 
-
-
 --- Tests and examples must use cosmic.* wrappers, never raw cosmo.* bindings
 --- (AGENTS.md "cosmo vs cosmic"). These files are the enumerated exceptions
 --- from the July audit's §1.7 — each needs the raw layer for a reason the
@@ -167,7 +165,6 @@ end
 local function is_exempt(path: string): boolean
   return path:match("%.d%.tl$") ~= nil
 end
-
 
 local function write_casts_baseline(files: {string}): integer
   local entries: {string} = {}

--- a/lib/cosmic/ansi.tl
+++ b/lib/cosmic/ansi.tl
@@ -202,9 +202,9 @@ end
 --- the NO_COLOR convention (https://no-color.org: set to any value,
 --- including empty, disables color), TERM=dumb, and whether the fd is
 --- a terminal.
---- @param fd number? File descriptor to check (default 1, stdout)
+--- @param fd integer? File descriptor to check (default 1, stdout)
 --- @return boolean True when it is reasonable to emit styled output
-local function enabled(fd?: number): boolean
+local function enabled(fd?: integer): boolean
   if env.get("NO_COLOR") ~= nil then
     return false
   end
@@ -236,7 +236,7 @@ local record AnsiModule
   underline: function(text: string): string
 
   strip: function(text: string): string
-  enabled: function(fd?: number): boolean
+  enabled: function(fd?: integer): boolean
 end
 
 local M: AnsiModule = {

--- a/lib/cosmic/child/fast.tl
+++ b/lib/cosmic/child/fast.tl
@@ -19,10 +19,10 @@ local CLOSED = -1
 -- Move std fd `n` out of the way. The copy is CLOEXEC (it must never
 -- leak into the child) and placed at 10+ so it cannot collide with the
 -- 0-2 range being wired.
--- @param n number the std fd (0, 1, or 2)
--- @return number | nil saved fd, CLOSED if `n` was not open, or nil when
+-- @param n integer the std fd (0, 1, or 2)
+-- @return integer | nil saved fd, CLOSED if `n` was not open, or nil when
 --   the caller should abandon the fast path
-local function save_fd(n: number): number | nil
+local function save_fd(n: integer): integer | nil
   local saved, _, eno = unix.dup(n, nil, unix.O_CLOEXEC, 10)
   if saved then
     return saved
@@ -40,16 +40,16 @@ end
 --- @param prog string resolved executable path
 --- @param argv {string} argument vector (argv[1] is the program name)
 --- @param envp {string} | nil environment, or nil to inherit
---- @param fd0 number child's stdin
---- @param fd1 number child's stdout
---- @param fd2 number child's stderr
---- @return number | nil child pid; nil means failure or fallback
+--- @param fd0 integer child's stdin
+--- @param fd1 integer child's stdout
+--- @param fd2 integer child's stderr
+--- @return integer | nil child pid; nil means failure or fallback
 --- @return string | nil error: set only for a real spawn failure that
 ---   should be reported; `nil, nil` means "fall back to the fork path"
 local function spawn(prog: string, argv: {string}, envp: {string} | nil,
-    fd0: number, fd1: number, fd2: number): number | nil, string
-  local targets: {number} = {fd0, fd1, fd2}
-  local saves: {number} = {}
+    fd0: integer, fd1: integer, fd2: integer): integer | nil, string
+  local targets: {integer} = {fd0, fd1, fd2}
+  local saves: {integer} = {}
 
   -- Save the std fds that are about to be replaced.
   for i = 1, 3 do
@@ -80,7 +80,7 @@ local function spawn(prog: string, argv: {string}, envp: {string} | nil,
     end
   end
 
-  local pid: number
+  local pid: integer
   local serr: string
   if wired then
     local p, e = unix.spawn(prog, argv, envp)
@@ -113,7 +113,7 @@ end
 
 local record FastModule
   spawn: function(prog: string, argv: {string}, envp: {string} | nil,
-  fd0: number, fd1: number, fd2: number): number | nil, string
+  fd0: integer, fd1: integer, fd2: integer): integer | nil, string
 end
 
 local M: FastModule = {

--- a/lib/cosmic/child/init.tl
+++ b/lib/cosmic/child/init.tl
@@ -43,7 +43,7 @@ local record Handle is stream.Reader
 
   --- Sends `sig` (default SIGTERM) to the child. Fails once the child has
   --- been reaped, since its pid may have been recycled.
-  kill: function(self: Handle, sig?: number): boolean, string
+  kill: function(self: Handle, sig?: integer): boolean, string
   --- Non-blocking reap: the cached/final Result if the child has finished,
   --- `nil, nil` while it is still running, or `nil, err` on a wait error.
   try_wait: function(self: Handle): Result | nil, string
@@ -56,7 +56,7 @@ local record Handle is stream.Reader
   --- stdout. Returns bare nil at end of file, matching the stream contract
   --- (cosmic.stream). For whole-output capture use `wait`/`run`, which
   --- also collect stderr and cannot deadlock.
-  read: function(self: Handle, size?: number): string | nil, string
+  read: function(self: Handle, size?: integer): string | nil, string
 end
 
 --- Options for spawning a process.
@@ -93,9 +93,9 @@ end
 
 --- Prepares an executable fd from a /zip/ path for fexecve.
 --- @param zip_path string Path starting with /zip/
---- @return number | nil The file descriptor ready for fexecve
+--- @return integer | nil The file descriptor ready for fexecve
 --- @return string Error message on failure
-local function prepare_zip_exec(zip_path: string): number | nil, string
+local function prepare_zip_exec(zip_path: string): integer | nil, string
   local fd = unix.open(zip_path, unix.O_RDONLY)
   if not fd then
     return nil, "failed to open zip path: " .. zip_path
@@ -113,16 +113,16 @@ local function close_fds(self: Handle)
 end
 
 -- Build and cache the Result from a reaped status word, then release fds.
-local function finish(self: Handle, status: number): Result
+local function finish(self: Handle, status: integer): Result
   local r: Result = {
     stdout = table.concat(self._st.out),
     stderr = table.concat(self._st.err_out),
   }
   if unix.WIFEXITED(status) then
-    r.code = unix.WEXITSTATUS(status) as integer
+    r.code = unix.WEXITSTATUS(status)
     r.ok = r.code == 0
   elseif unix.WIFSIGNALED(status) then
-    r.signal = unix.WTERMSIG(status) as integer
+    r.signal = unix.WTERMSIG(status)
     r.ok = false
   else
     r.ok = false
@@ -150,10 +150,10 @@ local handle_mt: metatable < Handle > = {
 }
 
 -- Attach the Handle methods and finalizers to a freshly forked child.
-local function make_handle(pid: number, st: childio.PumpState): Handle
-  local handle: Handle = {pid = pid as integer, _st = st}
+local function make_handle(pid: integer, st: childio.PumpState): Handle
+  local handle: Handle = {pid = pid, _st = st}
 
-  function handle:kill(sig?: number): boolean, string
+  function handle:kill(sig?: integer): boolean, string
     if self._result then
       return false, "kill: process already reaped"
     end
@@ -180,7 +180,7 @@ local function make_handle(pid: number, st: childio.PumpState): Handle
     if type(status) ~= "number" then
       return nil, "wait failed: " .. tostring(status)
     end
-    return finish(self, status as number)
+    return finish(self, status)
   end
 
   function handle:try_wait(): Result | nil, string
@@ -196,10 +196,10 @@ local function make_handle(pid: number, st: childio.PumpState): Handle
     end
     -- Reaped: the child is gone, so draining hits EOF promptly.
     childio.pump(self._st, nil)
-    return finish(self, status as number)
+    return finish(self, status)
   end
 
-  function handle:read(size?: number): string | nil, string
+  function handle:read(size?: integer): string | nil, string
     local fd = self._st.stdout_fd
     if not fd then
       return nil, "stdout not captured"
@@ -241,7 +241,7 @@ local function spawn(argv: {string}, opts?: Options): Handle | nil, string
 
   -- Resolve the executable into a LOCAL, never by mutating the caller's argv:
   -- a PATH search that wrote back into argv[1] corrupts the caller's table.
-  local exec_fd: number
+  local exec_fd: integer
   local prog = argv[1]
   if is_zip_path(argv[1]) then
     local fd, err = prepare_zip_exec(argv[1])
@@ -259,7 +259,7 @@ local function spawn(argv: {string}, opts?: Options): Handle | nil, string
 
   -- Track every fd we open so a mid-way pipe() failure (fd exhaustion) can be
   -- unwound cleanly, including the exec fd on the early-return path.
-  local opened: {number} = {}
+  local opened: {integer} = {}
   local function fail(msg: string): Handle, string
     for _, fd in ipairs(opened) do unix.close(fd) end
     if exec_fd then unix.close(exec_fd) end
@@ -269,7 +269,7 @@ local function spawn(argv: {string}, opts?: Options): Handle | nil, string
   -- spawned while this handle is still open (which would keep an earlier
   -- child from seeing stdin EOF). The child's own dup2 onto 0/1/2 clears
   -- CLOEXEC on the ends it keeps.
-  local function new_pipe(): number, number
+  local function new_pipe(): integer, integer
     local r, w = unix.pipe(unix.O_CLOEXEC)
     if r == nil or w == nil then
       return nil, nil
@@ -279,24 +279,24 @@ local function spawn(argv: {string}, opts?: Options): Handle | nil, string
     return r, w
   end
 
-  local stdin_r: number
-  local stdin_w: number
+  local stdin_r: integer
+  local stdin_w: integer
   local stdin_is_fd = stdin_fd ~= nil
   if not stdin_is_fd then
     stdin_r, stdin_w = new_pipe()
     if not stdin_w then return fail("pipe failed (stdin)") end
   end
 
-  local stdout_r: number
-  local stdout_w: number
+  local stdout_r: integer
+  local stdout_w: integer
   local stdout_is_fd = stdout_fd ~= nil
   if not stdout_is_fd then
     stdout_r, stdout_w = new_pipe()
     if not stdout_w then return fail("pipe failed (stdout)") end
   end
 
-  local stderr_r: number
-  local stderr_w: number
+  local stderr_r: integer
+  local stderr_w: integer
   local stderr_is_fd = stderr_fd ~= nil
   if not stderr_is_fd then
     stderr_r, stderr_w = new_pipe()
@@ -305,7 +305,7 @@ local function spawn(argv: {string}, opts?: Options): Handle | nil, string
 
   -- Parent-side epilogue shared by both spawn paths: release the pipe ends
   -- the child owns and build the pump state around the ends we keep.
-  local function parent_handle(pid: number): Handle
+  local function parent_handle(pid: integer): Handle
     if not stdin_is_fd then unix.close(stdin_r) end
     if not stdout_is_fd then unix.close(stdout_w) end
     if not stderr_is_fd then unix.close(stderr_w) end
@@ -484,7 +484,7 @@ local record ChildModule
   run: function(argv: {string}, opts?: Options): Result | nil, string
 
   -- Zip binary helper
-  prepare_zip_exec: function(zip_path: string): number | nil, string
+  prepare_zip_exec: function(zip_path: string): integer | nil, string
 end
 
 local M: ChildModule = {

--- a/lib/cosmic/child/io.tl
+++ b/lib/cosmic/child/io.tl
@@ -25,9 +25,9 @@ local CHUNK = 65536
 --- resumed pump only watches what is still live. `out`/`err_out` accumulate
 --- across calls; `stdin_off` records progress feeding `stdin_data`.
 local record PumpState
-  stdout_fd: number
-  stderr_fd: number
-  stdin_fd: number
+  stdout_fd: integer
+  stderr_fd: integer
+  stdin_fd: integer
   stdin_data: string
   stdin_off: integer
   out: {string}
@@ -40,9 +40,9 @@ end
 --- boundary speaks raw descriptors.
 local record Stdio
   stdin_data: string
-  stdin_fd: number
-  stdout_fd: number
-  stderr_fd: number
+  stdin_fd: integer
+  stdout_fd: integer
+  stderr_fd: integer
 end
 
 --- Resolve the caller's stdio options to raw descriptors, once, at the
@@ -86,7 +86,7 @@ end
 -- F_SETFL replaces the file-status flags, but a fresh pipe write end carries
 -- none worth preserving (F_SETFL ignores the access mode), so setting
 -- O_NONBLOCK outright is safe.
-local function set_nonblocking(fd: number): boolean, string
+local function set_nonblocking(fd: integer): boolean, string
   local ok = unix.fcntl(fd, unix.F_SETFL, unix.O_NONBLOCK)
   if not ok then
     return false, "fcntl F_SETFL O_NONBLOCK failed"
@@ -125,7 +125,7 @@ local function pump(state: PumpState, deadline_ms: number): boolean
   -- Read whatever is ready on fd into buf; on EOF, a read error, or a hangup
   -- with no pending data, drop it from the set and close/nil it in `state`.
   -- When both readable and hangup are set, data still remains, so read.
-  local function read_ready(fd: number, buf: {string}, which: string)
+  local function read_ready(fd: integer, buf: {string}, which: string)
     local ev0 = p:events(fd)
     if not ev0 then return end
     local ev = ev0 as {string: boolean}

--- a/lib/cosmic/compress.tl
+++ b/lib/cosmic/compress.tl
@@ -34,7 +34,7 @@ local record DecompressOptions
   --- input framing; defaults to "zlib"
   format: DecompressFormat
   --- cap on the decompressed size in bytes (default 64 MiB)
-  max_output: number
+  max_output: integer
 end
 
 --- Compress data using a standard framing.

--- a/lib/cosmic/embed.tl
+++ b/lib/cosmic/embed.tl
@@ -47,7 +47,7 @@ end
 
 --- Options for adding files to a ZIP archive.
 local record AddOptions
-  mode: number
+  mode: integer
   method: string
 end
 
@@ -61,8 +61,8 @@ end
 --- Directory entry returned by ZipReader:list().
 local record ZipEntry
   name: string
-  size: number
-  mode: number
+  size: integer
+  mode: integer
 end
 
 --- Reader interface for reading files from a ZIP archive.
@@ -77,7 +77,7 @@ end
 --- letting collect_dir skip a stat(2) call for entries d_type already
 --- identifies as neither a directory nor a regular file.
 local record EmbedDirHandle
-  read: function(self): string, number
+  read: function(self): string, integer
   close: function(self)
 end
 
@@ -85,7 +85,7 @@ end
 -- embed order without needing two parallel arrays.
 local record DirEntry
   name: string
-  kind: number
+  kind: integer
 end
 
 -- Internal record for files staged for embedding.
@@ -93,7 +93,7 @@ local record FileToEmbed
   path: string
   content: string
   stored_name: string
-  mode: number
+  mode: integer
 end
 
 --- Recursively collect all files from a directory.

--- a/lib/cosmic/fd.tl
+++ b/lib/cosmic/fd.tl
@@ -28,21 +28,21 @@ local record Handle is stream.Reader, stream.Writer
   metamethod __close: function(self: Handle)
   close: function(self: Handle): boolean, string
   closed: function(self: Handle): boolean
-  fd: function(self: Handle): number
-  read: function(self: Handle, size?: number, offset?: number): string | nil, string
-  write: function(self: Handle, data: string, offset?: number): number | nil, string
-  seek: function(self: Handle, offset: number, whence?: number): number | nil, string
-  truncate: function(self: Handle, length?: number): boolean, string
+  fd: function(self: Handle): integer
+  read: function(self: Handle, size?: integer, offset?: integer): string | nil, string
+  write: function(self: Handle, data: string, offset?: integer): integer | nil, string
+  seek: function(self: Handle, offset: integer, whence?: integer): integer | nil, string
+  truncate: function(self: Handle, length?: integer): boolean, string
   sync: function(self: Handle): boolean, string
   datasync: function(self: Handle): boolean, string
-  dup: function(self: Handle, newfd?: number, flags?: number, lowest?: number): Handle | nil, string
-  fcntl: function(self: Handle, cmd: number, arg?: number): number | nil, string
+  dup: function(self: Handle, newfd?: integer, flags?: integer, lowest?: integer): Handle | nil, string
+  fcntl: function(self: Handle, cmd: integer, arg?: integer): integer | nil, string
 end
 
-local make_handle: function(fd: number): Handle
+local make_handle: function(fd: integer): Handle
 
-make_handle = function(fd: number): Handle
-  local handle_fd: number = fd
+make_handle = function(fd: integer): Handle
+  local handle_fd: integer = fd
   local handle: Handle = {}
 
   --- Close the handle. Idempotent.
@@ -65,7 +65,7 @@ make_handle = function(fd: number): Handle
   end
 
   --- Returns the underlying file descriptor, or -1 if closed.
-  function handle:fd(): number
+  function handle:fd(): integer
     return handle_fd or -1
   end
 
@@ -75,7 +75,7 @@ make_handle = function(fd: number): Handle
   --- including EAGAIN on a nonblocking fd with no data, and EINTR when
   --- a signal interrupts the read (see the module header; not retried).
   --- If offset is provided, reads at that position (pread behavior).
-  function handle:read(size?: number, offset?: number): string | nil, string
+  function handle:read(size?: integer, offset?: integer): string | nil, string
     if not handle_fd then
       return nil, "handle closed"
     end
@@ -93,7 +93,7 @@ make_handle = function(fd: number): Handle
   --- than #data — callers writing everything must loop). On failure
   --- returns nil plus an error; EINTR is not retried (see module header).
   --- If offset is provided, writes at that position (pwrite behavior).
-  function handle:write(data: string, offset?: number): number | nil, string
+  function handle:write(data: string, offset?: integer): integer | nil, string
     if not handle_fd then
       return nil, "handle closed"
     end
@@ -106,7 +106,7 @@ make_handle = function(fd: number): Handle
 
   --- Seek to position. whence: SEEK_SET (default), SEEK_CUR, SEEK_END.
   --- On failure returns nil plus an error; EINTR is not retried.
-  function handle:seek(offset: number, whence?: number): number | nil, string
+  function handle:seek(offset: integer, whence?: integer): integer | nil, string
     if not handle_fd then
       return nil, "handle closed"
     end
@@ -118,7 +118,7 @@ make_handle = function(fd: number): Handle
   end
 
   --- Truncate to length (default 0).
-  function handle:truncate(length?: number): boolean, string
+  function handle:truncate(length?: integer): boolean, string
     if not handle_fd then
       return false, "handle closed"
     end
@@ -156,7 +156,7 @@ make_handle = function(fd: number): Handle
   --- Duplicate the handle.
   --- If newfd is provided, duplicates to that specific fd (dup2 behavior).
   --- flags can include O_CLOEXEC. lowest specifies minimum acceptable fd.
-  function handle:dup(newfd?: number, flags?: number, lowest?: number): Handle | nil, string
+  function handle:dup(newfd?: integer, flags?: integer, lowest?: integer): Handle | nil, string
     if not handle_fd then
       return nil, "handle closed"
     end
@@ -168,7 +168,7 @@ make_handle = function(fd: number): Handle
   end
 
   --- File control operations. cmd: F_GETFD, F_SETFD, F_GETFL, F_SETFL, F_SETLK, etc.
-  function handle:fcntl(cmd: number, value?: number): number | nil, string
+  function handle:fcntl(cmd: integer, value?: integer): integer | nil, string
     if not handle_fd then
       return nil, "handle closed"
     end
@@ -176,7 +176,7 @@ make_handle = function(fd: number): Handle
     if result == nil then
       return nil, errstr(err, "fcntl")
     end
-    return result as number
+    return result as integer
   end
 
   return setmetatable(handle, {
@@ -217,7 +217,7 @@ end
 
 --- Open a file. flags: O_RDONLY, O_WRONLY, O_RDWR, combined with O_CREAT, O_TRUNC, etc.
 --- If dirfd is provided, path is relative to that directory (openat behavior).
-local function open(path: string, flags: number, mode?: number, dirfd?: number): Handle | nil, string
+local function open(path: string, flags: integer, mode?: integer, dirfd?: integer): Handle | nil, string
   local fd, err = unix.open(path, flags, mode, dirfd)
   if not fd then
     return nil, errstr(err, "open: " .. path)
@@ -226,7 +226,7 @@ local function open(path: string, flags: number, mode?: number, dirfd?: number):
 end
 
 --- Create a pipe. flags: O_CLOEXEC, O_NONBLOCK.
-local function pipe(flags?: number): Pipe | nil, string
+local function pipe(flags?: integer): Pipe | nil, string
   local reader_fd, writer_fd = unix.pipe(flags)
   if not reader_fd then
     -- On failure the binding returns (nil, err, errno): the error string
@@ -241,7 +241,7 @@ end
 --- Handle world: h:read()/h:write()/h:close(), plus automatic cleanup
 --- via the __close metamethod. The Handle takes ownership: closing it
 --- closes the fd.
-local function wrap(rawfd: number): Handle
+local function wrap(rawfd: integer): Handle
   return make_handle(rawfd)
 end
 
@@ -250,40 +250,40 @@ local record FdModule
   type Handle = Handle
   type Pipe = Pipe
 
-  open: function(path: string, flags: number, mode?: number, dirfd?: number): Handle | nil, string
-  wrap: function(rawfd: number): Handle
-  pipe: function(flags?: number): Pipe | nil, string
+  open: function(path: string, flags: integer, mode?: integer, dirfd?: integer): Handle | nil, string
+  wrap: function(rawfd: integer): Handle
+  pipe: function(flags?: integer): Pipe | nil, string
 
-  O_RDONLY: number
-  O_WRONLY: number
-  O_RDWR: number
-  O_CREAT: number
-  O_TRUNC: number
-  O_APPEND: number
-  O_EXCL: number
-  O_CLOEXEC: number
-  O_NONBLOCK: number
-  O_DIRECT: number
-  O_DIRECTORY: number
-  O_NOFOLLOW: number
+  O_RDONLY: integer
+  O_WRONLY: integer
+  O_RDWR: integer
+  O_CREAT: integer
+  O_TRUNC: integer
+  O_APPEND: integer
+  O_EXCL: integer
+  O_CLOEXEC: integer
+  O_NONBLOCK: integer
+  O_DIRECT: integer
+  O_DIRECTORY: integer
+  O_NOFOLLOW: integer
 
-  SEEK_SET: number
-  SEEK_CUR: number
-  SEEK_END: number
+  SEEK_SET: integer
+  SEEK_CUR: integer
+  SEEK_END: integer
 
-  F_GETFD: number
-  F_SETFD: number
-  F_GETFL: number
-  F_SETFL: number
-  F_SETLK: number
-  F_SETLKW: number
-  F_GETLK: number
-  F_RDLCK: number
-  F_WRLCK: number
-  F_UNLCK: number
-  FD_CLOEXEC: number
+  F_GETFD: integer
+  F_SETFD: integer
+  F_GETFL: integer
+  F_SETFL: integer
+  F_SETLK: integer
+  F_SETLKW: integer
+  F_GETLK: integer
+  F_RDLCK: integer
+  F_WRLCK: integer
+  F_UNLCK: integer
+  FD_CLOEXEC: integer
 
-  AT_FDCWD: number
+  AT_FDCWD: integer
 end
 
 local M: FdModule = {

--- a/lib/cosmic/fetch/init_test.tl
+++ b/lib/cosmic/fetch/init_test.tl
@@ -31,7 +31,7 @@ end
 --- and close without answering (a transport failure for the client).
 --- A response of "echo" answers 200 with the raw request as the body.
 --- @return integer port, integer child pid (caller must proc.wait it)
-local function serve(responses: {string}): integer, number
+local function serve(responses: {string}): integer, integer
   local srv, port = net.listen_tcp("127.0.0.1", 0)
   assert(srv ~= nil, "listen_tcp failed")
   local s = srv as net.Socket

--- a/lib/cosmic/fetch/multiheader_test.tl
+++ b/lib/cosmic/fetch/multiheader_test.tl
@@ -14,7 +14,7 @@ local RESPONSE = "HTTP/1.1 200 OK\r\n"
 .. "Connection: close\r\n\r\nhi"
 
 --- Fork a loopback server answering n requests with RESPONSE.
-local function serve(n: integer): integer, number
+local function serve(n: integer): integer, integer
   local srv, port = net.listen_tcp("127.0.0.1", 0)
   assert(srv ~= nil, "listen_tcp failed")
   local s = srv as net.Socket

--- a/lib/cosmic/fetch/retry_test.tl
+++ b/lib/cosmic/fetch/retry_test.tl
@@ -24,7 +24,7 @@ end
 --- The child also arms a lifetime alarm: if the client stops early for
 --- any other reason, SIGALRM's default action kills the child so
 --- proc.wait() can never hang the suite.
-local function serve(responses: {string}): integer, number
+local function serve(responses: {string}): integer, integer
   local srv, port = net.listen_tcp("127.0.0.1", 0)
   assert(srv ~= nil, "listen_tcp failed")
   local s = srv as net.Socket

--- a/lib/cosmic/fetch/stream_test.tl
+++ b/lib/cosmic/fetch/stream_test.tl
@@ -8,7 +8,7 @@ local proc = require("cosmic.proc")
 
 --- Fork a loopback server answering one request per response string,
 --- closing the connection right after each send.
-local function serve(responses: {string}): integer, number
+local function serve(responses: {string}): integer, integer
   local srv, port = net.listen_tcp("127.0.0.1", 0)
   assert(srv ~= nil, "listen_tcp failed")
   local s = srv as net.Socket

--- a/lib/cosmic/fetch/verbs_test.tl
+++ b/lib/cosmic/fetch/verbs_test.tl
@@ -34,7 +34,7 @@ end
 --- then exits. A response of "echo" answers 200 with the raw request as
 --- the body.
 --- @return integer port, integer child pid (caller must proc.wait it)
-local function serve(responses: {string}): integer, number
+local function serve(responses: {string}): integer, integer
   local srv, port = net.listen_tcp("127.0.0.1", 0)
   assert(srv ~= nil, "listen_tcp failed")
   local s = srv as net.Socket

--- a/lib/cosmic/fs/file.tl
+++ b/lib/cosmic/fs/file.tl
@@ -21,10 +21,10 @@ end
 --- Write data to a file, creating or overwriting it.
 --- @param path string Path to the file
 --- @param data string Data to write
---- @param mode number Permission bits when creating (default 0644)
+--- @param mode integer Permission bits when creating (default 0644)
 --- @return boolean True on success
 --- @return string Error message if failed
-local function write(path: string, data: string, mode?: number): boolean, string
+local function write(path: string, data: string, mode?: integer): boolean, string
   local ok, err = cosmo.Barf(path, data, {mode = mode})
   if not ok then
     return false, err or ("failed to write file: " .. path)
@@ -34,10 +34,10 @@ end
 
 --- Truncate a file to the given length (default 0).
 --- @param path string Path to the file
---- @param length number New length in bytes (default 0)
+--- @param length integer New length in bytes (default 0)
 --- @return boolean True on success
 --- @return string Error message if failed
-local function truncate(path: string, length?: number): boolean, string
+local function truncate(path: string, length?: integer): boolean, string
   local ok, err = unix.truncate(path, length)
   if not ok then
     return false, errstr(err, "truncate: " .. path)
@@ -52,10 +52,10 @@ end
 --- temporary file is removed.
 --- @param path string Destination path
 --- @param data string Data to write
---- @param mode number Permission bits for the file (default 0644)
+--- @param mode integer Permission bits for the file (default 0644)
 --- @return boolean True on success
 --- @return string Error message if failed
-local function write_atomic(path: string, data: string, mode?: number): boolean, string
+local function write_atomic(path: string, data: string, mode?: integer): boolean, string
   -- The binding returns (fd, path) on success and (nil, Errno) on failure.
   local fd, tmp = unix.mkstemp(path .. ".XXXXXX")
   if not fd then
@@ -99,9 +99,9 @@ end
 
 local record FsFileModule
   read: function(path: string): string | nil, string
-  write: function(path: string, data: string, mode?: number): boolean, string
-  truncate: function(path: string, length?: number): boolean, string
-  write_atomic: function(path: string, data: string, mode?: number): boolean, string
+  write: function(path: string, data: string, mode?: integer): boolean, string
+  truncate: function(path: string, length?: integer): boolean, string
+  write_atomic: function(path: string, data: string, mode?: integer): boolean, string
 end
 
 local M: FsFileModule = {

--- a/lib/cosmic/fs/init.tl
+++ b/lib/cosmic/fs/init.tl
@@ -20,11 +20,11 @@ local type Handle = cfd.Handle
 
 -- Raw Dir type from cosmo.unix
 local record RawDir
-  read: function(self: RawDir): string, number
+  read: function(self: RawDir): string, integer
   close: function(self: RawDir)
-  fd: function(self: RawDir): number
+  fd: function(self: RawDir): integer
   rewind: function(self: RawDir)
-  tell: function(self: RawDir): number
+  tell: function(self: RawDir): integer
 end
 
 -- Wrap a raw cosmo Dir with __close support
@@ -35,7 +35,7 @@ local function make_dir(raw: RawDir): Dir
     -- The second return is the dirent d_type (fs.DT_DIR / DT_REG /
     -- DT_LNK / ... / DT_UNKNOWN) where the filesystem supports it,
     -- so "is this entry a directory" needs no stat(2) call.
-    read = function(_self: Dir): string, number
+    read = function(_self: Dir): string, integer
       if is_closed then return nil end
       return raw:read()
     end,
@@ -45,14 +45,14 @@ local function make_dir(raw: RawDir): Dir
         is_closed = true
       end
     end,
-    fd = function(_self: Dir): number
+    fd = function(_self: Dir): integer
       if is_closed then return -1 end
       return raw:fd()
     end,
     rewind = function(_self: Dir)
       if not is_closed then raw:rewind() end
     end,
-    tell = function(_self: Dir): number
+    tell = function(_self: Dir): integer
       if is_closed then return -1 end
       return raw:tell()
     end,
@@ -100,10 +100,10 @@ local function lstat(path: string): Stat | nil, string
 end
 
 --- Get file metadata from file descriptor.
---- @param fd number File descriptor
+--- @param fd integer File descriptor
 --- @return Stat | nil File metadata, or nil on error
 --- @return string Error message if failed
-local function fstat(fd: number): Stat | nil, string
+local function fstat(fd: integer): Stat | nil, string
   local st, err = unix.fstat(fd)
   if not st then
     return nil, errstr(err, "fstat")
@@ -116,10 +116,10 @@ end
 --- Create a directory.
 --- Parent directories must exist. Use makedirs() to create parents.
 --- @param path string Path to the directory to create
---- @param mode number Permission bits (default 0755)
+--- @param mode integer Permission bits (default 0755)
 --- @return boolean True on success
 --- @return string Error message if failed
-local function mkdir(path: string, mode?: number): boolean, string
+local function mkdir(path: string, mode?: integer): boolean, string
   mode = mode or tonumber("755", 8)
   local ok, err = unix.mkdir(path, mode)
   if not ok then
@@ -130,10 +130,10 @@ end
 
 --- Create a directory and any missing parent directories.
 --- @param path string Path to the directory to create
---- @param mode number Permission bits (default 0755)
+--- @param mode integer Permission bits (default 0755)
 --- @return boolean True on success
 --- @return string Error message if failed
-local function makedirs(path: string, mode?: number): boolean, string
+local function makedirs(path: string, mode?: integer): boolean, string
   mode = mode or tonumber("755", 8)
   local ok, err = unix.makedirs(path, mode)
   if not ok then
@@ -193,10 +193,10 @@ end
 
 --- Open a directory from a file descriptor.
 --- Supports automatic cleanup with `<close>` attribute.
---- @param fd number File descriptor for an open directory
+--- @param fd integer File descriptor for an open directory
 --- @return Dir | nil Directory handle, or nil on error
 --- @return string Error message if failed
-local function fdopendir(fd: number): Dir | nil, string
+local function fdopendir(fd: integer): Dir | nil, string
   local raw, err = unix.fdopendir(fd)
   if not raw then
     return nil, errstr(err, "fdopendir")
@@ -251,29 +251,29 @@ local record FsModule
   -- Stat operations
   stat: function(path: string): Stat | nil, string
   lstat: function(path: string): Stat | nil, string
-  fstat: function(fd: number): Stat | nil, string
+  fstat: function(fd: integer): Stat | nil, string
 
   -- Directory operations
-  mkdir: function(path: string, mode?: number): boolean, string
-  makedirs: function(path: string, mode?: number): boolean, string
+  mkdir: function(path: string, mode?: integer): boolean, string
+  makedirs: function(path: string, mode?: integer): boolean, string
   rmdir: function(path: string): boolean, string
   chdir: function(path: string): boolean, string
   getcwd: function(): string | nil, string
   opendir: function(path: string): Dir | nil, string
-  fdopendir: function(fd: number): Dir | nil, string
+  fdopendir: function(fd: integer): Dir | nil, string
 
   -- Whole-file operations
   read: function(path: string): string | nil, string
-  write: function(path: string, data: string, mode?: number): boolean, string
-  truncate: function(path: string, length?: number): boolean, string
+  write: function(path: string, data: string, mode?: integer): boolean, string
+  truncate: function(path: string, length?: integer): boolean, string
 
   -- File operations
   unlink: function(path: string): boolean, string
   rename: function(oldpath: string, newpath: string): boolean, string
   copy: function(src: string, dst: string): boolean, string
   move: function(oldpath: string, newpath: string): boolean, string
-  touch: function(path: string, mode?: number): boolean, string
-  write_atomic: function(path: string, data: string, mode?: number): boolean, string
+  touch: function(path: string, mode?: integer): boolean, string
+  write_atomic: function(path: string, data: string, mode?: integer): boolean, string
   link: function(existingpath: string, newpath: string): boolean, string
   symlink: function(target: string, linkpath: string): boolean, string
   readlink: function(path: string): string | nil, string
@@ -282,30 +282,30 @@ local record FsModule
   copytree: function(src: string, dst: string): boolean, string
 
   -- Permission operations
-  access: function(path: string, mode?: number): boolean
-  chmod: function(path: string, mode: number): boolean, string
-  chown: function(path: string, uid: number, gid: number): boolean, string
+  access: function(path: string, mode?: integer): boolean
+  chmod: function(path: string, mode: integer): boolean, string
+  chown: function(path: string, uid: integer, gid: integer): boolean, string
 
   -- Timestamp operations
-  utimensat: function(path: string, atime_secs: number, atime_nsecs: number, mtime_secs: number, mtime_nsecs: number): boolean, string
-  futimens: function(fd: number, atime_secs: number, atime_nsecs: number, mtime_secs: number, mtime_nsecs: number): boolean, string
+  utimensat: function(path: string, atime_secs: integer, atime_nsecs: integer, mtime_secs: integer, mtime_nsecs: integer): boolean, string
+  futimens: function(fd: integer, atime_secs: integer, atime_nsecs: integer, mtime_secs: integer, mtime_nsecs: integer): boolean, string
 
   -- Temporary file operations
   mkdtemp: function(template: string): string | nil, string
   tmpfile: function(template?: string): Handle | nil, string, string
-  tmpfd: function(): number | nil, string
+  tmpfd: function(): integer | nil, string
 
   -- Filesystem statistics
   statfs: function(path: string): Statfs | nil, string
-  fstatfs: function(fd: number): Statfs | nil, string
+  fstatfs: function(fd: integer): Statfs | nil, string
 
   --- Flush all filesystem buffers to disk, system-wide (sync(2)).
   --- Per-file flushing is Handle:sync()/Handle:datasync() in cosmic.fd.
   sync: function()
 
   -- Device number utilities
-  major: function(dev: number): number
-  minor: function(dev: number): number
+  major: function(dev: integer): integer
+  minor: function(dev: integer): integer
 
   --- Walk a directory tree depth-first, calling the visitor per entry.
   --- Visitor signature: visitor(path, name, st, ctx): nil | "skip" | "stop"
@@ -329,20 +329,20 @@ local record FsModule
   files: function(dir: string, pattern?: string): FileIter | nil, string, any, any
 
   -- Access mode constants
-  F_OK: number
-  R_OK: number
-  W_OK: number
-  X_OK: number
+  F_OK: integer
+  R_OK: integer
+  W_OK: integer
+  X_OK: integer
 
   -- Dirent d_type constants, as returned by Dir:read()'s second value
-  DT_BLK: number
-  DT_CHR: number
-  DT_DIR: number
-  DT_FIFO: number
-  DT_LNK: number
-  DT_REG: number
-  DT_SOCK: number
-  DT_UNKNOWN: number
+  DT_BLK: integer
+  DT_CHR: integer
+  DT_DIR: integer
+  DT_FIFO: integer
+  DT_LNK: integer
+  DT_REG: integer
+  DT_SOCK: integer
+  DT_UNKNOWN: integer
 end
 
 local M: FsModule = {

--- a/lib/cosmic/fs/ops.tl
+++ b/lib/cosmic/fs/ops.tl
@@ -120,10 +120,10 @@ end
 --- Update a file's access and modification times to now, creating the
 --- file (mode 0644 by default) if it does not exist.
 --- @param path string Path to the file
---- @param mode number Permission bits when creating (default 0644)
+--- @param mode integer Permission bits when creating (default 0644)
 --- @return boolean True on success
 --- @return string Error message if failed
-local function touch(path: string, mode?: number): boolean, string
+local function touch(path: string, mode?: integer): boolean, string
   local fd, oerr = unix.open(path,
     unix.O_WRONLY | unix.O_CREAT, mode or tonumber("644", 8))
   if not fd then
@@ -206,19 +206,19 @@ end
 
 --- Check if the current process has access to a file.
 --- @param path string Path to check
---- @param mode number Access mode: F_OK (exists, the default), R_OK, W_OK, X_OK
+--- @param mode integer Access mode: F_OK (exists, the default), R_OK, W_OK, X_OK
 --- @return boolean True if access is allowed
-local function access(path: string, mode?: number): boolean
+local function access(path: string, mode?: integer): boolean
   -- The binding returns true or nil, err; callers get an honest boolean.
   return unix.access(path, mode or unix.F_OK) == true
 end
 
 --- Change file permissions.
 --- @param path string Path to the file
---- @param mode number New permission bits (e.g., 0644)
+--- @param mode integer New permission bits (e.g., 0644)
 --- @return boolean True on success
 --- @return string Error message if failed
-local function chmod(path: string, mode: number): boolean, string
+local function chmod(path: string, mode: integer): boolean, string
   local ok, err = unix.chmod(path, mode)
   if not ok then
     return false, errstr(err, "chmod: " .. path)
@@ -228,11 +228,11 @@ end
 
 --- Change file owner and group.
 --- @param path string Path to the file
---- @param uid number New owner user ID
---- @param gid number New owner group ID
+--- @param uid integer New owner user ID
+--- @param gid integer New owner group ID
 --- @return boolean True on success
 --- @return string Error message if failed
-local function chown(path: string, uid: number, gid: number): boolean, string
+local function chown(path: string, uid: integer, gid: integer): boolean, string
   local ok, err = unix.chown(path, uid, gid)
   if not ok then
     return false, errstr(err, "chown: " .. path)
@@ -250,7 +250,7 @@ end
 --- @param mtime_nsecs number Modification time nanoseconds
 --- @return boolean True on success
 --- @return string Error message if failed
-local function utimensat(path: string, atime_secs: number, atime_nsecs: number, mtime_secs: number, mtime_nsecs: number): boolean, string
+local function utimensat(path: string, atime_secs: integer, atime_nsecs: integer, mtime_secs: integer, mtime_nsecs: integer): boolean, string
   local rc, err = unix.utimensat(path, atime_secs or 0, atime_nsecs or unix.UTIME_OMIT, mtime_secs or 0, mtime_nsecs or unix.UTIME_OMIT)
   if rc ~= 0 then
     return false, errstr(err, "utimensat: " .. path)
@@ -259,14 +259,14 @@ local function utimensat(path: string, atime_secs: number, atime_nsecs: number, 
 end
 
 --- Change file access and modification times on a file descriptor.
---- @param fd number File descriptor
---- @param atime_secs number Access time seconds (nil to keep current)
+--- @param fd integer File descriptor
+--- @param atime_secs integer Access time seconds (nil to keep current)
 --- @param atime_nsecs number Access time nanoseconds
 --- @param mtime_secs number Modification time seconds (nil to keep current)
 --- @param mtime_nsecs number Modification time nanoseconds
 --- @return boolean True on success
 --- @return string Error message if failed
-local function futimens(fd: number, atime_secs: number, atime_nsecs: number, mtime_secs: number, mtime_nsecs: number): boolean, string
+local function futimens(fd: integer, atime_secs: integer, atime_nsecs: integer, mtime_secs: integer, mtime_nsecs: integer): boolean, string
   local rc, err = unix.futimens(fd, atime_secs or 0, atime_nsecs or unix.UTIME_OMIT, mtime_secs or 0, mtime_nsecs or unix.UTIME_OMIT)
   if rc ~= 0 then
     return false, errstr(err, "futimens")
@@ -309,9 +309,9 @@ local function tmpfile(template?: string): Handle | nil, string, string
 end
 
 --- Create a temporary file descriptor.
---- @return number | nil File descriptor, or nil on error
+--- @return integer | nil File descriptor, or nil on error
 --- @return string Error message if failed
-local function tmpfd(): number | nil, string
+local function tmpfd(): integer | nil, string
   local fd, err = unix.tmpfd()
   if not fd then
     return nil, errstr(err, "tmpfd")
@@ -334,10 +334,10 @@ local function statfs(path: string): Statfs | nil, string
 end
 
 --- Get filesystem statistics from a file descriptor.
---- @param fd number File descriptor
+--- @param fd integer File descriptor
 --- @return Statfs | nil Filesystem statistics, or nil on error
 --- @return string Error message if failed
-local function fstatfs(fd: number): Statfs | nil, string
+local function fstatfs(fd: integer): Statfs | nil, string
   local info, err = unix.fstatfs(fd)
   if not info then
     return nil, errstr(err, "fstatfs")
@@ -355,16 +355,16 @@ end
 -- Device number utilities
 
 --- Extract major device number from a device ID.
---- @param dev number Device ID from stat
---- @return number Major device number
-local function major(dev: number): number
+--- @param dev integer Device ID from stat
+--- @return integer Major device number
+local function major(dev: integer): integer
   return unix.major(dev)
 end
 
 --- Extract minor device number from a device ID.
---- @param dev number Device ID from stat
---- @return number Minor device number
-local function minor(dev: number): number
+--- @param dev integer Device ID from stat
+--- @return integer Minor device number
+local function minor(dev: integer): integer
   return unix.minor(dev)
 end
 
@@ -373,29 +373,29 @@ local record FsOpsModule
   rename: function(oldpath: string, newpath: string): boolean, string
   copy: function(src: string, dst: string): boolean, string
   move: function(oldpath: string, newpath: string): boolean, string
-  touch: function(path: string, mode?: number): boolean, string
+  touch: function(path: string, mode?: integer): boolean, string
   link: function(existingpath: string, newpath: string): boolean, string
   symlink: function(target: string, linkpath: string): boolean, string
   readlink: function(path: string): string | nil, string
   realpath: function(path: string): string | nil, string
   rmrf: function(path: string): boolean, string
-  access: function(path: string, mode?: number): boolean
-  chmod: function(path: string, mode: number): boolean, string
-  chown: function(path: string, uid: number, gid: number): boolean, string
-  utimensat: function(path: string, atime_secs: number, atime_nsecs: number, mtime_secs: number, mtime_nsecs: number): boolean, string
-  futimens: function(fd: number, atime_secs: number, atime_nsecs: number, mtime_secs: number, mtime_nsecs: number): boolean, string
+  access: function(path: string, mode?: integer): boolean
+  chmod: function(path: string, mode: integer): boolean, string
+  chown: function(path: string, uid: integer, gid: integer): boolean, string
+  utimensat: function(path: string, atime_secs: integer, atime_nsecs: integer, mtime_secs: integer, mtime_nsecs: integer): boolean, string
+  futimens: function(fd: integer, atime_secs: integer, atime_nsecs: integer, mtime_secs: integer, mtime_nsecs: integer): boolean, string
   mkdtemp: function(template: string): string | nil, string
   tmpfile: function(template?: string): Handle | nil, string, string
-  tmpfd: function(): number | nil, string
+  tmpfd: function(): integer | nil, string
   statfs: function(path: string): Statfs | nil, string
-  fstatfs: function(fd: number): Statfs | nil, string
+  fstatfs: function(fd: integer): Statfs | nil, string
   sync: function()
-  major: function(dev: number): number
-  minor: function(dev: number): number
-  F_OK: number
-  R_OK: number
-  W_OK: number
-  X_OK: number
+  major: function(dev: integer): integer
+  minor: function(dev: integer): integer
+  F_OK: integer
+  R_OK: integer
+  W_OK: integer
+  X_OK: integer
 end
 
 local M: FsOpsModule = {

--- a/lib/cosmic/fs/traps_test.tl
+++ b/lib/cosmic/fs/traps_test.tl
@@ -9,7 +9,7 @@ global TEST_TMPDIR: string
 
 local fsa = fs as {string: any}
 
-local function write_file(path: string, content: string, mode?: number)
+local function write_file(path: string, content: string, mode?: integer)
   assert(fs.write(path, content, mode))
 end
 

--- a/lib/cosmic/fs/types.tl
+++ b/lib/cosmic/fs/types.tl
@@ -8,56 +8,56 @@ local record fs_types
   --- Returned by statfs() and fstatfs().
   record Statfs
     --- Returns filesystem type identifier.
-    type: function(self: Statfs): number
+    type: function(self: Statfs): integer
     --- Returns optimal transfer block size.
-    bsize: function(self: Statfs): number
+    bsize: function(self: Statfs): integer
     --- Returns total data blocks in filesystem.
-    blocks: function(self: Statfs): number
+    blocks: function(self: Statfs): integer
     --- Returns free blocks in filesystem.
-    bfree: function(self: Statfs): number
+    bfree: function(self: Statfs): integer
     --- Returns free blocks available to unprivileged user.
-    bavail: function(self: Statfs): number
+    bavail: function(self: Statfs): integer
     --- Returns total file nodes in filesystem.
-    files: function(self: Statfs): number
+    files: function(self: Statfs): integer
     --- Returns free file nodes in filesystem.
-    ffree: function(self: Statfs): number
-    --- Returns filesystem ID as two numbers.
-    fsid: function(self: Statfs): number, number
+    ffree: function(self: Statfs): integer
+    --- Returns filesystem ID as two integers.
+    fsid: function(self: Statfs): integer, integer
     --- Returns maximum length of filenames.
-    namelen: function(self: Statfs): number
+    namelen: function(self: Statfs): integer
     --- Returns fragment size.
-    frsize: function(self: Statfs): number
+    frsize: function(self: Statfs): integer
     --- Returns mount flags.
-    flags: function(self: Statfs): number
+    flags: function(self: Statfs): integer
   end
 
   --- File or directory metadata.
   --- Use the is_dir()/is_file()/is_link()/... methods to check file type.
   record Stat
     --- Returns file size in bytes.
-    size: function(self: Stat): number
+    size: function(self: Stat): integer
     --- Returns file mode (permissions and type bits).
-    mode: function(self: Stat): number
+    mode: function(self: Stat): integer
     --- Returns owner user ID.
-    uid: function(self: Stat): number
+    uid: function(self: Stat): integer
     --- Returns owner group ID.
-    gid: function(self: Stat): number
+    gid: function(self: Stat): integer
     --- Returns birth time as seconds, nanoseconds.
-    birthtim: function(self: Stat): number, number
+    birthtim: function(self: Stat): integer, integer
     --- Returns modification time as seconds, nanoseconds.
-    mtim: function(self: Stat): number, number
+    mtim: function(self: Stat): integer, integer
     --- Returns access time as seconds, nanoseconds.
-    atim: function(self: Stat): number, number
+    atim: function(self: Stat): integer, integer
     --- Returns status change time as seconds, nanoseconds.
-    ctim: function(self: Stat): number, number
+    ctim: function(self: Stat): integer, integer
     --- Returns number of 512-byte blocks allocated.
-    blocks: function(self: Stat): number
+    blocks: function(self: Stat): integer
     --- Returns number of hard links.
-    nlink: function(self: Stat): number
+    nlink: function(self: Stat): integer
     --- Returns device ID containing the file.
-    dev: function(self: Stat): number
+    dev: function(self: Stat): integer
     --- Returns device ID for special files (0 or -1 for non-devices).
-    rdev: function(self: Stat): number
+    rdev: function(self: Stat): integer
     --- Returns true if this is a directory.
     is_dir: function(self: Stat): boolean
     --- Returns true if this is a regular file.
@@ -85,22 +85,22 @@ local record fs_types
     --- return is the dirent d_type (fs.DT_DIR / DT_REG / DT_LNK / ... /
     --- DT_UNKNOWN where the filesystem does not expose it), so callers
     --- can classify entries without a stat(2) per entry.
-    read: function(self: Dir): string, number
+    read: function(self: Dir): string, integer
     --- Closes directory handle.
     close: function(self: Dir)
     --- Returns file descriptor for this directory.
-    fd: function(self: Dir): number
+    fd: function(self: Dir): integer
     --- Rewinds to beginning of directory.
     rewind: function(self: Dir)
     --- Returns current position in directory stream.
-    tell: function(self: Dir): number
+    tell: function(self: Dir): integer
     --- Returns true if directory handle is closed.
     closed: function(self: Dir): boolean
   end
 
   --- File information with Unix permissions.
   record FileInfo
-    mode: number
+    mode: integer
   end
 
   --- Wrap a raw cosmo.unix Stat so it carries the type predicates.
@@ -152,18 +152,18 @@ local record Wrapped
 end
 
 local stat_methods: {string: any} = {
-  size = function(self: Wrapped): number return self.raw:size() end,
-  mode = function(self: Wrapped): number return self.raw:mode() end,
-  uid = function(self: Wrapped): number return self.raw:uid() end,
-  gid = function(self: Wrapped): number return self.raw:gid() end,
-  birthtim = function(self: Wrapped): number, number return self.raw:birthtim() end,
-  mtim = function(self: Wrapped): number, number return self.raw:mtim() end,
-  atim = function(self: Wrapped): number, number return self.raw:atim() end,
-  ctim = function(self: Wrapped): number, number return self.raw:ctim() end,
-  blocks = function(self: Wrapped): number return self.raw:blocks() end,
-  nlink = function(self: Wrapped): number return self.raw:nlink() end,
-  dev = function(self: Wrapped): number return self.raw:dev() end,
-  rdev = function(self: Wrapped): number return self.raw:rdev() end,
+  size = function(self: Wrapped): integer return self.raw:size() end,
+  mode = function(self: Wrapped): integer return self.raw:mode() end,
+  uid = function(self: Wrapped): integer return self.raw:uid() end,
+  gid = function(self: Wrapped): integer return self.raw:gid() end,
+  birthtim = function(self: Wrapped): integer, integer return self.raw:birthtim() end,
+  mtim = function(self: Wrapped): integer, integer return self.raw:mtim() end,
+  atim = function(self: Wrapped): integer, integer return self.raw:atim() end,
+  ctim = function(self: Wrapped): integer, integer return self.raw:ctim() end,
+  blocks = function(self: Wrapped): integer return self.raw:blocks() end,
+  nlink = function(self: Wrapped): integer return self.raw:nlink() end,
+  dev = function(self: Wrapped): integer return self.raw:dev() end,
+  rdev = function(self: Wrapped): integer return self.raw:rdev() end,
   is_dir = function(self: Wrapped): boolean return unix.S_ISDIR(self.raw:mode()) end,
   is_file = function(self: Wrapped): boolean return unix.S_ISREG(self.raw:mode()) end,
   is_link = function(self: Wrapped): boolean return unix.S_ISLNK(self.raw:mode()) end,

--- a/lib/cosmic/hash.tl
+++ b/lib/cosmic/hash.tl
@@ -50,13 +50,13 @@ local valid_algos < total >: {Algo: boolean} = {
 --- All fields are optional and have sensible defaults.
 local record HashOptions
   --- Memory cost in kibibytes (default: 19456, i.e. 19 MiB per OWASP minimum)
-  m_cost: number
+  m_cost: integer
   --- Time cost / iterations (default: 3)
-  t_cost: number
+  t_cost: integer
   --- Parallelism factor (default: 1)
-  parallelism: number
+  parallelism: integer
   --- Output hash length in bytes (default: 32)
-  hash_len: number
+  hash_len: integer
   --- Variant: "argon2id" (default), "argon2i", or "argon2d"
   variant: argon2.Variant
 end

--- a/lib/cosmic/ip.tl
+++ b/lib/cosmic/ip.tl
@@ -23,13 +23,13 @@ end
 --- Compares by value (two Addrs are == when they hold the same
 --- address) and formats with tostring().
 local record Addr
-  _n: number
+  _n: integer
   --- Address family; "inet" for IPv4.
   family: Family
   --- Get the raw integer representation (the IPv4 payload).
   --- Use this at the C boundary or for arithmetic on the raw value.
   --- @return integer The IP address as an integer
-  int: function(Addr): number
+  int: function(Addr): integer
   --- Format as a dotted-quad string (e.g., "192.168.1.1").
   --- @return string The formatted IP address
   format: function(Addr): string
@@ -47,7 +47,7 @@ local record Addr
   is_public: function(Addr): boolean
 end
 
-local function addr_int(self: Addr): number
+local function addr_int(self: Addr): integer
   return self._n
 end
 
@@ -91,7 +91,7 @@ local Addr_mt: metatable < Addr > = {
   end,
 }
 
-local function make_addr(n: number): Addr
+local function make_addr(n: integer): Addr
   return setmetatable({_n = n} as Addr, Addr_mt)
 end
 
@@ -101,7 +101,7 @@ end
 --- hold an Addr.
 --- @param n integer The IP address as an integer
 --- @return Addr The typed IP address
-local function addr(n: number): Addr
+local function addr(n: integer): Addr
   return make_addr(n)
 end
 
@@ -168,8 +168,8 @@ local record Cidr
   --- @return Addr The broadcast address
   broadcast: function(Cidr): Addr
   --- Number of addresses in the block (including network/broadcast).
-  --- @return number The block size
-  size: function(Cidr): number
+  --- @return integer The block size
+  size: function(Cidr): integer
   --- Check whether the block contains an address.
   --- @param a Addr | string The address (typed or dotted quad)
   --- @return boolean True when contained; false (plus an error
@@ -204,7 +204,7 @@ local function cidr_broadcast(self: Cidr): Addr
   return make_addr(self._n | (~ cidr_mask(self._bits) & 0xFFFFFFFF))
 end
 
-local function cidr_size(self: Cidr): number
+local function cidr_size(self: Cidr): integer
   return 1 << (32 - self._bits)
 end
 
@@ -215,9 +215,9 @@ local function cidr_contains(self: Cidr, a: Addr | string): boolean, string
     if not parsed then
       return false, err
     end
-    n = math.tointeger((parsed as Addr):int())
+    n = (parsed as Addr):int()
   else
-    n = math.tointeger((a as Addr):int())
+    n = (a as Addr):int()
   end
   return (n & cidr_mask(self._bits)) == self._n
 end
@@ -272,7 +272,7 @@ local function cidr(str: string): Cidr | nil, string
     return nil, "invalid CIDR prefix '" .. bp .. "' in: " .. str
   end
   local b = bits as integer
-  local n = math.tointeger((base as Addr):int()) & cidr_mask(b)
+  local n = (base as Addr):int() & cidr_mask(b)
   return make_cidr(n, b)
 end
 
@@ -281,7 +281,7 @@ local record IpModule
   type Category = Category
   type Family = Family
   type Cidr = Cidr
-  addr: function(n: number): Addr
+  addr: function(n: integer): Addr
   parse: function(str: string): Addr | nil, string
   cidr: function(str: string): Cidr | nil, string
   lookup: function(hostname: string): Addr | nil, string

--- a/lib/cosmic/json.tl
+++ b/lib/cosmic/json.tl
@@ -27,7 +27,7 @@ local record EncodeOptions
   --- Indentation string used when pretty is true (default " ").
   indent: string
   --- Maximum serializer recursion depth (default 64, max 32767).
-  maxdepth: number
+  maxdepth: integer
   --- The only accepted value is "null": encode NaN and Infinity as
   --- `null` (the v8 behavior) instead of failing with nil, error.
   nan: string

--- a/lib/cosmic/net/connect_test.tl
+++ b/lib/cosmic/net/connect_test.tl
@@ -307,7 +307,7 @@ local function test_bind_error_names_errno()
   assert(first:listen())
   local _, port = first:getsockname()
   local second = assert(net.socket(net.AF_INET, net.SOCK_STREAM)) as net.Socket
-  local ok, berr = second:bind("127.0.0.1", port as number)
+  local ok, berr = second:bind("127.0.0.1", port)
   assert(ok == false, "second bind to same port should fail")
   assert(berr:match("EADDRINUSE"), "bind error should name EADDRINUSE, got: " .. berr)
   second:close()

--- a/lib/cosmic/net/init.tl
+++ b/lib/cosmic/net/init.tl
@@ -20,12 +20,12 @@ local type Address = net_socket.Address
 local make_socket = net_socket.make_socket
 
 --- Create a new socket.
---- @param family number Address family (AF_INET, AF_UNIX). Default: AF_INET
---- @param socktype number Socket type (SOCK_STREAM, SOCK_DGRAM). Default: SOCK_STREAM
---- @param protocol number Protocol (IPPROTO_TCP, IPPROTO_UDP). Default: 0
+--- @param family integer Address family (AF_INET, AF_UNIX). Default: AF_INET
+--- @param socktype integer Socket type (SOCK_STREAM, SOCK_DGRAM). Default: SOCK_STREAM
+--- @param protocol integer Protocol (IPPROTO_TCP, IPPROTO_UDP). Default: 0
 --- @return Socket | nil Socket handle
 --- @return string Error message on failure
-local function socket(family?: number, socktype?: number, protocol?: number): Socket | nil, string
+local function socket(family?: integer, socktype?: integer, protocol?: integer): Socket | nil, string
   family = family or unix.AF_INET
   socktype = socktype or unix.SOCK_STREAM
   protocol = protocol or 0
@@ -37,13 +37,13 @@ local function socket(family?: number, socktype?: number, protocol?: number): So
 end
 
 --- Create a pair of connected sockets.
---- @param family number Address family (AF_UNIX). Default: AF_UNIX
---- @param socktype number Socket type (SOCK_STREAM, SOCK_DGRAM). Default: SOCK_STREAM
---- @param protocol number Protocol. Default: 0
+--- @param family integer Address family (AF_UNIX). Default: AF_UNIX
+--- @param socktype integer Socket type (SOCK_STREAM, SOCK_DGRAM). Default: SOCK_STREAM
+--- @param protocol integer Protocol. Default: 0
 --- @return Socket | nil First socket of the pair
 --- @return Socket Second socket of the pair
 --- @return string Error message on failure
-local function socketpair(family?: number, socktype?: number, protocol?: number): Socket | nil, Socket, string
+local function socketpair(family?: integer, socktype?: integer, protocol?: integer): Socket | nil, Socket, string
   family = family or unix.AF_UNIX
   socktype = socktype or unix.SOCK_STREAM
   protocol = protocol or 0
@@ -56,10 +56,10 @@ end
 
 --- Create a Unix domain socket, bind it to a path, and start listening.
 --- @param path string Filesystem path for the socket
---- @param backlog number Maximum pending connections (default 128)
+--- @param backlog integer Maximum pending connections (default 128)
 --- @return Socket | nil Listening socket
 --- @return string Error message on failure
-local function listen_unix(path: string, backlog?: number): Socket | nil, string
+local function listen_unix(path: string, backlog?: integer): Socket | nil, string
   local sock, err = socket(unix.AF_UNIX, unix.SOCK_STREAM, 0)
   if not sock then
     return nil, err
@@ -100,10 +100,10 @@ end
 --- The address may be a dotted-quad string ("127.0.0.1") or an ip.Addr.
 --- IPv6 is not supported. For hostname resolution use dial().
 --- @param addr Address Remote IPv4 address
---- @param port number Remote port
+--- @param port integer Remote port
 --- @return Socket | nil Connected socket
 --- @return string Error message on failure
-local function connect_tcp(addr: Address, port: number): Socket | nil, string
+local function connect_tcp(addr: Address, port: integer): Socket | nil, string
   local sock, err = socket(unix.AF_INET, unix.SOCK_STREAM, 0)
   if not sock then
     return nil, err
@@ -124,10 +124,10 @@ end
 --- richer endpoint forms extend the values dial accepts, never the
 --- signature.
 --- @param host string Host to connect to: dotted-quad literal or DNS name
---- @param port number Remote TCP port
+--- @param port integer Remote TCP port
 --- @return Socket | nil Connected socket
 --- @return string Error message on failure
-local function dial(host: string, port: number): Socket | nil, string
+local function dial(host: string, port: integer): Socket | nil, string
   local a: ip.Addr
   local parsed = ip.parse(host)
   if parsed then
@@ -160,12 +160,12 @@ end
 --- usual value-then-error order.
 ---
 --- @param addr Address Local IPv4 address to bind ("127.0.0.1", "0.0.0.0" for all)
---- @param port number Local port to bind; use 0 for an OS-assigned ephemeral port
---- @param backlog number Maximum pending connections (default 128)
+--- @param port integer Local port to bind; use 0 for an OS-assigned ephemeral port
+--- @param backlog integer Maximum pending connections (default 128)
 --- @return Socket | nil Listening socket ready to accept
---- @return number Actual bound port (useful when port 0 was requested)
+--- @return integer Actual bound port (useful when port 0 was requested)
 --- @return string Error message on failure
-local function listen_tcp(addr: Address, port: number, backlog?: number): Socket | nil, number, string
+local function listen_tcp(addr: Address, port: integer, backlog?: integer): Socket | nil, integer, string
   local sock, serr = socket(unix.AF_INET, unix.SOCK_STREAM, 0)
   if not sock then
     return nil, nil, serr
@@ -201,11 +201,11 @@ end
 --- s:set_nonblocking(false) to restore blocking I/O.
 --- @param s Socket The socket to connect
 --- @param addr Address Remote IPv4 address
---- @param port number Remote port
---- @param timeoutms number Timeout in milliseconds (default 10000)
+--- @param port integer Remote port
+--- @param timeoutms integer Timeout in milliseconds (default 10000)
 --- @return boolean True on success
 --- @return string Error message on failure
-local function nb_connect(s: Socket, addr: Address, port: number, timeoutms?: number): boolean, string
+local function nb_connect(s: Socket, addr: Address, port: integer, timeoutms?: integer): boolean, string
   timeoutms = timeoutms or 10000
   local nb_ok, nb_err = s:set_nonblocking()
   if not nb_ok then
@@ -213,12 +213,12 @@ local function nb_connect(s: Socket, addr: Address, port: number, timeoutms?: nu
   end
   local ok, conn_err = s:connect(addr, port)
   if ok then return true end
-  local fds: {number: number} = {[s.fd] = unix.POLLOUT}
+  local fds: {integer: integer} = {[s.fd] = unix.POLLOUT}
   local revents = unix.poll(fds, timeoutms)
   if not revents then
     return false, "nb_connect: poll failed"
   end
-  local ev = (revents as {number: number})[s.fd] or 0
+  local ev = (revents as {integer: integer})[s.fd] or 0
   if ev == 0 then return false, "nb_connect: connect timed out" end
   if ev & unix.POLLERR ~= 0 then
     local so_err = s:getsockopt(unix.SOL_SOCKET, unix.SO_ERROR)
@@ -263,7 +263,7 @@ local function interfaces(): {Interface} | nil, string
   for i, entry in ipairs(raw as {{string: any}}) do
     list[i] = {
       name = entry["name"] as string,
-      ip = ip.addr(entry["ip"] as number),
+      ip = ip.addr(entry["ip"] as integer),
     }
   end
   return list
@@ -273,85 +273,85 @@ local record NetModule
   type Socket = Socket
   type Address = Address
   Interface: Interface
-  socket: function(family?: number, socktype?: number, protocol?: number): Socket | nil, string
-  socketpair: function(family?: number, socktype?: number, protocol?: number): Socket | nil, Socket, string
-  listen_unix: function(path: string, backlog?: number): Socket | nil, string
-  listen_tcp: function(addr: Address, port: number, backlog?: number): Socket | nil, number, string
+  socket: function(family?: integer, socktype?: integer, protocol?: integer): Socket | nil, string
+  socketpair: function(family?: integer, socktype?: integer, protocol?: integer): Socket | nil, Socket, string
+  listen_unix: function(path: string, backlog?: integer): Socket | nil, string
+  listen_tcp: function(addr: Address, port: integer, backlog?: integer): Socket | nil, integer, string
   connect_unix: function(path: string): Socket | nil, string
-  connect_tcp: function(addr: Address, port: number): Socket | nil, string
-  dial: function(host: string, port: number): Socket | nil, string
-  nb_connect: function(s: Socket, addr: Address, port: number, timeoutms?: number): boolean, string
+  connect_tcp: function(addr: Address, port: integer): Socket | nil, string
+  dial: function(host: string, port: integer): Socket | nil, string
+  nb_connect: function(s: Socket, addr: Address, port: integer, timeoutms?: integer): boolean, string
   gethostname: function(): string | nil, string
   interfaces: function(): {Interface} | nil, string
-  AF_INET: number
-  AF_UNIX: number
-  AF_UNSPEC: number
-  SOCK_STREAM: number
-  SOCK_DGRAM: number
-  SOCK_RAW: number
-  SOCK_RDM: number
-  SOCK_SEQPACKET: number
-  SOCK_CLOEXEC: number
-  SOCK_NONBLOCK: number
-  IPPROTO_TCP: number
-  IPPROTO_UDP: number
-  IPPROTO_IP: number
-  IPPROTO_ICMP: number
-  IPPROTO_RAW: number
-  SOL_SOCKET: number
-  SOL_TCP: number
-  SOL_UDP: number
-  SOL_IP: number
-  SO_REUSEADDR: number
-  SO_REUSEPORT: number
-  SO_KEEPALIVE: number
-  SO_BROADCAST: number
-  SO_LINGER: number
-  SO_RCVBUF: number
-  SO_SNDBUF: number
-  SO_RCVTIMEO: number
-  SO_SNDTIMEO: number
-  SO_ERROR: number
-  SO_TYPE: number
-  SO_ACCEPTCONN: number
-  SO_DEBUG: number
-  SO_DONTROUTE: number
-  SO_RCVLOWAT: number
-  SO_SNDLOWAT: number
-  TCP_NODELAY: number
-  TCP_CORK: number
-  TCP_KEEPIDLE: number
-  TCP_KEEPINTVL: number
-  TCP_KEEPCNT: number
-  TCP_MAXSEG: number
-  TCP_SYNCNT: number
-  TCP_DEFER_ACCEPT: number
-  TCP_FASTOPEN: number
-  TCP_FASTOPEN_CONNECT: number
-  TCP_QUICKACK: number
-  TCP_NOTSENT_LOWAT: number
-  TCP_WINDOW_CLAMP: number
-  TCP_SAVE_SYN: number
-  TCP_SAVED_SYN: number
-  SHUT_RD: number
-  SHUT_WR: number
-  SHUT_RDWR: number
-  POLLIN: number
-  POLLOUT: number
-  POLLERR: number
-  POLLHUP: number
-  POLLNVAL: number
-  POLLPRI: number
-  POLLRDBAND: number
-  POLLRDHUP: number
-  POLLRDNORM: number
-  POLLWRBAND: number
-  POLLWRNORM: number
-  MSG_PEEK: number
-  MSG_WAITALL: number
-  MSG_OOB: number
-  MSG_DONTROUTE: number
-  MSG_NOSIGNAL: number
+  AF_INET: integer
+  AF_UNIX: integer
+  AF_UNSPEC: integer
+  SOCK_STREAM: integer
+  SOCK_DGRAM: integer
+  SOCK_RAW: integer
+  SOCK_RDM: integer
+  SOCK_SEQPACKET: integer
+  SOCK_CLOEXEC: integer
+  SOCK_NONBLOCK: integer
+  IPPROTO_TCP: integer
+  IPPROTO_UDP: integer
+  IPPROTO_IP: integer
+  IPPROTO_ICMP: integer
+  IPPROTO_RAW: integer
+  SOL_SOCKET: integer
+  SOL_TCP: integer
+  SOL_UDP: integer
+  SOL_IP: integer
+  SO_REUSEADDR: integer
+  SO_REUSEPORT: integer
+  SO_KEEPALIVE: integer
+  SO_BROADCAST: integer
+  SO_LINGER: integer
+  SO_RCVBUF: integer
+  SO_SNDBUF: integer
+  SO_RCVTIMEO: integer
+  SO_SNDTIMEO: integer
+  SO_ERROR: integer
+  SO_TYPE: integer
+  SO_ACCEPTCONN: integer
+  SO_DEBUG: integer
+  SO_DONTROUTE: integer
+  SO_RCVLOWAT: integer
+  SO_SNDLOWAT: integer
+  TCP_NODELAY: integer
+  TCP_CORK: integer
+  TCP_KEEPIDLE: integer
+  TCP_KEEPINTVL: integer
+  TCP_KEEPCNT: integer
+  TCP_MAXSEG: integer
+  TCP_SYNCNT: integer
+  TCP_DEFER_ACCEPT: integer
+  TCP_FASTOPEN: integer
+  TCP_FASTOPEN_CONNECT: integer
+  TCP_QUICKACK: integer
+  TCP_NOTSENT_LOWAT: integer
+  TCP_WINDOW_CLAMP: integer
+  TCP_SAVE_SYN: integer
+  TCP_SAVED_SYN: integer
+  SHUT_RD: integer
+  SHUT_WR: integer
+  SHUT_RDWR: integer
+  POLLIN: integer
+  POLLOUT: integer
+  POLLERR: integer
+  POLLHUP: integer
+  POLLNVAL: integer
+  POLLPRI: integer
+  POLLRDBAND: integer
+  POLLRDHUP: integer
+  POLLRDNORM: integer
+  POLLWRBAND: integer
+  POLLWRNORM: integer
+  MSG_PEEK: integer
+  MSG_WAITALL: integer
+  MSG_OOB: integer
+  MSG_DONTROUTE: integer
+  MSG_NOSIGNAL: integer
 end
 
 local M: NetModule = {

--- a/lib/cosmic/net/socket.tl
+++ b/lib/cosmic/net/socket.tl
@@ -21,9 +21,9 @@ local function resolve_addr(addr: Address): integer | nil, string
     if not a then
       return nil, err
     end
-    return math.tointeger((a as ip.Addr):int())
+    return (a as ip.Addr):int()
   end
-  return math.tointeger((addr as ip.Addr):int())
+  return (addr as ip.Addr):int()
 end
 
 --- Socket handle for network I/O.
@@ -34,79 +34,79 @@ local stream = require("cosmic.stream")
 local record Socket is stream.Reader, stream.Writer
   metamethod __close: function(self: Socket)
   --- The underlying file descriptor.
-  fd: number
+  fd: integer
   --- Close the socket.
   close: function(self: Socket): boolean
   --- True when the socket has been closed.
   closed: function(self: Socket): boolean
   --- Shut down reading and/or writing (unix.SHUT_RD/WR/RDWR).
-  shutdown: function(self: Socket, how?: number): boolean, string
+  shutdown: function(self: Socket, how?: integer): boolean, string
   --- Send data; returns bytes sent, or nil + error.
-  send: function(self: Socket, data: string, flags?: number): number | nil, string
+  send: function(self: Socket, data: string, flags?: integer): integer | nil, string
   --- stream.Writer: alias for send (bytes written, or nil + error).
-  write: function(self: Socket, data: string): number | nil, string
+  write: function(self: Socket, data: string): integer | nil, string
   --- Send all of data, retrying partial writes until done.
   --- Returns false + error if any write fails; bytes already sent
   --- before the failure stay sent.
-  sendall: function(self: Socket, data: string, flags?: number): boolean, string
+  sendall: function(self: Socket, data: string, flags?: integer): boolean, string
   --- Send a datagram to addr:port; returns bytes sent, or nil + error.
-  sendto: function(self: Socket, data: string, addr: Address, port: number, flags?: number): number | nil, string
+  sendto: function(self: Socket, data: string, addr: Address, port: integer, flags?: integer): integer | nil, string
   --- Receive up to bufsiz bytes (blocks until data arrives).
   --- Returns bare nil (no error) when the peer closed the connection —
   --- end of stream, matching the stream contract (cosmic.stream). ""
   --- is only ever a zero-byte datagram on message sockets. Returns
   --- nil + error message on failure. bufsiz must be positive when
   --- given (default 65536).
-  recv: function(self: Socket, bufsiz?: number, flags?: number): string | nil, string
+  recv: function(self: Socket, bufsiz?: integer, flags?: integer): string | nil, string
   --- stream.Reader: alias for recv (chunk; bare nil at end of stream;
   --- nil + error on failure).
-  read: function(self: Socket, n?: number): string | nil, string
+  read: function(self: Socket, n?: integer): string | nil, string
   --- Receive exactly n bytes from a stream socket, blocking until they
   --- arrive. Returns nil + error if the peer closes the connection
   --- first (bytes read before the close are discarded).
-  recv_exact: function(self: Socket, n: number, flags?: number): string | nil, string
+  recv_exact: function(self: Socket, n: integer, flags?: integer): string | nil, string
   --- Read one line from a stream socket, blocking until a "\n" arrives.
   --- The trailing "\n" (and a "\r" before it) is consumed but not
   --- returned. At end of stream a final unterminated line is returned
   --- as-is; after that (or on an empty stream) returns bare nil, matching
   --- the stream contract. With max set, returns at most max bytes even
   --- if no newline was seen (the rest stays readable), like fgets.
-  readline: function(self: Socket, max?: number): string | nil, string
+  readline: function(self: Socket, max?: integer): string | nil, string
   --- Receive a datagram; returns data, sender Addr, sender port.
-  recvfrom: function(self: Socket, bufsiz?: number, flags?: number): string | nil, ip.Addr, number, string
+  recvfrom: function(self: Socket, bufsiz?: integer, flags?: integer): string | nil, ip.Addr, integer, string
   --- Local address as (Addr, port); use after bind for the real port.
-  getsockname: function(self: Socket): ip.Addr | nil, number, string
+  getsockname: function(self: Socket): ip.Addr | nil, integer, string
   --- Peer address as (Addr, port).
-  getpeername: function(self: Socket): ip.Addr | nil, number, string
+  getpeername: function(self: Socket): ip.Addr | nil, integer, string
   --- Bind to a local addr:port (default all interfaces, OS-assigned port).
-  bind: function(self: Socket, addr?: Address, port?: number): boolean, string
+  bind: function(self: Socket, addr?: Address, port?: integer): boolean, string
   --- Bind to a unix-domain socket path.
   bind_unix: function(self: Socket, path: string): boolean, string
   --- Start listening for connections.
-  listen: function(self: Socket, backlog?: number): boolean, string
+  listen: function(self: Socket, backlog?: integer): boolean, string
   --- Accept one connection (blocks until a client connects).
   --- Returns the connection socket, peer Addr, peer port.
-  accept: function(self: Socket, flags?: number): Socket | nil, ip.Addr, number, string
+  accept: function(self: Socket, flags?: integer): Socket | nil, ip.Addr, integer, string
   --- Connect to addr:port.
-  connect: function(self: Socket, addr: Address, port: number): boolean, string
+  connect: function(self: Socket, addr: Address, port: integer): boolean, string
   --- Connect to a unix-domain socket path.
   connect_unix: function(self: Socket, path: string): boolean, string
   --- Read a socket option value.
-  getsockopt: function(self: Socket, level: number, optname: number): number | boolean | nil, string
+  getsockopt: function(self: Socket, level: integer, optname: integer): integer | boolean | nil, string
   --- Set a socket option value.
-  setsockopt: function(self: Socket, level: number, optname: number, value: number | boolean): boolean, string
+  setsockopt: function(self: Socket, level: integer, optname: integer, value: integer | boolean): boolean, string
   --- Switch O_NONBLOCK on (default) or off for this socket.
   set_nonblocking: function(self: Socket, enable?: boolean): boolean, string
   --- Set a timeout in milliseconds for blocking sends and receives
   --- (SO_RCVTIMEO + SO_SNDTIMEO). Timed-out operations fail with an
   --- EAGAIN error. nil or 0 clears the timeout (block forever).
-  set_timeout: function(self: Socket, ms?: number): boolean, string
+  set_timeout: function(self: Socket, ms?: integer): boolean, string
 end
 
 --- Create a socket handle from a file descriptor.
---- @param fd number The file descriptor
+--- @param fd integer The file descriptor
 --- @return Socket The socket handle
-local function make_socket(fd: number): Socket
+local function make_socket(fd: integer): Socket
   local sock: Socket = {fd = fd}
 
   -- macOS honors SO_NOSIGPIPE, not MSG_NOSIGNAL, on send(); set it once at
@@ -130,7 +130,7 @@ local function make_socket(fd: number): Socket
     return self.fd == nil
   end
 
-  function sock:shutdown(how?: number): boolean, string
+  function sock:shutdown(how?: integer): boolean, string
     if not self.fd then return false, "socket closed" end
     how = how or unix.SHUT_RDWR
     local ok, err = unix.shutdown(self.fd, how)
@@ -144,7 +144,7 @@ local function make_socket(fd: number): Socket
   -- would otherwise kill the whole process (exit 141) instead of returning an
   -- EPIPE error the caller can handle. cosmo maps MSG_NOSIGNAL to the native
   -- per-OS flag, so ORing it in is portable.
-  function sock:send(data: string, flags?: number): number | nil, string
+  function sock:send(data: string, flags?: integer): integer | nil, string
     if not self.fd then return nil, "socket closed" end
     local n, err = unix.send(self.fd, data, (flags or 0) | unix.MSG_NOSIGNAL)
     if not n then
@@ -153,19 +153,19 @@ local function make_socket(fd: number): Socket
     return n
   end
 
-  function sock:sendall(data: string, flags?: number): boolean, string
+  function sock:sendall(data: string, flags?: integer): boolean, string
     local off: integer = 0
     while off < #data do
       local n, err = self:send(data:sub(off + 1), flags)
       if not n then
         return false, err
       end
-      off = off + math.floor(n)
+      off = off + n
     end
     return true
   end
 
-  function sock:sendto(data: string, addr: Address, port: number, flags?: number): number | nil, string
+  function sock:sendto(data: string, addr: Address, port: integer, flags?: integer): integer | nil, string
     if not self.fd then return nil, "socket closed" end
     local raw, aerr = resolve_addr(addr)
     if not raw then
@@ -182,7 +182,7 @@ local function make_socket(fd: number): Socket
   -- first empty recv and cached, so the common stream path pays nothing.
   local dgram: boolean = nil
 
-  function sock:recv(bufsiz?: number, flags?: number): string | nil, string
+  function sock:recv(bufsiz?: integer, flags?: integer): string | nil, string
     if not self.fd then return nil, "socket closed" end
     local data, err = unix.recv(self.fd, bufsiz or 65536, flags or 0)
     if not data then
@@ -205,7 +205,7 @@ local function make_socket(fd: number): Socket
   sock.read = sock.recv
   sock.write = sock.send
 
-  function sock:recv_exact(n: number, flags?: number): string | nil, string
+  function sock:recv_exact(n: integer, flags?: integer): string | nil, string
     local parts: {string} = {}
     local got = 0
     while got < n do
@@ -222,7 +222,7 @@ local function make_socket(fd: number): Socket
     return table.concat(parts)
   end
 
-  function sock:readline(max?: number): string | nil, string
+  function sock:readline(max?: integer): string | nil, string
     if not self.fd then return nil, "socket closed" end
     local parts: {string} = {}
     local total = 0
@@ -245,7 +245,7 @@ local function make_socket(fd: number): Socket
       local nl = string.find(d, "\n", 1, true)
       local take: integer = nl or #d
       if max and total + take > max then
-        take = math.floor(max - total)
+        take = max - total
         nl = nil
       end
       if take > 0 then
@@ -274,7 +274,7 @@ local function make_socket(fd: number): Socket
     return line
   end
 
-  function sock:recvfrom(bufsiz?: number, flags?: number): string | nil, ip.Addr, number, string
+  function sock:recvfrom(bufsiz?: integer, flags?: integer): string | nil, ip.Addr, integer, string
     if not self.fd then return nil, nil, nil, "socket closed" end
     local data, sender, port = unix.recvfrom(self.fd, bufsiz or 65536, flags or 0)
     if not data then
@@ -285,7 +285,7 @@ local function make_socket(fd: number): Socket
     return data, ip.addr(sender), port
   end
 
-  function sock:getsockname(): ip.Addr | nil, number, string
+  function sock:getsockname(): ip.Addr | nil, integer, string
     if not self.fd then return nil, nil, "socket closed" end
     local raw, port = unix.getsockname(self.fd)
     if not raw then
@@ -296,7 +296,7 @@ local function make_socket(fd: number): Socket
     return ip.addr(raw), port
   end
 
-  function sock:getpeername(): ip.Addr | nil, number, string
+  function sock:getpeername(): ip.Addr | nil, integer, string
     if not self.fd then return nil, nil, "socket closed" end
     local raw, port = unix.getpeername(self.fd)
     if not raw then
@@ -307,7 +307,7 @@ local function make_socket(fd: number): Socket
     return ip.addr(raw), port
   end
 
-  function sock:bind(addr?: Address, port?: number): boolean, string
+  function sock:bind(addr?: Address, port?: integer): boolean, string
     if not self.fd then return false, "socket closed" end
     local raw: integer = 0
     if addr ~= nil then
@@ -333,7 +333,7 @@ local function make_socket(fd: number): Socket
     return true
   end
 
-  function sock:listen(backlog?: number): boolean, string
+  function sock:listen(backlog?: integer): boolean, string
     if not self.fd then return false, "socket closed" end
     local ok, err = unix.listen(self.fd, backlog or 128)
     if not ok then
@@ -342,7 +342,7 @@ local function make_socket(fd: number): Socket
     return true
   end
 
-  function sock:accept(flags?: number): Socket | nil, ip.Addr, number, string
+  function sock:accept(flags?: integer): Socket | nil, ip.Addr, integer, string
     if not self.fd then return nil, nil, nil, "socket closed" end
     local clientfd, peer, port = unix.accept(self.fd, flags or 0)
     if not clientfd then
@@ -353,7 +353,7 @@ local function make_socket(fd: number): Socket
     return make_socket(clientfd), ip.addr(peer), port
   end
 
-  function sock:connect(addr: Address, port: number): boolean, string
+  function sock:connect(addr: Address, port: integer): boolean, string
     if not self.fd then return false, "socket closed" end
     local raw, aerr = resolve_addr(addr)
     if not raw then
@@ -375,7 +375,7 @@ local function make_socket(fd: number): Socket
     return true
   end
 
-  function sock:getsockopt(level: number, optname: number): number | boolean | nil, string
+  function sock:getsockopt(level: integer, optname: integer): integer | boolean | nil, string
     if not self.fd then return nil, "socket closed" end
     local val, err = unix.getsockopt(self.fd, level, optname)
     if val == nil then
@@ -400,7 +400,7 @@ local function make_socket(fd: number): Socket
     return true
   end
 
-  function sock:set_timeout(ms?: number): boolean, string
+  function sock:set_timeout(ms?: integer): boolean, string
     if not self.fd then return false, "socket closed" end
     ms = ms or 0
     local secs = math.floor(ms / 1000)
@@ -419,7 +419,7 @@ local function make_socket(fd: number): Socket
     return true
   end
 
-  function sock:setsockopt(level: number, optname: number, value: number | boolean): boolean, string
+  function sock:setsockopt(level: integer, optname: integer, value: integer | boolean): boolean, string
     if not self.fd then return false, "socket closed" end
     local ok, err = unix.setsockopt(self.fd, level, optname, value)
     if not ok then
@@ -436,7 +436,7 @@ end
 local record NetSocketModule
   type Socket = Socket
   type Address = Address
-  make_socket: function(fd: number): Socket
+  make_socket: function(fd: integer): Socket
 end
 
 local M: NetSocketModule = {

--- a/lib/cosmic/poll.tl
+++ b/lib/cosmic/poll.tl
@@ -5,13 +5,13 @@ local errno = require("cosmic.errno")
 
 --- Poll event flags.
 --- Use these to specify which events to monitor.
-local POLLIN: number = unix.POLLIN
-local POLLOUT: number = unix.POLLOUT
-local POLLPRI: number = unix.POLLPRI
-local POLLERR: number = unix.POLLERR
-local POLLHUP: number = unix.POLLHUP
-local POLLNVAL: number = unix.POLLNVAL
-local POLLRDHUP: number = unix.POLLRDHUP
+local POLLIN: integer = unix.POLLIN
+local POLLOUT: integer = unix.POLLOUT
+local POLLPRI: integer = unix.POLLPRI
+local POLLERR: integer = unix.POLLERR
+local POLLHUP: integer = unix.POLLHUP
+local POLLNVAL: integer = unix.POLLNVAL
+local POLLRDHUP: integer = unix.POLLRDHUP
 
 --- Resolved events from a poll operation.
 local record Events
@@ -26,45 +26,45 @@ local record Events
   --- True if the fd is invalid.
   invalid: boolean
   --- Raw revents bitmask from poll.
-  revents: number
+  revents: integer
 end
 
 --- Poll set for monitoring multiple file descriptors.
 local record Poller
   --- Add a file descriptor to the set.
-  --- @param fd number File descriptor number
-  --- @param events number Event mask (POLLIN, POLLOUT, etc.)
-  add: function(Poller, number, number)
+  --- @param fd integer File descriptor number
+  --- @param events integer Event mask (POLLIN, POLLOUT, etc.)
+  add: function(Poller, integer, integer)
   --- Remove a file descriptor from the set.
-  --- @param fd number The file descriptor to remove
-  remove: function(Poller, number)
+  --- @param fd integer The file descriptor to remove
+  remove: function(Poller, integer)
   --- Clear all file descriptors from the set.
   clear: function(Poller)
   --- Poll for events with optional timeout.
   --- Returns an iterator over (fd, events) pairs for ready descriptors.
   --- EINTR is retried internally. On a hard poll error the iterator is
   --- empty and the error string is returned as the second value.
-  --- @param timeoutms number Timeout in ms (-1 for infinite, 0 for non-blocking)
-  --- @return function Iterator yielding (fd: number, events: Events)
+  --- @param timeoutms integer Timeout in ms (-1 for infinite, 0 for non-blocking)
+  --- @return function Iterator yielding (fd: integer, events: Events)
   --- @return string? Error message when the underlying poll failed
-  wait: function(Poller, number): function(): (number, Events), string
+  wait: function(Poller, integer): function(): (integer, Events), string
   --- Poll and return count of ready descriptors.
-  --- @param timeoutms number Timeout in ms (-1 for infinite, 0 for non-blocking)
-  --- @return number | nil Count of ready descriptors
+  --- @param timeoutms integer Timeout in ms (-1 for infinite, 0 for non-blocking)
+  --- @return integer | nil Count of ready descriptors
   --- @return string Error message on failure
-  poll: function(Poller, number): number | nil, string
+  poll: function(Poller, integer): integer | nil, string
   --- Get events for a specific fd after poll().
-  --- @param fd number The file descriptor
+  --- @param fd integer The file descriptor
   --- @return Events | nil The events for this fd, or nil if not ready
-  events: function(Poller, number): Events | nil
+  events: function(Poller, integer): Events | nil
   --- Returns true if the poller has no registered fds.
   empty: function(Poller): boolean
   --- Returns the number of registered fds.
-  count: function(Poller): number
+  count: function(Poller): integer
 end
 
 --- Make Events from raw revents bitmask.
-local function make_events(revents: number): Events
+local function make_events(revents: integer): Events
   return {
     readable = (revents & POLLIN) ~= 0,
     writable = (revents & POLLOUT) ~= 0,
@@ -88,12 +88,12 @@ end
 ---     end
 ---   end
 local function new(): Poller
-  local fds: {number: number} = {}
-  local results: {number: number} = {}
+  local fds: {integer: integer} = {}
+  local results: {integer: integer} = {}
 
   local poller: Poller = {}
 
-  poller.add = function(_self: Poller, fd: number, events: number)
+  poller.add = function(_self: Poller, fd: integer, events: integer)
     if fd == nil then
       -- A nil fd is a caller bug (e.g. an unchecked open); registering
       -- nothing would silently turn every wait into a timeout.
@@ -102,7 +102,7 @@ local function new(): Poller
     fds[fd] = events
   end
 
-  poller.remove = function(_self: Poller, fd: number)
+  poller.remove = function(_self: Poller, fd: integer)
     if fd then
       fds[fd] = nil
       results[fd] = nil
@@ -118,7 +118,7 @@ local function new(): Poller
     return next(fds) == nil
   end
 
-  poller.count = function(_self: Poller): number
+  poller.count = function(_self: Poller): integer
     local n = 0
     for _ in pairs(fds) do
       n = n + 1
@@ -126,13 +126,13 @@ local function new(): Poller
     return n
   end
 
-  poller.poll = function(_self: Poller, timeoutms: number): number | nil, string
+  poller.poll = function(_self: Poller, timeoutms: integer): integer | nil, string
     -- Retry when a signal interrupts the wait: an unretried EINTR otherwise
     -- surfaces as a poll failure, and a caller that loops on it (e.g. a drain
     -- loop waiting on a child that raised SIGCHLD) spins at 100% CPU.
-    local res: {number: number}
+    local res: {integer: integer}
     local err: string
-    local eno: number
+    local eno: integer
     while true do
       res, err, eno = unix.poll(fds, timeoutms or -1)
       if res ~= nil or not errno.is(eno, "EINTR") then
@@ -150,7 +150,7 @@ local function new(): Poller
     return ready
   end
 
-  poller.events = function(_self: Poller, fd: number): Events | nil
+  poller.events = function(_self: Poller, fd: integer): Events | nil
     local revents = results[fd]
     if revents then
       return make_events(revents)
@@ -158,17 +158,17 @@ local function new(): Poller
     return nil
   end
 
-  poller.wait = function(self: Poller, timeoutms: number): function(): (number, Events), string
+  poller.wait = function(self: Poller, timeoutms: integer): function(): (integer, Events), string
     local n, err = self:poll(timeoutms)
     if n == nil then
-      return function(): (number, Events)
+      return function(): (integer, Events)
         return nil, nil
       end, err
     end
     local iter_results = results
-    local k: number = nil
-    return function(): (number, Events)
-      local v: number
+    local k: integer = nil
+    return function(): (integer, Events)
+      local v: integer
       k, v = next(iter_results, k)
       if k then
         return k, make_events(v)
@@ -187,19 +187,19 @@ local record PollModule
   new: function(): Poller
 
   --- Event mask for readable data.
-  POLLIN: number
+  POLLIN: integer
   --- Event mask for writable.
-  POLLOUT: number
+  POLLOUT: integer
   --- Event mask for priority data (e.g., OOB on TCP).
-  POLLPRI: number
+  POLLPRI: integer
   --- Event mask for error condition.
-  POLLERR: number
+  POLLERR: integer
   --- Event mask for hangup.
-  POLLHUP: number
+  POLLHUP: integer
   --- Event mask for invalid fd.
-  POLLNVAL: number
+  POLLNVAL: integer
   --- Event mask for peer closed connection.
-  POLLRDHUP: number
+  POLLRDHUP: integer
 end
 
 local M: PollModule = {

--- a/lib/cosmic/proc.tl
+++ b/lib/cosmic/proc.tl
@@ -22,20 +22,20 @@ local type Rusage = unix.Rusage
 -- Identity --
 
 --- Returns process id of current process; does not fail.
---- @return number The current process id
-local getpid: function(): number = unix.getpid
+--- @return integer The current process id
+local getpid: function(): integer = unix.getpid
 
 --- Returns process id of parent process; does not fail.
---- @return number The parent process id
-local getppid: function(): number = unix.getppid
+--- @return integer The parent process id
+local getppid: function(): integer = unix.getppid
 
 -- Session & Group --
 
 --- Gets session id for a process.
---- @param pid number The process id to query
---- @return number | nil The session id, or nil on failure
+--- @param pid integer The process id to query
+--- @return integer | nil The session id, or nil on failure
 --- @return string? Error message on failure
-local function getsid(pid: number): number | nil, string
+local function getsid(pid: integer): integer | nil, string
   local sid, err = unix.getsid(pid)
   if sid == nil then
     return nil, errstr(err, "getsid")
@@ -44,16 +44,16 @@ local function getsid(pid: number): number | nil, string
 end
 
 --- Gets process group id of calling process; does not fail.
---- @return number The process group id
-local function getpgrp(): number
+--- @return integer The process group id
+local function getpgrp(): integer
   return (unix.getpgrp())
 end
 
 --- Gets process group id for a specific process.
---- @param pid number The process id to query
---- @return number | nil The process group id, or nil on failure
+--- @param pid integer The process id to query
+--- @return integer | nil The process group id, or nil on failure
 --- @return string? Error message on failure
-local function getpgid(pid: number): number | nil, string
+local function getpgid(pid: integer): integer | nil, string
   local pgid, err = unix.getpgid(pid)
   if pgid == nil then
     return nil, errstr(err, "getpgid")
@@ -62,9 +62,9 @@ local function getpgid(pid: number): number | nil, string
 end
 
 --- Sets process group id (same as setpgid(0, 0)).
---- @return number | nil The new process group id, or nil on failure
+--- @return integer | nil The new process group id, or nil on failure
 --- @return string? Error message on failure
-local function setpgrp(): number | nil, string
+local function setpgrp(): integer | nil, string
   local pgid, err = unix.setpgrp()
   if pgid == nil then
     return nil, errstr(err, "setpgrp")
@@ -73,11 +73,11 @@ local function setpgrp(): number | nil, string
 end
 
 --- Sets process group id.
---- @param pid number Process id (0 means calling process)
---- @param pgid number Process group id (0 means use pid as pgid)
+--- @param pid integer Process id (0 means calling process)
+--- @param pgid integer Process group id (0 means use pid as pgid)
 --- @return boolean True on success
 --- @return string? Error message on failure
-local function setpgid(pid: number, pgid: number): boolean, string
+local function setpgid(pid: integer, pgid: integer): boolean, string
   local ok, err = unix.setpgid(pid, pgid)
   if not ok then
     return false, errstr(err, "setpgid")
@@ -89,9 +89,9 @@ end
 --- The calling process becomes the session leader and process group leader.
 --- Used for creating daemons.
 --- Fails with ENOSYS on Windows NT.
---- @return number | nil The new session id, or nil on failure
+--- @return integer | nil The new session id, or nil on failure
 --- @return string? Error message on failure
-local function setsid(): number | nil, string
+local function setsid(): integer | nil, string
   local sid, err = unix.setsid()
   if sid == nil then
     return nil, errstr(err, "setsid")
@@ -118,8 +118,8 @@ end
 --- Terminates the current process immediately.
 --- Memory is freed, file descriptors are closed, connections are reset.
 --- This function never returns.
---- @param exitcode number? Exit code (defaults to 0)
-local exit: function(exitcode?: number) = unix.exit
+--- @param exitcode integer? Exit code (defaults to 0)
+local exit: function(exitcode?: integer) = unix.exit
 
 -- Exec (replace current process) --
 
@@ -166,11 +166,11 @@ end
 
 --- Executes program from an already-opened file descriptor; never
 --- returns on success.
---- @param fd number Open file descriptor pointing to an executable
+--- @param fd integer Open file descriptor pointing to an executable
 --- @param argv {string} Argument vector passed to the program
 --- @param envp {string}? Environment variables. Inherits if not specified
 --- @return nil, string Only returns on error
-local function fexecve(fd: number, argv: {string}, envp?: {string}): nil, string
+local function fexecve(fd: integer, argv: {string}, envp?: {string}): nil, string
   local _, err = unix.fexecve(fd, argv, envp)
   return nil, errstr(err, "fexecve")
 end
@@ -178,8 +178,8 @@ end
 -- Process Control (children) --
 
 --- Creates a new process (fork).
---- @return number The child pid in the parent, 0 in the child
-local function fork(): number
+--- @return integer The child pid in the parent, 0 in the child
+local function fork(): integer
   return (unix.fork())
 end
 
@@ -187,8 +187,8 @@ end
 --- @param prog string Absolute path to the executable
 --- @param argv {string} Argument vector passed to the program
 --- @param envp {string}? Environment (KEY=value); inherits if omitted
---- @return number The child pid on success
-local function posix_spawn(prog: string, argv: {string}, envp?: {string}): number
+--- @return integer The child pid on success
+local function posix_spawn(prog: string, argv: {string}, envp?: {string}): integer
   return (unix.spawn(prog, argv, envp))
 end
 
@@ -196,19 +196,19 @@ end
 --- @param prog string Program name to execute
 --- @param argv {string} Argument vector passed to the program
 --- @param envp {string}? Environment (KEY=value); inherits if omitted
---- @return number The child pid on success
-local function posix_spawnp(prog: string, argv: {string}, envp?: {string}): number
+--- @return integer The child pid on success
+local function posix_spawnp(prog: string, argv: {string}, envp?: {string}): integer
   return (unix.spawnp(prog, argv, envp))
 end
 
 --- Waits for a child process to change state.
---- @param pid number? Child pid to wait for (-1 or nil for any child)
---- @param options number? Wait options (e.g. WNOHANG)
---- @return number | nil The pid that changed state (0 with WNOHANG if none), or nil on failure
---- @return number Status word (interpret with WIFEXITED/WEXITSTATUS/...)
+--- @param pid integer? Child pid to wait for (-1 or nil for any child)
+--- @param options integer? Wait options (e.g. WNOHANG)
+--- @return integer | nil The pid that changed state (0 with WNOHANG if none), or nil on failure
+--- @return integer Status word (interpret with WIFEXITED/WEXITSTATUS/...)
 --- @return Rusage Resource usage for the reaped child
 --- @return string? Error message on failure
-local function wait(pid?: number, options?: number): number | nil, number, Rusage, string
+local function wait(pid?: integer, options?: integer): integer | nil, integer, Rusage, string
   local wpid, status, rusage = unix.wait(pid, options)
   if wpid == nil then
     -- On failure the binding returns (nil, err, errno): the error string
@@ -219,31 +219,31 @@ local function wait(pid?: number, options?: number): number | nil, number, Rusag
 end
 
 --- Sends a signal to a process.
---- @param pid number Process id to signal
---- @param sig number Signal number (e.g. SIGTERM, SIGKILL)
+--- @param pid integer Process id to signal
+--- @param sig integer Signal number (e.g. SIGTERM, SIGKILL)
 --- @return boolean True on success
-local function kill(pid: number, sig: number): boolean
+local function kill(pid: integer, sig: integer): boolean
   return (unix.kill(pid, sig))
 end
 
 --- True if the child exited normally.
-local WIFEXITED: function(status: number): boolean = unix.WIFEXITED
+local WIFEXITED: function(status: integer): boolean = unix.WIFEXITED
 
 --- The exit code (valid when WIFEXITED is true).
-local WEXITSTATUS: function(status: number): number = unix.WEXITSTATUS
+local WEXITSTATUS: function(status: integer): integer = unix.WEXITSTATUS
 
 --- True if the child was terminated by a signal.
-local WIFSIGNALED: function(status: number): boolean = unix.WIFSIGNALED
+local WIFSIGNALED: function(status: integer): boolean = unix.WIFSIGNALED
 
 --- The terminating signal number (valid when WIFSIGNALED is true).
-local WTERMSIG: function(status: number): number = unix.WTERMSIG
+local WTERMSIG: function(status: integer): integer = unix.WTERMSIG
 
 -- Resource Usage --
 
 --- Gets resource usage statistics.
---- @param who number? Who to query: RUSAGE_SELF (default), RUSAGE_CHILDREN, RUSAGE_THREAD, RUSAGE_BOTH
+--- @param who integer? Who to query: RUSAGE_SELF (default), RUSAGE_CHILDREN, RUSAGE_THREAD, RUSAGE_BOTH
 --- @return Rusage Resource usage statistics
-local function getrusage(who?: number): Rusage
+local function getrusage(who?: integer): Rusage
   return (unix.getrusage(who))
 end
 
@@ -251,11 +251,11 @@ end
 
 --- Gets resource limits for the current process.
 --- Returns the soft and hard limits for the specified resource.
---- @param resource number The RLIMIT_* constant identifying the resource
---- @return number | nil Soft limit (can be exceeded, may generate signal), or nil on failure
---- @return number Hard limit (cannot be exceeded by unprivileged processes)
+--- @param resource integer The RLIMIT_* constant identifying the resource
+--- @return integer | nil Soft limit (can be exceeded, may generate signal), or nil on failure
+--- @return integer Hard limit (cannot be exceeded by unprivileged processes)
 --- @return string? Error message on failure
-local function getrlimit(resource: number): number | nil, number, string
+local function getrlimit(resource: integer): integer | nil, integer, string
   local soft, hard = unix.getrlimit(resource)
   if soft == nil then
     -- On failure the binding returns (nil, err, errno): the error string
@@ -268,12 +268,12 @@ end
 --- Sets resource limits for the current process.
 --- The soft limit can be raised up to the hard limit.
 --- Only privileged processes can raise the hard limit.
---- @param resource number The RLIMIT_* constant identifying the resource
---- @param soft number New soft limit
---- @param hard number? New hard limit (defaults to soft if not provided)
+--- @param resource integer The RLIMIT_* constant identifying the resource
+--- @param soft integer New soft limit
+--- @param hard integer? New hard limit (defaults to soft if not provided)
 --- @return boolean True on success
 --- @return string? Error message on failure
-local function setrlimit(resource: number, soft: number, hard?: number): boolean, string
+local function setrlimit(resource: integer, soft: integer, hard?: integer): boolean, string
   local ok, err = unix.setrlimit(resource, soft, hard)
   if not ok then
     return false, errstr(err, "setrlimit")
@@ -286,10 +286,10 @@ end
 --- Adjusts the nice value (scheduling priority) of the calling process.
 --- The nice value ranges from -20 (highest priority) to 19 (lowest priority).
 --- Only privileged processes can lower the nice value (increase priority).
---- @param inc number Value to add to current nice value
---- @return number | nil The new nice value, or nil on failure
+--- @param inc integer Value to add to current nice value
+--- @return integer | nil The new nice value, or nil on failure
 --- @return string? Error message on failure
-local function nice(inc: number): number | nil, string
+local function nice(inc: integer): integer | nil, string
   local val, err = unix.nice(inc)
   if val == nil then
     return nil, errstr(err, "nice")
@@ -298,11 +298,11 @@ local function nice(inc: number): number | nil, string
 end
 
 --- Gets the scheduling priority of a process, process group, or user.
---- @param which number What `who` refers to: PRIO_PROCESS, PRIO_PGRP, or PRIO_USER
---- @param who number The id to query (0 = calling process/group/user)
---- @return number | nil The priority value (-20 to 19), or nil on failure
+--- @param which integer What `who` refers to: PRIO_PROCESS, PRIO_PGRP, or PRIO_USER
+--- @param who integer The id to query (0 = calling process/group/user)
+--- @return integer | nil The priority value (-20 to 19), or nil on failure
 --- @return string? Error message on failure
-local function getpriority(which: number, who: number): number | nil, string
+local function getpriority(which: integer, who: integer): integer | nil, string
   local prio, err = unix.getpriority(which, who)
   if prio == nil then
     return nil, errstr(err, "getpriority")
@@ -311,12 +311,12 @@ local function getpriority(which: number, who: number): number | nil, string
 end
 
 --- Sets the scheduling priority of a process, process group, or user.
---- @param which number What `who` refers to: PRIO_PROCESS, PRIO_PGRP, or PRIO_USER
---- @param who number The id to modify (0 = calling process/group/user)
---- @param prio number New priority value (-20 to 19, lower = higher priority)
+--- @param which integer What `who` refers to: PRIO_PROCESS, PRIO_PGRP, or PRIO_USER
+--- @param who integer The id to modify (0 = calling process/group/user)
+--- @param prio integer New priority value (-20 to 19, lower = higher priority)
 --- @return boolean True on success
 --- @return string? Error message on failure
-local function setpriority(which: number, who: number, prio: number): boolean, string
+local function setpriority(which: integer, who: integer, prio: integer): boolean, string
   local ok, err = unix.setpriority(which, who, prio)
   if not ok then
     return false, errstr(err, "setpriority")
@@ -342,50 +342,50 @@ local is_main: function(): boolean = cosmo.is_main
 
 local record ProcModule
   -- Identity
-  getpid: function(): number
-  getppid: function(): number
+  getpid: function(): integer
+  getppid: function(): integer
 
   -- Session & Group
-  getsid: function(pid: number): number | nil, string
-  getpgrp: function(): number
-  getpgid: function(pid: number): number | nil, string
-  setpgrp: function(): number | nil, string
-  setpgid: function(pid: number, pgid: number): boolean, string
-  setsid: function(): number | nil, string
+  getsid: function(pid: integer): integer | nil, string
+  getpgrp: function(): integer
+  getpgid: function(pid: integer): integer | nil, string
+  setpgrp: function(): integer | nil, string
+  setpgid: function(pid: integer, pgid: integer): boolean, string
+  setsid: function(): integer | nil, string
   daemon: function(nochdir?: boolean, noclose?: boolean): boolean, string
 
   -- Termination
-  exit: function(exitcode?: number)
+  exit: function(exitcode?: integer)
 
   -- Exec
   commandv: function(prog: string): string
   execve: function(prog: string, args: {string}, env: {string}): nil, string
   execvp: function(prog: string, argv?: {string}): nil, string
   execvpe: function(prog: string, argv: {string}, envp?: {string}): nil, string
-  fexecve: function(fd: number, argv: {string}, envp?: {string}): nil, string
+  fexecve: function(fd: integer, argv: {string}, envp?: {string}): nil, string
 
   -- Process control (children)
-  fork: function(): number
-  posix_spawn: function(prog: string, argv: {string}, envp?: {string}): number
-  posix_spawnp: function(prog: string, argv: {string}, envp?: {string}): number
-  wait: function(pid?: number, options?: number): number | nil, number, Rusage, string
-  kill: function(pid: number, sig: number): boolean
-  WIFEXITED: function(status: number): boolean
-  WEXITSTATUS: function(status: number): number
-  WIFSIGNALED: function(status: number): boolean
-  WTERMSIG: function(status: number): number
+  fork: function(): integer
+  posix_spawn: function(prog: string, argv: {string}, envp?: {string}): integer
+  posix_spawnp: function(prog: string, argv: {string}, envp?: {string}): integer
+  wait: function(pid?: integer, options?: integer): integer | nil, integer, Rusage, string
+  kill: function(pid: integer, sig: integer): boolean
+  WIFEXITED: function(status: integer): boolean
+  WEXITSTATUS: function(status: integer): integer
+  WIFSIGNALED: function(status: integer): boolean
+  WTERMSIG: function(status: integer): integer
 
   -- Resource usage
-  getrusage: function(who?: number): Rusage
+  getrusage: function(who?: integer): Rusage
 
   -- Resource limits
-  getrlimit: function(resource: number): number | nil, number, string
-  setrlimit: function(resource: number, soft: number, hard?: number): boolean, string
+  getrlimit: function(resource: integer): integer | nil, integer, string
+  setrlimit: function(resource: integer, soft: integer, hard?: integer): boolean, string
 
   -- Priority
-  nice: function(inc: number): number | nil, string
-  getpriority: function(which: number, who: number): number | nil, string
-  setpriority: function(which: number, who: number, prio: number): boolean, string
+  nice: function(inc: integer): integer | nil, string
+  getpriority: function(which: integer, who: integer): integer | nil, string
+  setpriority: function(which: integer, who: integer, prio: integer): boolean, string
 
   -- Scheduling
   sched_yield: function()
@@ -394,28 +394,28 @@ local record ProcModule
   is_main: function(): boolean
 
   -- Rusage constants
-  RUSAGE_SELF: number
-  RUSAGE_CHILDREN: number
-  RUSAGE_THREAD: number
-  RUSAGE_BOTH: number
+  RUSAGE_SELF: integer
+  RUSAGE_CHILDREN: integer
+  RUSAGE_THREAD: integer
+  RUSAGE_BOTH: integer
 
   -- Resource limit constants
-  RLIMIT_AS: number
-  RLIMIT_CPU: number
-  RLIMIT_FSIZE: number
-  RLIMIT_NOFILE: number
-  RLIMIT_NPROC: number
-  RLIMIT_RSS: number
+  RLIMIT_AS: integer
+  RLIMIT_CPU: integer
+  RLIMIT_FSIZE: integer
+  RLIMIT_NOFILE: integer
+  RLIMIT_NPROC: integer
+  RLIMIT_RSS: integer
 
   -- Priority scope constants
-  PRIO_PROCESS: number
-  PRIO_PGRP: number
-  PRIO_USER: number
+  PRIO_PROCESS: integer
+  PRIO_PGRP: integer
+  PRIO_USER: integer
 
   -- Wait options
-  WNOHANG: number
-  WUNTRACED: number
-  WCONTINUED: number
+  WNOHANG: integer
+  WUNTRACED: integer
+  WCONTINUED: integer
 end
 
 local M: ProcModule = {

--- a/lib/cosmic/quicksand/proxy/dial.tl
+++ b/lib/cosmic/quicksand/proxy/dial.tl
@@ -62,10 +62,10 @@ local function resolve(host: string, timeout_ms: integer,
     unix.exit(0)
   end
   unix.close(wfd)
-  local fds: {number: number} = {}
+  local fds: {integer: integer} = {}
   fds[rfd] = unix.POLLIN
   local ready = unix.poll(fds, timeout_ms)
-  if not ready or not (ready as {number: number})[rfd] then
+  if not ready or not (ready as {integer: integer})[rfd] then
     pcall(unix.kill, pid, unix.SIGKILL)
     pcall(unix.wait, pid)
     unix.close(rfd)

--- a/lib/cosmic/quicksand/proxy/http.tl
+++ b/lib/cosmic/quicksand/proxy/http.tl
@@ -222,16 +222,16 @@ end
 --- unix.poll, and issues shutdown(SHUT_WR) toward the peer on each
 --- half-close so it sees clean EOF.
 local function pump(a: integer, b: integer)
-  local fds: {number: number} = {}
+  local fds: {integer: integer} = {}
   fds[a] = unix.POLLIN
   fds[b] = unix.POLLIN
-  local open: {number: boolean} = {}
+  local open: {integer: boolean} = {}
   open[a] = true
   open[b] = true
   local hup_mask = (unix.POLLHUP as integer)
   | (unix.POLLERR as integer)
   | (unix.POLLNVAL as integer)
-  local function close_side(fd: number, peer: integer)
+  local function close_side(fd: integer, peer: integer)
     pcall(unix.shutdown, peer, unix.SHUT_WR)
     fds[fd] = nil
     open[fd] = false
@@ -239,7 +239,7 @@ local function pump(a: integer, b: integer)
   while open[a] or open[b] do
     local ready = unix.poll(fds)
     if not ready then return end
-    for fd, ev in pairs(ready as {number: number}) do
+    for fd, ev in pairs(ready as {integer: integer}) do
       local peer = (fd == a) and b or a
       local evi = ev as integer
       local readable = (evi & (unix.POLLIN as integer)) ~= 0

--- a/lib/cosmic/rand.tl
+++ b/lib/cosmic/rand.tl
@@ -10,10 +10,10 @@
 local cosmo = require("cosmo")
 
 --- Generate cryptographically secure random bytes.
---- @param n number The number of random bytes to generate (1..4194304)
+--- @param n integer The number of random bytes to generate (1..4194304)
 --- @return string | nil Random bytes, or nil on failure
 --- @return string? Error message on failure
-local function bytes(n: number): string | nil, string
+local function bytes(n: integer): string | nil, string
   local data, err = cosmo.GetRandomBytes(n)
   if not data then
     return nil, err or "GetRandomBytes failed"
@@ -24,7 +24,7 @@ end
 --- Generate a fast 64-bit pseudo-random integer (non-cryptographic).
 --- Note: result is a signed 64-bit Lua integer; may appear negative if high bit is set.
 --- @return integer Random 64-bit integer
-local function rand64(): number
+local function rand64(): integer
   return cosmo.Rand64()
 end
 
@@ -144,13 +144,13 @@ local function token(len?: integer): string | nil, string
 end
 
 local record RandModule
-  bytes: function(n: number): string | nil, string
+  bytes: function(n: integer): string | nil, string
   int: function(min: integer, max: integer): integer | nil, string
   float: function(): number | nil, string
   choice: function(list: {any}): any, string
   shuffle: function(list: {any}): {any} | nil, string
   token: function(len?: integer): string | nil, string
-  rand64: function(): number
+  rand64: function(): integer
 end
 
 local M: RandModule = {

--- a/lib/cosmic/re.tl
+++ b/lib/cosmic/re.tl
@@ -19,20 +19,20 @@ local record Regex
   --- failure (e.g. out of memory) returns nil, err — the error string
   --- arrives in the second position, mirroring the cosmo.re binding.
   --- @param text string The text to search
-  --- @param flags number? Optional flags: NOTBOL, NOTEOL
+  --- @param flags integer? Optional flags: NOTBOL, NOTEOL
   --- @return string The matched substring, or nil if no match
   --- @return {string} Capture groups on match (error string on engine failure)
-  search: function(self: Regex, text: string, flags?: number): string, {string}, string | nil
+  search: function(self: Regex, text: string, flags?: integer): string, {string}, string | nil
 end
 
 --- Compile a regular expression pattern.
 --- Compiled patterns can be reused for efficient O(n) matching.
 --- Uses POSIX extended syntax by default.
 --- @param pattern string The regex pattern to compile
---- @param flags number? Optional flags: BASIC, ICASE, NEWLINE, NOSUB
+--- @param flags integer? Optional flags: BASIC, ICASE, NEWLINE, NOSUB
 --- @return Regex? The compiled regex, or nil on error
 --- @return string? Error message if compilation failed
-local function compile(pattern: string, flags?: number): Regex | nil, string
+local function compile(pattern: string, flags?: integer): Regex | nil, string
   local result, err = re.compile(pattern, flags)
   if not result then
     return nil, err as string
@@ -50,11 +50,11 @@ end
 --- nil, nil, err.
 --- @param pattern string The regex pattern to search for
 --- @param text string The text to search in
---- @param flags number? Optional compile flags: BASIC, ICASE, NEWLINE, NOSUB
+--- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE, NOSUB
 --- @return string | nil The matched substring, or nil on no match or error
 --- @return {string} | nil Capture groups on match
 --- @return string | nil Error message if compilation or the engine failed
-local function search(pattern: string, text: string, flags?: number): string | nil, {string} | nil, string | nil
+local function search(pattern: string, text: string, flags?: integer): string | nil, {string} | nil, string | nil
   local regex, cerr = compile(pattern, flags)
   if regex is Regex then
     -- Search flags (NOTBOL/NOTEOL) are not passed here; use compile() + :search() for those
@@ -78,10 +78,10 @@ end
 --- which returns the matched text.
 --- @param pattern string The regex pattern to match
 --- @param text string The text to search in
---- @param flags number? Optional compile flags: BASIC, ICASE, NEWLINE, NOSUB
+--- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE, NOSUB
 --- @return boolean True if pattern matches, false otherwise
 --- @return string? Error message if compilation or the engine failed
-local function test(pattern: string, text: string, flags?: number): boolean, string
+local function test(pattern: string, text: string, flags?: integer): boolean, string
   local m, _, err = search(pattern, text, flags)
   if err then
     return false, err
@@ -111,7 +111,7 @@ local function locate(regex: Regex, text: string, pos: integer, m: string): inte
     if not found then
       return nil
     end
-    local vflags: number = 0
+    local vflags: integer = 0
     if found > 1 then
       vflags = vflags | re.NOTBOL
     end
@@ -129,7 +129,7 @@ end
 --- Compile a pattern for iteration and reject patterns that can match
 --- the empty string: without offsets from the engine a zero-length
 --- match cannot be positioned or advanced past.
-local function compile_for_iter(pattern: string, flags?: number): Regex | nil, string
+local function compile_for_iter(pattern: string, flags?: integer): Regex | nil, string
   local regex, cerr = compile(pattern, flags)
   if not regex then
     return nil, cerr
@@ -148,7 +148,7 @@ local function all_matches(regex: Regex, text: string): {Span} | nil, string
   local spans: {Span} = {}
   local pos = 1
   while pos <= #text do
-    local sflags: number = 0
+    local sflags: integer = 0
     if pos > 1 then
       sflags = re.NOTBOL
     end
@@ -174,10 +174,10 @@ end
 --- first. Patterns that can match the empty string are rejected.
 --- @param pattern string The regex pattern to match
 --- @param text string The text to search in
---- @param flags number? Optional compile flags: BASIC, ICASE, NEWLINE
+--- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE
 --- @return {string} | nil The matched substrings (empty when none), or nil on error
 --- @return string? Error message on a bad pattern or engine failure
-local function findall(pattern: string, text: string, flags?: number): {string} | nil, string
+local function findall(pattern: string, text: string, flags?: integer): {string} | nil, string
   local regex, cerr = compile_for_iter(pattern, flags)
   if not regex then
     return nil, cerr
@@ -199,10 +199,10 @@ end
 --- Patterns that can match the empty string are rejected.
 --- @param pattern string The regex pattern to split on
 --- @param text string The text to split
---- @param flags number? Optional compile flags: BASIC, ICASE, NEWLINE
+--- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE
 --- @return {string} | nil The fields, or nil on error
 --- @return string? Error message on a bad pattern or engine failure
-local function split(pattern: string, text: string, flags?: number): {string} | nil, string
+local function split(pattern: string, text: string, flags?: integer): {string} | nil, string
   local regex, cerr = compile_for_iter(pattern, flags)
   if not regex then
     return nil, cerr
@@ -231,10 +231,10 @@ local type Repl = string | function(string, {string}): string
 --- @param pattern string The regex pattern to match
 --- @param text string The text to operate on
 --- @param repl Repl A literal replacement string, or function(match, caps)
---- @param flags number? Optional compile flags: BASIC, ICASE, NEWLINE
+--- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE
 --- @return string | nil The result, or nil on error
 --- @return string? Error message on a bad pattern or engine failure
-local function gsub(pattern: string, text: string, repl: Repl, flags?: number): string | nil, string
+local function gsub(pattern: string, text: string, repl: Repl, flags?: integer): string | nil, string
   local regex, cerr = compile_for_iter(pattern, flags)
   if not regex then
     return nil, cerr
@@ -269,22 +269,22 @@ local record ReModule
   type Repl = Repl
 
   -- Functions
-  compile: function(pattern: string, flags?: number): Regex | nil, string
-  search: function(pattern: string, text: string, flags?: number): string | nil, {string} | nil, string | nil
-  test: function(pattern: string, text: string, flags?: number): boolean, string
-  findall: function(pattern: string, text: string, flags?: number): {string} | nil, string
-  split: function(pattern: string, text: string, flags?: number): {string} | nil, string
-  gsub: function(pattern: string, text: string, repl: Repl, flags?: number): string | nil, string
+  compile: function(pattern: string, flags?: integer): Regex | nil, string
+  search: function(pattern: string, text: string, flags?: integer): string | nil, {string} | nil, string | nil
+  test: function(pattern: string, text: string, flags?: integer): boolean, string
+  findall: function(pattern: string, text: string, flags?: integer): {string} | nil, string
+  split: function(pattern: string, text: string, flags?: integer): {string} | nil, string
+  gsub: function(pattern: string, text: string, repl: Repl, flags?: integer): string | nil, string
 
   -- Compile flags
-  BASIC: number -- Use basic (obsolete) regex syntax instead of extended
-  ICASE: number -- Case-insensitive matching
-  NEWLINE: number -- Treat newline as special (affects ^ and $)
-  NOSUB: number -- Report only success/failure, not match position
+  BASIC: integer -- Use basic (obsolete) regex syntax instead of extended
+  ICASE: integer -- Case-insensitive matching
+  NEWLINE: integer -- Treat newline as special (affects ^ and $)
+  NOSUB: integer -- Report only success/failure, not match position
 
   -- Search flags
-  NOTBOL: number -- First character is not at beginning of line
-  NOTEOL: number -- Last character is not at end of line
+  NOTBOL: integer -- First character is not at beginning of line
+  NOTEOL: integer -- Last character is not at end of line
 end
 
 local M: ReModule = {

--- a/lib/cosmic/shm.tl
+++ b/lib/cosmic/shm.tl
@@ -22,41 +22,41 @@ local record ShmModule
   record Memory
     --- Read bytes from the region. With no bytes count, reads up to the
     --- first NUL byte (string semantics).
-    read: function(self: Memory, offset?: number, bytes?: number): string | nil, string
+    read: function(self: Memory, offset?: integer, bytes?: integer): string | nil, string
     --- Write bytes to the region (appends a NUL when no count is given).
-    write: function(self: Memory, data: string, offset?: number, bytes?: number): boolean, string
+    write: function(self: Memory, data: string, offset?: integer, bytes?: integer): boolean, string
     --- Atomic load of a word.
-    load: function(self: Memory, word_index: number): number | nil, string
+    load: function(self: Memory, word_index: integer): integer | nil, string
     --- Atomic store to a word.
-    store: function(self: Memory, word_index: number, value: number): boolean, string
+    store: function(self: Memory, word_index: integer, value: integer): boolean, string
     --- Atomic exchange; returns the old value.
-    xchg: function(self: Memory, word_index: number, value: number): number | nil, string
+    xchg: function(self: Memory, word_index: integer, value: integer): integer | nil, string
     --- Compare-and-exchange; returns success plus the actual old value.
-    cmpxchg: function(self: Memory, word_index: number, old: number, new: number): boolean | nil, number, string
+    cmpxchg: function(self: Memory, word_index: integer, old: integer, new: integer): boolean | nil, integer, string
     --- Atomic add; returns the old value.
-    fetch_add: function(self: Memory, word_index: number, value: number): number | nil, string
+    fetch_add: function(self: Memory, word_index: integer, value: integer): integer | nil, string
     --- Atomic AND; returns the old value.
-    fetch_and: function(self: Memory, word_index: number, value: number): number | nil, string
+    fetch_and: function(self: Memory, word_index: integer, value: integer): integer | nil, string
     --- Atomic OR; returns the old value.
-    fetch_or: function(self: Memory, word_index: number, value: number): number | nil, string
+    fetch_or: function(self: Memory, word_index: integer, value: integer): integer | nil, string
     --- Atomic XOR; returns the old value.
-    fetch_xor: function(self: Memory, word_index: number, value: number): number | nil, string
+    fetch_xor: function(self: Memory, word_index: integer, value: integer): integer | nil, string
     --- Wait until the word no longer holds `expect`. Returns 0 when
     --- woken; nil plus an error naming EAGAIN (value already differed),
     --- ETIMEDOUT (deadline expired), or EINTR (signal).
-    wait: function(self: Memory, word_index: number, expect: number, abs_deadline?: number, nanos?: number): number | nil, string
+    wait: function(self: Memory, word_index: integer, expect: integer, abs_deadline?: integer, nanos?: integer): integer | nil, string
     --- Wake processes waiting on a word; returns how many woke.
-    wake: function(self: Memory, word_index: number, count?: number): number
+    wake: function(self: Memory, word_index: integer, count?: integer): integer
     --- The mapped region size in bytes.
-    size: function(self: Memory): number
+    size: function(self: Memory): integer
   end
-  mapshared: function(size: number): Memory | nil, string
+  mapshared: function(size: integer): Memory | nil, string
 end
 
 local type Memory = ShmModule.Memory
 
 --- Validate a 0-based word index against the region size.
-local function check_word(word_index: number, size: number, op: string): string
+local function check_word(word_index: integer, size: integer, op: string): string
   if word_index == nil or word_index < 0 or word_index >= size // WORD then
     return op .. ": word_index out of range (0-" .. tostring(size // WORD - 1)
     .. "): " .. tostring(word_index)
@@ -72,14 +72,14 @@ end
 
 --- Wrap the raw unix.Memory userdata in a Memory record whose methods
 --- validate bounds in Lua and return nil, err instead of throwing.
-local function wrap(raw: unix.Memory, size: number): Memory
+local function wrap(raw: unix.Memory, size: integer): Memory
   local mem: Memory = {}
 
-  function mem:size(): number
+  function mem:size(): integer
     return size
   end
 
-  function mem:read(offset?: number, bytes?: number): string | nil, string
+  function mem:read(offset?: integer, bytes?: integer): string | nil, string
     local off = offset or 0
     if off < 0 or off > size then
       return nil, "read: offset out of range (0-" .. tostring(size) .. "): " .. tostring(off)
@@ -95,7 +95,7 @@ local function wrap(raw: unix.Memory, size: number): Memory
     return res as string
   end
 
-  function mem:write(data: string, offset?: number, bytes?: number): boolean, string
+  function mem:write(data: string, offset?: integer, bytes?: integer): boolean, string
     local off = offset or 0
     local n = bytes or #data
     if n > #data then
@@ -112,7 +112,7 @@ local function wrap(raw: unix.Memory, size: number): Memory
     return true
   end
 
-  function mem:load(word_index: number): number | nil, string
+  function mem:load(word_index: integer): integer | nil, string
     local range_err = check_word(word_index, size, "load")
     if range_err then
       return nil, range_err
@@ -121,10 +121,10 @@ local function wrap(raw: unix.Memory, size: number): Memory
     if not ok then
       return nil, thrown("load", res)
     end
-    return res as number
+    return res as integer
   end
 
-  function mem:store(word_index: number, value: number): boolean, string
+  function mem:store(word_index: integer, value: integer): boolean, string
     local range_err = check_word(word_index, size, "store")
     if range_err then
       return false, range_err
@@ -137,7 +137,7 @@ local function wrap(raw: unix.Memory, size: number): Memory
   end
 
   -- Shared body for the atomic read-modify-write word operations.
-  local function atomic(op: string, fn: function(unix.Memory, number, number): number, word_index: number, value: number): number | nil, string
+  local function atomic(op: string, fn: function(unix.Memory, integer, integer): integer, word_index: integer, value: integer): integer | nil, string
     local range_err = check_word(word_index, size, op)
     if range_err then
       return nil, range_err
@@ -146,30 +146,30 @@ local function wrap(raw: unix.Memory, size: number): Memory
     if not ok then
       return nil, thrown(op, res)
     end
-    return res as number
+    return res as integer
   end
 
-  function mem:xchg(word_index: number, value: number): number | nil, string
+  function mem:xchg(word_index: integer, value: integer): integer | nil, string
     return atomic("xchg", raw.xchg, word_index, value)
   end
 
-  function mem:fetch_add(word_index: number, value: number): number | nil, string
+  function mem:fetch_add(word_index: integer, value: integer): integer | nil, string
     return atomic("fetch_add", raw.fetch_add, word_index, value)
   end
 
-  function mem:fetch_and(word_index: number, value: number): number | nil, string
+  function mem:fetch_and(word_index: integer, value: integer): integer | nil, string
     return atomic("fetch_and", raw.fetch_and, word_index, value)
   end
 
-  function mem:fetch_or(word_index: number, value: number): number | nil, string
+  function mem:fetch_or(word_index: integer, value: integer): integer | nil, string
     return atomic("fetch_or", raw.fetch_or, word_index, value)
   end
 
-  function mem:fetch_xor(word_index: number, value: number): number | nil, string
+  function mem:fetch_xor(word_index: integer, value: integer): integer | nil, string
     return atomic("fetch_xor", raw.fetch_xor, word_index, value)
   end
 
-  function mem:cmpxchg(word_index: number, old: number, new: number): boolean | nil, number, string
+  function mem:cmpxchg(word_index: integer, old: integer, new: integer): boolean | nil, integer, string
     local range_err = check_word(word_index, size, "cmpxchg")
     if range_err then
       return nil, nil, range_err
@@ -178,10 +178,10 @@ local function wrap(raw: unix.Memory, size: number): Memory
     if not ok then
       return nil, nil, thrown("cmpxchg", success)
     end
-    return success as boolean, actual as number
+    return success as boolean, actual as integer
   end
 
-  function mem:wait(word_index: number, expect: number, abs_deadline?: number, nanos?: number): number | nil, string
+  function mem:wait(word_index: integer, expect: integer, abs_deadline?: integer, nanos?: integer): integer | nil, string
     local range_err = check_word(word_index, size, "wait")
     if range_err then
       return nil, range_err
@@ -196,10 +196,10 @@ local function wrap(raw: unix.Memory, size: number): Memory
     if rc == nil then
       return nil, errstr(err, "wait")
     end
-    return rc as number
+    return rc as integer
   end
 
-  function mem:wake(word_index: number, count?: number): number
+  function mem:wake(word_index: integer, count?: integer): integer
     local range_err = check_word(word_index, size, "wake")
     if range_err then
       -- wake never fails in the binding; an out-of-range index wakes
@@ -234,10 +234,10 @@ end
 --- mem:wake(LOCK, 1)
 --- ```
 ---
---- @param size number Size in bytes: positive, a multiple of the 8-byte word size
+--- @param size integer Size in bytes: positive, a multiple of the 8-byte word size
 --- @return Memory | nil Shared memory object, or nil on failure
 --- @return string? Error message on failure
-local function mapshared(size: number): Memory | nil, string
+local function mapshared(size: integer): Memory | nil, string
   if size == nil or size <= 0 then
     return nil, "mapshared: size must be a positive number of bytes: " .. tostring(size)
   end

--- a/lib/cosmic/signal.tl
+++ b/lib/cosmic/signal.tl
@@ -5,19 +5,19 @@ local errstr = require("cosmic.errno").str
 
 --- Options for setitimer: specifies which timer, initial fire time, and repeat interval.
 local record SetitimerOptions
-  which: number
-  valuesec: number
-  valuens: number
-  intervalsec: number
-  intervalns: number
+  which: integer
+  valuesec: integer
+  valuens: integer
+  intervalsec: integer
+  intervalns: integer
 end
 
 --- Result from setitimer: previous timer values.
 local record SetitimerResult
-  valuesec: number
-  valuens: number
-  intervalsec: number
-  intervalns: number
+  valuesec: integer
+  valuens: integer
+  intervalsec: integer
+  intervalns: integer
 end
 
 --- Signal set for blocking, unblocking, and waiting on signals.
@@ -27,15 +27,15 @@ end
 --- functions that construct them.
 local record Sigset
   --- Adds signal to bitset.
-  add: function(self: Sigset, sig: number)
+  add: function(self: Sigset, sig: integer)
   --- Removes signal from bitset.
-  remove: function(self: Sigset, sig: number)
+  remove: function(self: Sigset, sig: integer)
   --- Sets all bits in signal bitset to true.
   fill: function(self: Sigset)
   --- Sets all bits in signal bitset to false.
   clear: function(self: Sigset)
   --- Returns true if signal is in the bitset.
-  contains: function(self: Sigset, sig: number): boolean
+  contains: function(self: Sigset, sig: integer): boolean
 end
 
 --- Signal handling module.
@@ -43,70 +43,70 @@ end
 local record SignalModule
 
   -- Signal constants
-  SIGABRT: number
-  SIGALRM: number
-  SIGBUS: number
-  SIGCHLD: number
-  SIGCONT: number
-  SIGFPE: number
-  SIGHUP: number
-  SIGILL: number
-  SIGINT: number
-  SIGKILL: number
-  SIGPIPE: number
-  SIGPROF: number
-  SIGQUIT: number
-  SIGSEGV: number
-  SIGSTOP: number
-  SIGSYS: number
-  SIGTERM: number
-  SIGTRAP: number
-  SIGTSTP: number
-  SIGTTIN: number
-  SIGTTOU: number
-  SIGURG: number
-  SIGUSR1: number
-  SIGUSR2: number
-  SIGVTALRM: number
-  SIGWINCH: number
-  SIGXCPU: number
-  SIGXFSZ: number
+  SIGABRT: integer
+  SIGALRM: integer
+  SIGBUS: integer
+  SIGCHLD: integer
+  SIGCONT: integer
+  SIGFPE: integer
+  SIGHUP: integer
+  SIGILL: integer
+  SIGINT: integer
+  SIGKILL: integer
+  SIGPIPE: integer
+  SIGPROF: integer
+  SIGQUIT: integer
+  SIGSEGV: integer
+  SIGSTOP: integer
+  SIGSYS: integer
+  SIGTERM: integer
+  SIGTRAP: integer
+  SIGTSTP: integer
+  SIGTTIN: integer
+  SIGTTOU: integer
+  SIGURG: integer
+  SIGUSR1: integer
+  SIGUSR2: integer
+  SIGVTALRM: integer
+  SIGWINCH: integer
+  SIGXCPU: integer
+  SIGXFSZ: integer
 
   -- Signal mask operations
-  SIG_BLOCK: number
-  SIG_UNBLOCK: number
-  SIG_SETMASK: number
+  SIG_BLOCK: integer
+  SIG_UNBLOCK: integer
+  SIG_SETMASK: integer
 
   -- Default/ignore handlers
-  SIG_DFL: number
-  SIG_IGN: number
+  SIG_DFL: integer
+  SIG_IGN: integer
 
   -- sigaction flags
-  SA_NOCLDSTOP: number
-  SA_NOCLDWAIT: number
-  SA_NODEFER: number
-  SA_RESETHAND: number
-  SA_RESTART: number
+  SA_NOCLDSTOP: integer
+  SA_NOCLDWAIT: integer
+  SA_NODEFER: integer
+  SA_RESETHAND: integer
+  SA_RESTART: integer
 
   -- Timer types
-  ITIMER_REAL: number
-  ITIMER_VIRTUAL: number
-  ITIMER_PROF: number
+  ITIMER_REAL: integer
+  ITIMER_VIRTUAL: integer
+  ITIMER_PROF: integer
 
   --- Create a new signal set containing the specified signals.
   --- The returned Sigset has methods: add(sig), remove(sig), fill(), clear(), contains(sig).
-  Sigset: function(...: number): Sigset
+  Sigset: function(...: integer): Sigset
 
   --- Register a signal handler for the specified signal.
   --- The handler can be a Lua function, SIG_IGN, or SIG_DFL.
   --- Returns the previous handler, flags, and mask; on failure returns
   --- nil, nil, nil plus an error message.
-  sigaction: function(sig: number, handler?: function | number, flags?: number, mask?: Sigset): function | number, number, Sigset, string
+  sigaction: function(sig: integer, handler?: function | integer, flags?: integer, mask?: Sigset): function | integer, integer, Sigset, string
 
   --- Modify the process signal mask.
   --- how: SIG_BLOCK, SIG_UNBLOCK, or SIG_SETMASK
   --- Returns the previous signal mask, or nil plus an error message.
-  sigprocmask: function(how: number, set: Sigset): Sigset | nil, string
+  sigprocmask: function(how: integer, set: Sigset): Sigset | nil, string
 
   --- Suspend the process until a signal is delivered.
   --- Temporarily replaces the signal mask with the provided mask.
@@ -122,24 +122,24 @@ local record SignalModule
 
   --- Send a signal to a process.
   --- pid > 0 signals one process by id; 0 signals current group; -1 signals all.
-  kill: function(pid: number, sig: number): boolean, string
+  kill: function(pid: integer, sig: integer): boolean, string
 
   --- Send a signal to a process group.
-  killpg: function(pgrp: number, sig: number): boolean, string
+  killpg: function(pgrp: integer, sig: integer): boolean, string
 
   --- Send a signal to the current process.
-  raise: function(sig: number): boolean, string
+  raise: function(sig: integer): boolean, string
 
   --- Get the name of a signal.
-  strsignal: function(sig: number): string
+  strsignal: function(sig: integer): string
 end
 
 --- Send a signal to a process.
---- @param pid number The process ID (>0 for specific process, 0 for process group, -1 for all)
---- @param sig number The signal to send
+--- @param pid integer The process ID (>0 for specific process, 0 for process group, -1 for all)
+--- @param sig integer The signal to send
 --- @return boolean True on success
 --- @return string? Error message on failure
-local function kill(pid: number, sig: number): boolean, string
+local function kill(pid: integer, sig: integer): boolean, string
   local ok, err = unix.kill(pid, sig)
   if not ok then
     return false, errstr(err, "kill")
@@ -148,11 +148,11 @@ local function kill(pid: number, sig: number): boolean, string
 end
 
 --- Send a signal to a process group.
---- @param pgrp number The process group ID
---- @param sig number The signal to send
+--- @param pgrp integer The process group ID
+--- @param sig integer The signal to send
 --- @return boolean True on success
 --- @return string? Error message on failure
-local function killpg(pgrp: number, sig: number): boolean, string
+local function killpg(pgrp: integer, sig: integer): boolean, string
   local ok, err = unix.killpg(pgrp, sig)
   if not ok then
     return false, errstr(err, "killpg")
@@ -162,10 +162,10 @@ end
 
 --- Send a signal to the current process.
 --- Equivalent to kill(getpid(), sig).
---- @param sig number The signal to send
+--- @param sig integer The signal to send
 --- @return boolean True on success
 --- @return string? Error message on failure
-local function raise(sig: number): boolean, string
+local function raise(sig: integer): boolean, string
   local rc, err = unix.raise(sig)
   if rc == nil then
     return false, errstr(err, "raise")
@@ -174,9 +174,9 @@ local function raise(sig: number): boolean, string
 end
 
 --- Get the name of a signal.
---- @param sig number The signal number
+--- @param sig integer The signal number
 --- @return string The signal name (e.g., "SIGKILL")
-local function strsignal(sig: number): string
+local function strsignal(sig: integer): string
   return unix.strsignal(sig)
 end
 
@@ -208,23 +208,23 @@ end
 -- The binding's Sigset is a distinct nominal record the generated
 -- declarations do not export, so calls go through casts that mirror its
 -- signature — but never ones that erase the error slots.
-local raw_sigaction = unix.sigaction as function(sig: number, handler?: any, flags?: number, mask?: Sigset): (any, any, any)
-local raw_sigprocmask = unix.sigprocmask as function(number, Sigset): (Sigset, any)
+local raw_sigaction = unix.sigaction as function(sig: integer, handler?: any, flags?: integer, mask?: Sigset): (any, any, any)
+local raw_sigprocmask = unix.sigprocmask as function(integer, Sigset): (Sigset, any)
 local raw_sigsuspend = unix.sigsuspend as function(Sigset): (any, any)
 
 --- Register a signal handler for the specified signal.
---- @param sig number The signal to handle
---- @param handler function | number? Lua function, SIG_IGN, or SIG_DFL
---- @param flags number? sigaction flags (e.g. SA_RESTART)
+--- @param sig integer The signal to handle
+--- @param handler function | integer? Lua function, SIG_IGN, or SIG_DFL
+--- @param flags integer? sigaction flags (e.g. SA_RESTART)
 --- @param mask Sigset? Signals to block during handler execution
---- @return function | number The previous handler, or nil on failure
---- @return number The previous flags
+--- @return function | integer The previous handler, or nil on failure
+--- @return integer The previous flags
 --- @return Sigset The previous mask
 --- @return string? Error message on failure
 -- handler and the first return are typed any here because the formatter
--- cannot parse a bare `function | number` union in a function statement;
+-- cannot parse a bare `function | integer` union in a function statement;
 -- the SignalModule record above carries the precise public type.
-local function sigaction(sig: number, handler?: any, flags?: number, mask?: Sigset): any, number, Sigset, string
+local function sigaction(sig: integer, handler?: any, flags?: integer, mask?: Sigset): any, integer, Sigset, string
   -- Never pass explicit trailing nils: the binding leaves nil-valued
   -- stack slots 3/4 in place, which shifts the stack index it later uses
   -- to store a Lua handler in its registry table — the handler would be
@@ -244,15 +244,15 @@ local function sigaction(sig: number, handler?: any, flags?: number, mask?: Sigs
     -- arrives in the second slot.
     return nil, nil, nil, errstr(prev_flags, "sigaction")
   end
-  return prev, prev_flags as number, prev_mask as Sigset
+  return prev, prev_flags as integer, prev_mask as Sigset
 end
 
 --- Modify the process signal mask.
---- @param how number SIG_BLOCK, SIG_UNBLOCK, or SIG_SETMASK
+--- @param how integer SIG_BLOCK, SIG_UNBLOCK, or SIG_SETMASK
 --- @param set Sigset The signal set to apply
 --- @return Sigset | nil The previous signal mask, or nil on failure
 --- @return string? Error message on failure
-local function sigprocmask(how: number, set: Sigset): Sigset | nil, string
+local function sigprocmask(how: integer, set: Sigset): Sigset | nil, string
   local old, err = raw_sigprocmask(how, set)
   if old == nil then
     return nil, errstr(err, "sigprocmask")
@@ -271,7 +271,7 @@ end
 
 local M = {} as SignalModule
 
-M.Sigset = unix.Sigset as function(...: number): Sigset
+M.Sigset = unix.Sigset as function(...: integer): Sigset
 M.sigaction = sigaction
 M.sigprocmask = sigprocmask
 M.sigsuspend = sigsuspend

--- a/lib/cosmic/sqlite/init.tl
+++ b/lib/cosmic/sqlite/init.tl
@@ -77,9 +77,9 @@ local record Statement
   --- Reset for re-execution; existing bindings are kept.
   reset: function(self: Statement)
   --- Number of result columns.
-  columns: function(self: Statement): number
+  columns: function(self: Statement): integer
   --- Name of result column n (1-indexed).
-  column_name: function(self: Statement, n: number): string
+  column_name: function(self: Statement, n: integer): string
   --- Finalize the statement (idempotent); also runs on scope exit via
   --- to-be-closed.
   close: function(self: Statement)
@@ -121,9 +121,9 @@ local record Database
   --- see cosmic.sqlite.extras.
   savepoint: function(self: Database, fn: function(Database)): boolean, string
   --- rowid of the most recent successful INSERT (0 if closed).
-  last_insert_rowid: function(self: Database): number
+  last_insert_rowid: function(self: Database): integer
   --- Rows modified by the most recent INSERT/UPDATE/DELETE (0 if closed).
-  changes: function(self: Database): number
+  changes: function(self: Database): integer
   --- Close the database and its cached statements (idempotent); also
   --- runs on scope exit via to-be-closed.
   close: function(self: Database)
@@ -258,11 +258,11 @@ local function make_statement(raw_stmt: lsqlite3.Statement, raw_db: lsqlite3.Dat
     raw_stmt:reset()
   end
 
-  stmt.columns = function(_: Statement): number
+  stmt.columns = function(_: Statement): integer
     return raw_stmt:columns()
   end
 
-  stmt.column_name = function(_: Statement, n: number): string
+  stmt.column_name = function(_: Statement, n: integer): string
     return raw_stmt:get_name(n - 1)
   end
 
@@ -389,14 +389,14 @@ local function make_database(raw_db: lsqlite3.Database): Database
     return self:exec("COMMIT")
   end
 
-  function db:last_insert_rowid(): number
+  function db:last_insert_rowid(): integer
     if closed then
       return 0
     end
     return raw_db:last_insert_rowid()
   end
 
-  function db:changes(): number
+  function db:changes(): integer
     if closed then
       return 0
     end

--- a/lib/cosmic/stream_test.tl
+++ b/lib/cosmic/stream_test.tl
@@ -106,7 +106,7 @@ end
 test_child_handle_conforms()
 
 --- Fork a loopback server answering one request, closing right after.
-local function serve_once(response: string): integer, number
+local function serve_once(response: string): integer, integer
   local srv, port = net.listen_tcp("127.0.0.1", 0)
   assert(srv ~= nil, "listen_tcp failed")
   local s = srv as net.Socket

--- a/lib/cosmic/sys.tl
+++ b/lib/cosmic/sys.tl
@@ -84,11 +84,11 @@ end
 --- Query a runtime system configuration value.
 --- `name` is one of the `unix.SC_*` constants (e.g. `unix.SC_PAGESIZE`,
 --- `unix.SC_NPROCESSORS_ONLN`). Returns nil plus an error message on failure.
---- @param name number One of the unix.SC_* constants
---- @return number | nil The configuration value
+--- @param name integer One of the unix.SC_* constants
+--- @return integer | nil The configuration value
 --- @return string? Error message on failure
-local function sysconf(name: number): number | nil, string
-  local val, err = unix.sysconf(name) as(number, any)
+local function sysconf(name: integer): integer | nil, string
+  local val, err = unix.sysconf(name) as(integer, any)
   if not val then
     return nil, errstr(err, "sysconf")
   end
@@ -96,24 +96,24 @@ local function sysconf(name: number): number | nil, string
 end
 
 --- Number of processors currently online (available to run threads).
---- @return number | nil The online processor count
+--- @return integer | nil The online processor count
 --- @return string? Error message on failure
-local function nproc(): number | nil, string
+local function nproc(): integer | nil, string
   return sysconf(unix.SC_NPROCESSORS_ONLN)
 end
 
 --- Number of processors configured in the system.
 --- May exceed `nproc()` when some processors are offline.
---- @return number | nil The configured processor count
+--- @return integer | nil The configured processor count
 --- @return string? Error message on failure
-local function nproc_configured(): number | nil, string
+local function nproc_configured(): integer | nil, string
   return sysconf(unix.SC_NPROCESSORS_CONF)
 end
 
 --- Memory page size in bytes.
---- @return number | nil The page size in bytes
+--- @return integer | nil The page size in bytes
 --- @return string? Error message on failure
-local function page_size(): number | nil, string
+local function page_size(): integer | nil, string
   return sysconf(unix.SC_PAGESIZE)
 end
 
@@ -135,22 +135,22 @@ local record SysModule
   type Uname = Uname
 
   -- sysconf(3) name constants
-  SC_ARG_MAX: number
-  SC_CHILD_MAX: number
-  SC_CLK_TCK: number
-  SC_OPEN_MAX: number
-  SC_PAGESIZE: number
-  SC_NPROCESSORS_CONF: number
-  SC_NPROCESSORS_ONLN: number
+  SC_ARG_MAX: integer
+  SC_CHILD_MAX: integer
+  SC_CLK_TCK: integer
+  SC_OPEN_MAX: integer
+  SC_PAGESIZE: integer
+  SC_NPROCESSORS_CONF: integer
+  SC_NPROCESSORS_ONLN: integer
 
   host_os: function(): HostOs
   normalize_host_os: function(raw: string): HostOs
   host_isa: function(): string
   platform: function(): string
-  sysconf: function(name: number): number | nil, string
-  nproc: function(): number | nil, string
-  nproc_configured: function(): number | nil, string
-  page_size: function(): number | nil, string
+  sysconf: function(name: integer): integer | nil, string
+  nproc: function(): integer | nil, string
+  nproc_configured: function(): integer | nil, string
+  page_size: function(): integer | nil, string
   uname: function(): Uname | nil, string
 end
 

--- a/lib/cosmic/syslog.tl
+++ b/lib/cosmic/syslog.tl
@@ -22,9 +22,9 @@ local LOG_INFO < const > = unix.LOG_INFO
 local LOG_DEBUG < const > = unix.LOG_DEBUG
 
 --- Write a message to the system log.
---- @param priority number Log priority (LOG_EMERG through LOG_DEBUG)
+--- @param priority integer Log priority (LOG_EMERG through LOG_DEBUG)
 --- @param message string The message to log
-local function write(priority: number, message: string)
+local function write(priority: integer, message: string)
   unix.syslog(priority, message)
 end
 
@@ -78,7 +78,7 @@ end
 
 local record SyslogModule
   -- Writing
-  write: function(priority: number, message: string)
+  write: function(priority: integer, message: string)
   emerg: function(message: string)
   alert: function(message: string)
   crit: function(message: string)
@@ -89,14 +89,14 @@ local record SyslogModule
   debug: function(message: string)
 
   -- Priority constants
-  LOG_EMERG: number
-  LOG_ALERT: number
-  LOG_CRIT: number
-  LOG_ERR: number
-  LOG_WARNING: number
-  LOG_NOTICE: number
-  LOG_INFO: number
-  LOG_DEBUG: number
+  LOG_EMERG: integer
+  LOG_ALERT: integer
+  LOG_CRIT: integer
+  LOG_ERR: integer
+  LOG_WARNING: integer
+  LOG_NOTICE: integer
+  LOG_INFO: integer
+  LOG_DEBUG: integer
 end
 
 local M: SyslogModule = {

--- a/lib/cosmic/time.tl
+++ b/lib/cosmic/time.tl
@@ -13,43 +13,43 @@ local errno = require("cosmic.errno")
 --- DateTime represents a broken-down timestamp.
 --- Returned by gmtime() and localtime().
 local record DateTime
-  year: number -- Full year (e.g., 2024)
-  month: number -- Month (1-12)
-  day: number -- Day of month (1-31)
-  hour: number -- Hour (0-23)
-  min: number -- Minute (0-59)
-  sec: number -- Second (0-60, 60 for a leap second)
-  gmtoff: number -- Offset from UTC in seconds
-  wday: number -- Day of week (0=Sunday, 6=Saturday)
-  yday: number -- Day of year (0-365)
+  year: integer -- Full year (e.g., 2024)
+  month: integer -- Month (1-12)
+  day: integer -- Day of month (1-31)
+  hour: integer -- Hour (0-23)
+  min: integer -- Minute (0-59)
+  sec: integer -- Second (0-60, 60 for a leap second)
+  gmtoff: integer -- Offset from UTC in seconds
+  wday: integer -- Day of week (0=Sunday, 6=Saturday)
+  yday: integer -- Day of year (0-365)
   isdst: boolean -- True when daylight saving time is in effect
   zone: string -- Timezone name (e.g., "UTC", "PDT")
 end
 
 --- Get current time from the specified clock.
 --- Returns seconds since epoch and nanoseconds.
---- @param clock number? Clock identifier (default: CLOCK_REALTIME)
---- @return number Seconds since epoch
---- @return number Nanoseconds
-local function clock_gettime(clock?: number): number, number
+--- @param clock integer? Clock identifier (default: CLOCK_REALTIME)
+--- @return integer Seconds since epoch
+--- @return integer Nanoseconds
+local function clock_gettime(clock?: integer): integer, integer
   local secs, nanos = unix.clock_gettime(clock)
   return secs, nanos
 end
 
 --- Get current wall clock time (real time).
 --- Returns seconds since epoch and nanoseconds.
---- @return number Seconds since epoch
---- @return number Nanoseconds
-local function now(): number, number
+--- @return integer Seconds since epoch
+--- @return integer Nanoseconds
+local function now(): integer, integer
   local secs, nanos = unix.clock_gettime(unix.CLOCK_REALTIME)
   return secs, nanos
 end
 
 --- Get monotonic time (not affected by system time changes).
 --- Returns seconds and nanoseconds from an unspecified epoch.
---- @return number Seconds
---- @return number Nanoseconds
-local function monotonic(): number, number
+--- @return integer Seconds
+--- @return integer Nanoseconds
+local function monotonic(): integer, integer
   local secs, nanos = unix.clock_gettime(unix.CLOCK_MONOTONIC)
   return secs, nanos
 end
@@ -57,16 +57,16 @@ end
 --- Get current wall clock time in whole milliseconds since the epoch.
 --- Exact for timestamps within 2^53 ms (~285,000 years), so no manual
 --- (secs, nanos) arithmetic is needed for timeouts or timestamps.
---- @return number Milliseconds since epoch
-local function now_ms(): number
+--- @return integer Milliseconds since epoch
+local function now_ms(): integer
   local secs, nanos = unix.clock_gettime(unix.CLOCK_REALTIME)
   return secs * 1000 + math.floor(nanos / 1000000)
 end
 
 --- Get monotonic time in whole milliseconds from an unspecified epoch.
 --- Use differences between two calls to measure elapsed time.
---- @return number Milliseconds
-local function monotonic_ms(): number
+--- @return integer Milliseconds
+local function monotonic_ms(): integer
   local secs, nanos = unix.clock_gettime(unix.CLOCK_MONOTONIC)
   return secs * 1000 + math.floor(nanos / 1000000)
 end
@@ -76,12 +76,12 @@ end
 --- the sleep, returns the remaining seconds and nanoseconds plus an
 --- error string naming EINTR. Invalid input (e.g. a negative duration)
 --- returns nil, nil, and an error naming EINVAL.
---- @param seconds number Seconds to sleep
---- @param nanos number? Additional nanoseconds to sleep (default: 0)
---- @return number | nil Remaining seconds (0 on success), or nil on invalid input
---- @return number Remaining nanoseconds (0 on success)
+--- @param seconds integer Seconds to sleep
+--- @param nanos integer? Additional nanoseconds to sleep (default: 0)
+--- @return integer | nil Remaining seconds (0 on success), or nil on invalid input
+--- @return integer Remaining nanoseconds (0 on success)
 --- @return string? Error message when interrupted (EINTR) or invalid (EINVAL)
-local function sleep(seconds: number, nanos?: number): number | nil, number, string
+local function sleep(seconds: integer, nanos?: integer): integer | nil, integer, string
   local ns = nanos or 0
   local t0s, t0n = unix.clock_gettime(unix.CLOCK_MONOTONIC)
   -- On failure the binding returns (nil, err, errno): the error string
@@ -101,8 +101,8 @@ local function sleep(seconds: number, nanos?: number): number | nil, number, str
     if remaining < 0 then
       remaining = 0
     end
-    return math.floor(remaining / 1000000000) as number,
-    math.floor(remaining % 1000000000) as number,
+    return math.floor(remaining / 1000000000),
+    remaining % 1000000000,
     errno.str(rem_ns, "sleep")
   end
   return nil, nil, errno.str(rem_ns, "sleep")
@@ -115,23 +115,23 @@ end
 --- interrupts; nil, err on invalid input (EINVAL). time.sleep keeps
 --- its (secs, nanos, err) contract for symmetry with clock_gettime.
 --- @param ms number Milliseconds to sleep
---- @return number | nil Remaining milliseconds (0 on success), or nil on invalid input
+--- @return integer | nil Remaining milliseconds (0 on success), or nil on invalid input
 --- @return string? Error message when interrupted (EINTR) or invalid (EINVAL)
-local function sleep_ms(ms: number): number | nil, string
+local function sleep_ms(ms: number): integer | nil, string
   local seconds = math.floor(ms / 1000)
   local remaining_ms = ms % 1000
-  local rem_s, rem_ns, err = sleep(seconds, remaining_ms * 1000000)
+  local rem_s, rem_ns, err = sleep(seconds, math.floor(remaining_ms * 1000000))
   if rem_s == nil then
     return nil, err
   end
   -- Round up so an interrupted sleep never reports 0 remaining.
-  return math.ceil(rem_s * 1000 + rem_ns / 1000000) as number, err
+  return math.ceil(rem_s * 1000 + rem_ns / 1000000), err
 end
 
 --- Break down a UNIX timestamp into UTC (Zulu) time components.
---- @param unixts number UNIX timestamp (seconds since epoch)
+--- @param unixts integer UNIX timestamp (seconds since epoch)
 --- @return DateTime Broken-down time in UTC
-local function gmtime(unixts: number): DateTime
+local function gmtime(unixts: integer): DateTime
   local year, mon, mday, hour, min, sec, gmtoff, wday, yday, isdst, zone =
   unix.gmtime(unixts)
   return {
@@ -151,9 +151,9 @@ end
 
 --- Break down a UNIX timestamp into local time components.
 --- Respects the TZ environment variable.
---- @param unixts number UNIX timestamp (seconds since epoch)
+--- @param unixts integer UNIX timestamp (seconds since epoch)
 --- @return DateTime Broken-down time in local timezone
-local function localtime(unixts: number): DateTime
+local function localtime(unixts: integer): DateTime
   local year, mon, mday, hour, min, sec, gmtoff, wday, yday, isdst, zone =
   unix.localtime(unixts)
   return {
@@ -172,16 +172,16 @@ local function localtime(unixts: number): DateTime
 end
 
 --- Format a UNIX timestamp as an HTTP date string (RFC 7231).
---- @param timestamp number UNIX timestamp (seconds since epoch)
+--- @param timestamp integer UNIX timestamp (seconds since epoch)
 --- @return string HTTP date string (e.g., "Sun, 01 Feb 2026 12:00:00 GMT")
-local function format_http(timestamp: number): string
+local function format_http(timestamp: integer): string
   return cosmo.FormatHttpDateTime(timestamp)
 end
 
 --- Return true if year is a leap year (Gregorian rules).
---- @param year number Full year (e.g., 2024)
+--- @param year integer Full year (e.g., 2024)
 --- @return boolean True when the year has 366 days
-local function is_leap_year(year: number): boolean
+local function is_leap_year(year: integer): boolean
   return year % 4 == 0 and (year % 100 ~= 0 or year % 400 == 0)
 end
 
@@ -189,38 +189,38 @@ end
 local MONTH_DAYS: {integer} = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
 
 --- Number of days in the given month, accounting for leap years.
---- @param year number Full year (e.g., 2024)
---- @param month number Month (1-12)
---- @return number | nil Days in that month (28-31), or nil when month is out of range
+--- @param year integer Full year (e.g., 2024)
+--- @param month integer Month (1-12)
+--- @return integer | nil Days in that month (28-31), or nil when month is out of range
 --- @return string Error message when month is out of range
-local function days_in_month(year: number, month: number): number | nil, string
+local function days_in_month(year: integer, month: integer): integer | nil, string
   if month < 1 or month > 12 then
     return nil, "days_in_month: month out of range (1-12): " .. tostring(month)
   end
   if month == 2 and is_leap_year(year) then
     return 29
   end
-  return MONTH_DAYS[month as integer]
+  return MONTH_DAYS[month]
 end
 
 --- Convert UTC broken-down time to UNIX epoch seconds.
 --- Fields are range-checked; out-of-range values (e.g. month 13, Feb 30)
 --- return nil plus an error rather than throwing.
---- @param year number Full year (e.g., 2025)
---- @param month number Month (1-12)
---- @param day number Day of month (1-31)
---- @param hour number Hour (0-23)
---- @param min number Minute (0-59)
---- @param sec number Second (0-60)
---- @return number | nil UNIX epoch seconds, or nil on invalid input
+--- @param year integer Full year (e.g., 2025)
+--- @param month integer Month (1-12)
+--- @param day integer Day of month (1-31)
+--- @param hour integer Hour (0-23)
+--- @param min integer Minute (0-59)
+--- @param sec integer Second (0-60)
+--- @return integer | nil UNIX epoch seconds, or nil on invalid input
 --- @return string Error message when input is out of range
-local function timegm(year: number, month: number, day: number,
-    hour: number, min: number, sec: number): number | nil, string
+local function timegm(year: integer, month: integer, day: integer,
+    hour: integer, min: integer, sec: integer): integer | nil, string
   if month < 1 or month > 12 then
     return nil, "timegm: month out of range (1-12): " .. tostring(month)
   end
   -- month is already range-checked, so the nil arm is unreachable
-  local dim = days_in_month(year, month) as number
+  local dim = days_in_month(year, month) as integer
   if day < 1 or day > dim then
     return nil, "timegm: day out of range (1-" .. tostring(dim) .. "): "
     .. tostring(day)
@@ -250,7 +250,7 @@ local function timegm(year: number, month: number, day: number,
 end
 
 --- Month abbreviation (RFC 7231 IMF-fixdate) to month number.
-local MONTH_ABBR: {string: number} = {
+local MONTH_ABBR: {string: integer} = {
   Jan = 1, Feb = 2, Mar = 3, Apr = 4, May = 5, Jun = 6,
   Jul = 7, Aug = 8, Sep = 9, Oct = 10, Nov = 11, Dec = 12,
 }
@@ -260,9 +260,9 @@ local MONTH_ABBR: {string: number} = {
 --- requires senders to generate (e.g. "Sun, 06 Nov 1994 08:49:37 GMT").
 --- The obsolete RFC 850 and asctime forms are not accepted.
 --- @param str string HTTP date string
---- @return number | nil UNIX timestamp, or nil if parsing failed
+--- @return integer | nil UNIX timestamp, or nil if parsing failed
 --- @return string Error message on failure
-local function parse_http(str: string): number | nil, string
+local function parse_http(str: string): integer | nil, string
   local d, mon, y, h, mi, s = str:match(
     "^%a%a%a, (%d%d) (%a%a%a) (%d%d%d%d) (%d%d):(%d%d):(%d%d) GMT$")
   if not d then
@@ -273,15 +273,15 @@ local function parse_http(str: string): number | nil, string
     return nil, "parse_http: unknown month: " .. mon
   end
   return timegm(
-    tonumber(y) as number, month, tonumber(d) as number,
-    tonumber(h) as number, tonumber(mi) as number, tonumber(s) as number)
+    tonumber(y) as integer, month, tonumber(d) as integer,
+    tonumber(h) as integer, tonumber(mi) as integer, tonumber(s) as integer)
 end
 
 --- Format a UNIX timestamp as a date string in UTC.
---- @param timestamp number UNIX timestamp (seconds since epoch)
+--- @param timestamp integer UNIX timestamp (seconds since epoch)
 --- @return string | nil Date string (e.g., "2025-01-01"), or nil on error
 --- @return string Error message if formatting failed
-local function format_date(timestamp: number): string | nil, string
+local function format_date(timestamp: integer): string | nil, string
   local s, err = cosmo.Strftime("%Y-%m-%d", timestamp)
   if not s then
     return nil, err as string
@@ -291,23 +291,23 @@ end
 
 --- Parse a YYYY-MM-DD date string into a UNIX timestamp (midnight UTC).
 --- @param str string Date string (e.g., "2025-01-01")
---- @return number | nil UNIX timestamp, or nil if parsing failed
+--- @return integer | nil UNIX timestamp, or nil if parsing failed
 --- @return string Error message on failure
-local function parse_date(str: string): number | nil, string
+local function parse_date(str: string): integer | nil, string
   local y, mo, d = str:match("^(%d%d%d%d)-(%d%d)-(%d%d)$")
   if not y then
     return nil, "parse_date: not a YYYY-MM-DD date: " .. str
   end
   return timegm(
-    tonumber(y) as number, tonumber(mo) as number, tonumber(d) as number,
+    tonumber(y) as integer, tonumber(mo) as integer, tonumber(d) as integer,
     0, 0, 0)
 end
 
 --- Format a UNIX timestamp as an ISO 8601 string in UTC.
---- @param timestamp number UNIX timestamp (seconds since epoch)
+--- @param timestamp integer UNIX timestamp (seconds since epoch)
 --- @return string | nil ISO 8601 string (e.g., "2025-01-01T00:00:00Z"), or nil on error
 --- @return string Error message if formatting failed
-local function format_iso8601(timestamp: number): string | nil, string
+local function format_iso8601(timestamp: integer): string | nil, string
   local s, err = cosmo.Strftime("%Y-%m-%dT%H:%M:%SZ", timestamp)
   if not s then
     return nil, err as string
@@ -317,8 +317,8 @@ end
 
 --- Resolve an ISO 8601 timezone suffix into a signed offset in seconds.
 --- Accepts "", "Z"/"z" (UTC), "±HH:MM", "±HHMM", and "±HH".
---- @return number Offset east of UTC in seconds, or nil if unparseable
-local function parse_offset(tz: string): number, string
+--- @return integer Offset east of UTC in seconds, or nil if unparseable
+local function parse_offset(tz: string): integer, string
   if tz == "" or tz == "Z" or tz == "z" then
     return 0
   end
@@ -333,8 +333,8 @@ local function parse_offset(tz: string): number, string
   if not sign then
     return nil, "invalid timezone offset: " .. tz
   end
-  local h = tonumber(oh) as number
-  local m = tonumber(om) as number
+  local h = tonumber(oh) as integer
+  local m = tonumber(om) as integer
   if h > 23 or m > 59 then
     return nil, "timezone offset out of range: " .. tz
   end
@@ -348,14 +348,14 @@ end
 --- truncated to whole seconds. Also accepts date-only "YYYY-MM-DD" (midnight
 --- UTC).
 --- @param str string ISO 8601 string (e.g., "2025-01-01T00:00:00.5Z")
---- @return number | nil UNIX timestamp, or nil if parsing failed
+--- @return integer | nil UNIX timestamp, or nil if parsing failed
 --- @return string Error message on failure
-local function parse_iso8601(str: string): number | nil, string
+local function parse_iso8601(str: string): integer | nil, string
   -- try date-only format first
   local dy, dmo, dd = str:match("^(%d%d%d%d)-(%d%d)-(%d%d)$")
   if dy then
     return timegm(
-      tonumber(dy) as number, tonumber(dmo) as number, tonumber(dd) as number,
+      tonumber(dy) as integer, tonumber(dmo) as integer, tonumber(dd) as integer,
       0, 0, 0)
   end
   local y, mo, d, h, mi, s, rest = str:match(
@@ -367,8 +367,8 @@ local function parse_iso8601(str: string): number | nil, string
   local after = rest:match("^%.%d+(.*)$")
   local tz = after or rest
   local epoch, err = timegm(
-    tonumber(y) as number, tonumber(mo) as number, tonumber(d) as number,
-    tonumber(h) as number, tonumber(mi) as number, tonumber(s) as number)
+    tonumber(y) as integer, tonumber(mo) as integer, tonumber(d) as integer,
+    tonumber(h) as integer, tonumber(mi) as integer, tonumber(s) as integer)
   if not epoch then
     return nil, err
   end
@@ -381,34 +381,34 @@ end
 
 local record TimeModule
   -- Clock constants
-  CLOCK_REALTIME: number
-  CLOCK_MONOTONIC: number
-  CLOCK_BOOTTIME: number
-  CLOCK_MONOTONIC_RAW: number
-  CLOCK_REALTIME_COARSE: number
-  CLOCK_MONOTONIC_COARSE: number
-  CLOCK_THREAD_CPUTIME_ID: number
-  CLOCK_PROCESS_CPUTIME_ID: number
+  CLOCK_REALTIME: integer
+  CLOCK_MONOTONIC: integer
+  CLOCK_BOOTTIME: integer
+  CLOCK_MONOTONIC_RAW: integer
+  CLOCK_REALTIME_COARSE: integer
+  CLOCK_MONOTONIC_COARSE: integer
+  CLOCK_THREAD_CPUTIME_ID: integer
+  CLOCK_PROCESS_CPUTIME_ID: integer
 
   -- Functions
-  clock_gettime: function(clock?: number): number, number
-  now: function(): number, number
-  monotonic: function(): number, number
-  now_ms: function(): number
-  monotonic_ms: function(): number
-  sleep: function(seconds: number, nanos?: number): number | nil, number, string
-  sleep_ms: function(ms: number): number | nil, string
-  gmtime: function(unixts: number): DateTime
-  localtime: function(unixts: number): DateTime
-  format_http: function(timestamp: number): string
-  parse_http: function(str: string): number | nil, string
-  format_date: function(timestamp: number): string | nil, string
-  parse_date: function(str: string): number | nil, string
-  format_iso8601: function(timestamp: number): string | nil, string
-  parse_iso8601: function(str: string): number | nil, string
-  timegm: function(year: number, month: number, day: number, hour: number, min: number, sec: number): number | nil, string
-  is_leap_year: function(year: number): boolean
-  days_in_month: function(year: number, month: number): number | nil, string
+  clock_gettime: function(clock?: integer): integer, integer
+  now: function(): integer, integer
+  monotonic: function(): integer, integer
+  now_ms: function(): integer
+  monotonic_ms: function(): integer
+  sleep: function(seconds: integer, nanos?: integer): integer | nil, integer, string
+  sleep_ms: function(ms: number): integer | nil, string
+  gmtime: function(unixts: integer): DateTime
+  localtime: function(unixts: integer): DateTime
+  format_http: function(timestamp: integer): string
+  parse_http: function(str: string): integer | nil, string
+  format_date: function(timestamp: integer): string | nil, string
+  parse_date: function(str: string): integer | nil, string
+  format_iso8601: function(timestamp: integer): string | nil, string
+  parse_iso8601: function(str: string): integer | nil, string
+  timegm: function(year: integer, month: integer, day: integer, hour: integer, min: integer, sec: integer): integer | nil, string
+  is_leap_year: function(year: integer): boolean
+  days_in_month: function(year: integer, month: integer): integer | nil, string
 end
 
 local M: TimeModule = {

--- a/lib/cosmic/tty.tl
+++ b/lib/cosmic/tty.tl
@@ -10,8 +10,8 @@ local type Termios = unix.Termios
 local record TtyModule
   --- Window size information.
   record WinSize
-    rows: number
-    cols: number
+    rows: integer
+    cols: integer
   end
 
   --- Terminal I/O settings.
@@ -24,52 +24,52 @@ local record TtyModule
   end
 
   --- tcsetattr actions.
-  NOW: number
-  DRAIN: number
-  FLUSH: number
+  NOW: integer
+  DRAIN: integer
+  FLUSH: integer
 
   --- Common lflag constants.
-  ECHO: number
-  ICANON: number
-  ISIG: number
-  IEXTEN: number
+  ECHO: integer
+  ICANON: integer
+  ISIG: integer
+  IEXTEN: integer
 
   --- Input/output mode flag constants (for make_raw assertions).
-  IXON: number
-  ICRNL: number
-  BRKINT: number
-  OPOST: number
+  IXON: integer
+  ICRNL: integer
+  BRKINT: integer
+  OPOST: integer
 
   --- cc indices (C-style; the Lua cc array is 1-based, so cc[VMIN + 1]).
-  VMIN: number
-  VTIME: number
+  VMIN: integer
+  VTIME: integer
 
-  isatty: function(fd: number): boolean
-  winsize: function(fd: number): WinSize | nil, string
+  isatty: function(fd: integer): boolean
+  winsize: function(fd: integer): WinSize | nil, string
   stdin_isatty: function(): boolean
   stdout_isatty: function(): boolean
   stderr_isatty: function(): boolean
-  getattr: function(fd: number): Termios | nil, string
-  setattr: function(fd: number, action: number, termios: Termios): boolean, string
+  getattr: function(fd: integer): Termios | nil, string
+  setattr: function(fd: integer, action: integer, termios: Termios): boolean, string
   make_raw: function(termios: Termios, opts?: RawOptions): Termios
-  raw: function(fd: number, opts?: RawOptions): Termios | nil, string
-  noecho: function(fd: number): Termios | nil, string
-  restore: function(fd: number, termios: Termios): boolean, string
+  raw: function(fd: integer, opts?: RawOptions): Termios | nil, string
+  noecho: function(fd: integer): Termios | nil, string
+  restore: function(fd: integer, termios: Termios): boolean, string
   getpass: function(prompt: string): string | nil, string
 end
 
 --- Checks if a file descriptor refers to a terminal.
---- @param fd number File descriptor to check (0=stdin, 1=stdout, 2=stderr)
+--- @param fd integer File descriptor to check (0=stdin, 1=stdout, 2=stderr)
 --- @return boolean True if fd is a terminal
-local function isatty(fd: number): boolean
+local function isatty(fd: integer): boolean
   return (unix.isatty(fd))
 end
 
 --- Gets the terminal window size for a file descriptor.
---- @param fd number File descriptor (typically 0, 1, or 2)
+--- @param fd integer File descriptor (typically 0, 1, or 2)
 --- @return WinSize|nil Window size record with rows and cols, or nil on error
 --- @return string|nil Error message if not a terminal
-local function winsize(fd: number): TtyModule.WinSize | nil, string
+local function winsize(fd: integer): TtyModule.WinSize | nil, string
   local rows, cols = unix.tiocgwinsz(fd)
   if rows == nil then
     -- On failure the binding returns (nil, err, errno): the error string
@@ -98,10 +98,10 @@ local function stderr_isatty(): boolean
 end
 
 --- Gets terminal attributes for a file descriptor.
---- @param fd number File descriptor (typically 0 for stdin)
+--- @param fd integer File descriptor (typically 0 for stdin)
 --- @return Termios | nil Terminal attributes
 --- @return string? Error message if not a terminal
-local function getattr(fd: number): Termios | nil, string
+local function getattr(fd: integer): Termios | nil, string
   local termios, err = unix.tcgetattr(fd)
   if not termios then
     return nil, errstr(err, "tcgetattr")
@@ -110,12 +110,12 @@ local function getattr(fd: number): Termios | nil, string
 end
 
 --- Sets terminal attributes for a file descriptor.
---- @param fd number File descriptor
---- @param action number When to apply changes (NOW, DRAIN, or FLUSH)
+--- @param fd integer File descriptor
+--- @param action integer When to apply changes (NOW, DRAIN, or FLUSH)
 --- @param termios Termios Terminal attributes to set
 --- @return boolean True on success
 --- @return string? Error message on failure
-local function setattr(fd: number, action: number, termios: Termios): boolean, string
+local function setattr(fd: integer, action: integer, termios: Termios): boolean, string
   local ok, err = unix.tcsetattr(fd, action, termios)
   if not ok then
     return false, errstr(err, "tcsetattr")
@@ -130,7 +130,7 @@ end
 --- @param t Termios Terminal attributes to copy
 --- @return Termios An independent copy
 local function copy_termios(t: Termios): Termios
-  local cc: {number} = {}
+  local cc: {integer} = {}
   for i, v in ipairs(t.cc) do
     cc[i] = v
   end
@@ -166,8 +166,8 @@ local function make_raw(termios: Termios, opts?: TtyModule.RawOptions): Termios
   t.lflag = t.lflag & ~ lclear
   t.cflag = (t.cflag & ~ (unix.CSIZE | unix.PARENB)) | unix.CS8
   -- The Lua cc array is 1-based: cc[i + 1] holds C's c_cc[i].
-  t.cc[(unix.VMIN + 1) as integer] = 1
-  t.cc[(unix.VTIME + 1) as integer] = 0
+  t.cc[unix.VMIN + 1] = 1
+  t.cc[unix.VTIME + 1] = 0
   return t
 end
 
@@ -175,11 +175,11 @@ end
 --- keys (unless opts.keep_signals), no \r translation, no Ctrl-S flow
 --- control, no output post-processing (see make_raw).
 --- Returns the original termios for later restoration.
---- @param fd number File descriptor (typically 0 for stdin)
+--- @param fd integer File descriptor (typically 0 for stdin)
 --- @param opts RawOptions? keep_signals: keep Ctrl-C/Ctrl-Z generating signals
 --- @return Termios | nil Original terminal attributes for restore()
 --- @return string? Error message if not a terminal
-local function raw(fd: number, opts?: TtyModule.RawOptions): Termios | nil, string
+local function raw(fd: integer, opts?: TtyModule.RawOptions): Termios | nil, string
   local termios, err = getattr(fd)
   if not termios then
     return nil, err
@@ -195,10 +195,10 @@ end
 
 --- Disables echo on terminal (for password input).
 --- Returns the original termios for later restoration.
---- @param fd number File descriptor (typically 0 for stdin)
+--- @param fd integer File descriptor (typically 0 for stdin)
 --- @return Termios | nil Original terminal attributes for restore()
 --- @return string? Error message if not a terminal
-local function noecho(fd: number): Termios | nil, string
+local function noecho(fd: integer): Termios | nil, string
   local termios, err = getattr(fd)
   if not termios then
     return nil, err
@@ -214,11 +214,11 @@ local function noecho(fd: number): Termios | nil, string
 end
 
 --- Restores terminal attributes.
---- @param fd number File descriptor
+--- @param fd integer File descriptor
 --- @param termios Termios Terminal attributes from raw() or noecho()
 --- @return boolean True on success
 --- @return string? Error message on failure
-local function restore(fd: number, termios: Termios): boolean, string
+local function restore(fd: integer, termios: Termios): boolean, string
   return setattr(fd, unix.TCSANOW, termios)
 end
 

--- a/lib/cosmic/tty_test.tl
+++ b/lib/cosmic/tty_test.tl
@@ -209,7 +209,7 @@ test_getpass_non_tty_eof()
 -- (issue #529, review item 35).
 
 local function fixture_termios(): tty.Termios
-  local cc: {number} = {}
+  local cc: {integer} = {}
   for i = 1, 20 do
     cc[i] = i
   end
@@ -241,8 +241,8 @@ test_make_raw_clears_input_and_output_flags()
 local function test_make_raw_sets_vmin_vtime()
   local t = fixture_termios()
   local raw = tty.make_raw(t)
-  local vmin = (tty.VMIN + 1) as integer
-  local vtime = (tty.VTIME + 1) as integer
+  local vmin = tty.VMIN + 1
+  local vtime = tty.VTIME + 1
   assert(raw.cc[vmin] == 1, "raw mode must set VMIN=1")
   assert(raw.cc[vtime] == 0, "raw mode must set VTIME=0")
 end
@@ -259,8 +259,8 @@ test_make_raw_keep_signals()
 local function test_make_raw_does_not_alias_or_mutate_input()
   local t = fixture_termios()
   local raw = tty.make_raw(t)
-  local vmin = (tty.VMIN + 1) as integer
-  local vtime = (tty.VTIME + 1) as integer
+  local vmin = tty.VMIN + 1
+  local vtime = tty.VTIME + 1
   assert(raw.cc ~= t.cc, "make_raw must deep-copy cc, not alias it")
   assert(t.iflag & tty.IXON ~= 0, "make_raw must not mutate its input")
   assert(t.cc[vmin] ~= raw.cc[vmin] or t.cc[vtime] ~= raw.cc[vtime],

--- a/lib/cosmic/user.tl
+++ b/lib/cosmic/user.tl
@@ -4,15 +4,15 @@ local unix = require("cosmo.unix")
 local errstr = require("cosmic.errno").str
 
 --- Get the real user ID of the calling process.
---- @return number The real user ID
-local function getuid(): number
+--- @return integer The real user ID
+local function getuid(): integer
   return unix.getuid()
 end
 
 --- Get the real group ID of the calling process.
 --- On Windows this is polyfilled as getuid().
---- @return number The real group ID
-local function getgid(): number
+--- @return integer The real group ID
+local function getgid(): integer
   return unix.getgid()
 end
 
@@ -20,15 +20,15 @@ end
 --- For example, if your binary is setuid, getuid() returns the uid of the user
 --- running the program, while geteuid() returns the uid of the file owner.
 --- On Windows this is polyfilled as getuid().
---- @return number The effective user ID
-local function geteuid(): number
+--- @return integer The effective user ID
+local function geteuid(): integer
   return unix.geteuid()
 end
 
 --- Get the effective group ID of the calling process.
 --- On Windows this is polyfilled as getuid().
---- @return number The effective group ID
-local function getegid(): number
+--- @return integer The effective group ID
+local function getegid(): integer
   return unix.getegid()
 end
 
@@ -45,10 +45,10 @@ end
 
 --- Set the user ID of the calling process.
 --- Returns ENOSYS on Windows NT if uid isn't getuid().
---- @param uid number The user ID to set
+--- @param uid integer The user ID to set
 --- @return boolean True on success
 --- @return string? Error message on failure
-local function setuid(uid: number): boolean, string
+local function setuid(uid: integer): boolean, string
   local ok, err = unix.setuid(uid)
   if not ok then
     return false, errstr(err, "setuid")
@@ -58,10 +58,10 @@ end
 
 --- Set the group ID of the calling process.
 --- Returns ENOSYS on Windows NT if gid isn't getgid().
---- @param gid number The group ID to set
+--- @param gid integer The group ID to set
 --- @return boolean True on success
 --- @return string? Error message on failure
-local function setgid(gid: number): boolean, string
+local function setgid(gid: integer): boolean, string
   local ok, err = unix.setgid(gid)
   if not ok then
     return false, errstr(err, "setgid")
@@ -70,10 +70,10 @@ local function setgid(gid: number): boolean, string
 end
 
 --- Set the filesystem user ID.
---- @param uid number The filesystem user ID to set
+--- @param uid integer The filesystem user ID to set
 --- @return boolean True on success
 --- @return string? Error message on failure
-local function setfsuid(uid: number): boolean, string
+local function setfsuid(uid: integer): boolean, string
   local ok, err = unix.setfsuid(uid)
   if not ok then
     return false, errstr(err, "setfsuid")
@@ -83,12 +83,12 @@ end
 
 --- Set real, effective, and saved user IDs.
 --- Pass -1 for any argument to leave that ID unchanged.
---- @param real number The real user ID to set (-1 to leave unchanged)
---- @param effective number The effective user ID to set (-1 to leave unchanged)
---- @param saved number The saved user ID to set (-1 to leave unchanged)
+--- @param real integer The real user ID to set (-1 to leave unchanged)
+--- @param effective integer The effective user ID to set (-1 to leave unchanged)
+--- @param saved integer The saved user ID to set (-1 to leave unchanged)
 --- @return boolean True on success
 --- @return string? Error message on failure
-local function setresuid(real: number, effective: number, saved: number): boolean, string
+local function setresuid(real: integer, effective: integer, saved: integer): boolean, string
   local ok, err = unix.setresuid(real, effective, saved)
   if not ok then
     return false, errstr(err, "setresuid")
@@ -98,12 +98,12 @@ end
 
 --- Set real, effective, and saved group IDs.
 --- Pass -1 for any argument to leave that ID unchanged.
---- @param real number The real group ID to set (-1 to leave unchanged)
---- @param effective number The effective group ID to set (-1 to leave unchanged)
---- @param saved number The saved group ID to set (-1 to leave unchanged)
+--- @param real integer The real group ID to set (-1 to leave unchanged)
+--- @param effective integer The effective group ID to set (-1 to leave unchanged)
+--- @param saved integer The saved group ID to set (-1 to leave unchanged)
 --- @return boolean True on success
 --- @return string? Error message on failure
-local function setresgid(real: number, effective: number, saved: number): boolean, string
+local function setresgid(real: integer, effective: integer, saved: integer): boolean, string
   local ok, err = unix.setresgid(real, effective, saved)
   if not ok then
     return false, errstr(err, "setresgid")
@@ -114,9 +114,9 @@ end
 --- Set the file mode creation mask.
 --- The umask is used by open(), mkdir(), etc. to modify the permissions
 --- of newly created files and directories.
---- @param newmask number The new file mode creation mask
---- @return number The previous umask value
-local function umask(newmask: number): number
+--- @param newmask integer The new file mode creation mask
+--- @return integer The previous umask value
+local function umask(newmask: integer): integer
   return unix.umask(newmask)
 end
 
@@ -135,17 +135,17 @@ local function chroot(path: string): boolean, string
 end
 
 local record UserModule
-  getuid: function(): number
-  getgid: function(): number
-  geteuid: function(): number
-  getegid: function(): number
+  getuid: function(): integer
+  getgid: function(): integer
+  geteuid: function(): integer
+  getegid: function(): integer
   getlogin: function(): string | nil, string
-  setuid: function(uid: number): boolean, string
-  setgid: function(gid: number): boolean, string
-  setfsuid: function(uid: number): boolean, string
-  setresuid: function(real: number, effective: number, saved: number): boolean, string
-  setresgid: function(real: number, effective: number, saved: number): boolean, string
-  umask: function(newmask: number): number
+  setuid: function(uid: integer): boolean, string
+  setgid: function(gid: integer): boolean, string
+  setfsuid: function(uid: integer): boolean, string
+  setresuid: function(real: integer, effective: integer, saved: integer): boolean, string
+  setresgid: function(real: integer, effective: integer, saved: integer): boolean, string
+  umask: function(newmask: integer): integer
   chroot: function(path: string): boolean, string
 end
 

--- a/lib/cosmic/zip.tl
+++ b/lib/cosmic/zip.tl
@@ -11,9 +11,9 @@ local fs = require("cosmic.fs")
 --- Options for opening a ZIP archive.
 local record OpenOptions
   --- Compression level 0-9 (0=none, 9=maximum). Used when writing/appending.
-  level: number
+  level: integer
   --- Maximum file size limit in bytes.
-  max_file_size: number
+  max_file_size: integer
 end
 
 --- Options for adding a file to a ZIP archive.
@@ -21,25 +21,25 @@ local record AddOptions
   --- Compression method: "store" (no compression) or "deflate" (compressed).
   method: zip.CompressionMethod
   --- Modification time as Unix timestamp.
-  mtime: number
+  mtime: integer
   --- Unix file mode/permissions (default 0644).
-  mode: number
+  mode: integer
 end
 
 --- File metadata within a ZIP archive.
 local record Stat
   --- Uncompressed file size in bytes.
-  size: number
+  size: integer
   --- Compressed file size in bytes.
-  compressed_size: number
+  compressed_size: integer
   --- CRC32 checksum of uncompressed data.
-  crc32: number
+  crc32: integer
   --- Modification time as Unix timestamp.
-  mtime: number
+  mtime: integer
   --- Compression method (0=stored, 8=deflated).
-  method: number
+  method: integer
   --- Unix file mode/permissions.
-  mode: number
+  mode: integer
 end
 
 --- Directory entry returned by Reader:list().
@@ -47,9 +47,9 @@ local record Entry
   --- Entry path within the archive.
   name: string
   --- Uncompressed size in bytes.
-  size: number
+  size: integer
   --- Unix file mode/permissions.
-  mode: number
+  mode: integer
 end
 
 --- Reader for extracting files from a ZIP archive.
@@ -117,12 +117,12 @@ end
 local record ExtractOptions
   --- Refuse any entry whose declared uncompressed size exceeds this many
   --- bytes (checked before anything is read or written).
-  max_file_size: number
+  max_file_size: integer
 end
 
 -- Build a plain options table so the nominal cosmo.zip.OpenOptions record
 -- doesn't conflict with this module's OpenOptions.
-local function raw_options(options: OpenOptions): {string: number}
+local function raw_options(options: OpenOptions): {string: integer}
   return {
     level = options.level,
     max_file_size = options.max_file_size,
@@ -130,11 +130,11 @@ local function raw_options(options: OpenOptions): {string: number}
 end
 
 --- Open a ZIP archive for reading.
---- @param path string|number File path or file descriptor
+--- @param path string|integer File path or file descriptor
 --- @param options OpenOptions? Size limits
 --- @return Reader | nil The archive reader, or nil on error
 --- @return string? Error message if opening failed
-local function reader(path: string | number, options?: OpenOptions): Reader | nil, string
+local function reader(path: string | integer, options?: OpenOptions): Reader | nil, string
   local handle: any
   local err: string
   if options then
@@ -149,11 +149,11 @@ local function reader(path: string | number, options?: OpenOptions): Reader | ni
 end
 
 --- Create a new ZIP archive for writing. Any existing file is truncated.
---- @param path string|number File path or file descriptor
+--- @param path string|integer File path or file descriptor
 --- @param options OpenOptions? Compression level and size limits
 --- @return Writer | nil The archive writer, or nil on error
 --- @return string? Error message if opening failed
-local function writer(path: string | number, options?: OpenOptions): Writer | nil, string
+local function writer(path: string | integer, options?: OpenOptions): Writer | nil, string
   local handle: any
   local err: string
   if options then
@@ -319,8 +319,8 @@ local record ZipModule
   --- Appender for adding files to an existing ZIP archive.
   type Appender = Appender
 
-  reader: function(path: string | number, options?: OpenOptions): Reader | nil, string
-  writer: function(path: string | number, options?: OpenOptions): Writer | nil, string
+  reader: function(path: string | integer, options?: OpenOptions): Reader | nil, string
+  writer: function(path: string | integer, options?: OpenOptions): Writer | nil, string
   appender: function(path: string, options?: OpenOptions): Appender | nil, string
   from: function(data: string, options?: OpenOptions): Reader | nil, string
   extract: function(r: Reader, destdir: string, opts?: ExtractOptions): boolean, string

--- a/lib/docs/publish.tl
+++ b/lib/docs/publish.tl
@@ -98,7 +98,7 @@ local function is_public_page(rel_path: string, public_set: {string: boolean}): 
     return true
   end
   local name = rel_path:match("^lib/cosmic/([^/]+)%.md$")
-    or rel_path:match("^lib/cosmic/([^/]+)/init%.md$")
+  or rel_path:match("^lib/cosmic/([^/]+)/init%.md$")
   return name ~= nil and public_set[name] == true
 end
 

--- a/lib/perf/bench/http_bench.tl
+++ b/lib/perf/bench/http_bench.tl
@@ -18,7 +18,7 @@ local RESPONSE = "HTTP/1.1 200 OK\r\n"
 .. "Connection: close\r\n\r\n"
 .. BODY
 
-local server_pid: number
+local server_pid: integer
 local listener: net.Socket
 
 --- Read from a connection until the end of the request headers.

--- a/lib/perf/bench/stream_bench.tl
+++ b/lib/perf/bench/stream_bench.tl
@@ -35,7 +35,7 @@ local RESPONSE = "HTTP/1.1 200 OK\r\n"
 .. "Connection: close\r\n\r\n"
 .. BODY
 
-local server_pid: number
+local server_pid: integer
 local listener: net.Socket
 
 --- A single line-iteration outcome, checked after timing.

--- a/lib/types/cosmo.d.tl
+++ b/lib/types/cosmo.d.tl
@@ -34,21 +34,21 @@ local record EncoderOptions
   --- defaults to " ". This option controls the indentation of pretty formatting. This field is ignored if pretty isn't true.
   indent: string
   --- defaults to 64. This option controls the maximum amount of recursion the serializer is allowed to perform. The max is 32767. You might not be able to set it that high if there isn't enough C stack memory. Your serializer checks for this and will return an error rather than crashing.
-  maxdepth: number
+  maxdepth: integer
   --- `EncodeJson` only: encode NaN and Infinity as `null` (the v8 behavior) instead of failing with `nil, error`.
   nan: string
 end
 
 local record DeflateOptions
   --- compression level `-1`..`9`; defaults to `-1`, the zlib default (currently 6). `0` stores without compressing; higher levels are slower but compress better.
-  level: number
+  level: integer
   --- framing of the compressed stream; defaults to `"raw"` (headerless DEFLATE, as used inside ZIP files).
   format: string
 end
 
 local record InflateOptions
   --- cap on the decompressed size in bytes; defaults to 64 MiB. Decompression streams into a growing buffer and fails with `nil, error` once the cap is exceeded, so no attacker-controlled length is ever trusted as an allocation size.
-  maxsize: number
+  maxsize: integer
   --- framing of the compressed stream; defaults to `"raw"`. `"auto"` detects zlib or gzip framing from the stream header (but cannot detect `"raw"`).
   format: string
 end
@@ -61,7 +61,7 @@ local record FetchOptions
   --- request payload.
   body: string
   --- maximum number of redirects to follow.
-  maxredirects: number
+  maxredirects: integer
   --- whether to follow redirects. Defaults to `true`.
   followredirect: boolean
   --- allow requests to private, loopback, and other non-public network addresses (disables the SSRF guard). Applies to every hop of a redirect chain. Defaults to `false`.
@@ -71,18 +71,18 @@ local record FetchOptions
   --- proxy URL to route the request through.
   proxy: string
   --- limit on response (or per-read buffer) size.
-  maxresponse: number
+  maxresponse: integer
   --- request timeout in seconds. `0` or absent keeps the 60-second default; there is no "infinite" option.
   timeout: number
 end
 
 local record BarfOptions
   --- file mode for a newly created file, defaults to 0644
-  mode: number
+  mode: integer
   --- append to the file instead of truncating it (default false)
   append: boolean
   --- 1-indexed byte offset for overwriting a slice of the file; incompatible with `append`
-  offset: number
+  offset: integer
 end
 
 --- Streaming reader for an HTTP response body, returned by
@@ -162,11 +162,11 @@ local record cosmo
   ---     assert(Barf('x.txt', 'XX', {offset = 3}))
   ---     assert(assert(Slurp('x.txt', 1, 6)) == 'abXX23')
   Barf: function(filename: string, data: string, options?: BarfOptions): boolean | nil, string | nil, unix.Errno | nil
-  CategorizeIp: function(ip: number): IpCategory
+  CategorizeIp: function(ip: integer): IpCategory
   --- Computes Phil Katz CRC-32 used by zip/zlib/gzip/etc.
-  Crc32: function(initial: number, data: string): number
+  Crc32: function(initial: integer, data: string): integer
   --- Computes 32-bit Castagnoli Cyclic Redundancy Check.
-  Crc32c: function(initial: number, data: string): number
+  Crc32c: function(initial: integer, data: string): integer
   --- Turns ASCII into binary using the provided alphabet. The default
   --- decoding uses Crockford's base32 alphabet in a permissive way that
   --- ignores whitespace and dash (`-`) and stops at the first character
@@ -314,7 +314,7 @@ local record cosmo
   --- encodings in your input strings will be canonicalized rather than validated.
   EncodeJson: function(value: any, options?: EncoderOptions): string | nil, string | nil
   --- Turns UTF-8 into ISO-8859-1 string.
-  EncodeLatin1: function(utf8: string, flags?: number): string
+  EncodeLatin1: function(utf8: string, flags?: integer): string
   --- Turns Lua data structure into Lua code string.
   --- Since Lua uses tables as both hashmaps and arrays, tables will only be
   --- serialized as an array with determinate order, if it's an array in the
@@ -495,7 +495,7 @@ local record cosmo
   --- (malformed request or response), `"too_large"` (response exceeded
   --- `maxresponse`), or `"blocked"` (refused by SSRF protection or the
   --- HTTPS-to-HTTP downgrade guard).
-  Fetch: function(url: string, body?: string | FetchOptions): number | nil, {string: string}, string, string, string | nil, FetchErrorKind | nil
+  Fetch: function(url: string, body?: string | FetchOptions): integer | nil, {string: string}, string, string, string | nil, FetchErrorKind | nil
   --- Sends an HTTP/HTTPS request and returns a streaming reader for the response body.
   --- Useful for Server-Sent Events (SSE), large downloads, or processing data incrementally.
   --- Accepts the same options table as `Fetch()`, including `timeout`, `maxresponse`,
@@ -510,13 +510,13 @@ local record cosmo
   --- redirects. On failure, returns `nil`, a descriptive error message,
   --- and a machine-readable failure kind with the same values as
   --- `Fetch()`.
-  FetchStream: function(url: string, options?: FetchOptions): number | nil, {string: string}, StreamReader, string, string | nil, FetchErrorKind | nil
+  FetchStream: function(url: string, options?: FetchOptions): integer | nil, {string: string}, StreamReader, string, string | nil, FetchErrorKind | nil
   --- Converts UNIX timestamp to an RFC1123 string that looks like this:
   --- `Mon, 29 Mar 2021 15:37:13 GMT`. See `formathttpdatetime.c`.
-  FormatHttpDateTime: function(seconds: number): string
+  FormatHttpDateTime: function(seconds: integer): string
   --- Turns integer like `0x01020304` into a string like `"1.2.3.4"`. See also
   --- `ParseIp` for the inverse operation.
-  FormatIp: function(uint32: number): string
+  FormatIp: function(uint32: integer): string
   GetCryptoHash: function(name: string, payload: string, key?: string): string | nil, string | nil
   --- Returns string describing host instruction set architecture.
   --- This can return:
@@ -526,13 +526,13 @@ local record cosmo
   --- - `"S390X"` for IBM System/390 systems
   GetHostIsa: function(): string
   GetHostOs: function(): string | nil
-  GetHttpReason: function(code: number): string
+  GetHttpReason: function(code: integer): string
   --- This is useful for fixed-width formatting. For example, CJK characters
   --- typically take up two cells. This function takes into consideration combining
   --- characters, which are discounted, as well as control codes and ANSI escape
   --- sequences.
-  GetMonospaceWidth: function(str: string | number): number
-  GetRandomBytes: function(length?: number): string | nil, string | nil
+  GetMonospaceWidth: function(str: string | integer): integer
+  GetRandomBytes: function(length?: integer): string | nil, string | nil
   --- Returns `true` if the string contains forbidden control codes.
   --- `flags` selects which characters are considered forbidden and may be
   --- any combination of:
@@ -545,7 +545,7 @@ local record cosmo
   --- If `flags` is zero (the default) then no characters are forbidden
   --- and this function returns `false`. Raises an error if `flags` has
   --- bits outside the values above.
-  HasControlCodes: function(str: string, flags?: number): boolean
+  HasControlCodes: function(str: string, flags?: integer): boolean
   --- Decompresses data.
   --- This function performs the inverse of `Deflate()`. The decompressed
   --- size need not be known in advance: output streams into a growing
@@ -583,10 +583,10 @@ local record cosmo
   --- and numbers greater than 65535 are rejected. See
   --- `isacceptableport.c`.
   IsAcceptablePort: function(str: string): boolean
-  IsLoopbackIp: function(uint32: number): boolean
-  IsPrivateIp: function(uint32: number): boolean
+  IsLoopbackIp: function(uint32: integer): boolean
+  IsPrivateIp: function(uint32: integer): boolean
   --- Note: we intentionally regard TEST-NET IPs as public.
-  IsPublicIp: function(uint32: number): boolean
+  IsPublicIp: function(uint32: integer): boolean
   IsReasonablePath: function(str: string): boolean
   --- Returns `true` if a percent-encoded string is well-formed, i.e.
   --- every `%` byte begins a valid `%XX` sequence where both `X` are hex
@@ -617,7 +617,7 @@ local record cosmo
   --- Returns nil, err for invalid inputs (previously it returned the -1
   --- sentinel, which `FormatIp` rendered as the broadcast address). See also
   --- `FormatIp` for the inverse operation.
-  ParseIp: function(ip: string): number | nil, string | nil
+  ParseIp: function(ip: string): integer | nil, string | nil
   --- Parses `application/x-www-form-urlencoded` key/value parameters,
   --- e.g. `"a=b&c"` becomes `{{"a", "b"}, {"c"}}`. This returns the same
   --- data structure as the `params` field of the `Url` object returned by
@@ -658,10 +658,10 @@ local record cosmo
   --- won't make SIP easy. What it can do is parse HTTP URLs and most
   --- URIs like data:opaque, better in fact than most things which
   --- claim to be URI parsers.
-  ParseUrl: function(url: string, flags?: number): Url
+  ParseUrl: function(url: string, flags?: integer): Url
   --- This linear congruential generator passes practrand and bigcrush. This
   --- generator is safe across `fork()`, threads, and signal handlers.
-  Rand64: function(): number
+  Rand64: function(): integer
   --- Gets IP address associated with hostname.
   --- This function first checks if hostname is already an IP address, in which case
   --- it returns the result of `ParseIp`. Otherwise, it checks HOSTS.TXT on the local
@@ -675,7 +675,7 @@ local record cosmo
   --- If no IP address could be found, then `nil` is returned alongside a string of
   --- unspecified format describing the error. Calls to this function may be wrapped
   --- in `assert()` if an exception is desired.
-  ResolveIp: function(hostname: string): number | nil, string | nil
+  ResolveIp: function(hostname: string): integer | nil, string | nil
   --- Computes SHA256 checksum, returning 32 bytes of binary.
   Sha256: function(str: string): string
   --- Reads all data from file the easy way.
@@ -688,7 +688,7 @@ local record cosmo
   --- This function is uninterruptible so `unix.EINTR` errors will be ignored. This
   --- should only be a concern if you've installed signal handlers. Use the UNIX API
   --- if you need to react to it.
-  Slurp: function(filename: string, i?: number, j?: number): string | nil, string | nil, unix.Errno | nil
+  Slurp: function(filename: string, i?: integer, j?: integer): string | nil, string | nil, unix.Errno | nil
   --- Formats a timestamp using strftime(3) format specifiers.
   --- Common format specifiers:
   --- - `%Y` four-digit year
@@ -706,7 +706,7 @@ local record cosmo
   ---     Strftime("%F %T", os.time())            -- "2024-12-29 15:30:00"
   ---     Strftime("%a, %d %b %Y", 0)             -- "Thu, 01 Jan 1970"
   ---     Strftime("%F %T", os.time(), true)      -- local time instead of UTC
-  Strftime: function(format: string, timestamp?: number, localtime?: boolean): string | nil, string | nil
+  Strftime: function(format: string, timestamp?: integer, localtime?: boolean): string | nil, string | nil
   --- Unescapes URL parameter name or value. Decodes `%XX` hex sequences and
   --- converts `+` to space (common in application/x-www-form-urlencoded).
   --- This is the inverse of EscapeParam.

--- a/lib/types/cosmo/argon2.d.tl
+++ b/lib/types/cosmo/argon2.d.tl
@@ -4,13 +4,13 @@
 
 local record Config
   --- the memory hardness in kibibytes, which defaults to 4096 (4 mibibytes). It's recommended that this be tuned upwards.
-  m_cost: number
+  m_cost: integer
   --- the number of iterations, which defaults to `3`.
-  t_cost: number
+  t_cost: integer
   --- the parallelism factor, which defaults to `1`.
-  parallelism: number
+  parallelism: integer
   --- the number of desired bytes in hash output, which defaults to 32.
-  hash_len: number
+  hash_len: integer
   --- the Argon2 variant: `"argon2id"` blend of other two methods [default], `"argon2i"` maximize resistance to side-channel attacks, or `"argon2d"` maximize resistance to gpu cracking attacks
   variant: Variant
 end

--- a/lib/types/cosmo/lsqlite3.d.tl
+++ b/lib/types/cosmo/lsqlite3.d.tl
@@ -24,7 +24,7 @@ local record Context
   --- Sets the result of a callback function to the error value in `err`.
   result_error: function(self: Context, err: any)
   --- Sets the result of a callback function to the integer `number`
-  result_int: function(self: Context, number: number)
+  result_int: function(self: Context, number: integer)
   --- Sets the result of a callback function to `nil`.
   result_null: function(self: Context)
   --- Sets the result of a callback function to the string in `str`.
@@ -45,19 +45,19 @@ local record Database
   --- `0` if the transaction is to be aborted. All other values will result in
   --- another attempt to perform the transaction. (See the SQLite documentation
   --- for important hints about writing busy handlers.)
-  busy_handler: function(self: Database, func?: function(udata: any, tries: number), udata?: any)
+  busy_handler: function(self: Database, func?: function(udata: any, tries: integer), udata?: any)
   --- Sets a busy handler that waits for `milliseconds` if a transaction cannot proceed.
   --- Calling this function will remove any busy handler set by `db:busy_handler()`;
   --- calling it with an argument less than or equal to `0` will turn off all busy handlers.
-  busy_timeout: function(self: Database, milliseconds: number)
+  busy_timeout: function(self: Database, milliseconds: integer)
   --- Only changes that are directly specified by INSERT, UPDATE, or DELETE
   --- statements are counted. Auxiliary changes caused by triggers are not
   --- counted. Use `db:total_changes()` to find the total number of changes.
-  changes: function(self: Database): number
+  changes: function(self: Database): integer
   --- Closes a database. All SQL statements prepared using `db:prepare()` should
   --- have been finalized before this function is called. The function returns
   --- `lsqlite3.OK` on success or else a numerical error code.
-  close: function(self: Database): number
+  close: function(self: Database): integer
   --- Finalizes all statements that have not been explicitly finalized. If
   --- `temponly` is `true`, only internal, temporary statements are finalized.
   close_vm: function(self: Database, temponly?: boolean)
@@ -91,7 +91,7 @@ local record Database
   --- This prints:
   ---     Sum of col 1:   6
   ---     Sum of col 2:   66
-  create_aggregate: function(self: Database, name: string, nargs: number, step: function(ctx: Context, ...: string | number | nil), final: function(ctx: Context), userdata?: any): boolean
+  create_aggregate: function(self: Database, name: string, nargs: integer, step: function(ctx: Context, ...: string | number | nil), final: function(ctx: Context), userdata?: any): boolean
   --- This creates a collation callback. A collation callback is used to establish
   --- a collation order, mostly for string comparisons and sorting purposes.
   --- A simple example:
@@ -112,7 +112,7 @@ local record Database
   ---    for row in db:nrows('SELECT * FROM test') do
   ---      print(row.id, row.content)
   ---    end
-  create_collation: function(self: Database, name: string, func: (function(s1: string, s2: string): number))
+  create_collation: function(self: Database, name: string, func: (function(s1: string, s2: string): integer))
   --- This function creates a callback function. Callback function are called by
   --- SQLite3 once for every row in a query.
   --- It should accept a function context (see Methods for callback contexts) plus
@@ -128,7 +128,7 @@ local record Database
   ---     for col1,col2,col3,sum in db:urows('SELECT *,sum_cols(col1,col2,col3) FROM test') do
   ---       util.printf('%2i+%2i+%2i=%2i\n',col1,col2,col3,sum)
   ---     end
-  create_function: function(self: Database, name: string, nargs: number, func: function(ctx: Context, ...: any), userdata?: any): boolean
+  create_function: function(self: Database, name: string, nargs: integer, func: function(ctx: Context, ...: any), userdata?: any): boolean
   --- If there is no attached database name on the database connection, then no value is
   --- returned; if database name is a temporary or in-memory database, then an
   --- empty string is returned.
@@ -137,7 +137,7 @@ local record Database
   deserialize: function(self: Database, s: string)
   errcode: function(self: Database): ResultCode
   errmsg: function(self: Database): string
-  exec: function(self: Database, sql: string, func?: (function(udata: any, cols: number, values: {string}, names: {string}): number), udata?: any): ResultCode
+  exec: function(self: Database, sql: string, func?: (function(udata: any, cols: integer, values: {string}, names: {string}): integer), udata?: any): ResultCode
   --- This function causes any pending database operation to abort and return at
   --- the next opportunity.
   interrupt: function(self: Database)
@@ -149,7 +149,7 @@ local record Database
   --- If an INSERT occurs within a trigger, then the rowid of the inserted row is
   --- returned as long as the trigger is running. Once the trigger terminates, the
   --- value returned reverts to the last value inserted before the trigger fired.
-  last_insert_rowid: function(self: Database): number
+  last_insert_rowid: function(self: Database): integer
   --- Creates an iterator that returns the successive rows selected by the
   --- SQL statement given in string `sql`. Each call to the iterator
   --- returns a table in which the named fields correspond to the columns
@@ -206,7 +206,7 @@ local record Database
   --- This includes UPDATE, INSERT and DELETE statements executed as part of trigger
   --- programs. All changes are counted as soon as the statement that produces them
   --- is completed by calling either `stmt:reset()` or `stmt:finalize()`.
-  total_changes: function(self: Database): number
+  total_changes: function(self: Database): integer
   --- This function installs an update_hook Data Change Notification
   --- Callback handler. See: `db:commit_hook` and `db:rollback_hook`
   --- whenever a row is updated, inserted or deleted. This callback
@@ -218,7 +218,7 @@ local record Database
   --- database and table name containing the affected row. The final
   --- callback parameter is the rowid of the row. In the case of an
   --- update, this is the rowid after the update takes place.
-  update_hook: function(self: Database, func: function(udata: any, op: number, db: Database, name: string, rowid: number), udata: any)
+  update_hook: function(self: Database, func: function(udata: any, op: integer, db: Database, name: string, rowid: integer), udata: any)
   --- Creates an iterator that returns the successive rows selected by the SQL
   --- statement given in string sql. Each call to the iterator returns the values
   --- that correspond to the columns in the currently selected row.
@@ -235,8 +235,8 @@ local record Database
   ---     2       22
   ---     3       33
   urows: function(self: Database, sql: string): function, VM
-  wal_checkpoint: function(self: Database, mode?: number, name?: string): number | nil, number, ResultCode | nil
-  wal_hook: function(self: Database, func?: (function(udata: any, db: Database, name: string, page_count: number): number), udata?: any)
+  wal_checkpoint: function(self: Database, mode?: integer, name?: string): integer | nil, integer, ResultCode | nil
+  wal_hook: function(self: Database, func?: (function(udata: any, db: Database, name: string, page_count: integer): integer), udata?: any)
 end
 
 --- After creating a prepared statement with `db:prepare()` the returned statement
@@ -249,16 +249,16 @@ local record Statement
   --- `lua_isinteger`. If `value` is a boolean then it is bound as `0` for
   --- `false` or `1` for `true`. If `value` is `nil` or missing, any
   --- previous binding is removed.
-  bind: function(self: Statement, n: number, value: string | number | boolean | nil): number
+  bind: function(self: Statement, n: integer, value: string | number | boolean | nil): integer
   --- Binds string `blob` (which can be a binary string) as a blob to
   --- statement parameter `n`.
-  bind_blob: function(self: Statement, n: number, blob: string): number
+  bind_blob: function(self: Statement, n: integer, blob: string): integer
   --- Binds the values in `nametable` to statement parameters. If the
   --- statement parameters are named (i.e., of the form `":AAA"` or
   --- `"$AAA"`) then this function looks for appropriately named fields in
   --- nametable; if the statement parameters are not named, it looks for
   --- numerical fields 1 to the number of statement parameters.
-  bind_names: function(self: Statement, nametable: table): number, number
+  bind_names: function(self: Statement, nametable: table): integer, integer
   --- When the statement parameters are of the forms `":AAA"` or `"?"`, then they are
   --- assigned sequentially increasing numbers beginning with one, so the value
   --- returned is the number of parameters. However if the same statement parameter
@@ -268,20 +268,20 @@ local record Statement
   --- integer) then there might be gaps in the numbering and the value returned by
   --- this interface is the index of the statement parameter with the largest index
   --- value.
-  bind_parameter_count: function(self: Statement): number
+  bind_parameter_count: function(self: Statement): integer
   --- Statement parameters of the form `":AAA"` or `"@AAA"` or `"$VVV"` have a name
   --- which is the string `":AAA"` or `"@AAA"` or `"$VVV"`. In other words, the
   --- initial `":"` or `"$"` or `"@"` is included as part of the name. Parameters of
   --- the form `"?"` or `"?NNN"` have no name. The first bound parameter has an index
   --- of `1`. If the value `n` is out of range or if the `n`-th parameter is nameless,
   --- then `nil` is returned.
-  bind_parameter_name: function(self: Statement, n: number): string | nil
+  bind_parameter_name: function(self: Statement, n: integer): string | nil
   --- Binds the given values to statement parameters.
-  bind_values: function(self: Statement, ...: string | number | nil): number
-  columns: function(self: Statement): number
+  bind_values: function(self: Statement, ...: string | number | nil): integer
+  columns: function(self: Statement): integer
   --- This function frees the prepared statement.
-  finalize: function(self: Statement): number
-  get_name: function(self: Statement, n: number): string
+  finalize: function(self: Statement): integer
+  get_name: function(self: Statement, n: integer): string
   get_named_types: function(self: Statement): {string}
   --- Alias for `lsqlite3.Statement:get_named_types()`.
   type: function(self: Statement): {string}
@@ -291,14 +291,14 @@ local record Statement
   get_names: function(self: Statement): {string}
   --- Alias for `lsqlite3.Statement:get_names()`.
   inames: function(self: Statement): {string}
-  get_type: function(self: Statement, n: number): string | nil
+  get_type: function(self: Statement, n: integer): string | nil
   get_types: function(self: Statement): {string}
   --- Alias for `lsqlite3.Statement:get_types()`.
   itypes: function(self: Statement): {string}
   get_unames: function(self: Statement): string...
   get_utypes: function(self: Statement): string...
   get_uvalues: function(self: Statement): string | number | nil
-  get_value: function(self: Statement, n: number): string | number | nil
+  get_value: function(self: Statement, n: integer): string | number | nil
   get_values: function(self: Statement): {string | number | nil}
   --- Alias for `lsqlite3.Statement:get_values()`.
   idata: function(self: Statement): {string | number | nil}
@@ -334,20 +334,20 @@ local record Statement
   --- Each iteration returns the values for the current row. This is the prepared
   --- statement equivalent of `db:urows()`.
   urows: function(self: Statement): function(self: VM): any...
-  last_insert_rowid: function(self: Statement): number
+  last_insert_rowid: function(self: Statement): integer
 end
 
 local record VM
   userdata
-  bind: function(self: VM, index: number, value: string | number | boolean | nil): number
-  bind_blob: function(self: VM, index: number, value: string): number
-  bind_names: function(self: VM, names: {string}): number
-  bind_parameter_count: function(self: VM): number
+  bind: function(self: VM, index: integer, value: string | number | boolean | nil): integer
+  bind_blob: function(self: VM, index: integer, value: string): integer
+  bind_names: function(self: VM, names: {string}): integer
+  bind_parameter_count: function(self: VM): integer
   bind_parameter_name: function(self: VM, index: number): string
-  bind_values: function(self: VM, ...: string | number | nil): number
-  columns: function(self: VM): number
-  finalize: function(self: VM): number
-  get_name: function(self: VM, index: number): string
+  bind_values: function(self: VM, ...: string | number | nil): integer
+  columns: function(self: VM): integer
+  finalize: function(self: VM): integer
+  get_name: function(self: VM, index: integer): string
   get_named_types: function(self: VM): {string}
   --- Alias for `lsqlite3.VM:get_named_types()`.
   type: function(self: VM): {string}
@@ -357,19 +357,19 @@ local record VM
   get_names: function(self: VM): {string}
   --- Alias for `lsqlite3.VM:get_names()`.
   inames: function(self: VM): {string}
-  get_type: function(self: VM, index: number): string | nil
+  get_type: function(self: VM, index: integer): string | nil
   get_types: function(self: VM): {string}
   --- Alias for `lsqlite3.VM:get_types()`.
   itypes: function(self: VM): {string}
   get_unames: function(self: VM): string...
   get_utypes: function(self: VM): string...
   get_uvalues: function(self: VM): string | number | nil
-  get_value: function(self: VM, index: number): string | number | nil
+  get_value: function(self: VM, index: integer): string | number | nil
   get_values: function(self: VM): {string | number | nil}
   --- Alias for `lsqlite3.VM:get_values()`.
   idata: function(self: VM): {string | number | nil}
   isopen: function(self: VM): boolean
-  last_insert_rowid: function(self: VM): number
+  last_insert_rowid: function(self: VM): integer
   nrows: function(self: VM, sql: string): function(self: VM): {string: string | number}
   --- Returns `true` if the prepared statement makes no direct changes to
   --- the content of the database file, `false` otherwise.
@@ -383,11 +383,11 @@ end
 --- SQLite result/status code (the OK/ERROR/BUSY/DONE/ROW/... family
 --- of lsqlite3.* integer constants; see the SC() table in
 --- tool/net/lsqlite3.c).
-local type ResultCode = number
+local type ResultCode = integer
 
 --- Bitmask of lsqlite3.OPEN_* flags accepted by `lsqlite3.open` (see
 --- https://www.sqlite.org/c3ref/open.html).
-local type OpenFlag = number
+local type OpenFlag = integer
 
 local record lsqlite3
   type Context = Context
@@ -400,10 +400,10 @@ local record lsqlite3
   --- The `lsqlite3.OK` result code means that the operation was successful
   --- and that there were no errors. Most other result codes indicate an
   --- error.
-  OK: number
+  OK: integer
   --- The `lsqlite3.ERROR` result code is a generic error code that is used
   --- when no other more specific error code is available.
-  ERROR: number
+  ERROR: integer
   --- The `lsqlite3.INTERNAL` result code indicates an internal malfunction.
   --- In a working version of SQLite, an application should never see this
   --- result code. If application does encounter this result code, it shows
@@ -411,10 +411,10 @@ local record lsqlite3
   --- SQLite does not currently generate this result code. However,
   --- application-defined SQL functions or virtual tables, or VFSes, or other
   --- extensions might cause this result code to be returned.
-  INTERNAL: number
+  INTERNAL: integer
   --- The `lsqlite3.PERM` result code indicates that the requested access mode
   --- for a newly created database could not be provided.
-  PERM: number
+  PERM: integer
   --- The `lsqlite3.ABORT` result code indicates that an operation was aborted
   --- prior to completion, usually be application request. See also:
   --- `lsqlite3.INTERRUPT`.
@@ -423,7 +423,7 @@ local record lsqlite3
   --- If a ROLLBACK operation occurs on the same database connection as a
   --- pending read or write, then the pending read or write may fail with an
   --- `lsqlite3.ABORT` error.
-  ABORT: number
+  ABORT: integer
   --- The lsqlite3.BUSY result code indicates that the database file could not
   --- be written (or in some cases read) because of concurrent activity by
   --- some other database connection, usually a database connection in a
@@ -447,7 +447,7 @@ local record lsqlite3
   --- connection, probably in a separate process, whereas `lsqlite3.LOCKED`
   --- indicates a conflict within the same database connection (or sometimes
   --- a database connection with a shared cache).
-  BUSY: number
+  BUSY: integer
   --- The `lsqlite3.LOCKED` result code indicates that a write operation could
   --- not continue because of a conflict within the same database connection
   --- or a conflict with a different database connection that uses a shared
@@ -461,32 +461,32 @@ local record lsqlite3
   --- (or on a connection with a shared cache) whereas `lsqlite3.BUSY`
   --- indicates a conflict with a different database connection, probably in
   --- a different process.
-  LOCKED: number
+  LOCKED: integer
   --- The `lsqlite3.NOMEM` result code indicates that SQLite was unable to
   --- allocate all the memory it needed to complete the operation. In other
   --- words, an internal call to `sqlite3_malloc()` or `sqlite3_realloc()` has
   --- failed in a case where the memory being allocated was required in order
   --- to continue the operation.
-  NOMEM: number
+  NOMEM: integer
   --- The `lsqlite3.READONLY` result code is returned when an attempt is made
   --- to alter some data for which the current database connection does not
   --- have write permission.
-  READONLY: number
+  READONLY: integer
   --- The `lsqlite3.INTERRUPT` result code indicates that an operation was
   --- interrupted by the `sqlite3_interrupt()` interface. See also:
   --- `lsqlite3.ABORT`
-  INTERRUPT: number
+  INTERRUPT: integer
   --- The `lsqlite3.IOERR` result code says that the operation could not
   --- finish because the operating system reported an I/O error.
   --- A full disk drive will normally give an `lsqlite3.FULL` error rather
   --- than an `lsqlite3.IOERR` error.
   --- There are many different extended result codes for I/O errors that
   --- identify the specific I/O operation that failed.
-  IOERR: number
+  IOERR: integer
   --- The `lsqlite3.CORRUPT` result code indicates that the database file has
   --- been corrupted. See [How To Corrupt Your Database Files](https://www.sqlite.org/lockingv3.html#how_to_corrupt)
   --- for further discussion on how corruption can occur.
-  CORRUPT: number
+  CORRUPT: integer
   --- The `lsqlite3.NOTFOUND` result code is exposed in three ways:
   --- `lsqlite3.NOTFOUND` can be returned by the `sqlite3_file_control()`
   --- interface to indicate that the file control opcode passed as the third
@@ -499,7 +499,7 @@ local record lsqlite3
   --- The `lsqlite3.NOTFOUND` result code is also used internally by the
   --- SQLite implementation, but those internal uses are not exposed to the
   --- application.
-  NOTFOUND: number
+  NOTFOUND: integer
   --- The `lsqlite3.FULL` result code indicates that a write could not
   --- complete because the disk is full. Note that this error can occur when
   --- trying to write information into the main database file, or it can also
@@ -508,11 +508,11 @@ local record lsqlite3
   --- abundance of primary disk space because the error occurs when writing
   --- into temporary disk files on a system where temporary files are stored
   --- on a separate partition with much less space that the primary disk.
-  FULL: number
+  FULL: integer
   --- The `lsqlite3.CANTOPEN` result code indicates that SQLite was unable to
   --- open a file. The file in question might be a primary database file or
   --- one of several temporary disk files.
-  CANTOPEN: number
+  CANTOPEN: integer
   --- The `lsqlite3.PROTOCOL` result code indicates a problem with the file
   --- locking protocol used by SQLite. The `lsqlite3.PROTOCOL` error is
   --- currently only returned when using WAL mode and attempting to start a
@@ -525,9 +525,9 @@ local record lsqlite3
   --- appear in practice very, very rarely, and only when there are many
   --- separate processes all competing intensely to write to the same
   --- database.
-  PROTOCOL: number
+  PROTOCOL: integer
   --- The `lsqlite3.EMPTY` result code is not currently used.
-  EMPTY: number
+  EMPTY: integer
   --- The `lsqlite3.SCHEMA` result code indicates that the database schema has
   --- changed. This result code can be returned from `Statement:step()`. If
   --- the database schema was changed by some other process in between the
@@ -537,7 +537,7 @@ local record lsqlite3
   --- `SQLITE_MAX_SCHEMA_RETRY` times (default: 50). The `step()` interface
   --- will only return `lsqlite3.SCHEMA` back to the application if the
   --- failure persists after these many retries.
-  SCHEMA: number
+  SCHEMA: integer
   --- The `lsqlite3.TOOBIG` error code indicates that a string or BLOB was too
   --- large. The default maximum length of a string or BLOB in SQLite is
   --- 1,000,000,000 bytes. This maximum length can be changed at compile-time
@@ -548,7 +548,7 @@ local record lsqlite3
   --- statement is passed into one of the `db:prepare()` interface. The
   --- maximum length of an SQL statement defaults to a much smaller value of
   --- 1,000,000,000 bytes.
-  TOOBIG: number
+  TOOBIG: integer
   --- The `lsqlite3.CONSTRAINT` error code means that an SQL constraint
   --- violation occurred while trying to process an SQL statement. Additional
   --- information about the failed constraint can be found by consulting the
@@ -560,7 +560,7 @@ local record lsqlite3
   --- particular combination of inputs submitted to `xBestIndex()` cannot
   --- result in a usable query plan and should not be given further
   --- consideration.
-  CONSTRAINT: number
+  CONSTRAINT: integer
   --- SQLite is normally very forgiving about mismatches between the type of a
   --- value and the declared type of the container in which that value is to
   --- be stored. For example, SQLite allows the application to store a large
@@ -571,7 +571,7 @@ local record lsqlite3
   --- anything other than an integer (or a NULL which will be automatically
   --- converted into the next available integer rowid) results in an
   --- `lsqlite3.MISMATCH` error.
-  MISMATCH: number
+  MISMATCH: integer
   --- The `lsqlite3.MISUSE` return code might be returned if the application
   --- uses any SQLite interface in a way that is undefined or unsupported. For
   --- example, using a prepared statement after that prepared statement has
@@ -585,115 +585,115 @@ local record lsqlite3
   --- ship an application that sometimes returns `lsqlite3.MISUSE` from a
   --- standard SQLite interface because that application contains potentially
   --- serious bugs.
-  MISUSE: number
+  MISUSE: integer
   --- The `lsqlite3.NOLFS` error can be returned on systems that do not
   --- support large files when the database grows to be larger than what the
   --- filesystem can handle. "NOLFS" stands for "NO Large File Support".
-  NOLFS: number
+  NOLFS: integer
   --- The `lsqlite3.FORMAT` error code is not currently used by SQLite.
-  FORMAT: number
+  FORMAT: integer
   --- The `lsqlite3.RANGE` error indices that the parameter number argument to
   --- one of the `bind` routines or the column number in one of the `column`
   --- routines is out of range.
-  RANGE: number
+  RANGE: integer
   --- When attempting to open a file, the `lsqlite3.NOTADB` error indicates
   --- that the file being opened does not appear to be an SQLite database
   --- file.
-  NOTADB: number
+  NOTADB: integer
   --- The `lsqlite3.ROW` result code returned by sqlite3_step() indicates that
   --- another row of output is available.
-  ROW: number
+  ROW: integer
   --- The `lsqlite3.DONE` result code indicates that an operation has
   --- completed. The `lsqlite3.DONE` result code is most commonly seen as a
   --- return value from `step()` indicating that the SQL statement has run to
   --- completion, but `lsqlite3.DONE` can also be returned by other multi-step
   --- interfaces.
-  DONE: number
-  CREATE_INDEX: number
-  CREATE_TABLE: number
-  CREATE_TEMP_INDEX: number
-  CREATE_TEMP_TABLE: number
-  CREATE_TEMP_TRIGGER: number
-  CREATE_TEMP_VIEW: number
-  CREATE_TRIGGER: number
-  CREATE_VIEW: number
-  DELETE: number
-  DROP_INDEX: number
-  DROP_TABLE: number
-  DROP_TEMP_INDEX: number
-  DROP_TEMP_TABLE: number
-  DROP_TEMP_TRIGGER: number
-  DROP_TEMP_VIEW: number
-  DROP_TRIGGER: number
-  DROP_VIEW: number
-  INSERT: number
-  PRAGMA: number
-  READ: number
-  SELECT: number
-  TRANSACTION: number
-  UPDATE: number
-  ATTACH: number
-  DETACH: number
-  ALTER_TABLE: number
-  REINDEX: number
-  ANALYZE: number
-  CREATE_VTABLE: number
-  DROP_VTABLE: number
-  FUNCTION: number
-  SAVEPOINT: number
+  DONE: integer
+  CREATE_INDEX: integer
+  CREATE_TABLE: integer
+  CREATE_TEMP_INDEX: integer
+  CREATE_TEMP_TABLE: integer
+  CREATE_TEMP_TRIGGER: integer
+  CREATE_TEMP_VIEW: integer
+  CREATE_TRIGGER: integer
+  CREATE_VIEW: integer
+  DELETE: integer
+  DROP_INDEX: integer
+  DROP_TABLE: integer
+  DROP_TEMP_INDEX: integer
+  DROP_TEMP_TABLE: integer
+  DROP_TEMP_TRIGGER: integer
+  DROP_TEMP_VIEW: integer
+  DROP_TRIGGER: integer
+  DROP_VIEW: integer
+  INSERT: integer
+  PRAGMA: integer
+  READ: integer
+  SELECT: integer
+  TRANSACTION: integer
+  UPDATE: integer
+  ATTACH: integer
+  DETACH: integer
+  ALTER_TABLE: integer
+  REINDEX: integer
+  ANALYZE: integer
+  CREATE_VTABLE: integer
+  DROP_VTABLE: integer
+  FUNCTION: integer
+  SAVEPOINT: integer
   --- The database is created if it does not already exist.
-  OPEN_CREATE: number
+  OPEN_CREATE: integer
   --- The database is opened with shared cache disabled, overriding the
   --- default shared cache setting provided by sqlite3_enable_shared_cache().
-  OPEN_PRIVATECACHE: number
+  OPEN_PRIVATECACHE: integer
   --- The new database connection will use the "serialized" threading mode.
   --- This means the multiple threads can safely attempt to use the same
   --- database connection at the same time. (Mutexes will block any actual
   --- concurrency, but in this mode there is no harm in trying.)
-  OPEN_FULLMUTEX: number
+  OPEN_FULLMUTEX: integer
   --- The new database connection will use the "multi-thread" threading mode.
   --- This means that separate threads are allowed to use SQLite at the same
   --- time, as long as each thread is using a different database connection.
-  OPEN_NOMUTEX: number
+  OPEN_NOMUTEX: integer
   --- The database will be opened as an in-memory database. The database is
   --- named by the "filename" argument for the purposes of cache-sharing, if
   --- shared cache mode is enabled, but the "filename" is otherwise ignored.
-  OPEN_MEMORY: number
+  OPEN_MEMORY: integer
   --- The filename can be interpreted as a URI if this flag is set. See
   --- https://www.sqlite.org/c3ref/open.html
-  OPEN_URI: number
+  OPEN_URI: integer
   --- The database is opened for reading and writing if possible, or reading
   --- only if the file is write protected by the operating system. In either
   --- case the database must already exist, otherwise an error is returned.
-  OPEN_READWRITE: number
+  OPEN_READWRITE: integer
   --- The database is opened in read-only mode. If the database does not
   --- already exist, an error is returned.
-  OPEN_READONLY: number
+  OPEN_READONLY: integer
   --- The database is opened shared cache enabled, overriding the default
   --- shared cache setting provided by sqlite3_enable_shared_cache(). The use
   --- of shared cache mode is discouraged and hence shared cache capabilities
   --- may be omitted from many builds of SQLite. In such cases, this option is
   --- a no-op.
-  OPEN_SHAREDCACHE: number
-  TEXT: number
-  BLOB: number
-  NULL: number
-  FLOAT: number
-  INTEGER: number
-  CONFIG_SINGLETHREAD: number
-  CONFIG_MULTITHREAD: number
-  CONFIG_SERIALIZED: number
-  CONFIG_LOG: number
+  OPEN_SHAREDCACHE: integer
+  TEXT: integer
+  BLOB: integer
+  NULL: integer
+  FLOAT: integer
+  INTEGER: integer
+  CONFIG_SINGLETHREAD: integer
+  CONFIG_MULTITHREAD: integer
+  CONFIG_SERIALIZED: integer
+  CONFIG_LOG: integer
   --- for any database readers or writers to finish. See `db:wal_checkpoint`.
-  CHECKPOINT_PASSIVE: number
+  CHECKPOINT_PASSIVE: integer
   --- reading from the most recent database snapshot, then checkpoints all
   --- frames. See `db:wal_checkpoint`.
-  CHECKPOINT_FULL: number
+  CHECKPOINT_FULL: integer
   --- blocks until all readers are reading from the database file only.
   --- See `db:wal_checkpoint`.
-  CHECKPOINT_RESTART: number
+  CHECKPOINT_RESTART: integer
   --- truncates the log file before returning. See `db:wal_checkpoint`.
-  CHECKPOINT_TRUNCATE: number
+  CHECKPOINT_TRUNCATE: integer
 
   --- Opens (or creates if it does not exist) an SQLite database with name filename
   --- and returns its handle as userdata (the returned object should be used for all
@@ -724,7 +724,7 @@ local record lsqlite3
   ---   removes the current callback when `func` is `nil`. Returns
   ---   `lsqlite3.OK` followed by the previously installed callback and its
   ---   user data.
-  config: function(option: number, func?: function, udata?: any): number | nil, function | nil, any, number | nil
+  config: function(option: integer, func?: function, udata?: any): integer | nil, function | nil, any, integer | nil
 end
 
 return lsqlite3

--- a/lib/types/cosmo/re.d.tl
+++ b/lib/types/cosmo/re.d.tl
@@ -21,11 +21,11 @@ end
 --- Bitmask of compilation flags accepted by `re.compile` and
 --- `re.search` (`re.BASIC`, `re.ICASE`, `re.NEWLINE`, `re.NOSUB`;
 --- masked in `tool/net/lre.c`).
-local type CompileFlag = number
+local type CompileFlag = integer
 
 --- Bitmask of search-time flags accepted by `re.search` and
 --- `re.Regex:search` (`re.NOTBOL`, `re.NOTEOL`).
-local type SearchFlag = number
+local type SearchFlag = integer
 
 local record re
   type Regex = Regex
@@ -33,60 +33,60 @@ local record re
   type SearchFlag = SearchFlag
 
   --- No match
-  NOMATCH: number
+  NOMATCH: integer
   --- Invalid regex
-  BADPAT: number
+  BADPAT: integer
   --- Unknown collating element
-  ECOLLATE: number
+  ECOLLATE: integer
   --- Unknown character class name
-  ECTYPE: number
+  ECTYPE: integer
   --- Trailing backslash
-  EESCAPE: number
+  EESCAPE: integer
   --- Invalid back reference
-  ESUBREG: number
+  ESUBREG: integer
   --- Missing ]
-  EBRACK: number
+  EBRACK: integer
   --- Missing )
-  EPAREN: number
+  EPAREN: integer
   --- Missing }
-  EBRACE: number
+  EBRACE: integer
   --- Invalid contents of {}
-  BADBR: number
+  BADBR: integer
   --- Invalid character range.
-  ERANGE: number
+  ERANGE: integer
   --- Out of memory
-  ESPACE: number
+  ESPACE: integer
   --- Repetition not preceded by valid expression
-  BADRPT: number
+  BADRPT: integer
   --- Use this flag if you prefer the default POSIX regex syntax.
   --- We use extended regex notation by default. For example, an extended regular
   --- expression for matching an IP address might look like
   --- `([0-9]*)\.([0-9]*)\.([0-9]*)\.([0-9]*)` whereas with basic syntax it would
   --- look like `\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)`.
   --- This flag may only be used with `re.compile` and `re.search`.
-  BASIC: number
+  BASIC: integer
   --- Use this flag if you prefer the default POSIX regex syntax. We use extended
   ---  regex notation by default. For example, an extended regular expression for
   --- matching an IP address might look like `([0-9]*)\.([0-9]*)\.([0-9]*)\.([0-9]*)`
   --- whereas with basic syntax it would look like `\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)`.
   --- This flag may only be used with `re.compile` and `re.search`.
-  ICASE: number
+  ICASE: integer
   --- Use this flag to change the handling of NEWLINE (\x0a) characters. When this
   --- flag is set, (1) a NEWLINE shall not be matched by a "." or any form of a
   --- non-matching list, (2) a "^" shall match the zero-length string immediately
   --- after a NEWLINE (regardless of `re.NOTBOL`), and (3) a "$" shall match the
   --- zero-length string immediately before a NEWLINE (regardless of `re.NOTEOL`).
-  NEWLINE: number
+  NEWLINE: integer
   --- Causes `re.search` to only report success and failure. This is reported via
   --- the API by returning empty string for success. This flag may only be used
   --- ` with `re.compile` and `re.search`.
-  NOSUB: number
+  NOSUB: integer
   --- The first character of the string pointed to by string is not the beginning
   --- of the line. This flag may only be used with `re.search` and `regex_t*:search`.
-  NOTBOL: number
+  NOTBOL: integer
   --- The last character of the string pointed to by string is not the end of the
   --- line. This flag may only be used with `re.search` and `regex_t*:search`.
-  NOTEOL: number
+  NOTEOL: integer
 
   --- Searches for regular expression match in text.
   --- This is a shorthand notation roughly equivalent to:

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -20,19 +20,19 @@ end
 
 local record Termios
   --- Input mode flags (e.g. `unix.BRKINT`, `unix.ICRNL`).
-  iflag: number
+  iflag: integer
   --- Output mode flags (e.g. `unix.OPOST`, `unix.ONLCR`).
-  oflag: number
+  oflag: integer
   --- Control mode flags (e.g. `unix.CS8`, `unix.CREAD`).
-  cflag: number
+  cflag: integer
   --- Local mode flags (e.g. `unix.ECHO`, `unix.ICANON`).
-  lflag: number
+  lflag: integer
   --- Control characters array (indexed 1 to `unix.NCCS`).
-  cc: {number}
+  cc: {integer}
   --- Input baud rate.
-  ispeed: number
+  ispeed: integer
   --- Output baud rate.
-  ospeed: number
+  ospeed: integer
 end
 
 --- Shared memory for inter-process communication.
@@ -56,7 +56,7 @@ local record Memory
   --- This operation happens atomically. Each shared mapping has a
   --- single lock which is used to synchronize reads and writes to
   --- that specific map. To make it scale, create additional maps.
-  read: function(self: Memory, offset?: number, bytes?: number): string
+  read: function(self: Memory, offset?: integer, bytes?: integer): string
   --- Writes bytes to memory region.
   --- `offset` is the starting byte index to which memory is copied,
   --- which defaults to zero.
@@ -66,19 +66,19 @@ local record Memory
   --- This operation happens atomically. Each shared mapping has a
   --- single lock which is used to synchronize reads and writes to
   --- that specific map. To make it scale, create additional maps.
-  write: function(self: Memory, data: string, offset?: number, bytes?: number)
+  write: function(self: Memory, data: string, offset?: integer, bytes?: integer)
   --- Loads word from memory region.
   --- This operation is atomic and has relaxed barrier semantics.
-  load: function(self: Memory, word_index: number): number
+  load: function(self: Memory, word_index: integer): integer
   --- Stores word from memory region.
   --- This operation is atomic and has relaxed barrier semantics.
-  store: function(self: Memory, word_index: number, value: number)
+  store: function(self: Memory, word_index: integer, value: integer)
   --- Exchanges value.
   --- This sets word at `word_index` to `value` and returns the value
   --- previously held in by the word.
   --- This operation is atomic and provides the same memory barrier
   --- semantics as the aligned x86 LOCK XCHG instruction.
-  xchg: function(self: Memory, word_index: number, value: number): number
+  xchg: function(self: Memory, word_index: integer, value: integer): integer
   --- Compares and exchanges value.
   --- This inspects the word at `word_index` and if its value is the same
   --- as `old` then it'll be replaced by the value `new`, in which case
@@ -86,26 +86,26 @@ local record Memory
   --- word, then `false` shall be returned along with the word.
   --- This operation happens atomically and provides the same memory
   --- barrier semantics as the aligned x86 LOCK CMPXCHG instruction.
-  cmpxchg: function(self: Memory, word_index: number, old: number, new: number): boolean, number
+  cmpxchg: function(self: Memory, word_index: integer, old: integer, new: integer): boolean, integer
   --- Fetches then adds value.
   --- This method modifies the word at `word_index` to contain the sum of
   --- value and the `value` paremeter. This method then returns the value
   --- as it existed before the addition was performed.
   --- This operation is atomic and provides the same memory barrier
   --- semantics as the aligned x86 LOCK XADD instruction.
-  fetch_add: function(self: Memory, word_index: number, value: number): number
+  fetch_add: function(self: Memory, word_index: integer, value: integer): integer
   --- Fetches and bitwise ands value.
   --- This operation happens atomically and provides the same memory
   --- barrier ordering semantics as its x86 implementation.
-  fetch_and: function(self: Memory, word_index: number, value: number): number
+  fetch_and: function(self: Memory, word_index: integer, value: integer): integer
   --- Fetches and bitwise ors value.
   --- This operation happens atomically and provides the same memory
   --- barrier ordering semantics as its x86 implementation.
-  fetch_or: function(self: Memory, word_index: number, value: number): number
+  fetch_or: function(self: Memory, word_index: integer, value: integer): integer
   --- Fetches and bitwise xors value.
   --- This operation happens atomically and provides the same memory
   --- barrier ordering semantics as its x86 implementation.
-  fetch_xor: function(self: Memory, word_index: number, value: number): number
+  fetch_xor: function(self: Memory, word_index: integer, value: integer): integer
   --- Waits for word to have a different value.
   --- This method asks the kernel to suspend the process until either the
   --- absolute deadline expires or we're woken up by another process that
@@ -146,14 +146,14 @@ local record Memory
   --- `EAGAIN` is raised if, upon entry, the word at `word_index` had a
   --- different value than what's specified at `expect`.
   --- `ETIMEDOUT` is raised when the absolute deadline expires.
-  wait: function(self: Memory, word_index: number, expect: number, abs_deadline?: number, nanos?: number): number | nil, string | nil, Errno | nil
+  wait: function(self: Memory, word_index: integer, expect: integer, abs_deadline?: integer, nanos?: integer): integer | nil, string | nil, Errno | nil
   --- Wakes other processes waiting on word.
   --- This method may be used to signal or broadcast to waiters. The
   --- `count` specifies the number of processes that should be woken,
   --- which defaults to `INT_MAX`.
   --- The return value is the number of processes that were actually woken
   --- as a result of the system call. No failure conditions are defined.
-  wake: function(self: Memory, index: number, count?: number): number
+  wake: function(self: Memory, index: integer, count?: integer): integer
 end
 
 --- Directory handle for reading directory entries.
@@ -178,10 +178,10 @@ local record Dir
   --- - `DT_UNKNOWN`
   --- Note: This function also serves as the `__call` metamethod, so that
   --- `unix.Dir` objects may be used as a for loop iterator.
-  read: function(self: Dir): string | nil, number, number, number
+  read: function(self: Dir): string | nil, integer, integer, integer
   --- Returns `EOPNOTSUPP` if using a `/zip/...` path or if using Windows NT.
-  fd: function(self: Dir): number | nil, string | nil, Errno | nil
-  tell: function(self: Dir): number | nil, string | nil, Errno | nil
+  fd: function(self: Dir): integer | nil, string | nil, Errno | nil
+  tell: function(self: Dir): integer | nil, string | nil, Errno | nil
   --- Resets stream back to beginning.
   rewind: function(self: Dir)
 end
@@ -193,13 +193,13 @@ local record Rusage
   userdata
   --- It's always the case that `0 ≤ nanos < 1e9`.
   --- On Windows NT this is collected from GetProcessTimes().
-  utime: function(self: Rusage): number, number
+  utime: function(self: Rusage): integer, integer
   --- It's always the case that `0 ≤ nanos < 1e9`.
   --- On Windows NT this is collected from GetProcessTimes().
-  stime: function(self: Rusage): number, number
+  stime: function(self: Rusage): integer, integer
   --- On Windows NT this is collected from
   --- `NtProcessMemoryCountersEx::PeakWorkingSetSize / 1024`.
-  maxrss: function(self: Rusage): number
+  maxrss: function(self: Rusage): integer
   --- If you chart memory usage over the lifetime of your process, then
   --- this would be the space filled in beneath the chart. The frequency
   --- of kernel scheduling is defined as `unix.CLK_TCK`.  Each time a tick
@@ -207,7 +207,7 @@ local record Rusage
   --- it to this value. You can derive the average consumption from this
   --- value by computing how many ticks are in `utime + stime`.
   --- Currently only available on FreeBSD and NetBSD.
-  idrss: function(self: Rusage): number
+  idrss: function(self: Rusage): integer
   --- If you chart memory usage over the lifetime of your process, then
   --- this would be the space filled in beneath the chart. The frequency
   --- of kernel scheduling is defined as unix.CLK_TCK.  Each time a tick
@@ -215,7 +215,7 @@ local record Rusage
   --- it to this value. You can derive the average consumption from this
   --- value by computing how many ticks are in `utime + stime`.
   --- Currently only available on FreeBSD and NetBSD.
-  ixrss: function(self: Rusage): number
+  ixrss: function(self: Rusage): integer
   --- If you chart memory usage over the lifetime of your process, then
   --- this would be the space filled in beneath the chart. The frequency
   --- of kernel scheduling is defined as `unix.CLK_TCK`. Each time a tick
@@ -225,43 +225,43 @@ local record Rusage
   --- This is only applicable to redbean if its built with MODE=tiny,
   --- because redbean likes to allocate its own deterministic stack.
   --- Currently only available on FreeBSD and NetBSD.
-  isrss: function(self: Rusage): number
+  isrss: function(self: Rusage): integer
   --- This number indicates how many times redbean was preempted by the
   --- kernel to `memcpy()` a 4096-byte page. This is one of the tradeoffs
   --- `fork()` entails. This number is usually tinier, when your binaries
   --- are tinier.
   --- Not available on Windows NT.
-  minflt: function(self: Rusage): number
+  minflt: function(self: Rusage): integer
   --- Returns number of major page faults.
   --- This number indicates how many times redbean was preempted by the
   --- kernel to perform i/o. For example, you might have used `mmap()` to
   --- load a large file into memory lazily.
   --- On Windows NT this is `NtProcessMemoryCountersEx::PageFaultCount`.
-  majflt: function(self: Rusage): number
+  majflt: function(self: Rusage): integer
   --- Operating systems like to reserve hard disk space to back their RAM
   --- guarantees, like using a gold standard for fiat currency. When your
   --- system is under heavy memory load, swap operations may happen while
   --- redbean is working. This number keeps track of them.
   --- Not available on Linux, Windows NT.
-  nswap: function(self: Rusage): number
+  nswap: function(self: Rusage): integer
   --- On Windows NT this is `NtIoCounters::ReadOperationCount`.
-  inblock: function(self: Rusage): number
+  inblock: function(self: Rusage): integer
   --- On Windows NT this is `NtIoCounters::WriteOperationCount`.
-  oublock: function(self: Rusage): number
+  oublock: function(self: Rusage): integer
   --- Not available on Linux, Windows NT.
-  msgsnd: function(self: Rusage): number
+  msgsnd: function(self: Rusage): integer
   --- Not available on Linux, Windows NT.
-  msgrcv: function(self: Rusage): number
+  msgrcv: function(self: Rusage): integer
   --- Not available on Linux.
-  nsignals: function(self: Rusage): number
+  nsignals: function(self: Rusage): integer
   --- This number is a good thing. It means your redbean finished its work
   --- quickly enough within a time slice that it was able to give back the
   --- remaining time to the system.
-  nvcsw: function(self: Rusage): number
+  nvcsw: function(self: Rusage): integer
   --- This number is a bad thing. It means your redbean was preempted by a
   --- higher priority process after failing to finish its work, within the
   --- allotted time slice.
-  nivcsw: function(self: Rusage): number
+  nivcsw: function(self: Rusage): integer
 end
 
 --- File metadata and attributes.
@@ -270,7 +270,7 @@ end
 --- Use `unix.S_ISDIR()`, `unix.S_ISREG()`, etc. to check file type from mode.
 local record Stat
   userdata
-  size: function(self: Stat): number
+  size: function(self: Stat): integer
   --- Contains file type and permissions.
   --- For example, `0010644` is what you might see for a file and
   --- `0040755` is what you might see for a directory.
@@ -282,9 +282,9 @@ local record Stat
   --- - `unix.S_ISBLK(st:mode())` means block device
   --- - `unix.S_ISFIFO(st:mode())` means fifo or pipe
   --- - `unix.S_ISSOCK(st:mode())` means socket
-  mode: function(self: Stat): number
-  uid: function(self: Stat): number
-  gid: function(self: Stat): number
+  mode: function(self: Stat): integer
+  uid: function(self: Stat): integer
+  gid: function(self: Stat): integer
   --- File birth time.
   --- This field should be accurate on Apple, Windows, and BSDs. On Linux
   --- this is the minimum of atim/mtim/ctim. On Windows NT nanos is only
@@ -296,67 +296,67 @@ local record Stat
   ---   Write('%.4d-%.2d-%.2dT%.2d:%.2d:%.2d.%.9d%+.2d%.2d % {
   ---            year, mon, mday, hour, min, sec, nanos,
   ---            gmtoffsec / (60 * 60), math.abs(gmtoffsec) % 60})
-  birthtim: function(self: Stat): number, number
-  mtim: function(self: Stat): number, number
+  birthtim: function(self: Stat): integer, integer
+  mtim: function(self: Stat): integer, integer
   --- Please note that file systems are sometimes mounted with `noatime`
   --- out of concern for i/o performance. Linux also provides `O_NOATIME`
   --- as an option for open().
   --- On Windows NT this is the same as birth time.
-  atim: function(self: Stat): number, number
+  atim: function(self: Stat): integer, integer
   --- Means time file status was last changed on UNIX.
   --- On Windows NT this is the same as birth time.
-  ctim: function(self: Stat): number, number
+  ctim: function(self: Stat): integer, integer
   --- This provides some indication of how much physical storage a file
   --- actually consumes. For example, for small file systems, your system
   --- might report this number as being 8, which means 4096 bytes.
-  blocks: function(self: Stat): number
+  blocks: function(self: Stat): integer
   --- This field might be of assistance in computing optimal i/o sizes.
   --- Please note this field has no relationship to blocks, as the latter
   --- is fixed at a 512 byte size.
-  blksize: function(self: Stat): number
+  blksize: function(self: Stat): integer
   --- This can be used to detect some other process used `rename()` to swap
   --- out a file underneath you, so you can do a refresh. redbean does it
   --- during each main process heartbeat for its own use cases.
   --- On Windows NT this is set to `NtByHandleFileInformation::FileIndex`.
-  ino: function(self: Stat): number
+  ino: function(self: Stat): integer
   --- On Windows NT this is set to `NtByHandleFileInformation::VolumeSerialNumber`.
-  dev: function(self: Stat): number
+  dev: function(self: Stat): integer
   --- This value may be set to `0` or `-1` for files that aren't devices,
   --- depending on the operating system. `unix.major()` and `unix.minor()`
   --- may be used to extract the device numbers.
-  rdev: function(self: Stat): number
-  nlink: function(self: Stat): number
-  gen: function(self: Stat): number
-  flags: function(self: Stat): number
+  rdev: function(self: Stat): integer
+  nlink: function(self: Stat): integer
+  gen: function(self: Stat): integer
+  flags: function(self: Stat): integer
 end
 
 --- Filesystem statistics returned by `statfs()` and `fstatfs()`.
 local record Statfs
   userdata
   --- Returns filesystem type identifier.
-  type: function(self: Statfs): number
+  type: function(self: Statfs): integer
   --- Returns optimal transfer block size.
-  bsize: function(self: Statfs): number
+  bsize: function(self: Statfs): integer
   --- Returns total data blocks in filesystem.
-  blocks: function(self: Statfs): number
+  blocks: function(self: Statfs): integer
   --- Returns free blocks in filesystem.
-  bfree: function(self: Statfs): number
+  bfree: function(self: Statfs): integer
   --- Returns free blocks available to unprivileged user.
-  bavail: function(self: Statfs): number
+  bavail: function(self: Statfs): integer
   --- Returns total file nodes in filesystem.
-  files: function(self: Statfs): number
+  files: function(self: Statfs): integer
   --- Returns free file nodes in filesystem.
-  ffree: function(self: Statfs): number
+  ffree: function(self: Statfs): integer
   --- Returns filesystem ID as two numbers.
-  fsid: function(self: Statfs): number, number
+  fsid: function(self: Statfs): integer, integer
   --- Returns maximum length of filenames.
-  namelen: function(self: Statfs): number
+  namelen: function(self: Statfs): integer
   --- Returns fragment size.
-  frsize: function(self: Statfs): number
+  frsize: function(self: Statfs): integer
   --- Returns mount flags.
-  flags: function(self: Statfs): number
+  flags: function(self: Statfs): integer
   --- Returns the owner of the mount.
-  owner: function(self: Statfs): number
+  owner: function(self: Statfs): integer
   --- Returns the filesystem type name, e.g. "ext4".
   fstypename: function(self: Statfs): string
 end
@@ -364,14 +364,14 @@ end
 local record Sigset
   userdata
   --- Adds signal to bitset.
-  add: function(self: Sigset, sig: number)
+  add: function(self: Sigset, sig: integer)
   --- Removes signal from bitset.
-  remove: function(self: Sigset, sig: number)
+  remove: function(self: Sigset, sig: integer)
   --- Sets all bits in signal bitset to `true`.
   fill: function(self: Sigset)
   --- Sets all bits in signal bitset to `false`.
   clear: function(self: Sigset)
-  contains: function(self: Sigset, sig: number): boolean
+  contains: function(self: Sigset, sig: integer): boolean
   __repr: function(self: Sigset): string
   __tostring: function(self: Sigset): string
 end
@@ -381,12 +381,12 @@ end
 --- third_party/lua/lunix.c): always one of the exported E* constants
 --- (unix.EINTR, unix.ENOENT, ...). An alias rather than a checked
 --- enum: Teal enums are string-only.
-local type Errno = number
+local type Errno = integer
 
 --- An `unix.F_*` command constant selecting the operation performed by
 --- `unix.fcntl` (`unix.F_GETFD`, `unix.F_SETFD`, `unix.F_GETFL`,
 --- `unix.F_SETFL`, `unix.F_SETLK`, `unix.F_SETLKW`, `unix.F_GETLK`, ...).
-local type FcntlCmd = number
+local type FcntlCmd = integer
 
 local record unix
   type Uname = Uname
@@ -400,11 +400,11 @@ local record unix
   type FcntlCmd = FcntlCmd
 
   --- @type integer
-  AF_INET: number
+  AF_INET: integer
   --- @type integer
-  AF_UNIX: number
+  AF_UNIX: integer
   --- @type integer
-  AF_UNSPEC: number
+  AF_UNSPEC: integer
   --- @type integer Returns maximum length of arguments for new processes.
   --- This is the character limit when calling `execve()`. It's the sum of
   --- the lengths of `argv` and `envp` including any nul terminators and
@@ -415,58 +415,58 @@ local record unix
   --- On Windows NT it's 32767*2 because CreateProcess lpCommandLine and
   --- environment block are separately constrained to 32,767 characters.
   --- Most other systems define this limit much higher.
-  ARG_MAX: number
+  ARG_MAX: integer
   --- @type integer
-  AT_EACCESS: number
+  AT_EACCESS: integer
   --- @type integer
-  AT_FDCWD: number
+  AT_FDCWD: integer
   --- @type integer
-  AT_SYMLINK_NOFOLLOW: number
+  AT_SYMLINK_NOFOLLOW: integer
   --- @type integer Returns default buffer size.
   --- The UNIX module does not perform any buffering between calls.
   --- Each time a read or write is performed via the UNIX API your redbean
   --- will allocate a buffer of this size by default. This current default
   --- would be 4096 across platforms.
-  BUFSIZ: number
+  BUFSIZ: integer
   --- @type integer Returns the scheduler frequency.
   --- This is granularity at which the kernel does work. For example, the
   --- Linux kernel normally operates at 100hz so its CLK_TCK will be 100.
   --- This value is useful for making sense out of unix.Rusage data.
-  CLK_TCK: number
+  CLK_TCK: integer
   --- @type integer
-  CLOCK_REALTIME: number
+  CLOCK_REALTIME: integer
   --- @type integer
-  CLOCK_MONOTONIC: number
+  CLOCK_MONOTONIC: integer
   --- @type integer
-  CLOCK_BOOTTIME: number
+  CLOCK_BOOTTIME: integer
   --- @type integer
-  CLOCK_MONOTONIC_RAW: number
+  CLOCK_MONOTONIC_RAW: integer
   --- @type integer
-  CLOCK_REALTIME_COARSE: number
+  CLOCK_REALTIME_COARSE: integer
   --- @type integer
-  CLOCK_MONOTONIC_COARSE: number
-  CLOCK_THREAD_CPUTIME_ID: number
+  CLOCK_MONOTONIC_COARSE: integer
+  CLOCK_THREAD_CPUTIME_ID: integer
   --- @type integer
-  CLOCK_PROCESS_CPUTIME_ID: number
+  CLOCK_PROCESS_CPUTIME_ID: integer
   --- @type integer
-  DT_BLK: number
+  DT_BLK: integer
   --- @type integer
-  DT_CHR: number
+  DT_CHR: integer
   --- @type integer
-  DT_DIR: number
+  DT_DIR: integer
   --- @type integer
-  DT_FIFO: number
+  DT_FIFO: integer
   --- @type integer
-  DT_LNK: number
+  DT_LNK: integer
   --- @type integer
-  DT_REG: number
+  DT_REG: integer
   --- @type integer
-  DT_SOCK: number
+  DT_SOCK: integer
   --- @type integer
-  DT_UNKNOWN: number
+  DT_UNKNOWN: integer
   --- @type integer Argument list too long.
   --- Raised by `execve`, `sched_setattr`.
-  E2BIG: number
+  E2BIG: integer
   --- @type integer Permission denied.
   --- Raised by `access`, `bind`, `chdir`, `chmod`, `chown`, `chroot`,
   --- `clock_getres`, `connect`, `execve`, `fcntl`, `getpriority`,
@@ -474,13 +474,13 @@ local record unix
   --- `prctl`, `ptrace`, `readlink`, `rename`, `rmdir`, `semget`,
   --- `send`, `setpgid`, `socket`, `stat`, `symlink`, `truncate`,
   --- `unlink`, `uselib`, `utime`, `utimensat`.
-  EACCES: number
+  EACCES: integer
   --- @type integer Address already in use. Raised by `bind`, `connect`, `listen`.
-  EADDRINUSE: number
+  EADDRINUSE: integer
   --- @type integer Address not available. Raised by `bind`, `connect`.
-  EADDRNOTAVAIL: number
+  EADDRNOTAVAIL: integer
   --- @type integer Address family not supported. Raised by `connect`, `socket`, `socketpair`.
-  EAFNOSUPPORT: number
+  EAFNOSUPPORT: integer
   --- @type integer
   --- Resource temporarily unavailable (e.g. SO_RCVTIMEO expired, too many
   --- processes, too much memory locked, read or write with O_NONBLOCK
@@ -490,9 +490,9 @@ local record unix
   --- `send`, `setresuid`, `setreuid`, `setuid`, `sigwaitinfo`,
   --- `splice`, `tee`, `timer_create`, `timerfd_create`, `tkill`,
   --- `write`,
-  EAGAIN: number
+  EAGAIN: integer
   --- @type integer Connection already in progress. Raised by `connect`, `send`.
-  EALREADY: number
+  EALREADY: integer
   --- @type integer Bad file descriptor; cf. EBADFD.
   --- Raised by `accept`, `access`, `bind`, `chdir`, `chmod`, `chown`,
   --- `close`, `connect`, `copy_file_range`, `dup`, `fcntl`, `flock`,
@@ -502,97 +502,97 @@ local record unix
   --- `readlink`, `recv`, `rename`, `select`, `send`, `shutdown`,
   --- `splice`, `stat`, `symlink`, `sync`, `sync_file_range`,
   --- `timerfd_create`, `truncate`, `unlink`, `utimensat`, `write`.
-  EBADF: number
+  EBADF: integer
   --- @type integer
-  EBADFD: number
+  EBADFD: integer
   --- @type integer
-  EBADMSG: number
+  EBADMSG: integer
   --- @type integer Device or resource busy.
   --- Raised by dup, fcntl, msync, prctl, ptrace, rename,
   --- rmdir.
-  EBUSY: number
+  EBUSY: integer
   --- @type integer
-  ECANCELED: number
+  ECANCELED: integer
   --- @type integer No child process.
   --- Raised by `wait`, `waitpid`, `waitid`, `wait3`, `wait4`.
-  ECHILD: number
+  ECHILD: integer
   --- @type integer Connection reset before accept. Raised by `accept`.
-  ECONNABORTED: number
+  ECONNABORTED: integer
   --- @type integer System-imposed limit on the number of threads was encountered.
   --- Raised by connect, listen, recv.
-  ECONNREFUSED: number
-  ECONNRESET: number
+  ECONNREFUSED: integer
+  ECONNRESET: integer
   --- @type integer Resource deadlock avoided.
   --- Raised by `fcntl`.
-  EDEADLK: number
+  EDEADLK: integer
   --- @type integer Destination address required. Raised by `send`, `write`.
-  EDESTADDRREQ: number
+  EDESTADDRREQ: integer
   --- @type integer
-  EDOM: number
+  EDOM: integer
   --- @type integer Disk quota exceeded.
   --- Raised by link, mkdir, mknod, open, rename, symlink,
   --- write.
-  EDQUOT: number
+  EDQUOT: integer
   --- @type integer File exists.
   --- Raised by `link`, `mkdir`, `mknod`, `mmap`, `open`, `rename`,
   --- `rmdir`, `symlink`.
-  EEXIST: number
+  EEXIST: integer
   --- @type integer
-  EFAULT: number
+  EFAULT: integer
   --- @type integer File too large.
   --- Raised by `copy_file_range`, `open`, `truncate`, `write`.
-  EFBIG: number
+  EFBIG: integer
   --- @type integer Inappropriate file type or format.
-  EFTYPE: number
+  EFTYPE: integer
   --- @type integer Host is down. Raised by `accept`.
-  EHOSTDOWN: number
+  EHOSTDOWN: integer
   --- @type integer Host is unreachable. Raised by `accept`.
-  EHOSTUNREACH: number
+  EHOSTUNREACH: integer
   --- @type integer Memory page has hardware error.
-  EHWPOISON: number
+  EHWPOISON: integer
   --- @type integer Identifier removed. Raised by `msgctl`.
-  EIDRM: number
+  EIDRM: integer
   --- @type integer
-  EILSEQ: number
+  EILSEQ: integer
   --- @type integer
-  EINPROGRESS: number
+  EINPROGRESS: integer
   --- @type integer The greatest of all errnos; crucial for building real time reliable software.
   --- Raised by `accept`, `clock_nanosleep`, `close`, `connect`, `dup`, `fcntl`,
   --- `flock`, `getrandom`, `nanosleep`, `open`, `pause`, `poll`, `ptrace`, `read`, `recv`,
   --- `select`, `send`, `sigsuspend`, `sigwaitinfo`, `truncate`, `wait`, `write`.
-  EINTR: number
+  EINTR: integer
   --- @type integer Invalid argument.
   --- Raised by [pretty much everything].
-  EINVAL: number
+  EINVAL: integer
   --- @type integer
   --- Raised by `access`, `acct`, `chdir`, `chmod`, `chown`, `chroot`, `close`,
   --- `copy_file_range`, `execve`, `fallocate`, `fsync`, `ioperm`, `link`, `madvise`,
   --- `mbind`, `pciconfig_read`, `ptrace`, `read`, `readlink`, `sendfile`, `statfs`,
   --- `symlink`, `sync_file_range`, `truncate`, `unlink`, `write`.
-  EIO: number
-  EISCONN: number
+  EIO: integer
+  EISCONN: integer
   --- @type integer Is a directory.
   --- Raised by `copy_file_range`, `execve`, `open`, `read`, `rename`, `truncate`,
   --- `unlink`.
-  EISDIR: number
+  EISDIR: integer
   --- @type integer Too many levels of symbolic links.
   --- Raised by access, bind, chdir, chmod, chown, chroot, execve, link,
   --- mkdir, mknod, open, readlink, rename, rmdir, stat, symlink,
   --- truncate, unlink, utimensat.
-  ELOOP: number
+  ELOOP: integer
   --- @type integer Wrong medium type. Raised by `mount`.
-  EMEDIUMTYPE: number
+  EMEDIUMTYPE: integer
   --- @type integer Too many open files.
   --- Raised by `accept`, `dup`, `execve`, `fanotify_init`, `fcntl`,
   --- `open`, `pipe`, `socket`, `socketpair`, `timerfd_create`.
-  EMFILE: number
+  EMFILE: integer
   --- @type integer Too many links;
   --- Raised by `link`, `mkdir`, `rename`.
-  EMLINK: number
+  EMLINK: integer
   --- @type integer Message too long. Raised by `send`.
-  EMSGSIZE: number
+  EMSGSIZE: integer
   --- @type integer Multihop attempted.
-  EMULTIHOP: number
+  EMULTIHOP: integer
   --- @type integer Filename too long. Cosmopolitan Libc currently defines `PATH_MAX` as
   --- 1024 characters. On UNIX that limit should only apply to system call
   --- wrappers like realpath. On Windows NT it's observed by all system
@@ -601,68 +601,68 @@ local record unix
   --- `execve`, `gethostname`, `link`, `mkdir`, `mknod`, `open`,
   --- `readlink`, `rename`, `rmdir`, `stat`, `symlink`, `truncate`,
   --- `unlink`, `utimensat`.
-  ENAMETOOLONG: number
+  ENAMETOOLONG: integer
   --- @type integer Network is down. Raised by `accept`.
-  ENETDOWN: number
+  ENETDOWN: integer
   --- @type integer Connection reset by network.
-  ENETRESET: number
+  ENETRESET: integer
   --- @type integer Host is unreachable. Raised by `accept`, `connect`.
-  ENETUNREACH: number
+  ENETUNREACH: integer
   --- @type integer Too many open files in system.
   --- Raised by `accept`, `execve`, `mmap`, `open`, `pipe`, `socket`,
   --- `socketpair`, `swapon`, `timerfd_create`, `uselib`,
   --- `userfaultfd`.
-  ENFILE: number
+  ENFILE: integer
   --- @type integer No buffer space available;
   --- Raised by `getpeername`, `getsockname`, `send`.
-  ENOBUFS: number
+  ENOBUFS: integer
   --- @type integer No message is available in xsi stream or named pipe is being closed;
   --- no data available; barely in posix; returned by ioctl; very close in
   --- spirit to EPIPE?
-  ENODATA: number
+  ENODATA: integer
   --- @type integer No such device.
   --- Raised by `arch_prctl`, `mmap`, `open`, `prctl`, `timerfd_create`.
-  ENODEV: number
+  ENODEV: integer
   --- @type integer No such file or directory.
   --- Raised by `access`, `bind`, `chdir`, `chmod`, `chown`, `chroot`,
   --- `clock_getres`, `execve`, `opendir`, `link`, `mkdir`, `mknod`,
   --- `open`, `readlink`, `rename`, `rmdir`, `stat`, `swapon`,
   --- `symlink`, `truncate`, `unlink`, `utime`, `utimensat`.
-  ENOENT: number
+  ENOENT: integer
   --- @type integer Exec format error. Raised by `execve`, `uselib`.
-  ENOEXEC: number
+  ENOEXEC: integer
   --- @type integer No locks available. Raised by `fcntl`, `flock`.
-  ENOLCK: number
+  ENOLCK: integer
   --- @type integer Link has been severed.
-  ENOLINK: number
+  ENOLINK: integer
   --- @type integer No medium found. Raised by `mount`.
-  ENOMEDIUM: number
+  ENOMEDIUM: integer
   --- @type integer
-  ENOMEM: number
+  ENOMEM: integer
   --- @type integer Raised by `msgop`.
-  ENOMSG: number
+  ENOMSG: integer
   --- @type integer
-  ENONET: number
+  ENONET: integer
   --- @type integer Protocol not available. Raised by `getsockopt`, `accept`.
-  ENOPROTOOPT: number
+  ENOPROTOOPT: integer
   --- @type integer No space left on device.
   --- Raised by `copy_file_range`, `fsync`, `link`, `mkdir`, `mknod`,
   --- `open`, `rename`, `symlink`, `sync_file_range`, `write`.
-  ENOSPC: number
+  ENOSPC: integer
   --- @type integer Out of streams resources.
-  ENOSR: number
+  ENOSR: integer
   --- @type integer Device not a stream.
-  ENOSTR: number
+  ENOSTR: integer
   --- @type integer System call not available on this platform. On
   ---     Windows this is raised by `chroot`, `setuid`, `setgid`,
   ---     `getsid`, `setsid`, and others we're doing our best to
   ---     document.
-  ENOSYS: number
+  ENOSYS: integer
   --- @type integer Block device required. Raised by `umount`.
-  ENOTBLK: number
+  ENOTBLK: integer
   --- @type integer Socket is not connected.
   --- Raised by `getpeername`, `recv`, `send`, `shutdown`.
-  ENOTCONN: number
+  ENOTCONN: integer
   --- @type integer Not a directory. This means that a directory
   ---     component in a supplied path *existed* but wasn't a
   ---     directory. For example, if you try to `open("foo/bar")` and
@@ -671,33 +671,33 @@ local record unix
   --- `mkdir`, `mknod`, `opendir`, `readlink`, `rename`, `rmdir`,
   --- `stat`, `symlink`, `truncate`, `unlink`, `utimensat`, `bind`,
   --- `chmod`, `chown`, `fcntl`, `futimesat`.
-  ENOTDIR: number
+  ENOTDIR: integer
   --- @type integer Directory not empty. Raised by `rmdir`.
-  ENOTEMPTY: number
+  ENOTEMPTY: integer
   --- @type integer
-  ENOTRECOVERABLE: number
+  ENOTRECOVERABLE: integer
   --- @type integer Not a socket.
   --- Raised by `accept`, `bind`, `connect`, `getpeername`,
   --- `getsockname`, `getsockopt`, `listen`, `recv`, `send`,
   --- `shutdown`.
-  ENOTSOCK: number
+  ENOTSOCK: integer
   --- @type integer Operation not supported.
   --- Raised by `chmod`, `clock_getres`, `clock_nanosleep`,
   --- `timer_create`.
-  ENOTSUP: number
+  ENOTSUP: integer
   --- @type integer Inappropriate i/o control operation. Raised by `ioctl`.
-  ENOTTY: number
+  ENOTTY: integer
   --- @type integer No such device or address. Raised by `lseek`, `open`, `prctl`.
-  ENXIO: number
+  ENXIO: integer
   --- @type integer Socket operation not supported.
   --- Raised by accept, listen, mmap, prctl, readv, send,
   --- socketpair.
-  EOPNOTSUPP: number
+  EOPNOTSUPP: integer
   --- @type integer Raised by `copy_file_range`, `fanotify_init`, `lseek`, `mmap`,
   --- `open`, `stat`, `statfs`
-  EOVERFLOW: number
+  EOVERFLOW: integer
   --- @type integer
-  EOWNERDEAD: number
+  EOWNERDEAD: integer
   --- @type integer Operation not permitted.
   --- Raised by `accept`, `chmod`, `chown`, `chroot`,
   --- `copy_file_range`, `execve`, `fallocate`, `fanotify_init`,
@@ -719,9 +719,9 @@ local record unix
   --- `setxattr`, `sigaltstack`, `spu_create`, `stime`, `swapon`,
   --- `symlink`, `syslog`, `truncate`, `unlink`, `utime`, `utimensat`,
   --- `write`.
-  EPERM: number
+  EPERM: integer
   --- @type integer Protocol family not supported.
-  EPFNOSUPPORT: number
+  EPFNOSUPPORT: integer
   --- @type integer Broken pipe.
   --- Returned by `write`, `send`. This happens when you try
   --- to write data to a subprocess via a pipe but the reader end has
@@ -730,200 +730,200 @@ local record unix
   --- Unlike default UNIX programs, redbean currently ignores `SIGPIPE` by
   --- default, so this error code is a distinct possibility when pipes or
   --- sockets are being used.
-  EPIPE: number
+  EPIPE: integer
   --- @type integer Raised by `accept`, `connect`, `socket`, `socketpair`.
-  EPROTO: number
+  EPROTO: integer
   --- @type integer Protocol not supported. Raised by `socket`, `socketpair`.
-  EPROTONOSUPPORT: number
+  EPROTONOSUPPORT: integer
   --- @type integer Protocol wrong type for socket. Raised by `connect`.
-  EPROTOTYPE: number
+  EPROTOTYPE: integer
   --- @type integer Result too large.
   --- Raised by `prctl`.
-  ERANGE: number
+  ERANGE: integer
   --- @type integer
-  EREMOTE: number
+  EREMOTE: integer
   --- @type integer
-  ERESTART: number
+  ERESTART: integer
   --- @type integer Operation not possible due to RF-kill.
-  ERFKILL: number
+  ERFKILL: integer
   --- @type integer Read-only filesystem.
   --- Raised by access, bind, chmod, chown, link, mkdir, mknod, open,
   --- rename, rmdir, symlink, truncate, unlink, utime, utimensat.
-  EROFS: number
+  EROFS: integer
   --- @type integer Cannot send after transport endpoint shutdown; note that shutdown write is an `EPIPE`.
-  ESHUTDOWN: number
+  ESHUTDOWN: integer
   --- @type integer Socket type not supported.
-  ESOCKTNOSUPPORT: number
+  ESOCKTNOSUPPORT: integer
   --- @type integer Invalid seek.
   --- Raised by `lseek`, `splice`, `sync_file_range`.
-  ESPIPE: number
+  ESPIPE: integer
   --- @type integer No such process.
   --- Raised by `getpriority`, `getrlimit`, `getsid`, `ioprio_set`, `kill`, `setpgid`, `tkill`, `utimensat`.
-  ESRCH: number
+  ESRCH: integer
   --- @type integer
-  ESTALE: number
+  ESTALE: integer
   --- @type integer Timer expired. Raised by `connect`.
-  ETIME: number
+  ETIME: integer
   --- @type integer Connection timed out. Raised by `connect`.
-  ETIMEDOUT: number
+  ETIMEDOUT: integer
   --- @type integer Too many references: cannot splice. Raised by `sendmsg`.
-  ETOOMANYREFS: number
+  ETOOMANYREFS: integer
   --- @type integer Won't open executable that's executing in write mode.
   --- Raised by access, copy_file_range, execve, mmap, open, truncate.
-  ETXTBSY: number
+  ETXTBSY: integer
   --- @type integer
-  EUSERS: number
+  EUSERS: integer
   --- @type integer Improper link.
   --- Raised by copy_file_range, link, rename.
-  EXDEV: number
+  EXDEV: integer
   --- @type integer
-  FD_CLOEXEC: number
+  FD_CLOEXEC: integer
   --- @type integer
-  F_GETFD: number
+  F_GETFD: integer
   --- @type integer
-  F_GETFL: number
+  F_GETFL: integer
   --- @type integer
-  F_GETLK: number
+  F_GETLK: integer
   --- @type integer
-  F_OK: number
+  F_OK: integer
   --- @type integer
-  F_RDLCK: number
+  F_RDLCK: integer
   --- @type integer
-  F_SETFD: number
+  F_SETFD: integer
   --- @type integer
-  F_SETFL: number
+  F_SETFL: integer
   --- @type integer
-  F_SETLK: number
+  F_SETLK: integer
   --- @type integer
-  F_SETLKW: number
+  F_SETLKW: integer
   --- @type integer
-  F_UNLCK: number
+  F_UNLCK: integer
   --- @type integer
-  F_WRLCK: number
+  F_WRLCK: integer
   --- @type integer
-  IPPROTO_ICMP: number
+  IPPROTO_ICMP: integer
   --- @type integer
-  IPPROTO_IP: number
+  IPPROTO_IP: integer
   --- @type integer
-  IPPROTO_RAW: number
+  IPPROTO_RAW: integer
   --- @type integer
-  IPPROTO_TCP: number
+  IPPROTO_TCP: integer
   --- @type integer
-  IPPROTO_UDP: number
+  IPPROTO_UDP: integer
   --- @type integer
-  IP_ADD_MEMBERSHIP: number
+  IP_ADD_MEMBERSHIP: integer
   --- @type integer
-  IP_DROP_MEMBERSHIP: number
+  IP_DROP_MEMBERSHIP: integer
   --- @type integer
-  IP_HDRINCL: number
+  IP_HDRINCL: integer
   --- @type integer
-  IP_MTU: number
+  IP_MTU: integer
   --- @type integer
-  IP_MULTICAST_IF: number
+  IP_MULTICAST_IF: integer
   --- @type integer
-  IP_MULTICAST_LOOP: number
+  IP_MULTICAST_LOOP: integer
   --- @type integer
-  IP_MULTICAST_TTL: number
+  IP_MULTICAST_TTL: integer
   --- @type integer
-  IP_OPTIONS: number
+  IP_OPTIONS: integer
   --- @type integer
-  IP_PKTINFO: number
+  IP_PKTINFO: integer
   --- @type integer
-  IP_RECVTOS: number
+  IP_RECVTOS: integer
   --- @type integer
-  IP_RECVTTL: number
+  IP_RECVTTL: integer
   --- @type integer
-  IP_TOS: number
+  IP_TOS: integer
   --- @type integer
-  IP_TTL: number
+  IP_TTL: integer
   --- @type integer
-  ITIMER_PROF: number
+  ITIMER_PROF: integer
   --- @type integer
-  ITIMER_REAL: number
+  ITIMER_REAL: integer
   --- @type integer
-  ITIMER_VIRTUAL: number
+  ITIMER_VIRTUAL: integer
   --- @type integer
-  LOG_ALERT: number
+  LOG_ALERT: integer
   --- @type integer
-  LOG_CRIT: number
+  LOG_CRIT: integer
   --- @type integer
-  LOG_DEBUG: number
+  LOG_DEBUG: integer
   --- @type integer
-  LOG_EMERG: number
+  LOG_EMERG: integer
   --- @type integer
-  LOG_ERR: number
+  LOG_ERR: integer
   --- @type integer
-  LOG_INFO: number
+  LOG_INFO: integer
   --- @type integer
-  LOG_NOTICE: number
+  LOG_NOTICE: integer
   --- @type integer
-  LOG_WARNING: number
+  LOG_WARNING: integer
   --- @type integer
-  MSG_CTRUNC: number
+  MSG_CTRUNC: integer
   --- @type integer
-  MSG_DONTROUTE: number
+  MSG_DONTROUTE: integer
   --- @type integer
-  MSG_DONTWAIT: number
+  MSG_DONTWAIT: integer
   --- @type integer
-  MSG_NOSIGNAL: number
+  MSG_NOSIGNAL: integer
   --- @type integer
-  MSG_OOB: number
+  MSG_OOB: integer
   --- @type integer
-  MSG_PEEK: number
+  MSG_PEEK: integer
   --- @type integer
-  MSG_TRUNC: number
+  MSG_TRUNC: integer
   --- @type integer
-  MSG_WAITALL: number
+  MSG_WAITALL: integer
   --- @type integer  Returns maximum length of file path component.
   --- POSIX requires this be at least 14. Most operating systems define it
   --- as 255. It's a good idea to not exceed 253 since that's the limit on
   --- DNS labels.
-  NAME_MAX: number
+  NAME_MAX: integer
   --- @type integer Returns maximum number of signals supported by underlying system.
   --- The limit for unix.Sigset is 128 to support FreeBSD, but most
   --- operating systems define this much lower, like 32. This constant
   --- reflects the value chosen by the underlying operating system.
-  NSIG: number
+  NSIG: integer
   --- @type integer open for reading (default)
-  O_RDONLY: number
+  O_RDONLY: integer
   --- @type integer open for writing
-  O_WRONLY: number
+  O_WRONLY: integer
   --- @type integer open for reading and writing
-  O_RDWR: number
+  O_RDWR: integer
   --- @type integer create file if it doesn't exist
-  O_CREAT: number
+  O_CREAT: integer
   --- @type integer automatic `ftruncate(fd, 0)` if exists
-  O_TRUNC: number
+  O_TRUNC: integer
   --- @type integer automatic `close()` upon `execve()`
-  O_CLOEXEC: number
+  O_CLOEXEC: integer
   --- @type integer exclusive access (see below)
-  O_EXCL: number
+  O_EXCL: integer
   --- @type integer open file for append only
-  O_APPEND: number
+  O_APPEND: integer
   --- @type integer asks read/write to fail with EAGAIN rather than block
-  O_NONBLOCK: number
+  O_NONBLOCK: integer
   --- @type integer it's complicated (not supported on Apple and OpenBSD)
-  O_DIRECT: number
+  O_DIRECT: integer
   --- @type integer useful for stat'ing (hint on UNIX but required on NT)
-  O_DIRECTORY: number
+  O_DIRECTORY: integer
   --- @type integer fail if it's a symlink (zero on Windows)
-  O_NOFOLLOW: number
+  O_NOFOLLOW: integer
   --- @type integer automatically delete file upon close()
-  O_UNLINK: number
+  O_UNLINK: integer
   --- @type integer open a path reference only, without read/write access
   --- (Linux only; fails with EINVAL elsewhere). Usable with landlock
   --- rule paths and *at() calls even when the path itself is unreadable.
-  O_PATH: number
+  O_PATH: integer
   --- @type integer it's complicated (zero on non-Linux/Apple)
-  O_DSYNC: number
+  O_DSYNC: integer
   --- @type integer synchronize i/o operations appropriately
-  O_SYNC: number
+  O_SYNC: integer
   --- @type integer don't record access time (zero on non-Linux)
-  O_NOATIME: number
+  O_NOATIME: integer
   --- @type integer
-  O_ACCMODE: number
+  O_ACCMODE: integer
   --- @type integer
-  O_NOCTTY: number
+  O_NOCTTY: integer
   --- @type integer Returns maximum length of file path.
   --- This applies to a complete path being passed to system calls.
   --- POSIX.1 XSI requires this be at least 1024 so that's what most
@@ -934,20 +934,20 @@ local record unix
   --- implemented at the C library level; however such functions are
   --- the exception rather than the norm, and report `enametoolong()`,
   --- when exceeding the libc limit.
-  PATH_MAX: number
+  PATH_MAX: integer
   --- the default on Linux. It's effectively the same as killing the
   --- process, since redbean has no threads. The termination signal
   --- can't be caught and will be either `SIGSYS` or `SIGABRT`.
   --- Consider enabling stderr logging below so you'll know why your
   --- program failed. Otherwise check the system log.
-  PLEDGE_PENALTY_KILL_THREAD: number
+  PLEDGE_PENALTY_KILL_THREAD: integer
   --- This is always the case on OpenBSD.
-  PLEDGE_PENALTY_KILL_PROCESS: number
+  PLEDGE_PENALTY_KILL_PROCESS: integer
   --- instead of killing. This is a gentler solution that allows code to
   --- display a friendly warning. Please note this may lead to weird
   --- behaviors if the software being sandboxed is lazy about checking
   --- error results.
-  PLEDGE_PENALTY_RETURN_EPERM: number
+  PLEDGE_PENALTY_RETURN_EPERM: integer
   --- know which promises are needed whenever violations occur. Without
   --- this, violations will be logged to `dmesg` on Linux if the penalty
   --- is to kill the process. You would then need to manually look up
@@ -958,481 +958,481 @@ local record unix
   --- uses SECCOMP trapping) also means that the `unix.WTERMSIG()` on
   --- your killed processes will always be `unix.SIGABRT` on both Linux
   --- and OpenBSD. Otherwise, Linux prefers to raise `unix.SIGSYS`.
-  PLEDGE_STDERR_LOGGING: number
+  PLEDGE_STDERR_LOGGING: integer
   --- @type integer Returns maximum size at which pipe i/o is guaranteed atomic.
   --- POSIX requires this be at least 512. Linux is more generous and
   --- allows 4096. On Windows NT this is currently 4096, and it's the
   --- parameter redbean passes to `CreateNamedPipe()`.
-  PIPE_BUF: number
+  PIPE_BUF: integer
   --- @type integer
-  POLLERR: number
+  POLLERR: integer
   --- @type integer
-  POLLHUP: number
+  POLLHUP: integer
   --- @type integer
-  POLLIN: number
+  POLLIN: integer
   --- @type integer
-  POLLNVAL: number
+  POLLNVAL: integer
   --- @type integer
-  POLLOUT: number
+  POLLOUT: integer
   --- @type integer
-  POLLPRI: number
+  POLLPRI: integer
   --- @type integer
-  POLLRDBAND: number
+  POLLRDBAND: integer
   --- @type integer
-  POLLRDHUP: number
+  POLLRDHUP: integer
   --- @type integer
-  POLLRDNORM: number
+  POLLRDNORM: integer
   --- @type integer
-  POLLWRBAND: number
+  POLLWRBAND: integer
   --- @type integer
-  POLLWRNORM: number
+  POLLWRNORM: integer
   --- @type integer
-  RLIMIT_AS: number
+  RLIMIT_AS: integer
   --- @type integer
-  RLIMIT_CPU: number
+  RLIMIT_CPU: integer
   --- @type integer
-  RLIMIT_FSIZE: number
+  RLIMIT_FSIZE: integer
   --- @type integer
-  RLIMIT_NOFILE: number
+  RLIMIT_NOFILE: integer
   --- @type integer
-  RLIMIT_NPROC: number
+  RLIMIT_NPROC: integer
   --- @type integer
-  RLIMIT_RSS: number
+  RLIMIT_RSS: integer
   --- @type integer getpriority/setpriority: target is a process id
-  PRIO_PROCESS: number
+  PRIO_PROCESS: integer
   --- @type integer getpriority/setpriority: target is a process group id
-  PRIO_PGRP: number
+  PRIO_PGRP: integer
   --- @type integer getpriority/setpriority: target is a user id
-  PRIO_USER: number
+  PRIO_USER: integer
   --- @type integer sysconf: maximum length of arguments to exec()
-  SC_ARG_MAX: number
+  SC_ARG_MAX: integer
   --- @type integer sysconf: maximum simultaneous processes per user id
-  SC_CHILD_MAX: number
+  SC_CHILD_MAX: integer
   --- @type integer sysconf: clock ticks per second
-  SC_CLK_TCK: number
+  SC_CLK_TCK: integer
   --- @type integer sysconf: maximum number of open files per process
-  SC_OPEN_MAX: number
+  SC_OPEN_MAX: integer
   --- @type integer sysconf: size of a memory page in bytes
-  SC_PAGESIZE: number
+  SC_PAGESIZE: integer
   --- @type integer sysconf: number of processors configured
-  SC_NPROCESSORS_CONF: number
+  SC_NPROCESSORS_CONF: integer
   --- @type integer sysconf: number of processors currently online
-  SC_NPROCESSORS_ONLN: number
+  SC_NPROCESSORS_ONLN: integer
   --- @type integer termios input mode flags (Termios.iflag)
-  BRKINT: number
-  ICRNL: number
-  IGNBRK: number
-  IGNCR: number
-  IGNPAR: number
-  INLCR: number
-  INPCK: number
-  ISTRIP: number
-  IXANY: number
-  IXOFF: number
-  IXON: number
-  PARMRK: number
+  BRKINT: integer
+  ICRNL: integer
+  IGNBRK: integer
+  IGNCR: integer
+  IGNPAR: integer
+  INLCR: integer
+  INPCK: integer
+  ISTRIP: integer
+  IXANY: integer
+  IXOFF: integer
+  IXON: integer
+  PARMRK: integer
   --- @type integer termios output mode flags (Termios.oflag)
-  OPOST: number
-  OCRNL: number
-  ONLCR: number
-  ONLRET: number
-  ONOCR: number
+  OPOST: integer
+  OCRNL: integer
+  ONLCR: integer
+  ONLRET: integer
+  ONOCR: integer
   --- @type integer termios control mode flags (Termios.cflag)
-  CLOCAL: number
-  CREAD: number
-  CS5: number
-  CS6: number
-  CS7: number
-  CS8: number
-  CSIZE: number
-  CSTOPB: number
-  HUPCL: number
-  PARENB: number
-  PARODD: number
+  CLOCAL: integer
+  CREAD: integer
+  CS5: integer
+  CS6: integer
+  CS7: integer
+  CS8: integer
+  CSIZE: integer
+  CSTOPB: integer
+  HUPCL: integer
+  PARENB: integer
+  PARODD: integer
   --- @type integer termios local mode flags (Termios.lflag)
-  ECHO: number
-  ECHOE: number
-  ECHOK: number
-  ECHONL: number
-  ICANON: number
-  IEXTEN: number
-  ISIG: number
-  NOFLSH: number
-  TOSTOP: number
+  ECHO: integer
+  ECHOE: integer
+  ECHOK: integer
+  ECHONL: integer
+  ICANON: integer
+  IEXTEN: integer
+  ISIG: integer
+  NOFLSH: integer
+  TOSTOP: integer
   --- @type integer termios control-character indices (Termios.cc)
-  VEOF: number
-  VEOL: number
-  VERASE: number
-  VINTR: number
-  VKILL: number
-  VMIN: number
-  VQUIT: number
-  VSTART: number
-  VSTOP: number
-  VTIME: number
-  NCCS: number
+  VEOF: integer
+  VEOL: integer
+  VERASE: integer
+  VINTR: integer
+  VKILL: integer
+  VMIN: integer
+  VQUIT: integer
+  VSTART: integer
+  VSTOP: integer
+  VTIME: integer
+  NCCS: integer
   --- @type integer tcsetattr() action values
-  TCSANOW: number
-  TCSADRAIN: number
-  TCSAFLUSH: number
+  TCSANOW: integer
+  TCSADRAIN: integer
+  TCSAFLUSH: integer
   --- @type integer network interface ioctls (siocgifconf/ifreq)
-  IFNAMSIZ: number
-  IFF_ALLMULTI: number
-  IFF_AUTOMEDIA: number
-  IFF_BROADCAST: number
-  IFF_DEBUG: number
-  IFF_DYNAMIC: number
-  IFF_LOOPBACK: number
-  IFF_MASTER: number
-  IFF_MULTICAST: number
-  IFF_NOARP: number
-  IFF_NOTRAILERS: number
-  IFF_POINTOPOINT: number
-  IFF_PORTSEL: number
-  IFF_PROMISC: number
-  IFF_RUNNING: number
-  IFF_SLAVE: number
-  IFF_UP: number
-  SIOCGIFADDR: number
-  SIOCGIFBRDADDR: number
-  SIOCGIFDSTADDR: number
-  SIOCGIFFLAGS: number
-  SIOCGIFINDEX: number
-  SIOCGIFMETRIC: number
-  SIOCGIFMTU: number
-  SIOCGIFNAME: number
-  SIOCGIFNETMASK: number
-  SIOCSIFADDR: number
-  SIOCSIFBRDADDR: number
-  SIOCSIFDSTADDR: number
-  SIOCSIFFLAGS: number
-  SIOCSIFMETRIC: number
-  SIOCSIFMTU: number
-  SIOCSIFNETMASK: number
+  IFNAMSIZ: integer
+  IFF_ALLMULTI: integer
+  IFF_AUTOMEDIA: integer
+  IFF_BROADCAST: integer
+  IFF_DEBUG: integer
+  IFF_DYNAMIC: integer
+  IFF_LOOPBACK: integer
+  IFF_MASTER: integer
+  IFF_MULTICAST: integer
+  IFF_NOARP: integer
+  IFF_NOTRAILERS: integer
+  IFF_POINTOPOINT: integer
+  IFF_PORTSEL: integer
+  IFF_PROMISC: integer
+  IFF_RUNNING: integer
+  IFF_SLAVE: integer
+  IFF_UP: integer
+  SIOCGIFADDR: integer
+  SIOCGIFBRDADDR: integer
+  SIOCGIFDSTADDR: integer
+  SIOCGIFFLAGS: integer
+  SIOCGIFINDEX: integer
+  SIOCGIFMETRIC: integer
+  SIOCGIFMTU: integer
+  SIOCGIFNAME: integer
+  SIOCGIFNETMASK: integer
+  SIOCSIFADDR: integer
+  SIOCSIFBRDADDR: integer
+  SIOCSIFDSTADDR: integer
+  SIOCSIFFLAGS: integer
+  SIOCSIFMETRIC: integer
+  SIOCSIFMTU: integer
+  SIOCSIFNETMASK: integer
   --- @type integer unshare()/setns() namespace flags
-  CLONE_NEWCGROUP: number
-  CLONE_NEWIPC: number
-  CLONE_NEWNET: number
-  CLONE_NEWNS: number
-  CLONE_NEWPID: number
-  CLONE_NEWTIME: number
-  CLONE_NEWUSER: number
-  CLONE_NEWUTS: number
+  CLONE_NEWCGROUP: integer
+  CLONE_NEWIPC: integer
+  CLONE_NEWNET: integer
+  CLONE_NEWNS: integer
+  CLONE_NEWPID: integer
+  CLONE_NEWTIME: integer
+  CLONE_NEWUSER: integer
+  CLONE_NEWUTS: integer
   --- @type integer landlock access-rights bits (landlock_add_rule)
-  LANDLOCK_ACCESS_FS_EXECUTE: number
-  LANDLOCK_ACCESS_FS_WRITE_FILE: number
-  LANDLOCK_ACCESS_FS_READ_FILE: number
-  LANDLOCK_ACCESS_FS_READ_DIR: number
-  LANDLOCK_ACCESS_FS_REMOVE_DIR: number
-  LANDLOCK_ACCESS_FS_REMOVE_FILE: number
-  LANDLOCK_ACCESS_FS_MAKE_CHAR: number
-  LANDLOCK_ACCESS_FS_MAKE_DIR: number
-  LANDLOCK_ACCESS_FS_MAKE_REG: number
-  LANDLOCK_ACCESS_FS_MAKE_SOCK: number
-  LANDLOCK_ACCESS_FS_MAKE_FIFO: number
-  LANDLOCK_ACCESS_FS_MAKE_BLOCK: number
-  LANDLOCK_ACCESS_FS_MAKE_SYM: number
-  LANDLOCK_ACCESS_FS_REFER: number
-  LANDLOCK_ACCESS_FS_TRUNCATE: number
-  LANDLOCK_CREATE_RULESET_VERSION: number
-  LANDLOCK_RULE_PATH_BENEATH: number
+  LANDLOCK_ACCESS_FS_EXECUTE: integer
+  LANDLOCK_ACCESS_FS_WRITE_FILE: integer
+  LANDLOCK_ACCESS_FS_READ_FILE: integer
+  LANDLOCK_ACCESS_FS_READ_DIR: integer
+  LANDLOCK_ACCESS_FS_REMOVE_DIR: integer
+  LANDLOCK_ACCESS_FS_REMOVE_FILE: integer
+  LANDLOCK_ACCESS_FS_MAKE_CHAR: integer
+  LANDLOCK_ACCESS_FS_MAKE_DIR: integer
+  LANDLOCK_ACCESS_FS_MAKE_REG: integer
+  LANDLOCK_ACCESS_FS_MAKE_SOCK: integer
+  LANDLOCK_ACCESS_FS_MAKE_FIFO: integer
+  LANDLOCK_ACCESS_FS_MAKE_BLOCK: integer
+  LANDLOCK_ACCESS_FS_MAKE_SYM: integer
+  LANDLOCK_ACCESS_FS_REFER: integer
+  LANDLOCK_ACCESS_FS_TRUNCATE: integer
+  LANDLOCK_CREATE_RULESET_VERSION: integer
+  LANDLOCK_RULE_PATH_BENEATH: integer
   --- @type integer prctl() options
-  PR_CAPBSET_DROP: number
-  PR_CAPBSET_READ: number
-  PR_GET_CHILD_SUBREAPER: number
-  PR_GET_DUMPABLE: number
-  PR_GET_KEEPCAPS: number
-  PR_GET_NAME: number
-  PR_GET_NO_NEW_PRIVS: number
-  PR_GET_PDEATHSIG: number
-  PR_SET_CHILD_SUBREAPER: number
-  PR_SET_DUMPABLE: number
-  PR_SET_KEEPCAPS: number
-  PR_SET_NAME: number
-  PR_SET_NO_NEW_PRIVS: number
-  PR_SET_PDEATHSIG: number
+  PR_CAPBSET_DROP: integer
+  PR_CAPBSET_READ: integer
+  PR_GET_CHILD_SUBREAPER: integer
+  PR_GET_DUMPABLE: integer
+  PR_GET_KEEPCAPS: integer
+  PR_GET_NAME: integer
+  PR_GET_NO_NEW_PRIVS: integer
+  PR_GET_PDEATHSIG: integer
+  PR_SET_CHILD_SUBREAPER: integer
+  PR_SET_DUMPABLE: integer
+  PR_SET_KEEPCAPS: integer
+  PR_SET_NAME: integer
+  PR_SET_NO_NEW_PRIVS: integer
+  PR_SET_PDEATHSIG: integer
   --- @type integer Linux capability bits (prctl PR_CAPBSET_*, capget/capset).
-  CAP_AUDIT_CONTROL: number
-  CAP_AUDIT_READ: number
-  CAP_AUDIT_WRITE: number
-  CAP_BLOCK_SUSPEND: number
-  CAP_BPF: number
-  CAP_CHECKPOINT_RESTORE: number
-  CAP_CHOWN: number
-  CAP_DAC_OVERRIDE: number
-  CAP_DAC_READ_SEARCH: number
-  CAP_FOWNER: number
-  CAP_FSETID: number
-  CAP_IPC_LOCK: number
-  CAP_IPC_OWNER: number
-  CAP_KILL: number
-  CAP_LAST_CAP: number
-  CAP_LEASE: number
-  CAP_LINUX_IMMUTABLE: number
-  CAP_MAC_ADMIN: number
-  CAP_MAC_OVERRIDE: number
-  CAP_MKNOD: number
-  CAP_NET_ADMIN: number
-  CAP_NET_BIND_SERVICE: number
-  CAP_NET_BROADCAST: number
-  CAP_NET_RAW: number
-  CAP_PERFMON: number
-  CAP_SETFCAP: number
-  CAP_SETGID: number
-  CAP_SETPCAP: number
-  CAP_SETUID: number
-  CAP_SYSLOG: number
-  CAP_SYS_ADMIN: number
-  CAP_SYS_BOOT: number
-  CAP_SYS_CHROOT: number
-  CAP_SYS_MODULE: number
-  CAP_SYS_NICE: number
-  CAP_SYS_PACCT: number
-  CAP_SYS_PTRACE: number
-  CAP_SYS_RAWIO: number
-  CAP_SYS_RESOURCE: number
-  CAP_SYS_TIME: number
-  CAP_SYS_TTY_CONFIG: number
-  CAP_WAKE_ALARM: number
+  CAP_AUDIT_CONTROL: integer
+  CAP_AUDIT_READ: integer
+  CAP_AUDIT_WRITE: integer
+  CAP_BLOCK_SUSPEND: integer
+  CAP_BPF: integer
+  CAP_CHECKPOINT_RESTORE: integer
+  CAP_CHOWN: integer
+  CAP_DAC_OVERRIDE: integer
+  CAP_DAC_READ_SEARCH: integer
+  CAP_FOWNER: integer
+  CAP_FSETID: integer
+  CAP_IPC_LOCK: integer
+  CAP_IPC_OWNER: integer
+  CAP_KILL: integer
+  CAP_LAST_CAP: integer
+  CAP_LEASE: integer
+  CAP_LINUX_IMMUTABLE: integer
+  CAP_MAC_ADMIN: integer
+  CAP_MAC_OVERRIDE: integer
+  CAP_MKNOD: integer
+  CAP_NET_ADMIN: integer
+  CAP_NET_BIND_SERVICE: integer
+  CAP_NET_BROADCAST: integer
+  CAP_NET_RAW: integer
+  CAP_PERFMON: integer
+  CAP_SETFCAP: integer
+  CAP_SETGID: integer
+  CAP_SETPCAP: integer
+  CAP_SETUID: integer
+  CAP_SYSLOG: integer
+  CAP_SYS_ADMIN: integer
+  CAP_SYS_BOOT: integer
+  CAP_SYS_CHROOT: integer
+  CAP_SYS_MODULE: integer
+  CAP_SYS_NICE: integer
+  CAP_SYS_PACCT: integer
+  CAP_SYS_PTRACE: integer
+  CAP_SYS_RAWIO: integer
+  CAP_SYS_RESOURCE: integer
+  CAP_SYS_TIME: integer
+  CAP_SYS_TTY_CONFIG: integer
+  CAP_WAKE_ALARM: integer
   --- @type integer mount()/umount2() flags
-  MS_BIND: number
-  MS_DIRSYNC: number
-  MS_LAZYTIME: number
-  MS_MANDLOCK: number
-  MS_MOVE: number
-  MS_NOATIME: number
-  MS_NODEV: number
-  MS_NODIRATIME: number
-  MS_NOEXEC: number
-  MS_NOSUID: number
-  MS_POSIXACL: number
-  MS_PRIVATE: number
-  MS_RDONLY: number
-  MS_REC: number
-  MS_RELATIME: number
-  MS_REMOUNT: number
-  MS_SHARED: number
-  MS_SILENT: number
-  MS_SLAVE: number
-  MS_STRICTATIME: number
-  MS_SYNCHRONOUS: number
-  MS_UNBINDABLE: number
-  MNT_DETACH: number
-  MNT_EXPIRE: number
-  MNT_FORCE: number
-  UMOUNT_NOFOLLOW: number
+  MS_BIND: integer
+  MS_DIRSYNC: integer
+  MS_LAZYTIME: integer
+  MS_MANDLOCK: integer
+  MS_MOVE: integer
+  MS_NOATIME: integer
+  MS_NODEV: integer
+  MS_NODIRATIME: integer
+  MS_NOEXEC: integer
+  MS_NOSUID: integer
+  MS_POSIXACL: integer
+  MS_PRIVATE: integer
+  MS_RDONLY: integer
+  MS_REC: integer
+  MS_RELATIME: integer
+  MS_REMOUNT: integer
+  MS_SHARED: integer
+  MS_SILENT: integer
+  MS_SLAVE: integer
+  MS_STRICTATIME: integer
+  MS_SYNCHRONOUS: integer
+  MS_UNBINDABLE: integer
+  MNT_DETACH: integer
+  MNT_EXPIRE: integer
+  MNT_FORCE: integer
+  UMOUNT_NOFOLLOW: integer
   --- @type integer statvfs f_flag bits (unix.Statfs / statvfs)
-  ST_APPEND: number
-  ST_IMMUTABLE: number
-  ST_MANDLOCK: number
-  ST_NOATIME: number
-  ST_NODEV: number
-  ST_NODIRATIME: number
-  ST_NOEXEC: number
-  ST_NOSUID: number
-  ST_RDONLY: number
-  ST_RELATIME: number
-  ST_SYNCHRONOUS: number
-  ST_WRITE: number
+  ST_APPEND: integer
+  ST_IMMUTABLE: integer
+  ST_MANDLOCK: integer
+  ST_NOATIME: integer
+  ST_NODEV: integer
+  ST_NODIRATIME: integer
+  ST_NOEXEC: integer
+  ST_NOSUID: integer
+  ST_RDONLY: integer
+  ST_RELATIME: integer
+  ST_SYNCHRONOUS: integer
+  ST_WRITE: integer
   --- @type integer
-  RUSAGE_BOTH: number
+  RUSAGE_BOTH: integer
   --- @type integer
-  RUSAGE_CHILDREN: number
+  RUSAGE_CHILDREN: integer
   --- @type integer
-  RUSAGE_SELF: number
+  RUSAGE_SELF: integer
   --- @type integer
-  RUSAGE_THREAD: number
+  RUSAGE_THREAD: integer
   --- @type integer
-  R_OK: number
+  R_OK: integer
   --- @type integer
-  SA_NOCLDSTOP: number
+  SA_NOCLDSTOP: integer
   --- @type integer
-  SA_NOCLDWAIT: number
+  SA_NOCLDWAIT: integer
   --- @type integer
-  SA_NODEFER: number
+  SA_NODEFER: integer
   --- @type integer
-  SA_RESETHAND: number
+  SA_RESETHAND: integer
   --- @type integer
-  SA_RESTART: number
+  SA_RESTART: integer
   --- @type integer
-  SEEK_CUR: number
+  SEEK_CUR: integer
   --- @type integer
-  SEEK_END: number
+  SEEK_END: integer
   --- @type integer
-  SEEK_SET: number
-  SHUT_RD: number
-  SHUT_WR: number
-  SHUT_RDWR: number
+  SEEK_SET: integer
+  SHUT_RD: integer
+  SHUT_WR: integer
+  SHUT_RDWR: integer
   --- @type integer Process aborted.
-  SIGABRT: number
+  SIGABRT: integer
   --- @type integer Sent by setitimer().
-  SIGALRM: number
+  SIGALRM: integer
   --- @type integer Valid memory access that went beyond underlying end of file.
-  SIGBUS: number
+  SIGBUS: integer
   --- @type integer Child process exited or terminated and is now a zombie (unless this
   --- is `SIG_IGN` or `SA_NOCLDWAIT`) or child process stopped due to terminal
   --- i/o or profiling/debugging (unless you used `SA_NOCLDSTOP`)
-  SIGCHLD: number
+  SIGCHLD: integer
   --- @type integer Child process resumed from profiling/debugging.
-  SIGCONT: number
+  SIGCONT: integer
   --- @type integer Illegal math.
-  SIGFPE: number
+  SIGFPE: integer
   --- @type integer Terminal hangup or daemon reload; auto-broadcasted to process group.
-  SIGHUP: number
+  SIGHUP: integer
   --- @type integer Illegal instruction.
-  SIGILL: number
+  SIGILL: integer
   --- @type integer Terminal CTRL-C keystroke.
-  SIGINT: number
+  SIGINT: integer
   --- @type integer Terminate with extreme prejudice.
-  SIGKILL: number
+  SIGKILL: integer
   --- @type integer Write to closed file descriptor.
-  SIGPIPE: number
+  SIGPIPE: integer
   --- @type integer Profiling timer expired.
-  SIGPROF: number
+  SIGPROF: integer
   --- @type integer Terminal CTRL-\ keystroke.
-  SIGQUIT: number
+  SIGQUIT: integer
   --- @type integer Invalid memory access.
-  SIGSEGV: number
+  SIGSEGV: integer
   --- @type integer Child process stopped due to profiling/debugging.
-  SIGSTOP: number
+  SIGSTOP: integer
   --- @type integer
-  SIGSYS: number
+  SIGSYS: integer
   --- @type integer Terminate.
-  SIGTERM: number
+  SIGTERM: integer
   --- @type integer INT3 instruction.
-  SIGTRAP: number
+  SIGTRAP: integer
   --- @type integer Terminal CTRL-Z keystroke.
-  SIGTSTP: number
+  SIGTSTP: integer
   --- @type integer Terminal input for background process.
-  SIGTTIN: number
+  SIGTTIN: integer
   --- @type integer Terminal input for background process.
-  SIGTTOU: number
+  SIGTTOU: integer
   --- @type integer
-  SIGURG: number
+  SIGURG: integer
   --- @type integer Do whatever you want.
-  SIGUSR1: number
+  SIGUSR1: integer
   --- @type integer Do whatever you want.
-  SIGUSR2: number
+  SIGUSR2: integer
   --- @type integer Virtual alarm clock.
-  SIGVTALRM: number
+  SIGVTALRM: integer
   --- @type integer Terminal resized.
-  SIGWINCH: number
+  SIGWINCH: integer
   --- @type integer CPU time limit exceeded.
-  SIGXCPU: number
+  SIGXCPU: integer
   --- @type integer File size limit exceeded.
-  SIGXFSZ: number
+  SIGXFSZ: integer
   --- @type integer
-  SIG_BLOCK: number
+  SIG_BLOCK: integer
   --- @type integer
-  SIG_DFL: number
+  SIG_DFL: integer
   --- @type integer
-  SIG_IGN: number
+  SIG_IGN: integer
   --- @type integer
-  SIG_SETMASK: number
+  SIG_SETMASK: integer
   --- @type integer
-  SIG_UNBLOCK: number
+  SIG_UNBLOCK: integer
   --- @type integer
-  SOCK_CLOEXEC: number
+  SOCK_CLOEXEC: integer
   --- @type integer
-  SOCK_DGRAM: number
+  SOCK_DGRAM: integer
   --- @type integer
-  SOCK_NONBLOCK: number
+  SOCK_NONBLOCK: integer
   --- @type integer
-  SOCK_RAW: number
+  SOCK_RAW: integer
   --- @type integer
-  SOCK_RDM: number
+  SOCK_RDM: integer
   --- @type integer
-  SOCK_SEQPACKET: number
+  SOCK_SEQPACKET: integer
   --- @type integer
-  SOCK_STREAM: number
+  SOCK_STREAM: integer
   --- @type integer
-  SOL_IP: number
+  SOL_IP: integer
   --- @type integer
-  SOL_SOCKET: number
+  SOL_SOCKET: integer
   --- @type integer
-  SOL_TCP: number
+  SOL_TCP: integer
   --- @type integer
-  SOL_UDP: number
+  SOL_UDP: integer
   --- @type integer
-  SO_ACCEPTCONN: number
+  SO_ACCEPTCONN: integer
   --- @type integer
-  SO_BROADCAST: number
+  SO_BROADCAST: integer
   --- @type integer
-  SO_DEBUG: number
+  SO_DEBUG: integer
   --- @type integer
-  SO_DONTROUTE: number
+  SO_DONTROUTE: integer
   --- @type integer
-  SO_ERROR: number
+  SO_ERROR: integer
   --- @type integer
-  SO_KEEPALIVE: number
+  SO_KEEPALIVE: integer
   --- @type integer
-  SO_LINGER: number
+  SO_LINGER: integer
   --- @type integer
-  SO_NOSIGPIPE: number
+  SO_NOSIGPIPE: integer
   --- @type integer
-  SO_OOBINLINE: number
+  SO_OOBINLINE: integer
   --- @type integer
-  SO_RCVBUF: number
+  SO_RCVBUF: integer
   --- @type integer
-  SO_RCVLOWAT: number
+  SO_RCVLOWAT: integer
   --- @type integer
-  SO_RCVTIMEO: number
+  SO_RCVTIMEO: integer
   --- @type integer
-  SO_REUSEADDR: number
+  SO_REUSEADDR: integer
   --- @type integer
-  SO_REUSEPORT: number
+  SO_REUSEPORT: integer
   --- @type integer
-  SO_SNDBUF: number
+  SO_SNDBUF: integer
   --- @type integer
-  SO_SNDLOWAT: number
+  SO_SNDLOWAT: integer
   --- @type integer
-  SO_SNDTIMEO: number
+  SO_SNDTIMEO: integer
   --- @type integer
-  SO_TYPE: number
+  SO_TYPE: integer
   --- @type integer
-  TCP_CORK: number
+  TCP_CORK: integer
   --- @type integer
-  TCP_DEFER_ACCEPT: number
+  TCP_DEFER_ACCEPT: integer
   --- @type integer
-  TCP_FASTOPEN: number
+  TCP_FASTOPEN: integer
   --- @type integer
-  TCP_FASTOPEN_CONNECT: number
+  TCP_FASTOPEN_CONNECT: integer
   --- @type integer
-  TCP_KEEPCNT: number
+  TCP_KEEPCNT: integer
   --- @type integer
-  TCP_KEEPIDLE: number
+  TCP_KEEPIDLE: integer
   --- @type integer
-  TCP_KEEPINTVL: number
+  TCP_KEEPINTVL: integer
   --- @type integer
-  TCP_MAXSEG: number
+  TCP_MAXSEG: integer
   --- @type integer
-  TCP_NODELAY: number
+  TCP_NODELAY: integer
   --- @type integer
-  TCP_NOTSENT_LOWAT: number
+  TCP_NOTSENT_LOWAT: integer
   --- @type integer
-  TCP_QUICKACK: number
+  TCP_QUICKACK: integer
   --- @type integer
-  TCP_SAVED_SYN: number
+  TCP_SAVED_SYN: integer
   --- @type integer
-  TCP_SAVE_SYN: number
+  TCP_SAVE_SYN: integer
   --- @type integer
-  TCP_SYNCNT: number
+  TCP_SYNCNT: integer
   --- @type integer
-  TCP_WINDOW_CLAMP: number
+  TCP_WINDOW_CLAMP: integer
   --- @type integer
-  UTIME_NOW: number
+  UTIME_NOW: integer
   --- @type integer
-  UTIME_OMIT: number
+  UTIME_OMIT: integer
   --- @type integer
-  WNOHANG: number
+  WNOHANG: integer
   --- @type integer
-  WUNTRACED: number
+  WUNTRACED: integer
   --- @type integer Report continued child processes.
-  WCONTINUED: number
+  WCONTINUED: integer
   --- @type integer
-  W_OK: number
+  W_OK: integer
   --- @type integer
-  X_OK: number
+  X_OK: integer
 
   --- Opens file.
   --- Returns a file descriptor integer that needs to be closed, e.g.
@@ -1475,7 +1475,7 @@ local record unix
   --- Returns `ENOTDIR` if `path` contained a directory component that
   --- wasn't a directory
   --- .
-  open: function(path: string, flags: number, mode?: number, dirfd?: number): number | nil, string | nil, Errno | nil
+  open: function(path: string, flags: integer, mode?: integer, dirfd?: integer): integer | nil, string | nil, Errno | nil
   --- Closes file descriptor.
   --- This function should never be called twice for the same file
   --- descriptor, regardless of whether or not an error happened. The file
@@ -1491,19 +1491,19 @@ local record unix
   --- Returns `EBADF` if `fd` wasn't valid.
   --- Returns `EINTR` possibly maybe.
   --- Returns `EIO` if an i/o error occurred.
-  close: function(fd: number): boolean | nil, string | nil, Errno | nil
+  close: function(fd: integer): boolean | nil, string | nil, Errno | nil
   --- Reads from file descriptor.
   --- This function returns empty string on end of file. The exception is
   --- if `bufsiz` is zero, in which case an empty returned string means
   --- the file descriptor works.
-  read: function(fd: number, bufsiz?: number, offset?: number): string | nil, string | nil, Errno | nil
+  read: function(fd: integer, bufsiz?: integer, offset?: integer): string | nil, string | nil, Errno | nil
   --- Writes to file descriptor.
-  write: function(fd: number, data: string, offset?: number): number | nil, string | nil, Errno | nil
+  write: function(fd: integer, data: string, offset?: integer): integer | nil, string | nil, Errno | nil
   --- Invokes `_Exit(exitcode)` on the process. This will immediately
   --- halt the current process. Memory will be freed. File descriptors
   --- will be closed. Any open connections it owns will be reset. This
   --- function never returns.
-  exit: function(exitcode?: number)
+  exit: function(exitcode?: integer)
   --- Returns raw environment variables.
   --- This allocates and constructs the C/C++ `environ` variable as a Lua
   --- table consisting of string keys and string values.
@@ -1589,7 +1589,7 @@ local record unix
   --- Hence it should come as no surprise that `fork()` would go slower on
   --- operating systems that have more security features. So depending on
   --- your use case, you can choose the operating system that suits you.
-  fork: function(): number | nil, string | nil, Errno | nil
+  fork: function(): integer | nil, string | nil, Errno | nil
   --- Performs `$PATH` lookup of executable.
   ---     unix = require 'unix'
   ---     prog = assert(unix.commandv('ls'))
@@ -1650,7 +1650,7 @@ local record unix
   --- `envp` is the environment. If not specified, inherits the
   --- current environment.
   --- This function never returns on success.
-  fexecve: function(fd: number, argv: {string}, envp?: {string}): nil, string | nil, Errno | nil
+  fexecve: function(fd: integer, argv: {string}, envp?: {string}): nil, string | nil, Errno | nil
   --- Spawns a new process.
   --- Unlike `fork()` + `execve()`, this uses `posix_spawn()` which
   --- can be more efficient on some platforms.
@@ -1659,12 +1659,12 @@ local record unix
   --- `envp` is the environment. If not specified, inherits the
   --- current environment.
   --- Returns the child process id on success.
-  spawn: function(prog: string, argv: {string}, envp?: {string}): number | nil, string | nil, Errno | nil
+  spawn: function(prog: string, argv: {string}, envp?: {string}): integer | nil, string | nil, Errno | nil
   --- Spawns a new process with PATH search.
   --- Like `spawn()` but searches for `prog` in the directories
   --- listed in the `PATH` environment variable.
   --- Returns the child process id on success.
-  spawnp: function(prog: string, argv: {string}, envp?: {string}): number | nil, string | nil, Errno | nil
+  spawnp: function(prog: string, argv: {string}, envp?: {string}): integer | nil, string | nil, Errno | nil
   --- Duplicates file descriptor.
   --- `newfd` may be specified to choose a specific number for the new
   --- file descriptor. If it's already open, then the preexisting one will
@@ -1679,7 +1679,7 @@ local record unix
   --- Will ensure that, in the rare event standard output or standard
   --- error are closed, you won't accidentally duplicate standard input to
   --- those numbers.
-  dup: function(oldfd: number, newfd?: number, flags?: number, lowest?: number): number | nil, string | nil, Errno | nil
+  dup: function(oldfd: integer, newfd?: integer, flags?: integer, lowest?: integer): integer | nil, string | nil, Errno | nil
   --- Creates fifo which enables communication between processes.
   --- - `O_CLOEXEC`: Automatically close file descriptor upon execve()
   --- - `O_NONBLOCK`: Request `EAGAIN` be raised rather than blocking
@@ -1718,7 +1718,7 @@ local record unix
   ---        assert(unix.close(reader))
   ---        assert(unix.wait())
   ---     end
-  pipe: function(flags?: number): number | nil, number, string | nil, Errno | nil
+  pipe: function(flags?: integer): integer | nil, integer, string | nil, Errno | nil
   --- Waits for subprocess to terminate.
   --- `pid` defaults to `-1` which means any child process. Setting
   --- `pid` to `0` is equivalent to `-getpid()`. If `pid < -1` then
@@ -1752,22 +1752,22 @@ local record unix
   ---           break
   ---        end
   ---     end
-  wait: function(pid?: number, options?: number): number | nil, number, Rusage, string | nil, Errno | nil
+  wait: function(pid?: integer, options?: integer): integer | nil, integer, Rusage, string | nil, Errno | nil
   --- Returns `true` if process exited cleanly.
-  WIFEXITED: function(wstatus: number): boolean
+  WIFEXITED: function(wstatus: integer): boolean
   --- Returns code passed to exit() assuming `WIFEXITED(wstatus)` is true.
-  WEXITSTATUS: function(wstatus: number): number
+  WEXITSTATUS: function(wstatus: integer): integer
   --- Returns `true` if process terminated due to a signal.
-  WIFSIGNALED: function(wstatus: number): boolean
+  WIFSIGNALED: function(wstatus: integer): boolean
   --- Returns signal that caused process to terminate assuming
   --- `WIFSIGNALED(wstatus)` is `true`.
-  WTERMSIG: function(wstatus: number): number
+  WTERMSIG: function(wstatus: integer): integer
   --- Returns process id of current process.
   --- This function does not fail.
-  getpid: function(): number
+  getpid: function(): integer
   --- Returns process id of parent process.
   --- This function does not fail.
-  getppid: function(): number
+  getppid: function(): integer
   --- Sends signal to process(es).
   --- The impact of this action can be terminating the process, or
   --- interrupting it to request something happen.
@@ -1786,20 +1786,20 @@ local record unix
   --- standard, which are `SIGINT` and `SIGQUIT`. All other signals on the
   --- Windows platform that are sent to another process via kill() will be
   --- treated like `SIGKILL`.
-  kill: function(pid: number, sig: number): boolean | nil, string | nil, Errno | nil
+  kill: function(pid: integer, sig: integer): boolean | nil, string | nil, Errno | nil
   --- Sends signal to process group.
   --- This is similar to `kill()` but sends the signal to all processes
   --- in the specified process group.
   --- `pgrp` is the process group id. If 0, sends to the calling process's
   --- process group.
   --- `sig` can be any signal value (e.g., `SIGTERM`, `SIGKILL`, etc.).
-  killpg: function(pgrp: number, sig: number): boolean | nil, string | nil, Errno | nil
+  killpg: function(pgrp: integer, sig: integer): boolean | nil, string | nil, Errno | nil
   --- Triggers signal in current process.
   --- This is pretty much the same as `kill(getpid(), sig)`.
-  raise: function(sig: number): number | nil, string | nil, Errno | nil
+  raise: function(sig: integer): integer | nil, string | nil, Errno | nil
   --- Checks if effective user of current process has permission to access file.
   --- - `AT_SYMLINK_NOFOLLOW`: do not follow symbolic links.
-  access: function(path: string, how: number, flags?: number, dirfd?: number): boolean | nil, string | nil, Errno | nil
+  access: function(path: string, how: integer, flags?: integer, dirfd?: integer): boolean | nil, string | nil, Errno | nil
   --- Makes directory.
   --- `path` is the path of the directory you wish to create.
   --- `mode` is octal permission bits, e.g. `0755`.
@@ -1813,14 +1813,14 @@ local record unix
   --- Fails with `EACCES` if the parent directory doesn't grant write
   --- permission to the current user.
   --- Fails with `ENAMETOOLONG` if the path is too long.
-  mkdir: function(path: string, mode?: number, dirfd?: number): boolean | nil, string | nil, Errno | nil
+  mkdir: function(path: string, mode?: integer, dirfd?: integer): boolean | nil, string | nil, Errno | nil
   --- Unlike mkdir() this convenience wrapper will automatically create
   --- parent parent directories as needed. If the directory already exists
   --- then, unlike mkdir() which returns EEXIST, the makedirs() function
   --- will return success.
   --- `path` is the path of the directory you wish to create.
   --- `mode` is octal permission bits, e.g. `0755`.
-  makedirs: function(path: string, mode?: number): boolean | nil, string | nil, Errno | nil
+  makedirs: function(path: string, mode?: integer): boolean | nil, string | nil, Errno | nil
   --- Creates a temporary directory with a unique name.
   --- `template` must end with "XXXXXX" which will be replaced with random
   --- characters to create a unique directory name.
@@ -1839,26 +1839,26 @@ local record unix
   ---     unix.write(fd, "hello")
   ---     unix.close(fd)
   ---     unix.unlink(path)
-  mkstemp: function(template: string): number | nil, string, string | nil, Errno | nil
+  mkstemp: function(template: string): integer | nil, string, string | nil, Errno | nil
   --- Changes current directory to `path`.
   chdir: function(path: string): boolean | nil, string | nil, Errno | nil
   --- Removes file at `path`.
   --- If `path` refers to a symbolic link, the link is removed.
   --- Returns `EISDIR` if `path` refers to a directory. See `rmdir()`.
-  unlink: function(path: string, dirfd?: number): boolean | nil, string | nil, Errno | nil
+  unlink: function(path: string, dirfd?: integer): boolean | nil, string | nil, Errno | nil
   --- Removes empty directory at `path`.
   --- Returns `ENOTDIR` if `path` isn't a directory, or a path component
   --- in `path` exists yet wasn't a directory.
-  rmdir: function(path: string, dirfd?: number): boolean | nil, string | nil, Errno | nil
+  rmdir: function(path: string, dirfd?: integer): boolean | nil, string | nil, Errno | nil
   --- Renames file or directory.
-  rename: function(oldpath: string, newpath: string, olddirfd: number, newdirfd: number): boolean | nil, string | nil, Errno | nil
+  rename: function(oldpath: string, newpath: string, olddirfd: integer, newdirfd: integer): boolean | nil, string | nil, Errno | nil
   --- Creates hard link, so your underlying inode has two names.
-  link: function(existingpath: string, newpath: string, flags: number, olddirfd: number, newdirfd: number): boolean | nil, string | nil, Errno | nil
+  link: function(existingpath: string, newpath: string, flags: integer, olddirfd: integer, newdirfd: integer): boolean | nil, string | nil, Errno | nil
   --- Creates symbolic link.
   --- On Windows NT a symbolic link is called a "reparse point" and can
   --- only be created from an administrator account. Your redbean will
   --- automatically request the appropriate permissions.
-  symlink: function(target: string, linkpath: string, newdirfd?: number): boolean | nil, string | nil, Errno | nil
+  symlink: function(target: string, linkpath: string, newdirfd?: integer): boolean | nil, string | nil, Errno | nil
   --- Reads contents of symbolic link.
   --- Note that broken links are supported on all platforms. A symbolic
   --- link can contain just about anything. It's important to not assume
@@ -1867,7 +1867,7 @@ local record unix
   --- furthermore prefixes `//?/` to WIN32 DOS-style absolute paths,
   --- thereby assisting with simple absolute filename checks in addition
   --- to enabling one to exceed the traditional 260 character limit.
-  readlink: function(path: string, dirfd?: number): string | nil, string | nil, Errno | nil
+  readlink: function(path: string, dirfd?: integer): string | nil, string | nil, Errno | nil
   --- Returns absolute path of filename, with `.` and `..` components
   --- removed, and symlinks will be resolved.
   realpath: function(path: string): string | nil, string | nil, Errno | nil
@@ -1892,7 +1892,7 @@ local record unix
   --- - `AT_SYMLINK_NOFOLLOW`: Do not follow symbolic links. This makes it
   --- possible to edit the timestamps on the symbolic link itself,
   --- rather than the file it points to.
-  utimensat: function(path: string, asecs: number, ananos: number, msecs: number, mnanos: number, dirfd?: number, flags?: number): number | nil, string | nil, Errno | nil
+  utimensat: function(path: string, asecs: integer, ananos: integer, msecs: integer, mnanos: integer, dirfd?: integer, flags?: integer): integer | nil, string | nil, Errno | nil
   --- Changes access and/or modified timestamps on file descriptor.
   --- `fd` is the file descriptor of a file opened with `unix.open`.
   --- The `asecs` and `ananos` parameters set the access time. If they're
@@ -1908,14 +1908,14 @@ local record unix
   --- - `unix.UTIME_OMIT`: Do not alter this timestamp.
   --- This system call is currently not available on very old versions of
   --- Linux, e.g. RHEL5.
-  futimens: function(fd: number, asecs: number, ananos: number, msecs: number, mnanos: number): number | nil, string | nil, Errno | nil
+  futimens: function(fd: integer, asecs: integer, ananos: integer, msecs: integer, mnanos: integer): integer | nil, string | nil, Errno | nil
   --- Changes user and group on file.
   --- Returns `ENOSYS` on Windows NT.
-  chown: function(path: string, uid: number, gid: number, flags?: number, dirfd?: number): boolean | nil, string | nil, Errno | nil
+  chown: function(path: string, uid: integer, gid: integer, flags?: integer, dirfd?: integer): boolean | nil, string | nil, Errno | nil
   --- Changes mode bits on file.
   --- On Windows NT the chmod system call only changes the read-only
   --- status of a file.
-  chmod: function(path: string, mode: number, flags?: number, dirfd?: number): boolean | nil, string | nil, Errno | nil
+  chmod: function(path: string, mode: integer, flags?: integer, dirfd?: integer): boolean | nil, string | nil, Errno | nil
   --- Returns current working directory.
   --- On Windows NT, this function transliterates `\` to `/` and
   --- furthermore prefixes `//?/` to WIN32 DOS-style absolute paths,
@@ -2025,21 +2025,21 @@ local record unix
   ---   Returned `pid` is the process id of the current lock owner.
   ---   This function is currently not supported on Windows.
   ---   Returns `EBADF` if `fd` wasn't open.
-  fcntl: function(fd: number, cmd: FcntlCmd, ...: any): any | nil, string | nil, Errno | nil
+  fcntl: function(fd: integer, cmd: FcntlCmd, ...: any): any | nil, string | nil, Errno | nil
   --- Gets session id.
-  getsid: function(pid: number): number | nil, string | nil, Errno | nil
+  getsid: function(pid: integer): integer | nil, string | nil, Errno | nil
   --- Gets process group id.
-  getpgrp: function(): number | nil, string | nil, Errno | nil
+  getpgrp: function(): integer | nil, string | nil, Errno | nil
   --- Sets process group id. This is the same as `setpgid(0,0)`.
-  setpgrp: function(): number | nil, string | nil, Errno | nil
+  setpgrp: function(): integer | nil, string | nil, Errno | nil
   --- Sets process group id the modern way.
-  setpgid: function(pid: number, pgid: number): boolean | nil, string | nil, Errno | nil
+  setpgid: function(pid: integer, pgid: integer): boolean | nil, string | nil, Errno | nil
   --- Gets process group id the modern way.
-  getpgid: function(pid: number): number | nil, string | nil, Errno | nil
+  getpgid: function(pid: integer): integer | nil, string | nil, Errno | nil
   --- Sets session id.
   --- This function can be used to create daemons.
   --- Fails with `ENOSYS` on Windows NT.
-  setsid: function(): number | nil, string | nil, Errno | nil
+  setsid: function(): integer | nil, string | nil, Errno | nil
   --- Daemonizes the current process.
   --- This function performs the standard Unix daemonization steps:
   --- forks, creates a new session, and optionally changes directory
@@ -2055,22 +2055,22 @@ local record unix
   --- On Windows this system call is polyfilled by running `GetUserNameW()`
   --- through Knuth's multiplicative hash.
   --- This function does not fail.
-  getuid: function(): number
+  getuid: function(): integer
   --- Sets real group id.
   --- On Windows this system call is polyfilled as getuid().
   --- This function does not fail.
-  getgid: function(): number
+  getgid: function(): integer
   --- Gets effective user id.
   --- For example, if your redbean is a setuid binary, then getuid() will
   --- return the uid of the user running the program, and geteuid() shall
   --- return zero which means root, assuming that's the file owning user.
   --- On Windows this system call is polyfilled as getuid().
   --- This function does not fail.
-  geteuid: function(): number
+  geteuid: function(): integer
   --- Gets effective group id.
   --- On Windows this system call is polyfilled as getuid().
   --- This function does not fail.
-  getegid: function(): number
+  getegid: function(): integer
   --- Changes root directory.
   --- Returns `ENOSYS` on Windows NT.
   chroot: function(path: string): boolean | nil, string | nil, Errno | nil
@@ -2093,24 +2093,24 @@ local record unix
   --- system manual about the subtleties of changing user id in a way that
   --- isn't restorable.
   --- Returns `ENOSYS` on Windows NT if `uid` isn't `getuid()`.
-  setuid: function(uid: number): boolean | nil, string | nil, Errno | nil
+  setuid: function(uid: integer): boolean | nil, string | nil, Errno | nil
   --- Sets user id for file system ops.
-  setfsuid: function(uid: number): boolean | nil, string | nil, Errno | nil
+  setfsuid: function(uid: integer): boolean | nil, string | nil, Errno | nil
   --- Sets group id for file system ops.
-  setfsgid: function(gid: number): boolean | nil, string | nil, Errno | nil
+  setfsgid: function(gid: integer): boolean | nil, string | nil, Errno | nil
   --- Sets group id.
   --- Returns `ENOSYS` on Windows NT if `gid` isn't `getgid()`.
-  setgid: function(gid: number): boolean | nil, string | nil, Errno | nil
+  setgid: function(gid: integer): boolean | nil, string | nil, Errno | nil
   --- Sets real, effective, and saved user ids.
   --- If any of the above parameters are -1, then it's a no-op.
   --- Returns `ENOSYS` on Windows NT.
   --- Returns `ENOSYS` on Macintosh and NetBSD if `saved` isn't -1.
-  setresuid: function(real: number, effective: number, saved: number): boolean | nil, string | nil, Errno | nil
+  setresuid: function(real: integer, effective: integer, saved: integer): boolean | nil, string | nil, Errno | nil
   --- Sets real, effective, and saved group ids.
   --- If any of the above parameters are -1, then it's a no-op.
   --- Returns `ENOSYS` on Windows NT.
   --- Returns `ENOSYS` on Macintosh and NetBSD if `saved` isn't -1.
-  setresgid: function(real: number, effective: number, saved: number): boolean | nil, string | nil, Errno | nil
+  setresgid: function(real: integer, effective: integer, saved: integer): boolean | nil, string | nil, Errno | nil
   --- Sets file permission mask and returns the old one.
   --- This is used to remove bits from the `mode` parameter of functions
   --- like open() and mkdir(). The masks typically used are 027 and 022.
@@ -2122,14 +2122,14 @@ local record unix
   ---     unix.umask(mask)
   --- On Windows NT this is a no-op and `mask` is returned.
   --- This function does not fail.
-  umask: function(newmask: number): number
+  umask: function(newmask: integer): integer
   --- Queries a configurable system limit or value.
   --- `name` selects which value to return, e.g.
   ---     unix.sysconf(unix.SC_NPROCESSORS_ONLN)  -- online cpu count
   ---     unix.sysconf(unix.SC_PAGESIZE)          -- mmap() page size
   ---     unix.sysconf(unix.SC_CLK_TCK)           -- clock ticks per second
   --- Returns `nil` with an `EINVAL` errno when `name` isn't recognized.
-  sysconf: function(name: number): number | nil, string | nil, Errno | nil
+  sysconf: function(name: integer): integer | nil, string | nil, Errno | nil
   --- Returns identity of the current operating system.
   --- Example:
   ---     local u = assert(unix.uname())
@@ -2143,7 +2143,7 @@ local record unix
   --- `LOG_ERR`, `LOG_WARNING`, `LOG_NOTICE`, `LOG_INFO`, `LOG_DEBUG`.
   --- This function currently works on Linux, Windows, and NetBSD. On
   --- WIN32 it uses the ReportEvent() facility.
-  syslog: function(priority: number, msg: string)
+  syslog: function(priority: integer, msg: string)
   --- Returns nanosecond precision timestamp from system, e.g.
   ---    >: unix.clock_gettime()
   ---    1651137352      774458779
@@ -2213,32 +2213,32 @@ local record unix
   --- Returns `EINVAL` if clock isn't supported on platform.
   --- This function only fails if `clock` is invalid.
   --- This function goes fastest on Linux and Windows.
-  clock_gettime: function(clock?: number): number | nil, number, string | nil, Errno | nil
+  clock_gettime: function(clock?: integer): integer | nil, integer, string | nil, Errno | nil
   --- Sleeps with nanosecond precision.
   --- Returns `EINTR` if a signal was received while waiting.
-  nanosleep: function(seconds: number, nanos?: number): number | nil, number, string | nil, Errno | nil
+  nanosleep: function(seconds: integer, nanos?: integer): integer | nil, integer, string | nil, Errno | nil
   --- These functions are used to make programs slower by asking the
   --- operating system to flush data to the physical medium.
   sync: function()
   --- These functions are used to make programs slower by asking the
   --- operating system to flush data to the physical medium.
-  fsync: function(fd: number): boolean | nil, string | nil, Errno | nil
+  fsync: function(fd: integer): boolean | nil, string | nil, Errno | nil
   --- These functions are used to make programs slower by asking the
   --- operating system to flush data to the physical medium.
-  fdatasync: function(fd: number): boolean | nil, string | nil, Errno | nil
+  fdatasync: function(fd: integer): boolean | nil, string | nil, Errno | nil
   --- Seeks to file position.
   --- `whence` can be one of:
   --- - `SEEK_SET`: Sets the file position to `offset` [default]
   --- - `SEEK_CUR`: Sets the file position to `position + offset`
   --- - `SEEK_END`: Sets the file position to `filesize + offset`
   --- Returns the new position relative to the start of the file.
-  lseek: function(fd: number, offset: number, whence?: number): number | nil, string | nil, Errno | nil
+  lseek: function(fd: integer, offset: integer, whence?: integer): integer | nil, string | nil, Errno | nil
   --- Reduces or extends underlying physical medium of file.
   --- If file was originally larger, content >length is lost.
-  truncate: function(path: string, length?: number): boolean | nil, string | nil, Errno | nil
+  truncate: function(path: string, length?: integer): boolean | nil, string | nil, Errno | nil
   --- Reduces or extends underlying physical medium of open file.
   --- If file was originally larger, content >length is lost.
-  ftruncate: function(fd: number, length?: number): boolean | nil, string | nil, Errno | nil
+  ftruncate: function(fd: integer, length?: integer): boolean | nil, string | nil, Errno | nil
   --- - `AF_INET`: Creates Internet Protocol Version 4 (IPv4) socket.
   --- - `AF_UNIX`: Creates local UNIX domain socket. On the New Technology
   --- this requires Windows 10 and only works with `SOCK_STREAM`.
@@ -2256,7 +2256,7 @@ local record unix
   --- - `IPPROTO_RAW`
   --- - `IPPROTO_IP`
   --- - `IPPROTO_ICMP`
-  socket: function(family?: number, type?: number, protocol?: number): number | nil, string | nil, Errno | nil
+  socket: function(family?: integer, type?: integer, protocol?: integer): integer | nil, string | nil, Errno | nil
   --- Creates bidirectional pipe.
   --- - `SOCK_STREAM`
   --- - `SOCK_DGRAM`
@@ -2264,7 +2264,7 @@ local record unix
   --- You may bitwise OR any of the following into `type`:
   --- - `SOCK_CLOEXEC`
   --- - `SOCK_NONBLOCK`
-  socketpair: function(family?: number, type?: number, protocol?: number): number | nil, number, string | nil, Errno | nil
+  socketpair: function(family?: integer, type?: integer, protocol?: integer): integer | nil, integer, string | nil, Errno | nil
   ---  Binds socket.
   ---  `ip` and `port` are in host endian order. For example, if you
   ---  wanted to listen on `1.2.3.4:31337` you could do any of these
@@ -2286,7 +2286,7 @@ local record unix
   ---      end
   ---  Further note that calling `unix.bind(sock)` is equivalent to not
   ---  calling bind() at all, since the above behavior is the default.
-  bind: function(fd: number, ip?: number, port?: number): boolean | nil, string | nil, Errno | nil
+  bind: function(fd: integer, ip?: integer, port?: integer): boolean | nil, string | nil, Errno | nil
   --- Returns list of network adapter addresses.
   siocgifconf: function(): any, string | nil, Errno | nil
   --- Tunes networking parameters.
@@ -2376,7 +2376,7 @@ local record unix
   --- earlier on the listening socket. This is Linux-only. You can use the
   --- `OnServerListen` hook to enable SYN saving in your Redbean. When the
   --- `TCP_SAVE_SYN` option isn't used, this may return empty string.
-  getsockopt: function(fd: number, level: number, optname: number): number | nil, string | nil, Errno | nil
+  getsockopt: function(fd: integer, level: integer, optname: integer): integer | nil, string | nil, Errno | nil
   --- Tunes networking parameters.
   --- `level` and `optname` may be one of the following pairs. The ellipses
   --- type signature above changes depending on which options are used.
@@ -2464,7 +2464,7 @@ local record unix
   --- earlier on the listening socket. This is Linux-only. You can use the
   --- `OnServerListen` hook to enable SYN saving in your Redbean. When the
   --- `TCP_SAVE_SYN` option isn't used, this may return empty string.
-  setsockopt: function(fd: number, level: number, optname: number, value: boolean | number): boolean | nil, string | nil, Errno | nil
+  setsockopt: function(fd: integer, level: integer, optname: integer, value: boolean | integer): boolean | nil, string | nil, Errno | nil
   --- Checks for events on a set of file descriptors.
   --- The table of file descriptors to poll uses sparse integer keys. Any
   --- pairs with non-integer keys will be ignored. Pairs with negative
@@ -2486,7 +2486,7 @@ local record unix
   --- - `POLLNVAL` (revents): Invalid request.
   --- If this is set to -1 then that means block as long as it takes until there's an
   --- event or an interrupt. If the timeout expires, an empty table is returned.
-  poll: function(fds: {number: number}, timeoutms?: number): {number: number} | nil, string | nil, Errno | nil
+  poll: function(fds: {integer: integer}, timeoutms?: integer): {integer: integer} | nil, string | nil, Errno | nil
   --- Returns hostname of system.
   gethostname: function(): string | nil, string | nil, Errno | nil
   --- Sets hostname of system.
@@ -2494,53 +2494,53 @@ local record unix
   --- otherwise. Not supported on Windows, where it returns `ENOSYS`.
   sethostname: function(name: string): boolean | nil, string | nil, Errno | nil
   --- Begins listening for incoming connections on a socket.
-  listen: function(fd: number, backlog?: number): boolean | nil, string | nil, Errno | nil
+  listen: function(fd: integer, backlog?: integer): boolean | nil, string | nil, Errno | nil
   --- Accepts new client socket descriptor for a listening tcp socket.
   --- `flags` may have any combination (using bitwise OR) of:
   --- - `SOCK_CLOEXEC`
   --- - `SOCK_NONBLOCK`
-  accept: function(serverfd: number, flags?: number): number | nil, number, number, string | nil, Errno | nil
+  accept: function(serverfd: integer, flags?: integer): integer | nil, integer, integer, string | nil, Errno | nil
   ---  Connects a TCP socket to a remote host.
   ---  With TCP this is a blocking operation. For a UDP socket it simply
   ---  remembers the intended address so that `send()` or `write()` may be used
   ---  rather than `sendto()`.
-  connect: function(fd: number, ip: number, port: number): boolean | nil, string | nil, Errno | nil
+  connect: function(fd: integer, ip: integer, port: integer): boolean | nil, string | nil, Errno | nil
   --- Retrieves the local address of a socket.
-  getsockname: function(fd: number): number | nil, number, string | nil, Errno | nil
+  getsockname: function(fd: integer): integer | nil, integer, string | nil, Errno | nil
   --- Retrieves the remote address of a socket.
   --- This operation will either fail on `AF_UNIX` sockets or return an
   --- empty string.
-  getpeername: function(fd: number): number | nil, number, string | nil, Errno | nil
+  getpeername: function(fd: integer): integer | nil, integer, string | nil, Errno | nil
   --- - `MSG_WAITALL`
   --- - `MSG_DONTROUTE`
   --- - `MSG_PEEK`
   --- - `MSG_OOB`
-  recv: function(fd: number, bufsiz?: number, flags?: number): string | nil, string | nil, Errno | nil
+  recv: function(fd: integer, bufsiz?: integer, flags?: integer): string | nil, string | nil, Errno | nil
   --- - `MSG_WAITALL`
   --- - `MSG_DONTROUTE`
   --- - `MSG_PEEK`
   --- - `MSG_OOB`
-  recvfrom: function(fd: number, bufsiz?: number, flags?: number): string | nil, number, number, string | nil, Errno | nil
+  recvfrom: function(fd: integer, bufsiz?: integer, flags?: integer): string | nil, integer, integer, string | nil, Errno | nil
   --- This is the same as `write` except it has a `flags` argument
   --- that's intended for sockets.
   --- - `MSG_NOSIGNAL`: Don't SIGPIPE on EOF
   --- - `MSG_OOB`: Send stream data through out of bound channel
   --- - `MSG_DONTROUTE`: Don't go through gateway (for diagnostics)
   --- - `MSG_MORE`: Manual corking to belay nodelay (0 on non-Linux)
-  send: function(fd: number, data: string, flags?: number, offset?: number): number | nil, string | nil, Errno | nil
+  send: function(fd: integer, data: string, flags?: integer, offset?: integer): integer | nil, string | nil, Errno | nil
   --- This is useful for sending messages over UDP sockets to specific
   --- addresses.
   --- - `MSG_OOB`
   --- - `MSG_DONTROUTE`
   --- - `MSG_NOSIGNAL`
-  sendto: function(fd: number, data: string, ip: number, port: number, flags?: number): number | nil, string | nil, Errno | nil
+  sendto: function(fd: integer, data: string, ip: integer, port: integer, flags?: integer): integer | nil, string | nil, Errno | nil
   --- Partially closes socket.
   --- - `SHUT_RD`: sends a tcp half close for reading
   --- - `SHUT_WR`: sends a tcp half close for writing
   --- - `SHUT_RDWR`
   --- This system call currently has issues on Macintosh, so portable code
   --- should log rather than assert failures reported by `shutdown()`.
-  shutdown: function(fd: number, how: number): boolean | nil, string | nil, Errno | nil
+  shutdown: function(fd: integer, how: integer): boolean | nil, string | nil, Errno | nil
   --- Manipulates bitset of signals blocked by process.
   --- - `SIG_BLOCK`: applies `mask` to set of blocked signals using bitwise OR
   --- - `SIG_UNBLOCK`: removes bits in `mask` from set of blocked signals
@@ -2552,7 +2552,7 @@ local record unix
   ---   oldmask = assert(unix.sigprocmask(unix.SIG_BLOCK, newmask))
   ---   -- do something...
   ---   assert(unix.sigprocmask(unix.SIG_SETMASK, oldmask))
-  sigprocmask: function(how: number, newmask: Sigset): Sigset | nil, string | nil, Errno | nil
+  sigprocmask: function(how: integer, newmask: Sigset): Sigset | nil, string | nil, Errno | nil
   --- - `unix.SIGINT`
   --- - `unix.SIGQUIT`
   --- - `unix.SIGTERM`
@@ -2619,7 +2619,7 @@ local record unix
   --- handlers (e.g. `unix.SIG_IGN`, `unix.SIG_DFL`, or a raw function pointer)
   --- are installed directly and are not deferred.
   --- It's a good idea to not do too much work in a signal handler.
-  sigaction: function(sig: number, handler?: function | number, flags?: number, mask?: Sigset): function | number | nil, number, Sigset, string | nil, Errno | nil
+  sigaction: function(sig: integer, handler?: function | integer, flags?: integer, mask?: Sigset): function | integer | nil, integer, Sigset, string | nil, Errno | nil
   --- Waits for signal to be delivered.
   --- The signal mask is temporarily replaced with `mask` during this system call.
   sigsuspend: function(mask?: Sigset): nil, string | nil, Errno | nil
@@ -2641,7 +2641,7 @@ local record unix
   --- Here's how you'd do a single-shot timeout in 1 second:
   ---     unix.sigaction(unix.SIGALRM, MyOnSigAlrm, unix.SA_RESETHAND)
   ---     unix.setitimer(unix.ITIMER_REAL, 0, 0, 1, 0)
-  setitimer: function(which: number, intervalsec: number, intervalns: number, valuesec: number, valuens: number): number | nil, number, number, number, string | nil, Errno | nil
+  setitimer: function(which: integer, intervalsec: integer, intervalns: integer, valuesec: integer, valuens: integer): integer | nil, integer, integer, integer, string | nil, Errno | nil
   --- Turns platform-specific `sig` code into its symbolic name.
   --- For example:
   ---     >: unix.strsignal(9)
@@ -2650,7 +2650,7 @@ local record unix
   ---     "SIGKILL"
   --- Please note that signal numbers are normally different across
   --- supported platforms, and the constants should be preferred.
-  strsignal: function(sig: number): string
+  strsignal: function(sig: integer): string
   --- Changes resource limit.
   --- - `RLIMIT_AS` limits the size of the virtual address space. This
   --- will work on all platforms. It's emulated on XNU and Windows which
@@ -2671,9 +2671,9 @@ local record unix
   --- If a limit isn't supported by the host platform, it'll be set to
   --- 127. On most platforms these limits are enforced by the kernel and
   --- as such are inherited by subprocesses.
-  setrlimit: function(resource: number, soft: number, hard?: number): boolean | nil, string | nil, Errno | nil
+  setrlimit: function(resource: integer, soft: integer, hard?: integer): boolean | nil, string | nil, Errno | nil
   --- Returns information about resource limits for current process.
-  getrlimit: function(resource: number): number | nil, number, string | nil, Errno | nil
+  getrlimit: function(resource: integer): integer | nil, integer, string | nil, Errno | nil
   --- Adjusts the nice value (scheduling priority) of the calling process.
   --- The nice value ranges from -20 (highest priority) to 19 (lowest priority).
   --- Only privileged processes can lower the nice value (increase priority).
@@ -2681,7 +2681,7 @@ local record unix
   --- priority, negative values increase it.
   --- Returns the new nice value on success. Note that -1 is a valid return
   --- value, so errors must be detected by checking the second return value.
-  nice: function(inc: number): number | nil, string | nil, Errno | nil
+  nice: function(inc: integer): integer | nil, string | nil, Errno | nil
   --- Lowers the calling process to the lowest scheduling priority.
   --- On Linux this additionally requests the idle scheduling policy and a
   --- best-effort idle i/o priority. This function does not fail.
@@ -2694,7 +2694,7 @@ local record unix
   --- Returns the priority value (nice value) which ranges from -20 to 19.
   --- Note that -1 is a valid return value, so errors must be detected by
   --- checking the second return value.
-  getpriority: function(which: number, who: number): number | nil, string | nil, Errno | nil
+  getpriority: function(which: integer, who: integer): integer | nil, string | nil, Errno | nil
   --- Sets the scheduling priority of a process, process group, or user.
   --- `which` specifies what `who` refers to:
   --- - `PRIO_PROCESS`: `who` is a process id (0 = calling process)
@@ -2703,7 +2703,7 @@ local record unix
   --- `prio` is the new priority value (nice value), ranging from -20
   --- (highest priority) to 19 (lowest priority). Only privileged processes
   --- can set negative priority values.
-  setpriority: function(which: number, who: number, prio: number): boolean | nil, string | nil, Errno | nil
+  setpriority: function(which: integer, who: integer, prio: integer): boolean | nil, string | nil, Errno | nil
   --- Returns information about resource usage for current process, e.g.
   ---     >: unix.getrusage()
   ---     {utime={0, 53644000}, maxrss=44896, minflt=545, oublock=24, nvcsw=9}
@@ -2711,7 +2711,7 @@ local record unix
   --- - `RUSAGE_THREAD`: current thread
   --- - `RUSAGE_CHILDREN`: not supported on Windows NT
   --- - `RUSAGE_BOTH`: not supported on non-Linux
-  getrusage: function(who?: number): Rusage | nil, string | nil, Errno | nil
+  getrusage: function(who?: integer): Rusage | nil, string | nil, Errno | nil
   --- Restrict system operations.
   --- This can be used to sandbox your redbean workers. It allows finer
   --- customization compared to the `-S` flag.
@@ -2834,7 +2834,7 @@ local record unix
   ---   means that the `unix.WTERMSIG()` on your killed processes will
   ---   always be `unix.SIGABRT` on both Linux and OpenBSD. Otherwise,
   ---   Linux prefers to raise `unix.SIGSYS`.
-  pledge: function(promises?: string, execpromises?: string, mode?: number): boolean | nil, string | nil, Errno | nil
+  pledge: function(promises?: string, execpromises?: string, mode?: integer): boolean | nil, string | nil, Errno | nil
   --- Restricts filesystem operations, e.g.
   ---    unix.unveil(".", "r");     -- current dir + children visible
   ---    unix.unveil("/etc", "r");  -- make /etc readable too
@@ -2879,7 +2879,7 @@ local record unix
   ---   the pledge promise "cpath".
   unveil: function(path: string, permissions: string): boolean | nil, string | nil, Errno | nil
   --- Breaks down UNIX timestamp into Zulu Time numbers.
-  gmtime: function(unixts: number): number | nil, number, number, number, number, number, number, number, number, number, string, string | nil, Errno | nil
+  gmtime: function(unixts: integer): integer | nil, integer, integer, integer, integer, integer, integer, integer, integer, integer, string, string | nil, Errno | nil
   --- Breaks down UNIX timestamp into local time numbers, e.g.
   ---     >: unix.localtime(unix.clock_gettime())
   ---     2022    4       28      2       14      22      -25200  4       117     1       "PDT"
@@ -2905,24 +2905,24 @@ local record unix
   --- can simply copy it inside your redbean. The same is also the case
   --- for future updates to the database, which can be swapped out when
   --- needed, without having to recompile.
-  localtime: function(unixts: number): number | nil, number, number, number, number, number, number, number, number, number, string, string | nil, Errno | nil
+  localtime: function(unixts: integer): integer | nil, integer, integer, integer, integer, integer, integer, integer, integer, integer, string, string | nil, Errno | nil
   --- Gets information about file or directory.
   --- - `AT_SYMLINK_NOFOLLOW`: do not follow symbolic links.
-  stat: function(path: string, flags?: number, dirfd?: number): Stat | nil, string | nil, Errno | nil
+  stat: function(path: string, flags?: integer, dirfd?: integer): Stat | nil, string | nil, Errno | nil
   --- Tests if file mode represents a directory.
-  S_ISDIR: function(mode: number): boolean
+  S_ISDIR: function(mode: integer): boolean
   --- Tests if file mode represents a regular file.
-  S_ISREG: function(mode: number): boolean
+  S_ISREG: function(mode: integer): boolean
   --- Tests if file mode represents a symbolic link.
-  S_ISLNK: function(mode: number): boolean
+  S_ISLNK: function(mode: integer): boolean
   --- Tests if file mode represents a block device.
-  S_ISBLK: function(mode: number): boolean
+  S_ISBLK: function(mode: integer): boolean
   --- Tests if file mode represents a character device.
-  S_ISCHR: function(mode: number): boolean
+  S_ISCHR: function(mode: integer): boolean
   --- Tests if file mode represents a FIFO/pipe.
-  S_ISFIFO: function(mode: number): boolean
+  S_ISFIFO: function(mode: integer): boolean
   --- Tests if file mode represents a socket.
-  S_ISSOCK: function(mode: number): boolean
+  S_ISSOCK: function(mode: integer): boolean
   --- Gets information about opened file descriptor.
   --- `flags` may have any of:
   --- - `AT_SYMLINK_NOFOLLOW`: do not follow symbolic links.
@@ -2933,7 +2933,7 @@ local record unix
   ---     st = assert(unix.fstat(fd))
   ---     Log(kLogInfo, 'hello.txt is %d bytes in size' % {st:size()})
   ---     unix.close(fd)
-  fstat: function(fd: number): Stat | nil, string | nil, Errno | nil
+  fstat: function(fd: integer): Stat | nil, string | nil, Errno | nil
   --- Opens directory for listing its contents.
   --- For example, to print a simple directory listing:
   ---     Write('<ul>\r\n')
@@ -2947,15 +2947,15 @@ local record unix
   --- Opens directory for listing its contents, via an fd.
   --- The returned `unix.Dir` takes ownership of the file descriptor
   --- and will close it automatically when garbage collected.
-  fdopendir: function(fd: number): Dir | nil, string | nil, Errno | nil
+  fdopendir: function(fd: integer): Dir | nil, string | nil, Errno | nil
   --- Returns true if file descriptor is a teletypewriter. Otherwise nil
   --- with an Errno object holding one of the following values:
   --- - `ENOTTY` if `fd` is valid but not a teletypewriter
   --- - `EBADF` if `fd` isn't a valid file descriptor.
   --- - `EPERM` if pledge() is used without `tty` in lenient mode
   --- No other error numbers are possible.
-  isatty: function(fd: number): boolean | nil, string | nil, Errno | nil
-  tiocgwinsz: function(fd: number): number | nil, number, string | nil, Errno | nil
+  isatty: function(fd: integer): boolean | nil, string | nil, Errno | nil
+  tiocgwinsz: function(fd: integer): integer | nil, integer, string | nil, Errno | nil
   --- Gets terminal attributes.
   --- Returns a termios table containing the terminal I/O settings for the
   --- specified file descriptor. The table contains these fields:
@@ -2974,7 +2974,7 @@ local record unix
   ---     local password = io.read()
   ---     tio.lflag = old_lflag
   ---     unix.tcsetattr(0, unix.TCSANOW, tio)
-  tcgetattr: function(fd: number): Termios | nil, string | nil, Errno | nil
+  tcgetattr: function(fd: integer): Termios | nil, string | nil, Errno | nil
   --- Sets terminal attributes.
   --- Modifies the terminal I/O settings for the specified file descriptor
   --- using the provided termios table. The `action` parameter controls when
@@ -2985,7 +2985,7 @@ local record unix
   ---   input is discarded
   --- The termios table should contain the same fields as returned by
   --- `unix.tcgetattr()`. Missing fields default to zero.
-  tcsetattr: function(fd: number, action: number, termios: Termios): boolean | nil, string | nil, Errno | nil
+  tcsetattr: function(fd: integer, action: integer, termios: Termios): boolean | nil, string | nil, Errno | nil
   --- Returns file descriptor of open anonymous file.
   --- This creates a secure temporary file inside `$TMPDIR`. If it isn't
   --- defined, then `/tmp` is used on UNIX and GetTempPath() is used on
@@ -2996,25 +2996,25 @@ local record unix
   --- On the New Technology, temporary files created by this function
   --- should have better performance, because `kNtFileAttributeTemporary`
   --- asks the kernel to more aggressively cache and reduce i/o ops.
-  tmpfd: function(): number | nil, string | nil, Errno | nil
+  tmpfd: function(): integer | nil, string | nil, Errno | nil
   --- Relinquishes scheduled quantum.
   sched_yield: function()
   --- Disassociates parts of the caller's execution context, placing it
   --- into fresh namespace(s) specified by `flags` (bitwise OR of
   --- `unix.CLONE_NEW*` constants). Linux-only; returns ENOSYS elsewhere.
-  unshare: function(flags: number): boolean | nil, string | nil, Errno | nil
+  unshare: function(flags: integer): boolean | nil, string | nil, Errno | nil
   --- Reassociates the calling thread with the namespace referenced by
   --- `fd` (typically from `/proc/<pid>/ns/*`). `nstype`, if nonzero,
   --- must match a `unix.CLONE_NEW*` constant and asserts the kind of
   --- namespace. Linux-only; returns ENOSYS elsewhere.
-  setns: function(fd: number, nstype?: number): boolean | nil, string | nil, Errno | nil
+  setns: function(fd: integer, nstype?: integer): boolean | nil, string | nil, Errno | nil
   --- Mounts a filesystem. `flags` is a bitwise OR of `unix.MS_*`
   --- constants; `data` is a filesystem-specific options string.
-  mount: function(source?: string, target?: string, fstype?: string, flags?: number, data?: string): boolean | nil, string | nil, Errno | nil
+  mount: function(source?: string, target?: string, fstype?: string, flags?: integer, data?: string): boolean | nil, string | nil, Errno | nil
   --- Unmounts a filesystem. On Linux this is the `umount2` syscall.
   --- `flags` may include `unix.MNT_FORCE`, `unix.MNT_DETACH`,
   --- `unix.MNT_EXPIRE`, `unix.UMOUNT_NOFOLLOW`.
-  unmount: function(target: string, flags?: number): boolean | nil, string | nil, Errno | nil
+  unmount: function(target: string, flags?: integer): boolean | nil, string | nil, Errno | nil
   --- Moves the root filesystem of the current mount namespace to
   --- `put_old` and makes `new_root` the new root. Usually paired with
   --- `chdir("/")` in the child. Requires a private mount namespace.
@@ -3022,33 +3022,33 @@ local record unix
   --- Performs an operation on the calling process. `option` is one of
   --- the `unix.PR_*` constants; remaining arguments are option-specific.
   --- Returns the integer result (0 for most setters).
-  prctl: function(option: number, arg2?: number, arg3?: number, arg4?: number, arg5?: number): number | nil, string | nil, Errno | nil
+  prctl: function(option: integer, arg2?: integer, arg3?: integer, arg4?: integer, arg5?: integer): integer | nil, string | nil, Errno | nil
   --- Returns the calling thread's (or `pid`'s) capability sets as
   --- 64-bit bitmasks. Each bit position N corresponds to `unix.CAP_*`
   --- constant N. Linux-only.
-  capget: function(pid?: number): number | nil, number, number, string | nil, Errno | nil
+  capget: function(pid?: integer): integer | nil, integer, integer, string | nil, Errno | nil
   --- Sets the calling thread's (or `pid`'s) capability sets. Each
   --- argument is a 64-bit bitmask of `1 << unix.CAP_*` bits. Linux-only.
-  capset: function(effective: number, permitted: number, inheritable: number, pid?: number): boolean | nil, string | nil, Errno | nil
+  capset: function(effective: integer, permitted: integer, inheritable: integer, pid?: integer): boolean | nil, string | nil, Errno | nil
   --- Generic device control. When `arg` is nil or absent, the ioctl is
   --- invoked with a null pointer. When `arg` is an integer, it's passed
   --- by value. When `arg` is a string, a mutable copy of the same size
   --- is passed to the kernel and the (possibly-modified) buffer of the
   --- same length is returned.
-  ioctl: function(fd: number, request: number, arg?: number | string): boolean | string | nil, string | nil, Errno | nil
+  ioctl: function(fd: integer, request: integer, arg?: integer | string): boolean | string | nil, string | nil, Errno | nil
   --- Landlock: create ruleset. With no args, returns the kernel's
   --- supported ABI version. With `handled_access_fs`, creates a new
   --- ruleset file descriptor that handles the given access categories
   --- (bitwise OR of `unix.LANDLOCK_ACCESS_FS_*`). Linux 5.13+.
-  landlock_create_ruleset: function(handled_access_fs?: number, flags?: number): number | nil, string | nil, Errno | nil
+  landlock_create_ruleset: function(handled_access_fs?: integer, flags?: integer): integer | nil, string | nil, Errno | nil
   --- Landlock: add a PATH_BENEATH rule granting `allowed` access to the
   --- subtree rooted at `parent_fd` (opened with `unix.O_PATH`). `allowed`
   --- must be a subset of the ruleset's handled set.
-  landlock_add_rule: function(ruleset_fd: number, parent_fd: number, allowed: number, flags?: number): boolean | nil, string | nil, Errno | nil
+  landlock_add_rule: function(ruleset_fd: integer, parent_fd: integer, allowed: integer, flags?: integer): boolean | nil, string | nil, Errno | nil
   --- Landlock: apply the ruleset to the current thread (and its future
   --- children). Caller must set `PR_SET_NO_NEW_PRIVS` first or hold
   --- `CAP_SYS_ADMIN`. The restriction is irrevocable.
-  landlock_restrict_self: function(ruleset_fd: number, flags?: number): boolean | nil, string | nil, Errno | nil
+  landlock_restrict_self: function(ruleset_fd: integer, flags?: integer): boolean | nil, string | nil, Errno | nil
   --- Creates interprocess shared memory mapping.
   --- This function allocates special memory that'll be inherited across
   --- fork in a shared way. By default all memory in Redbean is "private"
@@ -3101,22 +3101,22 @@ local record unix
   --- the Cosmopolitan Libc mmap() granularity is 2**16.
   --- This system call does not fail. An exception is instead thrown
   --- if sufficient memory isn't available.
-  mapshared: function(size: number): Memory
+  mapshared: function(size: integer): Memory
   --- Extracts the major device number from a device id such as `Stat:rdev()`.
-  major: function(rdev: number): number
+  major: function(rdev: integer): integer
   --- Extracts the minor device number from a device id such as `Stat:rdev()`.
-  minor: function(rdev: number): number
+  minor: function(rdev: integer): integer
   --- Gets filesystem statistics for the filesystem that contains `path`.
   statfs: function(path: string): Statfs | nil, string | nil, Errno | nil
   --- Gets filesystem statistics via an open file descriptor.
-  fstatfs: function(fd: number): Statfs | nil, string | nil, Errno | nil
+  fstatfs: function(fd: integer): Statfs | nil, string | nil, Errno | nil
   --- Signal set for blocking, unblocking, and waiting on signals.
   --- Used with `unix.sigprocmask()`, `unix.sigaction()`, and `unix.sigsuspend()`.
   --- The unix.Sigset class defines a mutable bitset that may currently
   --- contain 128 entries. See `unix.NSIG` to find out how many signals
   --- your operating system actually supports.
   --- Constructs new signal bitset object.
-  Sigset: function(sig: number, ...: number): Sigset
+  Sigset: function(sig: integer, ...: integer): Sigset
 end
 
 return unix

--- a/lib/types/cosmo/zip.d.tl
+++ b/lib/types/cosmo/zip.d.tl
@@ -4,25 +4,25 @@
 
 local record OpenOptions
   --- Compression level 0-9 (for "w" and "a" modes)
-  level: number
+  level: integer
   --- Maximum file size limit in bytes
-  max_file_size: number
+  max_file_size: integer
 end
 
 --- File metadata within a ZIP archive.
 local record Stat
   --- Uncompressed file size in bytes
-  size: number
+  size: integer
   --- Compressed file size in bytes
-  compressed_size: number
+  compressed_size: integer
   --- CRC32 checksum of uncompressed data
-  crc32: number
+  crc32: integer
   --- Modification time as Unix timestamp
-  mtime: number
+  mtime: integer
   --- Compression method (0=stored, 8=deflated)
-  method: number
+  method: integer
   --- Unix file mode/permissions
-  mode: number
+  mode: integer
 end
 
 --- Directory entry returned by `zip.Reader:list`.
@@ -30,18 +30,18 @@ local record Entry
   --- Entry path within the archive
   name: string
   --- Uncompressed size in bytes
-  size: number
+  size: integer
   --- Unix file mode/permissions
-  mode: number
+  mode: integer
 end
 
 local record AddOptions
   --- Compression method: `"store"` or `"deflate"`
   method: CompressionMethod
   --- Modification time as Unix timestamp
-  mtime: number
+  mtime: integer
   --- Unix file mode (default 0644)
-  mode: number
+  mode: integer
 end
 
 --- Reader for extracting files from a ZIP archive.
@@ -114,12 +114,12 @@ local record zip
 
   --- Opens a ZIP archive for reading, writing, or appending.
   --- The first argument can be a file path string or a file descriptor integer.
-  open: function(path: string | number, mode?: OpenMode, options?: OpenOptions): any, string | nil
+  open: function(path: string | integer, mode?: OpenMode, options?: OpenOptions): any, string | nil
   --- Opens a ZIP archive from in-memory data for reading.
   from: function(data: string, options?: OpenOptions): Reader | nil, string | nil
   --- Creates a new ZIP archive for writing. This is equivalent to
   --- `zip.open(path, "w", options)`. Any existing file is truncated.
-  create: function(path: string | number, options?: OpenOptions): Writer | nil, string | nil
+  create: function(path: string | integer, options?: OpenOptions): Writer | nil, string | nil
   --- Opens an existing ZIP archive for appending. This is equivalent to
   --- `zip.open(path, "a", options)`. Unlike `zip.open` and `zip.create`,
   --- a file descriptor is not accepted; the archive must be given as a

--- a/lib/types/gentype_alias_test.tl
+++ b/lib/types/gentype_alias_test.tl
@@ -32,7 +32,7 @@ function zip.open(path, mode) end
     "literal-union alias should render as a Teal enum:\n" .. dtl)
   assert(dtl:match("--- Archive open modes%.\nlocal enum OpenMode"),
     "alias description should precede the enum:\n" .. dtl)
-  assert(dtl:match("local type Errno = number"),
+  assert(dtl:match("local type Errno = integer"),
     "scalar alias should render as a transparent type alias:\n" .. dtl)
   assert(dtl:match("  type OpenMode = OpenMode"),
     "enum should be re-exported on the module record:\n" .. dtl)

--- a/lib/types/gentype_parse.tl
+++ b/lib/types/gentype_parse.tl
@@ -283,13 +283,12 @@ local function parse_annotations(raw_lines: {string}): {string}, {Param}, {Retur
 
     local fname, ftype, fdesc = line:match("^%-%-%-@field%s+([%w_%.%?]+)%s+([^%s]+)%s*(.*)$")
     if fname then
-      local optional = false
+      -- Teal record fields have no optional marker; strip the `?` from
+      -- both name and type positions and drop the distinction.
       if fname:match("%?$") then
-        optional = true
         fname = fname:sub(1, -2)
       end
       if ftype:match("%?$") then
-        optional = true
         ftype = ftype:sub(1, -2)
       end
       table.insert(fields, {name = fname, field_type = ftype, description = {fdesc or ""}})
@@ -355,7 +354,7 @@ local function parse_annotations(raw_lines: {string}): {string}, {Param}, {Retur
         -- A variadic return (`@return string ... desc`) is rendered as a Teal
         -- vararg return type. Nothing can follow a vararg, so stop here.
         local va_type = return_part:match("^([%w_%.]+)%s+%.%.%.") or
-          (return_part == "..." and "any" or nil)
+        (return_part == "..." and "any" or nil)
         if va_type then
           table.insert(returns, {return_type = va_type .. "...", description = ""})
           break

--- a/lib/types/gentype_render.tl
+++ b/lib/types/gentype_render.tl
@@ -15,7 +15,10 @@ local current_module: string = nil
 
 -- Type conversion from LuaLS to Teal
 local TYPE_ALIASES: {string: string} = {
-  ["integer"] = "number",
+  -- Teal (targeting 5.4) has a real integer type; erasing upstream
+  -- integer annotations to number forced math.tointeger shims and
+  -- "got number, expected integer" casts on every consumer (#674).
+  ["integer"] = "integer",
   ["number"] = "number",
   ["string"] = "string",
   ["boolean"] = "boolean",
@@ -25,11 +28,11 @@ local TYPE_ALIASES: {string: string} = {
   ["function"] = "function",
   ["userdata"] = "userdata",
   ["FILE"] = "FILE",
-  ["uint32"] = "number",
-  ["uint16"] = "number",
-  ["uint8"] = "number",
-  ["int8"] = "number",
-  ["int64"] = "number",
+  ["uint32"] = "integer",
+  ["uint16"] = "integer",
+  ["uint8"] = "integer",
+  ["int8"] = "integer",
+  ["int64"] = "integer",
   -- definitions.lua declares these via ---@alias; the recursive JSON aliases
   -- have no Teal equivalent.
   ["JsonValue"] = "any",
@@ -63,8 +66,8 @@ local function convert_type(t: string): string
   if t:match("`") then return "any" end
   if TYPE_ALIASES[t] then return TYPE_ALIASES[t] end
   if t == "true" or t == "false" then return "boolean" end
-  if t:match("^%-?%d+$") then return "number" end
-  if t == "integer" then return "number" end
+  if t:match("^%-?%d+$") then return "integer" end
+  if t == "integer" then return "integer" end
   local fun_args, fun_ret = t:match("^fun%((.*)%)%s*:%s*(.+)$")
   if not fun_args then
     fun_args = t:match("^fun%((.*)%)$")

--- a/lib/types/gentype_test.tl
+++ b/lib/types/gentype_test.tl
@@ -31,18 +31,18 @@ end
 local function test_convert_type()
   -- Simple types
   assert(gentype.convert_type("string") == "string", "string type")
-  assert(gentype.convert_type("integer") == "number", "integer -> number (Teal compat)")
+  assert(gentype.convert_type("integer") == "integer", "integer stays integer")
   assert(gentype.convert_type("number") == "number", "number type")
   assert(gentype.convert_type("boolean") == "boolean", "boolean type")
   assert(gentype.convert_type("any") == "any", "any type")
 
   -- Alias types
-  assert(gentype.convert_type("uint32") == "number", "uint32 -> number (Teal compat)")
-  assert(gentype.convert_type("uint16") == "number", "uint16 -> number (Teal compat)")
+  assert(gentype.convert_type("uint32") == "integer", "uint32 -> integer")
+  assert(gentype.convert_type("uint16") == "integer", "uint16 -> integer")
 
   -- Array types
   assert(gentype.convert_type("string[]") == "{string}", "string[] -> {string}")
-  assert(gentype.convert_type("integer[]") == "{number}", "integer[] -> {number}")
+  assert(gentype.convert_type("integer[]") == "{integer}", "integer[] -> {integer}")
 
   -- Table types
   assert(gentype.convert_type("table<string,any>") == "{string: any}", "table<K,V> -> {K: V}")
@@ -50,23 +50,23 @@ local function test_convert_type()
 
   -- Nullable types render as a Teal union with nil.
   assert(gentype.convert_type("string?") == "string | nil", "string? -> string | nil")
-  assert(gentype.convert_type("integer?") == "number | nil", "integer? -> number | nil")
+  assert(gentype.convert_type("integer?") == "integer | nil", "integer? -> integer | nil")
 
   -- Parenthesized union types are unwrapped and converted (LuaLS grouping).
   assert(gentype.convert_type("(true | string)") == "boolean | string", "(true | string) union")
-  assert(gentype.convert_type("(integer | string)?") == "number | string | nil", "optional paren union")
+  assert(gentype.convert_type("(integer | string)?") == "integer | string | nil", "optional paren union")
 
   -- Variadic types keep the ellipsis with a converted base.
   assert(gentype.convert_type("string...") == "string...", "string... passthrough")
-  assert(gentype.convert_type("integer...") == "number...", "integer... -> number...")
+  assert(gentype.convert_type("integer...") == "integer...", "integer... passthrough")
 
   -- Function types convert their argument and return types. A function type
   -- with a return is parenthesized so a following `, next` in a type list
   -- cannot parse as another return of the nested function.
   assert(gentype.convert_type("fun(udata: integer, tries: integer)")
-    == "function(udata: number, tries: number)", "fun arg types convert")
+    == "function(udata: integer, tries: integer)", "fun arg types convert")
   assert(gentype.convert_type("fun(x: integer): integer")
-    == "(function(x: number): number)", "fun return type converts, parenthesized")
+    == "(function(x: integer): integer)", "fun return type converts, parenthesized")
 
   -- Module-prefixed types
   assert(gentype.convert_type("lsqlite3.Database") == "Database", "lsqlite3.Database -> Database")
@@ -149,14 +149,14 @@ function unix.dup(fd) end
     "fallible mkdir should render 'T | nil, Errno':\n" .. dtl)
   assert(dtl:match("getcwd: function%(%): string | nil, Errno"),
     "fallible getcwd should render 'T | nil, Errno':\n" .. dtl)
-  assert(dtl:match("getpid: function%(%): number"),
-    "getpid should still render its number return:\n" .. dtl)
+  assert(dtl:match("getpid: function%(%): integer"),
+    "getpid should still render its integer return:\n" .. dtl)
   assert(not dtl:match("getpid[^\n]*Errno"),
     "non-fallible getpid must NOT gain an Errno return:\n" .. dtl)
   assert(not dtl:match("getpid[^\n]*| nil"),
     "non-fallible getpid must NOT gain a nil union:\n" .. dtl)
-  assert(dtl:match("dup: function%([^\n]*%): number | nil, Errno"),
-    "dup should render 'number | nil' and a single trailing Errno:\n" .. dtl)
+  assert(dtl:match("dup: function%([^\n]*%): integer | nil, Errno"),
+    "dup should render 'integer | nil' and a single trailing Errno:\n" .. dtl)
   assert(not dtl:match("dup:[^\n]*Errno, Errno"),
     "dup must not gain a duplicate Errno:\n" .. dtl)
 
@@ -177,7 +177,7 @@ unix = {}
 function unix.ioctl(fd, request, arg) end
 ]==]
   local dtl = gentype.generate_dtl(gentype.parse_module(source, "unix"))
-  assert(dtl:match("ioctl: function%(fd: number, request: number, arg%?: number | string%): boolean | string | nil, Errno"),
+  assert(dtl:match("ioctl: function%(fd: integer, request: integer, arg%?: integer | string%): boolean | string | nil, Errno"),
     "parenthesized union types should render as Teal unions with a nil success:\n" .. dtl)
   print("test_paren_union_types: PASS")
 end
@@ -217,7 +217,7 @@ lsqlite3 = {}
 function lsqlite3.busy_handler(func, udata) end
 ]==]
   local dtl = gentype.generate_dtl(gentype.parse_module(source, "lsqlite3"))
-  assert(dtl:match("busy_handler: function%(func%?: function%(udata: any, tries: number%), udata%?: any%)"),
+  assert(dtl:match("busy_handler: function%(func%?: function%(udata: any, tries: integer%), udata%?: any%)"),
     "generic types should degrade to any:\n" .. dtl)
   print("test_generic_degrades_to_any: PASS")
 end
@@ -235,9 +235,9 @@ re = {
 }
 ]==]
   local dtl = gentype.generate_dtl(gentype.parse_module(source, "re"))
-  assert(dtl:match("%-%-%- Missing }\n  EBRACE: number"),
+  assert(dtl:match("%-%-%- Missing }\n  EBRACE: integer"),
     "constant doc comments should render above the constant:\n" .. dtl)
-  assert(dtl:match("BADBR: number"),
+  assert(dtl:match("BADBR: integer"),
     "constants after a stray `}` in a comment must still parse:\n" .. dtl)
   print("test_constant_docs_and_comment_braces: PASS")
 end
@@ -278,7 +278,7 @@ function argon2.hash_encoded(pass, config) end
   assert(dtl:match("type Variant = Variant"), "class types should be exported:\n" .. dtl)
   assert(dtl:match("variants: Variants"),
     "@type-annotated module field should render on the record:\n" .. dtl)
-  assert(dtl:match("m_cost: number"), "Config fields should render:\n" .. dtl)
+  assert(dtl:match("m_cost: integer"), "Config fields should render:\n" .. dtl)
   print("test_data_class_and_type_export: PASS")
 end
 
@@ -302,7 +302,7 @@ function lsqlite3.open(filename) end
 ]==]
   local dtl = gentype.generate_dtl(gentype.parse_module(source, "lsqlite3"))
   assert(dtl:match("local record Database"), "Database class should render:\n" .. dtl)
-  assert(dtl:match("changes: function%(self: Database%): number"),
+  assert(dtl:match("changes: function%(self: Database%): integer"),
     "qualified class method should attach to its class:\n" .. dtl)
   assert(dtl:match("open: function%(filename: string%): Database"),
     "module function should reference the class type:\n" .. dtl)


### PR DESCRIPTION
Closes #674. Teal/types hardening wave (#676), stack 6/9. **Stacked on #681** (merge order: #679 → #680 → #681 → this).

`gentype_render` mapped LuaLS `integer` (and the sized-int aliases) to Teal `number`, erasing Lua 5.4's real integer type from the entire generated `cosmo.*` surface. The erasure was self-inflicted friction: "got number, expected integer" is literally hint #1 in `cosmic.teal`, wrappers carried `math.tointeger` shims and casts the ratchet had to hold, and upstream already did its half (whilp/cosmopolitan#180 grouped the integer alias families).

**Generator** (`gentype_render.tl`): `integer` → `integer`, `uint32/uint16/uint8/int8/int64` → `integer`, numeric literal types → `integer`. All 7 declaration files regenerated (~900 lines of `number` → `integer`); gentype tests updated (`unix.Errno` is now a transparent `integer` alias).

**Wrapper migration** — the honest-propagation pass across 40+ files: fds, pids, uids/gids, ports, packed IPv4 addresses (`ip.Addr:int()`), signal numbers, wait statuses, rlimits, permission modes, sizes, offsets, futex word indexes, poll event masks, sqlite counts (`last_insert_rowid`, `changes`), zip/hash/embed option fields, and the AF_*/SOCK_*/SO_*/POLL*/SIG*/O_*/CLOCK_*/RLIMIT_*/DT_*/LOG_* constant surfaces all flip `number` → `integer` in public records and signatures. Genuinely fractional values stay `number`: `time.sleep_ms` keeps fractional milliseconds and now floors explicitly at the integer-nanos boundary (fixing previously non-integral float nanos products), io deadline arithmetic stays float.

**Cast movement is net DOWN**: ~20 obsolete casts and `math.tointeger`/`math.floor` shims deleted (child wait status, `WEXITSTATUS`/`WTERMSIG`, ip conversions, tty `VMIN`/`VTIME` indexing, net `sendall` arithmetic), zero new casts added; `casts-baseline` rewritten to lock the improvement in.

Also fixed en route: a dead `optional` local in `gentype_parse`'s `@field` branch and three stale formatter mismatches (lint.tl, publish.tl, gentype_parse.tl) that surfaced when the type regen invalidated cached check stamps.

Verified: `bin/make ci` green — with #670's strict compile gate checking every migrated file at build time, which is exactly the synergy that PR was for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3)_