### PR TITLE
sqlite: apply sensible per-connection defaults on open

### DIFF
--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -170,6 +170,7 @@
 5	lib/cosmic/sqlite/bind.tl
 17	lib/cosmic/sqlite/close_test.tl
 26	lib/cosmic/sqlite/data_test.tl
+10	lib/cosmic/sqlite/defaults_test.tl
 5	lib/cosmic/sqlite/extras.tl
 6	lib/cosmic/sqlite/extras_test.tl
 18	lib/cosmic/sqlite/init.tl

--- a/lib/cosmic/sqlite/defaults.tl
+++ b/lib/cosmic/sqlite/defaults.tl
@@ -1,0 +1,72 @@
+--- Internal helper for cosmic.sqlite: the per-connection defaults
+--- sqlite.open() applies and the OpenOptions record that tunes them.
+--- Lives in its own file so cosmic/sqlite/init.tl stays under the
+--- 500-line cap.
+
+local lsqlite3 = require("cosmo.lsqlite3")
+
+--- Options for opening a database.
+local record OpenOptions
+  --- Busy timeout in milliseconds (default 5000). When another connection
+  --- holds a conflicting lock, statements wait up to this long before
+  --- failing with SQLITE_BUSY. Pass 0 to fail immediately (SQLite's raw
+  --- default).
+  busy_timeout_ms: integer
+  --- Open the database read-only (default false). The file must exist.
+  read_only: boolean
+  --- Enforce FOREIGN KEY constraints (default true). SQLite's raw
+  --- default ignores them, allowing dangling references; set false to
+  --- restore that legacy behavior.
+  foreign_keys: boolean
+  --- Use write-ahead logging with synchronous=NORMAL (default true).
+  --- WAL makes writes faster and lets readers proceed alongside a
+  --- writer; synchronous=NORMAL keeps WAL transactions safe from
+  --- corruption while skipping redundant fsyncs. Set false to keep
+  --- SQLite's raw defaults (rollback journal, synchronous=FULL). Never
+  --- applied to read-only connections; a no-op for in-memory databases.
+  --- Note WAL mode persists in the database file once set.
+  wal: boolean
+end
+
+--- Apply cosmic's per-connection defaults to a freshly opened handle:
+--- busy_timeout (5000ms), foreign_keys=ON, and — unless the connection
+--- is read-only — journal_mode=WAL with synchronous=NORMAL.
+--- @param raw_db lsqlite3.Database Raw handle from lsqlite3.open
+--- @param opts OpenOptions Options passed to sqlite.open (may be nil)
+--- @return boolean true when all defaults were applied
+--- @return string Error message on failure
+local function apply(raw_db: lsqlite3.Database, opts: OpenOptions): boolean, string
+  local timeout_ms = 5000
+  if opts and opts.busy_timeout_ms ~= nil then
+    timeout_ms = opts.busy_timeout_ms
+  end
+  raw_db:busy_timeout(timeout_ms)
+
+  if not (opts and opts.foreign_keys == false) then
+    if raw_db:exec("PRAGMA foreign_keys = ON") ~= lsqlite3.OK then
+      return false, raw_db:errmsg()
+    end
+  end
+
+  if not (opts and (opts.wal == false or opts.read_only)) then
+    -- Databases that cannot switch journal mode (e.g. :memory:) report
+    -- their current mode instead of erroring; that clean no-op is fine.
+    if raw_db:exec("PRAGMA journal_mode = WAL") ~= lsqlite3.OK
+    or raw_db:exec("PRAGMA synchronous = NORMAL") ~= lsqlite3.OK then
+      return false, raw_db:errmsg()
+    end
+  end
+
+  return true
+end
+
+local record defaults
+  type OpenOptions = OpenOptions
+  apply: function(raw_db: lsqlite3.Database, opts: OpenOptions): boolean, string
+end
+
+local M: defaults = {
+  apply = apply,
+}
+
+return M

