### PR TITLE
build: de-shell compile/copy/link/doc-index and the .got captures (#732)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,8 @@ $(o)/test-summary.txt: $(all_tested) | $(cosmic_bin)
 
 export TEST_O := $(o)
 export TEST_PLATFORM := $(platform)
+# per-module target-specific TEST_DIR values reach recipe envs via this
+export TEST_DIR
 export TEST_BIN := $(o)/bin
 # TEST_TMPDIR is set per-test by cosmic --test command
 # tree_lua_path aggregates _lua_dirs from modules. Deliberately NOT
@@ -179,8 +181,7 @@ $(quicksand_sandbox_tests): .PLEDGE =
 $(quicksand_sandbox_tests): .UNVEIL =
 
 $(o)/%.tl.test.got: $(o)/%.lua $(cosmic_bin) $(ape_loader)
-	@mkdir -p $(@D)
-	@TEST_DIR=$(TEST_DIR) LUA_PATH="$(tree_lua_path)" PATH=$(CURDIR)/$(o)/bin:$$PATH $(cosmic_bin) --test $(basename $@) $(cosmic_bin) $<
+	@$(cosmic_bin) --test $(basename $@) $(cosmic_bin) $<
 
 # Test deps beyond the pattern rule (own compiled .lua + $(cosmic_bin))
 # live in each module's cook.mk: perf tests attach $(perf_lua), build
@@ -204,9 +205,9 @@ coverage: $(o)/coverage-summary.txt
 
 $(o)/coverage/%.tl.test.got: .PLEDGE := $(pledge_test)
 $(o)/coverage/%.tl.test.got: .UNVEIL := $(unveil_test)
+$(o)/coverage/%.tl.test.got: export COSMIC_COVERAGE := 1
 $(o)/coverage/%.tl.test.got: $(o)/%.lua $(cosmic_bin) $(ape_loader)
-	@mkdir -p $(@D)
-	@TEST_DIR=$(TEST_DIR) COSMIC_COVERAGE=1 LUA_PATH="$(tree_lua_path)" PATH=$(CURDIR)/$(o)/bin:$$PATH $(cosmic_bin) --test $(basename $@) $(cosmic_bin) $<
+	@$(cosmic_bin) --test $(basename $@) $(cosmic_bin) $<
 
 # Coverage ratchet: the committed baseline records covered/total per
 # file; the check fails when coverage declines or the file set drifts.
@@ -260,10 +261,9 @@ $(enforce_got): .SANDBOXED := 0
 $(enforce_got): .PLEDGE =
 $(enforce_got): .UNVEIL =
 
+$(o)/enforce/%.tl.test.got: export COSMIC_ENFORCE := 1
 $(o)/enforce/%.tl.test.got: $(o)/%.lua $(cosmic_bin)
-	@mkdir -p $(@D)
-	@TEST_BIN=$(o)/bin COSMIC_ENFORCE=1 LUA_PATH="$(tree_lua_path)" PATH=$(CURDIR)/$(o)/bin:$$PATH \
-	  $(cosmic_bin) --test $(basename $@) $(cosmic_bin) $<
+	@$(cosmic_bin) --test $(basename $@) $(cosmic_bin) $<
 
 $(o)/enforce-summary.txt: $(enforce_got) | $(cosmic_bin)
 	@$(cosmic_bin) --report $^ | tee $@
@@ -298,8 +298,7 @@ $(o)/teal-summary.txt: $(all_teals) | $(build_reporter)
 	@$(bootstrap_cosmic) -- $(build_reporter) --dir $(o) --out $@ $^
 
 $(o)/%.teal.got: $(o)/% $(cosmic_check_bin) | $(bootstrap_files)
-	@mkdir -p $(@D)
-	-@TL_PATH="$(tree_tl_path)" $(cosmic_check_bin) $(include_dir_flags) --check-types $< > $(basename $@).out 2> $(basename $@).err; STATUS=$$?; echo $$STATUS > $@
+	@$(cosmic_check_bin) --test $(basename $@) $(cosmic_check_bin) $(include_dir_flags) --check-types $<
 
 all_formats := $(patsubst %,%.format.got,$(all_checkable_files))
 
@@ -310,8 +309,7 @@ $(o)/format-summary.txt: $(all_formats) | $(build_reporter)
 	@$(bootstrap_cosmic) -- $(build_reporter) --dir $(o) --out $@ $^
 
 $(o)/%.format.got: $(o)/% $(cosmic_check_bin) | $(bootstrap_files)
-	@mkdir -p $(@D)
-	-@$(cosmic_check_bin) --check-format $< > $(basename $@).out 2> $(basename $@).err; STATUS=$$?; echo $$STATUS > $@
+	@$(cosmic_check_bin) --test $(basename $@) $(cosmic_check_bin) --check-format $<
 
 # Lint every tracked file (#719). git ls-files fails SILENTLY outside
 # a git checkout — an empty list would lint nothing and report green,
@@ -379,8 +377,7 @@ $(o)/example-summary.txt: $(all_examples) | $(build_reporter)
 	@$(bootstrap_cosmic) -- $(build_reporter) --dir $(o) --out $@ $^
 
 $(o)/%.tl.example.got: %.tl $(cosmic_bin) $(ape_loader) | $(bootstrap_files)
-	@mkdir -p $(@D)
-	@set +e; $(cosmic_bin) --check-examples $< > $(basename $@).out 2> $(basename $@).err; echo $$? > $@
+	@$(cosmic_bin) --test $(basename $@) $(cosmic_bin) --check-examples $<
 
 # Benchmark testing - run Benchmark_* functions in .tl files (exclude test files)
 all_benchmark_srcs := $(call filter-only,$(foreach m,$(modules),$(filter-out $($(m)_tests),$($(m)_tl))))
@@ -396,8 +393,7 @@ $(o)/benchmark-summary.txt: $(all_benchmarks) | $(build_reporter)
 $(o)/%.tl.benchmark.got: .PLEDGE := $(pledge_build)
 $(o)/%.tl.benchmark.got: .UNVEIL := $(unveil_run)
 $(o)/%.tl.benchmark.got: %.tl $(cosmic_bin) | $(bootstrap_files)
-	@mkdir -p $(@D)
-	@set +e; LUA_PATH="$(tree_lua_path)" $(cosmic_bin) --benchmark $< > $(basename $@).out 2> $(basename $@).err; echo $$? > $@
+	@$(cosmic_bin) --test $(basename $@) $(cosmic_bin) --benchmark $<
 
 # Documentation generation - render .tl files as markdown
 # Module sources for docs: all _tl files (excludes tests and examples).

--- a/Makefile
+++ b/Makefile
@@ -57,17 +57,16 @@ filter-only = $(if $(only),$(foreach f,$1,$(if $(findstring $(only),$(f)),$(f)))
 
 cp := cp -p
 
-# plain cp: -p's acl step trips the enforced pledge (#729); .exists orders
-# cold-tree copies after o/ exists (unveil skips missing paths silently)
-$(o)/%: % | $(o)/.exists
-	@mkdir -p $(@D) && cp $< $@
+# Copies and compiles run through the build-recipe driver (#732): no
+# shell, no host mkdir/cp/cat/cmp/mv (LUA_PATH pins live in cook.mk
+# with the family's other pattern vars). .exists orders cold-tree
+# copies after o/ exists (unveil skips missing paths silently).
+$(o)/%: % $(build_recipe) | $(o)/.exists $(bootstrap_cosmic)
+	@$(bootstrap_cosmic) -- $(build_recipe) copy $< $@
 $(o)/.exists: ; @mkdir -p $(@D) && touch $@
 
-# compile .tl to .lua; flag from cook.mk's probe (strict ;; vs tree path, #666)
-$(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files) $(compile_flag_stamp)
-	@mkdir -p $(@D)
-	@f=$$(cat $(compile_flag_stamp)); if [ "$$f" = "--compile-strict" ]; then export LUA_PATH=";;"; else export LUA_PATH="$(tree_lua_path)"; fi; export TL_PATH="$(tree_tl_path)"; $(bootstrap_cosmic) $(include_dir_flags) $$f $< > $@.tmp
-	@if cmp -s $@.tmp $@ 2>/dev/null; then rm $@.tmp; else mv $@.tmp $@; fi
+$(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files) $(compile_flag_stamp) $(build_recipe)
+	@$(bootstrap_cosmic) -- $(build_recipe) compile $(compile_flag_stamp) $(bootstrap_cosmic) $< $@ $(include_dir_flags)
 
 # tl files: modules declare _tl, derive compiled .lua outputs
 all_tl := $(call filter-only,$(foreach x,$(modules),$($(x)_tl)))
@@ -93,7 +92,7 @@ all_versions := $(call filter-only,$(foreach x,$(modules),$($(x)_version)))
 
 # versioned modules: o/module/.versioned -> version.lua
 $(foreach m,$(modules),$(if $($(m)_version),\
-  $(eval $(o)/$(m)/.versioned: $($(m)_version) ; @mkdir -p $$(@D) && ln -sfn $(CURDIR)/$$< $$@)))
+  $(eval $(o)/$(m)/.versioned: $($(m)_version) $(build_recipe) | $(bootstrap_cosmic) ; @$(bootstrap_cosmic) -- $(build_recipe) link $(CURDIR)/$$< $$@)))
 all_versioned := $(call filter-only,$(foreach m,$(modules),$(if $($(m)_version),$(o)/$(m)/.versioned)))
 
 # versions get fetched: o/module/.fetched -> o/fetched/module/<ver>-<sha>/<archive>
