### PR TITLE
build: pin in-tree type resolution to tree-only TL_PATH (#744)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ $(o)/.exists: ; @mkdir -p $(@D) && touch $@
 # compile .tl to .lua; flag from cook.mk's probe (strict ;; vs tree path, #666)
 $(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files) $(compile_flag_stamp)
 	@mkdir -p $(@D)
-	@f=$$(cat $(compile_flag_stamp)); if [ "$$f" = "--compile-strict" ]; then export LUA_PATH=";;"; else export LUA_PATH="$(tree_lua_path)"; fi; $(bootstrap_cosmic) $(include_dir_flags) $$f $< > $@.tmp
+	@f=$$(cat $(compile_flag_stamp)); if [ "$$f" = "--compile-strict" ]; then export LUA_PATH=";;"; else export LUA_PATH="$(tree_lua_path)"; fi; export TL_PATH="$(tree_tl_path)"; $(bootstrap_cosmic) $(include_dir_flags) $$f $< > $@.tmp
 	@if cmp -s $@.tmp $@ 2>/dev/null; then rm $@.tmp; else mv $@.tmp $@; fi
 
 # tl files: modules declare _tl, derive compiled .lua outputs
@@ -151,6 +151,8 @@ space := $(empty) $(empty)
 lua_path_dirs := $(foreach m,$(modules),$($(m)_lua_dirs))
 tree_lua_path := $(subst $(space),;,$(foreach d,$(lua_path_dirs),$(CURDIR)/$(d)/?.lua $(CURDIR)/$(d)/?/init.lua));;
 export NO_COLOR := 1
+# Tree-only absolute type-resolution path — TL_PATH pins tl.search_module to the tree, never the bootstrap's stale /zip copy (#744; see cook.mk, makefile_test).
+tree_tl_path := $(subst $(space),;,$(foreach d,$(CURDIR) $(foreach e,$(INCLUDE_DIRS),$(CURDIR)/$(e)) $(CURDIR)/lib/types,$(d)/?.lua $(d)/?/init.lua))
 
 # Test rule: execute test via cosmic --test command
 $(o)/%.tl.test.got: .PLEDGE := $(pledge_test)
@@ -298,7 +300,7 @@ $(o)/teal-summary.txt: $(all_teals) | $(build_reporter)
 
 $(o)/%.teal.got: $(o)/% $(cosmic_check_bin) | $(bootstrap_files)
 	@mkdir -p $(@D)
-	-@$(cosmic_check_bin) $(include_dir_flags) --check-types $< > $(basename $@).out 2> $(basename $@).err; STATUS=$$?; echo $$STATUS > $@
+	-@TL_PATH="$(tree_tl_path)" $(cosmic_check_bin) $(include_dir_flags) --check-types $< > $(basename $@).out 2> $(basename $@).err; STATUS=$$?; echo $$STATUS > $@
 
 all_formats := $(patsubst %,%.format.got,$(all_checkable_files))
 

--- a/cook.mk
+++ b/cook.mk
@@ -125,7 +125,10 @@ bootstrap_url := https://github.com/whilp/cosmic/releases/download/2026-07-19-5c
 # LUA_PATH=";;" compiles — a reproducibility requirement (#733): the
 # pre-strict tree-LUA_PATH path made compiled output depend on parallel
 # build order (bootstrap's embedded stdlib vs the tree's, whichever
-# existed first).
+# existed first). LUA_PATH governs runtime require; the TYPE-resolution
+# axis (tl.search_module) is pinned separately to the tree via TL_PATH in
+# the compile/check recipes, so a compile can never type-check against the
+# bootstrap's stale embedded source (#744 — see tree_tl_path).
 bootstrap_sha256 := 6c2a0afe6c942560ce2a0d796ddf8f8df096ce2c92b8ce142c28da59ecac6dc6
 
 $(bootstrap_cosmic):

--- a/lib/build/makefile_test.tl
+++ b/lib/build/makefile_test.tl
@@ -131,3 +131,35 @@ local function test_lint_guard_present()
     "expected lint_deleted (tracked-but-missing files) in database")
 end
 test_lint_guard_present()
