### PR TITLE
build: bump landlock-make to 2026.07.24-e95cebe09 — fixes #744

### DIFF
--- a/bin/make
+++ b/bin/make
@@ -4,11 +4,11 @@ set -e
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MAKE_BIN="${SCRIPT_DIR}/cosmo-make"
-RELEASE_URL="https://github.com/whilp/cosmopolitan/releases/download/2026.07.20-c5b6ed206/make"
+RELEASE_URL="https://github.com/whilp/cosmopolitan/releases/download/2026.07.24-e95cebe09/make"
 # SHA-256 of the landlock-make binary. This binary is executed with full
 # control over the build, so verify its integrity before running it. Update
 # this when bumping RELEASE_URL.
-MAKE_SHA256="1f0e254c075534da5518ffa1f6e040ea38bae9e0ea14bd5f7a726aef7420262e"
+MAKE_SHA256="186e4c9b65ec41bf126ffd79accc9b7c4d90ca3c6c1ffb25dde9b13547303d3d"
 
 verify_sha256() {
     # Usage: verify_sha256 <file> <expected-hex>. Returns non-zero on mismatch.


### PR DESCRIPTION
Fixes #744. Two-line pin bump picking up whilp/cosmopolitan#207 — the branch has been slimmed to just this; the investigation harness that found and proved the bug lives in this branch's pre-slim history at `d30b283` (and is fully documented on #744).

## What #744 actually was

A landlock-make defect, not anything in cosmic. `child_execute_job` fetched the **global** `.UNVEIL`/`.PLEDGE`/`.SANDBOXED` with `lookup_variable()`, which walks `current_variable_set_list` — state a forked child inherits from wherever the parent happened to be mid-traversal. When the parent started a recipe's next command line from inside another file's pattern-variable scope (a `$(shell)` evaluation reaping the previous line), the child's "global" lookup resolved the **pattern** `.UNVEIL` instead: pattern grants applied twice, global `r:lib r:3p` silently dropped, and tl's `TL_PATH` walk turned the resulting EACCES into a clean `module not found`.

## How it was proven (harness at `d30b283`)

- Variant matrix replaying the offline recipe: **8/8 reproduction** on the old pin; netns, sudo, and identity all ruled out (`ci-plain` hit 8/8 too); compile-only bursts clean (the trigger is the post-`staged` tree + the full ci graph).
- In-child probe under the failing child's own ruleset: prerequisite + pattern grants READABLE, global-only paths EACCES.
- `--debug=jobs` capture: the failing child's unveil sequence shows the pattern set doubled and zero global entries, while the sibling command line of the same recipe got the correct merge.
- `ci-unveilfix` (globals duplicated into the pattern value): green 0/8 in the same run where the baseline reproduced.

## Validation of this pin

On `d30b283` (this bump + the full harness):
- `repro-744` matrix: **all four variants green — `ci-netns` 0/8** where it was 8/8 on the previous pin, twice.
- pr.yml fully green **including the offline lane**, which had failed every recent run.
- sha256 verified against the release's published SHA256SUMS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq7b9HAyYqbkkmuFy4Ey3Y