### PR TITLE
gentype: emit real Teal generics for function-level @generic

### DIFF
--- a/lib/types/cosmo/lsqlite3.d.tl
+++ b/lib/types/cosmo/lsqlite3.d.tl
@@ -45,7 +45,7 @@ local record Database
   --- `0` if the transaction is to be aborted. All other values will result in
   --- another attempt to perform the transaction. (See the SQLite documentation
   --- for important hints about writing busy handlers.)
-  busy_handler: function(self: Database, func?: function(udata: any, tries: integer), udata?: any)
+  busy_handler: function<Udata>(self: Database, func?: function(udata: Udata, tries: integer), udata?: Udata)
   --- Sets a busy handler that waits for `milliseconds` if a transaction cannot proceed.
   --- Calling this function will remove any busy handler set by `db:busy_handler()`;
   --- calling it with an argument less than or equal to `0` will turn off all busy handlers.
@@ -65,7 +65,7 @@ local record Database
   --- If `func` returns `false` or `nil` the COMMIT is allowed to proceed,
   --- otherwise the COMMIT is converted to a ROLLBACK.
   --- See: `db:rollback_hook` and `db:update_hook`
-  commit_hook: function(self: Database, func: function(udata: any), udata: any)
+  commit_hook: function<Udata>(self: Database, func: function(udata: Udata), udata: Udata)
   --- It should accept a function context (see Methods for callback contexts) plus
   --- the same number of parameters as given in `nargs`.
   --- It receives one argument, the function context.
@@ -137,7 +137,7 @@ local record Database
   deserialize: function(self: Database, s: string)
   errcode: function(self: Database): ResultCode
   errmsg: function(self: Database): string
-  exec: function(self: Database, sql: string, func?: (function(udata: any, cols: integer, values: {string}, names: {string}): integer), udata?: any): ResultCode
+  exec: function<Udata>(self: Database, sql: string, func?: (function(udata: Udata, cols: integer, values: {string}, names: {string}): integer), udata?: Udata): ResultCode
   --- This function causes any pending database operation to abort and return at
   --- the next opportunity.
   interrupt: function(self: Database)
@@ -181,7 +181,7 @@ local record Database
   readonly: function(self: Database, name?: string): boolean | nil, string | nil
   --- This function installs a rollback_hook callback handler.
   --- See: `db:commit_hook` and `db:update_hook`
-  rollback_hook: function(self: Database, func: function(udata: any), udata: any)
+  rollback_hook: function<Udata>(self: Database, func: function(udata: Udata), udata: Udata)
   --- Creates an iterator that returns the successive rows selected by the SQL
   --- statement given in string `sql`. Each call to the iterator returns a table in
   --- which the numerical indices 1 to n correspond to the selected columns 1 to n in
@@ -218,7 +218,7 @@ local record Database
   --- database and table name containing the affected row. The final
   --- callback parameter is the rowid of the row. In the case of an
   --- update, this is the rowid after the update takes place.
-  update_hook: function(self: Database, func: function(udata: any, op: integer, db: Database, name: string, rowid: integer), udata: any)
+  update_hook: function<Udata>(self: Database, func: function(udata: Udata, op: integer, db: Database, name: string, rowid: integer), udata: Udata)
   --- Creates an iterator that returns the successive rows selected by the SQL
   --- statement given in string sql. Each call to the iterator returns the values
   --- that correspond to the columns in the currently selected row.
@@ -236,7 +236,7 @@ local record Database
   ---     3       33
   urows: function(self: Database, sql: string): function, VM
   wal_checkpoint: function(self: Database, mode?: integer, name?: string): integer | nil, integer, ResultCode | nil
-  wal_hook: function(self: Database, func?: (function(udata: any, db: Database, name: string, page_count: integer): integer), udata?: any)
+  wal_hook: function<Udata>(self: Database, func?: (function(udata: Udata, db: Database, name: string, page_count: integer): integer), udata?: Udata)
 end
 
 --- After creating a prepared statement with `db:prepare()` the returned statement

--- a/lib/types/gentype.tl
+++ b/lib/types/gentype.tl
@@ -25,7 +25,7 @@ end
 local extract = require("types.gentype_extract") as GentypeExtract
 
 local record GentypeParse
-  parse_annotations: function(raw_lines: {string}): {string}, {Param}, {Return}, boolean, string, {Field}, boolean, string
+  parse_annotations: function(raw_lines: {string}): {string}, {Param}, {Return}, boolean, string, {Field}, boolean, string, {string}
   valid_type: function(t: string): boolean
 end
 local parse = require("types.gentype_parse") as GentypeParse
@@ -266,12 +266,12 @@ local function parse_module(source: string, module_name: string): ModuleDecl
         anno_lines = func_lines
       end
 
