### PR TITLE
build: run the CI gate and release build in a digest-pinned container (#734)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,18 +11,62 @@ permissions:
   contents: read
 
 jobs:
+  # The make-ci gate runs in a DIGEST-pinned container (#734). On plain
+  # `ubuntu-latest` the OS image rolls monthly (e.g. ubuntu24/20260714.240),
+  # so it is an unpinned build input — the coverage-floor churn in #722 was
+  # exactly this leak (the ratchet's floors encode the environment, and the
+  # environment drifted). The image below is bumped deliberately, like any
+  # 3p/*/version.lua pin: change the digest, re-check the floors, commit.
+  #
+  # buildpack-deps:noble is Ubuntu 24.04 — the same release ubuntu-latest
+  # currently serves — and already ships git + curl + ca-certificates +
+  # coreutils, so the gate needs no apt-get; nothing re-introduces an
+  # unpinned package fetch. The digest is the multi-arch index for the
+  # `noble-scm` tag; GitHub pulls its linux/amd64 child on the x86-64 runner.
+  #
+  # Parity with the bare runner is load-bearing and comes from two knobs:
+  #   - options: --privileged so the container's capability profile matches
+  #     the host. make ci enforces .SANDBOXED via real Landlock (#729) and
+  #     the quicksand tests call unshare(CLONE_NEWUSER|NEWNET) + mount;
+  #     Docker's default seccomp/AppArmor would silently strip those,
+  #     degrading enforcement to a no-op and dropping coverage below the
+  #     committed baseline.
+  #   - a non-root builder user (below): GHA container jobs run as root, but
+  #     the gate is identity-sensitive — fs/walk_test skips its EACCES path
+  #     under geteuid()==0 — so running as root would move coverage. This
+  #     mirrors the offline lane's `sudo -u runner`.
+  # Only this correctness+coverage gate is pinned here; the offline and
+  # enforce lanes stay on the bare runner (they own sudo + host netns).
   build:
     runs-on: ubuntu-latest
+    container:
+      image: buildpack-deps@sha256:2458a10b05846cc49b2f09c1ae1b870e6656db9f85ac5454dcede21180673d70 # noble-scm (Ubuntu 24.04)
+      options: --privileged
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # Hand the checkout and HOME to a non-root user so `bin/make -j ci`
+      # runs with geteuid()!=0 (coverage parity, see the job comment). The
+      # system-wide safe.directory keeps git usable for every user — the
+      # gate shells out to `git ls-files` (lint) and `git describe`
+      # (version stamp) from inside the sandboxed recipes.
+      - name: prepare non-root builder
+        shell: bash
+        run: |
+          set -eux
+          useradd -m -s /bin/bash builder
+          chown -R builder:builder "$GITHUB_WORKSPACE" "$HOME"
+          git config --system --add safe.directory "$GITHUB_WORKSPACE"
 
       # timeout: a recipe child dying mid-test can leave forked test
       # parents blocked on accept/wait, wedging make — convert a hang
       # into a failure so the dump step below fires
       - name: make ci
         timeout-minutes: 20
-        shell: bash -x {0}
-        run: bin/make -j ci
+        shell: bash
+        run: |
+          set -eux
+          runuser -u builder -- env HOME="$HOME" PATH="$PATH" bin/make -j ci
 
       - name: dump failing test output
         if: failure()

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,10 +19,13 @@ jobs:
   # 3p/*/version.lua pin: change the digest, re-check the floors, commit.
   #
   # buildpack-deps:noble is Ubuntu 24.04 — the same release ubuntu-latest
-  # currently serves — and already ships git + curl + ca-certificates +
-  # coreutils, so the gate needs no apt-get; nothing re-introduces an
-  # unpinned package fetch. The digest is the multi-arch index for the
-  # `noble-scm` tag; GitHub pulls its linux/amd64 child on the x86-64 runner.
+  # currently serves — and its base tag ships git, curl, ca-certificates,
+  # coreutils AND unzip (the cosmos staging step shells out to
+  # /usr/bin/unzip to unpack cosmos.zip — a host-tool dependency #732
+  # will eventually fold into the bootstrap), so the gate needs no apt-get
+  # and nothing re-introduces an unpinned package fetch. The digest is the
+  # multi-arch index for the `noble` tag; GitHub pulls its linux/amd64
+  # child on the x86-64 runner.
   #
   # Parity with the bare runner is load-bearing and comes from two knobs:
   #   - options: --privileged so the container's capability profile matches
@@ -40,7 +43,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: buildpack-deps@sha256:2458a10b05846cc49b2f09c1ae1b870e6656db9f85ac5454dcede21180673d70 # noble-scm (Ubuntu 24.04)
+      image: buildpack-deps@sha256:cfb30ff3856780c63b00ec3ad2e4aed77ae6afce5975ebb8ad9525ec45354e2e # noble (Ubuntu 24.04)
       options: --privileged
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,8 +38,12 @@ jobs:
   #     the gate is identity-sensitive — fs/walk_test skips its EACCES path
   #     under geteuid()==0 — so running as root would move coverage. This
   #     mirrors the offline lane's `sudo -u runner`.
-  # Only this correctness+coverage gate is pinned here; the offline and
-  # enforce lanes stay on the bare runner (they own sudo + host netns).
+  # Every Linux lane shares this container block, repeated per job (#734)
+  # so each pin stays a visible, reviewable edit. All run their make step
+  # as the non-root builder; offline and enforce use the container's root
+  # (privileged) for the netns bring-up / real-Landlock work first, then
+  # drop to builder. The cross-OS `smoke` matrix stays on native
+  # macOS/Windows runners — it cannot run in a Linux container by design.
   build:
     runs-on: ubuntu-latest
     container:
@@ -97,32 +101,47 @@ jobs:
   # ENTIRE gate inside a network namespace whose only interface is
   # loopback (brought up for the localhost socket tests). A stray
   # download anywhere in a recipe, build script, or test fails loudly
-  # instead of working silently. The runner restricts unprivileged user
-  # namespaces (unshare --map-root-user dies writing uid_map), so the
-  # netns comes from real root via passwordless sudo: bring lo up as
-  # root — with the pinned bootstrap's own quicksand.netns, not host
-  # iproute2 (#732) — then drop back to the runner user so the build
-  # runs with the same identity as the main ci job.
+  # instead of working silently. In the privileged container we already
+  # hold root, so no sudo: unshare the net namespace, bring lo up as root
+  # with the pinned bootstrap's own quicksand.netns (not host iproute2,
+  # #732), then drop to the builder for `make ci` — the same non-root
+  # identity as every other lane, so coverage stays consistent.
   offline:
     runs-on: ubuntu-latest
+    # Pinned CI container (#734) — same block as build; see there for rationale.
+    container:
+      image: buildpack-deps@sha256:cfb30ff3856780c63b00ec3ad2e4aed77ae6afce5975ebb8ad9525ec45354e2e # noble (Ubuntu 24.04)
+      options: --privileged
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      # fetch and stage online; everything else — compiles, checks,
-      # tests, summaries — runs network-denied. (This split was briefly
-      # relaxed to build online while landlock-make corrupted sandbox
-      # state across vfork children under parallel bursts; fixed in
-      # whilp/cosmopolitan#201, pinned via bin/make.)
+      - name: prepare non-root builder
+        shell: bash
+        run: |
+          set -eux
+          useradd -m -s /bin/bash builder
+          chown -R builder:builder "$GITHUB_WORKSPACE" "$HOME"
+          git config --system --add safe.directory "$GITHUB_WORKSPACE"
+
+      # fetch and stage online (as builder); everything else — compiles,
+      # checks, tests, summaries — runs network-denied. (This split was
+      # briefly relaxed to build online while landlock-make corrupted
+      # sandbox state across vfork children under parallel bursts; fixed
+      # in whilp/cosmopolitan#201, pinned via bin/make.)
       - name: fetch and stage with network allowed
-        shell: bash -x {0}
-        run: bin/make -j staged
+        shell: bash
+        run: |
+          set -eux
+          runuser -u builder -- env HOME="$HOME" PATH="$PATH" bin/make -j staged
 
       - name: make ci with network denied
-        shell: bash -x {0}
+        shell: bash
         run: |
-          sudo unshare --net sh -c '
-            o/bootstrap/cosmic -e "assert(require(\"cosmic.quicksand.netns\").bring_up(\"lo\"))" \
-              && exec sudo -u runner bin/make -j ci'
+          set -eux
+          H="$HOME"; P="$PATH"
+          unshare --net -- bash -ec "
+            o/bootstrap/cosmic -e 'assert(require(\"cosmic.quicksand.netns\").bring_up(\"lo\"))'
+            exec runuser -u builder -- env HOME=$H PATH=$P bin/make -j ci"
 
   # Reproducibility gate (#733): build the binary twice from the same
   # tree — the second time into a fresh output tree so the whole
@@ -133,17 +152,31 @@ jobs:
   # deliberate git-describe input stays constant.
   reproducible:
     runs-on: ubuntu-latest
+    # Pinned CI container (#734) — same block as build; see there for rationale.
+    container:
+      image: buildpack-deps@sha256:cfb30ff3856780c63b00ec3ad2e4aed77ae6afce5975ebb8ad9525ec45354e2e # noble (Ubuntu 24.04)
+      options: --privileged
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: build twice and compare
-        shell: bash -x {0}
+      - name: prepare non-root builder
+        shell: bash
         run: |
-          bin/make -j build
-          cp o/bin/cosmic cosmic-first
-          bin/make -j o=o2 build
-          cmp cosmic-first o2/bin/cosmic
-          echo "reproducible: PASS — double build is byte-identical"
+          set -eux
+          useradd -m -s /bin/bash builder
+          chown -R builder:builder "$GITHUB_WORKSPACE" "$HOME"
+          git config --system --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: build twice and compare
+        shell: bash
+        run: |
+          set -eux
+          runuser -u builder -- env HOME="$HOME" PATH="$PATH" bash -ec '
+            bin/make -j build
+            cp o/bin/cosmic cosmic-first
+            bin/make -j o=o2 build
+            cmp cosmic-first o2/bin/cosmic
+            echo "reproducible: PASS — double build is byte-identical"'
 
   # Cross-OS smoke lane (#510 step 11). The full gate is Linux-only
   # (landlock-make), but the artifact is a fat APE binary shipped for six
@@ -153,12 +186,26 @@ jobs:
   # files (string, json, fs paths — including the Windows-path suite).
   smoke-build:
     runs-on: ubuntu-latest
+    # Pinned CI container (#734) — same block as build; see there for rationale.
+    container:
+      image: buildpack-deps@sha256:cfb30ff3856780c63b00ec3ad2e4aed77ae6afce5975ebb8ad9525ec45354e2e # noble (Ubuntu 24.04)
+      options: --privileged
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: prepare non-root builder
+        shell: bash
+        run: |
+          set -eux
+          useradd -m -s /bin/bash builder
+          chown -R builder:builder "$GITHUB_WORKSPACE" "$HOME"
+          git config --system --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: build cosmic
-        shell: bash -x {0}
-        run: bin/make -j build
+        shell: bash
+        run: |
+          set -eux
+          runuser -u builder -- env HOME="$HOME" PATH="$PATH" bin/make -j build
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
@@ -242,20 +289,38 @@ jobs:
   # and a tripwire fails the lane if nothing enforced at all.
   enforce:
     runs-on: ubuntu-latest
+    # Pinned CI container (#734) — same block as build; see there for rationale.
+    # --privileged keeps Landlock real inside the container, so this lane
+    # still proves enforcement on the host kernel.
+    container:
+      image: buildpack-deps@sha256:cfb30ff3856780c63b00ec3ad2e4aed77ae6afce5975ebb8ad9525ec45354e2e # noble (Ubuntu 24.04)
+      options: --privileged
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: prepare non-root builder
+        shell: bash
+        run: |
+          set -eux
+          useradd -m -s /bin/bash builder
+          chown -R builder:builder "$GITHUB_WORKSPACE" "$HOME"
+          git config --system --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: make enforce
-        shell: bash -x {0}
-        run: bin/make -j enforce
+        shell: bash
+        run: |
+          set -eux
+          runuser -u builder -- env HOME="$HOME" PATH="$PATH" bin/make -j enforce
 
       # Build-sandbox canary (#716): proves landlock-make's .SANDBOXED
       # enforcement mechanism blocks an out-of-grant write on a
       # Landlock-capable host. Runs here (not in `make ci`) because it
-      # needs the real kernel facility this runner provides.
+      # needs the real kernel facility the privileged container exposes.
       - name: make sandbox-canary
-        shell: bash -x {0}
-        run: bin/make sandbox-canary
+        shell: bash
+        run: |
+          set -eux
+          runuser -u builder -- env HOME="$HOME" PATH="$PATH" bin/make sandbox-canary
 
       - name: dump enforcement output
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,36 @@ env:
   PRERELEASE: true
 
 jobs:
+  # The release build runs in the same digest-pinned container as the CI
+  # lanes (#734, see pr.yml for the full rationale): the shipped binaries
+  # are built by the same make machinery the gate checks, and the
+  # reproducible lane only proves determinism WITHIN one environment —
+  # pinning here keeps the artifact's build environment a deliberate,
+  # reviewable input. The container-compat of every target below (teal,
+  # test, build) is proven by pr.yml's lanes in the identical image. The
+  # `release` job stays on the bare runner: it runs no build machinery,
+  # only artifact download + `gh release create` (gh is not in the image).
   build:
     runs-on: ubuntu-latest
+    container:
+      image: buildpack-deps@sha256:cfb30ff3856780c63b00ec3ad2e4aed77ae6afce5975ebb8ad9525ec45354e2e # noble (Ubuntu 24.04)
+      options: --privileged
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: prepare non-root builder
+        shell: bash
+        run: |
+          set -eux
+          useradd -m -s /bin/bash builder
+          chown -R builder:builder "$GITHUB_WORKSPACE" "$HOME"
+          git config --system --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: make teal test build
-        shell: bash -x {0}
-        run: bin/make -j teal test build
+        shell: bash
+        run: |
+          set -eux
+          runuser -u builder -- env HOME="$HOME" PATH="$PATH" bin/make -j teal test build
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:

--- a/3p/cosmos/cosmos_test.tl
+++ b/3p/cosmos/cosmos_test.tl
@@ -4,7 +4,14 @@ local check = require("cosmic.check")
 local spawn = require("cosmic.child")
 local fs = require("cosmic.fs")
 
-global TEST_DIR: string
+-- TEST_DIR is the staged cosmos dir, set by the make rule. Read it from
+-- the environment, like every other test (TEST_BIN/TEST_TMPDIR): a bare
+-- `global TEST_DIR` is never populated — cosmic injects only _G.arg — so
+-- it was always nil, making fs.join(nil, "zip") == "zip" and silently
+-- resolving lua/zip off PATH instead of the staged binaries. That passed
+-- only where the host shipped them; buildpack-deps ships unzip, not zip.
+local TEST_DIR = assert(os.getenv("TEST_DIR"),
+  "cosmos_test requires TEST_DIR (the staged cosmos dir)")
 
 local function test_lua()
   local bin = fs.join(TEST_DIR, "lua")

--- a/3p/tl/tl_test.tl
+++ b/3p/tl/tl_test.tl
@@ -1,12 +1,19 @@
 #!/usr/bin/env cosmic
 -- ast-grep ignore: test file needs package.path manipulation
 local path = require("cosmo.path")
-local tl = require("tl")
 
-global TEST_DIR: string
+-- TEST_DIR is the staged tl dir, set by the make rule. Read it from the
+-- environment, like every other test: a bare `global TEST_DIR` is never
+-- populated — cosmic injects only _G.arg — so it was always nil, the
+-- prepend below added a useless cwd-relative "?.lua", and the require
+-- resolved the binary's embedded tl instead of the staged source this
+-- test exists to exercise (and ran before the prepend besides).
+local TEST_DIR = assert(os.getenv("TEST_DIR"),
+  "tl_test requires TEST_DIR (the staged tl dir)")
 
--- add tl.lua to package.path
+-- add the staged tl.lua to package.path BEFORE requiring it
 package.path = path.join(TEST_DIR, "?.lua") .. ";" .. package.path
+local tl = require("tl")
 
 local function test_load_tl()
   assert(tl ~= nil, "failed to load tl")


### PR DESCRIPTION
Closes #734. Part of #728 (item 6 — pin the gate's environment). Supersedes #747: same four commits, rebased onto main now that the #744 flake that blocked it is root-caused and fixed (whilp/cosmopolitan#207, pinned via #749), plus two additions found while validating (below).

## What

Move every **Linux** CI lane — and the **release build** — off the bare `ubuntu-latest` runner and into a **digest-pinned** container. `ubuntu-latest` rolls its OS image monthly, so it's an unpinned build input — the coverage-floor churn in #722 was exactly this leak. The pin is bumped deliberately, like a `3p/*/version.lua` pin: change the digest, re-check the floors, commit.

```yaml
container:
  image: buildpack-deps@sha256:cfb30ff3856780c63b00ec3ad2e4aed77ae6afce5975ebb8ad9525ec45354e2e # noble (Ubuntu 24.04)
  options: --privileged
```

The block is repeated per job so each pin stays a visible, reviewable edit. Lanes containerized: `build`, `offline`, `reproducible`, `smoke-build`, `enforce` (pr.yml) and the release `build` job (release.yml). The cross-OS `smoke` matrix stays on native macOS/Windows runners by design; the gh-release job stays on the bare runner (no build machinery, and `gh` is not in the image); docs.yml is a deliberate follow-up (`doc-publish` is not exercised by any PR lane, so containerizing it is unproven risk).

## Why this image / parity with the bare runner

Carried over from #747, condensed: `buildpack-deps:noble` is Ubuntu 24.04 with git, curl, ca-certificates, coreutils and `unzip` — no `apt-get`, so nothing re-introduces an unpinned package fetch. `--privileged` keeps Landlock/`unshare`/`mount` real so `.SANDBOXED` enforcement (#729), the quicksand tests, and the `enforce` lane stay honest. A non-root `builder` user preserves identity-sensitive coverage (`fs/walk_test` skips its EACCES path under `geteuid()==0`); `offline` uses container root only for the netns bring-up, then drops to `builder`.

## New in this PR (vs #747)

- **`3p/tl/tl_test.tl` had the same nil-`TEST_DIR` bug** #747 found in cosmos_test, plus a second layer: `require("tl")` ran *before* the `package.path` prepend, so the test exercised the binary's embedded tl rather than the staged source its cook.mk declares as intent. Fixed the same way (env `TEST_DIR`, prepend before require).
- **release.yml's build job is pinned too.** The shipped binaries are built by the same make machinery, and the reproducible lane only proves determinism *within* one environment — the release environment was still unpinned. Every target it runs (`teal test build`) is proven in this image by the pr.yml lanes.

## Validation

- Full `bin/make -j ci` passes locally on this branch (including both fixed tests and the coverage ratchet): `ci: PASS`.
- The #744 blocker is closed: root cause was a landlock-make variable-scope bug (pattern grants applied twice, global `r:lib`/`r:3p` dropped in forked children), fixed upstream and pinned by #749, with the offline lane's reproduction harness going 0/8 across all variants under the new pin.
- The container/coverage parity claims were confirmed on #747's runs (full `make ci` incl. ratchet green in this container); this PR's own CI is the proof for the rebased result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9sZQU3fNPBndg6ekctHyw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9sZQU3fNPBndg6ekctHyw)_