### PR TITLE
check: must forwards extra returns, matching assert; retire the iterator exception

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,11 +147,12 @@ or map unions through truthiness (`if not x`). Three sanctioned tools:
   no cast, no assert. Lua passes multiple returns through, so a failing
   call reports the callee's own error string. `must` narrows nil only
   (`false` passes through), and it throws, so it is for tests/examples,
-  never library code. Never write `assert(x) as T` in a test; that
-  pattern is retired — EXCEPT for multi-return iterators: `must` forwards
-  only the first value, so `for p in assert(fs.files(d)) as fs.FileIter`
-  must stay (the 4th return is the to-be-closed guard; dropping it leaks
-  directory handles on early break).
+  never library code. Like `assert`, must forwards extra returns past
+  the second, so `for p in check.must(fs.files(d)) do` keeps the 4th
+  return (the to-be-closed guard that releases directory handles on
+  early break); a plain `value, err` pair still collapses to the value
+  alone. Never write `assert(x) as T` in a test; that pattern is
+  retired.
 - **Prefer `is` where the code branches, for table-backed records**:
   `if sock is net.Socket then sock:send(...) end` narrows `Socket | nil`
   inside the positive branch (compiles to one `type(x) == "table"` check).

--- a/lib/build/casts.txt
+++ b/lib/build/casts.txt
@@ -49,13 +49,12 @@
 1	lib/cosmic/fs/file.tl
 4	lib/cosmic/fs/ops.tl
 2	lib/cosmic/fs/path.tl
-9	lib/cosmic/fs/path_test.tl
-18	lib/cosmic/fs/traps_test.tl
+7	lib/cosmic/fs/path_test.tl
+17	lib/cosmic/fs/traps_test.tl
 4	lib/cosmic/fs/tree.tl
 5	lib/cosmic/fs/types.tl
 13	lib/cosmic/fs/walk.tl
-1	lib/cosmic/fs/walk_example.tl
-6	lib/cosmic/fs/walk_test.tl
+3	lib/cosmic/fs/walk_test.tl
 4	lib/cosmic/getopt.tl
 5	lib/cosmic/hash.tl
 3	lib/cosmic/hash_test.tl
@@ -129,7 +128,7 @@
 2	lib/perf/bench/child_bench.tl
 5	lib/perf/bench/embed_bench.tl
 3	lib/perf/bench/embed_startup_bench.tl
-7	lib/perf/bench/fs_bench.tl
+6	lib/perf/bench/fs_bench.tl
 1	lib/perf/bench/fuzzy_bench.tl
 5	lib/perf/bench/http_bench.tl
 7	lib/perf/bench/json_bench.tl

--- a/lib/cosmic/check.tl
+++ b/lib/cosmic/check.tl
@@ -128,7 +128,10 @@ end
 --- `for p in check.must(fs.files(d)) do` keeps the 4th return — the
 --- to-be-closed guard that releases directory handles on early break.
 --- A plain `value, err` pair still collapses to the value alone, so
---- `print(check.must(fs.read(p)))` prints no trailing nil.
+--- `print(check.must(fs.read(p)))` prints no trailing nil. The checker,
+--- though, sees the declared three-value tuple: when must is the LAST
+--- argument to another call, parenthesize to truncate it —
+--- `table.insert(parts, (check.must(chunk)))`.
 --- @param v T? The fallible value (nil on failure)
 --- @param e string? Failure message; a `nil, err` pair fills this in
 --- @param ... any Extra returns (iterator state, closing guard, ...)

--- a/lib/cosmic/check.tl
+++ b/lib/cosmic/check.tl
@@ -124,19 +124,25 @@ end
 --- need `assert(x) as T` at every site. `must` centralizes that unsoundness
 --- behind a runtime nil check. Lua passes multiple returns through, so
 --- `must(fs.read(path))` fails with fs.read's own error string.
