### PR TITLE
docs: state sigaction handler-safety and shm wait deadline clock (#508)

### DIFF
--- a/lib/cosmic/shm.tl
+++ b/lib/cosmic/shm.tl
@@ -47,9 +47,12 @@ local record ShmModule
     fetch_xor: function(self: Memory, word_index: integer, value: integer): integer | nil, string
     --- Wait until the word no longer holds `expect`. Returns 0 when
     --- woken; nil plus an error naming EAGAIN (value already differed)
-    --- or ETIMEDOUT (deadline expired). A wait interrupted by a signal
-    --- is retried automatically (#595); the absolute deadline keeps the
-    --- timeout exact across retries.
+    --- or ETIMEDOUT (deadline expired). The deadline is an ABSOLUTE
+    --- CLOCK_REALTIME time — whole seconds in `abs_deadline` plus
+    --- nanoseconds in `nanos` (e.g. from time.now()); omit both to wait
+    --- forever. A wait interrupted by a signal is retried automatically
+    --- (#595); the absolute deadline keeps the timeout exact across
+    --- retries.
     wait: function(self: Memory, word_index: integer, expect: integer, abs_deadline?: integer, nanos?: integer): integer | nil, string
     --- Wake processes waiting on a word; returns how many woke.
     wake: function(self: Memory, word_index: integer, count?: integer): integer

--- a/lib/cosmic/signal.tl
+++ b/lib/cosmic/signal.tl
@@ -102,6 +102,13 @@ local record SignalModule
 
   --- Register a signal handler for the specified signal.
   --- The handler can be a Lua function, SIG_IGN, or SIG_DFL.
+  --- Lua handlers are DEFERRED: the C-level handler only records the
+  --- signal, and the Lua function runs between VM instructions once the
+  --- interpreter regains control — ordinary VM context, so any Lua code
+  --- is safe inside it (no async-signal-safety constraints). A signal
+  --- arriving during a blocking call surfaces there as EINTR first; the
+  --- ergonomic wrappers run the handler and retry (cosmic.stream, #595).
+  --- An error raised inside a handler is logged, not propagated.
   --- Returns the previous handler, flags, and mask; on failure returns
   --- nil, nil, nil plus an error message.
   sigaction: function(sig: integer, handler?: function | integer, flags?: integer, mask?: Sigset): function | integer, integer, Sigset, string
@@ -219,6 +226,10 @@ local raw_sigprocmask = unix.sigprocmask as function(integer, Sigset): (Sigset, 
 local raw_sigsuspend = unix.sigsuspend as function(Sigset): (any, any)
 
 --- Register a signal handler for the specified signal.
+--- Lua handlers run deferred in ordinary VM context (see the
+--- SignalModule record doc): any Lua is safe inside one, delivery
+--- happens between VM instructions, and handler errors are logged,
+--- not propagated.
 --- @param sig integer The signal to handle
 --- @param handler function | integer? Lua function, SIG_IGN, or SIG_DFL
 --- @param flags integer? sigaction flags (e.g. SA_RESTART)


### PR DESCRIPTION
Closes out the last two residuals of #508 (found while triaging the audit issues against current main — everything else in #508 has landed: the 17 socket methods, the sqlite records, and child's wait/timeout docs are all documented).

- `signal.sigaction` now states the handler-safety model, verified against the binding source (`lunix.c`): Lua handlers are **deferred** — the C-level handler only records the signal and the Lua function runs between VM instructions in ordinary VM context, so any Lua code is safe inside one (no async-signal-safety constraints); a signal arriving during a blocking call surfaces as EINTR first and the ergonomic wrappers run the handler then retry (the #595 policy); handler errors are logged, not propagated.
- `shm.Memory:wait` now names its deadline clock and units, verified against `LuaUnixMemoryWait`: an **absolute CLOCK_REALTIME** time, whole seconds in `abs_deadline` plus nanoseconds in `nanos` (e.g. from `time.now()`); omit both to wait forever.

Doc-only; no behavior change. Gates: `bin/make ci` → `ci: PASS`.

Closes #508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7VLnnsGiDRsVGNvtRRq3K

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7VLnnsGiDRsVGNvtRRq3K)_