### PR TITLE
build: de-shell the binary pack rules via build-pack (#732)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,6 @@ help: $(build_files) | $(bootstrap_cosmic)
 ## Filter targets by substring (make test only=teal; also narrows fetch/stage)
 filter-only = $(if $(only),$(foreach f,$1,$(if $(findstring $(only),$(f)),$(f))),$1)
 
-cp := cp -p
-
 # Copies and compiles run through the build-recipe driver (#732): no
 # shell, no host mkdir/cp/cat/cmp/mv (LUA_PATH pins live in cook.mk
 # with the family's other pattern vars). .exists orders cold-tree

--- a/lib/build/build-pack.tl
+++ b/lib/build/build-pack.tl
@@ -1,0 +1,204 @@
+#!/usr/bin/env lua
+--- Shell-free binary packing (#732): replaces the cosmic_bin recipe's
+--- staging for-loops (mkdir/cp), the mtime clamp (find -exec touch),
+--- and the cd + zip pipeline. Make remains the source of truth for
+--- WHAT ships: it passes every file as an explicit --copy SRC DST pair
+--- (relative destinations computed with patsubst, not shell suffix
+--- stripping). This script owns HOW: stage, clamp, pack.
+---
+--- Pack policy (moved from the pack-cosmic define): the boot-critical
+--- Lua — .lua/cosmic/* modules, main.lua and .args — is inflate()d on
+--- EVERY invocation (29 inflate() calls at boot; whilp/cosmic#487), so
+--- store it uncompressed to skip the decompress. The rest (tl.lua,
+--- type declarations, docs, .tl source, skills) is large or lazy-loaded
+--- and stays deflated. -X strips Unix extra fields (atime/mtime/uid/
+--- gid): zip reading a staged file bumps its atime to pack time, which
+--- leaked into local headers even with mtimes clamped (#733). Entry
+--- mtimes stay as clamped DOS timestamps; mode bits live in the
+--- central attrs and survive -X.
+
+local child = require("cosmic.child")
+local fs = require("cosmic.fs")
+local fs_types = require("cosmic.fs.types")
+local proc = require("cosmic.proc")
+
+local function fail(msg: string): integer
+  io.stderr:write("build-pack: " .. msg .. "\n")
+  return 1
+end
+
+local function copy_file(src: string, dst: string): boolean, string
+  local content, rerr = fs.read(src)
+  if not content then
+    return false, "read " .. src .. " failed: " .. (rerr or "unknown error")
+  end
+  local st = fs.stat(src)
+  if not st then
+    return false, "stat " .. src .. " failed"
+  end
+  -- cast: mixed-representation Stat
+  local mode = (st as fs_types.Stat):mode() % 512
+  fs.makedirs(fs.dirname(dst))
+  local ok, werr = fs.write(dst, content, mode)
+  if not ok then
+    return false, "write " .. dst .. " failed: " .. (werr or "unknown error")
+  end
+  fs.chmod(dst, mode)
+  return true
+end
+
+local function copy_tree(src: string, dst: string): boolean, string
+  local dir0, derr = fs.opendir(src)
+  if not dir0 then
+    return false, "opendir " .. src .. " failed: " .. (derr or "unknown error")
+  end
+  local dh = dir0 as fs_types.Dir -- cast: record union after guard
+  fs.makedirs(dst)
+  while true do
+    local name = dh:read()
+    if not name then break end
+    if name ~= "." and name ~= ".." then
+      local s, d = fs.join(src, name), fs.join(dst, name)
+      local st = fs.stat(s)
+      if st and (st as fs_types.Stat):is_dir() then -- cast: mixed-representation Stat
+        local ok, err = copy_tree(s, d)
+        if not ok then return false, err end
+      else
+        local ok, err = copy_file(s, d)
+        if not ok then return false, err end
+      end
+    end
+  end
+  return true
+end
+
+--- Clamp mtimes (and atimes) of everything under path — children
+--- first, then the directory itself, so writes never re-bump a parent.
+local function clamp(path: string, epoch: integer): boolean, string
+  local st = fs.stat(path)
+  if not st then
+    return false, "stat " .. path .. " failed"
+  end
+  if (st as fs_types.Stat):is_dir() then -- cast: mixed-representation Stat
+    local dir0, derr = fs.opendir(path)
+    if not dir0 then
+      return false, "opendir " .. path .. " failed: " .. (derr or "unknown error")
+    end
+    local dh = dir0 as fs_types.Dir -- cast: record union after guard
+    while true do
+      local name = dh:read()
+      if not name then break end
+      if name ~= "." and name ~= ".." then
+        local ok, err = clamp(fs.join(path, name), epoch)
+        if not ok then return false, err end
+      end
+    end
+  end
+  local ok, uerr = fs.utimensat(path, epoch, 0, epoch, 0)
+  if not ok then
+    return false, "utimensat " .. path .. " failed: " .. (uerr or "unknown error")
+  end
+  return true
+end
+
+local function zip_add(zip_bin: string, built: string, out: string,
+    flags: string, entries: {string}): boolean, string
+  local argv: {string} = {zip_bin, flags}
+  table.insert(argv, out)
+  for _, e in ipairs(entries) do
+    table.insert(argv, e)
+  end
+  local result, serr = child.run(argv, {cwd = built})
+  if not result then
+    return false, "spawn " .. zip_bin .. " failed: " .. tostring(serr)
+  end
+  local r = result as child.Result -- cast: record union after guard
+  if r.stderr and r.stderr ~= "" then
+    io.stderr:write(r.stderr)
+  end
+  if not r.ok then
+    return false, "zip " .. flags .. " failed (exit " .. tostring(r.code) .. ")"
+  end
+  return true
+end
+
+--- pack --out BIN --built DIR --epoch N --zip ZIP --base SRCBIN
+---      [--copy SRC DST]... [--copytree SRC DST]...
+local function main(...: string): integer
+  local args = {...}
+  local out, built, zip_bin, base: string, string, string, string
+  local epoch = 0
+  local copies: {{string, string}} = {}
+  local trees: {{string, string}} = {}
+  local i = 1
+  while i <= #args do
+    local a = args[i]
+    if a == "--out" then
+      out = args[i + 1]; i = i + 2
+    elseif a == "--built" then
+      built = args[i + 1]; i = i + 2
+    elseif a == "--epoch" then
+      epoch = math.tointeger(tonumber(args[i + 1])) or 0; i = i + 2
+    elseif a == "--zip" then
+      zip_bin = args[i + 1]; i = i + 2
+    elseif a == "--base" then
+      base = args[i + 1]; i = i + 2
+    elseif a == "--copy" then
+      table.insert(copies, {args[i + 1], args[i + 2]}); i = i + 3
+    elseif a == "--copytree" then
+      table.insert(trees, {args[i + 1], args[i + 2]}); i = i + 3
+    else
+      return fail("unknown argument: " .. tostring(a))
+    end
+  end
+  if not out or not built or not zip_bin or not base then
+    return fail("usage: build-pack --out BIN --built DIR --epoch N --zip ZIP"
+      .. " --base SRCBIN [--copy SRC DST]... [--copytree SRC DST]...")
+  end
+
+  fs.rmrf(built)
+  for _, c in ipairs(copies) do
+    local ok, err = copy_file(c[1], fs.join(built, c[2]))
+    if not ok then return fail(err) end
+  end
+  for _, t in ipairs(trees) do
+    local ok, err = copy_tree(t[1], fs.join(built, t[2]))
+    if not ok then return fail(err) end
+  end
+
+  local ok, err = clamp(built, epoch)
+  if not ok then return fail(err) end
+
+  ok, err = copy_file(base, out)
+  if not ok then return fail(err) end
+  local exec_ok, cerr = fs.chmod(out, tonumber("755", 8) as integer) -- cast: octal is integral
+  if not exec_ok then
+    return fail("chmod " .. out .. " failed: " .. (cerr or "unknown error"))
+  end
+
+  -- cast: or fallback does not narrow
+  local cwd = (fs.getcwd() or ".") as string
+  -- the zip children run with cwd inside the staging tree, so both the
+  -- archive path and the zip binary itself must be absolute
+  local abs_out = out
+  if out:sub(1, 1) ~= "/" then
+    abs_out = fs.join(cwd, out)
+  end
+  if zip_bin:sub(1, 1) ~= "/" then
+    zip_bin = fs.join(cwd, zip_bin)
+  end
+  ok, err = zip_add(zip_bin, built, abs_out, "-qr0X", {".lua/cosmic"})
+  if not ok then return fail(err) end
+  ok, err = zip_add(zip_bin, built, abs_out, "-qrX",
+    {".lua", ".tl", ".docs", "sys", "skills", "-x", ".lua/cosmic/*"})
+  if not ok then return fail(err) end
+  ok, err = zip_add(zip_bin, built, abs_out, "-q0X", {"main.lua", ".args"})
+  if not ok then return fail(err) end
+  return 0
+end
+
+if proc.is_main() then
+  os.exit(main(...))
+end
+
+return {main = main}

--- a/lib/build/build-pack_test.tl
+++ b/lib/build/build-pack_test.tl
@@ -1,0 +1,84 @@
+#!/usr/bin/env cosmic
+-- Tests for the shell-free binary packer (#732): stage a tiny payload,
+-- pack it with the PINNED cosmos zip onto a base file, and assert the
+-- contract pieces — base prefix preserved, exec bit, mtime clamp.
+
+local check = require("cosmic.check")
+local child = require("cosmic.child")
+local fs = require("cosmic.fs")
+local fs_types = require("cosmic.fs.types")
+local zip = require("cosmic.zip")
+
+local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
+local test_bin = fs.join(os.getenv("TEST_BIN") or "", "cosmic")
+local test_o = os.getenv("TEST_O") or "o"
+local packer = fs.join(test_o, "lib/build/build-pack.lua")
+local zip_bin = fs.join(test_o, "cosmos/.staged/zip")
+
+local function run_pack(...: string): integer, string
+  local args: {string} = {test_bin, "--", packer}
+  for _, a in ipairs({...}) do
+    table.insert(args, a)
+  end
+  local result, serr = child.run(args)
+  if not result then
+    return 1, tostring(serr)
+  end
+  local r = result as child.Result -- cast: record union after guard
+  local code = 1
+  if r.code ~= nil then
+    code = r.code
+  end
+  return code, r.stderr
+end
+
+local function test_pack_end_to_end()
+  local src = fs.join(tmpdir, "src")
+  fs.makedirs(src)
+  assert(fs.write(fs.join(src, "mod.lua"), "return {}\n"))
+  assert(fs.write(fs.join(src, "main.lua"), "print('hi')\n"))
+  -- the real base (the cosmos lua APE) already contains a zip archive,
+  -- and the zip tool appends to that; stand in with a real archive
+  local base = fs.join(tmpdir, "base.bin")
+  local w = check.must(zip.writer(base))
+  assert(w:add("stub.txt", "preexisting\n"))
+  w:close()
+  local built = fs.join(tmpdir, "built")
+  local out = fs.join(tmpdir, "out.bin")
+
+  local code, err = run_pack(
+    "--out", out, "--built", built, "--epoch", "1700000000", "--zip", zip_bin,
+    "--base", base,
+    "--copy", fs.join(src, "mod.lua"), ".lua/cosmic/mod.lua",
+    "--copy", fs.join(src, "main.lua"), "main.lua")
+  assert(code == 0, "pack failed (" .. tostring(code) .. "): " .. err)
+
+  -- the packed output is a valid archive holding the base's entries
+  -- plus the staged payload
+  local r = check.must(zip.reader(out))
+  assert(r:read("stub.txt") == "preexisting\n", "base entry survives")
+  assert(r:read(".lua/cosmic/mod.lua") == "return {}\n", "module packed")
+  assert(r:read("main.lua") == "print('hi')\n", "main packed")
+  r:close()
+  local st = fs.stat(out)
+  assert(st, "out should stat")
+  local mode = (st as fs_types.Stat):mode() % 512 -- cast: mixed-representation Stat
+  assert(mode % 2 == 1, "packed binary keeps the exec bit")
+
+  -- the staged copy's mtime is clamped to the epoch (#733)
+  local staged = fs.stat(fs.join(built, "main.lua"))
+  assert(staged, "staged main.lua should exist")
+  local secs = (staged as fs_types.Stat):mtim() -- cast: mixed-representation Stat
+  assert(secs == 1700000000, "mtime clamped, got: " .. tostring(secs))
+end
+test_pack_end_to_end()
+
+local function test_pack_missing_input_fails()
+  local code, err = run_pack(
+    "--out", fs.join(tmpdir, "o2.bin"), "--built", fs.join(tmpdir, "b2"),
+    "--epoch", "1", "--zip", zip_bin, "--base", fs.join(tmpdir, "nope"),
+    "--copy", fs.join(tmpdir, "missing.lua"), ".lua/x.lua")
+  assert(code ~= 0, "missing copy source must fail")
+  assert(err:match("read .* failed"), "error names the read, got: " .. err)
+end
+test_pack_missing_input_fails()

--- a/lib/build/build-recipe.tl
+++ b/lib/build/build-recipe.tl
@@ -205,6 +205,22 @@ local function do_require_marker(args: {string}): integer
   return fail("no file under " .. dir .. " contains '" .. marker .. "'")
 end
 
+--- require-elf <file> — fail unless file starts with the ELF magic
+--- (the assimilation checks' `printf '\177ELF' | cmp` process
+--- substitution).
+local function do_require_elf(args: {string}): integer
+  local path = args[1]
+  if not path then
+    return fail("usage: require-elf <file>")
+  end
+  local content = fs.read(path)
+  if not content or string.sub(content, 1, 4) ~= "\127ELF" then
+    return fail(path .. " is not a native ELF — assimilation failed"
+      .. " (sandboxed rules need a native ELF, no loader grants)")
+  end
+  return 0
+end
+
 --- copy <src> <dst> — mkdir -p + cp, preserving the permission bits.
 local function do_copy(args: {string}): integer
   local src, dst = args[1], args[2]
@@ -252,6 +268,7 @@ local modes: {string: function({string}): integer} = {
   copy = do_copy,
   link = do_link,
   list = do_list,
+  ["require-elf"] = do_require_elf,
   ["require-marker"] = do_require_marker,
   tee = do_tee,
 }
@@ -261,7 +278,7 @@ local function main(...: string): integer
   local mode = table.remove(args, 1)
   local run_mode = mode and modes[mode]
   if not run_mode then
-    return fail("usage: build-recipe capture|compile|copy|link|list|require-marker|tee ...")
+    return fail("usage: build-recipe capture|compile|copy|link|list|require-elf|require-marker|tee ...")
   end
   return run_mode(args)
 end

--- a/lib/build/build-recipe_test.tl
+++ b/lib/build/build-recipe_test.tl
@@ -172,3 +172,16 @@ local function test_require_marker()
   assert(err:match("absent%-marker"), "failure names the marker, got: " .. err)
 end
 test_require_marker()
+
+local function test_require_elf()
+  local elf = fs.join(tmpdir, "native.bin")
+  assert(fs.write(elf, "\127ELF rest-of-binary"))
+  local code = run_driver("require-elf", elf)
+  assert(code == 0, "ELF magic must pass")
+  local ape = fs.join(tmpdir, "still-ape.bin")
+  assert(fs.write(ape, "MZqFpD='"))
+  local code2, _out, err = run_driver("require-elf", ape)
+  assert(code2 ~= 0, "non-ELF must fail")
+  assert(err:match("not a native ELF"), "failure explains, got: " .. err)
+end
+test_require_elf()

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -8,7 +8,8 @@ build_reporter := $(o)/lib/build/reporter.lua
 build_help := $(o)/lib/build/make-help.lua
 build_lint := $(o)/lib/build/lint.lua
 build_recipe := $(o)/lib/build/build-recipe.lua
-build_files := $(build_fetch) $(build_stage) $(build_untar) $(build_portable) $(build_reporter) $(build_help) $(build_lint)
+build_pack := $(o)/lib/build/build-pack.lua
+build_files := $(build_fetch) $(build_stage) $(build_untar) $(build_pack) $(build_portable) $(build_reporter) $(build_help) $(build_lint)
 
 # Self-bootstrap exception (#732): build-recipe drives the shell-free
 # compile/copy/link recipes, so it cannot be compiled by them — this one

--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -41,23 +41,31 @@ cosmic_version_lua := $(o)/cosmic/version.lua
 # clamped without touching build intermediates make still tracks).
 # Gate: the reproducible CI job double-builds and cmps.
 SOURCE_DATE_EPOCH ?= $(shell git log -1 --format=%ct 2>/dev/null || echo 0)
+# flatten NOW (parse time, real shell): a recursive value would expand
+# inside pack recipes, where $(shell) runs under the poisoned no-shell
+# SHELL and silently yields an empty epoch (#732)
+SOURCE_DATE_EPOCH := $(SOURCE_DATE_EPOCH)
 
-# Pack the cosmic payload into the binary given as $(1). The boot-critical
-# Lua — .lua/cosmic/* modules, main.lua and .args — is inflate()d on EVERY
-# invocation (29 inflate() calls at boot; see whilp/cosmic#487, backlog 24), so store
-# it uncompressed to skip the decompress. The rest (tl.lua, the type
-# declarations, docs, .tl source, skills) is either large or lazy-loaded and
-# not on the startup path, so keep it deflated to hold the size cost down.
-# -X strips the Unix extra fields (atime/mtime/uid/gid): zip reading a
-# staged file bumps its atime to pack time, which leaked into local
-# headers even with mtimes clamped. Entry mtimes stay as (clamped) DOS
-# timestamps; mode bits live in the central attrs and survive -X.
-define pack-cosmic
-	@find $(cosmic_built) -exec touch -d @$(SOURCE_DATE_EPOCH) {} +
-	@cd $(cosmic_built) && $(CURDIR)/$(cosmos_zip_bin) -qr0X $(CURDIR)/$(1) .lua/cosmic
-	@cd $(cosmic_built) && $(CURDIR)/$(cosmos_zip_bin) -qrX $(CURDIR)/$(1) .lua .tl .docs sys skills -x '.lua/cosmic/*'
-	@cd $(cosmic_built) && $(CURDIR)/$(cosmos_zip_bin) -q0X $(CURDIR)/$(1) main.lua .args
-endef
+# De-hosted pack (#732): staging, the SOURCE_DATE_EPOCH mtime clamp,
+# and the zip pipeline live in build-pack.tl (which owns the pack
+# policy: store boot-critical Lua, deflate the rest, -X for #733
+# reproducibility). Make stays the source of truth for WHAT ships —
+# every file is an explicit --copy SRC DST pair below; the zip tool is
+# the pinned cosmos binary, not a host tool. Recursive (=): expanded at
+# recipe time, after the includes define tl_dir/doc_index.
+pack_copies = \
+  $(foreach f,$(cosmic_lua),--copy $(f) .lua/cosmic/$(patsubst $(o)/lib/cosmic/%,%,$(f))) \
+  $(foreach f,$(cosmic_tl),--copy $(f) .tl/cosmic/$(patsubst lib/cosmic/%,%,$(f))) \
+  $(foreach f,$(cosmic_sys),--copy $(f) sys/$(notdir $(f))) \
+  $(foreach f,$(cosmic_skills),--copy $(f) skills/cosmic/$(notdir $(f))) \
+  --copy $(cosmic_version_lua) .lua/cosmic/version.lua \
+  --copy $(tl_dir)/tl.lua .lua/tl.lua \
+  --copy $(doc_index) .docs/index.lua \
+  --copy $(cosmic_main) main.lua \
+  --copy $(cosmic_args) .args \
+  --copytree lib/types .lua/types
+pack = $(bootstrap_cosmic) -- $(build_pack) --built $(cosmic_built) \
+  --epoch $(SOURCE_DATE_EPOCH) --zip $(cosmos_zip_bin) $(pack_copies)
 
 # Opt out of the enforced *.lua pattern family (#729): git describe
 # reads .git (never unveiled), and this recipe's `|| echo unknown`
@@ -76,40 +84,14 @@ $(cosmic_version_lua): .FORCE | $$(cosmos_staged)
 
 .PHONY: .FORCE
 
-$(cosmic_bin): $$(cosmic_lua) $(cosmic_main) $(cosmic_args) $$(tl_staged) $$(doc_index) $(cosmic_version_lua) $(cosmic_sys) $(cosmic_skills) $(cosmic_types)
-	@rm -rf $(cosmic_built)
-	@mkdir -p $(cosmic_built)/.lua/cosmic $(cosmic_built)/.tl/cosmic $(@D)
-	@for f in $(cosmic_lua); do \
-		rel="$${f#$(o)/lib/cosmic/}"; \
-		dst="$(cosmic_built)/.lua/cosmic/$$rel"; \
-		mkdir -p "$$(dirname "$$dst")"; \
-		$(cp) "$$f" "$$dst"; \
-	done
-	@for f in $(cosmic_tl); do \
-		rel="$${f#lib/cosmic/}"; \
-		dst="$(cosmic_built)/.tl/cosmic/$$rel"; \
-		mkdir -p "$$(dirname "$$dst")"; \
-		$(cp) "$$f" "$$dst"; \
-	done
-	@$(cp) $(cosmic_version_lua) $(cosmic_built)/.lua/cosmic/version.lua
-	@$(cp) $(tl_dir)/tl.lua $(cosmic_built)/.lua/
-	@cp -r lib/types $(cosmic_built)/.lua/types
-	@mkdir -p $(cosmic_built)/.docs
-	@$(cp) $(doc_index) $(cosmic_built)/.docs/index.lua
-	@mkdir -p $(cosmic_built)/sys
-	@$(cp) $(cosmic_sys) $(cosmic_built)/sys/
-	@mkdir -p $(cosmic_built)/skills/cosmic
-	@$(cp) $(cosmic_skills) $(cosmic_built)/skills/cosmic/
-	@$(cp) $(cosmic_main) $(cosmic_built)/main.lua
-	@$(cp) $(cosmic_args) $(cosmic_built)/.args
-	@$(cp) $(cosmos_lua_bin) $@
-	@chmod +x $@
-	$(call pack-cosmic,$@)
+$(cosmic_bin) $(cosmic_debug_bin): export LUA_PATH = $(tree_lua_path)
+$(cosmic_bin) $(cosmic_debug_bin): private SHELL := /dev/null/enoshell
+$(cosmic_bin) $(cosmic_debug_bin): private .SHELLFLAGS := -c
+$(cosmic_bin): $$(cosmic_lua) $(cosmic_main) $(cosmic_args) $$(tl_staged) $$(doc_index) $(cosmic_version_lua) $(cosmic_sys) $(cosmic_skills) $(cosmic_types) $(build_pack) | $(bootstrap_cosmic)
+	@$(pack) --out $@ --base $(cosmos_lua_bin)
 
-$(cosmic_debug_bin): $(cosmic_bin)
-	@$(cp) $(cosmos_lua_debug_bin) $@
-	@chmod +x $@
-	$(call pack-cosmic,$@)
+$(cosmic_debug_bin): $(cosmic_bin) $(build_pack)
+	@$(pack) --out $@ --base $(cosmos_lua_debug_bin)
 
 # Assimilated duplicate for sandboxed build-time exec (#729, third
 # family): the teal/format check rules exec cosmic hundreds of times,
@@ -118,10 +100,15 @@ $(cosmic_debug_bin): $(cosmic_bin)
 # ELF like the bootstrap; the shipped $(cosmic_bin) stays a fat APE
 # (the cross-OS smoke lanes cover real-APE behavior).
 cosmic_check_bin := $(o)/bin/cosmic-check
-$(cosmic_check_bin): $(cosmic_bin)
-	@$(cp) $< $@
-	@$@ --assimilate
-	@printf '\177ELF' | cmp -s - <(head -c 4 $@) || { echo "cosmic-check assimilation failed: still an APE" >&2; exit 1; }
+$(cosmic_check_bin): private SHELL := /dev/null/enoshell
+$(cosmic_check_bin): private .SHELLFLAGS := -c
+# --assimilate is handled by the APE shell stub, which a direct (no
+# shell) exec bypasses — the pinned cosmos assimilate tool converts in
+# place instead, keeping this recipe shell-free (#732).
+$(cosmic_check_bin): $(cosmic_bin) $(build_recipe) | $$(cosmos_staged)
+	@$(bootstrap_cosmic) -- $(build_recipe) copy $< $@
+	@$(cosmos_dir)/assimilate $@
+	@$(bootstrap_cosmic) -- $(build_recipe) require-elf $@
 
 # The APE loader, staged where the clamped PATH can see it (#729 test
 # family): the APE shell stub prefers `exec ape "$o" "$@"` for any

--- a/lib/cosmic/coverage/baseline.txt
+++ b/lib/cosmic/coverage/baseline.txt
@@ -1,7 +1,8 @@
 # coverage ratchet baseline: `bin/make coverage-baseline` rewrites this file.
 # columns: path covered-lines total-lines
 lib/build/build-fetch.tl 23 95
-lib/build/build-recipe.tl 133 165
+lib/build/build-pack.tl 97 132
+lib/build/build-recipe.tl 142 175
 lib/build/build-stage.tl 45 251
 lib/build/build-untar.tl 121 130
 lib/build/lint.tl 97 132
@@ -140,4 +141,4 @@ lib/types/gentype_parse.tl 267 288
 lib/types/gentype_render.tl 309 312
 lib/types/gentype_types.tl 2 2
 tlconfig.lua 7 7
-total 11313 14873
+total 11594 15194


### PR DESCRIPTION
Part of #732 / #728 (item 4). Round 6 — the last big family: the binary pack. The `cosmic`/`cosmic-debug`/`cosmic-check` recipes now spawn nothing from the host.

## What

**`lib/build/build-pack.tl`** absorbs the `cosmic_bin` recipe's three shell structures: the staging for-loops (`mkdir`/`cp` with `${f#prefix}` suffix stripping), the reproducibility clamp (`find -exec touch -d @EPOCH`), and the `cd` + three-invocation zip pipeline. The division of labor is explicit: **make remains the source of truth for WHAT ships** — every file arrives as a `--copy SRC DST` pair with destinations computed by `patsubst`, so the shipping manifest is still readable in cook.mk — while the script owns HOW (stage, clamp children-then-parent so writes never re-bump a directory, pack via the **pinned cosmos zip**, whose store-vs-deflate policy comment moves with the code). `cosmic-debug` reuses the same script with a different `--base`.

**`cosmic-check`**: `--assimilate` is handled by the APE *shell stub*, which a direct no-shell exec bypasses (the cosmic CLI rejects the flag — witnessed) — so assimilation moves to the pinned cosmos `assimilate` tool, and the `printf '\177ELF' | cmp <(head -c 4 …)` process-substitution check becomes a `require-elf` driver mode.

**Two make/shell mechanics surfaced by the poison**, both now documented in place:
- `$(shell …)` inside recipe expansion runs under the *target's* `SHELL` — a recursive `SOURCE_DATE_EPOCH` silently expanded to an empty epoch under `/dev/null/enoshell`. It is now flattened at parse time (still `?=`-overridable).
- The zip children run with `cwd` inside the staging tree, so the zip binary and archive paths are absolutized in the script.

The dead `cp := cp -p` macro is deleted. Deliberate exceptions, noted at their rules: the ape-loader extraction (`mktemp` + glob) and the bootstrap download/assimilation (the pre-driver trust root).

## Validation

- **Double build is byte-identical** (`bin/make build`, then `o=o2 build`, `cmp`) — the same check the #733 CI gate runs; the reproducible lane re-proves it on the runner.
- Cold-tree `bin/make -j ci` from `rm -rf o`: **PASS**; the built binary smoke-runs (`pack-ok: linux`).
- `build-pack_test.tl` packs a payload onto a real archive base (the cosmos lua APE is itself a zip — a plain file is not appendable, so the test builds its base with `cosmic.zip`) and asserts archive entries, exec bit, and the epoch clamp; missing-input failure named. `require-elf` tested both ways.
- Coverage baseline gains `build-pack` and raises `build-recipe` + the total to measured values.

## Remaining host surface (#732) — the tail

`bin/make` + the bootstrap download/assimilate rule (the trust root: host curl/sha256sum obtain the first two pins), the ape-loader extraction, version.lua (`git describe`), the flag-stamp probe and `$(o)/.exists`, the ci grading loop and test apparatus (canary, makefile fixtures, env-probe — gate logic, shell by design), the `help` target, gendoc/docs rules (no CI gate), and the coverage ratchet's conditional block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9sZQU3fNPBndg6ekctHyw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9sZQU3fNPBndg6ekctHyw)_