### PR TITLE
build: clamp the ambient environment — LC_ALL, TZ, deliberate PATH (#731)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ MAKEFLAGS += -j$(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || ech
 modules :=
 o := o
 
-export PATH := $(CURDIR)/$(o)/bin:$(PATH)
+# PATH, LC_ALL, TZ are clamped in cook.mk (#731) — deliberate, not inherited
 export STAGE_O := $(CURDIR)/$(o)/staged
 export FETCH_O := $(CURDIR)/$(o)/fetched
 

--- a/cook.mk
+++ b/cook.mk
@@ -1,6 +1,18 @@
 # cosmic repository module definitions
 # This file aggregates all modules for the build system
 
+# Environment clamp (#731): recipes otherwise inherit the caller's full
+# environment, so hermeticity would depend on the invoking shell being
+# unremarkable. Pin locale and timezone, and construct PATH deliberately
+# — o/bootstrap, o/bin (staged tools), then a small, visible host-tool
+# surface (#732 shrinks it; HOST_PATH= overrides for unusual hosts).
+# Entries are CURDIR-anchored: a relative entry breaks for any recipe
+# that cd's (#721). Gate: the env-clamp fixture in lib/build/cook.mk.
+export LC_ALL := C
+export TZ := UTC
+HOST_PATH ?= /usr/bin:/bin
+export PATH := $(CURDIR)/$(o)/bootstrap:$(CURDIR)/$(o)/bin:$(HOST_PATH)
+
 # Shared sandbox grant sets (#718): compose per rule, so a deliberate
 # deviation reads as `$(unveil_test) r:extra` at the rule instead of a
 # wall of near-identical 90-column strings. Defined here (before the
@@ -27,10 +39,6 @@ bootstrap_url := https://github.com/whilp/cosmic/releases/download/2026-07-06-9b
 # SHA-256 of the bootstrap cosmic binary. It compiles the entire project, so
 # verify it before executing. Update this when bumping bootstrap_url.
 bootstrap_sha256 := 2217687a73958110ebeae85a2d8b7af401472212bbdd168cd24a06fc37793173
-
-# anchored with CURDIR like the Makefile's $(o)/bin entry — a relative
-# entry breaks for any recipe that cd's (#721)
-export PATH := $(CURDIR)/$(o)/bootstrap:$(PATH)
 
 $(bootstrap_cosmic):
 	@mkdir -p $(@D)

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -120,7 +120,22 @@ $(build_make_out)/ci-launder.out: $(build_make_srcs)
 	@mkdir -p $(@D)
 	@code=0; $(MAKE) ci o=$(o)/citest ci_stages=ci-selftest-launder >$@.tmp 2>&1 || code=$$?; echo "exit:$$code" >> $@.tmp; mv $@.tmp $@
 
-build_make_outputs := $(build_make_out)/dry-run.out $(build_make_out)/database.out $(build_make_out)/only-database.out $(build_make_out)/ci-launder.out
+# Environment clamp probe (#731): echoes the env a recipe actually sees.
+# Test apparatus like ci-selftest-launder above, not a help target.
+.PHONY: env-probe
+env-probe:
+	@echo "LC_ALL=$$LC_ALL"; echo "TZ=$$TZ"; echo "PATH=$$PATH"
+
+# Gate for the clamp: run a nested make under a hostile caller env — a
+# non-C locale, a non-UTC timezone, a poisoned PATH head — and record
+# what the probe recipe saw. makefile_test asserts the clamp held; if
+# someone reverts the exports in cook.mk this fixture goes hostile and
+# the test fails, so the property stays falsifiable (#728).
+$(build_make_out)/env-clamp.out: $(build_make_srcs)
+	@mkdir -p $(@D)
+	@code=0; LC_ALL=tr_TR.UTF-8 TZ=Pacific/Kiritimati PATH="/hostile/bin:$$PATH" $(MAKE) -s env-probe >$@.tmp 2>&1 || code=$$?; echo "exit:$$code" >> $@.tmp; mv $@.tmp $@
+
+build_make_outputs := $(build_make_out)/dry-run.out $(build_make_out)/database.out $(build_make_out)/only-database.out $(build_make_out)/ci-launder.out $(build_make_out)/env-clamp.out
 
 # makefile_test consumes the fixtures in both test lanes
 build_makefile_test_got := \

--- a/lib/build/makefile_test.tl
+++ b/lib/build/makefile_test.tl
@@ -92,6 +92,29 @@ local function test_ci_grading_catches_exit_after_clean_summary()
 end
 test_ci_grading_catches_exit_after_clean_summary()
 
+-- test: the environment clamp holds under a hostile caller env (#731).
+-- The env-clamp.out fixture runs a nested make with a non-C locale, a
+-- non-UTC timezone, and a poisoned PATH head; the probe recipe echoes
+-- what it actually sees. Recipes must get the pinned values and the
+-- deliberately constructed PATH, never the caller's ambient ones.
+local function test_env_clamp_holds_under_hostile_env()
+  local result = read_make_output("env-clamp.out")
+  assert(result.exit_code == 0,
+    "expected env-probe to succeed under a hostile env, got code: " ..
+    tostring(result.exit_code) .. "\noutput: " .. result.output:sub(1, 500))
+  assert(result.output:match("\nLC_ALL=C\n") or result.output:match("^LC_ALL=C\n"),
+    "expected recipes to see LC_ALL=C\noutput: " .. result.output:sub(1, 500))
+  assert(result.output:match("\nTZ=UTC\n"),
+    "expected recipes to see TZ=UTC\noutput: " .. result.output:sub(1, 500))
+  local path = result.output:match("\nPATH=([^\n]*)")
+  assert(path, "expected a PATH= line in probe output")
+  assert(not path:find("/hostile/bin", 1, true),
+    "caller's PATH leaked into recipes: " .. path)
+  assert(path:find("/o/bootstrap:", 1, true) and path:find("/o/bin:", 1, true),
+    "expected the deliberate o/bootstrap and o/bin entries, got: " .. path)
+end
+test_env_clamp_holds_under_hostile_env()
+
 -- test: the lint stage is guarded against a silently-empty file list
 -- (#719). Outside a git checkout `git ls-files` fails silently and
 -- lint would green-light zero checks; the summary recipe must carry


### PR DESCRIPTION
Part of #728 (item 3); implements #731.

## Problem

Recipes inherited the caller's full environment: locale (`LC_*`) changes sort orders and tool output formats, `TZ` changes timestamps, and `PATH` beyond the two entries the build prepended was whatever the host session carried. This is the same leak class #720/#727 closed for `LUA_PATH`, one layer down — hermeticity depended on the invoking shell being unremarkable.

## Change

- **cook.mk** now clamps the environment for every recipe: `export LC_ALL := C`, `export TZ := UTC`, and a deliberately constructed `PATH` — `o/bootstrap`, `o/bin` (staged tools), then `HOST_PATH ?= /usr/bin:/bin`. The host-tool surface is now a single visible knob (feeds #732), overridable with `HOST_PATH=` for unusual hosts. Entries stay CURDIR-anchored (#721).
- **Makefile** retires its additive `export PATH := …:$(PATH)` prepend (the Makefile is at its 500-line cap, so the clamp lives in cook.mk per #728's non-goal note).
- **Gate** (#728 discipline: every hermeticity property gets a gate that proves it): a new `env-clamp.out` fixture in `lib/build/cook.mk` runs a nested make under a hostile caller env — `LC_ALL=tr_TR.UTF-8 TZ=Pacific/Kiritimati PATH=/hostile/bin:…` — and an `env-probe` apparatus target records what a recipe actually sees. `makefile_test.tl` asserts the pinned values arrived and the poisoned PATH head did not.

## Verification

- `bin/make ci` → `ci: PASS` (format, teal, test, example, lint, coverage — full gate, cold build).
- Red test: commenting out the exports and re-running `bin/make test only=makefile` fails the new assertion; restoring them passes. The property is falsifiable, not assumed.
- Fixture output on this host:
  ```
  LC_ALL=C
  TZ=UTC
  PATH=/home/user/cosmic/o/bootstrap:/home/user/cosmic/o/bin:/usr/bin:/bin
  ```

Deferred per the issue: the per-recipe env allowlist waits until recipes migrate to `.tl` scripts under the bootstrap (#732), where `cosmic.env` can own it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpRbXQpCHHmd3Tx15HC3P6

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpRbXQpCHHmd3Tx15HC3P6)_