--- a/lib/cosmic/sqlite/defaults_test.tl
+++ b/lib/cosmic/sqlite/defaults_test.tl
@@ -1,0 +1,105 @@
+#!/usr/bin/env cosmic
+--- Tests for the per-connection defaults sqlite.open() applies
+--- (foreign_keys=ON, WAL journal mode with synchronous=NORMAL) and
+--- their OpenOptions opt-outs. busy_timeout coverage lives in
+--- data_test.tl.
+
+local sqlite = require("cosmic.sqlite")
+local fs = require("cosmic.fs")
+
+local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
+
+-- foreign_keys default
+
+local function test_foreign_keys_enforced_by_default()
+  local db = sqlite.open(":memory:") as sqlite.Database
+  db:exec("CREATE TABLE parent (id INTEGER PRIMARY KEY)")
+  db:exec("CREATE TABLE child (pid INTEGER REFERENCES parent(id))")
+  local ok, err = db:exec("INSERT INTO child (pid) VALUES (?)", 42)
+  assert(not ok, "dangling reference should fail with foreign_keys on")
+  assert(err and err:match("FOREIGN KEY constraint failed"),
+    "error should name the FOREIGN KEY constraint, got: " .. tostring(err))
+  db:close()
+end
+test_foreign_keys_enforced_by_default()
+
+local function test_foreign_keys_opt_out()
+  local db = sqlite.open(":memory:", {foreign_keys = false}) as sqlite.Database
+  db:exec("CREATE TABLE parent (id INTEGER PRIMARY KEY)")
+  db:exec("CREATE TABLE child (pid INTEGER REFERENCES parent(id))")
+  local ok, err = db:exec("INSERT INTO child (pid) VALUES (?)", 42)
+  assert(ok, "foreign_keys=false should restore raw behavior: " .. tostring(err))
+  db:close()
+end
+test_foreign_keys_opt_out()
+
+-- WAL + synchronous defaults
+
+local function test_wal_default_on_file_db()
+  local path = fs.join(TEST_TMPDIR, "wal_default.db")
+  local db = sqlite.open(path) as sqlite.Database
+  local mode = db:query_value("PRAGMA journal_mode")
+  assert(mode == "wal", "file db should default to WAL, got: " .. tostring(mode))
+  local sync = db:query_value("PRAGMA synchronous")
+  assert(sync == 1, "WAL default should set synchronous=NORMAL(1), got: " .. tostring(sync))
+  db:close()
+end
+test_wal_default_on_file_db()
+
+local function test_wal_opt_out()
+  local path = fs.join(TEST_TMPDIR, "wal_optout.db")
+  local db = sqlite.open(path, {wal = false}) as sqlite.Database
+  local mode = db:query_value("PRAGMA journal_mode")
+  assert(mode == "delete", "wal=false should keep the rollback journal, got: " .. tostring(mode))
+  local sync = db:query_value("PRAGMA synchronous")
+  assert(sync == 2, "wal=false should keep synchronous=FULL(2), got: " .. tostring(sync))
+  db:close()
+end
+test_wal_opt_out()
+
+local function test_memory_db_ignores_wal()
+  local db = sqlite.open(":memory:") as sqlite.Database
+  local mode = db:query_value("PRAGMA journal_mode")
+  assert(mode == "memory", "in-memory db keeps journal_mode=memory, got: " .. tostring(mode))
+  db:exec("CREATE TABLE t (v TEXT)")
+  assert(db:exec("INSERT INTO t (v) VALUES (?)", "x"))
+  db:close()
+end
+test_memory_db_ignores_wal()
+
+local function test_read_only_skips_wal()
+  local path = fs.join(TEST_TMPDIR, "ro_defaults.db")
+  local db = sqlite.open(path, {wal = false}) as sqlite.Database
+  db:exec("CREATE TABLE t (v TEXT)")
+  db:exec("INSERT INTO t (v) VALUES (?)", "hello")
+  db:close()
+
+  local rdb = sqlite.open(path, {read_only = true}) as sqlite.Database
+  local mode = rdb:query_value("PRAGMA journal_mode")
+  assert(mode == "delete", "read-only open must not switch journal mode, got: " .. tostring(mode))
+  local row = rdb:query_one("SELECT v FROM t") as {string: any}
+  assert(row and row.v == "hello", "read-only handle should read data")
+  rdb:close()
+end
+test_read_only_skips_wal()
+
+local function test_wal_readers_not_blocked_by_writer()
+  -- WAL persists in the file, so the second connection shares it; a
+  -- reader proceeds while a writer holds an open transaction.
+  local path = fs.join(TEST_TMPDIR, "wal_share.db")
+  local a = sqlite.open(path) as sqlite.Database
+  a:exec("CREATE TABLE t (v TEXT)")
+  a:exec("INSERT INTO t (v) VALUES (?)", "one")
+  local b = sqlite.open(path, {busy_timeout_ms = 0}) as sqlite.Database
+
+  assert(a:exec("BEGIN IMMEDIATE"))
+  assert(a:exec("INSERT INTO t (v) VALUES (?)", "two"))
+  local c = b:query_value("SELECT COUNT(*) FROM t")
+  assert(c == 1, "reader should see pre-transaction state, got: " .. tostring(c))
+  assert(a:exec("COMMIT"))
+  local c2 = b:query_value("SELECT COUNT(*) FROM t")
+  assert(c2 == 2, "reader should see the committed row, got: " .. tostring(c2))
+  a:close()
+  b:close()
+end
+test_wal_readers_not_blocked_by_writer()

--- a/lib/cosmic/sqlite/init.tl
+++ b/lib/cosmic/sqlite/init.tl
@@ -14,10 +14,13 @@
 ---     db:close()
 ---
 --- Binary values: wrap with `sqlite.blob(s)` to store with BLOB affinity
---- (a bare Lua string always binds as TEXT). Opening sets a 5000ms busy
---- timeout by default; see `OpenOptions`.
+--- (a bare Lua string always binds as TEXT). Opening applies sensible
+--- per-connection defaults — a 5000ms busy timeout, foreign_keys=ON,
+--- and WAL journal mode with synchronous=NORMAL; each has an
+--- `OpenOptions` field to tune or disable it.
 
 local lsqlite3 = require("cosmo.lsqlite3")