-      local desc, params, returns, nodiscard, _, _, fallible, error_type = parse_annotations(anno_lines)
+      local desc, params, returns, nodiscard, _, _, fallible, error_type, generics = parse_annotations(anno_lines)
       params = reconcile_params(params, params_str)
       table.insert(module.functions, {
           name = fname, module = module_name, description = desc,
           params = params, returns = returns, is_method = false, nodiscard = nodiscard,
-          fallible = fallible, error_type = error_type,
+          fallible = fallible, error_type = error_type, generics = generics,
         })
       anno_lines = {}
       i = i + 1
@@ -279,13 +279,13 @@ local function parse_module(source: string, module_name: string): ModuleDecl
       local full_class_name, method_name = line:match("^function%s+([%w_%.]+):([%w_]+)%s*%(")
       local class_name = full_class_name:match("%.([%w_]+)$") or full_class_name
       local method_params_str = line:match("%((.-)%)")
-      local desc, params, returns, nodiscard, _, _, fallible, error_type = parse_annotations(anno_lines)
+      local desc, params, returns, nodiscard, _, _, fallible, error_type, generics = parse_annotations(anno_lines)
       params = reconcile_params(params, method_params_str)
       local method: FuncDecl = {
         name = method_name, module = module_name, description = desc,
         params = params, returns = returns, is_method = true,
         class_name = class_name, nodiscard = nodiscard,
-        fallible = fallible, error_type = error_type,
+        fallible = fallible, error_type = error_type, generics = generics,
       }
       local found = false
       for _, cls in ipairs(module.classes) do

--- a/lib/types/gentype_parse.tl
+++ b/lib/types/gentype_parse.tl
@@ -232,7 +232,7 @@ local function valid_type(t: string): boolean
 end
 
 --- Parse annotations from a block of text before a declaration.
-local function parse_annotations(raw_lines: {string}): {string}, {Param}, {Return}, boolean, string, {Field}, boolean, string
+local function parse_annotations(raw_lines: {string}): {string}, {Param}, {Return}, boolean, string, {Field}, boolean, string, {string}
   local desc: {string} = {}
   local params: {Param} = {}
   local returns: {Return} = {}
