### PR TITLE
build: enforce the example rule family (#729, fifth family)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,9 +377,7 @@ example: $(o)/example-summary.txt
 $(o)/example-summary.txt: $(all_examples) | $(build_reporter)
 	@$(reporter) --dir $(o) $^ | tee $@
 
-$(o)/%.tl.example.got: .PLEDGE := $(pledge_build)
-$(o)/%.tl.example.got: .UNVEIL := $(unveil_run)
-$(o)/%.tl.example.got: %.tl $(cosmic_bin) | $(bootstrap_files)
+$(o)/%.tl.example.got: %.tl $(cosmic_bin) $(ape_loader) | $(bootstrap_files)
 	@mkdir -p $(@D)
 	@set +e; $(cosmic_bin) --check-examples $< > $(basename $@).out 2> $(basename $@).err; echo $$? > $@
 

--- a/cook.mk
+++ b/cook.mk
@@ -89,6 +89,15 @@ $(o)/%.format.got: .SANDBOXED := 1
 $(o)/%.format.got: .PLEDGE := $(pledge_build)
 $(o)/%.format.got: .UNVEIL := rwc:$(o) r:tlconfig.lua $(unveil_hostx)
 
+# Fifth ENFORCED family (#729): examples. Same grant sets as the test
+# lanes — examples exercise the same modules (sockets, tty, chmod) and
+# embed/deploy examples exec what they build under TEST_TMPDIR. The
+# quicksand namespace examples opt out like their tests (no pledge
+# promise covers unshare); see lib/cosmic/cook.mk.
+$(o)/%.tl.example.got: .SANDBOXED := 1
+$(o)/%.tl.example.got: .PLEDGE := $(pledge_test)
+$(o)/%.tl.example.got: .UNVEIL := $(unveil_test)
+
 # Fourth ENFORCED family (#729): the plain and coverage test lanes,
 # running the real fat-APE $(cosmic_bin) via the staged o/bin/ape
 # loader (see lib/cosmic/cook.mk) — the APE stub prefers a loader

--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -148,3 +148,12 @@ cosmic_tty_test_got := \
   $(o)/lib/cosmic/tty_test.tl.test.got \
   $(o)/coverage/lib/cosmic/tty_test.tl.test.got
 $(cosmic_tty_test_got): .UNVEIL := $(unveil_test) rw:/dev/ptmx rw:/dev/pts
+
+# Namespace-exercising examples opt out of the enforced example family
+# like the quicksand tests: unshare has no pledge promise (#729)
+quicksand_sandbox_examples := \
+  $(o)/lib/cosmic/quicksand/netns_example.tl.example.got \
+  $(o)/lib/cosmic/quicksand/proxy_example.tl.example.got
+$(quicksand_sandbox_examples): .SANDBOXED := 0
+$(quicksand_sandbox_examples): .PLEDGE =
+$(quicksand_sandbox_examples): .UNVEIL =


### PR DESCRIPTION
Fifth enforced rule family for #729: `$(o)/%.tl.example.got` now runs `.SANDBOXED := 1`.

Examples exercise the same module surface as the tests (sockets, tty, chmod; embed/deploy examples exec what they build under TEST_TMPDIR), so they reuse the proven test grant sets — `pledge_test` + `unveil_test` — and stage `$(ape_loader)` as a prereq so the fat-APE exec resolves through granted paths on Landlock hosts, exactly as #743 established for the test lanes. The quicksand netns/proxy examples opt out like their tests: no pledge promise covers `unshare`.

Placement: the family block lives in root `cook.mk` beside families 1–3; the Makefile keeps only the rule itself, since it sits at its hard 500-line cap.

Deliberately not flipped: the benchmark family keeps its `.PLEDGE`/`.UNVEIL` annotations un-enforced — no CI lane runs benchmarks, so enforcing grants nothing ever exercises would violate the falsifiable-gate principle (#728). It should flip when a lane actually runs it.

Verified: all 30 examples pass under local seccomp enforcement, and `bin/make -j ci` is green; the runner's Landlock lane is the real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpRbXQpCHHmd3Tx15HC3P6

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpRbXQpCHHmd3Tx15HC3P6)_