### PR TITLE
net,tty,poll: surface hidden C options; document fd conventions (#493)

### DIFF
--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -112,7 +112,7 @@
 6	lib/cosmic/landlock_test.tl
 1	lib/cosmic/log_test.tl
 2	lib/cosmic/make.tl
-28	lib/cosmic/net/connect_test.tl
+31	lib/cosmic/net/connect_test.tl
 10	lib/cosmic/net/init.tl
 7	lib/cosmic/net/init_example.tl
 27	lib/cosmic/net/init_test.tl
@@ -196,7 +196,7 @@
 4	lib/cosmic/time_test.tl
 14	lib/cosmic/tl_loader_test.tl
 4	lib/cosmic/tty.tl
-12	lib/cosmic/tty_test.tl
+13	lib/cosmic/tty_test.tl
 4	lib/cosmic/unveil.tl
 1	lib/cosmic/unveil_example.tl
 3	lib/cosmic/unveil_test.tl

--- a/lib/cosmic/net/connect_test.tl
+++ b/lib/cosmic/net/connect_test.tl
@@ -341,3 +341,33 @@ local function test_dial()
     "dial failure names the operation: " .. tostring(berr))
 end
 test_dial()
+
+-- #493: listen_tcp socket options are configurable — SO_REUSEADDR stays
+-- the default but can be opted out, and SO_REUSEPORT can be opted in.
+local function test_listen_tcp_socket_options()
+  local s1, port, derr = net.listen_tcp("127.0.0.1", 0)
+  assert(s1 ~= nil, "listen_tcp failed: " .. tostring(derr))
+  assert(port > 0, "expected a bound port")
+  local d = s1 as net.Socket
+  local ra = d:getsockopt(net.SOL_SOCKET, net.SO_REUSEADDR)
+  assert(ra == true or ra == 1,
+    "SO_REUSEADDR should default on, got " .. tostring(ra))
+  d:close()
+
+  local s2, _, oerr = net.listen_tcp("127.0.0.1", 0, nil, {reuseaddr = false})
+  assert(s2 ~= nil, "listen_tcp with reuseaddr=false failed: " .. tostring(oerr))
+  local o = s2 as net.Socket
+  local ra2 = o:getsockopt(net.SOL_SOCKET, net.SO_REUSEADDR)
+  assert(ra2 == false or ra2 == 0,
+    "reuseaddr=false should leave SO_REUSEADDR off, got " .. tostring(ra2))
+  o:close()
+
+  local s3, _, perr = net.listen_tcp("127.0.0.1", 0, nil, {reuseport = true})
+  assert(s3 ~= nil, "listen_tcp with reuseport failed: " .. tostring(perr))
+  local p = s3 as net.Socket
+  local rp = p:getsockopt(net.SOL_SOCKET, net.SO_REUSEPORT)
+  assert(rp == true or rp == 1,
+    "reuseport=true should set SO_REUSEPORT, got " .. tostring(rp))
+  p:close()
+end
+test_listen_tcp_socket_options()

--- a/lib/cosmic/net/init.tl
+++ b/lib/cosmic/net/init.tl
@@ -142,6 +142,17 @@ local function dial(host: string, port: integer): Socket | nil, string
   return connect_tcp(a, port)
 end
 
+--- Socket options for listen_tcp (#493: the hidden SO_REUSEADDR is now
+--- an opt-out, and SO_REUSEPORT an opt-in).
+local record ListenOptions
+  --- Set SO_REUSEADDR on the listener (default true: rebinding a
+  --- just-closed address must not fail with EADDRINUSE).
+  reuseaddr: boolean
+  --- Set SO_REUSEPORT on the listener (default false): lets several
+  --- processes bind the same addr:port and share the accept load.
+  reuseport: boolean
+end
+
 --- Create a TCP socket, bind it to addr:port, and start listening.
 --- Passing port 0 lets the OS assign an ephemeral port; the actual port is
 --- returned as the second value so callers never need a separate getsockname