@@ -445,10 +444,9 @@ doc_index_script := lib/cosmic/doc/index.tl
 # any future build-logic change — arrives; a bare Makefile prereq missed
 # cook.mk edits (#717). The write-if-changed dance below keeps the
 # binary from re-embedding when the regenerated content is identical
-$(doc_index): $(doc_index_srcs) $(doc_index_lua) $(doc_index_script) $(MAKEFILE_LIST) | $(bootstrap_cosmic)
-	@mkdir -p $(@D)
-	@LUA_PATH="$(o)/lib/?.lua;$(o)/lib/?/init.lua;;" $(bootstrap_cosmic) $(doc_index_script) $(doc_index_srcs) > $@.tmp
-	@if cmp -s $@.tmp $@ 2>/dev/null; then rm $@.tmp; else mv $@.tmp $@; fi
+$(doc_index): export TREE_LUA_PATH = $(o)/lib/?.lua;$(o)/lib/?/init.lua;;
+$(doc_index): $(doc_index_srcs) $(doc_index_lua) $(doc_index_script) $(build_recipe) $(MAKEFILE_LIST) | $(bootstrap_cosmic)
+	@$(bootstrap_cosmic) -- $(build_recipe) capture $(bootstrap_cosmic) $@ $(doc_index_script) $(doc_index_srcs)
 
 .PHONY: doc-index
 ## Generate serialized documentation index

