### PR TITLE
build: enforce the sandbox on the bootstrap-exec rule family (#729)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -87,18 +87,13 @@ jobs:
         shell: bash
         run: |
           echo "compile-flag: $(cat o/bootstrap/compile-flag)"
-          ls -la o/bootstrap/
+          echo "bootstrap magic: $(head -c 4 o/bootstrap/cosmic | od -An -c | tr -d ' ')"
+          ls ~/.ape-* 2>/dev/null || echo "no ~/.ape loader"
           rm -f o/lib/docs/publish_test.lua o/ci-ok-* o/*-summary.txt
           sudo unshare --net sh -c '
             o/bootstrap/cosmic -e "assert(require(\"cosmic.quicksand.netns\").bring_up(\"lo\"))" \
               && exec sudo -u runner bin/make -j ci' 2>&1 \
-            | grep -a -B 15 -A 15 "module not found" | head -80
-          echo "=== solo rerun of the same target in this lane, for contrast ==="
-          rm -f o/lib/docs/publish_test.lua
-          sudo unshare --net sh -c '
-            o/bootstrap/cosmic -e "assert(require(\"cosmic.quicksand.netns\").bring_up(\"lo\"))" \
-              && exec sudo -u runner bin/make o/lib/docs/publish_test.lua' 2>&1 | head -20
-          echo "solo exit: $?; target exists: $(ls o/lib/docs/publish_test.lua 2>&1)"
+            | { grep -a -B 15 -A 15 "module not found" || echo "rerun did NOT reproduce"; } | head -80
 
   # Reproducibility gate (#733): build the binary twice from the same
   # tree — the second time into a fresh output tree so the whole

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,17 +57,19 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      # fetch AND stage online: staging is a local, deterministic
-      # function of the sha-pinned archives (the netns red-test proves a
-      # missing archive still fails loudly offline), and pre-staging
-      # keeps the offline phase's scheduling profile close to the build
-      # job's — a step-2 burst that raced staging against the leftover
-      # compiles produced a scheduling-sensitive module-resolution
-      # failure in publish_test that no grant explains (see the
-      # diagnostic step below).
-      - name: fetch and stage with network allowed
+      # fetch, stage, AND compile online; only the checks/tests/summaries
+      # phase runs network-denied. The compile rules are hermetic and
+      # pledge-denied network structurally (#729), so moving them online
+      # does not weaken the property this job proves — that the parts of
+      # the gate that RUN code (tests, examples, checks) cannot reach the
+      # network. The narrower split also sidesteps a first-fresh-run-only
+      # sandbox anomaly in this lane: a parallel burst of freshly
+      # sandboxed compiles under Landlock intermittently lost module
+      # resolution (identical unveil sets, solo rerun green) — suspected
+      # landlock-make vfork/unveil state interaction, tracked upstream.
+      - name: fetch, stage, and build with network allowed
         shell: bash -x {0}
-        run: bin/make -j staged
+        run: bin/make -j staged files
 
       - name: make ci with network denied
         shell: bash -x {0}
@@ -75,25 +77,6 @@ jobs:
           sudo unshare --net sh -c '
             o/bootstrap/cosmic -e "assert(require(\"cosmic.quicksand.netns\").bring_up(\"lo\"))" \
               && exec sudo -u runner bin/make -j ci'
-
-      # Temporary diagnostic (#729 family 2): the publish_test compile
-      # fails module resolution only in this lane and only under the ci
-      # sub-make — a solo rerun of the same target in the same netns
-      # passed with a complete unveil set. Reproduce IN the failing
-      # context (full ci goal, sub-make) with -d and capture that
-      # target's actual unveil dump plus the error.
-      - name: debug failed compile under sandbox
-        if: failure()
-        shell: bash
-        run: |
-          echo "compile-flag: $(cat o/bootstrap/compile-flag)"
-          echo "bootstrap magic: $(head -c 4 o/bootstrap/cosmic | od -An -c | tr -d ' ')"
-          ls ~/.ape-* 2>/dev/null || echo "no ~/.ape loader"
-          rm -f o/lib/docs/publish_test.lua o/ci-ok-* o/*-summary.txt
-          sudo unshare --net sh -c '
-            o/bootstrap/cosmic -e "assert(require(\"cosmic.quicksand.netns\").bring_up(\"lo\"))" \
-              && exec sudo -u runner bin/make -j ci' 2>&1 \
-            | { grep -a -B 15 -A 15 "module not found" || echo "rerun did NOT reproduce"; } | head -80
 
   # Reproducibility gate (#733): build the binary twice from the same
   # tree — the second time into a fresh output tree so the whole

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -77,17 +77,21 @@ jobs:
               && exec sudo -u runner bin/make -j ci'
 
       # Temporary diagnostic (#729 family 2): the publish_test compile
-      # failed module resolution ONLY in this lane; rerun it solo with
-      # landlock-make debug to see the exact unveil set it got.
+      # fails module resolution only in this lane and only under the ci
+      # sub-make — a solo rerun of the same target in the same netns
+      # passed with a complete unveil set. Reproduce IN the failing
+      # context (full ci goal, sub-make) with -d and capture that
+      # target's actual unveil dump plus the error.
       - name: debug failed compile under sandbox
         if: failure()
         shell: bash
         run: |
-          rm -f o/lib/docs/publish_test.lua
+          rm -f o/lib/docs/publish_test.lua o/ci-ok-* o/*-summary.txt
           sudo unshare --net sh -c '
             o/bootstrap/cosmic -e "assert(require(\"cosmic.quicksand.netns\").bring_up(\"lo\"))" \
-              && exec sudo -u runner bin/make -d o/lib/docs/publish_test.lua' 2>&1 \
-            | grep -aiE "unveil|pledging|sandboxing|publish|error|denied" | head -100
+              && exec sudo -u runner bin/make -j -d ci' 2>&1 \
+            | grep -aE "publish|module not found" -A 45 \
+            | grep -aiE "unveil|pledging|sandboxing|publish|error|denied|Executing" | head -150
 
   # Reproducibility gate (#733): build the binary twice from the same
   # tree — the second time into a fresh output tree so the whole

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,9 +57,17 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: fetch with network allowed
+      # fetch AND stage online: staging is a local, deterministic
+      # function of the sha-pinned archives (the netns red-test proves a
+      # missing archive still fails loudly offline), and pre-staging
+      # keeps the offline phase's scheduling profile close to the build
+      # job's — a step-2 burst that raced staging against the leftover
+      # compiles produced a scheduling-sensitive module-resolution
+      # failure in publish_test that no grant explains (see the
+      # diagnostic step below).
+      - name: fetch and stage with network allowed
         shell: bash -x {0}
-        run: bin/make -j fetched
+        run: bin/make -j staged
 
       - name: make ci with network denied
         shell: bash -x {0}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -86,12 +86,19 @@ jobs:
         if: failure()
         shell: bash
         run: |
+          echo "compile-flag: $(cat o/bootstrap/compile-flag)"
+          ls -la o/bootstrap/
           rm -f o/lib/docs/publish_test.lua o/ci-ok-* o/*-summary.txt
           sudo unshare --net sh -c '
             o/bootstrap/cosmic -e "assert(require(\"cosmic.quicksand.netns\").bring_up(\"lo\"))" \
-              && exec sudo -u runner bin/make -j -d ci' 2>&1 \
-            | grep -aE "publish|module not found" -A 45 \
-            | grep -aiE "unveil|pledging|sandboxing|publish|error|denied|Executing" | head -150
+              && exec sudo -u runner bin/make -j ci' 2>&1 \
+            | grep -a -B 15 -A 15 "module not found" | head -80
+          echo "=== solo rerun of the same target in this lane, for contrast ==="
+          rm -f o/lib/docs/publish_test.lua
+          sudo unshare --net sh -c '
+            o/bootstrap/cosmic -e "assert(require(\"cosmic.quicksand.netns\").bring_up(\"lo\"))" \
+              && exec sudo -u runner bin/make o/lib/docs/publish_test.lua' 2>&1 | head -20
+          echo "solo exit: $?; target exists: $(ls o/lib/docs/publish_test.lua 2>&1)"
 
   # Reproducibility gate (#733): build the binary twice from the same
   # tree — the second time into a fresh output tree so the whole

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -68,6 +68,19 @@ jobs:
             o/bootstrap/cosmic -e "assert(require(\"cosmic.quicksand.netns\").bring_up(\"lo\"))" \
               && exec sudo -u runner bin/make -j ci'
 
+      # Temporary diagnostic (#729 family 2): the publish_test compile
+      # failed module resolution ONLY in this lane; rerun it solo with
+      # landlock-make debug to see the exact unveil set it got.
+      - name: debug failed compile under sandbox
+        if: failure()
+        shell: bash
+        run: |
+          rm -f o/lib/docs/publish_test.lua
+          sudo unshare --net sh -c '
+            o/bootstrap/cosmic -e "assert(require(\"cosmic.quicksand.netns\").bring_up(\"lo\"))" \
+              && exec sudo -u runner bin/make -d o/lib/docs/publish_test.lua' 2>&1 \
+            | grep -aiE "unveil|pledging|sandboxing|publish|error|denied" | head -100
+
   # Reproducibility gate (#733): build the binary twice from the same
   # tree — the second time into a fresh output tree so the whole
   # pipeline (compile, doc index, version stamp, pack) reruns — and

--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,8 @@ fetched: $(all_fetched)
 stdlib_lua := $(patsubst %.tl,$(o)/%.lua,$(filter lib/cosmic/%,$(foreach x,$(modules),$($(x)_tl))))
 
 $(o)/%/.fetched: export SSL_USE_SYSTEM_CERTS = 1
-$(o)/%/.fetched: .PLEDGE := stdio rpath wpath cpath inet dns
-$(o)/%/.fetched: .UNVEIL := $(unveil_dep) r:/etc/resolv.conf r:/etc/ssl $(if $(SSL_CERT_FILE),r:$(SSL_CERT_FILE))
+$(o)/%/.fetched: .PLEDGE := $(pledge_build) inet dns
+$(o)/%/.fetched: .UNVEIL := $(unveil_dep) $(unveil_hostx) r:/etc/resolv.conf r:/etc/ssl $(if $(SSL_CERT_FILE),r:$(SSL_CERT_FILE))
 $(o)/%/.fetched: $(o)/%/.versioned $(build_files) $(stdlib_lua) | $(bootstrap_cosmic)
 	@LUA_PATH="$(tree_lua_path)" $(bootstrap_cosmic) -- $(build_fetch) $$(readlink $<) $(platform) $@
 
@@ -127,7 +127,7 @@ all_staged := $(patsubst %/.fetched,%/.staged,$(all_fetched))
 ## Fetch and extract all dependencies
 staged: $(all_staged)
 $(o)/%/.staged: .PLEDGE := $(pledge_build)
-$(o)/%/.staged: .UNVEIL := $(unveil_dep) rx:/usr/bin
+$(o)/%/.staged: .UNVEIL := $(unveil_dep) $(unveil_hostx)
 $(o)/%/.staged: $(o)/%/.fetched $(build_files) $(stdlib_lua)
 	@LUA_PATH="$(tree_lua_path)" $(bootstrap_cosmic) -- $(build_stage) $$(readlink $(o)/$*/.versioned) $(platform) $< $@
 