+local defaults_mod = require("cosmic.sqlite.defaults")
 local stmt_cache_mod = require("cosmic.sqlite.stmt_cache")
 local row_iter = require("cosmic.sqlite.row_iter")
 local bind_mod = require("cosmic.sqlite.bind")
@@ -416,27 +419,21 @@ local function make_database(raw_db: lsqlite3.Database): Database
     }) as Database
 end
 
---- Options for opening a database.
-local record OpenOptions
-  --- Busy timeout in milliseconds (default 5000). When another connection
-  --- holds a conflicting lock, statements wait up to this long before
-  --- failing with SQLITE_BUSY. Pass 0 to fail immediately (SQLite's raw
-  --- default).
-  busy_timeout_ms: integer
-  --- Open the database read-only (default false). The file must exist.
-  read_only: boolean
-end
+--- Options for opening a database (see cosmic.sqlite.defaults).
+local type OpenOptions = defaults_mod.OpenOptions
 
 --- Open or create an SQLite database.
 --- Relative paths are resolved against the current working directory.
 --- Absolute paths (e.g. "/var/data/app.db") work as expected.
 --- Use ":memory:" for an in-memory database that is not written to disk.
 --- The file is created if it does not already exist (unless read_only).
---- A 5000ms busy timeout is set by default so two processes sharing a
---- file database wait for each other instead of failing instantly with
---- SQLITE_BUSY; override with opts.busy_timeout_ms.
+--- Opening applies cosmic's per-connection defaults: a 5000ms busy
+--- timeout so concurrent processes wait for each other instead of
+--- failing instantly with SQLITE_BUSY, foreign_keys=ON, and — for
+--- writable connections — WAL journal mode with synchronous=NORMAL.
+--- Each default has an OpenOptions field to tune or disable it.
 --- @param filename string Database path (use ":memory:" for in-memory)
---- @param opts OpenOptions? busy_timeout_ms and read_only
+--- @param opts OpenOptions? busy_timeout_ms, read_only, foreign_keys, wal
 --- @return Database | nil Database handle with __close support
 --- @return string Error message on failure
 local function open(filename: string, opts?: OpenOptions): Database | nil, string
@@ -452,11 +449,11 @@ local function open(filename: string, opts?: OpenOptions): Database | nil, strin
   -- safe at this cosmo.* boundary since #681/#688 made the cosmic
   -- searcher the only loader cosmic installs.
   if raw_db is lsqlite3.Database then
-    local timeout_ms = 5000
-    if opts and opts.busy_timeout_ms ~= nil then
-      timeout_ms = opts.busy_timeout_ms
+    local ok, derr = defaults_mod.apply(raw_db, opts)
+    if not ok then
+      raw_db:close()
+      return nil, derr
     end
-    raw_db:busy_timeout(timeout_ms)
     return make_database(raw_db)
   end
   return nil, errmsg or ("error code " .. tostring(errcode))


### PR DESCRIPTION
Ships the sensible SQLite defaults recommended in [SQLite editions](https://mort.coffee/home/sqlite-editions/): `cosmic.sqlite.open()` now applies, in addition to the existing 5000ms busy timeout:

- **`PRAGMA foreign_keys = ON`** — FOREIGN KEY constraints are actually enforced instead of silently ignored (SQLite's raw default allows dangling references).
- **`PRAGMA journal_mode = WAL` + `PRAGMA synchronous = NORMAL`** for writable connections — faster writes, readers proceed alongside a writer, and NORMAL is still corruption-safe in WAL mode.

Details:

- Each default has an `OpenOptions` opt-out: `foreign_keys = false`, `wal = false` (and the existing `busy_timeout_ms`).
- WAL is never applied to read-only connections (it would fail — changing journal mode writes to the file), and it's a clean no-op for in-memory databases (`journal_mode` stays `memory`).
- WAL mode persists in the database file once set; this is documented in `OpenOptions`.
- The defaults and the `OpenOptions` record moved to a new internal `cosmic.sqlite.defaults` module so `init.tl` stays under the 500-line cap.
- STRICT tables, the article's remaining recommendation, are a per-`CREATE TABLE` keyword with no connection-level default, so they're out of scope.

No binding contract changes — this is purely the cosmic Teal layer; return shapes and existing option fields are unchanged, and `lib/perf/bench/sqlite_bench.tl` already set WAL+NORMAL manually (now redundant but harmless).

Tests: new `lib/cosmic/sqlite/defaults_test.tl` covers FK enforcement + opt-out, WAL/synchronous defaults + opt-out, in-memory no-op, read-only skip, and a WAL reader proceeding while a writer holds `BEGIN IMMEDIATE`. Cast ratchet pinned for the new test file. `bin/make ci` → `ci: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAoiHPZzTx8hvbqjWcJ16A

---
_Generated by [Claude Code](https://claude.ai/code/session_01DAoiHPZzTx8hvbqjWcJ16A)_