### PR TITLE
portability: Windows-aware fs paths, platforms guide, macOS/Windows smoke CI (#510 steps 11/12)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,6 +38,96 @@ jobs:
             fi
           done
 
+  # Cross-OS smoke lane (#510 step 11). The full gate is Linux-only
+  # (landlock-make), but the artifact is a fat APE binary shipped for six
+  # OSes — of which releases previously exercised zero beyond Linux. Build
+  # once on Linux, then prove on real macOS and Windows runners that the
+  # binary starts, serves embedded docs, and passes the portable test
+  # files (string, json, fs paths — including the Windows-path suite).
+  smoke-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: build cosmic
+        shell: bash -x {0}
+        run: bin/make -j build
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: cosmic-smoke
+          path: o/bin/cosmic
+
+  smoke:
+    needs: smoke-build
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: cosmic-smoke
+          path: dl/
+
+      - name: smoke test
+        shell: bash
+        run: |
+          set -euo pipefail
+          # upload-artifact >= v7 delivers a zip that download-artifact >= v8
+          # does not extract (same trap release.yml documents); unzip via
+          # python's zipfile so the step works in git-bash too, and handle
+          # the delivered-directly layout as well.
+          PY=$(command -v python3 || command -v python)
+          for z in $(find dl -type f -name '*.zip'); do
+            "$PY" -m zipfile -e "$z" dl/
+          done
+          src=$(find dl -type f -name cosmic | head -1)
+          if [ -z "$src" ]; then
+            echo "cosmic binary not found in downloaded artifact:" >&2
+            find dl >&2
+            exit 1
+          fi
+          # The .exe suffix is required for Windows to execute the APE
+          # (a valid PE); it is inert elsewhere.
+          cp "$src" cosmic.exe
+          chmod +x cosmic.exe
+
+          tmp="$RUNNER_TEMP/cosmic-smoke"
+          mkdir -p "$tmp"
+          # cosmic is a native binary: hand it a native (mixed-form)
+          # Windows path, not git-bash's /d/... POSIX rendering.
+          if command -v cygpath >/dev/null 2>&1; then tmp=$(cygpath -m "$tmp"); fi
+          export TEST_TMPDIR="$tmp"
+
+          echo "::group::cosmic -e"
+          out=$(./cosmic.exe -e 'print("smoke-" .. require("cosmic.sys").host_os())')
+          echo "$out"
+          case "$out" in *smoke-*) ;; *) echo "unexpected -e output" >&2; exit 1 ;; esac
+          echo "::endgroup::"
+
+          echo "::group::cosmic --docs"
+          ./cosmic.exe --docs guide.platforms > docs-smoke.txt
+          grep -q "Platform Support" docs-smoke.txt
+          ./cosmic.exe --docs fs.read > docs-fs.txt
+          grep -qi "read" docs-fs.txt
+          echo "::endgroup::"
+
+          for t in \
+            lib/cosmic/string_test.tl \
+            lib/cosmic/json_test.tl \
+            lib/cosmic/fs/path_test.tl \
+            lib/cosmic/fs/path_normalize_test.tl \
+            lib/cosmic/fs/path_windows_test.tl; do
+            echo "::group::$t"
+            ./cosmic.exe "$t"
+            echo "::endgroup::"
+          done
+          echo "smoke: PASS"
+
   # Privileged, unsandboxed lane that actually exercises the sandbox
   # primitives (audit §5.1). `make ci` runs under landlock-make, where the
   # sandbox tests skip their enforcement assertions; this lane runs them with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -386,6 +386,6 @@ work, whilp/cosmopolitan for the C layer); find work with
 
 ## CI
 
-- **pr.yml**: runs `make ci` (format + teal + test + example + lint + coverage ratchet) on push/PR to main
+- **pr.yml**: runs `make ci` (format + teal + test + example + lint + coverage ratchet) on push/PR to main, plus macOS/Windows smoke jobs that run the built binary (`-e`, `--docs`, portable test files) on real runners
 - **docs.yml**: publishes generated docs to `docs` branch on push to main
 - **release.yml**: daily release build producing `cosmic-lua` and `cosmic-lua-debug`

--- a/lib/cosmic/doc/guide_test.tl
+++ b/lib/cosmic/doc/guide_test.tl
@@ -96,6 +96,17 @@ local function test_guide_make()
 end
 test_guide_make()
 
