### PR TITLE
embed: --exe operates on an existing app instead of this exe (#690)

### DIFF
--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -54,7 +54,7 @@
 7	lib/cosmic/doc/query.tl
 2	lib/cosmic/doc/query_test.tl
 7	lib/cosmic/embed.tl
-42	lib/cosmic/embed_advanced_test.tl
+51	lib/cosmic/embed_advanced_test.tl
 8	lib/cosmic/embed_env_test.tl
 8	lib/cosmic/embed_example.tl
 42	lib/cosmic/embed_test.tl

--- a/lib/cosmic/cli/args.tl
+++ b/lib/cosmic/cli/args.tl
@@ -21,6 +21,7 @@ local longopts: {getopt.LongOpt} = {
   {name = "embed", has_arg = "required"},
   {name = "output", has_arg = "required"},
   {name = "extract", has_arg = "required"},
+  {name = "exe", has_arg = "required"},
   {name = "check-examples", has_arg = "required"},
   {name = "examples", has_arg = "optional"},
   {name = "benchmark", has_arg = "required"},

--- a/lib/cosmic/cli/main.tl
+++ b/lib/cosmic/cli/main.tl
@@ -36,6 +36,7 @@ local record Options
   embed: {string}
   output: string
   extract: string
+  exe: string
   check_examples: string
   examples: string
   benchmark: string
@@ -73,6 +74,7 @@ local function parse_args(): Options
     embed = {},
     output = nil,
     extract = nil,
+    exe = nil,
     check_examples = nil,
     examples = nil,
     benchmark = nil,
@@ -211,6 +213,14 @@ local function parse_args(): Options
     return opts
   end
 
+  -- Global modifiers are collected before the dispatch loop so they are
+  -- honored regardless of position (`--extract dir --exe app`).
+  for _, o in ipairs(r.opts) do
+    if o.opt == "exe" then
+      opts.exe = o.arg
+    end
+  end
+
   for _, o in ipairs(r.opts) do
     local opt = o.opt
     local optarg = o.arg
@@ -336,7 +346,6 @@ local function main(): integer, string
   if extract_env and not opts.extract then
     opts.extract = extract_env
   end
-
   if opts.version then return handlers.handle_version() end
   if opts.help then io.write(help.generate() .. "\n"); return 0 end
   if opts.welcome then io.write(handlers.generate_welcome()); return 0 end
@@ -359,8 +368,8 @@ local function main(): integer, string
   if opts.check_format then return handlers.handle_check_format(opts.check_format) end
   if opts.check_types then return handlers.handle_check_types(opts.check_types, opts.include_dirs) end
   if opts.check_style then return handlers.handle_check_style(opts.check_style) end
-  if #opts.embed > 0 then return handlers.handle_embed(opts.embed, opts.output) end
-  if opts.extract then return handlers.handle_extract(opts.extract) end
+  if #opts.embed > 0 then return handlers.handle_embed(opts.embed, opts.output, opts.exe) end
+  if opts.extract then return handlers.handle_extract(opts.extract, opts.exe) end
   if opts.check_examples then return handlers.handle_check_examples(opts.check_examples) end
 
   if opts.examples ~= nil then

--- a/lib/cosmic/cli/main_handlers.tl
+++ b/lib/cosmic/cli/main_handlers.tl
@@ -265,17 +265,17 @@ local function handle_check_types(file: string, include_dirs?: {string}): intege
 end
 
 --- Handle --embed flag.
-local function handle_embed(paths: {string}, output: string): integer
+local function handle_embed(paths: {string}, output: string, exe?: string): integer
   local embed = require("cosmic.embed")
-  local result = embed.run(paths, output)
+  local result = embed.run(paths, output, exe)
   io.write(result.message .. "\n")
   return result.ok and 0 or 1
 end
 
 --- Handle --extract flag.
-local function handle_extract(dir: string): integer
+local function handle_extract(dir: string, exe?: string): integer
   local embed = require("cosmic.embed")
-  local result = embed.extract(dir)
+  local result = embed.extract(dir, exe)
   io.write(result.message .. "\n")
   return result.ok and 0 or 1
 end
@@ -462,8 +462,8 @@ local record HandlersModule
   handle_check_format: function(file: string): integer
   handle_check_types: function(file: string, include_dirs?: {string}): integer
   handle_check_style: function(file: string): integer
-  handle_embed: function(paths: {string}, output: string): integer
-  handle_extract: function(dir: string): integer
+  handle_embed: function(paths: {string}, output: string, exe?: string): integer
+  handle_extract: function(dir: string, exe?: string): integer
   handle_check_examples: function(file: string): integer
   handle_examples: function(module_name: string): integer
   handle_benchmark: function(spec: string): integer

--- a/lib/cosmic/embed_advanced_test.tl
+++ b/lib/cosmic/embed_advanced_test.tl
@@ -355,4 +355,47 @@ local function test_embed_symlink_to_outside_file_skipped()
 end
 test_embed_symlink_to_outside_file_skipped()
 
+-- --exe operates on an existing app instead of the running executable
+-- (#690 F1): extract a produced app (restoring file modes), and layer
+-- new files onto it, all without extract/re-embed gymnastics. Flag
+-- order is free: --exe is collected before early-returning options.
+local function test_exe_flag_extract_and_layer()
+  local appdir = fs.join(tmpdir, "exeapp")
+  fs.makedirs(appdir)
+  fs.write(fs.join(appdir, "main.lua"),
+    'print("v1", io.open("/zip/extra.txt") and "extra" or "noextra")\n')
+  fs.write(fs.join(appdir, "tool.sh"), "#!/bin/sh\necho t\n")
+  fs.chmod(fs.join(appdir, "tool.sh"), tonumber("755", 8))
+
+  local app1 = fs.join(tmpdir, "exe-app1")
+  local __e1 = (spawn.spawn({cosmic, "--embed", appdir, "--output", app1}) as spawn.Handle):wait() as spawn.Result
+  assert(__e1.ok, "embed app1: " .. tostring(__e1.stderr))
+
+  -- Extract FROM the app (--exe after the early-returning --extract).
+  local x = fs.join(tmpdir, "exe-x")
+  local __e2 = (spawn.spawn({cosmic, "--extract", x, "--exe", app1}) as spawn.Handle):wait() as spawn.Result
+  assert(__e2.ok, "extract --exe: " .. tostring(__e2.stderr))
+  local wrapper = fs.read(fs.join(x, "main.lua"))
+  assert(wrapper and string.find(wrapper, "cosmic-embed searcher wrapper", 1, true),
+    "extracted main.lua should be the wrapper")
+  assert(fs.read(fs.join(x, "main.user.lua")), "user entry should extract")
+  local st = fs.stat(fs.join(x, "tool.sh"))
+  assert(st, "tool.sh should extract")
+  local mode = (st as fs_types.Stat):mode() & tonumber("777", 8)
+  assert(mode == tonumber("755", 8),
+    "exec mode should be restored, got " .. string.format("%o", mode))
+
+  -- Layer a file onto the existing app.
+  local extra = fs.join(tmpdir, "extra.txt")
+  fs.write(extra, "x")
+  local app2 = fs.join(tmpdir, "exe-app2")
+  local __e3 = (spawn.spawn({cosmic, "--embed", extra, "--output", app2, "--exe", app1})
+    as spawn.Handle):wait() as spawn.Result
+  assert(__e3.ok, "layer --exe: " .. tostring(__e3.stderr))
+  local __e4 = (spawn.spawn({app2}) as spawn.Handle):wait() as spawn.Result
+  assert(__e4.ok and tostring(__e4.stdout):match("v1"),
+    "layered app should run its entry: " .. tostring(__e4.stdout))
+end
+test_exe_flag_extract_and_layer()
+
 print("All embed tests passed!")

--- a/sys/help.md
+++ b/sys/help.md
@@ -17,6 +17,7 @@ Cosmic options:
   --embed <path>                embed file or directory into executable
   --output <file>               output file for --embed (default: cosmic)
   --extract <dir>               extract zip contents to directory
+  --exe <path>                  with --embed/--extract: operate on <path>, not this exe
   --benchmark <file.tl[:pat]>   run Benchmark_* functions, report timing
   --docs [query]                show documentation for module, symbol, or guide
   --test <output> <cmd>...      run test, write <output>.{got,out,err}


### PR DESCRIPTION
Implements finding F1 from #690: `--embed` and `--extract` gain a `--exe <path>` modifier so you can layer files onto an already-built app, or extract an app's contents, without executing that app.

```
cosmic --extract dir --exe app          # inspect an app's zip contents
cosmic --embed extra --output app2 --exe app1   # layer onto an existing app
```

Before this, both operations always used the running executable (`/zip` of the cosmic binary itself), so inspecting or updating a built app required running the app — which fails outright for apps whose entry point isn't the cosmic dispatcher.

- `lib/cosmic/cli/args.tl`: new `--exe <path>` long option (required arg).
- `lib/cosmic/cli/main.tl`: `Options.exe`; global modifiers are prescanned before the dispatch loop so `--extract dir --exe app` works regardless of option order (the dispatch loop early-returns on `--extract`/`--embed`).
- `lib/cosmic/cli/main_handlers.tl`: `handle_embed`/`handle_extract` pass the exe through to `embed.run`/`embed.extract` (which already accepted an `exe_path`).
- `sys/help.md`: documents the flag.
- `lib/cosmic/embed_advanced_test.tl`: end-to-end test — builds an app, extracts it via `--exe` (asserting the searcher wrapper, `main.user.lua`, and 755 mode restoration), layers an extra file onto it via `--embed … --exe`, and runs the layered app.

Manually verified the three scenarios from #690 that were previously blocked: extract-from-app, layered embed, and re-embed of an extracted wrapped tree.

`bin/make ci` → `ci: PASS` on the rebased branch.

Note on F3 (tracebacks name `/zip/main.user.lua` rather than `main.lua` in wrapped apps): cosmetic, intentionally left as-is — the name is accurate about which file holds the user's code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3)_