### PR TITLE
types: lift the cosmo-is ban; convert fs/sqlite boundary casts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,13 +153,13 @@ or map unions through truthiness (`if not x`). Two sanctioned tools:
   then return end` does not narrow below); and `is` is WRONG for
   mixed-representation records — `fs.Stat` is usually the raw stat
   userdata but falls back to a plain wrapper table, so neither marker
-  fits; it stays on casts. (The ban on `is` with REQUIRED `cosmo.*`
-  classes is NARROWED, not lifted: under the cosmic dispatcher the
-  runtime searcher (#669) resolves .d.tl markers, so `is` cannot
-  degrade there — but stdlib modules that EMBEDDED apps may recompile
-  via the documented `require("tl").loader()` main.lua pattern bypass
-  the cosmic searcher and still degrade; those keep casts, e.g.
-  fs.opendir.)
+  fits; it stays on casts. (The old ban on `is` with REQUIRED
+  `cosmo.*` classes is LIFTED: the cosmic searcher is the only loader
+  cosmic installs — the dispatcher (#669/#681) and the embed entry
+  wrapper (#687/#688) both resolve .d.tl markers, so `is` cannot
+  silently degrade. The one unsupported path is user code explicitly
+  calling `require("tl").loader()`, which shadows the cosmic searcher
+  with tl's silent one.)
 - **Cast in linear code and at userdata boundaries**: after an assert or
   early-exit guard, `(x as Rec).field`, `(x as {K:V})[k]`. Scalars
   (`string | nil`) narrow normally, except method-call syntax: use

--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -83,7 +83,6 @@
 12	lib/cosmic/fs/dir_test.tl
 1	lib/cosmic/fs/file.tl
 7	lib/cosmic/fs/glob_test.tl
-2	lib/cosmic/fs/init.tl
 1	lib/cosmic/fs/init_example.tl
 19	lib/cosmic/fs/init_test.tl
 4	lib/cosmic/fs/ops.tl
@@ -172,7 +171,7 @@
 26	lib/cosmic/sqlite/data_test.tl
 5	lib/cosmic/sqlite/extras.tl
 6	lib/cosmic/sqlite/extras_test.tl
-19	lib/cosmic/sqlite/init.tl
+18	lib/cosmic/sqlite/init.tl
 13	lib/cosmic/sqlite/init_example.tl
 64	lib/cosmic/sqlite/init_test.tl
 6	lib/cosmic/sqlite/params.tl

--- a/lib/cosmic/fs/init.tl
+++ b/lib/cosmic/fs/init.tl
@@ -176,16 +176,12 @@ end
 --- @return Dir | nil Directory handle, or nil on error
 --- @return string Error message if failed
 local function opendir(path: string): Dir | nil, string
-  -- Cast, not `is`: embedded apps whose main.lua installs
-  -- require("tl").loader() (the documented embed pattern) can
-  -- lax-recompile this module through tl's OWN loader, where the
-  -- cosmo.unix .d.tl marker doesn't resolve and `is` degrades to a
-  -- table test that rejects every real Dir handle (seen breaking
-  -- envd_example's re-embedded app). The cosmic searcher guarantees
-  -- resolution only inside the cosmic dispatcher.
+  -- `is` is safe here since every cosmic-installed loader (dispatcher
+  -- searcher #681, embed wrapper #688) resolves the unix.Dir userdata
+  -- marker; explicit tl.loader() installs are unsupported (#687).
   local raw, err = unix.opendir(path)
-  if raw ~= nil then
-    return make_dir(raw as unix.Dir)
+  if raw is unix.Dir then
+    return make_dir(raw)
   end
   return nil, errstr(err, "opendir: " .. path)
 end
@@ -196,10 +192,9 @@ end
 --- @return Dir | nil Directory handle, or nil on error
 --- @return string Error message if failed
 local function fdopendir(fd: integer): Dir | nil, string
-  -- Cast, not `is`: same tl.loader() degradation hazard as opendir.
   local raw, err = unix.fdopendir(fd)
-  if raw ~= nil then
-    return make_dir(raw as unix.Dir)
+  if raw is unix.Dir then
+    return make_dir(raw)
   end
   return nil, errstr(err, "fdopendir")
 end

--- a/lib/cosmic/sqlite/init.tl
+++ b/lib/cosmic/sqlite/init.tl
@@ -448,20 +448,18 @@ local function open(filename: string, opts?: OpenOptions): Database | nil, strin
   else
     raw_db, errcode, errmsg = sqlite3.open(filename)
   end
-  if not raw_db then
-    return nil, errmsg or ("error code " .. tostring(errcode))
+  -- `is` narrows in the positive branch (early-exit guards don't);
+  -- safe at this cosmo.* boundary since #681/#688 made the cosmic
+  -- searcher the only loader cosmic installs.
+  if raw_db is lsqlite3.Database then
+    local timeout_ms = 5000
+    if opts and opts.busy_timeout_ms ~= nil then
+      timeout_ms = opts.busy_timeout_ms
+    end
+    raw_db:busy_timeout(timeout_ms)
+    return make_database(raw_db)
   end
-  -- records don't flow-narrow; cast once after the guard. (`is` became
-  -- safe at cosmo.* boundaries once the cosmic runtime searcher (#669)
-  -- guaranteed .d.tl resolution; converting boundary casts like this
-  -- one is #491 follow-up work.)
-  local dbh = raw_db as lsqlite3.Database
-  local timeout_ms = 5000
-  if opts and opts.busy_timeout_ms ~= nil then
-    timeout_ms = opts.busy_timeout_ms
-  end
-  dbh:busy_timeout(timeout_ms)
-  return make_database(dbh)
+  return nil, errmsg or ("error code " .. tostring(errcode))
 end
 
 local record sqlite


### PR DESCRIPTION
Closes #687 (piece 2 of 2). **Stacked on #688** — merge that first.

With the cosmic searcher the only loader cosmic installs — the dispatcher (#681) and now the embed entry wrapper (#688) — required `.d.tl` userdata markers always resolve, so `is` on `cosmo.*` classes can no longer silently degrade to a table test. This lifts the ban:

- **fs.opendir/fdopendir**: back to `raw is unix.Dir` narrowing — reverting #685's defensive casts now that the hazard they guarded (embedded apps' `tl.loader()` prelude recompiling fs through tl's own loader) is closed by #688. fs/init cast pin drops 2 → 0.
- **sqlite.open**: `raw_db is lsqlite3.Database` in the positive branch (early-exit guards don't narrow, per the documented Teal caveat); sqlite/init pin 19 → 18.
- **AGENTS.md** narrowing note: the ban is **lifted**, with the one unsupported path named — user code explicitly calling `require("tl").loader()`, which shadows the cosmic searcher with tl's silent position-2 loader. Mixed-representation records (`fs.Stat`) stay on casts as before; remaining boundary casts convert opportunistically.

Verified: `bin/make ci` → `ci: PASS`; fs (10/10) and sqlite (5/5) suites; `envd_example`'s re-embedded app exercises the zipos Dir handle through the new `is` path end to end — the exact scenario that broke in #685's first cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3)_