+local function test_guide_platforms()
+  local __r10 = check.must(check.must(spawn.spawn({cosmic, "--docs", "guide.platforms"}, {env = clean_env()})):wait())
+  local ok, out = __r10.ok, __r10.stdout
+  assert(ok, "cosmic --docs guide.platforms should succeed")
+  local s = out
+  assert(s:find("Platform Support", 1, true), "platforms guide should contain Platform Support header")
+  assert(s:find("Sandbox Behavior", 1, true), "platforms guide should cover per-OS sandbox behavior")
+  assert(s:find("is_absolute", 1, true), "platforms guide should document Windows path handling")
+end
+test_guide_platforms()
+
 local function test_guide_unknown()
   local r = check.must(spawn.run(
       {cosmic, "--docs", "guide.nonexistent"}, {env = clean_env()}))

--- a/lib/cosmic/fs/init.tl
+++ b/lib/cosmic/fs/init.tl
@@ -237,6 +237,9 @@ local record FsModule
   isfile: function(path: string): boolean
   isdir: function(path: string): boolean
   islink: function(path: string): boolean
+  --- True for POSIX ("/x"), drive-letter ("C:/x", "C:\x"), and UNC
+  --- ("\\server\share") absolute paths.
+  is_absolute: function(p: string): boolean
   normalize: function(p: string): string
   abspath: function(p: string): string
   relpath: function(p: string, base?: string): string
