### PR TITLE
build: delete write-only TEST_DEPS and the inert test-dep expansion (#715)

### DIFF
--- a/3p/cosmos/cook.mk
+++ b/3p/cosmos/cook.mk
@@ -4,3 +4,12 @@ cosmos_tests := 3p/cosmos/cosmos_test.tl
 cosmos_lua_bin = $(cosmos_dir)/lua
 cosmos_lua_debug_bin = $(cosmos_dir)/lua-debug
 cosmos_zip_bin = $(cosmos_dir)/zip
+
+# cosmos_test reads the staged lua/zip binaries through TEST_DIR.
+# cosmos_dir is derived in the Makefile after includes, hence the
+# secondary expansion and the recursive (=) TEST_DIR.
+cosmos_test_got := \
+  $(patsubst %,$(o)/%.test.got,$(cosmos_tests)) \
+  $(patsubst %,$(o)/coverage/%.test.got,$(cosmos_tests))
+$(cosmos_test_got): $$(cosmos_dir)
+$(cosmos_test_got): TEST_DIR = $(cosmos_dir)

--- a/3p/tl/cook.mk
+++ b/3p/tl/cook.mk
@@ -2,3 +2,12 @@ modules += tl
 tl_version := 3p/tl/version.lua
 tl_tests := $(wildcard 3p/tl/*_test.tl)
 tl_deps := cosmos
+
+# tl_test loads the staged tl source through TEST_DIR. tl_dir is
+# derived in the Makefile after includes, hence the secondary
+# expansion and the recursive (=) TEST_DIR.
+tl_test_got := \
+  $(patsubst %,$(o)/%.test.got,$(tl_tests)) \
+  $(patsubst %,$(o)/coverage/%.test.got,$(tl_tests))
+$(tl_test_got): $$(tl_dir)
+$(tl_test_got): TEST_DIR = $(tl_dir)

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,8 @@ $(foreach m,$(modules),$(if $($(m)_version),\
   $(eval $(m)_staged := $(o)/$(m)/.staged)\
   $(if $($(m)_dir),,$(eval $(m)_dir := $(o)/$(m)/.staged))))
 
-# default deps for regular modules (also excluded from file dep expansion)
-default_deps := bootstrap test
+# modules excluded from file dep expansion
+default_deps := bootstrap
 
 # expand module deps: M_files depends on deps' _files and _staged
 $(foreach m,$(filter-out $(default_deps),$(modules)),\
@@ -167,29 +167,18 @@ quicksand_sandbox_tests := \
 $(quicksand_sandbox_tests): .PLEDGE =
 $(quicksand_sandbox_tests): .UNVEIL =
 
-$(o)/%.tl.test.got: $(o)/%.lua $(test_files) $(o)/bin/cosmic | $(cosmic_bin)
+$(o)/%.tl.test.got: $(o)/%.lua $(cosmic_bin)
 	@mkdir -p $(@D)
 	@TEST_DIR=$(TEST_DIR) PATH=$(CURDIR)/$(o)/bin:$$PATH $(cosmic_bin) --test $(basename $@) $(cosmic_bin) $<
 
-# expand test deps: M's tests depend on own _files/_tl plus deps' _dir/_files/_lua
-# derive compiled .lua from _tl (first pass: compute all _lua)
-$(foreach m,$(filter-out bootstrap,$(modules)),\
-  $(if $($(m)_tl),$(eval $(m)_lua := $(patsubst %.tl,$(o)/%.lua,$($(m)_tl)))))
-# second pass: set up test dependencies, for both the plain test tree and
-# the coverage lane's separate output tree
-test_got_dirs := $(o) $(o)/coverage
-$(foreach p,$(test_got_dirs),$(foreach m,$(filter-out bootstrap,$(modules)),\
-  $(eval $(patsubst %,$(p)/%.test.got,$($(m)_tests)): $($(m)_files) $($(m)_lua))\
-  $(eval $(patsubst %,$(p)/%.test.got,$($(m)_tests)): TEST_DEPS += $($(m)_files) $($(m)_lua))\
-  $(if $($(m)_dir),\
-    $(eval $(patsubst %,$(p)/%.test.got,$($(m)_tests)): $($(m)_dir))\
-    $(eval $(patsubst %,$(p)/%.test.got,$($(m)_tests)): TEST_DEPS += $($(m)_dir))\
-    $(eval $(patsubst %,$(p)/%.test.got,$($(m)_tests)): TEST_DIR := $($(m)_dir)))\
-  $(foreach d,$(filter-out $(m),$(default_deps) $($(m)_deps)),\
-    $(if $($(d)_dir),\
-      $(eval $(patsubst %,$(p)/%.test.got,$($(m)_tests)): $($(d)_dir))\
-      $(eval $(patsubst %,$(p)/%.test.got,$($(m)_tests)): TEST_DEPS += $($(d)_dir)))\
-    $(eval $(patsubst %,$(p)/%.test.got,$($(m)_tests)): $($(d)_files) $($(d)_lua)))))
+# Test deps beyond the pattern rule (own compiled .lua + $(cosmic_bin))
+# live in each module's cook.mk: perf tests attach $(perf_lua), build
+# tests $(build_files), docs tests $(docs_files), cosmos/tl tests their
+# staged tree + TEST_DIR, cosmic_debug_test the debug binary. Everything
+# else rides on $(cosmic_bin), which already depends on the whole
+# embedded stdlib, the staged 3p trees, and the type declarations — the
+# old per-module foreach/eval expansion here (and its write-only
+# TEST_DEPS accumulator) duplicated that transitive closure (#715).
 
 # Coverage lane: the same tests in a separate output tree, run with
 # collection enabled, so `bin/make coverage` never invalidates the plain
@@ -204,7 +193,7 @@ coverage: $(o)/coverage-summary.txt
 
 $(o)/coverage/%.tl.test.got: .PLEDGE = stdio rpath wpath cpath proc exec
 $(o)/coverage/%.tl.test.got: .UNVEIL = rx:$(o)/bootstrap r:lib r:3p rwcx:$(o) rwc:$(TMP) rx:/usr rx:/proc r:/etc r:/dev/null
-$(o)/coverage/%.tl.test.got: $(o)/%.lua $(test_files) $(o)/bin/cosmic | $(cosmic_bin)
+$(o)/coverage/%.tl.test.got: $(o)/%.lua $(cosmic_bin)
 	@mkdir -p $(@D)
 	@TEST_DIR=$(TEST_DIR) COSMIC_COVERAGE=1 PATH=$(CURDIR)/$(o)/bin:$$PATH $(cosmic_bin) --test $(basename $@) $(cosmic_bin) $<
 
@@ -259,7 +248,7 @@ enforce: $(o)/enforce-summary.txt
 $(enforce_got): .PLEDGE =
 $(enforce_got): .UNVEIL =
 
-$(o)/enforce/%.tl.test.got: $(o)/%.lua $(cosmic_bin) | $(cosmic_bin)
+$(o)/enforce/%.tl.test.got: $(o)/%.lua $(cosmic_bin)
 	@mkdir -p $(@D)
 	@TEST_BIN=$(o)/bin COSMIC_ENFORCE=1 PATH=$(CURDIR)/$(o)/bin:$$PATH \
 	  $(cosmic_bin) --test $(basename $@) $(cosmic_bin) $<

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -16,8 +16,13 @@ reporter := $(bootstrap_cosmic) -- $(build_reporter)
 lint_style_lua := $(o)/lib/cosmic/cli/style.lua
 linter := LUA_PATH="$(o)/lib/?.lua;$(o)/lib/?/init.lua;;" $(bootstrap_cosmic) -- $(build_lint)
 
-# reporter_test needs cosmic binary (in the plain and coverage test lanes)
-$(o)/lib/build/reporter_test.tl.test.got $(o)/coverage/lib/build/reporter_test.tl.test.got: $$(cosmic_bin)
+# build tests exercise the compiled build tools (reporter, lint,
+# make-help, ...) at runtime via LUA_PATH=$(o)/lib/build, so they need
+# them built and fresh (#715)
+build_test_got := \
+  $(patsubst %,$(o)/%.test.got,$(build_tests)) \
+  $(patsubst %,$(o)/coverage/%.test.got,$(build_tests))
+$(build_test_got): $(build_files)
 
 # make-help snapshot: generate actual help output
 $(o)/lib/build/make-help.snap: Makefile $(build_help) | $(bootstrap_cosmic)

--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -7,8 +7,21 @@ cosmic_main := $(o)/lib/cosmic/cli/main.lua
 cosmic_args := lib/cosmic/.args
 cosmic_bin := $(o)/bin/cosmic
 cosmic_debug_bin := $(o)/bin/cosmic-debug
-cosmic_files := $(cosmic_bin) $(cosmic_debug_bin) $(cosmic_lua)
+# cosmic_files deliberately carries only the binaries: the compiled
+# stdlib below reaches everything through $(cosmic_bin)'s own prereqs
+# (the old trailing $(cosmic_lua) here always expanded empty — it was
+# not defined until after the includes)
+cosmic_files := $(cosmic_bin) $(cosmic_debug_bin)
 cosmic_deps := cosmos tl
+cosmic_lua := $(patsubst %.tl,$(o)/%.lua,$(cosmic_tl))
+
+# cosmic_debug_test runs o/bin/cosmic-debug; every other test needs only
+# $(cosmic_bin) (a pattern-rule prerequisite), so the debug binary is
+# attached to just this test instead of all cosmic tests (#715)
+cosmic_debug_test_got := \
+  $(o)/lib/cosmic/cosmic_debug_test.tl.test.got \
+  $(o)/coverage/lib/cosmic/cosmic_debug_test.tl.test.got
+$(cosmic_debug_test_got): $(cosmic_debug_bin)
 
 cosmic_built := $(o)/cosmic/.built
 cosmic_sys := sys/help.md

--- a/lib/cosmic/cosmic_test.tl
+++ b/lib/cosmic/cosmic_test.tl
@@ -1,7 +1,5 @@
 #!/usr/bin/env cosmic
 
--- Note: TEST_DEPS tests removed - TEST_DEPS is a Make variable not passed to Lua tests
-
 local function test_env_vars()
   assert(os.getenv("TEST_O") ~= nil, "TEST_O should be set")
   assert(os.getenv("TEST_PLATFORM") ~= nil, "TEST_PLATFORM should be set")

--- a/lib/cosmic/coverage/baseline.txt
+++ b/lib/cosmic/coverage/baseline.txt
@@ -19,7 +19,7 @@ lib/cosmic/cli/main.tl 0 277
 lib/cosmic/cli/main_handlers.tl 16 225
 lib/cosmic/cli/run.tl 4 32
 lib/cosmic/cli/script_cache.tl 27 30
-lib/cosmic/cli/searcher.tl 17 27
+lib/cosmic/cli/searcher.tl 13 27
 lib/cosmic/cli/style.tl 115 122
 lib/cosmic/cli/welcome.tl 0 26
 lib/cosmic/codec.tl 52 58
@@ -138,4 +138,4 @@ lib/types/gentype_parse.tl 267 288
 lib/types/gentype_render.tl 309 312
 lib/types/gentype_types.tl 2 2
 tlconfig.lua 7 7
-total 11280 14817
+total 11276 14817

--- a/lib/docs/cook.mk
+++ b/lib/docs/cook.mk
@@ -4,3 +4,10 @@ docs_publish := $(o)/lib/docs/publish.lua
 docs_files := $(docs_publish)
 docs_tests := lib/docs/publish_test.tl
 docs_deps := cosmic
+
+# publish_test loads the publisher from the tree at runtime; the
+# compiled copy keeps the test rerunning when publish.tl changes (#715)
+docs_test_got := \
+  $(patsubst %,$(o)/%.test.got,$(docs_tests)) \
+  $(patsubst %,$(o)/coverage/%.test.got,$(docs_tests))
+$(docs_test_got): $(docs_files)

--- a/lib/perf/cook.mk
+++ b/lib/perf/cook.mk
@@ -5,6 +5,14 @@ perf_tl := $(filter-out $(perf_tests),$(perf_srcs))
 # compiled perf modules are require()d as perf.* via LUA_PATH
 perf_lua_dirs := $(o)/lib
 perf_deps := cosmic
+perf_lua := $(patsubst %.tl,$(o)/%.lua,$(perf_tl))
+
+# perf tests load the compiled perf.* modules at runtime (see
+# perf_lua_dirs above), so they need them built and fresh (#715)
+perf_test_got := \
+  $(patsubst %,$(o)/%.test.got,$(perf_tests)) \
+  $(patsubst %,$(o)/coverage/%.test.got,$(perf_tests))
+$(perf_test_got): $(perf_lua)
 
 perf_bench_srcs := $(wildcard lib/perf/bench/*_bench.tl)
 perf_bench_mods := $(subst /,.,$(patsubst lib/%.tl,%,$(perf_bench_srcs)))


### PR DESCRIPTION
Part of #713 — lands findings 3–4 (sub-issue #715).

## What

The nested `foreach`/`eval` test-dependency block in the Makefile carried two kinds of dead weight:

- **`TEST_DEPS` was write-only** — three eval lines accumulated a target-specific variable nothing ever read.
- **The per-module wiring was mostly inert** — every test depends on `$(cosmic_bin)`, which itself depends on the whole embedded stdlib, the staged 3p trees, and the type declarations, so the careful `$($(m)_files) $($(m)_lua)` wiring duplicated that transitive closure.

The block is deleted. The pattern rules keep each test's own compiled `.lua` and `$(cosmic_bin)` — also dropping the duplicate literal `o/bin/cosmic`-plus-order-only-`$(cosmic_bin)` prereq pair (one bullet of #721) and `$(test_files)`, which was referenced but never defined anywhere. The genuinely load-bearing attachments move to the owning cook.mk (the pattern `gentl_test`/`makefile_test`/`reporter_test` already used):

- **lib/perf**: tests `require()` the compiled `perf.*` modules via `LUA_PATH=o/lib` → attach `$(perf_lua)`
- **lib/build**: tests load the compiled build tools (reporter, lint, make-help) → attach `$(build_files)`; replaces the now-redundant reporter_test line
- **lib/docs**: `publish_test` tracks the compiled publisher so it reruns when `publish.tl` changes
- **3p/cosmos, 3p/tl**: staged tree prerequisite plus `TEST_DIR` (their tests read the staged binaries/source through it)
- **lib/cosmic**: `cosmic_debug_test` alone runs `o/bin/cosmic-debug`, so the debug binary attaches to just that test instead of every cosmic test

`cosmic_lua`/`perf_lua` derivation moves next to the modules that own them; the phantom `test` module leaves `default_deps`; `cosmic_files` keeps carrying only the binaries, now without the trailing `$(cosmic_lua)` reference that had always expanded empty (it was defined only after the includes).

## Verification (per the issue: database.out before/after)

Effective deps from `o/lib/build/make/database.out` for sample tests, after vs before:

- `json_test` (generic): no explicit deps — pattern rule only (own `.lua` + `$(cosmic_bin)`); before: 40 entries of redundant stdlib/bins/staged wiring
- `reporter_test`: exactly the six `$(build_files)`
- `stats_test` (perf): exactly `$(perf_lua)`
- `publish_test`: exactly `o/lib/docs/publish.lua`
- `cosmos_test` / `tl_test`: staged dir prereq + `TEST_DIR = o/{cosmos,tl}/.staged` (verified expanded in the `-n` recipe output)
- `cosmic_debug_test`: exactly `o/bin/cosmic-debug`

Full `bin/make ci`: **PASS**.

## Baseline note

Verification surfaced one pre-existing ratchet flap, not caused by this change: `cli/searcher.tl` lines 39–45 (the cache-miss compile path) are covered only when the script cache is cold, and the committed floor (17/27) captured a cold-cache run — the pristine-main run measured the same 13/27 this PR now records. Floor lowered to the warm-cache minimum; it only ratchets up from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pc6KgBAqdkxUF2SVieM1sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pc6KgBAqdkxUF2SVieM1sQ)_