### PR TITLE
embed: app-local modules beside main.lua resolve with no configuration

### DIFF
--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -57,7 +57,7 @@
 42	lib/cosmic/embed_advanced_test.tl
 8	lib/cosmic/embed_env_test.tl
 8	lib/cosmic/embed_example.tl
-38	lib/cosmic/embed_test.tl
+42	lib/cosmic/embed_test.tl
 1	lib/cosmic/envd.tl
 3	lib/cosmic/envd_example.tl
 1	lib/cosmic/envd_test.tl

--- a/lib/cosmic/embed.tl
+++ b/lib/cosmic/embed.tl
@@ -21,13 +21,12 @@
 --- myapp/main.lua becomes /zip/main.lua in the resulting executable.
 --- Embedding a main.lua overrides the default entry point. A custom
 --- entry is stored byte-identical at /zip/main.user.lua behind a
---- generated /zip/main.lua that first installs the cosmic runtime .tl
---- searcher (#687) — so require() in embedded apps resolves .tl
---- modules with the same guarantees as `cosmic script.tl` (markers
---- resolve, compile errors fail the require, output cached), with no
---- loader boilerplate in the app. An unmodified dispatcher main.lua
---- (extract/re-embed roundtrip) and an already-wrapped entry pass
---- through unchanged.
+--- generated /zip/main.lua that puts the zip root on the module path
+--- and installs the cosmic runtime .tl searcher (#687/#690): modules
+--- embedded beside main.lua resolve with the same guarantees as
+--- `cosmic script.tl`, no loader boilerplate. An unmodified
+--- dispatcher main.lua (extract/re-embed roundtrip) and an
+--- already-wrapped entry pass through unchanged.
 ---
 --- The resulting executable keeps cosmic's bundled libraries, so embedded
 --- code can require("cosmic.fetch"), require("lsqlite3"), etc.
@@ -189,9 +188,11 @@ end
 --- keeps wrapping idempotent across extract/embed roundtrips.
 local WRAP_SENTINEL < const > = "-- cosmic-embed searcher wrapper (#687); app entry: /zip/main.user.lua"
 
---- The generated /zip/main.lua: install the cosmic runtime .tl
---- searcher, then run the byte-identical user entry.
+--- The generated /zip/main.lua: put the app's zip root on the module
+--- path (embedded mod.lua / mod.tl beside main.lua resolve; #690),
+--- install the cosmic searcher, then run the byte-identical entry.
 local WRAP_MAIN < const > = WRAP_SENTINEL .. "\n" .. [[
+package.path = "/zip/?.lua;/zip/?/init.lua;" .. package.path
 require("cosmic.cli.searcher").install()
 local chunk = assert(loadfile("/zip/main.user.lua"))
 return chunk(...)

--- a/lib/cosmic/embed_test.tl
+++ b/lib/cosmic/embed_test.tl
@@ -261,6 +261,37 @@ local function test_embed_directory_executable()
 end
 test_embed_directory_executable()
 
+-- An app can require its own embedded modules beside main.lua with no
+-- configuration (#690): .lua via the wrapper's package.path prepend,
+-- .tl via the searcher's /zip include dir. A broken embedded .tl fails
+-- the require with the compile issue (the #681 guarantee, in-app).
+local function test_embed_app_local_requires()
+  local appdir = fs.join(tmpdir, "localmods")
+  fs.makedirs(appdir)
+  fs.write(fs.join(appdir, "greet.tl"),
+    'local function hi(n: string): string\n  return "hi " .. n\nend\n'
+    .. "return { hi = hi }\n")
+  fs.write(fs.join(appdir, "util.lua"), 'return { v = "lua-mod" }\n')
+  fs.write(fs.join(appdir, "bad.tl"), "local x: string = 42\nreturn { x = x }\n")
+  fs.write(fs.join(appdir, "main.lua"),
+    'print(require("greet").hi("zip"), require("util").v)\n'
+    .. 'local ok, err = pcall(require, "bad")\n'
+    .. 'print("bad:", ok, err)\n')
+
+  local output = fs.join(tmpdir, "cosmic-localmods")
+  local __r12 = (spawn.spawn({cosmic, "--embed", appdir, "--output", output}) as spawn.Handle):wait() as spawn.Result
+  assert(__r12.ok, "embed should succeed: " .. tostring(__r12.stderr))
+
+  local __r13 = (spawn.spawn({output}) as spawn.Handle):wait() as spawn.Result
+  local out = tostring(__r13.stdout)
+  assert(__r13.ok, "app should run: " .. tostring(__r13.stderr))
+  assert(out:match("hi zip"), "embedded .tl module should resolve: " .. out)
+  assert(out:match("lua%-mod"), "embedded .lua module should resolve: " .. out)
+  assert(out:match("bad:%s+false"), "broken .tl require should fail: " .. out)
+  assert(out:match("got integer"), "failure should carry the compile issue: " .. out)
+end
+test_embed_app_local_requires()
+
 -- Test that embedded non-.lua files use deflate compression (method=8)
 local function test_embed_uses_deflate()
   -- Use compressible content (repeated pattern) to ensure deflate is applied

--- a/lib/cosmic/teal.tl
+++ b/lib/cosmic/teal.tl
@@ -68,6 +68,7 @@ local function get_default_include_dirs(): {string}
     "lib/types", -- Local cosmic types (development, takes precedence)
     "/zip/.lua/types", -- Bundled cosmic types (in binary)
     "/zip/.tl", -- Bundled cosmic .tl source (for type checking)
+    "/zip", -- The app's own zip root: embedded modules beside main.lua (#690)
   }
 end
 

--- a/lib/cosmic/teal_config_test.tl
+++ b/lib/cosmic/teal_config_test.tl
@@ -53,7 +53,7 @@ local function test_tlconfig_matches_teal_defaults()
       "Makefile include dir '" .. d .. "' is missing from tlconfig.lua")
   end
   for _, d in ipairs(teal.get_default_include_dirs()) do
-    if d:sub(1, 5) ~= "/zip/" then
+    if d ~= "/zip" and d:sub(1, 5) ~= "/zip/" then
       assert(editor[d],
         "checker default include dir '" .. d
         .. "' is missing from tlconfig.lua")


### PR DESCRIPTION
#690 finding F2 (1 of 2; F1's `--exe` comes next, stacked).

An app embedding `greet.tl` or `util.lua` next to its `main.lua` couldn't `require()` them — `package.path` covered `/zip/.lua/?.lua` but not `/zip/?.lua`, and nothing searched `/zip/?.tl` (verified workaround was `TL_PATH=/zip/?.tl`). "Drop a module next to main.lua" is the obvious mental model; now it just works:

- The #688 entry wrapper prepends `/zip/?.lua;/zip/?/init.lua` to `package.path` → embedded `.lua` modules resolve.
- `cosmic.teal`'s default include dirs gain `/zip` (the app's own zip root, last) → the runtime searcher resolves embedded `.tl` modules with the full #681 guarantees — including that a broken embedded `.tl` fails its `require()` with the compile issue in the message, verified in-app.

New regression test: an app requiring an embedded `.tl` **and** `.lua` module runs with zero configuration; the broken-`.tl` case fails loudly with `got integer` in the error.

Verified: `bin/make ci` → `ci: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3)_