### PR TITLE
build: de-shell the summaries, lint family, and help snapshot (#732)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,8 +134,11 @@ all_tested := $(patsubst %,$(o)/%.test.got,$(all_tests))
 ## Run all tests (incremental)
 test: $(o)/test-summary.txt
 
-$(o)/test-summary.txt: $(all_tested) | $(cosmic_bin)
-	@$(cosmic_bin) --report $^ | tee $@
+$(o)/test-summary.txt: export LUA_PATH := ;;
+$(o)/test-summary.txt: private SHELL := /dev/null/enoshell
+$(o)/test-summary.txt: private .SHELLFLAGS := -c
+$(o)/test-summary.txt: $(all_tested) | $(cosmic_bin) $(build_recipe)
+	@$(bootstrap_cosmic) -- $(build_recipe) tee $@ $(cosmic_bin) --report $^
 
 export TEST_O := $(o)
 export TEST_PLATFORM := $(platform)
@@ -217,9 +220,9 @@ coverage_baseline_tool := $(o)/lib/cosmic/coverage/baseline.lua
 
 $(o)/coverage-summary.txt: .PLEDGE := $(pledge_build)
 $(o)/coverage-summary.txt: .UNVEIL := $(unveil_base) rwcx:$(o)
-$(o)/coverage-summary.txt: $(coverage_got) | $(cosmic_bin)
-	@$(cosmic_bin) --report $(coverage_got) > $(o)/coverage-tests.txt
-	@$(cosmic_bin) --coverage-report $(o)/coverage lib | tee $@
+$(o)/coverage-summary.txt: $(coverage_got) | $(cosmic_bin) $(build_recipe)
+	@$(bootstrap_cosmic) -- $(build_recipe) capture $(cosmic_bin) $(o)/coverage-tests.txt --report $(coverage_got)
+	@$(bootstrap_cosmic) -- $(build_recipe) tee $@ $(cosmic_bin) --coverage-report $(o)/coverage lib
 	@if [ -n "$(only)" ]; then \
 	  echo "coverage ratchet skipped (only=$(only))"; \
 	elif [ -f $(coverage_baseline) ]; then \
@@ -265,13 +268,14 @@ $(o)/enforce/%.tl.test.got: export COSMIC_ENFORCE := 1
 $(o)/enforce/%.tl.test.got: $(o)/%.lua $(cosmic_bin)
 	@$(cosmic_bin) --test $(basename $@) $(cosmic_bin) $<
 
-$(o)/enforce-summary.txt: $(enforce_got) | $(cosmic_bin)
-	@$(cosmic_bin) --report $^ | tee $@
-	@if ! grep -rqs "enforce-ran:" $(o)/enforce/; then \
-	  echo "enforce tripwire: no enforcement ran — every sandbox test skipped."; \
-	  echo "  the privileged lane is not exercising enforcement (outer sandbox still active?)."; \
-	  exit 1; \
-	fi
+# The require-marker line is the tripwire: it fails the lane when no
+# enforcement ran (every sandbox test skipped — outer sandbox active?).
+$(o)/enforce-summary.txt: export LUA_PATH := ;;
+$(o)/enforce-summary.txt: private SHELL := /dev/null/enoshell
+$(o)/enforce-summary.txt: private .SHELLFLAGS := -c
+$(o)/enforce-summary.txt: $(enforce_got) | $(cosmic_bin) $(build_recipe)
+	@$(bootstrap_cosmic) -- $(build_recipe) tee $@ $(cosmic_bin) --report $^
+	@$(bootstrap_cosmic) -- $(build_recipe) require-marker enforce-ran: $(o)/enforce
 
 all_built_files := $(call filter-only,$(foreach x,$(modules),$($(x)_files)))
 all_built_files += $(all_lua)
@@ -322,12 +326,11 @@ $(o)/%.format.got: $(o)/% $(cosmic_check_bin) | $(bootstrap_files)
 lint_tracked := $(shell git ls-files 2>/dev/null)
 lint_present := $(wildcard $(lint_tracked))
 lint_deleted := $(filter-out $(lint_present),$(lint_tracked))
-all_linted := $(patsubst %,$(o)/%.lint.ok,$(lint_present))
+all_linted := $(patsubst %,$(o)/%.lint.got,$(lint_present))
 
 lint_list_stamp := $(o)/lint-files.stamp
-$(lint_list_stamp): .FORCE
-	@mkdir -p $(@D); printf '%s\n' $(lint_present) > $@.tmp
-	@if cmp -s $@.tmp $@ 2>/dev/null; then rm $@.tmp; else mv $@.tmp $@; fi
+$(lint_list_stamp): .FORCE $(build_recipe)
+	@$(bootstrap_cosmic) -- $(build_recipe) list $@ $(lint_present)
 
 ## Check file length limits on all files
 lint: $(o)/lint-summary.txt
@@ -336,11 +339,10 @@ $(o)/lint-summary.txt: export REPORTER_NOTE = $(if $(lint_deleted),lint: skipped
 $(o)/lint-summary.txt: $(all_linted) $(lint_list_stamp) | $(build_reporter)
 	$(if $(strip $(lint_tracked)),,$(error lint: git ls-files found nothing — not a git checkout?))
 	$(if $(strip $(lint_present)),,$(error lint: no tracked file exists on disk — filter collapsed the list?))
-	@$(bootstrap_cosmic) -- $(build_reporter) --dir $(o) --out $@ $(patsubst %,%.got,$(basename $(all_linted)))
+	@$(bootstrap_cosmic) -- $(build_reporter) --dir $(o) --out $@ $(all_linted)
 
-$(o)/%.lint.ok: % $(build_lint) $(lint_style_lua) | $(bootstrap_cosmic)
-	@mkdir -p $(@D)
-	-@$(linter) $< > $(basename $@).out 2> $(basename $@).err; STATUS=$$?; echo $$STATUS > $(basename $@).got; cp $(basename $@).got $@
+$(o)/%.lint.got: % $(build_lint) $(lint_style_lua) | $(bootstrap_cosmic)
+	@$(bootstrap_cosmic) --test $(basename $@) $(bootstrap_cosmic) -- $(build_lint) $<
 
 .PHONY: clean
 ## Remove all build artifacts

--- a/cook.mk
+++ b/cook.mk
@@ -95,9 +95,17 @@ $(o)/%/.staged: .SANDBOXED := 1
 $(o)/%/.fetched $(o)/%/.staged: export LUA_PATH = $(tree_lua_path)
 $(o)/%/.fetched $(o)/%/.staged: private SHELL := /dev/null/enoshell
 $(o)/%/.fetched $(o)/%/.staged: private .SHELLFLAGS := -c
-$(o)/%.lint.ok: .SANDBOXED := 1
-$(o)/%.lint.ok: .PLEDGE := $(pledge_build)
-$(o)/%.lint.ok: .UNVEIL := rwc:$(o) $(unveil_hostx)
+# De-hosted (#732): lint runs through the pinned bootstrap's --test
+# capture (which mkdtemps under $(TMP)); the .ok alias file is retired —
+# the .got IS the target. LUA_PATH points the lint child at this tree's
+# compiled style code (the doc/index.tl pattern); the --test wrapper
+# sees it too, as the old shell prefix already had it.
+$(o)/%.lint.got: .SANDBOXED := 1
+$(o)/%.lint.got: .PLEDGE := $(pledge_build)
+$(o)/%.lint.got: .UNVEIL := rwc:$(o) rwc:$(TMP) $(unveil_dev)
+$(o)/%.lint.got: export LUA_PATH = $(o)/lib/?.lua;$(o)/lib/?/init.lua;;
+$(o)/%.lint.got: private SHELL := /dev/null/enoshell
+$(o)/%.lint.got: private .SHELLFLAGS := -c
 # Reporter summaries (bootstrap + tee). test/coverage/enforce summaries
 # exec $(cosmic_bin) and stay unsandboxed with the test lanes.
 reporter_summaries := $(o)/teal-summary.txt $(o)/format-summary.txt \

--- a/lib/build/build-recipe.tl
+++ b/lib/build/build-recipe.tl
@@ -94,23 +94,115 @@ local function do_compile(args: {string}): integer
 end
 
 --- capture <bootstrap> <out> <script+args...> — run a script under the
---- bootstrap with LUA_PATH=$TREE_LUA_PATH and write its stdout to out
---- if changed (the doc-index rule's shape).
+--- bootstrap and write its stdout to out if changed (the doc-index
+--- rule's shape). The child sees LUA_PATH=$TREE_LUA_PATH when the rule
+--- exports one; otherwise it inherits the recipe's ";;" (embedded).
 local function do_capture(args: {string}): integer
   local bootstrap, out = args[1], args[2]
   if not out or not args[3] then
     return fail("usage: capture <bootstrap> <out> <script> [args...]")
   end
   local tree = child_tree_lua_path()
-  if not tree then
-    return fail("TREE_LUA_PATH required for capture")
+  if tree then
+    env.set("LUA_PATH", tree)
   end
-  env.set("LUA_PATH", tree)
   local argv: {string} = {bootstrap}
   for i = 3, #args do
     table.insert(argv, args[i])
   end
   return run_into(argv, out)
+end
+
+--- tee <out> <cmd...> — run a command, print its stdout AND write it to
+--- out (the summary rules' `| tee $@` shape, pipefail semantics: the
+--- child's exit code propagates after the file is written).
+local function do_tee(args: {string}): integer
+  local out = args[1]
+  if not out or not args[2] then
+    return fail("usage: tee <out> <cmd> [args...]")
+  end
+  local argv: {string} = {}
+  for i = 2, #args do
+    table.insert(argv, args[i])
+  end
+  local result, serr = child.run(argv)
+  if not result then
+    return fail("spawn " .. argv[1] .. " failed: " .. tostring(serr))
+  end
+  local r = result as child.Result -- cast: record union after guard
+  if r.stderr and r.stderr ~= "" then
+    io.stderr:write(r.stderr)
+  end
+  io.write(r.stdout)
+  fs.makedirs(fs.dirname(out))
+  local ok, werr = fs.write(out, r.stdout)
+  if not ok then
+    return fail("write " .. out .. " failed: " .. (werr or "unknown error"))
+  end
+  if not r.ok then
+    return r.code or 1
+  end
+  return 0
+end
+
+--- list <out> <items...> — write items one per line, only if changed
+--- (the lint file-list stamp's printf + cmp/mv shape).
+local function do_list(args: {string}): integer
+  local out = args[1]
+  if not out then
+    return fail("usage: list <out> [items...]")
+  end
+  local parts: {string} = {}
+  for i = 2, #args do
+    table.insert(parts, args[i])
+  end
+  local content = table.concat(parts, "\n") .. "\n"
+  local existing = fs.read(out)
+  if existing == content then
+    return 0
+  end
+  fs.makedirs(fs.dirname(out))
+  local ok, werr = fs.write(out, content)
+  if not ok then
+    return fail("write " .. out .. " failed: " .. (werr or "unknown error"))
+  end
+  return 0
+end
+
+--- require-marker <marker> <dir> — fail unless some file under dir
+--- contains marker as a plain substring (the enforce lane's tripwire:
+--- grep -rqs replacement).
+local function do_require_marker(args: {string}): integer
+  local marker, dir = args[1], args[2]
+  if not dir then
+    return fail("usage: require-marker <marker> <dir>")
+  end
+  local function scan(d: string): boolean
+    local dir0 = fs.opendir(d)
+    if not dir0 then return false end
+    local dh = dir0 as fs_types.Dir -- cast: record union after guard
+    while true do
+      local name = dh:read()
+      if not name then break end
+      if name ~= "." and name ~= ".." then
+        local p = fs.join(d, name)
+        local st = fs.stat(p)
+        if st and (st as fs_types.Stat):is_dir() then -- cast: mixed-representation Stat
+          if scan(p) then return true end
+        else
+          local content = fs.read(p)
+          if content and string.find(content, marker, 1, true) then
+            return true
+          end
+        end
+      end
+    end
+    return false
+  end
+  if scan(dir) then
+    return 0
+  end
+  return fail("no file under " .. dir .. " contains '" .. marker .. "'")
 end
 
 --- copy <src> <dst> — mkdir -p + cp, preserving the permission bits.
@@ -159,6 +251,9 @@ local modes: {string: function({string}): integer} = {
   compile = do_compile,
   copy = do_copy,
   link = do_link,
+  list = do_list,
+  ["require-marker"] = do_require_marker,
+  tee = do_tee,
 }
 
 local function main(...: string): integer
@@ -166,7 +261,7 @@ local function main(...: string): integer
   local mode = table.remove(args, 1)
   local run_mode = mode and modes[mode]
   if not run_mode then
-    return fail("usage: build-recipe capture|compile|copy|link ...")
+    return fail("usage: build-recipe capture|compile|copy|link|list|require-marker|tee ...")
   end
   return run_mode(args)
 end

--- a/lib/build/build-recipe_test.tl
+++ b/lib/build/build-recipe_test.tl
@@ -121,3 +121,54 @@ local function test_unknown_mode()
   assert(err:match("usage"), "expected usage error, got: " .. err)
 end
 test_unknown_mode()
+
+local function test_tee_prints_and_writes()
+  local out = fs.join(tmpdir, "tee/summary.txt")
+  local code, stdout, err = run_driver("tee", out, test_bin, "-e", "print('report line')")
+  assert(code == 0, "tee failed (" .. tostring(code) .. "): " .. err)
+  assert(stdout:match("report line"), "tee must print to stdout")
+  -- cast: or fallback does not narrow
+  local written = (fs.read(out) or "") as string
+  assert(written:match("report line"), "tee must write the file")
+end
+test_tee_prints_and_writes()
+
+local function test_tee_propagates_failure_after_writing()
+  local out = fs.join(tmpdir, "tee/fail.txt")
+  local code = run_driver("tee", out, test_bin, "-e", "print('partial') os.exit(3)")
+  assert(code == 3, "tee must propagate the child's exit code, got: " .. tostring(code))
+  -- cast: or fallback does not narrow
+  local written = (fs.read(out) or "") as string
+  assert(written:match("partial"), "tee must write the file before failing")
+end
+test_tee_propagates_failure_after_writing()
+
+local function test_list_write_if_changed()
+  local out = fs.join(tmpdir, "list/files.stamp")
+  local code = run_driver("list", out, "a.tl", "b.tl")
+  assert(code == 0, "list failed")
+  assert(fs.read(out) == "a.tl\nb.tl\n", "list content")
+  local st1 = fs.stat(out)
+  assert(st1, "stamp should exist")
+  local s1, n1 = (st1 as fs_types.Stat):mtim() -- cast: mixed-representation Stat
+  code = run_driver("list", out, "a.tl", "b.tl")
+  assert(code == 0, "unchanged list must succeed")
+  local s2, n2 = (fs.stat(out) as fs_types.Stat):mtim() -- cast: mixed-representation Stat
+  assert(s1 == s2 and n1 == n2, "unchanged list must not rewrite the stamp")
+  code = run_driver("list", out, "a.tl")
+  assert(code == 0, "changed list must rewrite")
+  assert(fs.read(out) == "a.tl\n", "changed list content")
+end
+test_list_write_if_changed()
+
+local function test_require_marker()
+  local dir = fs.join(tmpdir, "markers/nested")
+  fs.makedirs(dir)
+  assert(fs.write(fs.join(dir, "probe.err"), "x enforce-ran: pledge\n"))
+  local code = run_driver("require-marker", "enforce-ran:", fs.join(tmpdir, "markers"))
+  assert(code == 0, "marker present must pass")
+  local code2, _out, err = run_driver("require-marker", "absent-marker:", fs.join(tmpdir, "markers"))
+  assert(code2 ~= 0, "missing marker must fail")
+  assert(err:match("absent%-marker"), "failure names the marker, got: " .. err)
+end
+test_require_marker()

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -30,7 +30,6 @@ build_tests := $(wildcard lib/build/*_test.tl)
 # at this tree's freshly compiled modules (the doc/index.tl pattern) so the
 # delegation runs THIS tree's style code, not the bootstrap's embedded copy.
 lint_style_lua := $(o)/lib/cosmic/cli/style.lua
-linter := LUA_PATH="$(o)/lib/?.lua;$(o)/lib/?/init.lua;;" $(bootstrap_cosmic) -- $(build_lint)
 
 # build tests exercise the compiled build tools (reporter, lint,
 # make-help, ...) at runtime via LUA_PATH=$(o)/lib/build, so they need
@@ -40,10 +39,13 @@ build_test_got := \
   $(patsubst %,$(o)/coverage/%.test.got,$(build_tests))
 $(build_test_got): $(build_files)
 
-# make-help snapshot: generate actual help output
-$(o)/lib/build/make-help.snap: Makefile $(build_help) | $(bootstrap_cosmic)
-	@mkdir -p $(@D)
-	@LUA_PATH="$(tree_lua_path)" $(bootstrap_cosmic) $(build_help) Makefile > $@
+# make-help snapshot: generate actual help output (driver capture, #732)
+$(o)/lib/build/make-help.snap: export LUA_PATH := ;;
+$(o)/lib/build/make-help.snap: export TREE_LUA_PATH = $(tree_lua_path)
+$(o)/lib/build/make-help.snap: private SHELL := /dev/null/enoshell
+$(o)/lib/build/make-help.snap: private .SHELLFLAGS := -c
+$(o)/lib/build/make-help.snap: Makefile $(build_help) $(build_recipe) | $(bootstrap_cosmic)
+	@$(bootstrap_cosmic) -- $(build_recipe) capture $(bootstrap_cosmic) $@ $(build_help) Makefile
 
 # makefile validation outputs
 build_make_out := $(o)/lib/build/make

--- a/lib/cosmic/coverage/baseline.txt
+++ b/lib/cosmic/coverage/baseline.txt
@@ -1,7 +1,7 @@
 # coverage ratchet baseline: `bin/make coverage-baseline` rewrites this file.
 # columns: path covered-lines total-lines
 lib/build/build-fetch.tl 23 95
-lib/build/build-recipe.tl 78 103
+lib/build/build-recipe.tl 133 165
 lib/build/build-stage.tl 45 251
 lib/build/build-untar.tl 121 130
 lib/build/lint.tl 97 132


### PR DESCRIPTION
Part of #732 / #728 (item 4). Round 5, building on #753's driver: the remaining `| tee` summaries, the lint family, the lint file-list stamp, and the help snapshot go shell-free.

## What

Three new `build-recipe` modes finish the tee/redirect plumbing:

- **`tee <out> <cmd…>`** — run a command, print stdout *and* write the file, propagating the child's exit code after the file lands (the summary rules' `| tee $@` with the pipefail semantics the global `.SHELLFLAGS` provided).
- **`list <out> <items…>`** — items one per line, write-if-changed (the lint stamp's `printf`+`cmp`/`mv`).
- **`require-marker <marker> <dir>`** — recursive plain-substring scan (the enforce lane's `grep -rqs` tripwire; failure names the marker and dir).
- `capture` now treats `TREE_LUA_PATH` as optional, so scripts that never had a `LUA_PATH` prefix keep embedded resolution.

Converted rules:

- **test-summary / enforce-summary** → `tee` (+ `require-marker` keeps the enforce tripwire falsifiable — it still fails the lane when no enforcement ran).
- **coverage-summary** → `capture` (`--report` into coverage-tests.txt) + `tee` (`--coverage-report`); the ratchet's make-conditional block deliberately keeps the real shell.
- **lint** — the `.ok` alias file is retired (`%.lint.got` *is* the target; the summary consumes `$(all_linted)` directly), lint runs through the pinned bootstrap's `--test` capture, and the family's grants drop `$(unveil_hostx)` for `rwc:$(o) rwc:$(TMP) $(unveil_dev)`. The shell-quoting `linter` macro is deleted.
- **lint list stamp** → `list`; **make-help.snap** → `capture`.

## Validation

- Cold-tree `bin/make -j ci` from `rm -rf o`: **PASS** (375 lint checks through the new path).
- Driver tests for the three new modes: tee prints *and* writes, exit-code propagation after the file is written, list write-if-changed proven by `mtim` (the chmod tripwire is identity-sensitive — root bypasses permission bits, the fs/walk_test lesson), marker present/absent.
- The driver's coverage floor rises to its new measured value (133/165).
- Runner's enforced lanes prove the lint-family grant deletion, per the established pattern.

## Remaining host surface (#732)

The binary pack rules (`$(cp)` loops + `zip` in lib/cosmic/cook.mk — the last big family), the coverage ratchet's conditional block, the `help` target's interactive recipe, the makefile fixtures and canary (test apparatus, shell by design), `$(o)/.exists` + the flag-stamp probe + the driver's own self-bootstrap compile (the deliberate exceptions), version.lua's git dependency, and `bin/make`'s irreducible curl bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9sZQU3fNPBndg6ekctHyw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9sZQU3fNPBndg6ekctHyw)_