--- a/cook.mk
+++ b/cook.mk
@@ -22,10 +22,14 @@ export PATH := $(CURDIR)/$(o)/bootstrap:$(CURDIR)/$(o)/bin:$(HOST_PATH)
 pledge_build := stdio rpath wpath cpath proc exec
 unveil_base := rx:$(o)/bootstrap r:lib r:3p
 unveil_host := rx:/usr rx:/proc r:/etc r:/dev/null
-# Host set proven under real enforcement by the sandbox-canary (#724):
-# shell + coreutils + loaders. ENOENT entries are skipped, so the
+# Host set proven under real enforcement by the sandbox-canary (#724)
+# and the enforced families' CI runs: shell + coreutils + loaders.
+# /dev/null must be writable (recipes redirect to it); /dev/urandom is
+# mbedtls3's entropy source (its non-glibc build cannot use the
+# getrandom syscall, so TLS init fopens the device — fetch SIGILLed
+# under Landlock without it). ENOENT entries are skipped, so the
 # generous list is safe across hosts.
-unveil_hostx := rx:/usr rx:/bin rx:/lib rx:/lib64 rx:/proc r:/etc r:/dev/null
+unveil_hostx := rx:/usr rx:/bin rx:/lib rx:/lib64 rx:/proc r:/etc rw:/dev/null r:/dev/urandom
 unveil_dep := rx:$(o)/bootstrap r:3p rwc:$(o)
 unveil_test := $(unveil_base) rwcx:$(o) rwc:$(TMP) $(unveil_host)
 unveil_run := $(unveil_base) rwc:$(o) rwc:$(TMP) $(unveil_host)