--- a/cook.mk
+++ b/cook.mk
@@ -59,7 +59,19 @@ pledge_test := $(pledge_build) fattr inet dns unix tty id flock
 # otherwise silently mint an artifact with no version.
 $(o)/%.lua: .SANDBOXED := 1
 $(o)/%.lua: .PLEDGE := $(pledge_build) fattr
-$(o)/%.lua: .UNVEIL := rwc:$(o) r:tlconfig.lua $(unveil_hostx)
+# De-hosted (#732): compiles and the $(o)/%: % copies run through the
+# build-recipe driver — direct bootstrap execs under the same no-shell
+# fast path + poisoned-SHELL tripwire as fetch/stage. The driver's own
+# compile opts back out in lib/build/cook.mk (self-bootstrap exception).
+$(o)/%.lua: .UNVEIL := rwc:$(o) r:tlconfig.lua $(unveil_dev)
+$(o)/%.lua: private SHELL := /dev/null/enoshell
+$(o)/%.lua: private .SHELLFLAGS := -c
+# LUA_PATH=;; pins the DRIVER to the bootstrap's embedded stdlib (a
+# caller's LUA_PATH must not redirect its requires); the compile child
+# gets ";;" (strict) or TREE_LUA_PATH — the #666 axis, one layer down.
+$(o)/%.lua: export LUA_PATH := ;;
+$(o)/%.lua: export TREE_LUA_PATH = $(tree_lua_path)
+$(o)/%.lua: export TL_PATH = $(tree_tl_path)
 
 # Second ENFORCED family (#729): every remaining rule that execs the
 # assimilated bootstrap — fetch, stage, lint, and the reporter

--- a/cook.mk
+++ b/cook.mk
@@ -116,12 +116,20 @@ $(reporter_summaries): private .SHELLFLAGS := -c
 # the assimilated $(cosmic_check_bin) duplicate (see lib/cosmic/cook.mk)
 # instead of the fat-APE artifact. Failures inside the sandbox surface
 # as check failures in the summaries — loud, not silent.
+# De-hosted (#732): the checks run through `--test` capture on the
+# assimilated check binary — no shell, no redirect plumbing, no host
+# grants. testrun mkdtemps the per-check TEST_TMPDIR under $(TMP).
 $(o)/%.teal.got: .SANDBOXED := 1
 $(o)/%.teal.got: .PLEDGE := $(pledge_build)
-$(o)/%.teal.got: .UNVEIL := rwc:$(o) r:tlconfig.lua $(unveil_hostx)
+$(o)/%.teal.got: .UNVEIL := rwc:$(o) r:tlconfig.lua rwc:$(TMP) $(unveil_dev)
+$(o)/%.teal.got: export TL_PATH = $(tree_tl_path)
+$(o)/%.teal.got: private SHELL := /dev/null/enoshell
+$(o)/%.teal.got: private .SHELLFLAGS := -c
 $(o)/%.format.got: .SANDBOXED := 1
 $(o)/%.format.got: .PLEDGE := $(pledge_build)
