### PR TITLE
types: shed remaining hand-redeclared C records

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,11 +153,13 @@ or map unions through truthiness (`if not x`). Two sanctioned tools:
   then return end` does not narrow below); and `is` is WRONG for
   mixed-representation records — `fs.Stat` is usually the raw stat
   userdata but falls back to a plain wrapper table, so neither marker
-  fits; it stays on casts. (The old ban on `is` with REQUIRED
-  `cosmo.*` classes is lifted: the cosmic runtime searcher (#669)
-  resolves .d.tl markers through the same include dirs as the
-  checker, so `is` can no longer silently degrade to a table test;
-  existing boundary casts get converted incrementally.)
+  fits; it stays on casts. (The ban on `is` with REQUIRED `cosmo.*`
+  classes is NARROWED, not lifted: under the cosmic dispatcher the
+  runtime searcher (#669) resolves .d.tl markers, so `is` cannot
+  degrade there — but stdlib modules that EMBEDDED apps may recompile
+  via the documented `require("tl").loader()` main.lua pattern bypass
+  the cosmic searcher and still degrade; those keep casts, e.g.
+  fs.opendir.)
 - **Cast in linear code and at userdata boundaries**: after an assert or
   early-exit guard, `(x as Rec).field`, `(x as {K:V})[k]`. Scalars
   (`string | nil`) narrow normally, except method-call syntax: use

--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -96,7 +96,7 @@
 13	lib/cosmic/fs/walk.tl
 2	lib/cosmic/fs/walk_example.tl
 6	lib/cosmic/fs/walk_test.tl
-10	lib/cosmic/getopt.tl
+4	lib/cosmic/getopt.tl
 3	lib/cosmic/getopt_example.tl
 16	lib/cosmic/getopt_test.tl
 3	lib/cosmic/hash.tl
@@ -203,7 +203,7 @@
 6	lib/cosmic/url.tl
 14	lib/cosmic/url_test.tl
 7	lib/cosmic/version_test.tl
-8	lib/cosmic/zip.tl
+1	lib/cosmic/zip.tl
 44	lib/cosmic/zip_test.tl
 7	lib/docs/publish.tl
 2	lib/docs/publish_test.tl

--- a/lib/cosmic/fs/init.tl
+++ b/lib/cosmic/fs/init.tl
@@ -18,17 +18,8 @@ local fs_file = require("cosmic.fs.file")
 local cfd = require("cosmic.fd")
 local type Handle = cfd.Handle
 
--- Raw Dir type from cosmo.unix
-local record RawDir
-  read: function(self: RawDir): string, integer
-  close: function(self: RawDir)
-  fd: function(self: RawDir): integer
-  rewind: function(self: RawDir)
-  tell: function(self: RawDir): integer
-end
-
--- Wrap a raw cosmo Dir with __close support
-local function make_dir(raw: RawDir): Dir
+-- Wrap a raw unix.Dir with __close support
+local function make_dir(raw: unix.Dir): Dir
   local is_closed = false
 
   local dir: Dir = {
@@ -37,7 +28,8 @@ local function make_dir(raw: RawDir): Dir
     -- so "is this entry a directory" needs no stat(2) call.
     read = function(_self: Dir): string, integer
       if is_closed then return nil end
-      return raw:read()
+      local name, kind = raw:read()
+      return name, kind
     end,
     close = function(_self: Dir)
       if not is_closed then
@@ -47,14 +39,14 @@ local function make_dir(raw: RawDir): Dir
     end,
     fd = function(_self: Dir): integer
       if is_closed then return -1 end
-      return raw:fd()
+      return (raw:fd())
     end,
     rewind = function(_self: Dir)
       if not is_closed then raw:rewind() end
     end,
     tell = function(_self: Dir): integer
       if is_closed then return -1 end
-      return raw:tell()
+      return (raw:tell())
     end,
     closed = function(_self: Dir): boolean
       return is_closed
@@ -184,11 +176,18 @@ end
 --- @return Dir | nil Directory handle, or nil on error
 --- @return string Error message if failed
 local function opendir(path: string): Dir | nil, string
+  -- Cast, not `is`: embedded apps whose main.lua installs
+  -- require("tl").loader() (the documented embed pattern) can
+  -- lax-recompile this module through tl's OWN loader, where the
+  -- cosmo.unix .d.tl marker doesn't resolve and `is` degrades to a
+  -- table test that rejects every real Dir handle (seen breaking
+  -- envd_example's re-embedded app). The cosmic searcher guarantees
+  -- resolution only inside the cosmic dispatcher.
   local raw, err = unix.opendir(path)
-  if not raw then
-    return nil, errstr(err, "opendir: " .. path)
+  if raw ~= nil then
+    return make_dir(raw as unix.Dir)
   end
-  return make_dir(raw as RawDir)
+  return nil, errstr(err, "opendir: " .. path)
 end
 
 --- Open a directory from a file descriptor.
@@ -197,11 +196,12 @@ end
 --- @return Dir | nil Directory handle, or nil on error
 --- @return string Error message if failed
 local function fdopendir(fd: integer): Dir | nil, string
+  -- Cast, not `is`: same tl.loader() degradation hazard as opendir.
   local raw, err = unix.fdopendir(fd)
-  if not raw then
-    return nil, errstr(err, "fdopendir")
+  if raw ~= nil then
+    return make_dir(raw as unix.Dir)
   end
-  return make_dir(raw as RawDir)
+  return nil, errstr(err, "fdopendir")
 end
 
 -- Re-export walk functions from fs_walk submodule

--- a/lib/cosmic/getopt.tl
+++ b/lib/cosmic/getopt.tl
@@ -5,15 +5,17 @@
 local cosmo_getopt = require("cosmo.getopt")
 
 -- The underlying cosmo.getopt binding changed shape across cosmos releases:
--- newer builds expose a single-shot `parse`, while older ones (including the
--- pinned build bootstrap) expose the stateful `new`/parser iterator. Describe
--- both shapes loosely so we can feature-detect whichever is present at
--- runtime; either field may be nil depending on the cosmos version.
-local record RawGetopt
+-- newer builds expose the single-shot `parse` the generated declarations
+-- describe, while older ones (including the pinned build bootstrap) expose
+-- only a stateful `new`/parser iterator that the generated declarations no
+-- longer carry. This record is that legacy surface, kept for runtime
+-- feature detection; either field may be nil depending on the cosmos
+-- version.
+local record LegacyGetopt
   parse: function(args: {string}, optstring: string, longopts: {table}): any, any
   new: function(args: {string}, optstring: string, longopts: {table}): any
 end
-local raw = cosmo_getopt as RawGetopt
+local legacy = cosmo_getopt as LegacyGetopt
 
 --- Defines a long option with its name, argument behavior, and optional short alias.
 --- @field name string The long option name (e.g., "help" for --help)
@@ -25,28 +27,22 @@ local record LongOpt
   short: string
 end
 
---- A single recognized option and its argument.
+--- A single recognized option and its argument (the generated
+--- cosmo.getopt.Option record).
 --- For a long option that has a short alias, `opt` is that short letter; for a
 --- long-only option, `opt` is the long name. `arg` is nil when the option takes
 --- no argument.
 --- @field opt string The option letter or long name
 --- @field arg string|nil The option's argument, if any
-local record Option
-  opt: string
-  arg: string
-end
+local type Option = cosmo_getopt.Option
 
---- The outcome of a single `parse` call.
+--- The outcome of a single `parse` call (the generated
+--- cosmo.getopt.Result record).
 --- @field opts {Option} Recognized options, in the order encountered
 --- @field args {string} Non-option (positional) arguments
 --- @field unknown {string} Unrecognized options, each including its dashes
 --- @field missing {string} Options that required an argument but got none
-local record Result
-  opts: {Option}
-  args: {string}
-  unknown: {string}
-  missing: {string}
-end
+local type Result = cosmo_getopt.Result
 
 --- A parser object for iterating through command-line options one at a time.
 --- Retained as a thin compatibility shim over `parse`; prefer `parse`.
@@ -109,13 +105,13 @@ end
 local function parse(args: {string}, optstring: string, longopts?: {LongOpt}): Result | nil, string
   local raw_longopts = to_raw_longopts(longopts)
 
-  if raw.parse then
-    -- Newer cosmos: native single-shot parse.
-    local res, err = raw.parse(args, optstring, raw_longopts)
+  if legacy.parse then
+    -- Newer cosmos: native single-shot parse via the generated surface.
+    local res, err = cosmo_getopt.parse(args, optstring, raw_longopts)
     if not res then
-      return nil, err as string
+      return nil, err
     end
-    return res as Result
+    return res
   end
 
   -- Older cosmos (build bootstrap): emulate parse via the iterator. The
@@ -123,19 +119,19 @@ local function parse(args: {string}, optstring: string, longopts?: {LongOpt}): R
   -- `unknown` here; the accurate split is only available on the native path,
   -- which is what the shipped binary uses.
   local result: Result = {opts = {}, args = {}, unknown = {}, missing = {}}
-  local p = raw.new(args, optstring, raw_longopts) as Parser
+  local p = legacy.new(args, optstring, raw_longopts) as Parser
   while true do
     local opt, optarg = p:next()
     if not opt then
       break
     end
     if opt == "?" then
-      table.insert(result.unknown, optarg as string)
+      table.insert(result.unknown, optarg)
     else
-      table.insert(result.opts, {opt = opt as string, arg = optarg as string})
+      table.insert(result.opts, {opt = opt, arg = optarg})
     end
   end
-  result.args = p:remaining() as {string}
+  result.args = p:remaining()
   return result
 end
 
@@ -147,9 +143,9 @@ end
 --- @param longopts {LongOpt}|nil Long option definitions
 --- @return Parser A parser instance for iterating through options
 local function new(args: {string}, optstring: string, longopts?: {LongOpt}): Parser
-  if raw.new then
+  if legacy.new then
     -- Older cosmos: use the native iterator directly.
-    return raw.new(args, optstring, to_raw_longopts(longopts)) as Parser
+    return legacy.new(args, optstring, to_raw_longopts(longopts)) as Parser
   end
 
   -- Newer cosmos: replay parse() results through an iterator interface.

--- a/lib/cosmic/shm.tl
+++ b/lib/cosmic/shm.tl
@@ -19,6 +19,9 @@ local record ShmModule
   --- Words are 64-bit; word_index is 0-based. Futex words (wait/wake)
   --- only inspect the low 32 bits — store only int32 values in words
   --- you wait on.
+  --- Not a mirror of the generated unix.Memory: this is a deliberately
+  --- narrowed surface whose methods validate bounds in Lua, return
+  --- nil, err instead of throwing, and add size().
   record Memory
     --- Read bytes from the region. With no bytes count, reads up to the
     --- first NUL byte (string semantics).

--- a/lib/cosmic/signal.tl
+++ b/lib/cosmic/signal.tl
@@ -22,6 +22,9 @@ end
 
 --- Signal set for blocking, unblocking, and waiting on signals.
 --- Wraps unix.Sigset for use with sigprocmask, sigaction, and sigsuspend.
+--- This mirror is deliberate: the generated unix record cannot re-export
+--- the Sigset record type because its `Sigset` name is taken by the
+--- constructor function field, so the binding's type is unnameable here.
 --- Sigset is PascalCase because it is a record constructor: cosmic names
 --- functions snake_case and reserves PascalCase for records and the
 --- functions that construct them.

--- a/lib/cosmic/zip.tl
+++ b/lib/cosmic/zip.tl
@@ -8,125 +8,45 @@
 local zip = require("cosmo.zip")
 local fs = require("cosmic.fs")
 
---- Options for opening a ZIP archive.
-local record OpenOptions
-  --- Compression level 0-9 (0=none, 9=maximum). Used when writing/appending.
-  level: integer
-  --- Maximum file size limit in bytes.
-  max_file_size: integer
-end
+--- Options for opening a ZIP archive: compression level 0-9 (used when
+--- writing/appending) and max_file_size limit. The generated
+--- cosmo.zip.OpenOptions record.
+local type OpenOptions = zip.OpenOptions
 
---- Options for adding a file to a ZIP archive.
-local record AddOptions
-  --- Compression method: "store" (no compression) or "deflate" (compressed).
-  method: zip.CompressionMethod
-  --- Modification time as Unix timestamp.
-  mtime: integer
-  --- Unix file mode/permissions (default 0644).
-  mode: integer
-end
+--- Options for adding a file to a ZIP archive: method ("store" or
+--- "deflate"), mtime, and mode. The generated cosmo.zip.AddOptions record.
+local type AddOptions = zip.AddOptions
 
---- File metadata within a ZIP archive.
-local record Stat
-  --- Uncompressed file size in bytes.
-  size: integer
-  --- Compressed file size in bytes.
-  compressed_size: integer
-  --- CRC32 checksum of uncompressed data.
-  crc32: integer
-  --- Modification time as Unix timestamp.
-  mtime: integer
-  --- Compression method (0=stored, 8=deflated).
-  method: integer
-  --- Unix file mode/permissions.
-  mode: integer
-end
+--- File metadata within a ZIP archive: size, compressed_size, crc32,
+--- mtime, method (0=stored, 8=deflated), and mode. The generated
+--- cosmo.zip.Stat record.
+local type Stat = zip.Stat
 
---- Directory entry returned by Reader:list().
-local record Entry
-  --- Entry path within the archive.
-  name: string
-  --- Uncompressed size in bytes.
-  size: integer
-  --- Unix file mode/permissions.
-  mode: integer
-end
+--- Directory entry returned by Reader:list(): name, size, and mode. The
+--- generated cosmo.zip.Entry record.
+local type Entry = zip.Entry
 
---- Reader for extracting files from a ZIP archive.
-local record Reader
-  --- Lists all files in the ZIP archive, in archive order. Each record
-  --- carries the entry's name, uncompressed size, and mode, so bulk
-  --- operations don't need a follow-up stat per entry.
-  --- Entry names come raw from the central directory: an archive built by
-  --- another tool can contain absolute or "../" names. Validate before
-  --- using a name as a filesystem path, or use extract().
-  --- @return {Entry} Directory entry records for the archive
-  list: function(self: Reader): {Entry}
+--- Reader for extracting files from a ZIP archive (the generated
+--- cosmo.zip.Reader class): list(), stat(name), read(name), close().
+--- Entry names come raw from the central directory: an archive built by
+--- another tool can contain absolute or "../" names. Validate before
+--- using a name as a filesystem path, or use extract().
+local type Reader = zip.Reader
 
-  --- Gets metadata for a specific file in the archive.
-  --- @param name string The file path within the archive
-  --- @return Stat | nil File metadata
-  --- @return string? Error message when the entry is absent
-  stat: function(self: Reader, name: string): Stat | nil, string
+--- Writer for creating new ZIP archives (the generated cosmo.zip.Writer
+--- class): add(name, content, options?), close().
+local type Writer = zip.Writer
 
-  --- Reads the contents of a file from the archive.
-  --- @param name string The file path within the archive
-  --- @return string? The file contents, or nil on error
-  --- @return string? Error message if reading failed
-  read: function(self: Reader, name: string): string | nil, string
-
-  --- Closes the ZIP reader and releases resources.
-  close: function(self: Reader)
-end
-
---- Writer for creating new ZIP archives.
-local record Writer
-  --- Adds a file to the ZIP archive.
-  --- @param name string The file path within the archive
-  --- @param content string The file contents
-  --- @param options AddOptions? Optional compression and metadata settings
-  --- @return boolean? true on success, nil on failure
-  --- @return string? Error message if adding failed
-  add: function(self: Writer, name: string, content: string, options?: AddOptions): boolean | nil, string
-
-  --- Closes the ZIP archive and writes the central directory.
-  close: function(self: Writer)
-end
-
---- Appender for adding files to an existing ZIP archive.
-local record Appender
-  --- Adds a file to the ZIP archive.
-  --- @param name string The file path within the archive
-  --- @param content string The file contents
-  --- @param options AddOptions? Optional compression and metadata settings
-  --- @return boolean? true on success, nil on failure
-  --- @return string? Error message if adding failed
-  add: function(self: Appender, name: string, content: string, options?: AddOptions): boolean | nil, string
-
-  --- Removes a file from the ZIP archive by name.
-  --- @param name string The file path within the archive to remove
-  --- @return boolean? true on success, nil on failure
-  --- @return string? Error message if removal failed
-  remove: function(self: Appender, name: string): boolean | nil, string
-
-  --- Closes the ZIP archive and writes the updated central directory.
-  close: function(self: Appender)
-end
+--- Appender for adding files to an existing ZIP archive (the generated
+--- cosmo.zip.Appender class): add(name, content, options?), remove(name),
+--- close().
+local type Appender = zip.Appender
 
 --- Options for extract().
 local record ExtractOptions
   --- Refuse any entry whose declared uncompressed size exceeds this many
   --- bytes (checked before anything is read or written).
   max_file_size: integer
-end
-
--- Build a plain options table so the nominal cosmo.zip.OpenOptions record
--- doesn't conflict with this module's OpenOptions.
-local function raw_options(options: OpenOptions): {string: integer}
-  return {
-    level = options.level,
-    max_file_size = options.max_file_size,
-  }
 end
 
 --- Open a ZIP archive for reading.
@@ -138,7 +58,7 @@ local function reader(path: string | integer, options?: OpenOptions): Reader | n
   local handle: any
   local err: string
   if options then
-    handle, err = zip.open(path, "r", raw_options(options) as zip.OpenOptions)
+    handle, err = zip.open(path, "r", options)
   else
     handle, err = zip.open(path, "r")
   end
@@ -154,17 +74,17 @@ end
 --- @return Writer | nil The archive writer, or nil on error
 --- @return string? Error message if opening failed
 local function writer(path: string | integer, options?: OpenOptions): Writer | nil, string
-  local handle: any
+  local handle: Writer
   local err: string
   if options then
-    handle, err = zip.create(path, raw_options(options) as zip.OpenOptions)
+    handle, err = zip.create(path, options)
   else
     handle, err = zip.create(path)
   end
   if not handle then
     return nil, err or "failed to create zip archive"
   end
-  return handle as Writer
+  return handle
 end
 
 --- Open a ZIP archive for appending, creating it if it does not exist.
@@ -175,17 +95,17 @@ end
 --- @return Appender | nil The archive appender, or nil on error
 --- @return string? Error message if opening failed
 local function appender(path: string, options?: OpenOptions): Appender | nil, string
-  local handle: any
+  local handle: Appender
   local err: string
   if options then
-    handle, err = zip.append(path, raw_options(options) as zip.OpenOptions)
+    handle, err = zip.append(path, options)
   else
     handle, err = zip.append(path)
   end
   if not handle then
     return nil, err or "failed to open zip archive for appending"
   end
-  return handle as Appender
+  return handle
 end
 
 --- Open a ZIP archive from in-memory data for reading.
@@ -194,17 +114,17 @@ end
 --- @return Reader? The archive reader, or nil on error
 --- @return string? Error message if opening failed
 local function from(data: string, options?: OpenOptions): Reader | nil, string
-  local handle: any
+  local handle: Reader
   local err: string
   if options then
-    handle, err = zip.from(data, raw_options(options) as zip.OpenOptions)
+    handle, err = zip.from(data, options)
   else
     handle, err = zip.from(data)
   end
   if not handle then
     return nil, err or "failed to open zip from data"
   end
-  return handle as Reader
+  return handle
 end
 
 --- Report whether a zip entry name would escape the extraction root

--- a/lib/cosmic/zip_test.tl
+++ b/lib/cosmic/zip_test.tl
@@ -190,7 +190,7 @@ local function test_appender_remove()
   assert(kept == "keep me", "surviving entry content must be intact")
   local gone, read_err = r:read("gone.txt")
   assert(gone == nil, "the removed entry must not be readable")
-  assert(read_err and read_err:match("not found"),
+  assert(read_err and string.match(read_err, "not found"),
     "reading a removed entry should say not found, got: " .. tostring(read_err))
   r:close()
 end
@@ -205,7 +205,7 @@ local function test_appender_remove_missing_entry()
   local appender = zip.appender(p) as zip.Appender
   local ok, err = appender:remove("no-such-entry.txt")
   assert(ok == nil, "remove of a missing entry should fail")
-  assert(err and err:match("not found"),
+  assert(err and string.match(err, "not found"),
     "error should say the entry was not found, got: " .. tostring(err))
   appender:close()
 


### PR DESCRIPTION
Closes #491. Teal/types hardening wave (#676), stack 9/9 — the last cosmic piece. **Stacked on #684**.

Finish the cleanup sqlite started in #639 — import generated records instead of casting into weaker local duplicates:

- **fs/init**: `RawDir` deleted; `make_dir` takes the generated `unix.Dir` directly.
- **getopt**: `RawGetopt` and the local `Option`/`Result` mirrors deleted; `parse()` uses the generated `cosmo.getopt` surface (public names unchanged). A minimal `LegacyGetopt` record remains for the pre-parse stateful iterator the generated declarations no longer carry (bootstrap feature-detect path; documented in-file).
- **zip**: all seven local records were field-for-field duplicates of the generated `cosmo.zip` records — now aliases; the `raw_options()` shim built solely to dodge the nominal-record conflict is deleted, and `writer`/`appender`/`from` return typed handles without casts.
- **Kept, with in-file justification** (per #491's "reserve local records for genuinely narrowed surfaces, documented"): `signal.Sigset` — the generated unix record's `Sigset` *type* is unnameable outside the .d.tl because the constructor function field occupies the name; `shm.Memory` — a genuinely narrowed public surface over the generated `unix.Memory` it already uses internally; `tty.RawOptions` — a cosmic-only options record, not a Termios mirror (Termios was already aliased).

Cast pins: getopt 10→4, zip 8→1, net −13 after the fs note below.

**Found the hard way**: the first cut converted `fs.opendir`/`fdopendir` to `is unix.Dir` narrowing, and `envd_example`'s re-embedded app broke — an embedded app whose `main.lua` follows the documented `require("tl").loader()` pattern recompiles stdlib `.tl` through **tl's own loader** (bypassing #681's cosmic searcher) wherever `tl.path` can reach the sources; there the `.d.tl` marker doesn't resolve and `is` degrades to a table test that rejects every real Dir handle. Those two sites stay on casts with the reason written at the site, and the AGENTS.md narrowing note now says the cosmo-`is` ban is **narrowed** (safe under the cosmic dispatcher), not lifted — an honest correction to #681's doc claim.

Verified: `bin/make ci` green, including the envd embedded-app example re-run under the exported-`LUA_PATH` environment that exposed the degradation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3)_