--- a/cook.mk
+++ b/cook.mk
@@ -99,6 +99,7 @@ $(bootstrap_cosmic):
 	@echo "$(bootstrap_sha256)  $@" | sha256sum -c - || { rm -f $@; echo "bootstrap cosmic checksum verification failed" >&2; exit 1; }
 	chmod +x $@
 	@$@ --assimilate
+	@printf '\177ELF' | cmp -s - <(head -c 4 $@) || { echo "bootstrap assimilation failed: $@ is still an APE — sandboxed rules need a native ELF (no loader grants)" >&2; exit 1; }
 	@ln -sf cosmic $(@D)/lua
 
 # Strict-compile capability probe: newer bootstraps ship --compile-strict

--- a/cook.mk
+++ b/cook.mk
@@ -49,6 +49,26 @@ $(o)/%.lua: .SANDBOXED := 1
 $(o)/%.lua: .PLEDGE := $(pledge_build) fattr
 $(o)/%.lua: .UNVEIL := rwc:$(o) r:tlconfig.lua $(unveil_hostx)
 
+# Second ENFORCED family (#729): every remaining rule that execs the
+# assimilated bootstrap — fetch, stage, lint, and the reporter
+# summaries. (The check/test rules exec $(cosmic_bin), which must stay
+# a fat APE; enforcing them needs an answer for the APE loader first,
+# so they are the next family, not this one.) fetch/stage keep their
+# annotations at the rules in the Makefile; the flips live here beside
+# the grant sets.
+$(o)/%/.fetched: .SANDBOXED := 1
+$(o)/%/.staged: .SANDBOXED := 1
+$(o)/%.lint.ok: .SANDBOXED := 1
+$(o)/%.lint.ok: .PLEDGE := $(pledge_build)
+$(o)/%.lint.ok: .UNVEIL := rwc:$(o) $(unveil_hostx)
+# Reporter summaries (bootstrap + tee). test/coverage/enforce summaries
+# exec $(cosmic_bin) and stay unsandboxed with the check rules.
+reporter_summaries := $(o)/teal-summary.txt $(o)/format-summary.txt \
+  $(o)/lint-summary.txt $(o)/example-summary.txt $(o)/benchmark-summary.txt
+$(reporter_summaries): .SANDBOXED := 1
+$(reporter_summaries): .PLEDGE := $(pledge_build)
+$(reporter_summaries): .UNVEIL := rwc:$(o) $(unveil_hostx)
+
 # Type definition generation (define early so it's available to all modules).
 # Must match MODULES in lib/types/gentype.tl: "cosmo" renders the top-level
 # cosmo record (lib/types/cosmo.d.tl); the rest render lib/types/cosmo/<m>.d.tl.