@@ -162,19 +173,30 @@ end
 --- @param addr Address Local IPv4 address to bind ("127.0.0.1", "0.0.0.0" for all)
 --- @param port integer Local port to bind; use 0 for an OS-assigned ephemeral port
 --- @param backlog integer Maximum pending connections (default 128)
+--- @param opts ListenOptions? Socket options (reuseaddr default true, reuseport default false)
 --- @return Socket | nil Listening socket ready to accept
 --- @return integer Actual bound port (useful when port 0 was requested)
 --- @return string Error message on failure
-local function listen_tcp(addr: Address, port: integer, backlog?: integer): Socket | nil, integer, string
+local function listen_tcp(addr: Address, port: integer, backlog?: integer, opts?: ListenOptions): Socket | nil, integer, string
+  opts = opts or {}
   local sock, serr = socket(unix.AF_INET, unix.SOCK_STREAM, 0)
   if not sock then
     return nil, nil, serr
   end
   local s = sock as Socket
-  local ok, setopt_err = s:setsockopt(unix.SOL_SOCKET, unix.SO_REUSEADDR, true)
-  if not ok then
-    s:close()
-    return nil, nil, setopt_err
+  if opts.reuseaddr ~= false then
+    local ok, setopt_err = s:setsockopt(unix.SOL_SOCKET, unix.SO_REUSEADDR, true)
+    if not ok then
+      s:close()
+      return nil, nil, setopt_err
+    end
+  end
+  if opts.reuseport then
+    local ok, setopt_err = s:setsockopt(unix.SOL_SOCKET, unix.SO_REUSEPORT, true)
+    if not ok then
+      s:close()
+      return nil, nil, setopt_err
+    end
   end
   local bok, bind_err = s:bind(addr, port)
   if not bok then
@@ -272,11 +294,12 @@ end
 local record NetModule
   type Socket = Socket
   type Address = Address
+  type ListenOptions = ListenOptions
   Interface: Interface
   socket: function(family?: integer, socktype?: integer, protocol?: integer): Socket | nil, string
   socketpair: function(family?: integer, socktype?: integer, protocol?: integer): Socket | nil, Socket, string
   listen_unix: function(path: string, backlog?: integer): Socket | nil, string
-  listen_tcp: function(addr: Address, port: integer, backlog?: integer): Socket | nil, integer, string
+  listen_tcp: function(addr: Address, port: integer, backlog?: integer, opts?: ListenOptions): Socket | nil, integer, string
   connect_unix: function(path: string): Socket | nil, string
   connect_tcp: function(addr: Address, port: integer): Socket | nil, string
   dial: function(host: string, port: integer): Socket | nil, string

--- a/lib/cosmic/net/io_test.tl
+++ b/lib/cosmic/net/io_test.tl
@@ -265,3 +265,18 @@ local function test_recv_retries_eintr()
   b:close()
 end
 test_recv_retries_eintr()
+
+-- #493: send exposes the binding's offset parameter — a partial-send
+-- loop can window the buffer without copying via data:sub.
+local function test_send_offset()
+  local a, b = pair()
+  local n, err = a:send("XXhello", 0, 2)
+  assert(n == 5, "send with offset should send the tail, got "
+    .. tostring(n) .. " (err: " .. tostring(err) .. ")")
+  local got = b:recv()
+  assert(got == "hello", "peer should see bytes past the offset, got: "
+    .. tostring(got))
+  a:close()
+  b:close()
+end
+test_send_offset()

--- a/lib/cosmic/net/socket.tl
+++ b/lib/cosmic/net/socket.tl
@@ -45,8 +45,10 @@ local record Socket is stream.Reader, stream.Writer
   closed: function(self: Socket): boolean
   --- Shut down reading and/or writing (unix.SHUT_RD/WR/RDWR).
   shutdown: function(self: Socket, how?: integer): boolean, string
