### PR TITLE
build: de-host the reporter summary rules — reporter writes its own file (#732)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ check: teal
 teal: $(o)/teal-summary.txt
 
 $(o)/teal-summary.txt: $(all_teals) | $(build_reporter)
-	@$(reporter) --dir $(o) $^ | tee $@
+	@$(bootstrap_cosmic) -- $(build_reporter) --dir $(o) --out $@ $^
 
 $(o)/%.teal.got: $(o)/% $(cosmic_check_bin) | $(bootstrap_files)
 	@mkdir -p $(@D)
@@ -308,7 +308,7 @@ all_formats := $(patsubst %,%.format.got,$(all_checkable_files))
 format: $(o)/format-summary.txt
 
 $(o)/format-summary.txt: $(all_formats) | $(build_reporter)
-	@$(reporter) --dir $(o) $^ | tee $@
+	@$(bootstrap_cosmic) -- $(build_reporter) --dir $(o) --out $@ $^
 
 $(o)/%.format.got: $(o)/% $(cosmic_check_bin) | $(bootstrap_files)
 	@mkdir -p $(@D)
@@ -335,11 +335,11 @@ $(lint_list_stamp): .FORCE
 ## Check file length limits on all files
 lint: $(o)/lint-summary.txt
 
+$(o)/lint-summary.txt: export REPORTER_NOTE = $(if $(lint_deleted),lint: skipped deleted tracked file(s): $(lint_deleted))
 $(o)/lint-summary.txt: $(all_linted) $(lint_list_stamp) | $(build_reporter)
-	@test -n "$(strip $(lint_tracked))" || { echo "lint: git ls-files found nothing — not a git checkout?"; exit 1; }
-	@test -n "$(strip $(lint_present))" || { echo "lint: no tracked file exists on disk — filter collapsed the list?"; exit 1; }
-	@$(reporter) --dir $(o) $(patsubst %,%.got,$(basename $(all_linted))) | tee $@
-	@$(if $(lint_deleted),echo "lint: skipped deleted tracked file(s): $(lint_deleted)" | tee -a $@,true)
+	$(if $(strip $(lint_tracked)),,$(error lint: git ls-files found nothing — not a git checkout?))
+	$(if $(strip $(lint_present)),,$(error lint: no tracked file exists on disk — filter collapsed the list?))
+	@$(bootstrap_cosmic) -- $(build_reporter) --dir $(o) --out $@ $(patsubst %,%.got,$(basename $(all_linted)))
 
 $(o)/%.lint.ok: % $(build_lint) $(lint_style_lua) | $(bootstrap_cosmic)
 	@mkdir -p $(@D)
@@ -377,7 +377,7 @@ all_examples := $(patsubst %.tl,$(o)/%.tl.example.got,$(all_example_srcs))
 example: $(o)/example-summary.txt
 
 $(o)/example-summary.txt: $(all_examples) | $(build_reporter)
-	@$(reporter) --dir $(o) $^ | tee $@
+	@$(bootstrap_cosmic) -- $(build_reporter) --dir $(o) --out $@ $^
 
 $(o)/%.tl.example.got: %.tl $(cosmic_bin) $(ape_loader) | $(bootstrap_files)
 	@mkdir -p $(@D)
@@ -392,7 +392,7 @@ all_benchmarks := $(patsubst %.tl,$(o)/%.tl.benchmark.got,$(all_benchmark_srcs))
 benchmark: $(o)/benchmark-summary.txt
 
 $(o)/benchmark-summary.txt: $(all_benchmarks) | $(build_reporter)
-	@$(reporter) --dir $(o) $^ | tee $@
+	@$(bootstrap_cosmic) -- $(build_reporter) --dir $(o) --out $@ $^
 
 $(o)/%.tl.benchmark.got: .PLEDGE := $(pledge_build)
 $(o)/%.tl.benchmark.got: .UNVEIL := $(unveil_run)

--- a/cook.mk
+++ b/cook.mk
@@ -92,7 +92,13 @@ reporter_summaries := $(o)/teal-summary.txt $(o)/format-summary.txt \
   $(o)/lint-summary.txt $(o)/example-summary.txt $(o)/benchmark-summary.txt
 $(reporter_summaries): .SANDBOXED := 1
 $(reporter_summaries): .PLEDGE := $(pledge_build)
-$(reporter_summaries): .UNVEIL := rwc:$(o) $(unveil_hostx)
+# De-hosted (#732): the reporter writes its own summary (--out replaces
+# `| tee`), so these recipes are direct bootstrap execs — same no-shell
+# fast path + tripwire as fetch/stage above.
+$(reporter_summaries): .UNVEIL := rwc:$(o) $(unveil_dev)
+$(reporter_summaries): export LUA_PATH = $(tree_lua_path)
+$(reporter_summaries): private SHELL := /dev/null/enoshell
+$(reporter_summaries): private .SHELLFLAGS := -c
 
 # Third ENFORCED family (#729): the teal/format check rules, which exec
 # the assimilated $(cosmic_check_bin) duplicate (see lib/cosmic/cook.mk)

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -10,9 +10,6 @@ build_lint := $(o)/lib/build/lint.lua
 build_files := $(build_fetch) $(build_stage) $(build_untar) $(build_portable) $(build_reporter) $(build_help) $(build_lint)
 build_tests := $(wildcard lib/build/*_test.tl)
 
-# recursive (=): tree_lua_path is computed in the Makefile after the
-# includes; recipes expand it at run time (#720)
-reporter = LUA_PATH="$(tree_lua_path)" $(bootstrap_cosmic) -- $(build_reporter)
 # lint.lua delegates its shared checks to cosmic.cli.style; LUA_PATH points
 # at this tree's freshly compiled modules (the doc/index.tl pattern) so the
 # delegation runs THIS tree's style code, not the bootstrap's embedded copy.

--- a/lib/build/reporter.tl
+++ b/lib/build/reporter.tl
@@ -96,8 +96,12 @@ end
 local function main(...: string): integer, string
   local args = {...}
   local dir: string = nil
+  local out: string = nil
 
-  local longopts: {getopt.LongOpt} = {{name = "dir", has_arg = "required"}}
+  local longopts: {getopt.LongOpt} = {
+    {name = "dir", has_arg = "required"},
+    {name = "out", has_arg = "required"},
+  }
   local parser = getopt.new(args, "", longopts)
 
   while true do
@@ -105,14 +109,16 @@ local function main(...: string): integer, string
     if not opt then break end
     if opt == "dir" then
       dir = optarg
+    elseif opt == "out" then
+      out = optarg
     elseif opt == "?" then
-      return 1, "usage: reporter.lua --dir DIR FILES..."
+      return 1, "usage: reporter.lua --dir DIR [--out FILE] FILES..."
     end
   end
 
   local files = parser:remaining()
   if not files or #files == 0 then
-    return 1, "usage: reporter.lua --dir DIR FILES..."
+    return 1, "usage: reporter.lua --dir DIR [--out FILE] FILES..."
   end
   if not dir then
     return 1, "error: --dir is required"
@@ -242,7 +248,24 @@ local function main(...: string): integer, string
     table.insert(parts, failures)
   end
 
-  print(table.concat(parts, "\n"))
+  -- REPORTER_NOTE: an extra line from the make rule (e.g. lint's
+  -- skipped-deleted-files notice). An env var, not a flag: note text
+  -- carries spaces, which a shell-free recipe argv cannot (#732).
+  local note = os.getenv("REPORTER_NOTE")
+  if note and note ~= "" then
+    table.insert(parts, note)
+  end
+
+  local report = table.concat(parts, "\n")
+  print(report)
+  -- --out replaces the recipes' `| tee $@` (#732): the reporter writes
+  -- its own summary file, so the rule needs no shell and no host tee.
+  if out then
+    local ok, werr = fs.write(out, report .. "\n")
+    if not ok then
+      return 1, "error: cannot write " .. out .. ": " .. (werr or "unknown error")
+    end
+  end
   return total_failed == 0 and 0 or 1, nil
 end
 

--- a/lib/build/reporter_test.tl
+++ b/lib/build/reporter_test.tl
@@ -138,3 +138,47 @@ local function test_message_from_stderr()
   assert(stdout:match("first line error"), "expected first line of stderr as message")
 end
 test_message_from_stderr()
+
+-- --out writes the same report the recipes used to `| tee` (#732)
+local function test_out_writes_file()
+  local test_dir = fs.join(tmpdir, "out-file")
+  fs.makedirs(test_dir)
+
+  write_test_result(fs.join(test_dir, "a.test"), 0, "ok\n", "")
+  local out_path = fs.join(test_dir, "summary.txt")
+
+  local code, stdout, _stderr = run_reporter(
+    "--dir", test_dir, "--out", out_path,
+    fs.join(test_dir, "a.test.got")
+  )
+
+  assert(code == 0, "expected exit code 0, got: " .. tostring(code))
+  local written = fs.read(out_path)
+  assert(written == stdout, "summary file must match stdout, got: " .. tostring(written))
+end
+test_out_writes_file()
+
+-- REPORTER_NOTE appends a line to report and file: note text carries
+-- spaces, which a shell-free recipe argv cannot pass as a flag (#732)
+local function test_reporter_note()
+  local test_dir = fs.join(tmpdir, "note")
+  fs.makedirs(test_dir)
+
+  write_test_result(fs.join(test_dir, "a.test"), 0, "ok\n", "")
+  local out_path = fs.join(test_dir, "summary.txt")
+  env.set("REPORTER_NOTE", "lint: skipped deleted tracked file(s): gone.tl")
+
+  local code, stdout, _stderr = run_reporter(
+    "--dir", test_dir, "--out", out_path,
+    fs.join(test_dir, "a.test.got")
+  )
+  env.unset("REPORTER_NOTE")
+
+  assert(code == 0, "expected exit code 0, got: " .. tostring(code))
+  assert(stdout:match("skipped deleted tracked file%(s%): gone%.tl"),
+    "expected note in stdout, got: " .. stdout)
+  -- cast: or fallback does not narrow
+  local written = (fs.read(out_path) or "") as string
+  assert(written:match("gone%.tl"), "expected note in summary file")
+end
+test_reporter_note()


### PR DESCRIPTION
Part of #732 / #728 (item 4). Second de-hosted rule family, applying #751's pattern to the five sandboxed summary rules (`teal`/`format`/`lint`/`example`/`benchmark`-summary.txt).

## What

- **`--out FILE`** on the reporter: it writes its own summary file while still printing to stdout — replacing `| tee $@` in every summary recipe. A write failure is a loud error, not a silent half-summary.
- **`REPORTER_NOTE`** env hook: appends one line to the report (stdout + file). This carries lint's skipped-deleted-files notice, which previously needed `echo … | tee -a` — the note text contains spaces, which a shell-free recipe argv cannot pass as a flag, so it rides the environment via a target-scoped `export` like `SSL_USE_SYSTEM_CERTS`/`LUA_PATH`.
- **lint-summary's two `test -n` guards** become make-level `$(if …,,$(error …))` conditionals, expanded when the rule fires — same failure semantics, no shell.
- With that, every summary recipe is a metacharacter-free direct exec of the pinned bootstrap, under the same `private .SHELLFLAGS := -c` fast path and poisoned `SHELL := /dev/null/enoshell` tripwire as fetch/stage (#751).
- **Grants**: `reporter_summaries` drops `$(unveil_hostx)` for `rwc:$(o) $(unveil_dev)` (plus the merged global base). The shell-quoting `$(reporter)` macro is deleted — no remaining users.

## Validation

- Full `bin/make -j ci`: **PASS** — the graded verdict itself reads the summary files the reporter now writes, so the tee-replacement is exercised by the gate's own plumbing, not just by tests.
- New `reporter_test.tl` cases: `--out` file content byte-equals stdout; `REPORTER_NOTE` appears in both stdout and the file.
- Landlock is unavailable in the dev sandbox; the runner's enforced lanes are the authority for the tightened grants (expected to pass — the reporter reads/writes only under `o/`, all inside `rwc:$(o)` + the global base grants).

## Remaining for #732 (unchanged ranking)

Compile rule's `cat`/`cmp`/`mv` write-if-changed dance (the biggest family — likely needs a bootstrap-side compile wrapper, with a self-bootstrap special case), the check/example/benchmark `.got` capture recipes (candidate: reuse the `--test` capture machinery), `.versioned`'s `mkdir`/`ln`, the test-lane `--report | tee` rules (this tree's `--report` gains `--out` trivially once the test family is tackled), and `bin/make`'s irreducible curl bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9sZQU3fNPBndg6ekctHyw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9sZQU3fNPBndg6ekctHyw)_