### PR TITLE
build: bump landlock-make pin to 2026.07.20-a93ff63d7; restore offline split

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,19 +57,14 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      # fetch, stage, AND compile online; only the checks/tests/summaries
-      # phase runs network-denied. The compile rules are hermetic and
-      # pledge-denied network structurally (#729), so moving them online
-      # does not weaken the property this job proves — that the parts of
-      # the gate that RUN code (tests, examples, checks) cannot reach the
-      # network. The narrower split also sidesteps a first-fresh-run-only
-      # sandbox anomaly in this lane: a parallel burst of freshly
-      # sandboxed compiles under Landlock intermittently lost module
-      # resolution (identical unveil sets, solo rerun green) — suspected
-      # landlock-make vfork/unveil state interaction, tracked upstream.
-      - name: fetch, stage, and build with network allowed
+      # fetch and stage online; everything else — compiles, checks,
+      # tests, summaries — runs network-denied. (This split was briefly
+      # relaxed to build online while landlock-make corrupted sandbox
+      # state across vfork children under parallel bursts; fixed in
+      # whilp/cosmopolitan#201, pinned via bin/make.)
+      - name: fetch and stage with network allowed
         shell: bash -x {0}
-        run: bin/make -j staged files
+        run: bin/make -j staged
 
       - name: make ci with network denied
         shell: bash -x {0}

--- a/bin/make
+++ b/bin/make
@@ -4,11 +4,11 @@ set -e
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MAKE_BIN="${SCRIPT_DIR}/cosmo-make"
-RELEASE_URL="https://github.com/whilp/cosmopolitan/releases/download/2026.01.04-bc03f9aa8/make"
+RELEASE_URL="https://github.com/whilp/cosmopolitan/releases/download/2026.07.20-a93ff63d7/make"
 # SHA-256 of the landlock-make binary. This binary is executed with full
 # control over the build, so verify its integrity before running it. Update
 # this when bumping RELEASE_URL.
-MAKE_SHA256="c7c8e7f09a1ed51d875bd6b3b1048e9faeb9d76cb3c7eedf01e153cced4a9373"
+MAKE_SHA256="0f8df501908d629c748dc337682832894c2ef60cb20534833883f5e8e1902248"
 
 verify_sha256() {
     # Usage: verify_sha256 <file> <expected-hex>. Returns non-zero on mismatch.


### PR DESCRIPTION
Part of #728/#729 follow-through.

## Change

- **`bin/make` pin → `2026.07.20-a93ff63d7`**, the first release carrying whilp/cosmopolitan#201: landlock-make now `fork()`s sandboxed children instead of `vfork()`ing them. Under vfork, the sandbox setup shared cosmo unveil's `_Thread_local` Landlock state (`State.fd`) with make itself, so one abnormal child exit could corrupt every later child's ruleset — the root cause of the offline lane's intermittent lost-grant failures in #740. sha256 verified against the release's `SHA256SUMS`.
- **Offline gate restored to its stricter split**: fetch and stage online; everything else — the fresh compile burst included — network-denied. This reverts the #740 sidestep now that the cause is fixed at the source.

## Verification

- Local end-to-end with the new pin: fresh `bin/cosmo-make` download + sha verification, `staged` online, then the **full ci inside the netns** — the exact fresh-burst sequence that reproduced the corruption four times in CI — → `ci: PASS`.
- This PR's own offline job is the first real-Landlock exercise of the fixed make under that sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpRbXQpCHHmd3Tx15HC3P6

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpRbXQpCHHmd3Tx15HC3P6)_