### PR TITLE
build: enforce the sandbox on the teal/format check family (#729)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,9 +296,9 @@ teal: $(o)/teal-summary.txt
 $(o)/teal-summary.txt: $(all_teals) | $(build_reporter)
 	@$(reporter) --dir $(o) $^ | tee $@
 
-$(o)/%.teal.got: $(o)/% $(cosmic_bin) | $(bootstrap_files)
+$(o)/%.teal.got: $(o)/% $(cosmic_check_bin) | $(bootstrap_files)
 	@mkdir -p $(@D)
-	-@$(cosmic_bin) $(include_dir_flags) --check-types $< > $(basename $@).out 2> $(basename $@).err; STATUS=$$?; echo $$STATUS > $@
+	-@$(cosmic_check_bin) $(include_dir_flags) --check-types $< > $(basename $@).out 2> $(basename $@).err; STATUS=$$?; echo $$STATUS > $@
 
 all_formats := $(patsubst %,%.format.got,$(all_checkable_files))
 
@@ -308,9 +308,9 @@ format: $(o)/format-summary.txt
 $(o)/format-summary.txt: $(all_formats) | $(build_reporter)
 	@$(reporter) --dir $(o) $^ | tee $@
 
-$(o)/%.format.got: $(o)/% $(cosmic_bin) | $(bootstrap_files)
+$(o)/%.format.got: $(o)/% $(cosmic_check_bin) | $(bootstrap_files)
 	@mkdir -p $(@D)
-	-@$(cosmic_bin) --check-format $< > $(basename $@).out 2> $(basename $@).err; STATUS=$$?; echo $$STATUS > $@
+	-@$(cosmic_check_bin) --check-format $< > $(basename $@).out 2> $(basename $@).err; STATUS=$$?; echo $$STATUS > $@
 
 # Lint every tracked file (#719). git ls-files fails SILENTLY outside
 # a git checkout — an empty list would lint nothing and report green,

--- a/cook.mk
+++ b/cook.mk
@@ -67,12 +67,25 @@ $(o)/%.lint.ok: .SANDBOXED := 1
 $(o)/%.lint.ok: .PLEDGE := $(pledge_build)
 $(o)/%.lint.ok: .UNVEIL := rwc:$(o) $(unveil_hostx)
 # Reporter summaries (bootstrap + tee). test/coverage/enforce summaries
-# exec $(cosmic_bin) and stay unsandboxed with the check rules.
+# exec $(cosmic_bin) and stay unsandboxed with the test lanes.
 reporter_summaries := $(o)/teal-summary.txt $(o)/format-summary.txt \
   $(o)/lint-summary.txt $(o)/example-summary.txt $(o)/benchmark-summary.txt
 $(reporter_summaries): .SANDBOXED := 1
 $(reporter_summaries): .PLEDGE := $(pledge_build)
 $(reporter_summaries): .UNVEIL := rwc:$(o) $(unveil_hostx)
+
+# Third ENFORCED family (#729): the teal/format check rules, which exec
+# the assimilated $(cosmic_check_bin) duplicate (see lib/cosmic/cook.mk)
+# instead of the fat-APE artifact. Failures inside the sandbox surface
+# as check failures in the summaries — loud, not silent. The test and
+# example lanes (running arbitrary module code against the real APE)
+# stay unsandboxed for now.
+$(o)/%.teal.got: .SANDBOXED := 1
+$(o)/%.teal.got: .PLEDGE := $(pledge_build)
+$(o)/%.teal.got: .UNVEIL := rwc:$(o) r:tlconfig.lua $(unveil_hostx)
+$(o)/%.format.got: .SANDBOXED := 1
+$(o)/%.format.got: .PLEDGE := $(pledge_build)
+$(o)/%.format.got: .UNVEIL := rwc:$(o) r:tlconfig.lua $(unveil_hostx)
 
 # Type definition generation (define early so it's available to all modules).
 # Must match MODULES in lib/types/gentype.tl: "cosmo" renders the top-level

--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -106,6 +106,18 @@ $(cosmic_debug_bin): $(cosmic_bin)
 	@chmod +x $@
 	$(call pack-cosmic,$@)
 
+# Assimilated duplicate for sandboxed build-time exec (#729, third
+# family): the teal/format check rules exec cosmic hundreds of times,
+# and a raw APE exec falls back to loader paths (~/.ape-*) no grant
+# covers. Same bytes as the artifact, converted in place to a native
+# ELF like the bootstrap; the shipped $(cosmic_bin) stays a fat APE
+# (the cross-OS smoke lanes cover real-APE behavior).
+cosmic_check_bin := $(o)/bin/cosmic-check
+$(cosmic_check_bin): $(cosmic_bin)
+	@$(cp) $< $@
+	@$@ --assimilate
+	@printf '\177ELF' | cmp -s - <(head -c 4 $@) || { echo "cosmic-check assimilation failed: still an APE" >&2; exit 1; }
+
 cosmic: $(cosmic_bin)
 
 cosmic-debug: $(cosmic_debug_bin)


### PR DESCRIPTION
Part of #728 (item 1); third family of #729, after #739 (compile) and #740 (bootstrap-exec). First family to land on the fixed landlock-make pin (#741 / whilp/cosmopolitan#201), whose fork-based sandboxed children make parallel bursts of enforced rules safe.

## What flips

`.SANDBOXED := 1` on the teal and format check rules — the rules that exec cosmic hundreds of times per run.

**The APE-loader answer**: the shipped binary must stay a fat APE, but a raw APE exec under unveil falls back to loader paths (`~/.ape-*`) no grant covers. The checks now exec a new **assimilated duplicate**, `o/bin/cosmic-check` — same bytes as the artifact, converted in place to a native ELF, with the same verified-or-fail magic check as the bootstrap. The macOS/Windows smoke lanes continue to exercise the shipped binary's real-APE behavior.

Grants mirror the compile family (`rwc:$(o)`, `r:tlconfig.lua`, `unveil_hostx`); each check's input and the check binary are auto-unveiled prerequisites. A sandbox failure surfaces as a check failure in the summaries — loud, never silent.

**Deliberately still unsandboxed**: the test/example/benchmark lanes (they run arbitrary module code against the real APE — that boundary is intentional and where #729's incremental arc pauses), the version stamp (explicit opt-out), packing, and the ci harness itself.

## Verification

- Full cold-tree `bin/make -j ci` under the newly pinned make → `ci: PASS`, with ~600 checks running enforced (pledge live via seccomp locally; this PR's CI exercises the unveil half under real Landlock).

After this family, every rule that *builds or checks* the tree runs under active enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpRbXQpCHHmd3Tx15HC3P6

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpRbXQpCHHmd3Tx15HC3P6)_