-$(o)/%.format.got: .UNVEIL := rwc:$(o) r:tlconfig.lua $(unveil_hostx)
+$(o)/%.format.got: .UNVEIL := rwc:$(o) r:tlconfig.lua rwc:$(TMP) $(unveil_dev)
+$(o)/%.format.got: private SHELL := /dev/null/enoshell
+$(o)/%.format.got: private .SHELLFLAGS := -c
 
 # Fifth ENFORCED family (#729): examples. Same grant sets as the test
 # lanes — examples exercise the same modules (sockets, tty, chmod) and
@@ -131,6 +139,8 @@ $(o)/%.format.got: .UNVEIL := rwc:$(o) r:tlconfig.lua $(unveil_hostx)
 $(o)/%.tl.example.got: .SANDBOXED := 1
 $(o)/%.tl.example.got: .PLEDGE := $(pledge_test)
 $(o)/%.tl.example.got: .UNVEIL := $(unveil_test)
+$(o)/%.tl.example.got: private SHELL := /dev/null/enoshell
+$(o)/%.tl.example.got: private .SHELLFLAGS := -c
 
 # Fourth ENFORCED family (#729): the plain and coverage test lanes,
 # running the real fat-APE $(cosmic_bin) via the staged o/bin/ape
@@ -140,8 +150,21 @@ $(o)/%.tl.example.got: .UNVEIL := $(unveil_test)
 # lane opt back out where their empty grant overrides live in the
 # Makefile: they exercise unshare and real self-sandboxing, which no
 # outer sandbox can permit.
+# The test/coverage/enforce recipes are shell-free too (#732): the env
+# prefixes became target-scoped exports (TEST_DIR is exported globally
+# in the Makefile so per-module target values reach recipe envs; the
+# PATH prefix was redundant since the #731 clamp already puts o/bin on
+# PATH). Their grants are unchanged — tests legitimately exec host
+# tools (sh, etc.) under $(unveil_test).
 $(o)/%.tl.test.got: .SANDBOXED := 1
+$(o)/%.tl.test.got: export LUA_PATH = $(tree_lua_path)
+$(o)/%.tl.test.got: private SHELL := /dev/null/enoshell
+$(o)/%.tl.test.got: private .SHELLFLAGS := -c
 $(o)/coverage/%.tl.test.got: .SANDBOXED := 1
+$(o)/enforce/%.tl.test.got: export LUA_PATH = $(tree_lua_path)
+$(o)/%.tl.benchmark.got: export LUA_PATH = $(tree_lua_path)
+$(o)/%.tl.benchmark.got: private SHELL := /dev/null/enoshell
+$(o)/%.tl.benchmark.got: private .SHELLFLAGS := -c
 
 # Type definition generation (define early so it's available to all modules).
 # Must match MODULES in lib/types/gentype.tl: "cosmo" renders the top-level

