### PR TITLE
3p: bump cosmos to 2026.07.19-ed74a7a16; adopt named alias types (#193)

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "c46ddd491c254a3c05cc7aa9237c2c88f71bb7fc1b6f876ad7e5072abe63ae2f"}},
+  platforms = {["*"] = {sha = "9bf704870e52d8ed919323c14a82a7fed92b62a22111292ccee03521f49dd87c"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.18-feb77961c"
+  version = "2026.07.19-ed74a7a16"
 }

--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -98,7 +98,7 @@
 4	lib/cosmic/getopt.tl
 3	lib/cosmic/getopt_example.tl
 16	lib/cosmic/getopt_test.tl
-3	lib/cosmic/hash.tl
+5	lib/cosmic/hash.tl
 6	lib/cosmic/hash_test.tl
 13	lib/cosmic/include_dir_test.tl
 3	lib/cosmic/init.tl

--- a/lib/cosmic/compress.tl
+++ b/lib/cosmic/compress.tl
@@ -7,21 +7,12 @@
 local cosmo = require("cosmo")
 
 --- Compressed stream framing produced by compress().
-local enum Format
-  "zlib"
-  "gzip"
-  "raw"
-end
+local type Format = cosmo.CompressFormat
 
 --- Framing accepted by decompress(). "auto" detects zlib or gzip from
 --- the stream header; raw streams carry no header and must be named
 --- explicitly.
-local enum DecompressFormat
-  "zlib"
-  "gzip"
-  "raw"
-  "auto"
-end
+local type DecompressFormat = cosmo.UncompressFormat
 
 --- Options for compress().
 local record CompressOptions

--- a/lib/cosmic/hash.tl
+++ b/lib/cosmic/hash.tl
@@ -92,7 +92,8 @@ local function digest(algo: Algo, data: string): string | nil, string
   if not valid_algos[algo] then
     return nil, "unknown hash algorithm: " .. tostring(algo)
   end
-  local d, err = cosmo.GetCryptoHash(algo, data)
+  local d, err = cosmo.GetCryptoHash(
+    string.upper(algo) as cosmo.CryptoHashName, data)
   if not d then
     return nil, err as string
   end
@@ -117,7 +118,8 @@ local function hmac(algo: Algo, key: string, data: string): string | nil, string
   if #key == 0 then
     return nil, "hmac: key must be non-empty"
   end
-  local d, err = cosmo.GetCryptoHash(algo, data, key)
+  local d, err = cosmo.GetCryptoHash(
+    string.upper(algo) as cosmo.CryptoHashName, data, key)
   if not d then
     return nil, err as string
   end

--- a/lib/types/cosmo.d.tl
+++ b/lib/types/cosmo.d.tl
@@ -36,21 +36,21 @@ local record EncoderOptions
   --- defaults to 64. This option controls the maximum amount of recursion the serializer is allowed to perform. The max is 32767. You might not be able to set it that high if there isn't enough C stack memory. Your serializer checks for this and will return an error rather than crashing.
   maxdepth: integer
   --- `EncodeJson` only: encode NaN and Infinity as `null` (the v8 behavior) instead of failing with `nil, error`.
-  nan: string
+  nan: JsonNanMode
 end
 
 local record DeflateOptions
   --- compression level `-1`..`9`; defaults to `-1`, the zlib default (currently 6). `0` stores without compressing; higher levels are slower but compress better.
   level: integer
   --- framing of the compressed stream; defaults to `"raw"` (headerless DEFLATE, as used inside ZIP files).
-  format: string
+  format: CompressFormat
 end
 
 local record InflateOptions
   --- cap on the decompressed size in bytes; defaults to 64 MiB. Decompression streams into a growing buffer and fails with `nil, error` once the cap is exceeded, so no attacker-controlled length is ever trusted as an allocation size.
   maxsize: integer
   --- framing of the compressed stream; defaults to `"raw"`. `"auto"` detects zlib or gzip framing from the stream header (but cannot detect `"raw"`).
-  format: string
+  format: UncompressFormat
 end
 
 local record FetchOptions
@@ -141,6 +141,58 @@ local enum IpCategory
   "ANONYMOUS"
 end
 
+--- The only accepted `nan` mode in `EncodeJson` options: serialize NaN
+--- and Infinity as `null` (the v8 behavior) instead of failing.
+local type JsonNanMode = string
+
+--- Framing of a compressed stream produced by `Deflate`.
+local enum CompressFormat
+  "raw"
+  "zlib"
+  "gzip"
+end
+
+--- Framing accepted by `Inflate`; `"auto"` detects zlib or gzip framing
+--- from the stream header (but cannot detect `"raw"`).
+local enum UncompressFormat
+  "raw"
+  "zlib"
+  "gzip"
+  "auto"
+end
+
+--- Hash function names accepted by `GetCryptoHash`, exactly the set
+--- `tool/lua/test_crypto_hash.lua` verifies against the C.
+local enum CryptoHashName
+  "MD5"
+  "SHA1"
+  "SHA224"
+  "SHA256"
+  "SHA384"
+  "SHA512"
+  "BLAKE2B256"
+end
+
+--- Host instruction set architecture names returned by `GetHostIsa`.
+local enum HostIsa
+  "X86_64"
+  "AARCH64"
+  "POWERPC64"
+  "S390X"
+end
+
+--- Host OS names returned by `GetHostOs` (nil when unrecognized stays at
+--- the call site's return annotation).
+local enum HostOs
+  "LINUX"
+  "METAL"
+  "WINDOWS"
+  "XNU"
+  "NETBSD"
+  "FREEBSD"
+  "OPENBSD"
+end
+
 local record cosmo
   type Url = Url
   type EncoderOptions = EncoderOptions
@@ -151,6 +203,12 @@ local record cosmo
   type StreamReader = StreamReader
   type FetchErrorKind = FetchErrorKind
   type IpCategory = IpCategory
+  type JsonNanMode = JsonNanMode
+  type CompressFormat = CompressFormat
+  type UncompressFormat = UncompressFormat
+  type CryptoHashName = CryptoHashName
+  type HostIsa = HostIsa
+  type HostOs = HostOs
 
   --- Writes all data to file the easy way.
   --- This function writes to the local file system. By default it truncates
@@ -517,15 +575,15 @@ local record cosmo
   --- Turns integer like `0x01020304` into a string like `"1.2.3.4"`. See also
   --- `ParseIp` for the inverse operation.
   FormatIp: function(uint32: integer): string
-  GetCryptoHash: function(name: string, payload: string, key?: string): string | nil, string | nil
+  GetCryptoHash: function(name: CryptoHashName, payload: string, key?: string): string | nil, string | nil
   --- Returns string describing host instruction set architecture.
   --- This can return:
   --- - `"X86_64"` for Intel and AMD systems
   --- - `"AARCH64"` for ARM64, M1, and Raspberry Pi systems
   --- - `"POWERPC64"` for OpenPOWER Raptor Computing Systems
   --- - `"S390X"` for IBM System/390 systems
-  GetHostIsa: function(): string
-  GetHostOs: function(): string | nil
+  GetHostIsa: function(): HostIsa
+  GetHostOs: function(): HostOs | nil
   GetHttpReason: function(code: integer): string
   --- This is useful for fixed-width formatting. For example, CJK characters
   --- typically take up two cells. This function takes into consideration combining


### PR DESCRIPTION
Bumps the cosmos pin from `2026.07.18-feb77961c` to `2026.07.19-ed74a7a16`, the first release containing whilp/cosmopolitan#193 (name inline literal-string unions as aliases) and #194 (runtime type-truthfulness probe). This closes the last deferred item from the #676 wave.

## Generated type changes (`bin/make regen-types`, verified by `test only=gentype`)

`lib/types/cosmo.d.tl` gains six named types, and the signatures that previously took/returned bare `string` now use them:

- `CompressFormat` / `UncompressFormat` enums — `DeflateOptions.format`, `InflateOptions.format`
- `CryptoHashName` enum — `GetCryptoHash(name, …)`
- `HostIsa` / `HostOs` enums — `GetHostIsa()`, `GetHostOs()`
- `JsonNanMode` — `EncoderOptions.nan`

## Wrapper adoption

- **`compress.tl`**: its hand-declared `Format`/`DecompressFormat` enums (structurally identical to the new upstream aliases) are replaced by type aliases to `cosmo.CompressFormat`/`cosmo.UncompressFormat` — same #491 shed-the-redeclaration pattern, and the module's exported type names are unchanged so callers see no difference.
- **`hash.tl`**: the public API keeps its lowercase `Algo` surface (`"sha256"` etc.); the boundary now passes `string.upper(algo)` cast to `cosmo.CryptoHashName`, matching the annotation's verified uppercase set instead of relying on the C binding's case-insensitivity while the type says otherwise. Cast pin raised 3 → 5 in `lib/build/casts.txt`.
- `sys.tl` and `json.tl` needed no changes — enum returns narrow to `string` and the `nan` field accepts the literal under the alias.

`bin/make ci` → `ci: PASS` (full gate: format + teal 294/294 + test + example + lint + coverage).

Note: this is a one-day pin advance motivated by type adoption; no C hot-path changes rode along upstream, so no `perf-compare` was run for this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbBUEJjUvgv2nPHukGRPu3)_