--- a/cook.mk
+++ b/cook.mk
@@ -24,12 +24,13 @@ unveil_base := rx:$(o)/bootstrap r:lib r:3p
 unveil_host := rx:/usr rx:/proc r:/etc r:/dev/null
 # Host set proven under real enforcement by the sandbox-canary (#724)
 # and the enforced families' CI runs: shell + coreutils + loaders.
-# /dev/null must be writable (recipes redirect to it); /dev/urandom is
-# mbedtls3's entropy source (its non-glibc build cannot use the
-# getrandom syscall, so TLS init fopens the device — fetch SIGILLed
-# under Landlock without it). ENOENT entries are skipped, so the
+# /dev/null must be writable (recipes redirect to it). mbedtls3's
+# non-glibc build cannot use the getrandom syscall, so TLS entropy
+# fopens MBEDTLS_PLATFORM_DEV_RANDOM — which defaults to /dev/random,
+# not /dev/urandom (platform.h:398) — and fetch SIGILLs under Landlock
+# without it; grant both devices. ENOENT entries are skipped, so the
 # generous list is safe across hosts.
-unveil_hostx := rx:/usr rx:/bin rx:/lib rx:/lib64 rx:/proc r:/etc rw:/dev/null r:/dev/urandom
+unveil_hostx := rx:/usr rx:/bin rx:/lib rx:/lib64 rx:/proc r:/etc rw:/dev/null r:/dev/random r:/dev/urandom
 unveil_dep := rx:$(o)/bootstrap r:3p rwc:$(o)
 unveil_test := $(unveil_base) rwcx:$(o) rwc:$(TMP) $(unveil_host)
 unveil_run := $(unveil_base) rwc:$(o) rwc:$(TMP) $(unveil_host)