--- a/lib/build/build-recipe.tl
+++ b/lib/build/build-recipe.tl
@@ -1,0 +1,178 @@
+#!/usr/bin/env lua
+--- Shell-free recipe steps for the compile, copy, version-link, and
+--- doc-index rules (#732): `compile` replaces the cat/if/redirect/
+--- cmp/mv dance, `copy` replaces mkdir+cp, `link` replaces
+--- mkdir+ln -sfn, `capture` replaces redirect+cmp/mv for scripts.
+---
+--- Runs under the PINNED bootstrap against its EMBEDDED stdlib only —
+--- deliberately no tree requires, unlike every other build script: the
+--- compile rule is what BUILDS the tree's .lua files, so a tree
+--- dependency here is circular, and the recipes export LUA_PATH=";;"
+--- so a caller's LUA_PATH cannot redirect the driver's own requires.
+--- The bootstrap sha therefore covers this driver's entire runtime; a
+--- bootstrap bump that breaks an embedded API fails the build loudly.
+--- The driver's own .lua is compiled by a self-bootstrap exception
+--- rule (see lib/build/cook.mk) — it cannot compile itself.
+
+local child = require("cosmic.child")
+local env = require("cosmic.env")
+local fs = require("cosmic.fs")
+local fs_types = require("cosmic.fs.types")
+local proc = require("cosmic.proc")
+
+local function fail(msg: string): integer
+  io.stderr:write("build-recipe: " .. msg .. "\n")
+  return 1
+end
+
+--- Run argv, pass stderr through, and write stdout to out only when
+--- the content changed — preserving the old cmp/mv contract that an
+--- unchanged result does not touch the output's mtime.
+local function run_into(argv: {string}, out: string): integer
+  local result, serr = child.run(argv)
+  if not result then
+    return fail("spawn " .. argv[1] .. " failed: " .. tostring(serr))
+  end
+  local r = result as child.Result -- cast: record union after guard
+  if r.stderr and r.stderr ~= "" then
+    io.stderr:write(r.stderr)
+  end
+  if not r.ok then
+    return r.code or 1
+  end
+  local existing = fs.read(out)
+  if existing == r.stdout then
+    return 0
+  end
+  fs.makedirs(fs.dirname(out))
+  local ok, werr = fs.write(out, r.stdout)
+  if not ok then
+    return fail("write " .. out .. " failed: " .. (werr or "unknown error"))
+  end
+  return 0
+end
+
+local function child_tree_lua_path(): string
+  local tree = os.getenv("TREE_LUA_PATH")
+  if not tree or tree == "" then
+    return nil
+  end
+  return tree
+end
+
+--- compile <flag_stamp> <bootstrap> <src> <out> [compiler flags...]
+--- Reads the probed flag and sets the child's LUA_PATH (";;" for
+--- strict compiles, $TREE_LUA_PATH otherwise; TL_PATH passes through
+--- from the rule's export).
+local function do_compile(args: {string}): integer
+  local stamp, bootstrap, src, out = args[1], args[2], args[3], args[4]
+  if not out then
+    return fail("usage: compile <flag_stamp> <bootstrap> <src> <out> [flags...]")
+  end
+  -- cast: or fallback does not narrow
+  local flag = ((fs.read(stamp) or "") as string):match("%S+")
+  if flag ~= "--compile-strict" and flag ~= "--compile" then
+    return fail("bad compile flag in " .. stamp .. ": " .. tostring(flag))
+  end
+  if flag == "--compile-strict" then
+    env.set("LUA_PATH", ";;")
+  else
+    local tree = child_tree_lua_path()
+    if not tree then
+      return fail("TREE_LUA_PATH required for non-strict compiles")
+    end
+    env.set("LUA_PATH", tree)
+  end
+
+  local argv: {string} = {bootstrap}
+  for i = 5, #args do
+    table.insert(argv, args[i])
+  end
+  table.insert(argv, flag)
+  table.insert(argv, src)
+  return run_into(argv, out)
+end
+
+--- capture <bootstrap> <out> <script+args...> — run a script under the
+--- bootstrap with LUA_PATH=$TREE_LUA_PATH and write its stdout to out
+--- if changed (the doc-index rule's shape).
+local function do_capture(args: {string}): integer
+  local bootstrap, out = args[1], args[2]
+  if not out or not args[3] then
+    return fail("usage: capture <bootstrap> <out> <script> [args...]")
+  end
+  local tree = child_tree_lua_path()
+  if not tree then
+    return fail("TREE_LUA_PATH required for capture")
+  end
+  env.set("LUA_PATH", tree)
+  local argv: {string} = {bootstrap}
+  for i = 3, #args do
+    table.insert(argv, args[i])
+  end
+  return run_into(argv, out)
+end
+
+--- copy <src> <dst> — mkdir -p + cp, preserving the permission bits.
+local function do_copy(args: {string}): integer
+  local src, dst = args[1], args[2]
+  if not dst then
+    return fail("usage: copy <src> <dst>")
+  end
+  local content, rerr = fs.read(src)
+  if not content then
+    return fail("read " .. src .. " failed: " .. (rerr or "unknown error"))
+  end
+  local st = fs.stat(src)
+  if not st then
+    return fail("stat " .. src .. " failed")
+  end
+  -- cast: mixed-representation Stat
+  local mode = (st as fs_types.Stat):mode() % 512 -- permission bits (0777)
+  fs.makedirs(fs.dirname(dst))
+  local ok, werr = fs.write(dst, content, mode)
+  if not ok then
+    return fail("write " .. dst .. " failed: " .. (werr or "unknown error"))
+  end
+  fs.chmod(dst, mode) -- write's mode only applies on create
+  return 0
+end
+
+--- link <target> <linkpath> — mkdir -p + ln -sfn.
+local function do_link(args: {string}): integer
+  local target, linkpath = args[1], args[2]
+  if not linkpath then
+    return fail("usage: link <target> <linkpath>")
+  end
+  fs.makedirs(fs.dirname(linkpath))
+  fs.unlink(linkpath)
+  local ok, lerr = fs.symlink(target, linkpath)
+  if not ok then
+    return fail("symlink " .. linkpath .. " -> " .. target .. " failed: "
+      .. (lerr or "unknown error"))
+  end
+  return 0
+end
+
+local modes: {string: function({string}): integer} = {
+  capture = do_capture,
+  compile = do_compile,
+  copy = do_copy,
+  link = do_link,
+}
+
+local function main(...: string): integer
+  local args = {...}
+  local mode = table.remove(args, 1)
+  local run_mode = mode and modes[mode]
+  if not run_mode then
+    return fail("usage: build-recipe capture|compile|copy|link ...")
+  end
+  return run_mode(args)
+end
+
+if proc.is_main() then
+  os.exit(main(...))
+end
+
+return {main = main}

--- a/lib/build/build-recipe_test.tl
+++ b/lib/build/build-recipe_test.tl
@@ -1,0 +1,123 @@
+#!/usr/bin/env cosmic
+-- Tests for the build-recipe driver (#732). The driver is spawned the
+-- way make spawns it, with the test cosmic binary standing in as the
+-- pinned bootstrap for compile mode.
+
+local child = require("cosmic.child")
+local env = require("cosmic.env")
+local fs = require("cosmic.fs")
+local fs_types = require("cosmic.fs.types")
+
+local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
+local test_bin = fs.join(os.getenv("TEST_BIN") or "", "cosmic")
+local test_o = os.getenv("TEST_O") or "o"
+local driver = fs.join(test_o, "lib/build/build-recipe.lua")
+
+local function run_driver(...: string): integer, string, string
+  local args: {string} = {test_bin, "--", driver}
+  for _, a in ipairs({...}) do
+    table.insert(args, a)
+  end
+  local result, serr = child.run(args)
+  if not result then
+    return 1, "", tostring(serr)
+  end
+  local r = result as child.Result -- cast: record union after guard
+  local code = 1
+  if r.code ~= nil then
+    code = r.code
+  end
+  return code, r.stdout, r.stderr
+end
+
+local function test_copy_preserves_mode()
+  local src = fs.join(tmpdir, "tool.sh")
+  local dst = fs.join(tmpdir, "out/deep/tool.sh")
+  assert(fs.write(src, "#!/bin/sh\n", tonumber("755", 8) as integer)) -- cast: octal is integral
+  local code, _out, err = run_driver("copy", src, dst)
+  assert(code == 0, "copy failed (" .. tostring(code) .. "): " .. err)
+  assert(fs.read(dst) == "#!/bin/sh\n", "copy content")
+  local st = fs.stat(dst)
+  assert(st, "dst should stat")
+  local mode = (st as fs_types.Stat):mode() % 512 -- cast: mixed-representation Stat
+  assert(mode % 2 == 1, "exec bit preserved, mode: " .. string.format("%o", mode))
+end
+test_copy_preserves_mode()
+
+local function test_link_replaces()
+  local linkpath = fs.join(tmpdir, "links/v.lua")
+  local code, _out, err = run_driver("link", "/some/target", linkpath)
+  assert(code == 0, "link failed: " .. err)
+  assert(fs.readlink(linkpath) == "/some/target", "link target")
+  -- ln -sfn semantics: re-linking replaces
+  code, _out, err = run_driver("link", "/other/target", linkpath)
+  assert(code == 0, "relink failed: " .. err)
+  assert(fs.readlink(linkpath) == "/other/target", "link replaced")
+end
+test_link_replaces()
+
+local function compile_fixture(name: string, content: string): string, string, string
+  local dir = fs.join(tmpdir, name)
+  fs.makedirs(dir)
+  local stamp = fs.join(dir, "compile-flag")
+  local src = fs.join(dir, "mod.tl")
+  local out = fs.join(dir, "mod.lua")
+  assert(fs.write(stamp, "--compile\n"))
+  assert(fs.write(src, content))
+  return stamp, src, out
+end
+
+local function test_compile_writes_output()
+  local stamp, src, out = compile_fixture("c-ok", "local x: number = 1\nprint(x)\n")
+  env.set("TREE_LUA_PATH", ";;")
+  local code, _out, err = run_driver("compile", stamp, test_bin, src, out)
+  assert(code == 0, "compile failed (" .. tostring(code) .. "): " .. err)
+  -- cast: or fallback does not narrow
+  local lua = (fs.read(out) or "") as string
+  assert(lua:match("print"), "expected compiled lua, got: " .. lua)
+end
+test_compile_writes_output()
+
+local function test_compile_unchanged_keeps_mtime()
+  local stamp, src, out = compile_fixture("c-mtime", "print(1)\n")
+  env.set("TREE_LUA_PATH", ";;")
+  local code = run_driver("compile", stamp, test_bin, src, out)
+  assert(code == 0, "first compile failed")
+  local st1 = fs.stat(out)
+  assert(st1, "output should exist")
+  local s1, n1 = (st1 as fs_types.Stat):mtim() -- cast: mixed-representation Stat
+  -- second run with identical content must not rewrite the output
+  fs.chmod(out, tonumber("444", 8) as integer) -- cast: octal is integral
+  code = run_driver("compile", stamp, test_bin, src, out)
+  assert(code == 0, "second compile failed")
+  local st2 = fs.stat(out)
+  local s2, n2 = (st2 as fs_types.Stat):mtim() -- cast: mixed-representation Stat
+  assert(s1 == s2 and n1 == n2, "unchanged compile must not touch the output")
+end
+test_compile_unchanged_keeps_mtime()
+
+local function test_compile_failure_no_output()
+  local stamp, src, out = compile_fixture("c-bad", "local x: number = \"not a number\"\n")
+  env.set("TREE_LUA_PATH", ";;")
+  local code, _out, err = run_driver("compile", stamp, test_bin, src, out)
+  assert(code ~= 0, "type error must fail the compile")
+  assert(err ~= "", "compiler stderr must pass through")
+  assert(not fs.stat(out), "failed compile must not write output")
+end
+test_compile_failure_no_output()
+
+local function test_compile_rejects_bad_stamp()
+  local stamp, src, out = compile_fixture("c-stamp", "print(1)\n")
+  assert(fs.write(stamp, "--rm -rf\n"))
+  local code, _out, err = run_driver("compile", stamp, test_bin, src, out)
+  assert(code ~= 0, "bad stamp must fail")
+  assert(err:match("bad compile flag"), "expected stamp error, got: " .. err)
+end
+test_compile_rejects_bad_stamp()
+
+local function test_unknown_mode()
+  local code, _out, err = run_driver("explode")
+  assert(code ~= 0, "unknown mode must fail")
+  assert(err:match("usage"), "expected usage error, got: " .. err)
+end
+test_unknown_mode()

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -7,7 +7,23 @@ build_portable := $(o)/lib/build/portable.lua
 build_reporter := $(o)/lib/build/reporter.lua
 build_help := $(o)/lib/build/make-help.lua
 build_lint := $(o)/lib/build/lint.lua
+build_recipe := $(o)/lib/build/build-recipe.lua
 build_files := $(build_fetch) $(build_stage) $(build_untar) $(build_portable) $(build_reporter) $(build_help) $(build_lint)
+
+# Self-bootstrap exception (#732): build-recipe drives the shell-free
+# compile/copy/link recipes, so it cannot be compiled by them — this one
+# target keeps the old shell recipe (and the host grants + real shell it
+# needs), and everything else compiles through the driver. The driver
+# runs against the bootstrap's EMBEDDED stdlib (see its header), so the
+# bootstrap sha covers its runtime and no tree .lua is required first.
+$(build_recipe): SHELL := /bin/bash
+$(build_recipe): .SHELLFLAGS := -o pipefail -c
+$(build_recipe): export LUA_PATH := ;;
+$(build_recipe): .UNVEIL := rwc:$(o) r:tlconfig.lua $(unveil_hostx)
+$(build_recipe): lib/build/build-recipe.tl $(types_files) $(tl_files) $(bootstrap_files) $(compile_flag_stamp)
+	@mkdir -p $(@D)
+	@f=$$(cat $(compile_flag_stamp)); if [ "$$f" = "--compile-strict" ]; then export LUA_PATH=";;"; else export LUA_PATH="$(tree_lua_path)"; fi; export TL_PATH="$(tree_tl_path)"; $(bootstrap_cosmic) $(include_dir_flags) $$f $< > $@.tmp
+	@if cmp -s $@.tmp $@ 2>/dev/null; then rm $@.tmp; else mv $@.tmp $@; fi
 build_tests := $(wildcard lib/build/*_test.tl)
 
 # lint.lua delegates its shared checks to cosmic.cli.style; LUA_PATH points

--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -64,6 +64,11 @@ endef
 # fallback would swallow the denial into a silently version-less
 # artifact. Target-specific wins over pattern-specific.
 $(cosmic_version_lua): .SANDBOXED := 0
+# a .lua-named target inherits the compile family's poisoned no-shell
+# SHELL (#732); this recipe is a deliberate host exception (git) and
+# keeps the real shell alongside its sandbox opt-out above
+$(cosmic_version_lua): SHELL := /bin/bash
+$(cosmic_version_lua): .SHELLFLAGS := -o pipefail -c
 $(cosmic_version_lua): .FORCE | $$(cosmos_staged)
 	@mkdir -p $(@D)
 	@echo "return { cosmic = \"$$(git describe --tags --always --dirty 2>/dev/null || echo unknown)\", cosmos = \"$$($(cosmos_lua_bin) -e "print(dofile('3p/cosmos/version.lua').version)")\" }" > $@.tmp

--- a/lib/cosmic/coverage/baseline.txt
+++ b/lib/cosmic/coverage/baseline.txt
@@ -1,6 +1,7 @@
 # coverage ratchet baseline: `bin/make coverage-baseline` rewrites this file.
 # columns: path covered-lines total-lines
 lib/build/build-fetch.tl 23 95
+lib/build/build-recipe.tl 78 103
 lib/build/build-stage.tl 45 251
 lib/build/build-untar.tl 121 130
 lib/build/lint.tl 97 132


### PR DESCRIPTION
Part of #732 / #728 (item 4). Two rounds on one branch: the compile family (with copies, versioned links, doc-index) moves onto a `build-recipe` driver, and every `.got` capture recipe converges on the existing `--test` machinery. Together they de-shell all ~1000 recipe invocations of a full `ci` run except the deliberate exceptions listed at the end.

## Round 1 — `build-recipe` driver (commit `9aa4832`)

**`lib/build/build-recipe.tl`** — four modes: `compile` (replaces the `cat`-stamp / conditional-`LUA_PATH` / redirect / `cmp`+`mv` dance, preserving `;;`-strict vs `TREE_LUA_PATH` (#666), stderr passthrough, no-output-on-failure, and unchanged-output-keeps-mtime), `copy` (`mkdir -p && cp`, permission bits preserved), `link` (`.versioned`'s `ln -sfn`), `capture` (doc-index's redirect+`cmp`/`mv`).

**The self-bootstrap knot**: the driver compiles the tree's `.lua`, so it cannot depend on them — it is the one build script running against the pinned bootstrap's **embedded** stdlib (`LUA_PATH=;;` exported so caller env cannot redirect its requires; the bootstrap sha covers its whole runtime). Its own `.lua` compiles via a single exception rule keeping the old shell recipe. The compile family (`$(o)/%.lua`, which also governs the copies by pattern name) drops `$(unveil_hostx)` for `rwc:$(o) r:tlconfig.lua $(unveil_dev)`. The poisoned pattern flushed out the two `.lua`-named explicit rules: doc-index → `capture`; version.lua keeps a real shell beside its `.SANDBOXED := 0` opt-out (`git describe` is the documented host exception).

## Round 2 — `.got` captures via `--test` (commit `4b7ebf2`)

All seven `.got` families (teal, format, example, benchmark, test, coverage, enforce) carried the same shell shape — `cmd > out 2> err; echo $? > got` — which is exactly what `cosmic --test <base> <cmd…>` does (plus makedirs and the per-test `COSMIC_COVERAGE` redirect). Now: checks wrap the assimilated check binary; test lanes keep wrapping the fat APE — **cosmo-make's cosmopolitan `execve` loads APE directly**, proven by running the suite under the poisoned `SHELL`. Env prefixes became target-scoped exports (`TEST_DIR` is exported globally so per-module target values reach recipe envs; the `PATH=` prefix was redundant since the #731 clamp stages `o/bin`). teal/format drop `$(unveil_hostx)` for `rwc:$(o) r:tlconfig.lua rwc:$(TMP) $(unveil_dev)` (the wrapper mkdtemps per-check under `$TMP`); test/example grants are deliberately unchanged — tests legitimately exec host tools under `$(unveil_test)`.

## Validation

- Cold-tree `bin/make -j ci` from `rm -rf o` after each round: **PASS**, identical coverage totals.
- `build-recipe_test.tl`: all four modes, exec-bit preservation, `ln -sfn` replace semantics, unchanged-compile-keeps-mtime (chmod-444 tripwire), failed compiles write nothing, stamp validation, usage errors. Coverage baseline gains the driver at its measured floor.
- The runner's enforced lanes are the authority for the grant deletions, as with #751/#752.

## Remaining host surface (#732)

The binary pack rules' `$(cp)` loops and `zip` invocations (lib/cosmic/cook.mk), the `--report | tee` summary rules (test/coverage/enforce — candidates for a `--report --out` flag on this tree's CLI), `make-help.snap` and the makefile fixtures (test apparatus), `$(o)/.exists` and the flag-stamp probe (tiny, unsandboxed), version.lua's git dependency, and `bin/make`'s irreducible curl bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9sZQU3fNPBndg6ekctHyw