### PR TITLE
build: regen-types no longer needs the tree to compile (#711)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,12 @@ bin/make test only=gentype
 # 2. fix any lib/cosmic wrappers the new types break; commit everything together
 ```
 
+`regen-types` runs the generator under the staged cosmos binary with only
+gentype's require closure compiled, so it works even when the rest of the
+tree does not compile yet — e.g. wrapper code staged ahead of the pin bump
+that introduces its bindings (#711). On a cold tree, run `bin/make staged`
+once first.
+
 `GENTYPE_DEFS=/path/to/definitions.lua` overrides the definitions source for
 validating against a cosmopolitan checkout before a release is cut.
 

--- a/Makefile
+++ b/Makefile
@@ -381,28 +381,6 @@ $(o)/%.tl.benchmark.got: %.tl $(cosmic_bin) | $(bootstrap_files)
 	@mkdir -p $(@D)
 	@set +e; $(cosmic_bin) --benchmark $< > $(basename $@).out 2> $(basename $@).err; echo $$? > $@
 
-# Type definition regeneration.
-# The generated .d.tl files are a pure function of (lib/types/gentype*.tl, the
-# definitions.lua embedded in the pinned cosmos release). This target runs the
-# CURRENT generator from the freshly built cosmic binary against the CURRENT
-# pin, so regen is reproducible: bump 3p/cosmos/version.lua, run
-# `bin/make regen-types`, commit. The gentype drift test fails until you do.
-# Module list ($(type_modules)) defined in cook.mk
-
-.PHONY: regen-types
-## Regenerate .d.tl type definitions from the pinned cosmos definitions.lua
-regen-types: $(cosmic_bin)
-	@echo "Regenerating type definitions from the pinned cosmos definitions.lua..."
-	@for mod in $(type_modules); do \
-		case $$mod in \
-			cosmo) out=lib/types/cosmo.d.tl ;; \
-			*) out=lib/types/cosmo/$$mod.d.tl ;; \
-		esac; \
-		echo "  $$out"; \
-		$(cosmic_bin) -e "local r = require('types.gentype').run('$$mod'); assert(r.success, r.error); io.write(r.output)" > $$out.tmp && mv $$out.tmp $$out || { rm -f $$out.tmp; exit 1; }; \
-	done
-	@echo "Type definitions regenerated. Verify with: bin/make test only=gentype"
-
 # Documentation generation - render .tl files as markdown
 # Module sources for docs: all _tl files (excludes tests and examples).
 # Deliberately NOT filter-only'd: these feed artifacts (published docs and

--- a/cook.mk
+++ b/cook.mk
@@ -39,3 +39,51 @@ $(compile_flag_stamp): $(bootstrap_files)
 		echo --compile > $@; \
 	fi
 	@rm -f $@.probe.tl
+
+# Type definition regeneration.
+# The generated .d.tl files are a pure function of (lib/types/gentype*.tl, the
+# definitions.lua embedded in the pinned cosmos release). This target runs the
+# CURRENT generator against the CURRENT pin, so regen is reproducible: bump
+# 3p/cosmos/version.lua, run `bin/make regen-types`, commit. The gentype drift
+# test fails until you do. Module list ($(type_modules)) defined above.
+#
+# gentype runs under the STAGED cosmos lua binary — whose embedded
+# /zip/.lua/definitions.lua IS the pinned source of truth — with LUA_PATH
+# limited to gentype's compiled require closure. Depending on $(cosmic_bin)
+# here would compile the WHOLE tree against the old committed .d.tl,
+# deadlocking any pin bump that lands together with code already using the
+# new bindings (#711). The closure below is the transitive requires of
+# types.gentype; if it drifts, the recipe fails loudly with "module not
+# found" — extend the list, and do NOT swap in $(stdlib_lua) (that
+# re-creates the deadlock).
+#
+# The staged cosmos/tl trees are checked at RECIPE time, not as
+# prerequisites: the .staged targets themselves depend on $(stdlib_lua)
+# (their fetch/stage scripts run against the tree's cosmic.* APIs), so a
+# make-graph dependency on them would re-import the whole-tree compile
+# this target exists to avoid. On a cold tree, run `bin/make staged`
+# once first.
+gentype_closure_tl := \
+  $(wildcard lib/types/gentype*.tl) \
+  lib/cosmic/init.tl lib/cosmic/proc.tl lib/cosmic/errno.tl \
+  lib/cosmic/fd.tl lib/cosmic/stream.tl \
+  lib/cosmic/fs/init.tl lib/cosmic/fs/file.tl lib/cosmic/fs/ops.tl \
+  lib/cosmic/fs/path.tl lib/cosmic/fs/tree.tl lib/cosmic/fs/types.tl \
+  lib/cosmic/fs/walk.tl
+gentype_closure_lua := $(patsubst %.tl,$(o)/%.lua,$(gentype_closure_tl))
+
+.PHONY: regen-types
+## Regenerate .d.tl type definitions from the pinned cosmos definitions.lua
+regen-types: $(gentype_closure_lua)
+	@test -x $(cosmos_lua_bin) || { echo "regen-types: staged cosmos missing; run 'bin/make staged' first"; exit 1; }
+	@test -f $(tl_dir)/tl.lua || { echo "regen-types: staged tl missing; run 'bin/make staged' first"; exit 1; }
+	@echo "Regenerating type definitions from the pinned cosmos definitions.lua..."
+	@for mod in $(type_modules); do \
+		case $$mod in \
+			cosmo) out=lib/types/cosmo.d.tl ;; \
+			*) out=lib/types/cosmo/$$mod.d.tl ;; \
+		esac; \
+		echo "  $$out"; \
+		LUA_PATH="$(o)/lib/?.lua;$(o)/lib/?/init.lua;$(tl_dir)/?.lua;;" $(cosmos_lua_bin) -e "local r = require('types.gentype').run('$$mod'); assert(r.success, r.error); io.write(r.output)" > $$out.tmp && mv $$out.tmp $$out || { rm -f $$out.tmp; exit 1; }; \
+	done
+	@echo "Type definitions regenerated. Verify with: bin/make test only=gentype"


### PR DESCRIPTION
Closes #711.

## Problem

`regen-types` depended on `$(cosmic_bin)`, so regenerating the `.d.tl` files required compiling **every** `.tl` in the tree against the *old committed* declarations — a chicken-and-egg for any pin bump that lands together with code already using the new bindings. Hit for real in #710, worked around by manually reverting the consumer files, regenerating, and restoring.

## Change

- The generator now runs under the **staged cosmos lua binary** — whose embedded `/zip/.lua/definitions.lua` *is* the pinned source of truth (the cosmic binary's copy is inherited from it unchanged) — with `LUA_PATH` limited to gentype's compiled require closure: the `gentype*` modules plus `cosmic` init/proc/errno/fd/stream and the fs family. Nothing else in the tree compiles.
- The staged cosmos/tl trees are checked at **recipe time** with a clear "run `bin/make staged` first" message, not as make prerequisites — the `.staged` targets themselves depend on `$(stdlib_lua)` (their fetch/stage scripts run against the tree's `cosmic.*` APIs), so a graph dependency on them would re-import exactly the whole-tree compile this target exists to avoid. (That was the first attempt; the deadlock test below caught it.)
- The block moves from the Makefile to `cook.mk` — which already owns `$(type_modules)` and is described as the type-gen home — keeping the Makefile under its own 500-line cap.
- AGENTS.md's update procedure notes the new property: regen works on a tree that doesn't compile yet; cold trees need `bin/make staged` once.
- If the closure drifts (gentype grows a require), the recipe fails loudly with "module not found" — the comment says to extend the list and warns against swapping in `$(stdlib_lua)`.

## Verification

- `bin/make regen-types` output is byte-identical to the committed `.d.tl` files (clean `git status` after a run).
- **Deadlock scenario reproduced and fixed**: with `netns.tl` deliberately referencing a nonexistent `unix.*` binding (so the tree cannot compile — confirmed `bin/make build` fails), `regen-types` now completes successfully; before the fix it died compiling `o/lib/cosmic/quicksand/netns.lua`.
- `bin/make ci` → `ci: PASS`; `bin/make help` still lists the target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1mSrjdmbjMuSiqVrBvoAs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1mSrjdmbjMuSiqVrBvoAs)_