### PR TITLE
shm: deterministic Memory:unmap; cosmos 2026.07.19-b4958a67e (#493)

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "9bf704870e52d8ed919323c14a82a7fed92b62a22111292ccee03521f49dd87c"}},
+  platforms = {["*"] = {sha = "612b20cac515ebcdd7d00f0267a79688402eb1843f8253222cccd235afcfdd2a"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.19-ed74a7a16"
+  version = "2026.07.19-b4958a67e"
 }

--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -163,7 +163,7 @@
 39	lib/cosmic/script_test.tl
 9	lib/cosmic/shm.tl
 3	lib/cosmic/shm_example.tl
-19	lib/cosmic/shm_test.tl
+20	lib/cosmic/shm_test.tl
 7	lib/cosmic/signal.tl
 11	lib/cosmic/skill_test.tl
 51	lib/cosmic/sqlite/advanced_test.tl
@@ -225,4 +225,5 @@
 1	lib/perf/perf_test.tl
 3	lib/perf/run.tl
 4	lib/types/gentype.tl
+0	lib/types/gentype_return_test.tl
 1	lib/types/tl_conformance_test.tl

--- a/lib/cosmic/shm.tl
+++ b/lib/cosmic/shm.tl
@@ -55,7 +55,13 @@ local record ShmModule
     --- retries.
     wait: function(self: Memory, word_index: integer, expect: integer, abs_deadline?: integer, nanos?: integer): integer | nil, string
     --- Wake processes waiting on a word; returns how many woke.
+    --- Wakes nothing once the region has been unmapped.
     wake: function(self: Memory, word_index: integer, count?: integer): integer
+    --- Release the mapping now instead of waiting for the garbage
+    --- collector. Idempotent: true when this call released the mapping,
+    --- false when it was already unmapped. Afterwards every fallible
+    --- method returns an error naming the unmapped state (#493).
+    unmap: function(self: Memory): boolean
     --- The mapped region size in bytes.
     size: function(self: Memory): integer
   end
@@ -214,14 +220,24 @@ local function wrap(raw: unix.Memory, size: integer): Memory
     return rc as integer
   end
 
+  -- wake is declared infallible, so it cannot grow an error slot for the
+  -- unmapped state; mirror the out-of-range posture (wake nothing) and
+  -- keep the raw call — which throws once unmapped — behind the flag.
+  local unmapped = false
+
   function mem:wake(word_index: integer, count?: integer): integer
     local range_err = check_word(word_index, size, "wake")
-    if range_err then
+    if range_err or unmapped then
       -- wake never fails in the binding; an out-of-range index wakes
       -- nothing rather than growing an error slot for it.
       return 0
     end
     return raw:wake(word_index, count)
+  end
+
+  function mem:unmap(): boolean
+    unmapped = true
+    return (raw:unmap())
   end
 
   return mem

--- a/lib/cosmic/shm_test.tl
+++ b/lib/cosmic/shm_test.tl
@@ -259,3 +259,24 @@ local function test_memory_wait_retries_eintr_until_deadline()
     .. tostring(err))
 end
 test_memory_wait_retries_eintr_until_deadline()
+
+-- #493: unmap releases the mapping deterministically instead of waiting
+-- for the garbage collector. Idempotent and observable; afterwards every
+-- fallible method returns an error instead of touching freed memory, and
+-- wake wakes nothing.
+local function test_memory_unmap()
+  local mem = assert(shm.mapshared(64)) as shm.Memory
+  assert(mem:store(0, 7))
+  assert(mem:unmap() == true, "first unmap should release and say so")
+  assert(mem:unmap() == false, "second unmap should be a no-op")
+  local v, err = mem:load(0)
+  assert(v == nil, "load after unmap should fail")
+  assert(type(err) == "string" and err:find("unmapped"),
+    "load error should say unmapped, got: " .. tostring(err))
+  local ok, werr = mem:write("x")
+  assert(ok == false and type(werr) == "string", "write after unmap should fail")
+  local rc, werr2 = mem:wait(0, 0)
+  assert(rc == nil and type(werr2) == "string", "wait after unmap should fail")
+  assert(mem:wake(0) == 0, "wake after unmap should wake nothing")
+end
+test_memory_unmap()

--- a/lib/types/cook.mk
+++ b/lib/types/cook.mk
@@ -3,7 +3,7 @@ modules += types
 # binary via cosmos) and the committed lib/types/cosmo/*.d.tl, so it runs as a
 # normal test under $(cosmic_bin). It guards the generator against drift, e.g.
 # the errno-return contract in unix.d.tl (see test_errno_drift_unix).
-types_tests := lib/types/gentype_test.tl lib/types/gentype_alias_test.tl lib/types/gentl_test.tl lib/types/tl_conformance_test.tl
+types_tests := lib/types/gentype_test.tl lib/types/gentype_alias_test.tl lib/types/gentype_return_test.tl lib/types/gentl_test.tl lib/types/tl_conformance_test.tl
 # types_deps is intentionally not set - types_files are source files (.d.tl),
 # not built outputs. The regen-types target uses bootstrap_cosmic directly.
 

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -154,6 +154,11 @@ local record Memory
   --- The return value is the number of processes that were actually woken
   --- as a result of the system call. No failure conditions are defined.
   wake: function(self: Memory, index: integer, count?: integer): integer
+  --- Releases the shared-memory mapping immediately, instead of waiting
+  --- for the garbage collector to do it. Idempotent: repeat calls are
+  --- no-ops. After unmap, calling any other method on this object raises
+  --- an error rather than touching the freed memory.
+  unmap: function(self: Memory): boolean
 end
 
 --- Directory handle for reading directory entries.

--- a/lib/types/gentype_parse.tl
+++ b/lib/types/gentype_parse.tl
@@ -316,15 +316,22 @@ local function parse_annotations(raw_lines: {string}): {string}, {Param}, {Retur
           -- Split into another return only when the comma is followed by a
           -- genuine type token: a builtin type name or a module-dotted type
           -- (`unix.Errno`). Prose in a trailing description ("ARIN, APNIC,
-          -- DOD, etc.") must stay in the description.
+          -- DOD, etc.") must stay in the description. The literal types
+          -- true/false/nil are deliberately NOT continuation tokens: no
+          -- annotation continues a return list with a bare literal, but
+          -- boolean descriptions routinely read "true when ..., false when
+          -- ..." and failure prose "..., nil on failure" — treating those
+          -- words as types grew phantom returns (unix.Memory:unmap,
+          -- whilp/cosmopolitan#198). Literals on their own @return lines
+          -- are unaffected; only this comma decision is narrowed.
           local rest_after_comma = full_return:sub(i + 1)
           local next_word = rest_after_comma:match("^%s*([%w_%.]+)")
           local builtin_types: {string: boolean} = {
             ["integer"] = true, ["string"] = true, ["number"] = true,
-            ["boolean"] = true, ["any"] = true, ["nil"] = true,
+            ["boolean"] = true, ["any"] = true,
             ["table"] = true, ["function"] = true, ["userdata"] = true,
             ["uint32"] = true, ["uint16"] = true, ["int64"] = true,
-            ["true"] = true, ["false"] = true, ["fun"] = true,
+            ["fun"] = true,
           }
           local is_type_token = false
           if next_word then

--- a/lib/types/gentype_return_test.tl
+++ b/lib/types/gentype_return_test.tl
@@ -1,0 +1,74 @@
+#!/usr/bin/env cosmic
+--- Tests for gentype's @return comma handling: a top-level comma continues
+--- the return list only when followed by a genuine type token. Literal
+--- types (true/false/nil) never legitimately continue a return list in
+--- definitions.lua, but boolean descriptions routinely say ", false when
+--- ..." — treating those words as types generated phantom returns
+--- (found via unix.Memory:unmap, whilp/cosmopolitan#198).
+--- Split from gentype_test.tl to respect the 500-line file cap.
+
+local gentype = require("types.gentype")
+
+-- A comma inside a description whose next word is a boolean literal stays
+-- description: one return, not a phantom second boolean.
+local function test_boolean_description_comma_is_not_a_return()
+  local source = [==[
+shm = {}
+
+--- Releases the mapping.
+---@return boolean unmapped true when this call released the mapping, false when it was already unmapped
+function shm.unmap() end
+]==]
+  local dtl = gentype.generate_dtl(gentype.parse_module(source, "shm"))
+  assert(dtl:match("unmap: function%(%): boolean\n"),
+    "description comma before 'false' must not grow a second return:\n" .. dtl)
+end
+test_boolean_description_comma_is_not_a_return()
+
+-- The same shape with 'nil' prose ("..., nil on failure") stays one return.
+local function test_nil_prose_comma_is_not_a_return()
+  local source = [==[
+shm = {}
+
+--- Opens a thing.
+---@return integer fd the descriptor on success, nil on failure
+function shm.open() end
+]==]
+  local dtl = gentype.generate_dtl(gentype.parse_module(source, "shm"))
+  assert(dtl:match("open: function%(%): integer\n"),
+    "description comma before 'nil' must not grow a second return:\n" .. dtl)
+end
+test_nil_prose_comma_is_not_a_return()
+
+-- Regression pin: genuine multi-returns keep splitting, including a
+-- trailing description on the final segment (the corpus does this:
+-- "integer seconds, integer nanos amount of CPU consumed").
+local function test_genuine_multi_return_still_splits()
+  local source = [==[
+shm = {}
+
+--- Reports CPU time.
+---@return integer seconds, integer nanos amount of CPU consumed in userspace.
+function shm.cputime() end
+]==]
+  local dtl = gentype.generate_dtl(gentype.parse_module(source, "shm"))
+  assert(dtl:match("cputime: function%(%): integer, integer\n"),
+    "a real type token after the comma must still split:\n" .. dtl)
+end
+test_genuine_multi_return_still_splits()
+
+-- Single-segment literal returns are not continuations and stay typed.
+local function test_single_segment_literal_return_unaffected()
+  local source = [==[
+shm = {}
+
+--- Always fails.
+---@return nil
+---@return string errmsg
+function shm.fail() end
+]==]
+  local dtl = gentype.generate_dtl(gentype.parse_module(source, "shm"))
+  assert(dtl:match("fail: function%(%): nil, string\n"),
+    "leading literal types on their own @return lines keep working:\n" .. dtl)
+end
+test_single_segment_literal_return_unaffected()


### PR DESCRIPTION
The last in-repo item of #493: deterministic shared-memory release. Bumps the cosmos pin to `2026.07.19-b4958a67e` to pick up `unix.Memory:unmap()` (whilp/cosmopolitan#197), wraps it, and hardens the type generator against the annotation pitfall found while consuming it.

## shm

- `Memory:unmap()` releases the mapping now instead of waiting for GC — returns `true` when this call released it, `false` when already unmapped (observable idempotence).
- After unmap, the binding guards every accessor, so the wrapper's fallible methods degrade to `nil`/`false` + an "already unmapped" error through the existing pcall translation — no crashes, no new error slots.
- `wake` is declared infallible, so it can't grow an error slot: it mirrors its documented out-of-range posture and wakes nothing once unmapped (guarded by a wrapper-side flag, since the raw call would throw).

## gentype

Consuming the release exposed a generator bug: `@return` lines split into multi-returns at top-level commas when the next word looks like a type — and `true`/`false` were in that token list, so unmap's description ("true when …, **false** when it was already unmapped") grew a phantom second boolean and `unix.d.tl` rendered `boolean, boolean`. The literal types `true`/`false`/`nil` are no longer continuation tokens: no annotation continues a return list with a bare literal, while boolean/failure prose uses those words after commas constantly. Genuine multi-returns (`integer seconds, integer nanos …`) still split, and literals on their own `@return` lines are untouched — all pinned by the new `gentype_return_test.tl`. `unix.d.tl` is regenerated with the honest single `boolean`. (Upstream whilp/cosmopolitan#198 terses the annotation anyway as hygiene, but no longer gates anything.)

## TDD

- shm: red against the record (no `unmap`), then green — release/idempotence, `load`/`write`/`wait` failing with "unmapped" errors, `wake` waking nothing.
- gentype: red against the old parser (phantom second boolean), plus pins for the nil-prose case, genuine multi-return splitting, and single-line literal returns.

Gates: `bin/make ci` → `ci: PASS` (verdict line, not exit code). Cast pins: `shm_test` 19→20; new test file registered in `lib/types/cook.mk` and `casts.txt`.

Closes #493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7VLnnsGiDRsVGNvtRRq3K

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7VLnnsGiDRsVGNvtRRq3K)_