### PR TITLE
stream: automatic EINTR retry across blocking wrappers (#595)

### DIFF
--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -18,6 +18,7 @@
 48	lib/cosmic/child/init_test.tl
 5	lib/cosmic/child/io.tl
 5	lib/cosmic/child/io_test.tl
+1	lib/cosmic/child/signal_test.tl
 91	lib/cosmic/cli/args_test.tl
 2	lib/cosmic/cli/help.tl
 9	lib/cosmic/cli/instrument.tl
@@ -66,7 +67,7 @@
 7	lib/cosmic/example_test.tl
 3	lib/cosmic/fd.tl
 3	lib/cosmic/fd_example.tl
-7	lib/cosmic/fd_read_test.tl
+8	lib/cosmic/fd_read_test.tl
 24	lib/cosmic/fd_test.tl
 9	lib/cosmic/fetch/extras.tl
 2	lib/cosmic/fetch/headers.tl
@@ -162,7 +163,7 @@
 39	lib/cosmic/script_test.tl
 9	lib/cosmic/shm.tl
 3	lib/cosmic/shm_example.tl
-18	lib/cosmic/shm_test.tl
+19	lib/cosmic/shm_test.tl
 7	lib/cosmic/signal.tl
 11	lib/cosmic/skill_test.tl
 51	lib/cosmic/sqlite/advanced_test.tl

--- a/lib/cosmic/child/init.tl
+++ b/lib/cosmic/child/init.tl
@@ -139,7 +139,7 @@ local function cleanup(self: Handle)
   self._closed = true
   if not self._result then
     unix.kill(self.pid, unix.SIGKILL)
-    unix.wait(self.pid)
+    childio.wait_retry(self.pid)
   end
   close_fds(self)
 end
@@ -176,7 +176,7 @@ local function make_handle(pid: integer, st: childio.PumpState): Handle
     if timed_out then
       return nil, "timeout"
     end
-    local _, status = unix.wait(self.pid)
+    local _, status = childio.wait_retry(self.pid)
     if type(status) ~= "number" then
       return nil, "wait failed: " .. tostring(status)
     end
@@ -204,7 +204,7 @@ local function make_handle(pid: integer, st: childio.PumpState): Handle
     if not fd then
       return nil, "stdout not captured"
     end
-    local chunk, err = unix.read(fd, size or 65536)
+    local chunk, err = childio.read_retry(fd, size or 65536)
     if chunk == nil then
       return nil, errno.str(err, "read")
     end
@@ -447,11 +447,12 @@ local function spawn(argv: {string}, opts?: Options): Handle | nil, string
   unix.close(exec_w)
 
   -- A non-empty read means exec failed inside the child: reap it and surface
-  -- the error from spawn itself. EOF (empty read) means exec succeeded.
-  local exec_msg = unix.read(exec_r, 4096)
+  -- the error from spawn itself. EOF (empty read) means exec succeeded — so
+  -- the read must retry EINTR (read_retry), not misreport it as EOF.
+  local exec_msg = childio.read_retry(exec_r, 4096)
   unix.close(exec_r)
   if exec_msg ~= nil and exec_msg ~= "" then
-    unix.wait(pid)
+    childio.wait_retry(pid)
     if not stdin_is_fd then unix.close(stdin_w) end
     if not stdout_is_fd then unix.close(stdout_r) end
     if not stderr_is_fd then unix.close(stderr_r) end

--- a/lib/cosmic/child/io.tl
+++ b/lib/cosmic/child/io.tl
@@ -81,6 +81,27 @@ local function now_ms(): number
   return secs * 1000 + nanos / 1000000
 end
 
+--- Read up to bufsiz bytes from fd, retrying when a signal interrupts the
+--- read (the signal-safety wave, #595). Returns unix.read's (data, err).
+local function read_retry(fd: integer, bufsiz: integer): string | nil, string | nil
+  local data, err, eno = unix.read(fd, bufsiz)
+  while data == nil and errno.is(eno, "EINTR") do
+    data, err, eno = unix.read(fd, bufsiz)
+  end
+  return data, err
+end
+
+--- Reap pid with a blocking wait, retrying when a signal interrupts it
+--- (the signal-safety wave, #595). Returns (pid, status); on a hard wait
+--- failure pid is nil and the error string sits in the status slot.
+local function wait_retry(pid: integer): integer | nil, integer
+  local wpid, status, weno = unix.wait(pid)
+  while wpid == nil and errno.is(weno, "EINTR") do
+    wpid, status, weno = unix.wait(pid)
+  end
+  return wpid, status
+end
+
 -- Put a pipe write end into non-blocking mode so a stdin write in the pump
 -- can never block the loop that is simultaneously draining stdout/stderr.
 -- F_SETFL replaces the file-status flags, but a fresh pipe write end carries
@@ -130,8 +151,11 @@ local function pump(state: PumpState, deadline_ms: number): boolean
     if not ev0 then return end
     local ev = ev0 as {string: boolean}
     if ev.readable then
-      local chunk, rerr = unix.read(fd, CHUNK)
+      local chunk, rerr, reno = unix.read(fd, CHUNK)
       if chunk == nil then
+        -- Interrupted by a signal: leave the fd registered; the next poll
+        -- round retries (the signal-safety wave, #595).
+        if errno.is(reno, "EINTR") then return end
         state.io_err = state.io_err or errno.str(rerr, "read")
         p:remove(fd); unix.close(fd)
         if which == "out" then state.stdout_fd = nil else state.stderr_fd = nil end
@@ -175,8 +199,9 @@ local function pump(state: PumpState, deadline_ms: number): boolean
           if state.stdin_off >= #state.stdin_data then
             p:remove(state.stdin_fd); unix.close(state.stdin_fd); state.stdin_fd = nil
           end
-        elseif errno.is(weno, "EAGAIN") then
-          -- Not actually writable yet; try again on the next poll.
+        elseif errno.is(weno, "EAGAIN") or errno.is(weno, "EINTR") then
+          -- Not actually writable yet (EAGAIN), or a signal interrupted the
+          -- write (EINTR): try again on the next poll.
         elseif errno.is(weno, "EPIPE") then
           -- The child stopped reading stdin; stop feeding it (not an error).
           p:remove(state.stdin_fd); unix.close(state.stdin_fd); state.stdin_fd = nil
@@ -200,6 +225,8 @@ local record ChildIoModule
   Stdio: Stdio
   pump: function(state: PumpState, deadline_ms: number): boolean
   now_ms: function(): number
+  read_retry: function(fd: integer, bufsiz: integer): string | nil, string | nil
+  wait_retry: function(pid: integer): integer | nil, integer
   resolve_stdio: function(stdin?: string | cfd.Handle, stdout?: cfd.Handle,
   stderr?: cfd.Handle): Stdio | nil, string
 end
@@ -207,6 +234,8 @@ end
 local M: ChildIoModule = {
   pump = pump,
   now_ms = now_ms,
+  read_retry = read_retry,
+  wait_retry = wait_retry,
   resolve_stdio = resolve_stdio,
 }
 

--- a/lib/cosmic/child/signal_test.tl
+++ b/lib/cosmic/child/signal_test.tl
@@ -1,0 +1,39 @@
+#!/usr/bin/env cosmic
+--- Tests for the #595 signal-safety wave: blocking child I/O interrupted
+--- by a signal is retried automatically instead of surfacing EINTR.
+local child = require("cosmic.child")
+local signal = require("cosmic.signal")
+
+-- A blocking streaming read on the child's stdout is retried when a
+-- signal interrupts it, so it returns bare nil at the child's EOF
+-- instead of surfacing EINTR mid-wait.
+local function test_read_retries_eintr()
+  local h = child.spawn({"sleep", "0.3"}) as child.Handle
+  assert(h ~= nil, "spawn should succeed")
+  local old_handler = signal.sigaction(signal.SIGALRM, function(_: number) end)
+  -- Interval timer: fires several times while read blocks on the silent
+  -- child, each one interrupting the read.
+  signal.setitimer({
+      which = signal.ITIMER_REAL,
+      valuesec = 0,
+      valuens = 50000000,
+      intervalsec = 0,
+      intervalns = 50000000,
+    })
+  local data, err = h:read()
+  -- Disarm and restore before asserting so a failure can't leave a
+  -- ticking timer behind.
+  signal.setitimer({
+      which = signal.ITIMER_REAL,
+      valuesec = 0,
+      valuens = 0,
+      intervalsec = 0,
+      intervalns = 0,
+    })
+  signal.sigaction(signal.SIGALRM, old_handler)
+  assert(data == nil and err == nil,
+    "interrupted read should retry to the child's EOF, got "
+    .. tostring(data) .. " (err: " .. tostring(err) .. ")")
+  assert(h:wait())
+end
+test_read_retries_eintr()

--- a/lib/cosmic/fd.tl
+++ b/lib/cosmic/fd.tl
@@ -10,14 +10,15 @@
 --- For whole-file path-based operations use cosmic.fs: fs.read(path),
 --- fs.write(path, data), fs.truncate(path).
 ---
---- EINTR posture: Handle read/write/seek do NOT retry automatically. When
---- a signal interrupts the call, it returns nil plus an EINTR-tagged
---- error; callers that install signal handlers detect it with
---- `errno.name_of(err) == "EINTR"` and retry themselves. (Automatic
---- retry is deferred to the signal-safety wave, tracked in #595; the
---- stream-contract EINTR decision is #589.)
+--- EINTR posture: Handle read/write retry automatically when a signal
+--- interrupts the call (the signal-safety wave, #595). A pending Lua
+--- signal handler runs between the interrupted call and its retry, so
+--- handlers never starve; to break out of a blocking call instead, use
+--- O_NONBLOCK plus poll, or close the descriptor from the handler.
+--- The full policy and its exceptions live in cosmic.stream.
 local unix = require("cosmo.unix")
 local errstr = require("cosmic.errno").str
+local errno_is = require("cosmic.errno").is
 local stream = require("cosmic.stream")
 
 --- File handle for I/O operations.
@@ -72,14 +73,17 @@ make_handle = function(fd: integer): Handle
   --- Read up to size bytes. Returns nil with NO error on EOF (Lua
   --- convention: `while true do local chunk = h:read(n); if not chunk
   --- then break end ... end`), and nil WITH an error on failure —
-  --- including EAGAIN on a nonblocking fd with no data, and EINTR when
-  --- a signal interrupts the read (see the module header; not retried).
+  --- including EAGAIN on a nonblocking fd with no data. A read
+  --- interrupted by a signal is retried (see the module header).
   --- If offset is provided, reads at that position (pread behavior).
   function handle:read(size?: integer, offset?: integer): string | nil, string
     if not handle_fd then
       return nil, "handle closed"
     end
-    local data, err = unix.read(handle_fd, size, offset)
+    local data, err, eno = unix.read(handle_fd, size, offset)
+    while data == nil and errno_is(eno, "EINTR") do
+      data, err, eno = unix.read(handle_fd, size, offset)
+    end
     if data == nil and err then
       return nil, errstr(err, "read")
     end
@@ -91,13 +95,17 @@ make_handle = function(fd: integer): Handle
 
   --- Write data. Returns number of bytes written (which may be fewer
   --- than #data — callers writing everything must loop). On failure
-  --- returns nil plus an error; EINTR is not retried (see module header).
+  --- returns nil plus an error. A write interrupted by a signal before
+  --- any byte lands is retried (see the module header).
   --- If offset is provided, writes at that position (pwrite behavior).
   function handle:write(data: string, offset?: integer): integer | nil, string
     if not handle_fd then
       return nil, "handle closed"
     end
-    local n, err = unix.write(handle_fd, data, offset)
+    local n, err, eno = unix.write(handle_fd, data, offset)
+    while n == nil and errno_is(eno, "EINTR") do
+      n, err, eno = unix.write(handle_fd, data, offset)
+    end
     if not n then
       return nil, errstr(err, "write")
     end
@@ -105,7 +113,7 @@ make_handle = function(fd: integer): Handle
   end
 
   --- Seek to position. whence: SEEK_SET (default), SEEK_CUR, SEEK_END.
-  --- On failure returns nil plus an error; EINTR is not retried.
+  --- On failure returns nil plus an error.
   function handle:seek(offset: integer, whence?: integer): integer | nil, string
     if not handle_fd then
       return nil, "handle closed"

--- a/lib/cosmic/fd_read_test.tl
+++ b/lib/cosmic/fd_read_test.tl
@@ -63,6 +63,46 @@ local function test_nonblocking_pipe_read_names_eagain()
 end
 test_nonblocking_pipe_read_names_eagain()
 
+-- #595 signal-safety wave: a blocking read interrupted by a signal is
+-- retried automatically instead of surfacing EINTR. Pending Lua signal
+-- handlers run between retries — this handler supplies the payload the
+-- retried read then returns.
+local function test_blocking_read_retries_eintr()
+  local signal = require("cosmic.signal")
+  local p = assert(cfd.pipe()) as cfd.Pipe
+  local fired = false
+  local old_handler = signal.sigaction(signal.SIGALRM, function(_: number)
+      if not fired then
+        fired = true
+        p.writer:write("x")
+      end
+    end)
+  -- Interval timer: keeps firing until the blocked read observes a signal,
+  -- so the test cannot hang however the timing lands.
+  signal.setitimer({
+      which = signal.ITIMER_REAL,
+      valuesec = 0,
+      valuens = 30000000,
+      intervalsec = 0,
+      intervalns = 30000000,
+    })
+  local data, err = p.reader:read(10)
+  -- Disarm and restore before asserting so a failure can't leave a
+  -- ticking timer behind.
+  signal.setitimer({
+      which = signal.ITIMER_REAL,
+      valuesec = 0,
+      valuens = 0,
+      intervalsec = 0,
+      intervalns = 0,
+    })
+  signal.sigaction(signal.SIGALRM, old_handler)
+  assert(data == "x", "interrupted read should retry and return the handler's"
+    .. " payload, got " .. tostring(data) .. " (err: " .. tostring(err) .. ")")
+  p:close()
+end
+test_blocking_read_retries_eintr()
+
 -- The system-wide sync(2) belongs to fs, not fd (no alias, pre-stable).
 local function test_sync_moved_to_fs()
   assert((cfd as {string: any}).sync == nil, "fd.sync should be gone")

--- a/lib/cosmic/net/io_test.tl
+++ b/lib/cosmic/net/io_test.tl
@@ -225,3 +225,43 @@ local function test_socket_is_stream()
   b:close()
 end
 test_socket_is_stream()
+
+-- #595 signal-safety wave: a blocking recv interrupted by a signal is
+-- retried automatically instead of surfacing EINTR. The handler supplies
+-- the payload via the peer socket.
+local function test_recv_retries_eintr()
+  local signal = require("cosmic.signal")
+  local a, b = pair()
+  local fired = false
+  local old_handler = signal.sigaction(signal.SIGALRM, function(_: number)
+      if not fired then
+        fired = true
+        a:sendall("ping")
+      end
+    end)
+  -- Interval timer: keeps firing until the blocked recv observes a signal,
+  -- so the test cannot hang however the timing lands.
+  signal.setitimer({
+      which = signal.ITIMER_REAL,
+      valuesec = 0,
+      valuens = 30000000,
+      intervalsec = 0,
+      intervalns = 30000000,
+    })
+  local data, err = b:recv()
+  -- Disarm and restore before asserting so a failure can't leave a
+  -- ticking timer behind.
+  signal.setitimer({
+      which = signal.ITIMER_REAL,
+      valuesec = 0,
+      valuens = 0,
+      intervalsec = 0,
+      intervalns = 0,
+    })
+  signal.sigaction(signal.SIGALRM, old_handler)
+  assert(data == "ping", "interrupted recv should retry and return the peer's"
+    .. " payload, got " .. tostring(data) .. " (err: " .. tostring(err) .. ")")
+  a:close()
+  b:close()
+end
+test_recv_retries_eintr()

--- a/lib/cosmic/net/socket.tl
+++ b/lib/cosmic/net/socket.tl
@@ -5,6 +5,7 @@
 --- of the public surface (wrap C-boundary integers with ip.addr()).
 local unix = require("cosmo.unix")
 local errstr = require("cosmic.errno").str
+local errno_is = require("cosmic.errno").is
 local ip = require("cosmic.ip")
 
 --- An address the socket layer accepts: a dotted-quad string
@@ -28,7 +29,10 @@ end
 
 --- Socket handle for network I/O.
 --- Sockets are BLOCKING by default: recv and accept wait until data or a
---- connection arrives. Supports Lua 5.4's to-be-closed via __close.
+--- connection arrives. Blocking calls interrupted by a signal are retried
+--- automatically (the signal-safety wave, #595; policy in cosmic.stream)
+--- — except connect, see its doc. Use set_timeout or poll for
+--- interruptible waits. Supports Lua 5.4's to-be-closed via __close.
 local stream = require("cosmic.stream")
 
 local record Socket is stream.Reader, stream.Writer
@@ -87,7 +91,10 @@ local record Socket is stream.Reader, stream.Writer
   --- Accept one connection (blocks until a client connects).
   --- Returns the connection socket, peer Addr, peer port.
   accept: function(self: Socket, flags?: integer): Socket | nil, ip.Addr, integer, string
-  --- Connect to addr:port.
+  --- Connect to addr:port. The one blocking call NOT retried on EINTR:
+  --- POSIX keeps the connection attempt going in the background after a
+  --- signal, so a blind retry would fail with EALREADY. On EINTR, poll
+  --- the socket for writability to learn the outcome.
   connect: function(self: Socket, addr: Address, port: integer): boolean, string
   --- Connect to a unix-domain socket path.
   connect_unix: function(self: Socket, path: string): boolean, string
@@ -146,7 +153,10 @@ local function make_socket(fd: integer): Socket
   -- per-OS flag, so ORing it in is portable.
   function sock:send(data: string, flags?: integer): integer | nil, string
     if not self.fd then return nil, "socket closed" end
-    local n, err = unix.send(self.fd, data, (flags or 0) | unix.MSG_NOSIGNAL)
+    local n, err, eno = unix.send(self.fd, data, (flags or 0) | unix.MSG_NOSIGNAL)
+    while n == nil and errno_is(eno, "EINTR") do
+      n, err, eno = unix.send(self.fd, data, (flags or 0) | unix.MSG_NOSIGNAL)
+    end
     if not n then
       return nil, errstr(err, "send")
     end
@@ -171,7 +181,10 @@ local function make_socket(fd: integer): Socket
     if not raw then
       return nil, aerr
     end
-    local n, err = unix.sendto(self.fd, data, raw, port, (flags or 0) | unix.MSG_NOSIGNAL)
+    local n, err, eno = unix.sendto(self.fd, data, raw, port, (flags or 0) | unix.MSG_NOSIGNAL)
+    while n == nil and errno_is(eno, "EINTR") do
+      n, err, eno = unix.sendto(self.fd, data, raw, port, (flags or 0) | unix.MSG_NOSIGNAL)
+    end
     if not n then
       return nil, errstr(err, "sendto")
     end
@@ -184,7 +197,10 @@ local function make_socket(fd: integer): Socket
 
   function sock:recv(bufsiz?: integer, flags?: integer): string | nil, string
     if not self.fd then return nil, "socket closed" end
-    local data, err = unix.recv(self.fd, bufsiz or 65536, flags or 0)
+    local data, err, eno = unix.recv(self.fd, bufsiz or 65536, flags or 0)
+    while data == nil and errno_is(eno, "EINTR") do
+      data, err, eno = unix.recv(self.fd, bufsiz or 65536, flags or 0)
+    end
     if not data then
       return nil, errstr(err, "recv")
     end
@@ -230,7 +246,10 @@ local function make_socket(fd: integer): Socket
     while true do
       -- Peek without consuming, then consume exactly through the newline,
       -- so bytes past the line stay readable by recv/recv_exact.
-      local data, err = unix.recv(self.fd, 4096, unix.MSG_PEEK)
+      local data, err, eno = unix.recv(self.fd, 4096, unix.MSG_PEEK)
+      while data == nil and errno_is(eno, "EINTR") do
+        data, err, eno = unix.recv(self.fd, 4096, unix.MSG_PEEK)
+      end
       if not data then
         return nil, errstr(err, "readline")
       end
@@ -277,6 +296,9 @@ local function make_socket(fd: integer): Socket
   function sock:recvfrom(bufsiz?: integer, flags?: integer): string | nil, ip.Addr, integer, string
     if not self.fd then return nil, nil, nil, "socket closed" end
     local data, sender, port = unix.recvfrom(self.fd, bufsiz or 65536, flags or 0)
+    while data == nil and errno_is(port, "EINTR") do
+      data, sender, port = unix.recvfrom(self.fd, bufsiz or 65536, flags or 0)
+    end
     if not data then
       -- On failure the binding returns (nil, err, errno): the error string
       -- arrives in the second slot, where the sender ip would have been.
@@ -345,6 +367,9 @@ local function make_socket(fd: integer): Socket
   function sock:accept(flags?: integer): Socket | nil, ip.Addr, integer, string
     if not self.fd then return nil, nil, nil, "socket closed" end
     local clientfd, peer, port = unix.accept(self.fd, flags or 0)
+    while clientfd == nil and errno_is(port, "EINTR") do
+      clientfd, peer, port = unix.accept(self.fd, flags or 0)
+    end
     if not clientfd then
       -- On failure the binding returns (nil, err, errno): the error string
       -- arrives in the second slot, where the peer ip would have been.

--- a/lib/cosmic/proc.tl
+++ b/lib/cosmic/proc.tl
@@ -202,6 +202,7 @@ local function posix_spawnp(prog: string, argv: {string}, envp?: {string}): inte
 end
 
 --- Waits for a child process to change state.
+--- A raw passthrough: EINTR surfaces here, unlike child.Handle:wait (#595).
 --- @param pid integer? Child pid to wait for (-1 or nil for any child)
 --- @param options integer? Wait options (e.g. WNOHANG)
 --- @return integer | nil The pid that changed state (0 with WNOHANG if none), or nil on failure

--- a/lib/cosmic/shm.tl
+++ b/lib/cosmic/shm.tl
@@ -10,6 +10,7 @@
 --- pcall-translated.
 local unix = require("cosmo.unix")
 local errstr = require("cosmic.errno").str
+local errno_is = require("cosmic.errno").is
 
 local WORD = 8
 
@@ -45,8 +46,10 @@ local record ShmModule
     --- Atomic XOR; returns the old value.
     fetch_xor: function(self: Memory, word_index: integer, value: integer): integer | nil, string
     --- Wait until the word no longer holds `expect`. Returns 0 when
-    --- woken; nil plus an error naming EAGAIN (value already differed),
-    --- ETIMEDOUT (deadline expired), or EINTR (signal).
+    --- woken; nil plus an error naming EAGAIN (value already differed)
+    --- or ETIMEDOUT (deadline expired). A wait interrupted by a signal
+    --- is retried automatically (#595); the absolute deadline keeps the
+    --- timeout exact across retries.
     wait: function(self: Memory, word_index: integer, expect: integer, abs_deadline?: integer, nanos?: integer): integer | nil, string
     --- Wake processes waiting on a word; returns how many woke.
     wake: function(self: Memory, word_index: integer, count?: integer): integer
@@ -189,10 +192,16 @@ local function wrap(raw: unix.Memory, size: integer): Memory
     if range_err then
       return nil, range_err
     end
-    -- The binding returns (nil, err, errno) for EAGAIN/ETIMEDOUT/EINTR
-    -- and throws for a futex word with nonzero high bits; keep both as
-    -- error returns.
-    local ok, rc, err = pcall(raw.wait, raw, word_index, expect, abs_deadline, nanos)
+    -- The binding returns (nil, err, errno) for EAGAIN/ETIMEDOUT and
+    -- throws for a futex word with nonzero high bits; keep both as
+    -- error returns. A wait interrupted by a signal is retried (the
+    -- signal-safety wave, #595): the deadline is absolute, so retrying
+    -- keeps the timeout exact, and a word that changed meanwhile
+    -- surfaces honestly as EAGAIN on the retry.
+    local ok, rc, err, weno = pcall(raw.wait, raw, word_index, expect, abs_deadline, nanos)
+    while ok and rc == nil and errno_is(weno, "EINTR") do
+      ok, rc, err, weno = pcall(raw.wait, raw, word_index, expect, abs_deadline, nanos)
+    end
     if not ok then
       return nil, thrown("wait", rc)
     end

--- a/lib/cosmic/shm_test.tl
+++ b/lib/cosmic/shm_test.tl
@@ -218,3 +218,44 @@ local function test_memory_wait_wrong_expect_returns_eagain()
     "wait error should name EAGAIN, got: " .. tostring(err))
 end
 test_memory_wait_wrong_expect_returns_eagain()
+
+-- #595 signal-safety wave: a futex wait interrupted by a signal is retried
+-- automatically — the absolute deadline keeps the timeout exact across
+-- retries, so the wait ends in ETIMEDOUT, never EINTR.
+local function test_memory_wait_retries_eintr_until_deadline()
+  local signal = require("cosmic.signal")
+  local time = require("cosmic.time")
+  local mem = assert(shm.mapshared(64)) as shm.Memory
+  mem:store(0, 0)
+  local old_handler = signal.sigaction(signal.SIGALRM, function(_: number) end)
+  -- Interval timer: interrupts the wait several times before the deadline.
+  signal.setitimer({
+      which = signal.ITIMER_REAL,
+      valuesec = 0,
+      valuens = 30000000,
+      intervalsec = 0,
+      intervalns = 30000000,
+    })
+  local secs, nanos = time.now()
+  nanos = nanos + 200000000
+  if nanos >= 1000000000 then
+    secs = secs + 1
+    nanos = nanos - 1000000000
+  end
+  local rc, err = mem:wait(0, 0, secs, nanos)
+  -- Disarm and restore before asserting so a failure can't leave a
+  -- ticking timer behind.
+  signal.setitimer({
+      which = signal.ITIMER_REAL,
+      valuesec = 0,
+      valuens = 0,
+      intervalsec = 0,
+      intervalns = 0,
+    })
+  signal.sigaction(signal.SIGALRM, old_handler)
+  assert(rc == nil, "wait on an unchanged word should time out")
+  assert(type(err) == "string" and err:match("ETIMEDOUT"),
+    "interrupted wait should retry to the deadline (ETIMEDOUT), got: "
+    .. tostring(err))
+end
+test_memory_wait_retries_eintr_until_deadline()

--- a/lib/cosmic/signal.tl
+++ b/lib/cosmic/signal.tl
@@ -115,6 +115,9 @@ local record SignalModule
   --- Temporarily replaces the signal mask with the provided mask.
   --- Always returns nil plus an error message: EINTR once a signal
   --- was delivered and handled, or another errno on failure.
+  --- A deliberate exception to the automatic EINTR retry policy
+  --- (cosmic.stream, #595): waiting for the interruption is the call's
+  --- entire purpose.
   sigsuspend: function(mask?: Sigset): nil, string
 
   --- Schedule SIGALRM signals at intervals.

--- a/lib/cosmic/stream.tl
+++ b/lib/cosmic/stream.tl
@@ -16,13 +16,21 @@
 --- (recv returns nil on peer close); wrap a socket's descriptor with
 --- fd.wrap(sock.fd) to use it where a Reader or Writer is expected.
 ---
---- EINTR posture, recorded (api-review-2, #589): conforming reads and
---- writes do NOT retry automatically when a signal interrupts them —
---- the call surfaces nil plus an EINTR-tagged error, detected with
---- errno.name_of(err) == "EINTR", and callers that install signal
---- handlers retry themselves. poll retries internally. Making retry
---- automatic across the wrappers is the post-stable signal-safety
---- wave, tracked in #595.
+--- EINTR posture (the signal-safety wave, #595; pre-stable decision in
+--- #589): blocking calls on the ergonomic wrappers retry automatically
+--- when a signal interrupts them — EINTR never surfaces from
+--- fd.Handle read/write, socket send/recv/accept, child wait/read,
+--- poll, or shm futex waits. Pending Lua signal handlers still run:
+--- delivery is deferred to the VM, so each handler fires between an
+--- interrupted call and its retry. To break out of a blocking call,
+--- give it a deadline (socket set_timeout, poll's timeout, shm wait's
+--- absolute deadline) or close the descriptor from the handler.
+--- The deliberate exceptions, where the interruption IS the result:
+--- time.sleep (returns the remainder plus an EINTR error),
+--- signal.sigsuspend, socket connect (POSIX keeps connecting in the
+--- background after EINTR, so a blind retry would misreport), and the
+--- raw cosmic.proc/cosmo.unix passthroughs, which surface errnos
+--- verbatim.
 local record stream
   --- A source of bytes. read(n?) returns the next chunk (at most n
   --- bytes when n is given), bare nil at end of stream, or nil plus an

--- a/lib/cosmic/time.tl
+++ b/lib/cosmic/time.tl
@@ -76,6 +76,9 @@ end
 --- the sleep, returns the remaining seconds and nanoseconds plus an
 --- error string naming EINTR. Invalid input (e.g. a negative duration)
 --- returns nil, nil, and an error naming EINVAL.
+--- sleep is a deliberate exception to the automatic EINTR retry policy
+--- (cosmic.stream, #595): the interruption IS the result, and the
+--- remainder lets callers resume or bail as they choose.
 --- @param seconds integer Seconds to sleep
 --- @param nanos integer? Additional nanoseconds to sleep (default: 0)
 --- @return integer | nil Remaining seconds (0 on success), or nil on invalid input


### PR DESCRIPTION
Implements the signal-safety wave tracked in #595: one coherent EINTR policy across the blocking wrappers — retry automatically everywhere, except where the interruption is the point.

## Policy (recorded in `cosmic.stream`)

Blocking calls on the ergonomic wrappers retry automatically when a signal interrupts them; EINTR never surfaces from them. This is sound because `unix.sigaction` defers Lua handlers to the VM (the C handler only records the signal and arms a debug hook), so a pending handler always runs between an interrupted call and its Teal-level retry — handlers never starve, and the PEP-475-style retry loop cannot swallow them. To break out of a blocking call, use a deadline (`set_timeout`, poll's timeout, shm's absolute deadline) or close the descriptor from the handler.

## Retried

- `fd.Handle` `read`/`write`
- `net.Socket` `send`/`sendto`/`recv`/`recvfrom`/`accept`, and `readline`'s MSG_PEEK recv
- `child.Handle` `wait` (the final reap) and `read`; the spawn exec handshake — where an interrupted read previously returned nil, which the parent treated as EOF and **misreported a failed exec as a running child**; the `__gc`/`__close` reap; and the pump's stdin feed and stdout/stderr drains (EINTR now retries on the next poll round instead of being recorded as an I/O error and closing the stream)
- `shm` `Memory:wait` — the deadline is absolute, so retrying keeps the timeout exact; a word changed mid-retry still surfaces honestly as EAGAIN
- `poll` already retried (unchanged)

## Deliberate exceptions (documented)

- `time.sleep` — the interruption is the result; keeps its remainder + EINTR contract (pinned by `time_test`)
- `signal.sigsuspend` — waiting for the interruption is the call's purpose
- `net.Socket:connect` — POSIX keeps the connection attempt going in the background after EINTR, so a blind retry would fail with EALREADY; documented with the poll-for-writability recipe
- raw `cosmic.proc` / `cosmo.unix` passthroughs — surface errnos verbatim (quicksand's supervisor loops rely on seeing EINTR)

## TDD

Red tests written first, each observed failing with an EINTR-tagged error, then green after the change:

- `fd_read_test`: blocked pipe read; the SIGALRM handler writes the payload, the retried read returns it
- `net/io_test`: blocked `recv`; the handler sends via the peer socket
- `child/signal_test` (new file): streaming `read` to a silent child's EOF under an interval timer
- `shm_test`: interrupted `wait` with an absolute deadline ends in ETIMEDOUT, never EINTR

Gates: `bin/make ci` → `ci: PASS`. Cast-ratchet pins raised deliberately for the two test files that gained an `as` cast; no new casts in library code.

Closes #595.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7VLnnsGiDRsVGNvtRRq3K

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7VLnnsGiDRsVGNvtRRq3K)_