### PR TITLE
build: retire the ambient export LUA_PATH for explicit per-recipe paths (#720)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,16 +36,13 @@ include 3p/tl/cook.mk
 
 
 # landlock-make sandbox annotations. IMPORTANT (#716): landlock-make
-# only enforces .PLEDGE/.UNVEIL for rules that set .SANDBOXED = 1, and
-# nothing in this build sets it except the sandbox-canary probe — so
-# these annotations, and every per-rule override below, are currently
-# documented intent, not active enforcement. (Even with .SANDBOXED,
-# cosmopolitan's unveil() silently no-ops on hosts without Landlock.)
-# The sandbox-canary target proves the mechanism itself still works;
-# see it before flipping enforcement on for real rules. NOTE: make
-# hands .UNVEIL values to unveil UNEXPANDED, so .PLEDGE/.UNVEIL are
-# assigned with := repo-wide, composed from the shared grant sets in
-# cook.mk (#718); keep any new override in that spelling.
+# only enforces .PLEDGE/.UNVEIL for rules that set .SANDBOXED = 1 —
+# nothing here sets it except the sandbox-canary probe, so these
+# annotations are documented intent, not active enforcement (and
+# cosmopolitan's unveil() no-ops without Landlock). The canary proves
+# the mechanism works; see it before flipping enforcement on. NOTE:
+# make hands .UNVEIL values to unveil UNEXPANDED — assign with := and
+# compose from the shared grant sets in cook.mk (#718).
 # global defaults: read-only access, no network, basic stdio
 .PLEDGE := stdio rpath
 .UNVEIL := $(unveil_base)
@@ -53,7 +50,7 @@ include 3p/tl/cook.mk
 .PHONY: help
 ## Show this help message
 help: $(build_files) | $(bootstrap_cosmic)
-	@$(bootstrap_cosmic) $(build_help) $(MAKEFILE_LIST)
+	@LUA_PATH="$(tree_lua_path)" $(bootstrap_cosmic) $(build_help) $(MAKEFILE_LIST)
 
 ## Filter targets by pattern (make test only=teal)
 filter-only = $(if $(only),$(foreach f,$1,$(if $(findstring $(only),$(f)),$(f))),$1)
@@ -68,7 +65,7 @@ $(o)/%: %
 # hermetic LUA_PATH=";;", pre-flag -> tree LUA_PATH self-healing, #666).
 $(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files) $(compile_flag_stamp)
 	@mkdir -p $(@D)
-	@f=$$(cat $(compile_flag_stamp)); if [ "$$f" = "--compile-strict" ]; then export LUA_PATH=";;"; fi; $(bootstrap_cosmic) $(include_dir_flags) $$f $< > $@.tmp
+	@f=$$(cat $(compile_flag_stamp)); if [ "$$f" = "--compile-strict" ]; then export LUA_PATH=";;"; else export LUA_PATH="$(tree_lua_path)"; fi; $(bootstrap_cosmic) $(include_dir_flags) $$f $< > $@.tmp
 	@if cmp -s $@.tmp $@ 2>/dev/null; then rm $@.tmp; else mv $@.tmp $@; fi
 
 # tl files: modules declare _tl, derive compiled .lua outputs
@@ -109,9 +106,9 @@ fetched: $(all_fetched)
 # trust the host CA store so fetches work on stock runners and behind
 # TLS-intercepting proxies. An operator SSL_CERT_FILE bundle is unveiled.
 # Fetch/stage scripts run under the pinned bootstrap but are written
-# against THIS tree's cosmic.* APIs (via the exported LUA_PATH). Without
-# the compiled stdlib as a prerequisite, a cold parallel build let
-# require() fall back to the bootstrap's embedded older-API stdlib
+# against THIS tree's cosmic.* APIs (via their explicit LUA_PATH).
+# Without the compiled stdlib as a prerequisite, a cold parallel build
+# let require() fall back to the bootstrap's embedded older-API stdlib
 # mid-compile. Unfiltered: only= must not shrink the closure.
 stdlib_lua := $(patsubst %.tl,$(o)/%.lua,$(filter lib/cosmic/%,$(foreach x,$(modules),$($(x)_tl))))
 
@@ -119,7 +116,7 @@ $(o)/%/.fetched: export SSL_USE_SYSTEM_CERTS = 1
 $(o)/%/.fetched: .PLEDGE := stdio rpath wpath cpath inet dns
 $(o)/%/.fetched: .UNVEIL := $(unveil_dep) r:/etc/resolv.conf r:/etc/ssl $(if $(SSL_CERT_FILE),r:$(SSL_CERT_FILE))
 $(o)/%/.fetched: $(o)/%/.versioned $(build_files) $(stdlib_lua) | $(bootstrap_cosmic)
-	@$(bootstrap_cosmic) -- $(build_fetch) $$(readlink $<) $(platform) $@
+	@LUA_PATH="$(tree_lua_path)" $(bootstrap_cosmic) -- $(build_fetch) $$(readlink $<) $(platform) $@
 
 # versions get staged: o/module/.staged -> o/staged/module/<ver>-<sha>
 .PHONY: staged
@@ -129,7 +126,7 @@ staged: $(all_staged)
 $(o)/%/.staged: .PLEDGE := $(pledge_build)
 $(o)/%/.staged: .UNVEIL := $(unveil_dep) rx:/usr/bin
 $(o)/%/.staged: $(o)/%/.fetched $(build_files) $(stdlib_lua)
-	@$(bootstrap_cosmic) -- $(build_stage) $$(readlink $(o)/$*/.versioned) $(platform) $< $@
+	@LUA_PATH="$(tree_lua_path)" $(bootstrap_cosmic) -- $(build_stage) $$(readlink $(o)/$*/.versioned) $(platform) $< $@
 
 all_tests := $(call filter-only,$(foreach x,$(modules),$($(x)_tests)))
 all_tested := $(patsubst %,$(o)/%.test.got,$(all_tests))
@@ -144,10 +141,13 @@ export TEST_O := $(o)
 export TEST_PLATFORM := $(platform)
 export TEST_BIN := $(o)/bin
 # TEST_TMPDIR is set per-test by cosmic --test command
-# LUA_PATH: aggregate _lua_dirs from modules
+# tree_lua_path aggregates _lua_dirs from modules. Deliberately NOT
+# exported (#720): the ambient export was the root of the stale-stdlib
+# bug class (#666, #608) — recipes opt in via LUA_PATH="$(tree_lua_path)";
+# everything else runs against the binary's embedded copy.
 space := $(subst ,, )
 lua_path_dirs := $(foreach m,$(modules),$($(m)_lua_dirs))
-export LUA_PATH := $(subst $(space),;,$(foreach d,$(lua_path_dirs),$(CURDIR)/$(d)/?.lua $(CURDIR)/$(d)/?/init.lua));;
+tree_lua_path := $(subst $(space),;,$(foreach d,$(lua_path_dirs),$(CURDIR)/$(d)/?.lua $(CURDIR)/$(d)/?/init.lua));;
 export NO_COLOR := 1
 
 # Test rule: execute test via cosmic --test command
@@ -176,7 +176,7 @@ $(quicksand_sandbox_tests): .UNVEIL =
 
 $(o)/%.tl.test.got: $(o)/%.lua $(cosmic_bin)
 	@mkdir -p $(@D)
-	@TEST_DIR=$(TEST_DIR) PATH=$(CURDIR)/$(o)/bin:$$PATH $(cosmic_bin) --test $(basename $@) $(cosmic_bin) $<
+	@TEST_DIR=$(TEST_DIR) LUA_PATH="$(tree_lua_path)" PATH=$(CURDIR)/$(o)/bin:$$PATH $(cosmic_bin) --test $(basename $@) $(cosmic_bin) $<
 
 # Test deps beyond the pattern rule (own compiled .lua + $(cosmic_bin))
 # live in each module's cook.mk: perf tests attach $(perf_lua), build
@@ -202,7 +202,7 @@ $(o)/coverage/%.tl.test.got: .PLEDGE := $(pledge_build)
 $(o)/coverage/%.tl.test.got: .UNVEIL := $(unveil_test)
 $(o)/coverage/%.tl.test.got: $(o)/%.lua $(cosmic_bin)
 	@mkdir -p $(@D)
-	@TEST_DIR=$(TEST_DIR) COSMIC_COVERAGE=1 PATH=$(CURDIR)/$(o)/bin:$$PATH $(cosmic_bin) --test $(basename $@) $(cosmic_bin) $<
+	@TEST_DIR=$(TEST_DIR) COSMIC_COVERAGE=1 LUA_PATH="$(tree_lua_path)" PATH=$(CURDIR)/$(o)/bin:$$PATH $(cosmic_bin) --test $(basename $@) $(cosmic_bin) $<
 
 # Coverage ratchet: the committed baseline records covered/total per
 # file; the check fails when coverage declines or the file set drifts.
@@ -257,7 +257,7 @@ $(enforce_got): .UNVEIL =
 
 $(o)/enforce/%.tl.test.got: $(o)/%.lua $(cosmic_bin)
 	@mkdir -p $(@D)
-	@TEST_BIN=$(o)/bin COSMIC_ENFORCE=1 PATH=$(CURDIR)/$(o)/bin:$$PATH \
+	@TEST_BIN=$(o)/bin COSMIC_ENFORCE=1 LUA_PATH="$(tree_lua_path)" PATH=$(CURDIR)/$(o)/bin:$$PATH \
 	  $(cosmic_bin) --test $(basename $@) $(cosmic_bin) $<
 
 $(o)/enforce-summary.txt: $(enforce_got) | $(cosmic_bin)
@@ -394,7 +394,7 @@ $(o)/%.tl.benchmark.got: .PLEDGE := $(pledge_build)
 $(o)/%.tl.benchmark.got: .UNVEIL := $(unveil_run)
 $(o)/%.tl.benchmark.got: %.tl $(cosmic_bin) | $(bootstrap_files)
 	@mkdir -p $(@D)
-	@set +e; $(cosmic_bin) --benchmark $< > $(basename $@).out 2> $(basename $@).err; echo $$? > $@
+	@set +e; LUA_PATH="$(tree_lua_path)" $(cosmic_bin) --benchmark $< > $(basename $@).out 2> $(basename $@).err; echo $$? > $@
 
 # Documentation generation - render .tl files as markdown
 # Module sources for docs: all _tl files (excludes tests and examples).
@@ -456,7 +456,7 @@ doc-publish: .PLEDGE := $(pledge_build) inet dns
 doc-publish: .UNVEIL := $(unveil_run) rwc:.git rwc:. r:/home r:/root
 doc-publish: $(all_docs) $(docs_publish) | $(bootstrap_cosmic)
 	@test -n "$(SOURCE_SHA)" || { echo "SOURCE_SHA required"; exit 1; }
-	@$(bootstrap_cosmic) -- $(docs_publish) $(SOURCE_SHA) $(o)/docs $(or $(DOCS_BRANCH),docs)
+	@LUA_PATH="$(tree_lua_path)" $(bootstrap_cosmic) -- $(docs_publish) $(SOURCE_SHA) $(o)/docs $(or $(DOCS_BRANCH),docs)
 
 # CI stages
 ci_stages := format teal test example lint coverage

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -9,7 +9,9 @@ build_lint := $(o)/lib/build/lint.lua
 build_files := $(build_fetch) $(build_stage) $(build_portable) $(build_reporter) $(build_help) $(build_lint)
 build_tests := $(wildcard lib/build/*_test.tl)
 
-reporter := $(bootstrap_cosmic) -- $(build_reporter)
+# recursive (=): tree_lua_path is computed in the Makefile after the
+# includes; recipes expand it at run time (#720)
+reporter = LUA_PATH="$(tree_lua_path)" $(bootstrap_cosmic) -- $(build_reporter)
 # lint.lua delegates its shared checks to cosmic.cli.style; LUA_PATH points
 # at this tree's freshly compiled modules (the doc/index.tl pattern) so the
 # delegation runs THIS tree's style code, not the bootstrap's embedded copy.
@@ -27,7 +29,7 @@ $(build_test_got): $(build_files)
 # make-help snapshot: generate actual help output
 $(o)/lib/build/make-help.snap: Makefile $(build_help) | $(bootstrap_cosmic)
 	@mkdir -p $(@D)
-	@$(bootstrap_cosmic) $(build_help) Makefile > $@
+	@LUA_PATH="$(tree_lua_path)" $(bootstrap_cosmic) $(build_help) Makefile > $@
 
 # makefile validation outputs
 build_make_out := $(o)/lib/build/make

--- a/lib/perf/cook.mk
+++ b/lib/perf/cook.mk
@@ -34,7 +34,7 @@ PERF_ONLY ?=
 PERF_THRESHOLD ?= 10
 
 perf_only_flag = $(if $(PERF_ONLY),--only $(PERF_ONLY))
-perf_cmd = PERF_BIN=$(PERF_BIN) $(PERF_BIN) -- $(perf_run) \
+perf_cmd = PERF_BIN=$(PERF_BIN) LUA_PATH="$(tree_lua_path)" $(PERF_BIN) -- $(perf_run) \
 	--samples $(PERF_SAMPLES) --min-secs $(PERF_MIN_SECS) $(perf_only_flag)
 
 perf_sandbox := $(o)/perf
@@ -73,14 +73,14 @@ perf-baseline: $$(perf_lua) $(cosmic_bin)
 perf-compare: .PLEDGE := $(pledge_build)
 perf-compare: .UNVEIL := $(unveil_test)
 
-perf_compare_cmd = $(PERF_BIN) -- $(perf_run) --compare \
+perf_compare_cmd = LUA_PATH="$(tree_lua_path)" $(PERF_BIN) -- $(perf_run) --compare \
 	$(perf_sandbox)/baseline.json $(perf_sandbox)/current.json \
 	--threshold $(PERF_THRESHOLD)
 
 # Final stage: reclassify any surviving regression the current binary
 # cannot reproduce against itself (selfcheck-b vs the current run) as
 # "noise" rather than a failure — the A/A control, run automatically.
-perf_triage_cmd = $(PERF_BIN) -- $(perf_run) --compare \
+perf_triage_cmd = LUA_PATH="$(tree_lua_path)" $(PERF_BIN) -- $(perf_run) --compare \
 	$(perf_sandbox)/baseline.json $(perf_sandbox)/current.json \
 	--threshold $(PERF_THRESHOLD) \
 	--selfcheck-a $(perf_sandbox)/current.json \
@@ -104,7 +104,7 @@ perf-compare: perf
 perf-selfcheck: .PLEDGE := $(pledge_build)
 perf-selfcheck: .UNVEIL := $(unveil_test)
 
-perf_selfcheck_cmd = $(PERF_BIN) -- $(perf_run) --compare \
+perf_selfcheck_cmd = LUA_PATH="$(tree_lua_path)" $(PERF_BIN) -- $(perf_run) --compare \
 	$(perf_sandbox)/selfcheck-a.json $(perf_sandbox)/selfcheck-b.json \
 	--threshold $(PERF_THRESHOLD)
 


### PR DESCRIPTION
Part of #713 — lands finding 8 (sub-issue #720), finishing the direction #666 started.

## What

The Makefile globally exported a tree-wide `LUA_PATH`, so every recipe inherited it — the root of the recurring stale-code bug class (#666's mid-compile fallback, #608's poisoned index): a `require` in any build script could silently resolve against the bootstrap's embedded older stdlib or a stale tree copy, and hermeticity depended on individual recipes remembering to override.

The aggregate value survives as **`tree_lua_path`, deliberately not exported**. Per the issue's inventory step, each call site was classified by what it actually `require`s:

**Opt in with `LUA_PATH="$(tree_lua_path)"`** (genuinely need tree modules):
- the three test lanes — tests require `types.*`, `lib.docs.*`, the build tools, and `perf.*` from the tree, and spawned children inherit the value
- fetch/stage — their scripts run under the pinned bootstrap against *this* tree's `cosmic.*` APIs (previously via the ambient export; the comment said so explicitly)
- reporter, make-help (help target + snapshot), doc-publish — compiled build tools run under the bootstrap
- benchmark (the perf bench harness requires `perf.*`) and the four `perf_*` command variables
- the non-strict compile fallback (the pre-#666 self-healing path; strict compiles stay `LUA_PATH=";;"`)

**Now hermetic** (embedded stdlib only): `--report`, `--check-types`/`--check-format`, gendoc/docs rules, the coverage report/baseline tools, the canary feature check. The embedded copies are byte-identical to the tree copies at build time (the binary depends on them) minus exactly the mid-rebuild shadowing where this bug class lives.

**Untouched**: the already-explicit narrow spellings (doc-index, linter, regen-types) — they were the model for this change.

One mechanical note: `reporter` becomes recursively expanded (`=`) because `tree_lua_path` is computed in the Makefile after the cook.mk includes; recipes expand it at run time.

## Verification

`bin/make clean && bin/make ci` — a **from-clean** run, so fetch, stage, the full compile, and every gate stage executed under the new explicit paths (a warm run would have skipped the reworked recipes): **`ci: PASS`**. Tests that manipulate `LUA_PATH` themselves (`binary_test`, `guide_test`, `skill_test` strip it; `reporter_test` extends it) all pass — none required the ambient export.

The one path CI doesn't exercise is `doc-publish` (needs `SOURCE_SHA` and pushes the docs branch); it gets the same tree path it previously inherited ambiently, and docs.yml will exercise it on the next push to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pc6KgBAqdkxUF2SVieM1sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pc6KgBAqdkxUF2SVieM1sQ)_