@@ -351,6 +354,7 @@ local M: FsModule = {
   isfile = fs_path.isfile,
   isdir = fs_path.isdir,
   islink = fs_path.islink,
+  is_absolute = fs_path.is_absolute,
   normalize = fs_path.normalize,
   abspath = fs_path.abspath,
   relpath = fs_path.relpath,

--- a/lib/cosmic/fs/path.tl
+++ b/lib/cosmic/fs/path.tl
@@ -69,14 +69,91 @@ local function islink(p: string): boolean
   return cosmo_path.islink(p)
 end
 
+--- Return the drive letter (uppercased) when the path begins with a
+--- Windows drive-letter root like "C:/" or "C:\". Drive-relative forms
+--- ("C:foo") are not roots and return nil.
+local function win_drive(p: string): string | nil
+  local d = p:match("^(%a):[/\\]")
+  if d then
+    return d:upper()
+  end
+  return nil
+end
+
+--- Check whether a path is absolute on any supported OS.
+--- Absolute forms: POSIX ("/usr/lib"), Windows drive-letter roots
+--- ("C:/foo", "C:\foo"), and UNC roots ("\\server\share"). A single
+--- leading backslash is NOT absolute: on POSIX, "\" is an ordinary
+--- filename character, and cosmic runs the same code on every OS.
+--- Drive-relative forms ("C:foo") are not absolute either.
+--- @param p string The path to check
+--- @return boolean True if the path is absolute
+local function is_absolute(p: string): boolean
+  if p:sub(1, 1) == "/" then
+    return true
+  end
+  if p:sub(1, 2) == "\\\\" then
+    return true
+  end
+  return win_drive(p) ~= nil
+end
+
+--- Split on the separator pattern and collapse "." and ".." components.
+--- Rooted paths drop a leading ".."; relative paths preserve it.
+local function collapse(p: string, rooted: boolean, pat: string): {string}
+  local parts: {string} = {}
+  local n = 0
+  for part in p:gmatch(pat) do
+    if part == "." then
+      -- skip current dir
+    elseif part == ".." then
+      if n > 0 and parts[n] ~= ".." then
+        parts[n] = nil
+        n = n - 1
+      elseif not rooted then
+        -- for relative paths, preserve leading ..
+        n = n + 1
+        parts[n] = ".."
+      end
+      -- for rooted paths starting with /.., just ignore the ..
+    else
+      n = n + 1
+      parts[n] = part
+    end
+  end
+  return parts
+end
+
 --- Normalize path by removing `.` and `..` components without filesystem access.
 --- Also removes redundant slashes. Pure string manipulation.
 --- Examples: "/usr/./lib" -> "/usr/lib", "/usr/lib/../bin" -> "/usr/bin"
+--- Windows-absolute inputs keep their root: drive-letter paths ("C:\foo",
+--- "C:/foo") normalize to a forward-slash form with an uppercase drive
+--- ("C:/foo"), and UNC paths ("\\server\share") keep the backslash form.
+--- Elsewhere in a POSIX path, "\" is an ordinary filename character.
 --- @param p string The path to normalize
 --- @return string The normalized path
 local function normalize(p: string): string
   if p == "" then
     return "."
+  end
+
+  -- Windows drive-letter root: both separators split the body, the
+  -- result uses forward slashes (accepted by Windows and cosmopolitan),
+  -- and the drive letter is canonicalized to upper case.
+  local drive = win_drive(p)
+  if drive then
+    local parts = collapse(p:sub(4), true, "[^/\\]+")
+    if #parts == 0 then
+      return drive .. ":/"
+    end
+    return drive .. ":/" .. table.concat(parts, "/")
+  end
+
+  -- UNC root: keep the leading "\\" (so the result is still recognized
+  -- as UNC) and the backslash separators.
+  if p:sub(1, 2) == "\\\\" then
+    return "\\\\" .. table.concat(collapse(p:sub(3), true, "[^/\\]+"), "\\")
   end
 
   -- Fast path: a path that is already normal — no redundant "//" or
@@ -97,38 +174,17 @@ local function normalize(p: string): string
     return p
   end
 
-  local is_absolute = p:sub(1, 1) == "/"
+  local rooted = p:sub(1, 1) == "/"
+  local parts = collapse(p, rooted, "[^/]+")
 
-  -- Split into components, filtering empty strings (from // or trailing /)
-  local parts: {string} = {}
-  local n = 0
-  for part in p:gmatch("[^/]+") do
-    if part == "." then
-      -- skip current dir
-    elseif part == ".." then
-      if n > 0 and parts[n] ~= ".." then
-        parts[n] = nil
-        n = n - 1
-      elseif not is_absolute then
-        -- for relative paths, preserve leading ..
-        n = n + 1
-        parts[n] = ".."
-      end
-      -- for absolute paths starting with /.., just ignore the ..
-    else
-      n = n + 1
-      parts[n] = part
-    end
-  end
-
-  if is_absolute then
-    if n == 0 then
+  if rooted then
+    if #parts == 0 then
       return "/"
     else
       return "/" .. table.concat(parts, "/")
     end
   else
-    if n == 0 then
+    if #parts == 0 then
       return "."
     else
       return table.concat(parts, "/")
@@ -138,13 +194,15 @@ end
 
 --- Convert relative path to absolute by prepending cwd.
 --- Does NOT resolve symlinks or access filesystem (except to get cwd).
+--- Windows-absolute paths (drive-letter or UNC roots, see is_absolute)
+--- are already absolute and only get normalized — cwd is not prepended.
 --- @param p string The path to make absolute
 --- @return string The absolute path
 local function abspath(p: string): string
   if p == "" then
     return unix.getcwd() or "."
   end
-  if p:sub(1, 1) == "/" then
+  if is_absolute(p) then
     return normalize(p)
   end
   local cwd = unix.getcwd()
@@ -154,8 +212,26 @@ local function abspath(p: string): string
   return normalize(cwd .. "/" .. p)
 end
 
+--- Root classification for relpath: paths under different roots (drive
+--- letters, UNC shares, POSIX "/") have no relative form.
+local function root_of(p: string): string
+  local drive = win_drive(p)
+  if drive then
+    return drive .. ":"
+  end
+  if p:sub(1, 2) == "\\\\" then
+    -- UNC: the root is the \\server\share pair — different shares have
+    -- no relative form. An unparseable UNC prefix compares as itself.
+    return p:match("^(\\\\[^/\\]+[/\\][^/\\]+)") or p
+  end
+  return "/"
+end
+
 --- Make path relative to another path (defaults to cwd).
 --- Pure string manipulation - does not access the filesystem.
+--- When the two paths live under different roots (different drive
+--- letters, UNC vs drive, Windows vs POSIX), no relative path exists;
+--- the normalized absolute target is returned instead.
 --- @param p string The path to make relative
 --- @param base string? The base path (defaults to cwd)
 --- @return string The relative path
@@ -168,7 +244,7 @@ local function relpath(p: string, base?: string): string
   if base then
     abs_p = abspath(p)
     abs_base = abspath(base)
-  elseif p:sub(1, 1) == "/" then
+  elseif is_absolute(p) then
     abs_p = normalize(p)
     abs_base = unix.getcwd() or "."
   else
@@ -177,10 +253,23 @@ local function relpath(p: string, base?: string): string
     abs_base = cwd
   end
 
+  local root = root_of(abs_p)
+  if root ~= root_of(abs_base) then
+    return abs_p
+  end
+
+  -- After normalize, drive-letter paths use "/" separators (the "C:"
+  -- prefix survives splitting as an ordinary first component, so equal
+  -- drives fall into the common prefix); UNC paths use "\".
+  local pat = "[^/]+"
+  if root:sub(1, 2) == "\\\\" then
+    pat = "[^\\]+"
+  end
+
   -- Split into components
   local function split_path(s: string): {string}
     local path_parts: {string} = {}
-    for part in s:gmatch("[^/]+") do
+    for part in s:gmatch(pat) do
       table.insert(path_parts, part)
     end
     return path_parts
@@ -334,6 +423,7 @@ local record FsPathModule
   isfile: function(path: string): boolean
   isdir: function(path: string): boolean
   islink: function(path: string): boolean
+  is_absolute: function(p: string): boolean
   normalize: function(p: string): string
   abspath: function(p: string): string
   relpath: function(p: string, base?: string): string
@@ -351,6 +441,7 @@ local M: FsPathModule = {
   isfile = isfile,
   isdir = isdir,
   islink = islink,
+  is_absolute = is_absolute,
   normalize = normalize,
   abspath = abspath,
   relpath = relpath,

--- a/lib/cosmic/fs/path_windows_test.tl
+++ b/lib/cosmic/fs/path_windows_test.tl
@@ -1,0 +1,123 @@
+#!/usr/bin/env cosmic
+-- Windows-absolute path handling (#510 step 12). These are pure string
+-- operations, so they run — and must pass — on every OS: cosmic ships
+-- one binary, and a path pasted from a Windows shell must not turn into
+-- garbage on the machine that happens to process it.
+local fs = require("cosmic.fs")
+
+-- is_absolute: POSIX, drive-letter, and UNC roots
+
+local function test_is_absolute_posix()
+  assert(fs.is_absolute("/"), "/ is absolute")
+  assert(fs.is_absolute("/usr/lib"), "/usr/lib is absolute")
+  assert(not fs.is_absolute("usr/lib"), "relative path")
+  assert(not fs.is_absolute("./x"), "explicit relative")
+  assert(not fs.is_absolute(""), "empty path")
+end
+test_is_absolute_posix()
+
+local function test_is_absolute_drive()
+  assert(fs.is_absolute("C:/foo"), "forward-slash drive root")
+  assert(fs.is_absolute("C:\\foo"), "backslash drive root")
+  assert(fs.is_absolute("c:\\foo"), "lowercase drive root")
+  assert(fs.is_absolute("C:/"), "bare drive root")
+  assert(not fs.is_absolute("C:foo"), "drive-relative is not absolute")
+  assert(not fs.is_absolute("C:"), "bare drive is not absolute")
+  assert(not fs.is_absolute("1:/foo"), "non-letter drive")
+  assert(not fs.is_absolute("CC:/foo"), "multi-letter drive")
+end
+test_is_absolute_drive()
+
+local function test_is_absolute_unc_and_backslash()
+  assert(fs.is_absolute("\\\\server\\share"), "UNC root")
+  -- On POSIX "\" is an ordinary filename character; a single leading
+  -- backslash stays a relative path.
+  assert(not fs.is_absolute("\\foo"), "single backslash is relative")
+  assert(not fs.is_absolute("a\\b"), "interior backslash is relative")
+end
+test_is_absolute_unc_and_backslash()
+
+-- normalize: drive-letter roots
+
+local function test_normalize_drive_separators()
+  assert(fs.normalize("C:\\foo\\bar") == "C:/foo/bar",
+    "backslashes become forward slashes under a drive root")
+  assert(fs.normalize("C:/foo//bar") == "C:/foo/bar", "redundant slashes")
+  assert(fs.normalize("C:\\foo/bar") == "C:/foo/bar", "mixed separators")
+end
+test_normalize_drive_separators()
+
+local function test_normalize_drive_dots()
+  assert(fs.normalize("c:/a/./b/../c") == "C:/a/c",
+    "dots collapse and the drive letter uppercases")
+  assert(fs.normalize("C:\\..") == "C:/", ".. at the root is ignored")
+  assert(fs.normalize("C:/") == "C:/", "bare root unchanged")
+end
+test_normalize_drive_dots()
+
+local function test_normalize_drive_idempotent()
+  local once = fs.normalize("c:\\a\\..\\b\\.\\c")
+  assert(once == "C:/b/c", "got: " .. once)
+  assert(fs.normalize(once) == once, "normalize is idempotent")
+end
+test_normalize_drive_idempotent()
+
+-- normalize: UNC roots keep the backslash form
+
+local function test_normalize_unc()
+  assert(fs.normalize("\\\\server\\share\\a\\..\\b") == "\\\\server\\share\\b",
+    "UNC dots collapse, backslash form kept")
+  local unc = fs.normalize("\\\\server\\share")
+  assert(unc == "\\\\server\\share", "got: " .. unc)
+  assert(fs.normalize(unc) == unc, "UNC normalize is idempotent")
+end
+test_normalize_unc()
+
+-- normalize: POSIX paths still treat "\" as a filename character
+
+local function test_normalize_posix_backslash_preserved()
+  assert(fs.normalize("a\\b/c") == "a\\b/c", "backslash inside component")
+  assert(fs.normalize("/a\\b/../c") == "/c", "backslash component pops as one")
+end
+test_normalize_posix_backslash_preserved()
+
+-- abspath: Windows-absolute paths never get cwd prepended
+
+local function test_abspath_drive()
+  assert(fs.abspath("C:\\foo") == "C:/foo", "drive path stays rooted")
+  assert(fs.abspath("c:/a/../b") == "C:/b", "drive path normalizes")
+end
+test_abspath_drive()
+
+local function test_abspath_unc()
+  assert(fs.abspath("\\\\srv\\share\\x") == "\\\\srv\\share\\x",
+    "UNC path stays rooted")
+end
+test_abspath_unc()
+
+-- relpath: same drive walks, different roots return the absolute target
+
+local function test_relpath_same_drive()
+  assert(fs.relpath("C:/a/b", "C:/a") == "b", "child of base")
+  assert(fs.relpath("C:/a", "C:/b") == "../a", "sibling")
+  assert(fs.relpath("C:\\a\\b", "c:\\a") == "b", "mixed case and separators")
+  assert(fs.relpath("C:/a", "C:/a") == ".", "same path")
+end
+test_relpath_same_drive()
+
+local function test_relpath_different_roots()
+  assert(fs.relpath("C:/x", "D:/y") == "C:/x", "different drives")
+  assert(fs.relpath("C:\\x", "/tmp") == "C:/x", "drive vs POSIX")
+  assert(fs.relpath("/tmp/x", "C:/a") == "/tmp/x", "POSIX vs drive")
+  assert(fs.relpath("\\\\srv\\s\\x", "C:/a") == "\\\\srv\\s\\x",
+    "UNC vs drive")
+end
+test_relpath_different_roots()
+
+local function test_relpath_unc()
+  assert(fs.relpath("\\\\srv\\s\\a\\b", "\\\\srv\\s\\a") == "b",
+    "same share walks")
+  assert(fs.relpath("\\\\srv\\a\\x", "\\\\srv\\b\\y") == "\\\\srv\\a\\x",
+    "different shares have no relative form")
+end
+test_relpath_unc()

--- a/skills/cosmic/platforms.md
+++ b/skills/cosmic/platforms.md
@@ -1,0 +1,80 @@
+# Platform Support
+
+cosmic ships one fat binary that runs on Linux, macOS, Windows, FreeBSD, OpenBSD, and NetBSD (x86_64 and aarch64). the language, compiler, and almost all of the standard library behave identically everywhere; the differences that exist are listed here, per module. detect the host at runtime with `cosmic.sys`:
+
+```teal
+local sys = require("cosmic.sys")
+sys.host_os()  -- "linux" | "macos" | "windows" | "freebsd" | "openbsd" | "netbsd"
+sys.platform() -- "linux-x86_64", "macos-aarch64", ...
+```
+
+## Module × OS Matrix
+
+everything not listed in a table below is pure Lua or a fully portable cosmopolitan binding and works the same on all six OSes: ansi, benchmark, codec, compress, doc, embed, env, envd, example, fetch, flags, format, fuzzy, getopt, hash, html, ip, json, log, net, poll, re, rand, sqlite, sse, string, sys, table, teal, testrun, time, url, uuid, zip.
+
+modules with per-OS differences:
+
+| module | linux | macos | windows | freebsd | openbsd | netbsd | notes |
+|--------|-------|-------|---------|---------|---------|--------|-------|
+| fs | full | full | full | full | full | full | symlink creation on Windows needs a privileged or Developer-Mode process |
+| child | full | full | full | full | full | full | spawn is fork+execve; fork on Windows is emulated by cosmopolitan and is slower |
+| proc | full | full | partial | full | full | full | `rusage_children` fails with ENOSYS on Windows |
+| user | full | full | partial | full | full | full | uid/gid are polyfilled from getuid(); `set_uid`/`set_gid` return ENOSYS for any other id |
+| signal | full | full | partial | full | full | full | cosmopolitan emulates the core POSIX signals on Windows; timers and rare signals may degrade |
+| tty | full | full | partial | full | full | full | termios on Windows maps onto the console API; not every flag is honored |
+| shm | full | degraded | degraded | full | full | degraded | kernel futexes on Linux/FreeBSD/OpenBSD; elsewhere wait/wake fall back to sched_yield — correct but not scalable under contention |
+| syslog | full | no-op | full | no-op | no-op | full | delivered via syslogd on Linux/NetBSD and ReportEvent() on Windows; silently dropped elsewhere |
+| pledge | enforced | no-op* | no-op* | no-op* | enforced | no-op* | see sandbox matrix below |
+| unveil | enforced | no-op* | no-op* | no-op* | enforced | no-op* | see sandbox matrix below |
+| landlock | >=5.13 | no | no | no | no | no | Linux-only kernel feature |
+| quicksand | full | no | no | no | no | no | Linux namespaces; elsewhere `capabilities().linux == false` and calls return ENOSYS-shaped errors |
+| sandbox | enforced | fail-closed | fail-closed | fail-closed | enforced | fail-closed | facade over the three above |
+
+\* "no-op" means the mechanism does not exist on that OS — but the cosmic wrappers are fail-closed, so calls return an error instead of silently pretending (next section).
+
+## Sandbox Behavior Per OS
+
+the sandbox family is where OSes differ most. all four modules are **fail-closed**: on a host that cannot enforce a policy, `apply`/`allow`/`commit` return `false, "... unsupported on this host"` rather than reporting a sandbox that does not exist. every module exposes `available()` so callers can branch, and `best_effort = true` opts into skip-if-unenforceable.
+
+| mechanism | enforced on | on violation | notes |
+|-----------|------------|--------------|-------|
+| pledge | Linux, OpenBSD | Linux: EPERM; OpenBSD: process killed | irreversible once applied |
+| unveil | OpenBSD (native), Linux (backed by landlock, kernel >=5.13) | path invisible (ENOENT/EACCES) | `commit()` seals the policy |
+| landlock | Linux >=5.13 | EACCES | inherited by children; only narrows |
+| quicksand | Linux | n/a — setup fails fast | network namespaces + allowlist proxy |
+
+`cosmic.sandbox` (the facade) picks the right mechanism per OS and applies fs policy before sys policy; use its `available()` to report what the host can enforce:
+
+```teal
+local sandbox = require("cosmic.sandbox")
+if sandbox.available().fs then
+  assert(sandbox.apply{fs = {ro = {"/usr"}, rw = {"/tmp"}}})
+end
+```
+
+## Paths on Windows
+
+`cosmic.fs` path functions understand Windows-absolute forms on every OS, so a path pasted from a Windows shell never gets cwd glued onto it:
+
+- `is_absolute(p)` — true for `/x`, `C:/x`, `C:\x`, and UNC `\\server\share`.
+- `normalize(p)` — drive-letter paths normalize to a forward-slash, uppercase-drive form (`"c:\a\..\b"` -> `"C:/b"`); UNC paths keep the backslash form; both collapse `.`/`..`.
+- `abspath(p)` — Windows-absolute paths are only normalized, never prefixed with cwd.
+- `relpath(p, base)` — walks within one root; across roots (different drives, different UNC shares, drive vs POSIX) no relative path exists, so the normalized absolute target is returned.
+
+two deliberate limits:
+
+- a single leading `\` or interior `\` is an ordinary filename character: cosmic runs the same code on POSIX, where `\` is legal in names. only the unambiguous `C:/`, `C:\`, and `\\server\share` forms are treated as Windows roots.
+- drive-relative forms (`C:foo`) are not absolute and are not resolved against a per-drive cwd.
+
+forward slashes are accepted by Windows and by cosmopolitan everywhere, so normalized drive paths are directly usable in `fs.*` calls.
+
+## Other Windows Notes
+
+- the first-run welcome marker lives in the per-user config dir (`%LOCALAPPDATA%\cosmic`, or `$XDG_CONFIG_HOME/cosmic` / `$HOME/.config/cosmic` elsewhere); the installed binary is never modified, so release checksums stay valid.
+- `proc.search_path` discovery expects programs installed without an `.exe`/`.com` suffix.
+- `fs.home()` falls back from `$HOME` to `%USERPROFILE%`.
+- `zip`/`embed` extraction rejects Windows-absolute and UNC target paths on every OS (zip-slip defense).
+
+## CI Coverage
+
+Linux runs the full gate (`bin/make ci`). macOS and Windows run smoke jobs on every PR: the freshly built binary executes `-e`, `--docs guide.platforms`, and the string/json/fs-path test files. the remaining BSDs are release-tested via cosmopolitan upstream; platform-specific bugs there are tracked as issues.


### PR DESCRIPTION
Completes steps 11 and 12 of #510 (step 10 landed in #695), plus the per-OS sandbox documentation from the trailing checklist item.

## Step 12 — Windows-aware `fs` paths

`fs_path` was pure-POSIX: `abspath("C:\\foo")` prepended cwd and produced garbage. Now:

- **`fs.is_absolute(p)`** (new): true for POSIX `/x`, drive-letter `C:/x` / `C:\x`, and UNC `\\server\share` roots. Deliberately conservative: a lone or interior `\` stays an ordinary filename character (legal on POSIX, where the same code runs), and drive-relative `C:foo` is not absolute.
- **`normalize`**: drive-letter paths normalize to a forward-slash, uppercase-drive form (`c:\a\..\b` → `C:/b` — forward slashes are accepted by Windows and cosmopolitan); UNC paths keep the backslash form; both collapse `.`/`..`. POSIX behavior is unchanged (the `.`/`..` collapse loop is now shared, not duplicated).
- **`abspath`**: Windows-absolute paths are only normalized, never cwd-prefixed.
- **`relpath`**: walks within one root; across roots (different drives, different UNC shares, drive vs POSIX) no relative path exists, so it returns the normalized absolute target.

Pinned by a new pure-string test suite (`lib/cosmic/fs/path_windows_test.tl`) that runs — and must pass — on every OS.

## Step 12 — platform matrix docs

New `skills/cosmic/platforms.md`, surfaced as `cosmic --docs guide.platforms` (auto-listed with the other guides, pinned by a new `guide_test` case):

- per-module × OS support matrix (portable-everywhere set called out; per-OS rows for fs, child, proc, user, signal, tty, shm, syslog, and the sandbox family), with claims sourced from the module docs and the generated cosmo annotations (e.g. futex scalability tiers, syslog's Linux/Windows/NetBSD delivery).
- **per-OS sandbox behavior** (the trailing #510 checklist item): enforcement matrix for pledge/unveil/landlock/quicksand, fail-closed semantics, and the `available()` predicates (which already exist on all mechanisms and the facade).
- Windows path semantics and misc Windows notes (welcome marker location, `%USERPROFILE%`, zip-slip defense).

## Step 11 — macOS/Windows CI smoke jobs

`pr.yml` gains a cross-OS smoke lane: build the fat APE binary once on ubuntu, upload it, then `macos-latest` and `windows-latest` run it for real — `-e` (prints the detected host OS), `--docs guide.platforms` / `--docs fs.read`, and the portable test files (`string_test`, `json_test`, and all three fs path suites including the new Windows-path tests). The lane handles the upload/download-artifact zip layout trap release.yml documents (extracting via python's zipfile so it works in git-bash), names the binary `cosmic.exe` (required for Windows to execute the APE-as-PE, inert elsewhere), and hands cosmic a native mixed-form `TEST_TMPDIR` via `cygpath -m` on Windows.

## Not in this PR

The `posix_spawn` consideration for `child.spawn` (last bullet of #510's trailing item) is a C-layer/perf change and stays open on the issue.

## Gates

- `bin/make ci` → `ci: PASS` (includes the new path and guide tests)
- The full smoke command sequence was executed locally against the built binary on Linux; the macOS/Windows legs run on this PR's own CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1mSrjdmbjMuSiqVrBvoAs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1mSrjdmbjMuSiqVrBvoAs)_