### PR TITLE
build: de-host the fetch/stage rules — in-process extraction, no shell, no unveil_hostx (#732)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,23 +101,23 @@ all_versioned := $(call filter-only,$(foreach m,$(modules),$(if $($(m)_version),
 all_fetched := $(patsubst %/.versioned,%/.fetched,$(all_versioned))
 ## Fetch all dependencies only
 fetched: $(all_fetched)
-# Downloads are integrity-checked against the sha256 pinned in each module's
-# version.lua, so TLS is a transport safeguard, not the trust root. The
-# bootstrap trusts only its embedded CA set (too narrow for github.com);
-# trust the host CA store so fetches work on stock runners and behind
-# TLS-intercepting proxies. An operator SSL_CERT_FILE bundle is unveiled.
-# Fetch/stage scripts run under the pinned bootstrap but are written
-# against THIS tree's cosmic.* APIs (via their explicit LUA_PATH).
-# Without the compiled stdlib as a prerequisite, a cold parallel build
-# let require() fall back to the bootstrap's embedded older-API stdlib
-# mid-compile. Unfiltered: only= must not shrink the closure.
+# Downloads are integrity-checked against the sha256 pinned in each
+# module's version.lua — TLS is transport, not the trust root — via the
+# host CA store (the bootstrap's embedded CAs are too narrow for
+# github.com; an operator SSL_CERT_FILE bundle is unveiled). The scripts
+# run under the pinned bootstrap against THIS tree's cosmic.* APIs —
+# the compiled stdlib is a prerequisite (a cold parallel build once fell
+# back to the bootstrap's embedded stdlib; only= must not shrink it) —
+# and are de-hosted (#732): .versioned resolution and extraction happen
+# in-process, LUA_PATH by target-scoped export (ambient export retired,
+# #727; compile recipes set their own), so each recipe is a plain argv: no /bin/sh, no $(unveil_hostx), only the bootstrap executes.
 stdlib_lua := $(patsubst %.tl,$(o)/%.lua,$(filter lib/cosmic/%,$(foreach x,$(modules),$($(x)_tl))))
-
+$(o)/%/.fetched $(o)/%/.staged: export LUA_PATH = $(tree_lua_path)
 $(o)/%/.fetched: export SSL_USE_SYSTEM_CERTS = 1
 $(o)/%/.fetched: .PLEDGE := $(pledge_build) inet dns
-$(o)/%/.fetched: .UNVEIL := $(unveil_dep) $(unveil_hostx) r:/etc/resolv.conf r:/etc/ssl $(if $(SSL_CERT_FILE),r:$(SSL_CERT_FILE))
+$(o)/%/.fetched: .UNVEIL := $(unveil_dep) $(unveil_dev) r:/etc/resolv.conf r:/etc/hosts r:/etc/ssl $(if $(SSL_CERT_FILE),r:$(SSL_CERT_FILE))
 $(o)/%/.fetched: $(o)/%/.versioned $(build_files) $(stdlib_lua) | $(bootstrap_cosmic)
-	@LUA_PATH="$(tree_lua_path)" $(bootstrap_cosmic) -- $(build_fetch) $$(readlink $<) $(platform) $@
+	@$(bootstrap_cosmic) -- $(build_fetch) $< $(platform) $@
 
 # versions get staged: o/module/.staged -> o/staged/module/<ver>-<sha>
 .PHONY: staged
@@ -125,9 +125,9 @@ all_staged := $(patsubst %/.fetched,%/.staged,$(all_fetched))
 ## Fetch and extract all dependencies
 staged: $(all_staged)
 $(o)/%/.staged: .PLEDGE := $(pledge_build)
-$(o)/%/.staged: .UNVEIL := $(unveil_dep) $(unveil_hostx)
+$(o)/%/.staged: .UNVEIL := $(unveil_dep) $(unveil_dev)
 $(o)/%/.staged: $(o)/%/.fetched $(build_files) $(stdlib_lua)
-	@LUA_PATH="$(tree_lua_path)" $(bootstrap_cosmic) -- $(build_stage) $$(readlink $(o)/$*/.versioned) $(platform) $< $@
+	@$(bootstrap_cosmic) -- $(build_stage) $(o)/$*/.versioned $(platform) $< $@
 
 all_tests := $(call filter-only,$(foreach x,$(modules),$($(x)_tests)))
 all_tested := $(patsubst %,$(o)/%.test.got,$(all_tests))

--- a/Makefile
+++ b/Makefile
@@ -103,19 +103,19 @@ all_fetched := $(patsubst %/.versioned,%/.fetched,$(all_versioned))
 fetched: $(all_fetched)
 # Downloads are integrity-checked against the sha256 pinned in each
 # module's version.lua — TLS is transport, not the trust root — via the
-# host CA store (the bootstrap's embedded CAs are too narrow for
-# github.com; an operator SSL_CERT_FILE bundle is unveiled). The scripts
-# run under the pinned bootstrap against THIS tree's cosmic.* APIs —
-# the compiled stdlib is a prerequisite (a cold parallel build once fell
-# back to the bootstrap's embedded stdlib; only= must not shrink it) —
-# and are de-hosted (#732): .versioned resolution and extraction happen
-# in-process, LUA_PATH by target-scoped export (ambient export retired,
-# #727; compile recipes set their own), so each recipe is plain argv. No $(unveil_hostx): beyond $(unveil_shell), only the bootstrap executes.
+# host CA store (bootstrap CAs are too narrow for github.com; an
+# operator SSL_CERT_FILE bundle is unveiled). The scripts run under the
+# pinned bootstrap against THIS tree's cosmic.* APIs — the compiled
+# stdlib is a prerequisite (a cold parallel build once fell back to the
+# bootstrap's embedded stdlib; only= must not shrink it). De-hosted
+# (#732): symlink resolution and extraction are in-process, and the
+# no-shell/LUA_PATH target variables in cook.mk (with the .SANDBOXED
+# flips) make each recipe a direct bootstrap exec — no $(unveil_hostx):
+# ONLY the pinned bootstrap executes under these grants.
 stdlib_lua := $(patsubst %.tl,$(o)/%.lua,$(filter lib/cosmic/%,$(foreach x,$(modules),$($(x)_tl))))
-$(o)/%/.fetched $(o)/%/.staged: export LUA_PATH = $(tree_lua_path)
 $(o)/%/.fetched: export SSL_USE_SYSTEM_CERTS = 1
 $(o)/%/.fetched: .PLEDGE := $(pledge_build) inet dns
-$(o)/%/.fetched: .UNVEIL := $(unveil_dep) $(unveil_dev) $(unveil_shell) r:/etc/resolv.conf r:/etc/hosts r:/etc/ssl $(if $(SSL_CERT_FILE),r:$(SSL_CERT_FILE))
+$(o)/%/.fetched: .UNVEIL := $(unveil_dep) $(unveil_dev) r:/etc/resolv.conf r:/etc/hosts r:/etc/ssl $(if $(SSL_CERT_FILE),r:$(SSL_CERT_FILE))
 $(o)/%/.fetched: $(o)/%/.versioned $(build_files) $(stdlib_lua) | $(bootstrap_cosmic)
 	@$(bootstrap_cosmic) -- $(build_fetch) $< $(platform) $@
 
@@ -125,7 +125,7 @@ all_staged := $(patsubst %/.fetched,%/.staged,$(all_fetched))
 ## Fetch and extract all dependencies
 staged: $(all_staged)
 $(o)/%/.staged: .PLEDGE := $(pledge_build)
-$(o)/%/.staged: .UNVEIL := $(unveil_dep) $(unveil_dev) $(unveil_shell)
+$(o)/%/.staged: .UNVEIL := $(unveil_dep) $(unveil_dev)
 $(o)/%/.staged: $(o)/%/.fetched $(build_files) $(stdlib_lua)
 	@$(bootstrap_cosmic) -- $(build_stage) $(o)/$*/.versioned $(platform) $< $@
 

--- a/Makefile
+++ b/Makefile
@@ -110,12 +110,12 @@ fetched: $(all_fetched)
 # back to the bootstrap's embedded stdlib; only= must not shrink it) —
 # and are de-hosted (#732): .versioned resolution and extraction happen
 # in-process, LUA_PATH by target-scoped export (ambient export retired,
-# #727; compile recipes set their own), so each recipe is a plain argv: no /bin/sh, no $(unveil_hostx), only the bootstrap executes.
+# #727; compile recipes set their own), so each recipe is plain argv. No $(unveil_hostx): beyond $(unveil_shell), only the bootstrap executes.
 stdlib_lua := $(patsubst %.tl,$(o)/%.lua,$(filter lib/cosmic/%,$(foreach x,$(modules),$($(x)_tl))))
 $(o)/%/.fetched $(o)/%/.staged: export LUA_PATH = $(tree_lua_path)
 $(o)/%/.fetched: export SSL_USE_SYSTEM_CERTS = 1
 $(o)/%/.fetched: .PLEDGE := $(pledge_build) inet dns
-$(o)/%/.fetched: .UNVEIL := $(unveil_dep) $(unveil_dev) r:/etc/resolv.conf r:/etc/hosts r:/etc/ssl $(if $(SSL_CERT_FILE),r:$(SSL_CERT_FILE))
+$(o)/%/.fetched: .UNVEIL := $(unveil_dep) $(unveil_dev) $(unveil_shell) r:/etc/resolv.conf r:/etc/hosts r:/etc/ssl $(if $(SSL_CERT_FILE),r:$(SSL_CERT_FILE))
 $(o)/%/.fetched: $(o)/%/.versioned $(build_files) $(stdlib_lua) | $(bootstrap_cosmic)
 	@$(bootstrap_cosmic) -- $(build_fetch) $< $(platform) $@
 
@@ -125,7 +125,7 @@ all_staged := $(patsubst %/.fetched,%/.staged,$(all_fetched))
 ## Fetch and extract all dependencies
 staged: $(all_staged)
 $(o)/%/.staged: .PLEDGE := $(pledge_build)
-$(o)/%/.staged: .UNVEIL := $(unveil_dep) $(unveil_dev)
+$(o)/%/.staged: .UNVEIL := $(unveil_dep) $(unveil_dev) $(unveil_shell)
 $(o)/%/.staged: $(o)/%/.fetched $(build_files) $(stdlib_lua)
 	@$(bootstrap_cosmic) -- $(build_stage) $(o)/$*/.versioned $(platform) $< $@
 

--- a/cook.mk
+++ b/cook.mk
@@ -21,15 +21,18 @@ export PATH := $(CURDIR)/$(o)/bootstrap:$(CURDIR)/$(o)/bin:$(HOST_PATH)
 # enforcement unexpanded (see the sandbox-canary note in lib/build).
 pledge_build := stdio rpath wpath cpath proc exec
 unveil_base := rx:$(o)/bootstrap r:lib r:3p
-# Host set proven under real enforcement by the sandbox-canary (#724)
-# and the enforced families' CI runs: shell + coreutils + loaders.
+# Device nodes the cosmic runtime itself touches — not host tools, so
+# de-hosted rules (#732) grant these without the toolchain surface.
 # /dev/null must be writable (recipes redirect to it). mbedtls3's
 # non-glibc build cannot use the getrandom syscall, so TLS entropy
 # fopens MBEDTLS_PLATFORM_DEV_RANDOM — which defaults to /dev/random,
 # not /dev/urandom (platform.h:398) — and fetch SIGILLs under Landlock
 # without it; grant both devices. ENOENT entries are skipped, so the
 # generous list is safe across hosts.
-unveil_hostx := rx:/usr rx:/bin rx:/lib rx:/lib64 rx:/proc r:/etc rw:/dev/null r:/dev/random r:/dev/urandom
+unveil_dev := rw:/dev/null r:/dev/random r:/dev/urandom
+# Host set proven under real enforcement by the sandbox-canary (#724)
+# and the enforced families' CI runs: shell + coreutils + loaders.
+unveil_hostx := rx:/usr rx:/bin rx:/lib rx:/lib64 rx:/proc r:/etc $(unveil_dev)
 unveil_dep := rx:$(o)/bootstrap r:3p rwc:$(o)
 # TMP is x: tests exec what they build there — embed outputs, scripts
 # under TEST_TMPDIR (proven need: embed/child/testrun under Landlock)

--- a/cook.mk
+++ b/cook.mk
@@ -30,6 +30,13 @@ unveil_base := rx:$(o)/bootstrap r:lib r:3p
 # without it; grant both devices. ENOENT entries are skipped, so the
 # generous list is safe across hosts.
 unveil_dev := rw:/dev/null r:/dev/random r:/dev/urandom
+# cosmo-make runs every recipe line through $(SHELL) (bash, pipefail),
+# even a metacharacter-free argv — witnessed on the runner: dropping
+# these grants fails with "/bin/bash: Permission denied". De-hosted
+# rules (#732) grant the shell binary and its loader/libraries, nothing
+# else from the host toolchain (rx:/lib resolves to /usr/lib on merged-
+# usr hosts — libraries, not the /usr/bin tool surface).
+unveil_shell := rx:/bin/bash rx:/lib rx:/lib64
 # Host set proven under real enforcement by the sandbox-canary (#724)
 # and the enforced families' CI runs: shell + coreutils + loaders.
 unveil_hostx := rx:/usr rx:/bin rx:/lib rx:/lib64 rx:/proc r:/etc $(unveil_dev)

--- a/cook.mk
+++ b/cook.mk
@@ -30,13 +30,6 @@ unveil_base := rx:$(o)/bootstrap r:lib r:3p
 # without it; grant both devices. ENOENT entries are skipped, so the
 # generous list is safe across hosts.
 unveil_dev := rw:/dev/null r:/dev/random r:/dev/urandom
-# cosmo-make runs every recipe line through $(SHELL) (bash, pipefail),
-# even a metacharacter-free argv — witnessed on the runner: dropping
-# these grants fails with "/bin/bash: Permission denied". De-hosted
-# rules (#732) grant the shell binary and its loader/libraries, nothing
-# else from the host toolchain (rx:/lib resolves to /usr/lib on merged-
-# usr hosts — libraries, not the /usr/bin tool surface).
-unveil_shell := rx:/bin/bash rx:/lib rx:/lib64
 # Host set proven under real enforcement by the sandbox-canary (#724)
 # and the enforced families' CI runs: shell + coreutils + loaders.
 unveil_hostx := rx:/usr rx:/bin rx:/lib rx:/lib64 rx:/proc r:/etc $(unveil_dev)
@@ -77,6 +70,19 @@ $(o)/%.lua: .UNVEIL := rwc:$(o) r:tlconfig.lua $(unveil_hostx)
 # the grant sets.
 $(o)/%/.fetched: .SANDBOXED := 1
 $(o)/%/.staged: .SANDBOXED := 1
+# De-hosted (#732): these recipes are metacharacter-free argv, so a
+# plain -c re-enables make's direct-exec fast path (the global pipefail
+# .SHELLFLAGS forces the shell; these recipes have no pipes) and no
+# shell runs at all — the poisoned SHELL is the tripwire that fails
+# loudly if a recipe ever regresses to shell syntax. private: cold-tree
+# prerequisites (stdlib compiles) must not inherit either override —
+# but NOT on the export: a private export never reaches the recipe env
+# (witnessed: bootstrap fell back to its embedded stdlib); inheritance
+# is benign because every compile recipe sets LUA_PATH explicitly.
+# Recursive (=): tree_lua_path is computed after the includes (#720).
+$(o)/%/.fetched $(o)/%/.staged: export LUA_PATH = $(tree_lua_path)
+$(o)/%/.fetched $(o)/%/.staged: private SHELL := /dev/null/enoshell
+$(o)/%/.fetched $(o)/%/.staged: private .SHELLFLAGS := -c
 $(o)/%.lint.ok: .SANDBOXED := 1
 $(o)/%.lint.ok: .PLEDGE := $(pledge_build)
 $(o)/%.lint.ok: .UNVEIL := rwc:$(o) $(unveil_hostx)

--- a/lib/build/build-fetch.tl
+++ b/lib/build/build-fetch.tl
@@ -88,6 +88,14 @@ local function main(version_file: string, platform: string, output: string): boo
     return nil, "FETCH_O env var required"
   end
 
+  -- the make rule passes o/<module>/.versioned, a symlink to the module's
+  -- version.lua; resolve it here so error messages name the real file and
+  -- the recipe needs no host readlink (#732)
+  local resolved = fs.readlink(version_file)
+  if resolved then
+    version_file = resolved
+  end
+
   -- cast: pcall returns any
   local ok, spec = pcall(dofile, version_file) as(boolean, VersionSpec)
   if not ok then

--- a/lib/build/build-stage.tl
+++ b/lib/build/build-stage.tl
@@ -2,11 +2,13 @@
 -- ast-grep ignore: builds relative symlink paths
 -- stage.lua: extract fetched archives based on version.lua format
 
+local compress = require("cosmic.compress")
 local fs = require("cosmic.fs")
 local fs_types = require("cosmic.fs.types")
 local portable = require("build.portable")
 local proc = require("cosmic.proc")
-local spawn = require("cosmic.child")
+local untar = require("build.build-untar")
+local zip = require("cosmic.zip")
 
 local record PlatformSpec
   sha: string
@@ -85,31 +87,36 @@ local function strip_components(source_dir: string, dest_dir: string, strip: num
   end
 end
 
+-- Extraction is in-process (#732): cosmic.zip / build.build-untar /
+-- cosmic.compress instead of spawning host unzip/tar/gunzip, so the
+-- stage rule's unveil set carries no host-toolchain grants.
 local function extract_zip(archive: string, dest_dir: string, strip: number): boolean, string
   local temp_dir = fs.mkdtemp(fs.join(fs.dirname(dest_dir), ".stage_XXXXXX"))
-  local result = spawn.run({"/usr/bin/unzip", "-o", "-q", "-d", temp_dir, archive})
-  local r = result as spawn.Result -- cast: record union, nil checked below
-  if not r or not r.ok then
+  local reader, open_err = zip.reader(archive)
+  if not reader then
     fs.rmrf(temp_dir)
-    return nil, "unzip failed with exit code " .. tostring(r and r.code)
+    return nil, "zip open failed: " .. (open_err or "unknown error")
   end
-  local ok, err = strip_components(temp_dir, dest_dir, strip)
+  local r = reader as zip.Reader -- cast: record union after guard
+  local ok, err = zip.extract(r, temp_dir)
+  r:close()
+  if not ok then
+    fs.rmrf(temp_dir)
+    return nil, "zip extract failed: " .. (err or "unknown error")
+  end
+  ok, err = strip_components(temp_dir, dest_dir, strip)
   fs.rmrf(temp_dir)
   return ok, err
 end
 
 local function extract_targz(archive: string, dest_dir: string, strip: number): boolean, string
   local temp_dir = fs.mkdtemp(fs.join(fs.dirname(dest_dir), ".stage_XXXXXX"))
-  -- -m / --no-same-owner: a staged tree should not inherit the archive's
-  -- mtimes or ownership, and restoring them needs utimensat/chown, which
-  -- the stage rule's pledge (#729) deliberately does not promise
-  local result = spawn.run({"tar", "-xzmf", archive, "--no-same-owner", "-C", temp_dir})
-  local r = result as spawn.Result -- cast: record union, nil checked below
-  if not r or not r.ok then
+  local ok, err = untar.extract(archive, temp_dir)
+  if not ok then
     fs.rmrf(temp_dir)
-    return nil, "tar failed with exit code " .. tostring(r and r.code)
+    return nil, err
   end
-  local ok, err = strip_components(temp_dir, dest_dir, strip)
+  ok, err = strip_components(temp_dir, dest_dir, strip)
   fs.rmrf(temp_dir)
   return ok, err
 end
@@ -133,15 +140,14 @@ local function extract_gz(archive: string, dest_dir: string, module_name: string
   local bin_dir = fs.join(dest_dir, "bin")
   fs.makedirs(bin_dir)
   local dest = fs.join(bin_dir, module_name)
-  local result, serr = spawn.run({"gunzip", "-c", archive})
-  if not result then
-    return nil, "gunzip failed: " .. tostring(serr)
+  local body, read_err = fs.read(archive)
+  if not body then
+    return nil, "read " .. archive .. " failed: " .. (read_err or "unknown error")
   end
-  local r = result as spawn.Result -- cast: record union after guard
-  if not r.ok then
-    return nil, "gunzip failed (exit " .. tostring(r.code) .. "): " .. r.stderr
+  local content, gz_err = compress.decompress(body, {format = "gzip"})
+  if not content then
+    return nil, "gunzip " .. archive .. " failed: " .. (gz_err or "unknown error")
   end
-  local content = r.stdout
   local ok, write_err = portable.write_file(dest, content, tonumber("755", 8))
   if not ok then
     return nil, "failed to create " .. dest .. ": " .. (write_err or "unknown error")
@@ -298,6 +304,14 @@ local function main(version_file: string, platform: string, input: string, outpu
   local stage_o = os.getenv("STAGE_O")
   if not stage_o then
     return nil, "STAGE_O env var required"
+  end
+
+  -- the make rule passes o/<module>/.versioned, a symlink to the module's
+  -- version.lua; resolve it here so error messages name the real file and
+  -- the recipe needs no host readlink (#732)
+  local resolved = fs.readlink(version_file)
+  if resolved then
+    version_file = resolved
   end
 
   -- cast: pcall returns any

--- a/lib/build/build-untar.tl
+++ b/lib/build/build-untar.tl
@@ -1,0 +1,212 @@
+#!/usr/bin/env lua
+--- In-process .tar.gz extraction for the stage pipeline (#732), replacing
+--- the host `tar -xzmf` spawn. Covers what pinned release tarballs
+--- actually contain — the ustar/pax layouts git archive and GNU tar emit:
+--- regular files, directories, symlinks, pax extended headers (path
+--- override), and GNU longnames. Anything else fails loudly. Modes are
+--- masked to 0777; mtimes and ownership are deliberately not restored
+--- (the stage rule's pledge does not promise utimensat/chown — the same
+--- policy the old `-m --no-same-owner` tar flags encoded).
+
+local compress = require("cosmic.compress")
+local fs = require("cosmic.fs")
+local portable = require("build.portable")
+
+local BLOCK = 512
+--- Decompression cap: input integrity comes from the fetch rule's sha256
+--- pin; this only keeps a corrupt archive from eating the build host.
+--- Fetch caps downloads at 100 MiB compressed.
+local MAX_TAR = 512 * 1024 * 1024
+
+local record Header
+  name: string
+  mode: integer
+  size: integer
+  typeflag: string
+  linkname: string
+end
+
+local function str_field(block: string, from: integer, len: integer): string
+  local raw = block:sub(from, from + len - 1)
+  return raw:match("^[^\0]*")
+end
+
+local function octal_field(block: string, from: integer, len: integer): integer
+  local digits = block:sub(from, from + len - 1):match("([0-7]+)")
+  if not digits then return 0 end
+  return tonumber(digits, 8) as integer -- cast: octal digits parse integral
+end
+
+--- Verify the header checksum: the byte sum of the block with the
+--- checksum field (bytes 149-156) read as spaces. Catches parser/block
+--- desync and corruption with a loud error instead of garbage paths.
+local function checksum_ok(block: string): boolean
+  local stored = octal_field(block, 149, 8)
+  local sum = 0
+  for i = 1, BLOCK do
+    if i >= 149 and i <= 156 then
+      sum = sum + 32
+    else
+      sum = sum + block:byte(i)
+    end
+  end
+  return sum == stored
+end
+
+local function parse_header(block: string): Header
+  local name = str_field(block, 1, 100)
+  local magic = block:sub(258, 262)
+  if magic == "ustar" then
+    local prefix = str_field(block, 346, 155)
+    if prefix ~= "" then
+      name = prefix .. "/" .. name
+    end
+  end
+  return {
+    name = name,
+    mode = octal_field(block, 101, 8),
+    size = octal_field(block, 125, 12),
+    typeflag = block:sub(157, 157),
+    linkname = str_field(block, 158, 100),
+  }
+end
+
+--- Parse a pax extended header payload: "<len> <key>=<value>\n" records,
+--- where <len> counts the whole record including itself.
+local function parse_pax(data: string): {string: string}
+  local out: {string: string} = {}
+  local pos = 1
+  while pos <= #data do
+    local len_str = data:match("^(%d+) ", pos)
+    local len = len_str and math.tointeger(tonumber(len_str))
+    if not len or len <= 0 then break end
+    local rec = data:sub(pos, pos + len - 1)
+    local key, value = rec:match("^%d+ ([^=]+)=(.*)\n$")
+    if key then
+      out[key] = value
+    end
+    pos = pos + len
+  end
+  return out
+end
+
+--- Reject entry names that would escape the extraction root: empty,
+--- absolute, backslashed, or containing a ".." component.
+local function unsafe_path(p: string): boolean
+  if not p or p == "" then return true end
+  if p:sub(1, 1) == "/" then return true end
+  if p:find("\\", 1, true) then return true end
+  for component in (p .. "/"):gmatch("([^/]*)/") do
+    if component == ".." then return true end
+  end
+  return false
+end
+
+--- Symlink targets must stay inside the tree: relative, no "..".
+local function unsafe_link_target(target: string): boolean
+  if not target or target == "" then return true end
+  if target:sub(1, 1) == "/" then return true end
+  for component in (target .. "/"):gmatch("([^/]*)/") do
+    if component == ".." then return true end
+  end
+  return false
+end
+
+local function write_entry(hdr: Header, name: string, payload: string,
+    destdir: string): boolean, string
+  if unsafe_path(name) then
+    return false, "unsafe path in archive: " .. name
+  end
+  local dest = fs.join(destdir, name)
+  local t = hdr.typeflag
+  if t == "5" or name:sub(-1) == "/" then
+    local ok, err = fs.makedirs(dest)
+    if not ok then
+      return false, "mkdir " .. dest .. " failed: " .. (err or "unknown error")
+    end
+  elseif t == "0" or t == "\0" then
+    fs.makedirs(fs.dirname(dest))
+    local mode = hdr.mode % 512 -- permission bits only (0777 mask)
+    if mode == 0 then mode = tonumber("644", 8) as integer end -- cast: octal is integral
+    local ok, err = portable.write_file(dest, payload, mode)
+    if not ok then
+      return false, "write " .. dest .. " failed: " .. (err or "unknown error")
+    end
+  elseif t == "2" then
+    if unsafe_link_target(hdr.linkname) then
+      return false, "unsafe symlink target in archive: " .. name .. " -> " .. hdr.linkname
+    end
+    fs.makedirs(fs.dirname(dest))
+    local ok, err = fs.symlink(hdr.linkname, dest)
+    if not ok then
+      return false, "symlink " .. dest .. " failed: " .. (err or "unknown error")
+    end
+  else
+    return false, "unsupported tar entry type '" .. t .. "': " .. name
+  end
+  return true
+end
+
+--- Extract a gzip-compressed tarball into destdir.
+--- @param archive string Path to the .tar.gz file
+--- @param destdir string Directory to extract into (created if needed)
+--- @return boolean true when every entry was written
+--- @return string? Error message on failure
+local function extract(archive: string, destdir: string): boolean, string
+  local gz, read_err = fs.read(archive)
+  if not gz then
+    return false, "read " .. archive .. " failed: " .. (read_err or "unknown error")
+  end
+  local data, gz_err = compress.decompress(gz, {format = "gzip", max_output = MAX_TAR})
+  if not data then
+    return false, "gunzip " .. archive .. " failed: " .. (gz_err or "unknown error")
+  end
+  local ok_mk, mk_err = fs.makedirs(destdir)
+  if not ok_mk then
+    return false, "mkdir " .. destdir .. " failed: " .. (mk_err or "unknown error")
+  end
+
+  local zero_block = string.rep("\0", BLOCK)
+  local pos = 1
+  local pending_path: string = nil -- pax 'x' path= or GNU 'L' longname
+  while pos + BLOCK - 1 <= #data do
+    local block = string.sub(data, pos, pos + BLOCK - 1)
+    pos = pos + BLOCK
+    if block == zero_block then
+      return true -- end-of-archive marker
+    end
+    if not checksum_ok(block) then
+      return false, "bad tar header checksum at offset " .. tostring(pos - BLOCK - 1)
+    end
+    local hdr = parse_header(block)
+    if pos + hdr.size - 1 > #data then
+      return false, "truncated archive: entry " .. hdr.name .. " exceeds data"
+    end
+    local payload = string.sub(data, pos, pos + hdr.size - 1)
+    pos = pos + math.ceil(hdr.size / BLOCK) * BLOCK
+
+    local t = hdr.typeflag
+    if t == "x" then
+      local pax = parse_pax(payload)
+      if pax.path then pending_path = pax.path end
+    elseif t == "L" then
+      pending_path = payload:match("^[^\0]*")
+    elseif t == "g" then
+      -- global pax header (git archive stamps the commit here): ignore
+    else
+      local name = pending_path or hdr.name
+      pending_path = nil
+      local ok, err = write_entry(hdr, name, payload, destdir)
+      if not ok then
+        return false, err
+      end
+    end
+  end
+  return true -- archive ended without zero blocks: accept, all entries written
+end
+
+return {
+  extract = extract,
+  parse_pax = parse_pax,
+  unsafe_path = unsafe_path,
+}

--- a/lib/build/build-untar_test.tl
+++ b/lib/build/build-untar_test.tl
@@ -1,0 +1,199 @@
+#!/usr/bin/env cosmic
+-- Tests for the in-process tar extractor (#732). Archives are built
+-- in-process — no host tar — so the tests exercise exactly the ustar/pax
+-- shapes the extractor claims to handle, plus its rejection paths.
+
+local compress = require("cosmic.compress")
+local fs = require("cosmic.fs")
+local fs_types = require("cosmic.fs.types")
+local untar = require("build.build-untar")
+
+local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
+local BLOCK = 512
+
+local function oct(s: string): integer
+  return tonumber(s, 8) as integer -- cast: octal digits parse integral
+end
+
+local function pad(s: string, len: integer): string
+  return s .. string.rep("\0", len - #s)
+end
+
+local function tar_header(name: string, mode: integer, size: integer,
+    typeflag: string, linkname: string): string
+  local h = pad(name, 100)
+  .. pad(string.format("%07o", mode), 8)
+  .. pad("0000000", 8) -- uid
+  .. pad("0000000", 8) -- gid
+  .. pad(string.format("%011o", size), 12)
+  .. pad("00000000000", 12) -- mtime
+  .. "        " -- checksum placeholder: 8 spaces while summing
+  .. typeflag
+  .. pad(linkname, 100)
+  .. pad("ustar", 6)
+  .. "00"
+  h = pad(h, BLOCK)
+  local sum = 0
+  for i = 1, BLOCK do
+    sum = sum + h:byte(i)
+  end
+  return h:sub(1, 148) .. string.format("%06o\0 ", sum) .. h:sub(157)
+end
+
+local function tar_entry(name: string, content: string, mode: integer,
+    typeflag: string, linkname: string): string
+  local out = tar_header(name, mode, #content, typeflag, linkname)
+  if #content > 0 then
+    local blocks = math.ceil(#content / BLOCK)
+    out = out .. content .. string.rep("\0", blocks * BLOCK - #content)
+  end
+  return out
+end
+
+local function make_targz(path: string, parts: {string})
+  local archive = table.concat(parts) .. string.rep("\0", 2 * BLOCK)
+  local gz = compress.compress(archive, {format = "gzip"})
+  assert(fs.write(path, gz))
+end
+
+local function test_extract_files_dirs_modes()
+  local dest = fs.join(tmpdir, "untar-basic")
+  local ar = fs.join(tmpdir, "basic.tar.gz")
+  make_targz(ar, {
+      tar_entry("pkg/", "", oct("755"), "5", ""),
+      tar_entry("pkg/tool", "#!/bin/sh\necho hi\n", oct("755"), "0", ""),
+      tar_entry("pkg/doc.txt", "docs\n", oct("644"), "0", ""),
+    })
+  local ok, err = untar.extract(ar, dest)
+  assert(ok, "extract failed: " .. tostring(err))
+  assert(fs.read(fs.join(dest, "pkg/doc.txt")) == "docs\n", "doc content")
+  assert(fs.read(fs.join(dest, "pkg/tool")) == "#!/bin/sh\necho hi\n", "tool content")
+  local st = fs.stat(fs.join(dest, "pkg/tool"))
+  assert(st, "tool should stat")
+  -- exec bit survives extraction (the reason unzip/tar mattered at all)
+  local mode = (st as fs_types.Stat):mode() -- cast: mixed-representation Stat
+  assert(mode % 2 == 1, "tool should keep the exec bit, mode: " .. string.format("%o", mode))
+end
+test_extract_files_dirs_modes()
+
+-- A pax record's length prefix counts the whole record including itself:
+-- iterate to the fixpoint (the digit count can shift the total).
+local function pax_record(key: string, value: string): string
+  local rec = key .. "=" .. value .. "\n"
+  local len = #rec
+  while true do
+    local total = #tostring(len) + 1 + #rec
+    if total == len then break end
+    len = total
+  end
+  local out = string.format("%d %s", len, rec)
+  assert(#out == len, "pax record length must be self-consistent")
+  return out
+end
+
+local function test_pax_path_override()
+  local dest = fs.join(tmpdir, "untar-pax")
+  local ar = fs.join(tmpdir, "pax.tar.gz")
+  local long = "deeply/nested/directory/holding/a-rather-long-name.txt"
+  local pax = pax_record("path", long)
+  make_targz(ar, {
+      tar_entry("PaxHeaders/ignored", pax, oct("644"), "x", ""),
+      tar_entry("short-name", "payload\n", oct("644"), "0", ""),
+    })
+  local ok, err = untar.extract(ar, dest)
+  assert(ok, "pax extract failed: " .. tostring(err))
+  assert(fs.read(fs.join(dest, long)) == "payload\n", "pax path override should win")
+  assert(not fs.stat(fs.join(dest, "short-name")), "header name must not also be written")
+end
+test_pax_path_override()
+
+local function test_symlink_entry()
+  local dest = fs.join(tmpdir, "untar-link")
+  local ar = fs.join(tmpdir, "link.tar.gz")
+  make_targz(ar, {
+      tar_entry("real.txt", "target\n", oct("644"), "0", ""),
+      tar_entry("alias.txt", "", oct("777"), "2", "real.txt"),
+    })
+  local ok, err = untar.extract(ar, dest)
+  assert(ok, "symlink extract failed: " .. tostring(err))
+  assert(fs.readlink(fs.join(dest, "alias.txt")) == "real.txt", "symlink target")
+end
+test_symlink_entry()
+
+local function test_rejects_traversal()
+  local dest = fs.join(tmpdir, "untar-evil")
+  local ar = fs.join(tmpdir, "evil.tar.gz")
+  make_targz(ar, {
+      tar_entry("../evil.txt", "boom\n", oct("644"), "0", ""),
+    })
+  local ok, err = untar.extract(ar, dest)
+  assert(not ok, "traversal entry must be rejected")
+  assert(err and err:match("unsafe path"), "expected unsafe path error, got: " .. tostring(err))
+end
+test_rejects_traversal()
+
+local function test_rejects_absolute_symlink_target()
+  local dest = fs.join(tmpdir, "untar-evil-link")
+  local ar = fs.join(tmpdir, "evil-link.tar.gz")
+  make_targz(ar, {
+      tar_entry("alias", "", oct("777"), "2", "/etc/passwd"),
+    })
+  local ok, err = untar.extract(ar, dest)
+  assert(not ok, "absolute symlink target must be rejected")
+  assert(err and err:match("unsafe symlink"), "expected unsafe symlink error, got: " .. tostring(err))
+end
+test_rejects_absolute_symlink_target()
+
+local function test_rejects_bad_checksum()
+  local dest = fs.join(tmpdir, "untar-badsum")
+  local ar = fs.join(tmpdir, "badsum.tar.gz")
+  local entry = tar_entry("ok.txt", "fine\n", oct("644"), "0", "")
+  -- flip a name byte after the checksum was computed
+  local corrupt = "X" .. entry:sub(2)
+  make_targz(ar, {corrupt})
+  local ok, err = untar.extract(ar, dest)
+  assert(not ok, "corrupt header must be rejected")
+  assert(err and err:match("checksum"), "expected checksum error, got: " .. tostring(err))
+end
+test_rejects_bad_checksum()
+
+local function test_rejects_truncated_archive()
+  local dest = fs.join(tmpdir, "untar-trunc")
+  local ar = fs.join(tmpdir, "trunc.tar.gz")
+  local entry = tar_entry("big.txt", string.rep("a", 600), oct("644"), "0", "")
+  -- header claims 600 bytes; hand extract() only the header + 100 bytes
+  local gz = compress.compress(entry:sub(1, BLOCK + 100), {format = "gzip"})
+  assert(fs.write(ar, gz))
+  local ok, err = untar.extract(ar, dest)
+  assert(not ok, "truncated archive must be rejected")
+  assert(err and err:match("truncated"), "expected truncated error, got: " .. tostring(err))
+end
+test_rejects_truncated_archive()
+
+local function test_rejects_unknown_entry_type()
+  local dest = fs.join(tmpdir, "untar-hardlink")
+  local ar = fs.join(tmpdir, "hardlink.tar.gz")
+  make_targz(ar, {
+      tar_entry("hard", "", oct("644"), "1", "other"),
+    })
+  local ok, err = untar.extract(ar, dest)
+  assert(not ok, "hardlink entry must be rejected loudly")
+  assert(err and err:match("unsupported"), "expected unsupported error, got: " .. tostring(err))
+end
+test_rejects_unknown_entry_type()
+
+local function test_parse_pax()
+  local rec = "22 path=some/file.txt\n"
+  local fields = untar.parse_pax(rec)
+  assert(fields["path"] == "some/file.txt", "pax path parse, got: " .. tostring(fields["path"]))
+end
+test_parse_pax()
+
+local function test_unsafe_path()
+  assert(untar.unsafe_path(""), "empty")
+  assert(untar.unsafe_path("/abs"), "absolute")
+  assert(untar.unsafe_path("a/../b"), "dotdot")
+  assert(untar.unsafe_path("a\\b"), "backslash")
+  assert(not untar.unsafe_path("a/b.txt"), "plain path is safe")
+end
+test_unsafe_path()

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -2,11 +2,12 @@ modules += build
 build_lua_dirs := $(o)/lib/build
 build_fetch := $(o)/lib/build/build-fetch.lua
 build_stage := $(o)/lib/build/build-stage.lua
+build_untar := $(o)/lib/build/build-untar.lua
 build_portable := $(o)/lib/build/portable.lua
 build_reporter := $(o)/lib/build/reporter.lua
 build_help := $(o)/lib/build/make-help.lua
 build_lint := $(o)/lib/build/lint.lua
-build_files := $(build_fetch) $(build_stage) $(build_portable) $(build_reporter) $(build_help) $(build_lint)
+build_files := $(build_fetch) $(build_stage) $(build_untar) $(build_portable) $(build_reporter) $(build_help) $(build_lint)
 build_tests := $(wildcard lib/build/*_test.tl)
 
 # recursive (=): tree_lua_path is computed in the Makefile after the

--- a/lib/cosmic/coverage/baseline.txt
+++ b/lib/cosmic/coverage/baseline.txt
@@ -1,7 +1,8 @@
 # coverage ratchet baseline: `bin/make coverage-baseline` rewrites this file.
 # columns: path covered-lines total-lines
-lib/build/build-fetch.tl 23 92
-lib/build/build-stage.tl 43 243
+lib/build/build-fetch.tl 23 95
+lib/build/build-stage.tl 45 251
+lib/build/build-untar.tl 121 130
 lib/build/lint.tl 97 132
 lib/build/make-help.tl 79 97
 lib/build/portable.tl 16 18
@@ -65,7 +66,7 @@ lib/cosmic/json.tl 23 24
 lib/cosmic/landlock.tl 58 101
 lib/cosmic/log.tl 72 74
 lib/cosmic/make.tl 122 133
-lib/cosmic/net/init.tl 180 209
+lib/cosmic/net/init.tl 180 213
 lib/cosmic/net/socket.tl 225 252
 lib/cosmic/pledge.tl 28 39
 lib/cosmic/poll.tl 82 96
@@ -88,7 +89,7 @@ lib/cosmic/quicksand/types.tl 3 3
 lib/cosmic/rand.tl 66 73
 lib/cosmic/re.tl 115 125
 lib/cosmic/require.tl 93 124
-lib/cosmic/sandbox.tl 85 107
+lib/cosmic/sandbox.tl 85 108
 lib/cosmic/shm.tl 117 128
 lib/cosmic/signal.tl 101 109
 lib/cosmic/sqlite/bind.tl 15 15
@@ -138,4 +139,4 @@ lib/types/gentype_parse.tl 267 288
 lib/types/gentype_render.tl 309 312
 lib/types/gentype_types.tl 2 2
 tlconfig.lua 7 7
-total 11190 14727
+total 11313 14873


### PR DESCRIPTION
Part of #732 / #728 (item 4 — shrink the host-toolchain surface). First fully de-hosted rule family: the fetch and stage rules execute exactly one thing — the sha-pinned bootstrap. No shell, no coreutils, no `/usr`.

## What

**In-process extraction** (`lib/build/build-stage.tl`): the stage script's three host-tool spawns are gone —

- `/usr/bin/unzip` → `cosmic.zip.extract` (modes preserved masked to 0777, zip-slip validated, all entries checked before any byte is written)
- `gunzip -c` → `cosmic.compress` gzip decompression
- `tar -xzmf` → a new `build.build-untar` module: a ~200-line ustar/pax reader covering what pinned release tarballs actually contain (regular files, dirs, symlinks, pax `path` overrides, GNU longnames), verifying header checksums, and failing loudly on anything else (hard links, unknown types, traversal names, absolute/`..` symlink targets, truncation). Mtimes/ownership deliberately not restored — the policy the old `-m --no-same-owner` flags encoded, matching the stage pledge.

**Shell-free recipes** (Makefile + cook.mk): the recipes' remaining host dependencies were `$(readlink …)` command substitution, the quoted `LUA_PATH` prefix — and the shell itself. The scripts now resolve the `.versioned` symlink in-process (`fs.readlink`); `LUA_PATH` arrives by target-scoped export (the fetched rule's existing `SSL_USE_SYSTEM_CERTS` pattern — not the retired ambient export #727; compile recipes still set their own). That leaves each recipe a metacharacter-free argv, and the only reason bash still ran was the global `.SHELLFLAGS := -o pipefail -c`, which disables make's direct-exec fast path. So:

```make
$(o)/%/.fetched $(o)/%/.staged: export LUA_PATH = $(tree_lua_path)
$(o)/%/.fetched $(o)/%/.staged: private SHELL := /dev/null/enoshell
$(o)/%/.fetched $(o)/%/.staged: private .SHELLFLAGS := -c
```

`.SHELLFLAGS := -c` re-enables the fast path (no pipes in these recipes — pipefail loses nothing) and make execs the bootstrap directly. The poisoned `SHELL` is a permanent tripwire: a recipe regressing to shell syntax fails loudly on every host, Landlock or not, instead of silently re-acquiring the shell. `private` is load-bearing on those two (cold-tree stdlib compile prerequisites need real bash) and deliberately absent on the export (a private export never reaches the recipe environment — witnessed as the bootstrap silently falling back to its embedded stdlib).

**Grants deleted** (the #732 metric): both rules drop `$(unveil_hostx)` entirely — no `rx:/usr`, `rx:/bin`, `rx:/lib*`, `rx:/proc`, and fetch's blanket `r:/etc` narrowed to `resolv.conf`/`hosts`/`ssl`. The device nodes mbedtls needs for TLS entropy split into their own `unveil_dev` set (kernel surface, not host tools):

```
$(o)/%/.fetched: .UNVEIL := $(unveil_dep) $(unveil_dev) r:/etc/resolv.conf r:/etc/hosts r:/etc/ssl …
$(o)/%/.staged:  .UNVEIL := $(unveil_dep) $(unveil_dev)
```

## Validation

- Cold-tree `bin/make -j ci` from `rm -rf o`: real fetches of the cosmos zip and the tl GitHub tarball, staged by the new code (binaries keep 755; full 237-file tl tree), stdlib compiled by prerequisites under real bash while fetch/stage ran shell-free — `ci: PASS`.
- The no-shell claim was proven with the same pinned cosmo-make CI uses, by running the rules with `SHELL` pointed at a nonexistent path — and that proof is now permanent (the tripwire ships).
- `build-untar_test.tl` builds its archives in-process (no host tar in the test either): mode preservation, pax path override, symlinks, and six rejection paths (traversal, absolute symlink target, bad checksum, truncation, hard links).
- The first enforced runner pass surfaced one gap (`/bin/bash: Permission denied` across all four Linux lanes — cosmo-make invoking the shell for a plain argv), which drove the investigation that removed the shell instead of granting it. The runner's enforced lanes on this head are the authority for the final grants.

## Remaining host surface (follow-ups for #732)

`SHELL := /bin/bash` for every other rule family, the `.versioned` recipe (`mkdir`/`ln`), the `| tee $@` summary rules, write-if-changed `cmp`/`mv` dances, `cp` in the binary rule, and `bin/make`'s curl bootstrap (irreducible: it exists to obtain the first pinned binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9sZQU3fNPBndg6ekctHyw