### PR TITLE
build: end ci with an explicit PASS/FAIL verdict line; document the pipe trap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,6 +278,12 @@ all modules are under `lib/cosmic/` and imported as `cosmic.*`:
 
 ## Testing
 
+**Reading gate results**: `bin/make ci` (and each stage) signals via exit
+code AND ends with a `ci: PASS` / `ci: FAIL (stages)` verdict line. Never
+launder a gate's exit status through a pipe (`bin/make ci | tail` returns
+tail's status, not make's) — use `set -o pipefail`, or read the verdict
+line, which survives any truncation.
+
 ```bash
 bin/make test                 # all tests
 bin/make coverage             # tests with line coverage + ratchet vs lib/cosmic/coverage/baseline.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,12 @@ all modules are under `lib/cosmic/` and imported as `cosmic.*`:
 
 ## Testing
 
+**Reading gate results**: `bin/make ci` (and each stage) signals via exit
+code AND ends with a `ci: PASS` / `ci: FAIL (stages)` verdict line. Never
+launder a gate's exit status through a pipe (`bin/make ci | tail` returns
+tail's status, not make's) — use `set -o pipefail`, or read the verdict
+line, which survives any truncation.
+
 ```bash
 bin/make test                 # all tests
 bin/make coverage             # tests with line coverage + ratchet vs lib/cosmic/coverage/baseline.txt

--- a/Makefile
+++ b/Makefile
@@ -493,7 +493,7 @@ ci:
 		fi; \
 		echo "::endgroup::"; \
 	done
-	@if [ -f $(o)/failed ]; then echo "failed:"; cat $(o)/failed; exit 1; fi
+	@if [ -f $(o)/failed ]; then echo "ci: FAIL ($$(paste -sd' ' $(o)/failed))"; exit 1; else echo "ci: PASS"; fi
 
 debug-modules:
 	@echo $(modules)


### PR DESCRIPTION
Follow-up to the #676 wave, stacked on #685 (last in the stack).

`bin/make ci` signaled only via exit code, and an exit code is easy to launder: `bin/make ci | tail -N` returns **tail's** status, not make's, unless `pipefail` is set — exactly how several local gate runs read as green while failing during this stack's development (caught and re-verified before push, but the trap remains for anyone truncating output for readability).

Two-layer fix:

- **The verdict lives in the output**: `ci` now ends with `ci: PASS` or `ci: FAIL (<stages>)` as its final line, so any truncated view — tail, scrollback, CI log groups — still carries the truth regardless of how the exit status was consumed.
- **The convention is written down**: AGENTS.md/CLAUDE.md's Testing section now says never to launder a gate's exit status through a pipe; use `set -o pipefail` or read the verdict line.

Verified: `bin/make ci` green ending in `ci: PASS` with real exit 0; the failing path was exercised earlier the honest way (Makefile momentarily over the 500-line cap → `ci: FAIL` + exit 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3)_