---- CAVEAT: must returns ONLY the first value. Never wrap a call whose
---- extra returns feed a generic-for (e.g. `fs.files`, whose 4th return
---- is the to-be-closed guard that releases directory handles on early
---- break) — keep `for p in assert(fs.files(d)) as fs.FileIter do` there,
---- since assert forwards all four returns and must would drop the guard.
+--- Like `assert`, must forwards extra returns past the second, so
+--- `for p in check.must(fs.files(d)) do` keeps the 4th return — the
+--- to-be-closed guard that releases directory handles on early break.
+--- A plain `value, err` pair still collapses to the value alone, so
+--- `print(check.must(fs.read(p)))` prints no trailing nil.
 --- @param v T? The fallible value (nil on failure)
 --- @param e string? Failure message; a `nil, err` pair fills this in
+--- @param ... any Extra returns (iterator state, closing guard, ...)
 --- @return T The value, known non-nil
-local function must<T>(v: T | nil, e?: string): T
+--- @return string The second argument, forwarded when extras exist
+--- @return any... The extra returns, forwarded unchanged
+local function must<T>(v: T | nil, e?: string, ...: any): T, string, any ...
   if v == nil then
     error(e or "must failed: expected value, got nil", 2)
   end
-  return v
+  if select("#", ...) == 0 then
+    return v
+  end
+  return v, e, ...
 end
 
 --- Report whether the enforcement lane is active.
@@ -179,7 +185,7 @@ local record CheckModule
   eq: function<T>(actual: T, expected: T, label?: string)
   ne: function<T>(actual: T, expected: T, label?: string)
   ok: function(value: any, label?: string)
-  must: function<T>(v: T | nil, e?: string): T
+  must: function<T>(v: T | nil, e?: string, ...: any): T, string, any ...
   err: function(value: any, e: string, label?: string)
   enforcing: function(): boolean
   skip: function(reason: string, strict?: boolean)

--- a/lib/cosmic/check_assertions_test.tl
+++ b/lib/cosmic/check_assertions_test.tl
@@ -266,6 +266,53 @@ local function test_must_passes_false_through()
 end
 test_must_passes_false_through()
 
+-- must: multi-return forwarding (the assert-parity contract)
+
+local type Iter = function(): string
+
+-- mimic fs.files' shape: iterator, err, control, to-be-closed guard
+local function fake_files(fail: boolean, guard: any): Iter | nil, string, any, any
+  if fail then
+    return nil, "cannot open"
+  end
+  local n = 0
+  local iter = function(): string
+    n = n + 1
+    if n <= 2 then
+      return "f" .. n
+    end
+    return nil
+  end
+  return iter, nil, nil, guard
+end
+
+local function test_must_single_pair_collapses()
+  -- a plain value, err pair yields exactly one value: no trailing nil
+  -- in print()/varargs contexts
+  check.eq(select("#", check.must(make_widget(false))), 1)
+end
+test_must_single_pair_collapses()
+
+local function test_must_forwards_extra_returns()
+  local guard: any = {}
+  check.eq(select("#", check.must(fake_files(false, guard))), 4)
+  local _iter, _e, _ctl, g = check.must(fake_files(false, guard))
+  check.ok(rawequal(g, guard), "4th return must be the same guard value")
+end
+test_must_forwards_extra_returns()
+
+local function test_must_keeps_closing_guard_in_for()
+  -- the reason forwarding matters: the 4th return is Lua 5.4's
+  -- to-be-closed slot, so an early break must still run __close
+  local closed = false
+  local guard = setmetatable({}, {__close = function() closed = true end})
+  for _ in check.must(fake_files(false, guard)) do
+    break
+  end
+  check.ok(closed, "early break must close the forwarded guard")
+end
+test_must_keeps_closing_guard_in_for()
+
 -- must: failing cases
 
 local function test_must_uses_err_string_from_multi_return()

--- a/lib/cosmic/coverage/lines_test.tl
+++ b/lib/cosmic/coverage/lines_test.tl
@@ -5,7 +5,7 @@ local cov_lines = require("cosmic.coverage.lines")
 
 --- Compute lines for Lua source, asserting the parse succeeded.
 local function lines_of(source: string, name: string): {integer: boolean}
