### PR TITLE
build: de-shell the ci grading loop and the last small recipes (#732)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,11 @@ include 3p/tl/cook.mk
 
 .PHONY: help
 ## Show this help message
+help: export LUA_PATH = $(tree_lua_path)
+help: private SHELL := /dev/null/enoshell
+help: private .SHELLFLAGS := -c
 help: $(build_files) | $(bootstrap_cosmic)
-	@LUA_PATH="$(tree_lua_path)" $(bootstrap_cosmic) $(build_help) $(MAKEFILE_LIST)
+	@$(bootstrap_cosmic) $(build_help) $(MAKEFILE_LIST)
 
 ## Filter targets by substring (make test only=teal; also narrows fetch/stage)
 filter-only = $(if $(only),$(foreach f,$1,$(if $(findstring $(only),$(f)),$(f))),$1)
@@ -61,7 +64,10 @@ filter-only = $(if $(only),$(foreach f,$1,$(if $(findstring $(only),$(f)),$(f)))
 # copies after o/ exists (unveil skips missing paths silently).
 $(o)/%: % $(build_recipe) | $(o)/.exists $(bootstrap_cosmic)
 	@$(bootstrap_cosmic) -- $(build_recipe) copy $< $@
-$(o)/.exists: ; @mkdir -p $(@D) && touch $@
+$(o)/.exists: private SHELL := /dev/null/enoshell
+$(o)/.exists: private .SHELLFLAGS := -c
+$(o)/.exists: $(build_recipe) | $(bootstrap_cosmic)
+	@$(bootstrap_cosmic) -- $(build_recipe) list $@
 
 $(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files) $(compile_flag_stamp) $(build_recipe)
 	@$(bootstrap_cosmic) -- $(build_recipe) compile $(compile_flag_stamp) $(bootstrap_cosmic) $< $@ $(include_dir_flags)
@@ -467,28 +473,20 @@ ci_marks := $(foreach s,$(ci_stages),$(o)/ci-ok-$(s))
 # laundered its exit status through the already-tee'd summary). All
 # markers build in ONE sub-make, so stages keep sharing the target graph
 # and run in parallel without racing on common prerequisites.
+$(o)/ci-ok-%: private SHELL := /dev/null/enoshell
+$(o)/ci-ok-%: private .SHELLFLAGS := -c
 $(o)/ci-ok-%: %
-	@mkdir -p $(@D)
-	@touch $@
+	@$(bootstrap_cosmic) -- $(build_recipe) list $@
 
 .PHONY: ci
 ## Run CI checks (format, teal, test, example, lint) in parallel
-ci:
-	@rm -f $(o)/failed $(ci_summaries) $(ci_marks)
-	@$(MAKE) --keep-going $(ci_marks) || true
-	@for s in $(ci_stages); do \
-		echo "::group::$$s"; \
-		if [ -f $(o)/$$s-summary.txt ]; then \
-			cat $(o)/$$s-summary.txt; \
-			if grep -qE "[1-9][0-9]* failed" $(o)/$$s-summary.txt; then \
-				echo $$s >> $(o)/failed; \
-			elif [ ! -f $(o)/ci-ok-$$s ]; then \
-				echo "$$s (exit)" >> $(o)/failed; \
-			fi; \
-		else \
-			echo "$$s: no summary produced"; \
-			echo $$s >> $(o)/failed; \
-		fi; \
-		echo "::endgroup::"; \
-	done
-	@if [ -f $(o)/failed ]; then echo "ci: FAIL ($$(paste -sd' ' $(o)/failed))"; exit 1; else echo "ci: PASS"; fi
+# De-hosted (#732): the grading loop lives in the driver's verdict mode
+# (same #714 semantics — summary text AND exit marker — gated by the
+# ci-launder fixture); `-` on the sub-make replaces `|| true`.
+ci: private SHELL := /dev/null/enoshell
+ci: private .SHELLFLAGS := -c
+ci: export LUA_PATH := ;;
+ci: | $(bootstrap_cosmic) $(build_recipe)
+	@$(bootstrap_cosmic) -- $(build_recipe) remove $(ci_summaries) $(ci_marks)
+	-@$(MAKE) --keep-going $(ci_marks)
+	@$(bootstrap_cosmic) -- $(build_recipe) verdict $(o) $(ci_stages)

--- a/cook.mk
+++ b/cook.mk
@@ -210,6 +210,9 @@ $(bootstrap_cosmic):
 # ships that did not typecheck); the pinned bootstrap may predate the flag.
 # Probe once and use the best flag it supports — after a bootstrap pin bump
 # (or CI's stage1 refresh) in-tree compiles become strict automatically.
+# Shell exception (#732): the probe is pre-driver trust machinery — the
+# driver's own compile READS this stamp, so probing through the driver
+# would cycle. It stays shell, grouped with the bootstrap download.
 compile_flag_stamp := $(o)/bootstrap/compile-flag
 $(compile_flag_stamp): $(bootstrap_files)
 	@mkdir -p $(@D)

--- a/lib/build/build-recipe.tl
+++ b/lib/build/build-recipe.tl
@@ -221,6 +221,49 @@ local function do_require_elf(args: {string}): integer
   return 0
 end
 
+--- remove <paths...> — rm -f: delete files, ignoring missing ones.
+local function do_remove(args: {string}): integer
+  for _, p in ipairs(args) do
+    fs.unlink(p)
+  end
+  return 0
+end
+
+--- verdict <o_dir> <stages...> — the ci grading loop (#714): print each
+--- stage's summary in a log group, grade it by summary text AND the
+--- per-stage ci-ok exit marker (a stage failing after writing a clean
+--- summary must still fail), and end with the verdict line.
+local function do_verdict(args: {string}): integer
+  local o_dir = args[1]
+  if not o_dir or not args[2] then
+    return fail("usage: verdict <o_dir> <stages...>")
+  end
+  local failed: {string} = {}
+  for i = 2, #args do
+    local s = args[i]
+    io.write("::group::" .. s .. "\n")
+    local summary = fs.read(fs.join(o_dir, s .. "-summary.txt"))
+    if summary then
+      io.write(summary)
+      if string.match(summary, "[1-9]%d* failed") then
+        table.insert(failed, s)
+      elseif not fs.stat(fs.join(o_dir, "ci-ok-" .. s)) then
+        table.insert(failed, s .. " (exit)")
+      end
+    else
+      io.write(s .. ": no summary produced\n")
+      table.insert(failed, s)
+    end
+    io.write("::endgroup::\n")
+  end
+  if #failed > 0 then
+    io.write("ci: FAIL (" .. table.concat(failed, " ") .. ")\n")
+    return 1
+  end
+  io.write("ci: PASS\n")
+  return 0
+end
+
 --- copy <src> <dst> — mkdir -p + cp, preserving the permission bits.
 local function do_copy(args: {string}): integer
   local src, dst = args[1], args[2]
@@ -268,9 +311,11 @@ local modes: {string: function({string}): integer} = {
   copy = do_copy,
   link = do_link,
   list = do_list,
+  remove = do_remove,
   ["require-elf"] = do_require_elf,
   ["require-marker"] = do_require_marker,
   tee = do_tee,
+  verdict = do_verdict,
 }
 
 local function main(...: string): integer
@@ -278,7 +323,7 @@ local function main(...: string): integer
   local mode = table.remove(args, 1)
   local run_mode = mode and modes[mode]
   if not run_mode then
-    return fail("usage: build-recipe capture|compile|copy|link|list|require-elf|require-marker|tee ...")
+    return fail("usage: build-recipe <mode> ... (see the modes table)")
   end
   return run_mode(args)
 end

--- a/lib/build/build-recipe_test.tl
+++ b/lib/build/build-recipe_test.tl
@@ -185,3 +185,37 @@ local function test_require_elf()
   assert(err:match("not a native ELF"), "failure explains, got: " .. err)
 end
 test_require_elf()
+
+local function test_remove()
+  local a = fs.join(tmpdir, "rm-a")
+  assert(fs.write(a, "x"))
+  local code = run_driver("remove", a, fs.join(tmpdir, "rm-missing"))
+  assert(code == 0, "remove must succeed, missing files ignored")
+  assert(not fs.stat(a), "existing file removed")
+end
+test_remove()
+
+local function test_verdict()
+  local o_dir = fs.join(tmpdir, "verdict")
+  fs.makedirs(o_dir)
+  -- pass: clean summary + marker; launder: clean summary, NO marker;
+  -- bad: failing summary; ghost: no summary at all
+  assert(fs.write(fs.join(o_dir, "good-summary.txt"), "good: 2 checks: 2 passed, 0 failed\n"))
+  assert(fs.write(fs.join(o_dir, "ci-ok-good"), "\n"))
+  assert(fs.write(fs.join(o_dir, "launder-summary.txt"), "launder: 1 passed\n"))
+  assert(fs.write(fs.join(o_dir, "bad-summary.txt"), "bad: 3 checks: 2 passed, 1 failed\n"))
+  assert(fs.write(fs.join(o_dir, "ci-ok-bad"), "\n"))
+
+  local code, stdout = run_driver("verdict", o_dir, "good")
+  assert(code == 0, "all-green must pass")
+  assert(stdout:match("ci: PASS"), "expected PASS verdict")
+
+  code, stdout = run_driver("verdict", o_dir, "good", "launder", "bad", "ghost")
+  assert(code ~= 0, "failures must fail the verdict")
+  assert(stdout:match("::group::good"), "stage groups printed")
+  -- the #714 grading: text-clean summary without an exit marker fails
+  assert(stdout:match("ci: FAIL %(launder %(exit%) bad ghost%)"),
+    "expected marker/summary/missing grading, got: " .. stdout)
+  assert(stdout:match("ghost: no summary produced"), "missing summary named")
+end
+test_verdict()

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -133,9 +133,12 @@ $(o)/ci-selftest-launder-summary.txt:
 # above; the graded verdict must be FAIL. o= points the nested run at
 # its own output tree so its failed/summary/marker files never collide
 # with the real ci run that builds this fixture.
+# The nested tree has no bootstrap/driver of its own; the ci recipe's
+# remove/verdict steps exec them, so the fixture hands in the parent's
+# by absolute path (#732).
 $(build_make_out)/ci-launder.out: $(build_make_srcs)
 	@mkdir -p $(@D)
-	@code=0; $(MAKE) ci o=$(o)/citest ci_stages=ci-selftest-launder >$@.tmp 2>&1 || code=$$?; echo "exit:$$code" >> $@.tmp; mv $@.tmp $@
+	@code=0; $(MAKE) ci o=$(o)/citest ci_stages=ci-selftest-launder bootstrap_cosmic=$(CURDIR)/$(bootstrap_cosmic) build_recipe=$(CURDIR)/$(build_recipe) >$@.tmp 2>&1 || code=$$?; echo "exit:$$code" >> $@.tmp; mv $@.tmp $@
 
 # Environment clamp probe (#731): echoes the env a recipe actually sees.
 # Test apparatus like ci-selftest-launder above, not a help target.

--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -122,6 +122,9 @@ $(cosmic_check_bin): $(cosmic_bin) $(build_recipe) | $$(cosmos_staged)
 # (the exact flow every pre-#742 runner exec used), then move the cache
 # file the stub writes into place. A relative TMPDIR segfaulted on the
 # runner.
+# Shell exception (#732): extraction IS the APE shell-stub flow — a
+# direct cosmopolitan exec maps the binary and never writes the .ape-*
+# cache (witnessed), so this recipe must go through a real shell.
 ape_loader := $(o)/bin/ape
 $(ape_loader): $(cosmic_bin)
 	@t=$$(mktemp -d) && PATH="$(HOST_PATH)" TMPDIR=$$t $(CURDIR)/$< -e 'return' >/dev/null && \

--- a/lib/cosmic/coverage/baseline.txt
+++ b/lib/cosmic/coverage/baseline.txt
@@ -2,7 +2,7 @@
 # columns: path covered-lines total-lines
 lib/build/build-fetch.tl 23 95
 lib/build/build-pack.tl 97 132
-lib/build/build-recipe.tl 142 175
+lib/build/build-recipe.tl 172 206
 lib/build/build-stage.tl 45 251
 lib/build/build-untar.tl 121 130
 lib/build/lint.tl 97 132
@@ -141,4 +141,4 @@ lib/types/gentype_parse.tl 267 288
 lib/types/gentype_render.tl 309 312
 lib/types/gentype_types.tl 2 2
 tlconfig.lua 7 7
-total 11594 15194
+total 11624 15225


### PR DESCRIPTION
Closes #732 (with a closing comment to follow). The residue round: after this, every conversion the issue's fix sketch names is delivered, and everything still on a shell is a documented exception.

## What

**The ci grading loop** — the largest remaining shell block, and the last of the issue's three named conversions ("summary plumbing → the reporter") — moves into the driver's `verdict` mode. The #714 grading semantics are intact: each stage's summary prints in its log group, graded by summary text **and** the per-stage `ci-ok` exit marker, so a stage that fails after writing a clean summary still fails with the `(exit)` suffix; the verdict line format is unchanged. The `ci-launder` fixture still gates this — it now hands the nested `o=o/citest` tree the parent's bootstrap and driver by absolute path (the nested tree has neither). A `remove` mode replaces the `rm -f` preamble, `-` on the sub-make replaces `|| true`, and `ci` takes order-only prereqs on the bootstrap and driver so a cold tree can execute its first recipe line.

**Also converted**: `help` (target-scoped `LUA_PATH` export + direct exec), `$(o)/.exists`, and the per-stage `ci-ok` markers (both via the driver's `list`).

**Attempted, disproven, recorded as exceptions at their rules** — both were part of the plan and the empirics said no:
- the strict-compile **probe**: the driver's own compile reads the stamp, so probing through the driver is a dependency cycle. It stays shell, grouped with the bootstrap download as pre-driver trust machinery.
- the **ape-loader extraction**: extraction *is* the APE shell-stub flow — a direct cosmopolitan exec maps the binary and never writes the `.ape-*` cache (witnessed on this tree). The rule's purpose is to exercise that stub path, so it keeps a real shell.

## Validation

- Cold-tree `bin/make -j ci` from `rm -rf o`: **PASS** — including the first-recipe-line-on-empty-tree path this round introduced (and initially broke; the order-only prereqs are the fix).
- Driver tests for `remove` and the full `verdict` grading matrix: all-green PASS, text-clean summary without a marker → `(exit)`, failing summary, missing summary — asserting the exact verdict string the makefile_test fixture greps.
- Driver coverage floor raised to measured (172/206).

## The final exception list (everything still on a shell, all commented in place)

`bin/make` + the bootstrap download/assimilate rule and the strict-compile probe (pre-driver trust machinery), the driver's own self-bootstrap compile, the ape-loader extraction (shell-stub flow by nature), version.lua (`git describe`), the coverage ratchet's conditional block, the launder fixture recipe (deliberately shell — it tests grading), the canary / makefile fixtures / env-probe (test apparatus for shell+make behavior), and gendoc/docs rules (no CI gate; convert when one exists). Structural follow-ups live in #756.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9sZQU3fNPBndg6ekctHyw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9sZQU3fNPBndg6ekctHyw)_