### PR TITLE
ci: stale only=-filtered summaries must not grade a full ci run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -478,7 +478,7 @@ ci_summaries := $(foreach s,$(ci_stages),$(o)/$(s)-summary.txt)
 .PHONY: ci
 ## Run CI checks (format, teal, test, example, lint) in parallel
 ci:
-	@rm -f $(o)/failed
+	@rm -f $(o)/failed $(ci_summaries)
 	@$(MAKE) --keep-going $(ci_stages) || true
 	@for s in $(ci_stages); do \
 		echo "::group::$$s"; \


### PR DESCRIPTION
## What

Fixes the local-CI blind spot that let #704's `check_test` fixture regression ship with a local `ci: PASS`.

**Mechanism, reproduced:** every stage summary target's prerequisite list is `only=`-filtered, so `bin/make test only=X` writes a fresh-stamped summary covering only a subset of the suite — at the same `o/<stage>-summary.txt` path the `ci` target greps for its verdict. A later `ci` can consider that summary up-to-date and grade subset-green as suite-green, hiding any test broken since the last full run. Reproduction: break the `check_test` fixture, run a green `test only=gentype`, run `ci` → PASS on a failing tree. (The inverse also reproduces: a stale *failing* filtered summary makes a clean `ci` fail.) GitHub CI was never affected because it starts with no `o/`.

**Fix:** `ci` already deletes `$(o)/failed` before running stages; now it deletes the stage summaries too, so every verdict comes from a report generated by *that* ci run. Cheap — `--report` re-reads cached stage outputs (`.got` files); no stage work re-runs. The existing "no summary produced → stage failed" branch keeps missing-summary cases loud.

Verified: poisoned-summary + broken-fixture tree now fails `ci`; clean tree passes; the Makefile stays at exactly its 500-line lint cap (which is why the rationale lives in the commit message rather than a comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Xqj3KJ2dsSFoWsR8sBz6t

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xqj3KJ2dsSFoWsR8sBz6t)_