@@ -409,8 +409,11 @@ local function parse_annotations(raw_lines: {string}): {string}, {Param}, {Retur
     end
   end
 
-  -- LuaLS generics (`---@generic T`) have no Teal equivalent in a record
-  -- field type; degrade each generic name to `any` wherever it appears.
+  -- Function-level generics render as real Teal type parameters
+  -- (`function<T>(...)`), so params/returns keep the generic names.
+  -- Record FIELD types have no per-field generic scope in Teal; degrade
+  -- generic names to `any` there only.
+  local generic_list: {string} = {}
   if next(generics) then
     local function degrade(t: string): string
       if not t then return t end
@@ -419,17 +422,19 @@ local function parse_annotations(raw_lines: {string}): {string}, {Param}, {Retur
       end
       return t
     end
-    for _, p in ipairs(params) do p.param_type = degrade(p.param_type) end
-    for _, r in ipairs(returns) do r.return_type = degrade(r.return_type) end
     for _, f in ipairs(fields) do f.field_type = degrade(f.field_type) end
+    for g in pairs(generics) do
+      generic_list[#generic_list + 1] = g
+    end
+    table.sort(generic_list)
   end
 
-  return desc, params, returns, nodiscard, class_annotation, fields, fallible, error_type
+  return desc, params, returns, nodiscard, class_annotation, fields, fallible, error_type, generic_list
 end
 
 local record GentypeParseModule
   split_type_desc: function(rest: string): string, string
-  parse_annotations: function(raw_lines: {string}): {string}, {Param}, {Return}, boolean, string, {Field}, boolean, string
+  parse_annotations: function(raw_lines: {string}): {string}, {Param}, {Return}, boolean, string, {Field}, boolean, string, {string}
   valid_type: function(t: string): boolean
 end
 

--- a/lib/types/gentype_render.tl
+++ b/lib/types/gentype_render.tl
@@ -162,6 +162,17 @@ local function convert_type(t: string): string
   return t
 end
 
+--- Render a Teal generic type-parameter list (`<Udata>`), or "" when the
+--- function declares none. Generic names pass through convert_type's
+--- identifier fallthrough untouched, so params/returns reference them
+--- directly.
+local function render_generics(generics: {string}): string
+  if not generics or #generics == 0 then
+    return ""
+  end
+  return "<" .. table.concat(generics, ", ") .. ">"
+end
+
 --- Render a parameter list (optionally with a self receiver).
 local function render_params(params: {Param}, self_name: string): string
   local parts: {string} = {}
@@ -350,7 +361,8 @@ local function generate_dtl(module: ModuleDecl): string
         end
         local params_str = render_params(method.params, cls.name)
         local ret_str = render_returns(method.returns, method.fallible, method.error_type)
-        table.insert(out, "  " .. method.name .. ": function(" .. params_str .. ")" .. ret_str)
+        table.insert(out, "  " .. method.name .. ": function" .. render_generics(method.generics)
+          .. "(" .. params_str .. ")" .. ret_str)
       end
       table.insert(out, "end")
       table.insert(out, "")
@@ -426,7 +438,8 @@ local function generate_dtl(module: ModuleDecl): string
     end
     local params_str = render_params(func.params, nil)
     local ret_str = render_returns(func.returns, func.fallible, func.error_type)
-    table.insert(out, "  " .. func.name .. ": function(" .. params_str .. ")" .. ret_str)
+    table.insert(out, "  " .. func.name .. ": function" .. render_generics(func.generics)
+      .. "(" .. params_str .. ")" .. ret_str)
   end
 
   table.insert(out, "end")

--- a/lib/types/gentype_test.tl
+++ b/lib/types/gentype_test.tl
@@ -205,9 +205,10 @@ function re.search(regex, text) end
   print("test_vararg_return: PASS")
 end
 
--- LuaLS generics (`---@generic T`) have no Teal record-field equivalent; each
--- generic name degrades to `any` wherever it appears.
-local function test_generic_degrades_to_any()
+-- LuaLS function-level generics (`---@generic T`) render as real Teal
+-- generic type parameters (`function<T>(...)`), with the generic name
+-- kept in the params/returns that reference it.
+local function test_generics_emitted()
   local source = [==[
 lsqlite3 = {}
 --- Sets a busy handler.
@@ -217,9 +218,9 @@ lsqlite3 = {}
 function lsqlite3.busy_handler(func, udata) end
 ]==]
   local dtl = gentype.generate_dtl(gentype.parse_module(source, "lsqlite3"))
-  assert(dtl:match("busy_handler: function%(func%?: function%(udata: any, tries: integer%), udata%?: any%)"),
-    "generic types should degrade to any:\n" .. dtl)
-  print("test_generic_degrades_to_any: PASS")
+  assert(dtl:match("busy_handler: function<Udata>%(func%?: function%(udata: Udata, tries: integer%), udata%?: Udata%)"),
+    "generics should render as Teal type parameters:\n" .. dtl)
+  print("test_generics_emitted: PASS")
 end
 
 -- Constants inside the module table are indented, and so are their doc
@@ -476,7 +477,7 @@ local function run_tests()
   test_errno_overload_render()
   test_paren_union_types()
   test_vararg_return()
-  test_generic_degrades_to_any()
+  test_generics_emitted()
   test_constant_docs_and_comment_braces()
   test_data_class_and_type_export()
   test_qualified_class_methods()

--- a/lib/types/gentype_types.tl
+++ b/lib/types/gentype_types.tl
@@ -23,6 +23,9 @@ local record gentype_types
     is_method: boolean
     class_name: string
     nodiscard: boolean
+    -- Sorted `---@generic` type-parameter names, rendered as a Teal
+    -- generic function signature (`function<T>(...)`).
+    generics: {string}
     -- True when an `@overload fun(...): nil, <error> Errno` failure form is
     -- present, meaning the call returns `<value>, Errno` at runtime.
     fallible: boolean


### PR DESCRIPTION
Closes #675. Teal/types hardening wave (#676), stack 7/9. **Stacked on #682**.

`gentype_parse` degraded every `---@generic` type parameter to `any` wherever it appeared, erasing the callback/userdata pairing on the six lsqlite3 hook installers (`busy_handler`, `commit_hook`, `rollback_hook`, `update_hook`, `wal_hook`, `Database:exec`). Teal has real generic function types, and the codebase already adopted its first generic in `cosmic.check` (#644) — the consumer side was proven.

- `parse_annotations` keeps generic names in params/returns and returns the sorted name list; only record **field** types (which have no per-field generic scope in Teal) still degrade to `any`, as documented.
- `FuncDecl` grows `generics`; the renderer emits `function<Udata>(...)` on module functions and class methods. Generic names ride through `convert_type`'s identifier fallthrough untouched.
- Regenerated: the six lsqlite3 hook signatures now pair the callback's `udata` with the installer's `udata` argument instead of `any`/`any` — e.g. `busy_handler: function<Udata>(self: Database, func?: function(udata: Udata, tries: integer), udata?: Udata)`.
- `gentype_test`: `test_generic_degrades_to_any` becomes `test_generics_emitted`; also trued-up three integer-era expectations the incremental test lane hadn't re-run yet (`integer?`, paren unions, `m_cost`, `Database:changes`).

Verified: `bin/make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3)_