-  --- Send data; returns bytes sent, or nil + error.
-  send: function(self: Socket, data: string, flags?: integer): integer | nil, string
+  --- Send data; returns bytes sent, or nil + error. offset skips that
+  --- many leading bytes of data (0-based), so partial-send loops can
+  --- window the buffer without copying it via data:sub.
+  send: function(self: Socket, data: string, flags?: integer, offset?: integer): integer | nil, string
   --- stream.Writer: alias for send (bytes written, or nil + error).
   write: function(self: Socket, data: string): integer | nil, string
   --- Send all of data, retrying partial writes until done.
@@ -151,11 +153,11 @@ local function make_socket(fd: integer): Socket
   -- would otherwise kill the whole process (exit 141) instead of returning an
   -- EPIPE error the caller can handle. cosmo maps MSG_NOSIGNAL to the native
   -- per-OS flag, so ORing it in is portable.
-  function sock:send(data: string, flags?: integer): integer | nil, string
+  function sock:send(data: string, flags?: integer, offset?: integer): integer | nil, string
     if not self.fd then return nil, "socket closed" end
-    local n, err, eno = unix.send(self.fd, data, (flags or 0) | unix.MSG_NOSIGNAL)
+    local n, err, eno = unix.send(self.fd, data, (flags or 0) | unix.MSG_NOSIGNAL, offset)
     while n == nil and errno_is(eno, "EINTR") do
-      n, err, eno = unix.send(self.fd, data, (flags or 0) | unix.MSG_NOSIGNAL)
+      n, err, eno = unix.send(self.fd, data, (flags or 0) | unix.MSG_NOSIGNAL, offset)
     end
     if not n then
       return nil, errstr(err, "send")
@@ -166,7 +168,7 @@ local function make_socket(fd: integer): Socket
   function sock:sendall(data: string, flags?: integer): boolean, string
     local off: integer = 0
     while off < #data do
-      local n, err = self:send(data:sub(off + 1), flags)
+      local n, err = self:send(data, flags, off)
       if not n then
         return false, err
       end

--- a/lib/cosmic/poll.tl
+++ b/lib/cosmic/poll.tl
@@ -1,5 +1,12 @@
 --- Typed interface for polling file descriptors.
 --- Provides an ergonomic wrapper around unix.poll().
+---
+--- Descriptor conventions (#493, deliberate): poll is the lowest layer
+--- and speaks raw integer fds. net.Socket exposes a public `fd` field
+--- (sockets hand their descriptor around by design); fd.Handle exposes
+--- :fd() as a method because the Handle owns its descriptor and
+--- invalidates it on close — :fd() returns -1 once closed, and a -1
+--- must never be registered here.
 local unix = require("cosmo.unix")
 local errno = require("cosmic.errno")
 
@@ -79,9 +86,9 @@ end
 --- @return Poller A new poll set
 --- Example:
 ---   local p = poll.new()
----   p:add(handle.stdout.fd, poll.POLLIN)  -- child.Pipe: use .fd field
----   p:add(reader:fd(), poll.POLLIN)       -- io.Handle: call :fd() method
----   p:add(sock.fd, poll.POLLIN)           -- net.Socket: use .fd field
+---   p:add(sock.fd, poll.POLLIN)           -- net.Socket: .fd field
+---   p:add(h:fd(), poll.POLLIN)            -- fd.Handle: :fd() method
+---   p:add(pipe.reader:fd(), poll.POLLIN)  -- fd.Pipe ends are Handles
 ---   for fd, events in p:wait(30000) do
 ---     if events.readable then
 ---       -- read from fd

--- a/lib/cosmic/tty.tl
+++ b/lib/cosmic/tty.tl
@@ -54,7 +54,7 @@ local record TtyModule
   make_raw: function(termios: Termios, opts?: RawOptions): Termios
   raw: function(fd: integer, opts?: RawOptions): Termios | nil, string
   noecho: function(fd: integer): Termios | nil, string
-  restore: function(fd: integer, termios: Termios): boolean, string
+  restore: function(fd: integer, termios: Termios, action?: integer): boolean, string
   getpass: function(prompt: string): string | nil, string
 end
 
@@ -216,10 +216,12 @@ end
 --- Restores terminal attributes.
 --- @param fd integer File descriptor
 --- @param termios Termios Terminal attributes from raw() or noecho()
+--- @param action integer? When to apply: NOW (default), DRAIN (after
+--- pending output is written), or FLUSH (DRAIN + discard pending input)
 --- @return boolean True on success
 --- @return string? Error message on failure
-local function restore(fd: integer, termios: Termios): boolean, string
-  return setattr(fd, unix.TCSANOW, termios)
+local function restore(fd: integer, termios: Termios, action?: integer): boolean, string
+  return setattr(fd, action or unix.TCSANOW, termios)
 end
 
 --- Reads a password from the terminal without echoing.

--- a/lib/cosmic/tty_test.tl
+++ b/lib/cosmic/tty_test.tl
@@ -277,3 +277,18 @@ local function test_winsize_error_names_errno()
     "winsize error should name the errno, got: " .. tostring(err))
 end
 test_winsize_error_names_errno()