-  return check.must(cov_lines.executable_lines(source, name))
+  return (check.must(cov_lines.executable_lines(source, name)))
 end
 
 local function test_marks_basic_statements()

--- a/lib/cosmic/envd_test.tl
+++ b/lib/cosmic/envd_test.tl
@@ -360,7 +360,7 @@ local function load_dir_capturing_stderr(dir: string): envd.LoadResult, string
   local result = envd.load_dir(dir)
   io.stderr:close()
   io.stderr = real_stderr
-  return result, check.must(fs.read(capture_path))
+  return result, (check.must(fs.read(capture_path)))
 end
 
 local function test_cosmic_debug_empty_not_enabled()

--- a/lib/cosmic/flags_test.tl
+++ b/lib/cosmic/flags_test.tl
@@ -16,7 +16,7 @@ local spec: flags.Spec = {
 
 -- Parse a command line that must succeed.
 local function must(s: flags.Spec, argv: {string}): flags.Parsed
-  return check.must(flags.parse(s, argv))
+  return (check.must(flags.parse(s, argv)))
 end
 
 local function test_short_and_long_forms()

--- a/lib/cosmic/fs/path_test.tl
+++ b/lib/cosmic/fs/path_test.tl
@@ -1,4 +1,5 @@
 #!/usr/bin/env cosmic
+local check = require("cosmic.check")
 local fs = require("cosmic.fs")
 local fs_types = require("cosmic.fs.types")
 
@@ -212,7 +213,7 @@ local function test_files_iterator()
   local walk_dir = setup_walk()
   local found: {string: boolean} = {}
 
-  for filepath in assert(fs.files(walk_dir, "*.lua")) as fs.FileIter do
+  for filepath in check.must(fs.files(walk_dir, "*.lua")) do
     found[fs.basename(filepath)] = true
   end
 
@@ -228,7 +229,7 @@ local function test_files_iterator_all()
   local walk_dir = setup_walk()
   local count = 0
 
-  for _ in assert(fs.files(walk_dir)) as fs.FileIter do
+  for _ in check.must(fs.files(walk_dir)) do
     count = count + 1
   end
 

--- a/lib/cosmic/fs/traps_test.tl
+++ b/lib/cosmic/fs/traps_test.tl
@@ -126,7 +126,7 @@ local function test_files_pattern_is_always_glob()
 
   -- "foo?.lua" is a glob: ? is exactly one character.
   local seen: {string: boolean} = {}
-  for p in assert(fs.files(dir, "foo?.lua")) as fs.FileIter do
+  for p in check.must(fs.files(dir, "foo?.lua")) do
     seen[fs.basename(p)] = true
   end
   assert(seen["foo1.lua"], "glob ? matches one char")

--- a/lib/cosmic/fs/walk.tl
+++ b/lib/cosmic/fs/walk.tl
@@ -343,9 +343,10 @@ local type FileIter = function(): string
 --- loop adopts it as the loop's closing value (Lua 5.4), so directory
 --- handles are closed even when the loop exits early via break/error.
 --- If the root directory cannot be opened, returns nil plus the error —
---- iterate the checked value: `for f in assert(fs.files(dir)) as fs.FileIter do`
---- (assert passes all four returns through, keeping the closing guard;
---- the cast only narrows the type, it does not drop return values).
+--- in tests/examples iterate the checked value with
+--- `for f in check.must(fs.files(dir)) do` (must, like assert, forwards
+--- all four returns, keeping the closing guard); in library code use
+--- `assert(fs.files(dir)) as fs.FileIter`, which also forwards them.
 --- @param dir string The directory to search
 --- @param pattern string Glob pattern (*.lua) - defaults to all files (*)
 --- @return function | nil Iterator yielding file paths, or nil if the root could not be opened

--- a/lib/cosmic/fs/walk_example.tl
+++ b/lib/cosmic/fs/walk_example.tl
@@ -69,6 +69,7 @@ end
 
 -- Example_files demonstrates the files() iterator for streaming traversal.
 local function Example_files()
+  local check = require("cosmic.check")
   local fs = require("cosmic.fs")
 
   local tmpdir = fs.mkdtemp("/tmp/files_ex_XXXXXX")
@@ -78,10 +79,9 @@ local function Example_files()
   assert(fs.write(fs.join(tmpdir, "b.txt"), "b\n"))
 
   local names: {string} = {}
-  -- files() returns nil, err if the root cannot be opened; assert passes
-  -- the iterator and its closing guard through on success (the cast only
-  -- narrows the type — it does not drop the extra return values).
-  for p in assert(fs.files(tmpdir, "*.txt")) as fs.FileIter do
+  -- files() returns nil, err if the root cannot be opened; must passes
+  -- the iterator and its closing guard through on success.
+  for p in check.must(fs.files(tmpdir, "*.txt")) do
     table.insert(names, fs.basename(p))
   end
   table.sort(names)

--- a/lib/cosmic/fs/walk_test.tl
+++ b/lib/cosmic/fs/walk_test.tl
@@ -1,9 +1,9 @@
 #!/usr/bin/env cosmic
 --- Tests for fs_walk module (symlink cycle safety)
+local check = require("cosmic.check")
 local fs_walk = require("cosmic.fs.walk")
 local fs = require("cosmic.fs")
 local user = require("cosmic.user")
-local type FileIter = fs_walk.FileIter
 local type WalkAction = fs_walk.WalkAction
 
 local tmpdir = os.getenv("TEST_TMPDIR") as string
@@ -86,7 +86,7 @@ local function test_files_symlink_cycle_terminates()
   fs.symlink("..", fs.join(subdir, "loop"))
 
   local collected: {string} = {}
-  for p in assert(fs_walk.files(base, "*.lua")) as FileIter do
+  for p in check.must(fs_walk.files(base, "*.lua")) do
     collected[#collected + 1] = p
     -- Safety: abort if we find more than a small number
     assert(#collected <= 10,
@@ -312,7 +312,7 @@ test_collect_success_has_no_error()
 local function count_open_fds(): integer
   -- Exhausting the iterator closes its own handle as it goes.
   local n = 0
-  local iter = assert(fs_walk.files("/proc/self/fd")) as FileIter
+  local iter = check.must(fs_walk.files("/proc/self/fd"))
   for _ in iter do n = n + 1 end
   return n
 end
@@ -329,7 +329,7 @@ local function test_files_early_break_closes_handles()
   end
 
   local before = count_open_fds()
-  for p in assert(fs_walk.files(base, "*.txt")) as FileIter do
+  for p in check.must(fs_walk.files(base, "*.txt")) do
     assert(p, "expected a path")
     break -- abandon the iterator with directories still open
   end

--- a/lib/cosmic/ip_test.tl
+++ b/lib/cosmic/ip_test.tl
@@ -4,7 +4,7 @@ local ip = require("cosmic.ip")
 
 --- Parse an address the test knows is valid, asserting success.
 local function p(s: string): ip.Addr
-  return check.must(ip.parse(s))
+  return (check.must(ip.parse(s)))
 end
 
 -- parse tests: parse returns a typed Addr (api-review-2, #588)

--- a/lib/cosmic/json_test.tl
+++ b/lib/cosmic/json_test.tl
@@ -175,7 +175,7 @@ test_integer_precision_roundtrip()
 
 local function test_float_precision_roundtrip()
   for _, f in ipairs({0.1, 3.141592653589793, 1e308, -2.5e-10}) do
-    local decoded = json.decode(check.must(json.encode(f)))
+    local decoded = json.decode((check.must(json.encode(f))))
     assert(decoded as number == f,
       "float should round-trip bit-exactly: " .. tostring(f)
       .. " -> " .. tostring(decoded))
@@ -201,7 +201,7 @@ local function test_nul_byte_roundtrip()
   local encoded = json.encode("\0")
   assert(encoded == '"\\u0000"',
     "an embedded NUL should encode as \\u0000, got: " .. tostring(encoded))
-  local rt = json.decode(check.must(json.encode("a\0b"))) as string
+  local rt = json.decode((check.must(json.encode("a\0b")))) as string
   assert(rt == "a\0b" and #rt == 3, "NUL inside a string must round-trip")
 end
 test_nul_byte_roundtrip()

--- a/lib/cosmic/net/io_test.tl
+++ b/lib/cosmic/net/io_test.tl
@@ -5,7 +5,7 @@ local net = require("cosmic.net")
 local function pair(): net.Socket, net.Socket
   local a, b, err = net.socketpair()
   assert(a ~= nil and b ~= nil, "socketpair failed: " .. tostring(err))
-  return check.must(a), b
+  return (check.must(a)), b
 end
 
 -- sendall tests

--- a/lib/cosmic/quicksand/proxy/serve_test.tl
+++ b/lib/cosmic/quicksand/proxy/serve_test.tl
@@ -34,7 +34,7 @@ local function roundtrip(srv: serve.Server, request: string): string
   while true do
     local chunk = sock:recv(4096)
     if not chunk then break end
-    table.insert(parts, check.must(chunk))
+    table.insert(parts, (check.must(chunk)))
   end
   sock:close()
   return table.concat(parts)

--- a/lib/perf/bench/fs_bench.tl
+++ b/lib/perf/bench/fs_bench.tl
@@ -2,6 +2,7 @@
 --- Exercises cosmic.fs and cosmic.fd wrappers over the cosmo unix/path
 --- C bindings, against a real temp directory tree.
 
+local check = require("cosmic.check")
 local fs = require("cosmic.fs")
 local fs_types = require("cosmic.fs.types")
 local pt = require("perf.perf_types")
@@ -84,7 +85,7 @@ local function scenarios(): {pt.Scenario}, string
       name = "fs_files_tree",
       fn = function(_: any): any
         local count = 0
-        for _ in assert(fs.files(tmpdir, "*.txt")) as fs.FileIter do
+        for _ in check.must(fs.files(tmpdir, "*.txt")) do
           count = count + 1
         end
         return count


### PR DESCRIPTION
## What

Follow-up to #699. `check.must` returned only the first value, which forced the one exception to the retired `assert(x) as T` idiom: multi-return iterators like `fs.files`, whose 4th return is the Lua 5.4 to-be-closed guard that releases directory handles on early `break`.

`must<T>(v: T | nil, e?: string, ...: any): T, string, any...` now forwards extra returns the way `assert` does, with one refinement: a plain `value, err` pair still collapses to the value alone (`select("#", ...) == 0` → return `v`), so `print(check.must(fs.read(p)))` prints no trailing nil and example outputs are unchanged.

- The fs iterator sites held back from #699 (`walk_test`, `path_test`, `traps_test`, `walk_example`, `fs_bench`) now use `for p in check.must(fs.files(...)) do`; the `walk_test` early-break fd-accounting test passes through `must`, confirming the guard survives.
- New tests in `check_assertions_test.tl` pin the contract: single-pair collapse (`select("#") == 1`), 4-value forwarding with guard identity, and `__close` firing on early break through the forwarded slot.
- One checker-level consequence, documented in `must`'s doc comment: the *declared* three-value tuple spreads when `must` is the last argument or return expression, so those sites truncate with parens — `table.insert(parts, (check.must(chunk)))`. Six sites adjusted.
- CLAUDE.md/AGENTS.md guidance updated: the iterator exception is gone; `assert(x) as T` is fully retired in tests/examples. `walk.tl`'s doc comment now shows the `check.must` form.
- Cast baseline drops further: **807 → 799**.

Local `bin/make ci`: **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Xqj3KJ2dsSFoWsR8sBz6t

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xqj3KJ2dsSFoWsR8sBz6t)_