--- a/lib/build/build-stage.tl
+++ b/lib/build/build-stage.tl
@@ -100,7 +100,10 @@ end
 
 local function extract_targz(archive: string, dest_dir: string, strip: number): boolean, string
   local temp_dir = fs.mkdtemp(fs.join(fs.dirname(dest_dir), ".stage_XXXXXX"))
-  local result = spawn.run({"tar", "-xzf", archive, "-C", temp_dir})
+  -- -m / --no-same-owner: a staged tree should not inherit the archive's
+  -- mtimes or ownership, and restoring them needs utimensat/chown, which
+  -- the stage rule's pledge (#729) deliberately does not promise
+  local result = spawn.run({"tar", "-xzmf", archive, "--no-same-owner", "-C", temp_dir})
   local r = result as spawn.Result -- cast: record union, nil checked below
   if not r or not r.ok then
     fs.rmrf(temp_dir)


### PR DESCRIPTION
Part of #728 (item 1); second family of #729, after #739's compile rule.

## What flips

`.SANDBOXED := 1` on every remaining rule whose recipe execs the assimilated bootstrap:

- `$(o)/%/.fetched` — pledge gains `proc exec` (the recipe's `$(readlink …)` command substitution forks) and unveil gains the executable host dirs; network promises stay scoped here (`inet dns`), which is the structural half of #730's no-network property.
- `$(o)/%/.staged` — bare `rx:/usr/bin` becomes `unveil_hostx` (tar's gzip child needs loader paths).
- `$(o)/%.lint.ok` — `rwc:$(o)` + host dirs; sources/style/linter are auto-unveiled prerequisites.
- teal/format/lint/example/benchmark `-summary.txt` — reporter (bootstrap) + `tee`.

**Deliberately not in this family**: every rule that execs `$(cosmic_bin)` (check `.got`s, test lanes, test/coverage/enforce summaries). The built binary must stay a fat APE; enforcing those needs an answer for the APE loader under unveil first.

## What enforcement surfaced

Local pledge (seccomp) caught: tar restoring archive mtimes/ownership needs promises the stage pledge shouldn't grant — `build-stage` now extracts with `-m --no-same-owner`, which is also simply correct for a staged tree.

Real Landlock in CI caught two grant gaps, both fixed in `unveil_hostx`: `/dev/null` must be **writable** (recipes redirect to it), and mbedtls3's entropy device is **`/dev/random`** (its non-glibc build can't use the getrandom syscall, so TLS init fopens `MBEDTLS_PLATFORM_DEV_RANDOM` — fetch SIGILLed in `psa_crypto_init` without the grant). The bootstrap rule now also **verifies assimilation** (ELF magic) instead of trusting `--assimilate` silently.

## The offline-lane anomaly (upstream issue filed)

The netns lane intermittently failed exactly one compile's module resolution on the first fresh-tree run — with `landlock-make -d` proving the child's unveil set identical to passing runs, correct stamps, verified-ELF bootstrap, and any rerun (solo or full ci) green in the same lane. Suspected root cause after reading `libc/calls/unveil.c`: unveil's Landlock state is `_Thread_local static`, and landlock-make sandboxes children **between vfork() and exec()** where the child shares the parent's memory — an abnormal child exit can poison `State.fd` for later children. Filed as whilp/cosmopolitan#200 with the full evidence trail.

Sidestep here: the offline job builds online (`staged files`) and runs the checks/tests/summaries phase network-denied. Compiles are hermetic and pledge-denied network structurally, so the property the job uniquely proves — the code-running parts of the gate can't reach the network — is preserved.

## Verification

- Sandboxed fetch works end-to-end with `inet dns` through a TLS-intercepting proxy locally; sandboxed stage extracts both dep archives.
- Full cold-tree `bin/make -j ci` → `ci: PASS` locally (pledge enforced); `build` job green under real Landlock with both families enforced.
- Local netns run of the exact offline sequence (warm build → network-denied ci) → `ci: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpRbXQpCHHmd3Tx15HC3P6