### PR TITLE
embed: wrap custom entries with the cosmic runtime searcher

### DIFF
--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -53,7 +53,7 @@
 3	lib/cosmic/doc/public_test.tl
 7	lib/cosmic/doc/query.tl
 2	lib/cosmic/doc/query_test.tl
-6	lib/cosmic/embed.tl
+7	lib/cosmic/embed.tl
 42	lib/cosmic/embed_advanced_test.tl
 8	lib/cosmic/embed_env_test.tl
 8	lib/cosmic/embed_example.tl

--- a/lib/cosmic/cli/searcher.tl
+++ b/lib/cosmic/cli/searcher.tl
@@ -58,11 +58,17 @@ local function cosmic_tl_searcher(module_name: string): any, any
   return chunk, found
 end
 
---- Append the searcher to package.searchers (no-op without searchers).
+local installed = false
+
+--- Append the searcher to package.searchers. Idempotent (the embed
+--- wrapper installs it before the app entry, which may itself be the
+--- dispatcher that installs it too); no-op without package.searchers.
 local function install()
-  if package.searchers then
-    table.insert(package.searchers, cosmic_tl_searcher)
+  if installed or not package.searchers then
+    return
   end
+  installed = true
+  table.insert(package.searchers, cosmic_tl_searcher)
 end
 
 local record SearcherModule

--- a/lib/cosmic/embed.tl
+++ b/lib/cosmic/embed.tl
@@ -19,7 +19,15 @@
 ---
 --- Directory contents are stored relative to the directory root, so
 --- myapp/main.lua becomes /zip/main.lua in the resulting executable.