+
+-- test: in-tree compiles pin type resolution to an absolute, tree-only
+-- search path (#744). tl.search_module walks its path with io.open and
+-- treats any failure — ENOENT, but also a transient EMFILE/ENFILE under
+-- the offline lane's parallel sandbox — as "file absent", falling through
+-- to the next entry. Its default path also carries the bootstrap's OWN
+-- embedded, older copy of this tree under /zip, so a transient miss on a
+-- tree source resolved cosmic.* to that stale copy (a cosmic.check
+-- predating check.must → "invalid key 'must'"). The compile recipe must
+-- set TL_PATH (which overrides tl.path outright) to tree-only roots: no
+-- /zip fallback, so a miss fails honestly instead of resolving stale, and
+-- CURDIR-anchored so a mis-rooted recipe still resolves.
+local function test_compile_pins_tree_only_tl_path()
+  local out = read_make_output("database.out").output
+  -- the recipe must wire type resolution to the tree-only path
+  assert(out:find('export TL_PATH="$(tree_tl_path)"', 1, true),
+    "expected the compile recipe to export TL_PATH=$(tree_tl_path)")
+  -- and the resolved value must be absolute, tree-only, no /zip fallback
+  local tl_path = out:match("\ntree_tl_path := ([^\n]*)")
+  assert(tl_path, "expected tree_tl_path definition in database output")
+  assert(tl_path:find("/lib/?.lua", 1, true),
+    "tree_tl_path should search the tree's lib/ absolutely, got: " .. tl_path)
+  assert(tl_path:find("/lib/types/?.lua", 1, true),
+    "tree_tl_path should search lib/types absolutely, got: " .. tl_path)
+  assert(not tl_path:find("/zip", 1, true),
+    "tree_tl_path must not fall back to the bootstrap's embedded /zip source, got: " .. tl_path)
+  for entry in tl_path:gmatch("[^;]+") do
+    assert(entry:sub(1, 1) == "/",
+      "tree_tl_path entries must be absolute (CURDIR-anchored), got: " .. entry)
+  end
+end
+test_compile_pins_tree_only_tl_path()


### PR DESCRIPTION
Fixes #744.

## What was happening

The offline lane's fresh parallel `make ci` intermittently failed two compiles with misleading module-resolution errors — `module not found: 'lib.docs.publish'` and `invalid key 'must' in record 'check'` — while ~200 sibling compiles under the same `$(o)/%.lua` rule, and the build lane on the identical tree, compiled cleanly. Reruns passed. The earlier attribution (landlock-make vfork/TLS sharing, whilp/cosmopolitan#200/#201) was incomplete: the flake recurred under the fixed pin.

## Root cause of the misleading signature

The in-tree compile rule runs the **pinned bootstrap**, whose `tl.search_module` walks its search path with `io.open` and treats **every** failure identically as "file absent" (`search_for`, tl.lua:7407) — ENOENT, but also a transient `EMFILE`/`ENFILE` under the offline lane's parallel sandbox — falling silently through to the next path entry. That default path also carries the bootstrap's **own embedded, older copy of this tree** under `/zip/.tl`.

So a transient miss on a tree source silently resolved `cosmic.*` to the stale embedded copy. The pinned bootstrap (`5c6bce5`, #698) **predates `check.must` (#699)**, so its embedded `cosmic.check` genuinely lacks `must` → `invalid key 'must'`. Where nothing shadowed the tree (`lib.docs.publish` isn't embedded), the same miss surfaced as `module not found`.

The issue note's assumption that the pinned bootstrap "has `must`" was incorrect — that stale embedded copy is the *"somewhere other than the current tree"* the record came from. Reproduced directly: forcing resolution to `/zip/.tl/cosmic/check.tl` reproduces the exact `invalid key 'must'` error.

## Fix

`TL_PATH` overrides `tl.path` outright (`tl.search_module` reads `getenv("TL_PATH") or tl.path`), so the compile and check recipes now pin type resolution to **absolute, tree-only** roots:

- **No `/zip` fallback** — a transient miss now fails honestly and retryably (`module not found`) instead of silently type-checking against the bootstrap's stale API. The `invalid key 'must'` face is impossible.
- **CURDIR-anchored** — a mis-rooted recipe still resolves (the #721 rationale, extended to the type-search axis).

This closes the hermeticity hole #733 left open: it pinned runtime `require` (`LUA_PATH=";;"`) but not the type-resolution axis. This is a Makefile-only change; it works with the current pinned bootstrap (no bump needed).

## Verification

- `make ci` → `ci: PASS`.
- Reproducibility double-build → **byte-identical**. Compiled output is unchanged (require resolution affects type-checking only, not codegen), confirmed byte-identical across the two failing files and a representative sample.
- New `makefile_test` case asserts the compile recipe pins an absolute, tree-only `TL_PATH` with no `/zip` fallback.
- **The `#744` signature is gone.** On this branch the offline lane's `teal` (type-check) stage passes **299/299**; `module not found` / `invalid key 'must'` no longer appear. Corroborated by 31 consecutive fresh, high-concurrency instrumented offline `make build` bursts (netns + root→runner, an `io.open` shim on every strict compile) coming back **clean** — the compile/resolution lane no longer flakes.

## CI status — the remaining offline red is a *separate* flake

The `offline` job stays red, but **not on anything this PR touches**. Under #746 the offline lane now fails only at:

```
test: no summary produced
coverage: no summary produced
ci: FAIL (test coverage)
```

— empty stage bodies with zero diagnostics, i.e. a sandboxed **test/coverage** child dying hard under the parallel netns+Landlock burst, *not* a compile or resolution error. Decisive localization: the **same `make ci` passes in the plain `build` job** (no netns / root-drop wrap) on the identical commit — it fails only in the `offline` job. This is the deeper transient the scope note below flagged as decoupled-not-eliminated, now surfacing one lane deeper (the heaviest fat-APE sandboxed children that themselves fork/exec/unshare).

Tracked separately as **whilp/cosmopolitan#206** (landlock-make / sandbox-setup, the #200/#201 family). It is out of scope here and should not gate this PR: every other stage — `format`, `teal`, `example`, `lint`, plain-`ci` `build`, `reproducible`, macOS/Windows smoke — is green.

## Scope note

The deeper transient-open trigger (resource pressure below cosmic, in landlock-make/kernel) is **decoupled here, not eliminated**: on the compile axis it now presents as an honest, retryable `module not found` rather than a silent stale resolution or a correctness hazard; on the test/coverage axis it presents as the child death tracked in whilp/cosmopolitan#206. Both remain cosmopolitan-layer concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7dDy7dEqAFbZ7Zh5Bm8ba

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7dDy7dEqAFbZ7Zh5Bm8ba)_