+
+-- #493: restore accepts a tcsetattr action (NOW default, DRAIN, FLUSH)
+-- instead of hard-coding TCSANOW. No pty here, so exercise the
+-- signature and the error path on a non-tty fd.
+local function test_restore_accepts_action()
+  assert(type(tty.DRAIN) == "number", "DRAIN constant should be exported")
+  assert(type(tty.FLUSH) == "number", "FLUSH constant should be exported")
+  local p = assert(cfd.pipe()) as cfd.Pipe
+  local t = fixture_termios()
+  local ok, err = tty.restore(p.reader:fd(), t, tty.DRAIN)
+  assert(not ok, "restore on a non-tty fd should fail")
+  assert(type(err) == "string", "expected an error message")
+  p:close()
+end
+test_restore_accepts_action()


### PR DESCRIPTION
The remaining unblocked items from #493 (thin/leaky abstractions). All additive — no signature breaks.

## Changes

- **`Socket:send(data, flags?, offset?)`** — exposes the binding's offset parameter (verified in `lunix.c`: 0-based bytes skipped, clamped). `sendall` now windows the buffer via the offset instead of copying with `data:sub` on every partial send.
- **`listen_tcp(addr, port, backlog?, opts?)`** — new `ListenOptions` record: `reuseaddr` (default true, now an opt-out instead of a hidden hard-coded SO_REUSEADDR) and `reuseport` (opt-in SO_REUSEPORT for accept-load sharing across processes).
- **`tty.restore(fd, termios, action?)`** — accepts the tcsetattr action (`NOW` default, `DRAIN`, `FLUSH`) instead of hard-coding TCSANOW.
- **poll** — documents the deliberate descriptor conventions (#493 called the three-way split out): poll speaks raw integers as the lowest layer; `net.Socket` exposes a public `fd` field; `fd.Handle` exposes an owning `:fd()` method that invalidates on close. Also fixes the stale example that referenced a `child.Pipe` `.fd` field that doesn't exist (`fd.Pipe` ends are Handles).

## TDD

Red first (all three failed the type gate on arity before the change), then green:
- `net/io_test`: `send` with offset delivers the tail without the skipped prefix
- `net/connect_test`: SO_REUSEADDR defaults on, `reuseaddr=false` leaves it off, `reuseport=true` sets SO_REUSEPORT (asserted via `getsockopt`)
- `tty_test`: `restore` accepts an action constant; error path on a non-tty fd

Gates: `bin/make ci` → `ci: PASS`. Cast pins raised for the two test files that gained casts.

## What this leaves in #493

- `shm` unmap needs an upstream binding (in flight in whilp/cosmopolitan — `Memory:unmap` + mapped-guards, since the process-shared mutex lives inside the mapping); the cosmic wrapper follows the next cosmos pin bump.
- The `net.interfaces` blob cast waits on U2 (whilp/cosmopolitan#141).
- `proc`'s raw wstatus/Rusage returns are the documented raw-passthrough layer (`child` is the ergonomic wrapper on top) — treated as the intended split, not a leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7VLnnsGiDRsVGNvtRRq3K

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7VLnnsGiDRsVGNvtRRq3K)_