### PR TITLE
build: smaller sharp edges — shadow guard, honest only= docs, derived platform, anchored PATH (#721)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,7 +346,7 @@ line, which survives any truncation.
 bin/make test                 # all tests
 bin/make coverage             # tests with line coverage + ratchet vs lib/cosmic/coverage/baseline.txt
 bin/make coverage-baseline    # rewrite the committed coverage ratchet floor
-bin/make test only=sqlite     # filter by pattern
+bin/make test only=sqlite     # filter by substring (also narrows fetch/stage)
 bin/make example              # run Example_* functions
 bin/make benchmark            # run Benchmark_* functions
 ```

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,9 @@ export FETCH_O := $(CURDIR)/$(o)/fetched
 TMP ?= /tmp
 export TMPDIR := $(TMP)
 
-# Platform for build scripts (all deps use wildcard "*" platform)
-platform := linux-x86_64
+# Platform tag for fetch/stage matching and TEST_PLATFORM. All deps pin
+# "*" today; derived so a non-wildcard dep cannot mis-fetch cross-OS (#721)
+platform := $(shell uname -s | tr '[:upper:]' '[:lower:]')-$(shell uname -m)
 
 ## INCLUDE_DIRS: directories to search for type definitions (repeatable)
 INCLUDE_DIRS ?= lib
@@ -52,7 +53,7 @@ include 3p/tl/cook.mk
 help: $(build_files) | $(bootstrap_cosmic)
 	@LUA_PATH="$(tree_lua_path)" $(bootstrap_cosmic) $(build_help) $(MAKEFILE_LIST)
 
-## Filter targets by pattern (make test only=teal)
+## Filter targets by substring (make test only=teal; also narrows fetch/stage)
 filter-only = $(if $(only),$(foreach f,$1,$(if $(findstring $(only),$(f)),$(f))),$1)
 
 cp := cp -p
@@ -145,7 +146,8 @@ export TEST_BIN := $(o)/bin
 # exported (#720): the ambient export was the root of the stale-stdlib
 # bug class (#666, #608) — recipes opt in via LUA_PATH="$(tree_lua_path)";
 # everything else runs against the binary's embedded copy.
-space := $(subst ,, )
+empty :=
+space := $(empty) $(empty)
 lua_path_dirs := $(foreach m,$(modules),$($(m)_lua_dirs))
 tree_lua_path := $(subst $(space),;,$(foreach d,$(lua_path_dirs),$(CURDIR)/$(d)/?.lua $(CURDIR)/$(d)/?/init.lua));;
 export NO_COLOR := 1
@@ -495,6 +497,4 @@ ci:
 	done
 	@if [ -f $(o)/failed ]; then echo "ci: FAIL ($$(paste -sd' ' $(o)/failed))"; exit 1; else echo "ci: PASS"; fi
 
-debug-modules:
-	@echo $(modules)
 

--- a/cook.mk
+++ b/cook.mk
@@ -28,7 +28,9 @@ bootstrap_url := https://github.com/whilp/cosmic/releases/download/2026-07-06-9b
 # verify it before executing. Update this when bumping bootstrap_url.
 bootstrap_sha256 := 2217687a73958110ebeae85a2d8b7af401472212bbdd168cd24a06fc37793173
 
-export PATH := $(o)/bootstrap:$(PATH)
+# anchored with CURDIR like the Makefile's $(o)/bin entry — a relative
+# entry breaks for any recipe that cd's (#721)
+export PATH := $(CURDIR)/$(o)/bootstrap:$(PATH)
 
 $(bootstrap_cosmic):
 	@mkdir -p $(@D)

--- a/lib/cook.mk
+++ b/lib/cook.mk
@@ -9,3 +9,11 @@ include lib/cosmic/cook.mk
 include lib/docs/cook.mk
 include lib/perf/cook.mk
 include lib/types/cook.mk
+
+# A committed foo.lua beside a module's foo.tl would shadow the .tl at
+# require time (package.path tries .lua first), and invites stale-copy
+# confusion in o/ — refuse to configure (#721). Note make itself is NOT
+# the hazard: shortest-stem selection picks the %.tl compile rule over
+# the $(o)/%: % copy rule (verified against cosmo-make).
+tl_shadowed := $(wildcard $(patsubst %.tl,%.lua,$(foreach m,$(modules),$($(m)_tl))))
+$(if $(tl_shadowed),$(error committed .lua beside .tl source: $(tl_shadowed)))


### PR DESCRIPTION
Part of #713 — lands finding 9 (sub-issue #721), the last open sub-issue.

## Items

- **Sibling `.lua` guard** — a committed `foo.lua` beside a module's `foo.tl` now fails at parse time with the offending path (`lib/cook.mk`, after all `_tl` declarers are included). One empirical correction to the issue's premise: **make itself is not the hazard** — shortest-stem rule selection picks `$(o)/%.lua: %.tl` over `$(o)/%: %` regardless of declaration order (verified against cosmo-make with a live `foo.tl`/`foo.lua` pair; the compile rule fired). The real hazard is *require time*: `package.path` tries `.lua` before the `.tl` searcher, so a stale committed copy would silently shadow the source. The guard covers both readings either way.
- **`only=` documented honestly** as a substring match (`findstring`) in the help text and AGENTS.md — including the undocumented-but-useful fact that it also narrows fetch/stage targets. Documenting rather than upgrading to `%`-patterns keeps the "no behavior change" non-goal.
- **`platform` derived** from `uname -s`/`-m` instead of hardcoded `linux-x86_64` (expands to the identical string on Linux — verified in the database dump). Every dep pins `"*"` today, so this only prevents a future non-wildcard dep from silently mis-fetching cross-OS.
- **Bootstrap `PATH` export anchored with `$(CURDIR)`**, matching the Makefile's `$(o)/bin` entry — a relative entry breaks for any recipe that `cd`s.
- **`space := $(subst ,, )`** rewritten as the standard `empty :=` / `space := $(empty) $(empty)` idiom.
- **`debug-modules`** (undocumented echo target) dropped for the line budget; `make -p` serves the same purpose.

The remaining #721 bullet — the duplicate cosmic prereq in the test rule — already landed with #715 (#723).

## Verification

- Guard: planted `lib/cosmic/json.lua` → `lib/cook.mk:19: *** committed .lua beside .tl source: lib/cosmic/json.lua. Stop.`; removed → parses clean.
- `platform := linux-x86_64` byte-identical in the database dump.
- Full `bin/make ci`: PASS, Makefile at the 500-line cap.

With this merged, all nine #713 findings are landed (#714–#721 complete). Follow-on direction lives in the hermeticity tracking issue #728.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pc6KgBAqdkxUF2SVieM1sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pc6KgBAqdkxUF2SVieM1sQ)_