### PR TITLE
quicksand: delegate ifreq and bounded resolve to the C bindings (#494)

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "612b20cac515ebcdd7d00f0267a79688402eb1843f8253222cccd235afcfdd2a"}},
+  platforms = {["*"] = {sha = "342358e70501b49f19d7b47d27418086b4ca93f54585dfa371c40c215300fb48"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.19-b4958a67e"
+  version = "2026.07.19-120e27dbc"
 }

--- a/lib/cosmic/quicksand/netns.tl
+++ b/lib/cosmic/quicksand/netns.tl
@@ -20,50 +20,18 @@
 local unix = require("cosmo.unix")
 local errno = require("cosmic.errno")
 
-local IFREQ_UNION_SIZE < const > = 24
-local IFNAMSIZ < const > = 16 -- mirrors unix.IFNAMSIZ; kernel ABI constant
-
---- Build a `struct ifreq` for SIOCGIFFLAGS/SIOCSIFFLAGS: char
---- ifr_name[IFNAMSIZ] at offset 0, int16 ifr_flags at offset IFNAMSIZ,
---- padded to the largest union member.
-local function build_ifreq(name: string, flags: integer): string
-  assert(#name < IFNAMSIZ, "interface name too long")
-  local name_field = name .. string.rep("\0", IFNAMSIZ - #name)
-  -- Pack the 16-bit ifr_flags unsigned: IFF_* bits above 0x7fff (the sign
-  -- bit of a signed i2) would overflow "<i2" and raise from string.pack.
-  local flags_field = string.pack("<I2", flags)
-  return name_field .. flags_field
-  .. string.rep("\0", IFREQ_UNION_SIZE - #flags_field)
-end
-
---- Parse the 16-bit flags field out of an ifreq returned by ioctl().
-local function parse_ifreq_flags(ifr: string): integer
-  return (string.unpack("<I2", ifr, IFNAMSIZ + 1))
-end
-
---- Open an AF_INET dgram socket for the SIOC* interface ioctls.
---- SOCK_CLOEXEC: don't leak this short-lived control socket into any
---- exec'd child.
-local function control_socket(): integer, string
-  local sk, err = unix.socket(
-    unix.AF_INET, unix.SOCK_DGRAM | unix.SOCK_CLOEXEC, 0)
-  if not sk then return nil, errno.str(err, "socket") end
-  return sk
-end
-
 --- Read the current IFF_* flags on `name` in the current net namespace.
+--- The `struct ifreq` ABI lives in the C binding (cosmopolitan#199);
+--- no kernel structs are packed here.
 ---
 --- @param name string interface name (e.g. "lo")
 --- @return integer? flags bitmask on success
 --- @return string? error message on failure
 local function get_flags(name: string): integer | nil, string
-  if #name >= IFNAMSIZ then return nil, "interface name too long" end
-  local sk, err = control_socket()
-  if not sk then return nil, err end
-  local result, ioerr = unix.ioctl(sk, unix.SIOCGIFFLAGS, build_ifreq(name, 0))
-  unix.close(sk)
-  if not result then return nil, errno.str(ioerr, "SIOCGIFFLAGS") end
-  return parse_ifreq_flags(result as string) -- cast: ioctl union to string
+  if #name >= unix.IFNAMSIZ then return nil, "interface name too long" end
+  local flags, err = unix.siocgifflags(name)
+  if not flags then return nil, errno.str(err, "SIOCGIFFLAGS") end
+  return flags
 end
 
 --- Set the IFF_* flags on `name` in the current net namespace.
@@ -73,12 +41,9 @@ end
 --- @return boolean true on success
 --- @return string? error message on failure
 local function set_flags(name: string, flags: integer): boolean, string
-  if #name >= IFNAMSIZ then return false, "interface name too long" end
-  local sk, err = control_socket()
-  if not sk then return false, err end
-  local ok, ioerr = unix.ioctl(sk, unix.SIOCSIFFLAGS, build_ifreq(name, flags))
-  unix.close(sk)
-  if not ok then return false, errno.str(ioerr, "SIOCSIFFLAGS") end
+  if #name >= unix.IFNAMSIZ then return false, "interface name too long" end
+  local ok, err = unix.siocsifflags(name, flags)
+  if not ok then return false, errno.str(err, "SIOCSIFFLAGS") end
   return true
 end
 

--- a/lib/cosmic/quicksand/netns_test.tl
+++ b/lib/cosmic/quicksand/netns_test.tl
@@ -80,7 +80,8 @@ io.write("ok\n")
 end
 test_unshare_subprocess()
 
--- get_flags/set_flags exercise the ifreq packing + SIOC* ioctls that
+-- get_flags/set_flags exercise the unix.siocgifflags/siocsifflags
+-- bindings (struct ifreq lives in C, cosmopolitan#199) that
 -- bring_up/bring_down are built on. Loopback exists in any namespace,
 -- but an outer sandbox may deny AF_INET sockets — tolerate that.
 local function test_get_flags_loopback()
@@ -101,9 +102,9 @@ local function test_get_flags_bad_interface()
 end
 test_get_flags_bad_interface()
 
--- A flag with the 0x8000 bit set must not overflow the ifreq packing:
--- "<i2" (signed) would raise "integer overflow" from string.pack, "<I2"
--- (unsigned) packs it cleanly. The interface is nonexistent so
+-- A flag with the 0x8000 bit set must pass through cleanly (the old
+-- Teal ifreq packing once overflowed signed 16-bit here, cosmic#431;
+-- the C binding stores it as uint16_t). The interface is nonexistent so
 -- SIOCSIFFLAGS can never mutate a real device, regardless of privilege.
 local function test_set_flags_high_bit_no_overflow()
   local ok, err = netns.set_flags("nope0", 0x8000)

--- a/lib/cosmic/quicksand/proxy/dial.tl
+++ b/lib/cosmic/quicksand/proxy/dial.tl
@@ -12,79 +12,34 @@ local cosmo = require("cosmo")
 local errno = require("cosmic.errno")
 
 --- Resolve `host` to an IPv4 integer. Literal IPs parse immediately;
---- otherwise the lookup goes through `resolver` (default
---- cosmo.ResolveIp, which uses the system resolver in the *current*
---- netns — call after setns() to the upstream namespace).
+--- hostnames go through cosmo.ResolveIp, which uses the system
+--- resolver in the *current* netns — call after setns() to the
+--- upstream namespace.
 ---
---- When `timeout_ms` is non-nil the lookup runs in a forked helper
---- and the parent polls the result pipe; past the deadline the helper
---- is SIGKILL'd and (nil, "resolve timeout") is returned, so a
---- hostile or tarpitting resolver can't wedge a per-connection worker
---- past its budget. Literal IPs skip the fork entirely.
+--- When `timeout_ms` is non-nil the lookup is bounded by the C
+--- binding's own deadline (cosmopolitan#199): past it, ResolveIp
+--- disowns its worker and returns a "DNS lookup timed out" error, so
+--- a hostile or tarpitting resolver can't wedge a per-connection
+--- worker past its budget. Literal IPs never wait.
 ---
 --- @param host string hostname or literal IPv4
 --- @param timeout_ms integer? resolution deadline (nil = unbounded)
---- @param resolver function? test seam returning (ip, err); defaults
----   to cosmo.ResolveIp
+--- @param resolver function? test seam returning (ip, err); called
+---   without a deadline — bounded lookups are the C binding's job
 --- @return integer? IPv4 address as an integer
 --- @return string? error message on failure
 local function resolve(host: string, timeout_ms: integer,
     resolver: function(string): integer, any): integer | nil, string
   local ip = cosmo.ParseIp(host)
   if ip and ip ~= -1 then return ip end
-  if not resolver then
-    resolver = cosmo.ResolveIp as function(string): integer, any -- cast: function shape
-  end
-  if not timeout_ms then
+  if resolver then
     local resolved, rerr = resolver(host)
     if not resolved then return nil, errno.str(rerr, "resolve") end
     return resolved
   end
-  local r, w = unix.pipe()
-  if not r then return nil, errno.str(w, "pipe") end
-  local rfd = r
-  local wfd = w
-  local pid, ferr = unix.fork()
-  if not pid then
-    unix.close(rfd)
-    unix.close(wfd)
-    return nil, errno.str(ferr, "fork")
-  end
-  if pid == 0 then
-    unix.close(rfd)
-    local resolved, rerr = resolver(host)
-    if resolved then
-      unix.write(wfd, "O" .. string.pack("<i8", resolved))
-    else
-      unix.write(wfd, "E" .. tostring(rerr or "resolve failed"))
-    end
-    unix.close(wfd)
-    unix.exit(0)
-  end
-  unix.close(wfd)
-  local fds: {integer: integer} = {}
-  fds[rfd] = unix.POLLIN
-  local ready = unix.poll(fds, timeout_ms)
-  -- cast: record union after guard
-  if not ready or not (ready as {integer: integer})[rfd] then
-    pcall(unix.kill, pid, unix.SIGKILL)
-    pcall(unix.wait, pid)
-    unix.close(rfd)
-    return nil, "resolve timeout"
-  end
-  -- Drain the pipe. The helper writes at most 9 bytes (1 status byte
-  -- + 8-byte packed int) on success, or "E" + a short error string.
-  local data = (unix.read(rfd, 4096) or "") as string -- cast: union survives or-default
-  unix.close(rfd)
-  pcall(unix.wait, pid)
-  local tag = data:sub(1, 1)
-  if tag == "O" and #data >= 9 then
-    return (string.unpack("<i8", data, 2))
-  end
-  if tag == "E" then
-    return nil, data:sub(2)
-  end
-  return nil, "resolve failed"
+  local resolved, rerr = cosmo.ResolveIp(host, timeout_ms)
+  if not resolved then return nil, rerr end
+  return resolved
 end
 
 --- Open a TCP connection to (host, port) in the namespace identified

--- a/lib/cosmic/quicksand/proxy/dial_test.tl
+++ b/lib/cosmic/quicksand/proxy/dial_test.tl
@@ -1,9 +1,7 @@
 #!/usr/bin/env cosmic
 local check = require("cosmic.check")
 local dial = require("cosmic.quicksand.proxy.dial")
-local quicksand = require("cosmic.quicksand")
 local ip = require("cosmic.ip")
-local time = require("cosmic.time")
 
 -- SSRF protection: dialing a private / reserved literal must be
 -- refused after resolution, before any socket is opened. Covers
@@ -49,36 +47,23 @@ local function test_resolve_error_propagates()
 end
 test_resolve_error_propagates()
 
--- The bounded path forks a helper and ships the result (or error)
--- back over a pipe.
-local function test_resolve_bounded_roundtrip()
-  local c = quicksand.capabilities()
-  if not c.linux then return end
-  local got, err = dial.resolve("host.test", 2000,
+-- Bounded lookups are the C binding's job now (cosmo.ResolveIp's
+-- timeout_ms, cosmopolitan#199, where the deadline behavior is pinned
+-- against a tarpitted resolver upstream). At this layer: a deadline
+-- must not disturb the literal fast path, and a seam resolver's value
+-- comes back directly — no helper process, no pipe.
+local function test_resolve_literal_with_deadline()
+  local got, err = dial.resolve("8.8.8.8", 150, nil)
+  assert(got == check.must(ip.parse("8.8.8.8")):int(),
+    "literal must parse immediately under a deadline: " .. tostring(err))
+end
+test_resolve_literal_with_deadline()
+
+local function test_resolve_seam_value_returned_directly()
+  local got, err = dial.resolve("host.test", nil,
     function(_: string): integer, any
       return 1234
     end)
-  assert(got == 1234, "value should cross the pipe: " .. tostring(err))
-  got, err = dial.resolve("host.test", 2000,
-    function(_: string): integer, any
-      return nil, "nope"
-    end)
-  assert(got == nil and err == "nope",
-    "error should cross the pipe, got: " .. tostring(err))
+  assert(got == 1234, "seam value should return directly: " .. tostring(err))
 end
-test_resolve_bounded_roundtrip()
-
--- A resolver that outlives its deadline is SIGKILL'd and reported as
--- a timeout, so a tarpitting DNS server can't wedge a worker.
-local function test_resolve_timeout_kills_slow_resolver()
-  local c = quicksand.capabilities()
-  if not c.linux then return end
-  local got, err = dial.resolve("host.test", 150,
-    function(_: string): integer, any
-      time.sleep(30)
-      return 1
-    end)
-  assert(got == nil, "slow resolve should fail")
-  assert(err == "resolve timeout", "expected timeout, got: " .. tostring(err))
-end
-test_resolve_timeout_kills_slow_resolver()
+test_resolve_seam_value_returned_directly()

--- a/lib/types/cosmo.d.tl
+++ b/lib/types/cosmo.d.tl
@@ -733,7 +733,14 @@ local record cosmo
   --- If no IP address could be found, then `nil` is returned alongside a string of
   --- unspecified format describing the error. Calls to this function may be wrapped
   --- in `assert()` if an exception is desired.
-  ResolveIp: function(hostname: string): integer | nil, string
+  --- When `timeout_ms` is given and non-negative, the DNS lookup is bounded:
+  --- past the deadline `nil` is returned with a "DNS lookup timed out" error
+  --- instead of blocking for the resolver's full internal budget. The lookup
+  --- runs on a disowned worker thread past the deadline, so a slow resolver
+  --- costs a bounded background thread, never the caller's time. Literal IP
+  --- inputs parse immediately and never wait. Omit `timeout_ms` (or pass a
+  --- negative value) for the unbounded blocking behavior.
+  ResolveIp: function(hostname: string, timeout_ms?: integer): integer | nil, string
   --- Computes SHA256 checksum, returning 32 bytes of binary.
   Sha256: function(str: string): string
   --- Reads all data from file the easy way.

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -155,9 +155,10 @@ local record Memory
   --- as a result of the system call. No failure conditions are defined.
   wake: function(self: Memory, index: integer, count?: integer): integer
   --- Releases the shared-memory mapping immediately, instead of waiting
-  --- for the garbage collector to do it. Idempotent: repeat calls are
-  --- no-ops. After unmap, calling any other method on this object raises
-  --- an error rather than touching the freed memory.
+  --- for the garbage collector to do it. Idempotent: returns true when
+  --- this call released the mapping and false when it was already
+  --- unmapped. After unmap, calling any other method on this object
+  --- raises an error rather than touching the freed memory.
   unmap: function(self: Memory): boolean
 end
 
@@ -2294,6 +2295,15 @@ local record unix
   bind: function(fd: integer, ip?: integer, port?: integer): boolean | nil, string, Errno
   --- Returns list of network adapter addresses.
   siocgifconf: function(): any, string, Errno
+  --- Reads the IFF_* flag bitmask of the named network interface
+  --- (SIOCGIFFLAGS). The `struct ifreq` ABI lives in C, so callers pass
+  --- the interface name instead of hand-packing kernel structs.
+  siocgifflags: function(ifname: string): integer | nil, string, Errno
+  --- Writes the IFF_* flag bitmask of the named network interface
+  --- (SIOCSIFFLAGS). Typically requires privilege (or a user namespace
+  --- that grants it, e.g. for bringing loopback up in a fresh netns).
+  --- Read-modify-write with `unix.siocgifflags` to change single bits.
+  siocsifflags: function(ifname: string, flags: integer): boolean | nil, string, Errno
   --- Tunes networking parameters.
   --- `level` and `optname` may be one of the following pairs. The ellipses
   --- type signature above changes depending on which options are used.


### PR DESCRIPTION
Closes #494. Deletes the last two wrong-layer Teal workarounds now that whilp/cosmopolitan#199 shipped in release `2026.07.19-120e27dbc`, and bumps the pin to it.

## Change

- **netns**: `get_flags`/`set_flags` call the new `unix.siocgifflags`/`unix.siocsifflags` bindings. Deleted: `build_ifreq`, `parse_ifreq_flags`, the control-socket helper, the hardcoded `IFNAMSIZ = 16`, the guessed `IFREQ_UNION_SIZE = 24`, and the `string.pack` sign trap that once shipped as #431. The `struct ifreq` ABI now lives in C. The friendly `"interface name too long"` pre-check stays, driven by the declared `unix.IFNAMSIZ` constant.
- **dial**: `resolve()` delegates the deadline to `cosmo.ResolveIp(host, timeout_ms)` — the ~45-line fork + pipe + poll + SIGKILL dance is deleted. Literal IPs still parse immediately and never wait; the resolver test seam remains (deadline-free by design — bounded lookups are the C binding's job).
- **pin**: `3p/cosmos/version.lua` → `2026.07.19-120e27dbc` (sha256 verified), `bin/make regen-types` — `unix.d.tl` gains the two ioctl bindings, `cosmo.d.tl` gains `ResolveIp`'s `timeout_ms?`.

The branch is two commits by design: the deletions staged first (red against the old pin, as its interim PR body noted), then the pin bump that makes them real — each reviewable on its own.

## Tests

- netns pins unchanged in substance (loopback flags read, nonexistent-interface failure, high-bit `0x8000` flag write, too-long-name message) — now exercising the C bindings, and green against the new binary.
- dial: the two fork-mechanics pins (value/error across the pipe, SIGKILL of a slow resolver) are replaced by literal-under-deadline and seam-direct-return pins. The deadline behavior itself is pinned upstream, where cosmopolitan#199 verified it against a genuinely tarpitted resolver (300ms bounded vs 5005ms unbounded).

## Gates

`bin/make ci` → `ci: PASS` on the new pin (gentype drift test green from the regen; `netns_test` and `dial_test` pass against the released binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1mSrjdmbjMuSiqVrBvoAs