### PR TITLE
fetch: delegate URL parsing to cosmo.ParseUrl, dot-segments to fs.normalize (#494)

### DIFF
--- a/lib/cosmic/fetch/extras.tl
+++ b/lib/cosmic/fetch/extras.tl
@@ -2,6 +2,7 @@
 --- body building (query/json/form/multipart), the verb helpers, and
 --- download. Lives in its own file so fetch/init.tl stays under the
 --- 500-line cap; init wires everything together.
+local cosmo = require("cosmo")
 local url_mod = require("cosmic.url")
 local json_mod = require("cosmic.json")
 local codec = require("cosmic.codec")
@@ -22,17 +23,28 @@ local record Part
   content_type: string
 end
 
+--- Validate a fetch URL with the same parser the HTTP client uses
+--- (cosmo.ParseUrl) rather than a hand-rolled scheme pattern that could
+--- disagree with it (audit §1.6). ParseUrl preserves scheme case, so
+--- the http/https comparison still lowercases; a scheme-only URL like
+--- "http://" parses but carries no host, which fetch cannot use.
+--- @param url string The URL to validate
+--- @return string? Error message, or nil when the URL is usable
 local function validate_url(url: string): string
   if url == "" then
     return "empty URL"
   end
-  local scheme = url:match("^([a-zA-Z][a-zA-Z0-9+%-.]*)://")
+  local u = cosmo.ParseUrl(url)
+  local scheme = u.scheme
   if not scheme then
     return "unsupported URL scheme: (none)"
   end
   scheme = scheme:lower()
   if scheme ~= "http" and scheme ~= "https" then
     return "unsupported URL scheme: " .. scheme
+  end
+  if not u.host or u.host == "" then
+    return "missing URL host"
   end
   return nil
 end
@@ -79,8 +91,12 @@ local function unix_proxy(path: string): string | nil, string
   if path:sub(1, 1) ~= "/" then
     return nil, "socket path must be absolute"
   end
-  if path:match("/%.%./") or path:match("/%.%.$") or path:match("/%./") or path:match("/%.$") then
-    return nil, "socket path must not contain . or .. segments"
+  -- Delegate segment logic to fs.normalize instead of hand-rolled dot
+  -- patterns (audit §1.6): a path that is not already normal carries a
+  -- "." or ".." segment or a redundant slash, and is rejected rather
+  -- than silently rewritten.
+  if fs.normalize(path) ~= path then
+    return nil, "socket path must not contain . or .. segments or redundant slashes"
   end
   -- unix(7) sockaddr_un sun_path is typically 108 bytes
   if #path >= 108 then

--- a/lib/cosmic/fetch/init_test.tl
+++ b/lib/cosmic/fetch/init_test.tl
@@ -273,6 +273,25 @@ local function test_fetch_no_scheme_rejected()
 end
 test_fetch_no_scheme_rejected()
 
+local function test_fetch_missing_host_rejected()
+  local result = fetch.fetch("http://")
+  assert(result.ok == false, "result.ok should be false for host-less URL")
+  assert(result.error == "missing URL host",
+    "expected 'missing URL host', got: " .. tostring(result.error))
+end
+test_fetch_missing_host_rejected()
+
+-- The scheme comparison is case-insensitive: an uppercase scheme must
+-- get past the scheme check (this host-less URL then fails on the host,
+-- proving the scheme was accepted without any network traffic).
+local function test_fetch_uppercase_scheme_accepted()
+  local result = fetch.fetch("HTTPS://")
+  assert(result.ok == false, "host-less URL still fails")
+  assert(result.error == "missing URL host",
+    "uppercase scheme should pass the scheme check, got: " .. tostring(result.error))
+end
+test_fetch_uppercase_scheme_accepted()
+
 -- unix_proxy helper tests
 
 local function test_unix_proxy_valid_path()
@@ -296,19 +315,46 @@ local function test_unix_proxy_relative_path()
 end
 test_unix_proxy_relative_path()
 
+local unix_proxy_segment_err = "socket path must not contain . or .. segments or redundant slashes"
+
 local function test_unix_proxy_dotdot_segment()
   local url, err = fetch.unix_proxy("/tmp/../etc/proxy.sock")
   assert(url == nil, "expected nil for path with .. segment")
-  assert(err == "socket path must not contain . or .. segments", "expected segment error, got: " .. tostring(err))
+  assert(err == unix_proxy_segment_err, "expected segment error, got: " .. tostring(err))
 end
 test_unix_proxy_dotdot_segment()
 
 local function test_unix_proxy_dot_segment()
   local url, err = fetch.unix_proxy("/tmp/./proxy.sock")
   assert(url == nil, "expected nil for path with . segment")
-  assert(err == "socket path must not contain . or .. segments", "expected segment error, got: " .. tostring(err))
+  assert(err == unix_proxy_segment_err, "expected segment error, got: " .. tostring(err))
 end
 test_unix_proxy_dot_segment()
+
+-- The delegated fs.normalize check also catches what the old dot
+-- patterns missed: redundant and trailing slashes.
+local function test_unix_proxy_redundant_slash()
+  local url, err = fetch.unix_proxy("/tmp//proxy.sock")
+  assert(url == nil, "expected nil for path with redundant slash")
+  assert(err == unix_proxy_segment_err, "expected segment error, got: " .. tostring(err))
+end
+test_unix_proxy_redundant_slash()
+
+local function test_unix_proxy_trailing_slash()
+  local url, err = fetch.unix_proxy("/tmp/proxy.sock/")
+  assert(url == nil, "expected nil for path with trailing slash")
+  assert(err == unix_proxy_segment_err, "expected segment error, got: " .. tostring(err))
+end
+test_unix_proxy_trailing_slash()
+
+-- Trailing ".." with no slash after it — a shape the old hand-rolled
+-- patterns had to cover with a dedicated case each.
+local function test_unix_proxy_trailing_dotdot()
+  local url, err = fetch.unix_proxy("/tmp/..")
+  assert(url == nil, "expected nil for path ending in ..")
+  assert(err == unix_proxy_segment_err, "expected segment error, got: " .. tostring(err))
+end
+test_unix_proxy_trailing_dotdot()
 
 local function test_unix_proxy_too_long_path()
   local long_path = "/" .. string.rep("a", 108)


### PR DESCRIPTION
The cosmic-side piece of #494 (audit §1.6, wrong-layer Teal logic) — the one part not blocked on upstream bindings.

## Change

- **`validate_url`** now parses with `cosmo.ParseUrl` — the same parser the HTTP client uses — instead of a hand-rolled scheme regex that could disagree with it. Error strings are unchanged for the existing cases (`empty URL`, `unsupported URL scheme: ...`; ParseUrl preserves scheme case, so the http/https comparison still lowercases). One new rejection falls out of having a real parse: a host-less URL like `http://` now fails fast with `missing URL host` instead of slipping through to `cosmo.Fetch`.
- **`unix_proxy`** replaces its four hand-rolled dot-segment patterns (`/%.%./`, `/%.%.$`, `/%./`, `/%.$` — the "risk bypass variants" evidence in the audit) with a single `fs.normalize(path) ~= path` comparison: a socket path that is not already in normal form is rejected rather than silently rewritten. This is strictly stronger — redundant (`/tmp//x`) and trailing (`/tmp/x/`) slashes are now caught too.

## Tests

- New: `missing URL host` pin; uppercase-scheme acceptance (proven without network traffic via a host-less `HTTPS://` URL that must fail on the *host* check); `unix_proxy` redundant-slash, trailing-slash, and trailing-`..` rejections.
- Updated: the two dot-segment pins to the new error message.

## Rest of #494

- netns ifreq → blocked on U7 (whilp/cosmopolitan#146)
- dial resolve-with-timeout → blocked on U6 (whilp/cosmopolitan#145)
- codec hex → already done (delegates to `cosmo.DecodeHex`)

## Gates

`bin/make ci` → `ci: PASS` (fetch suite 7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1mSrjdmbjMuSiqVrBvoAs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1mSrjdmbjMuSiqVrBvoAs)_