---- Embedding a main.lua overrides the default entry point.
+--- Embedding a main.lua overrides the default entry point. A custom
+--- entry is stored byte-identical at /zip/main.user.lua behind a
+--- generated /zip/main.lua that first installs the cosmic runtime .tl
+--- searcher (#687) — so require() in embedded apps resolves .tl
+--- modules with the same guarantees as `cosmic script.tl` (markers
+--- resolve, compile errors fail the require, output cached), with no
+--- loader boilerplate in the app. An unmodified dispatcher main.lua
+--- (extract/re-embed roundtrip) and an already-wrapped entry pass
+--- through unchanged.
 ---
 --- The resulting executable keeps cosmic's bundled libraries, so embedded
 --- code can require("cosmic.fetch"), require("lsqlite3"), etc.
@@ -177,6 +185,64 @@ local function collect_dir(dir: string): {FileToEmbed} | nil, string
   return collected, nil
 end
 
+--- Sentinel first line of the generated entry wrapper; recognizing it
+--- keeps wrapping idempotent across extract/embed roundtrips.
+local WRAP_SENTINEL < const > = "-- cosmic-embed searcher wrapper (#687); app entry: /zip/main.user.lua"
+
+--- The generated /zip/main.lua: install the cosmic runtime .tl
+--- searcher, then run the byte-identical user entry.
+local WRAP_MAIN < const > = WRAP_SENTINEL .. "\n" .. [[
+require("cosmic.cli.searcher").install()
+local chunk = assert(loadfile("/zip/main.user.lua"))
+return chunk(...)
+]]
+
+--- Wrap a user-supplied main.lua behind the searcher-installing entry.
+--- Mutates files_to_embed in place: the user entry moves to
+--- main.user.lua and the generated wrapper becomes main.lua. Skipped
+--- when the embedded main.lua is the source executable's own (an
+--- unmodified dispatcher roundtrip) or already the wrapper.
+--- @param files_to_embed {FileToEmbed} Collected entries (mutated)
+--- @param exe_path string Source executable (for the roundtrip check)
+--- @return string|nil Error message, or nil
+local function wrap_user_main(files_to_embed: {FileToEmbed}, exe_path: string): string | nil
+  local main_entry: FileToEmbed = nil
+  local has_user_slot = false
+  for _, f in ipairs(files_to_embed) do
+    if f.stored_name == "main.lua" then
+      main_entry = f
+    elseif f.stored_name == "main.user.lua" then
+      has_user_slot = true
+    end
+  end
+  if not main_entry then
+    return nil
+  end
+  if main_entry.content:sub(1, #WRAP_SENTINEL) == WRAP_SENTINEL then
+    return nil -- already wrapped (extract/embed roundtrip)
+  end
+  local exe_reader = czip.reader(exe_path)
+  if exe_reader ~= nil then
+    local rd = exe_reader as czip.Reader
+    local exe_main = rd:read("main.lua")
+    rd:close()
+    if exe_main == main_entry.content then
+      return nil -- unmodified dispatcher entry: keep the roundtrip exact
+    end
+  end
+  if has_user_slot then
+    return "error: main.user.lua is reserved by the embed entry wrapper (#687); rename that file"
+  end
+  main_entry.stored_name = "main.user.lua"
+  files_to_embed[#files_to_embed + 1] = {
+    path = "main.lua",
+    content = WRAP_MAIN,
+    stored_name = "main.lua",
+    mode = tonumber("644", 8),
+  }
+  return nil
+end
+
 --- Embed files and directories into a copy of the cosmic executable.
 --- Creates a new executable with the given paths appended to the zip archive.
 --- Paths can be files or directories. Directories are walked recursively and
@@ -236,6 +302,11 @@ local function run(paths: {string}, output?: string, exe_path?: string): EmbedRe
 
   if #files_to_embed == 0 then
     return {ok = false, message = "error: no files found to embed", file_count = 0}
+  end
+
+  local wrap_err = wrap_user_main(files_to_embed, exe_path)
+  if wrap_err then
+    return {ok = false, message = wrap_err, file_count = 0}
   end
 
   -- Build in a temp file, then atomically rename into place.

--- a/lib/cosmic/embed_advanced_test.tl
+++ b/lib/cosmic/embed_advanced_test.tl
@@ -113,11 +113,15 @@ local function test_embed_overwrites_cleanly()
   local ok, out = __r7.ok, __r7.stdout
   assert(ok, "embed should succeed: " .. (out or ""))
 
-  -- The new zip should have main.lua with the new content
+  -- The custom entry is wrapped (#687): main.lua is the generated
+  -- searcher wrapper; the user content lives at main.user.lua.
   local new_data = fs.read(output)
   local new_reader = zip.from(new_data) as zip.Reader
   local new_main = new_reader:read("main.lua")
-  assert(new_main == 'print("new")\n', "main.lua should have new content: " .. tostring(new_main))
+  assert(new_main and string.find(new_main, "cosmic-embed searcher wrapper", 1, true),
+    "main.lua should be the embed wrapper: " .. tostring(new_main))
+  local user_main = new_reader:read("main.user.lua")
+  assert(user_main == 'print("new")\n', "main.user.lua should have the new content: " .. tostring(user_main))
 
   -- All original files should still be present
   for name in pairs(orig_files) do

--- a/lib/cosmic/embed_test.tl
+++ b/lib/cosmic/embed_test.tl
@@ -170,8 +170,14 @@ local function test_embed_directory()
   assert(reader_maybe, "failed to open zip from data")
   local reader = reader_maybe as zip.Reader
 
+  -- A custom entry is wrapped (#687): main.lua is the generated
+  -- searcher-installing wrapper; the user entry is byte-identical at
+  -- main.user.lua.
   local c1 = reader:read("main.lua")
-  assert(c1 == 'print("hello")\n', "main.lua should be at zip root: " .. tostring(c1))
+  assert(c1 and string.find(c1, "cosmic-embed searcher wrapper", 1, true),
+    "main.lua should be the embed wrapper: " .. tostring(c1))
+  local cu = reader:read("main.user.lua")
+  assert(cu == 'print("hello")\n', "main.user.lua should hold the user entry: " .. tostring(cu))
 
   local c2 = reader:read("lib/util.lua")
   assert(c2 == 'return {x=1}\n', "lib/util.lua should be relative")
@@ -226,8 +232,8 @@ local function test_embed_mixed()
   assert(reader_maybe, "failed to open zip from data")
   local reader = reader_maybe as zip.Reader
 
-  local c1 = reader:read("main.lua")
-  assert(c1 == 'print("mixed")\n', "directory file should be present")
+  local c1 = reader:read("main.user.lua")
+  assert(c1 == 'print("mixed")\n', "directory entry should be present (wrapped, #687)")
 
   local extra_name = extra:gsub("^/+", "")
   local c2 = reader:read(extra_name)

--- a/lib/cosmic/envd_example.tl
+++ b/lib/cosmic/envd_example.tl
@@ -52,8 +52,9 @@ local function Example_extract_update_embed()
   fs.write(fs.join(envd_dir, "credentials"), "MY_SECRET_TOKEN=tok-example-12345\n")
 
   -- 3. re-embed with a main.lua that loads env.d and prints the var name
+  -- No loader prelude: --embed wraps a custom entry with the cosmic
+  -- runtime searcher (#687), so require() just works.
   fs.write(fs.join(extractdir, "main.lua"), [[
-require("tl").loader()
 local envd = require("cosmic.envd")
 local env = require("cosmic.env")
 local result = envd.load()


### PR DESCRIPTION
#687 piece 1 of 2.

The cosmic searcher's guarantees (#669/#681 — `.d.tl` markers resolve so `is` can't degrade, broken modules fail the `require()` loudly, require-tree caching) covered `cosmic script.tl` and evaporated in **embedded apps**, whose own `main.lua` boots without the dispatcher. The documented compensation, `require("tl").loader()`, is exactly what resurrected the `is`-degradation during #685's investigation.

`--embed` / `embed.run()` now store a custom entry **byte-identical** at `/zip/main.user.lua` behind a generated `/zip/main.lua` that installs `cosmic.cli.searcher` and runs the user chunk (`loadfile`, args forwarded). The wrap is skipped when the embedded `main.lua` is the source executable's own (unmodified dispatcher — the extract/re-embed roundtrip stays byte-exact) or already the wrapper (sentinel line), making it idempotent across roundtrips. `main.user.lua` is reserved (clear error on collision). `searcher.install()` is now idempotent, since the wrapped entry may itself be the dispatcher.

`envd_example` drops its `require("tl").loader()` prelude — its extract/update/re-embed flow now regression-tests the wrapper end to end (verified: the re-embedded app loads its env.d with zero loader boilerplate). Embed tests updated to the wrapper contract.

**Behavior change worth release-noting**: an embedded app with a broken `.tl` module on its search path now fails the require with the compile issues instead of silently running it — that's the feature.

Piece 2 (stacked next): lift the `is`-ban fully now that no cosmic-controlled path installs tl's loader.

Verified: `bin/make ci` → `ci: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3)_