### PR TITLE
build: unify the pins — extract make from cosmos.zip (#756 item 6)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,10 +20,9 @@ jobs:
   #
   # buildpack-deps:noble is Ubuntu 24.04 — the same release ubuntu-latest
   # currently serves — and its base tag ships git, curl, ca-certificates,
-  # coreutils AND unzip (the cosmos staging step shells out to
-  # /usr/bin/unzip to unpack cosmos.zip — a host-tool dependency #732
-  # will eventually fold into the bootstrap), so the gate needs no apt-get
-  # and nothing re-introduces an unpinned package fetch. The digest is the
+  # and coreutils (archive extraction is in-process since #732 — no host
+  # unzip/tar in the build), so the gate needs no apt-get and nothing
+  # re-introduces an unpinned package fetch. The digest is the
   # multi-arch index for the `noble` tag; GitHub pulls its linux/amd64
   # child on the x86-64 runner.
   #
@@ -94,8 +93,9 @@ jobs:
           done
 
   # No-network gate (#730). By design only three things touch the
-  # network — the landlock-make download, the bootstrap download, and
-  # the fetch rule — each integrity-checked against a committed sha256,
+  # network — the bootstrap download and the cosmos.zip download that
+  # yields bin/cosmo-make (both via bin/make, #756 item 6), and the
+  # fetch rule — each integrity-checked against a committed sha256,
   # so the pins are the trust root and TLS is transport. This job makes
   # the property falsifiable: fetch with network allowed, then run the
   # ENTIRE gate inside a network namespace whose only interface is

--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "342358e70501b49f19d7b47d27418086b4ca93f54585dfa371c40c215300fb48"}},
+  platforms = {["*"] = {sha = "31418749959219e71c3dbfdf0cfa0a3e36aa9fe88868716c138d94cf418d5a27"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.19-120e27dbc"
+  version = "2026.07.24-e95cebe09"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,9 @@ lib/
   cosmos/              Cosmopolitan Lua binary + zip tool
   tl/                  Teal compiler
 bin/
-  make                 bootstrap script that downloads landlock-make
-  cosmo-make           landlock-make binary (gitignored, downloaded)
+  make                 trust-root script: fetches the pinned bootstrap cosmic,
+                       which extracts make from the pinned cosmos.zip
+  cosmo-make           landlock-make binary (gitignored, extracted from cosmos.zip)
 .github/workflows/
   pr.yml               CI on push/PR (make ci)
   docs.yml             publish docs on push to main

--- a/bin/make
+++ b/bin/make
@@ -1,14 +1,20 @@
 #!/bin/sh
 set -e
 
-# Get the directory where this script is located
+# Trust root (#756 item 6). This script is the only host-shell step in the
+# build: with POSIX sh + curl + sha256sum + sed/od it obtains ONE pinned
+# artifact — the bootstrap cosmic (url + sha in cook.mk, single source for
+# this script and the Makefile's own rule) — and everything after runs
+# under that pin: the bootstrap extracts `make` from the sha-pinned
+# cosmos.zip (pin in 3p/cosmos/version.lua) via lib/build/make-boot.tl,
+# so no separate landlock-make release asset and no host unzip exist in
+# the chain. Trust root: kernel -> this script -> two pinned artifacts ->
+# everything else.
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 MAKE_BIN="${SCRIPT_DIR}/cosmo-make"
-RELEASE_URL="https://github.com/whilp/cosmopolitan/releases/download/2026.07.24-e95cebe09/make"
-# SHA-256 of the landlock-make binary. This binary is executed with full
-# control over the build, so verify its integrity before running it. Update
-# this when bumping RELEASE_URL.
-MAKE_SHA256="186e4c9b65ec41bf126ffd79accc9b7c4d90ca3c6c1ffb25dde9b13547303d3d"
+BOOTSTRAP="${ROOT}/o/bootstrap/cosmic"
 
 verify_sha256() {
     # Usage: verify_sha256 <file> <expected-hex>. Returns non-zero on mismatch.
@@ -25,31 +31,69 @@ verify_sha256() {
     [ "${actual}" = "${expected}" ]
 }
 
-# Download make if it doesn't exist. Retry on transient CDN errors
-# (e.g. 504 Gateway Timeout) that occasionally hit unauthenticated GitHub
-# release downloads.
-if [ ! -f "${MAKE_BIN}" ]; then
-    MAKE_BIN_TMP="${MAKE_BIN}.tmp.$$"
-    echo "Downloading landlock-make..." >&2
+download() {
+    # Usage: download <url> <dest>. Atomic, with retries on transient CDN
+    # errors (e.g. 504 Gateway Timeout) that occasionally hit
+    # unauthenticated GitHub release downloads.
+    url="$1"
+    dest="$2"
+    dest_tmp="${dest}.tmp.$$"
     attempt=0
     until curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
-        -o "${MAKE_BIN_TMP}" "${RELEASE_URL}"; do
+        -o "${dest_tmp}" "${url}"; do
         attempt=$((attempt + 1))
         if [ "${attempt}" -ge 3 ]; then
-            echo "Failed to download landlock-make after ${attempt} attempts" >&2
-            rm -f "${MAKE_BIN_TMP}"
-            exit 1
+            echo "Failed to download ${url} after ${attempt} attempts" >&2
+            rm -f "${dest_tmp}"
+            return 1
         fi
-        echo "Retrying landlock-make download (attempt ${attempt})..." >&2
+        echo "Retrying download of ${url} (attempt ${attempt})..." >&2
         sleep $((attempt * 5))
     done
-    if ! verify_sha256 "${MAKE_BIN_TMP}" "${MAKE_SHA256}"; then
-        echo "landlock-make checksum verification failed; refusing to run" >&2
-        rm -f "${MAKE_BIN_TMP}"
+    mv -f "${dest_tmp}" "${dest}"
+}
+
+ensure_bootstrap() {
+    # Mirror of the Makefile's $(bootstrap_cosmic) rule (which still
+    # covers the MAKE_BIN-exists-but-o/-cleaned case): download, verify
+    # against the cook.mk pin, assimilate to a native ELF (sandboxed
+    # rules cannot grant the APE loader's ~/.ape-* extraction), check.
+    [ -x "${BOOTSTRAP}" ] && return 0
+    bootstrap_url="$(sed -n 's/^bootstrap_url := //p' "${ROOT}/cook.mk")"
+    bootstrap_sha256="$(sed -n 's/^bootstrap_sha256 := //p' "${ROOT}/cook.mk")"
+    if [ -z "${bootstrap_url}" ] || [ -z "${bootstrap_sha256}" ]; then
+        echo "could not read bootstrap_url/bootstrap_sha256 from ${ROOT}/cook.mk" >&2
         exit 1
     fi
-    chmod +x "${MAKE_BIN_TMP}"
-    mv -f "${MAKE_BIN_TMP}" "${MAKE_BIN}"
+    echo "Downloading bootstrap cosmic..." >&2
+    mkdir -p "${ROOT}/o/bootstrap"
+    boot_tmp="${BOOTSTRAP}.boot.$$"
+    download "${bootstrap_url}" "${boot_tmp}" || exit 1
+    if ! verify_sha256 "${boot_tmp}" "${bootstrap_sha256}"; then
+        echo "bootstrap cosmic checksum verification failed; refusing to run" >&2
+        rm -f "${boot_tmp}"
+        exit 1
+    fi
+    chmod +x "${boot_tmp}"
+    "${boot_tmp}" --assimilate
+    if [ "$(head -c 4 "${boot_tmp}" | od -An -tx1 | tr -d ' \n')" != "7f454c46" ]; then
+        echo "bootstrap assimilation failed: still an APE — sandboxed rules need a native ELF (no loader grants)" >&2
+        rm -f "${boot_tmp}"
+        exit 1
+    fi
+    mv -f "${boot_tmp}" "${BOOTSTRAP}"
+    ln -sf cosmic "${ROOT}/o/bootstrap/lua"
+}
+
+if [ ! -f "${MAKE_BIN}" ]; then
+    ensure_bootstrap
+    # SSL_USE_SYSTEM_CERTS: the bootstrap's embedded CAs are too narrow
+    # for github.com (same knob as the Makefile's fetch rule); the sha
+    # pin is the trust root, TLS is transport. LUA_PATH=";;" pins
+    # make-boot's requires to the bootstrap's embedded stdlib.
+    SSL_USE_SYSTEM_CERTS=1 LUA_PATH=";;" "${BOOTSTRAP}" \
+        "${ROOT}/lib/build/make-boot.tl" \
+        "${ROOT}/3p/cosmos/version.lua" make "${MAKE_BIN}"
 fi
 
 # Execute make with all arguments

--- a/cook.mk
+++ b/cook.mk
@@ -196,6 +196,8 @@ bootstrap_url := https://github.com/whilp/cosmic/releases/download/2026-07-19-5c
 # bootstrap's stale embedded source (#744 — see tree_tl_path).
 bootstrap_sha256 := 6c2a0afe6c942560ce2a0d796ddf8f8df096ce2c92b8ce142c28da59ecac6dc6
 
+# bin/make mirrors this rule (ensure_bootstrap, parsing the pin above via
+# sed) for the cold-tree case where no make exists yet — keep them in sync.
 $(bootstrap_cosmic):
 	@mkdir -p $(@D)
 	curl -fsSL -o $@ $(bootstrap_url)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -9,7 +9,7 @@ bin/make build    # downloads bootstrap, fetches deps, builds cosmic
 bin/make test     # run tests
 ```
 
-`bin/make` is a shell script that downloads landlock-make on first run. all build artifacts go to `o/`.
+`bin/make` is a shell script that, on first run, downloads the sha-pinned bootstrap cosmic and uses it to extract `make` from the sha-pinned cosmos.zip (`lib/build/make-boot.tl`). all build artifacts go to `o/`.
 
 ## Workflow
 

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -9,7 +9,11 @@ build_help := $(o)/lib/build/make-help.lua
 build_lint := $(o)/lib/build/lint.lua
 build_recipe := $(o)/lib/build/build-recipe.lua
 build_pack := $(o)/lib/build/build-pack.lua
-build_files := $(build_fetch) $(build_stage) $(build_untar) $(build_pack) $(build_portable) $(build_reporter) $(build_help) $(build_lint)
+# make-boot runs from SOURCE under the bootstrap (bin/make invokes it
+# before any make exists); the compiled copy is built so it gets the
+# strict-compile type gate like every other build script.
+build_makeboot := $(o)/lib/build/make-boot.lua
+build_files := $(build_fetch) $(build_stage) $(build_untar) $(build_pack) $(build_portable) $(build_reporter) $(build_help) $(build_lint) $(build_makeboot)
 
 # Self-bootstrap exception (#732): build-recipe drives the shell-free
 # compile/copy/link recipes, so it cannot be compiled by them — this one

--- a/lib/build/make-boot.tl
+++ b/lib/build/make-boot.tl
@@ -1,0 +1,185 @@
+#!/usr/bin/env lua
+-- Trust-root make extractor (#756 item 6). bin/make runs this under the
+-- sha-pinned bootstrap cosmic BEFORE any make binary exists, to produce
+-- bin/cosmo-make from the sha-pinned cosmos.zip — no host unzip, and no
+-- separate landlock-make release asset. Nothing else can be assumed at
+-- that point: the tree is not compiled, so requires are limited to the
+-- bootstrap's EMBEDDED cosmic.* stdlib (never build.* — bin/make invokes
+-- this with LUA_PATH=";;" to keep that honest).
+local fetch = require("cosmic.fetch")
+local fs = require("cosmic.fs")
+local hash = require("cosmic.hash")
+local proc = require("cosmic.proc")
+local zip = require("cosmic.zip")
+
+local record PlatformSpec
+  sha: string
+end
+
+local record VersionSpec
+  version: string
+  url: string
+  platforms: {string: PlatformSpec}
+end
+
+--- URL and pinned sha256 resolved from a version.lua spec.
+local record Pin
+  url: string
+  sha: string
+end
+
+--- Load a 3p version.lua pin file.
+--- @param path string Path to the version.lua file
+--- @return VersionSpec | nil The parsed spec, or nil on error
+--- @return string? Error message if loading failed
+local function load_spec(path: string): VersionSpec | nil, string
+  -- cast: pcall returns any
+  local ok, spec = pcall(dofile, path) as (boolean, VersionSpec)
+  if not ok then
+    return nil, "failed to load " .. path .. ": " .. tostring(spec)
+  end
+  return spec
+end
+
+--- Resolve the archive URL and pinned sha from a version spec. Only the
+--- "*" platform is supported: cosmos.zip is a fat archive, so its pin is
+--- platform-independent.
+--- @param spec VersionSpec The parsed version.lua spec
+--- @return Pin | nil The resolved url + sha, or nil on error
+--- @return string? Error message if the spec is incomplete
+local function resolve_pin(spec: VersionSpec): Pin | nil, string
+  if not spec.version or not spec.url then
+    return nil, "version spec missing version or url"
+  end
+  local plat: PlatformSpec
+  if spec.platforms then
+    plat = spec.platforms["*"]
+  end
+  if not plat or not plat.sha then
+    return nil, "version spec missing platforms['*'].sha"
+  end
+  return {
+    url = (spec.url:gsub("{version}", spec.version)),
+    sha = plat.sha,
+  }
+end
+
+--- Download a URL into memory, with retries (the same fetch options as
+--- build-fetch, which cannot be required here — see the header).
+--- @param url string The URL to download
+--- @return string | nil The response body, or nil on error
+--- @return string? Error message if the download failed
+local function download(url: string): string | nil, string
+  local result = fetch.fetch(url, {
+      headers = {["User-Agent"] = "curl/8.0"},
+      maxresponse = 100 * 1024 * 1024,
+      max_attempts = 8,
+    })
+  if not result.ok then
+    return nil, "fetch failed: " .. result.error
+  end
+  if result.status ~= 200 then
+    return nil, "fetch status " .. tostring(result.status)
+  end
+  return result.body
+end
+
+--- Read one member out of an in-memory zip archive.
+--- @param archive string The zip archive bytes
+--- @param name string The member name to extract
+--- @return string | nil The member's contents, or nil on error
+--- @return string? Error message if opening or reading failed
+local function extract_member(archive: string, name: string): string | nil, string
+  local reader, open_err = zip.from(archive)
+  if not reader then
+    return nil, "zip open failed: " .. (open_err or "unknown error")
+  end
+  local r = reader as zip.Reader -- cast: record union after guard
+  local data, read_err = r:read(name)
+  r:close()
+  if not data then
+    return nil, "zip member " .. name .. ": " .. (read_err or "not found")
+  end
+  return data
+end
+
+--- Atomically write an executable file (mode 0755), creating parent
+--- directories as needed.
+--- @param path string Destination path
+--- @param data string File contents
+--- @return boolean true when the file was written
+--- @return string? Error message if writing failed
+local function write_executable(path: string, data: string): boolean, string
+  local dir = fs.dirname(path)
+  if dir and dir ~= "" then
+    local made, mkdir_err = fs.makedirs(dir)
+    if not made then
+      return false, "makedirs " .. dir .. ": " .. (mkdir_err or "unknown error")
+    end
+  end
+  -- cast: tonumber of an octal literal is non-nil
+  local mode = tonumber("755", 8) as integer
+  local wrote, write_err = fs.write_atomic(path, data, mode)
+  if not wrote then
+    return false, "write " .. path .. ": " .. (write_err or "unknown error")
+  end
+  return true
+end
+
+--- Fetch the pinned archive named by a version.lua, verify its sha256,
+--- and install one member of it as an executable.
+--- @param version_file string Path to the version.lua pin
+--- @param member string Zip member to extract (e.g. "make")
+--- @param output string Destination path for the executable
+--- @return boolean true when the member was installed
+--- @return string? Error message on failure
+local function main(version_file: string, member: string, output: string): boolean, string
+  if not version_file or not member or not output then
+    return false, "usage: make-boot.tl <version.lua> <member> <output>"
+  end
+  local spec, spec_err = load_spec(version_file)
+  if not spec then
+    return false, spec_err
+  end
+  -- cast: record union after guard
+  local pin, pin_err = resolve_pin(spec as VersionSpec)
+  if not pin then
+    return false, pin_err
+  end
+  local p = pin as Pin -- cast: record union after guard
+  io.stderr:write("↓ FETCH  " .. p.url .. "\n")
+  local body, dl_err = download(p.url)
+  if not body then
+    return false, dl_err
+  end
+  local actual = hash.sha256_hex(body)
+  if actual ~= string.lower(p.sha) then
+    return false, string.format(
+      "sha256 mismatch for %s: expected %s, got %s", p.url, p.sha, actual)
+  end
+  local data, extract_err = extract_member(body, member)
+  if not data then
+    return false, extract_err
+  end
+  local ok, write_err = write_executable(output, data)
+  if not ok then
+    return false, write_err
+  end
+  return true
+end
+
+if proc.is_main() then
+  local ok, err = main(arg[1], arg[2], arg[3])
+  if not ok then
+    io.stderr:write("error: " .. err .. "\n")
+    os.exit(1)
+  end
+end
+
+return {
+  load_spec = load_spec,
+  resolve_pin = resolve_pin,
+  extract_member = extract_member,
+  write_executable = write_executable,
+  main = main,
+}

--- a/lib/build/make-boot_test.tl
+++ b/lib/build/make-boot_test.tl
@@ -1,0 +1,110 @@
+#!/usr/bin/env cosmic
+-- Tests for the trust-root make extractor (#756 item 6): pin parsing and
+-- url interpolation, member extraction from a real zip, and the
+-- executable install. The network path (download) is deliberately not
+-- exercised here — the sha pin it enforces is proven by every cold
+-- bootstrap.
+
+local check = require("cosmic.check")
+local fs = require("cosmic.fs")
+local fs_types = require("cosmic.fs.types")
+local makeboot = require("build.make-boot")
+local zip = require("cosmic.zip")
+
+local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
+
+local function test_resolve_pin_interpolates_url()
+  local pin = check.must(makeboot.resolve_pin({
+        version = "2026.07.24-e95cebe09",
+        url = "https://example.com/{version}/cosmos.zip",
+        platforms = {["*"] = {sha = "AB12"}},
+      }))
+  assert(pin.url == "https://example.com/2026.07.24-e95cebe09/cosmos.zip",
+    "got url: " .. pin.url)
+  assert(pin.sha == "AB12", "got sha: " .. pin.sha)
+end
+test_resolve_pin_interpolates_url()
+
+local function test_resolve_pin_requires_star_platform()
+  local pin, err = makeboot.resolve_pin({
+      version = "1.0",
+      url = "https://example.com/x.zip",
+      platforms = {["linux-x86_64"] = {sha = "AB12"}},
+    })
+  assert(not pin, "expected failure without a '*' platform")
+  assert(err and tostring(err):find("platforms"), "got: " .. tostring(err))
+end
+test_resolve_pin_requires_star_platform()
+
+local function test_resolve_pin_requires_version_and_url()
+  local pin, err = makeboot.resolve_pin({
+      platforms = {["*"] = {sha = "AB12"}},
+    })
+  assert(not pin, "expected failure without version/url")
+  assert(err ~= nil, "expected an error message")
+end
+test_resolve_pin_requires_version_and_url()
+
+local function test_load_spec_reads_version_lua()
+  local path = fs.join(tmpdir, "version.lua")
+  assert(fs.write(path, [[
+return {
+  platforms = {["*"] = {sha = "cafe"}},
+  url = "https://example.com/{version}/cosmos.zip",
+  version = "1.2.3"
+}
+]]))
+  local spec = check.must(makeboot.load_spec(path))
+  assert(spec.version == "1.2.3", "got version: " .. tostring(spec.version))
+  local pin = check.must(makeboot.resolve_pin(spec))
+  assert(pin.url == "https://example.com/1.2.3/cosmos.zip", "got url: " .. pin.url)
+end
+test_load_spec_reads_version_lua()
+
+local function test_load_spec_missing_file()
+  local spec, err = makeboot.load_spec(fs.join(tmpdir, "no-such-version.lua"))
+  assert(not spec, "expected failure for a missing pin file")
+  assert(err ~= nil, "expected an error message")
+end
+test_load_spec_missing_file()
+
+local function make_archive(): string
+  local path = fs.join(tmpdir, "fixture.zip")
+  local w = check.must(zip.writer(path))
+  assert(w:add("lua", "not the droid\n"))
+  assert(w:add("make", "#!/fake/make\n"))
+  w:close()
+  local data = check.must(fs.read(path))
+  return data
+end
+
+local function test_extract_member_reads_named_member()
+  local data = check.must(makeboot.extract_member(make_archive(), "make"))
+  assert(data == "#!/fake/make\n", "got: " .. data)
+end
+test_extract_member_reads_named_member()
+
+local function test_extract_member_missing_member()
+  local data, err = makeboot.extract_member(make_archive(), "unzip")
+  assert(not data, "expected failure for a missing member")
+  assert(err and tostring(err):find("unzip"), "got: " .. tostring(err))
+end
+test_extract_member_missing_member()
+
+local function test_extract_member_rejects_garbage()
+  local data, err = makeboot.extract_member("this is not a zip", "make")
+  assert(not data, "expected failure for a non-zip input")
+  assert(err ~= nil, "expected an error message")
+end
+test_extract_member_rejects_garbage()
+
+local function test_write_executable_sets_exec_bit()
+  local out = fs.join(tmpdir, "boot", "cosmo-make")
+  assert(check.must(makeboot.write_executable(out, "#!/fake/make\n")))
+  assert(check.must(fs.read(out)) == "#!/fake/make\n", "content round-trips")
+  local st = fs.stat(out)
+  assert(st, "output should stat")
+  local mode = (st as fs_types.Stat):mode() % 512 -- cast: mixed-representation Stat
+  assert(mode % 2 == 1, "installed file keeps the exec bit")
+end
+test_write_executable_sets_exec_bit()

--- a/lib/cosmic/coverage/baseline.txt
+++ b/lib/cosmic/coverage/baseline.txt
@@ -6,6 +6,7 @@ lib/build/build-recipe.tl 172 206
 lib/build/build-stage.tl 45 251
 lib/build/build-untar.tl 121 130
 lib/build/lint.tl 97 132
+lib/build/make-boot.tl 51 86
 lib/build/make-help.tl 79 97
 lib/build/portable.tl 16 18
 lib/build/reporter.tl 145 159
@@ -141,4 +142,4 @@ lib/types/gentype_parse.tl 267 288
 lib/types/gentype_render.tl 309 312
 lib/types/gentype_types.tl 2 2
 tlconfig.lua 7 7
-total 11624 15225
+total 11675 15311

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -2781,7 +2781,10 @@ local record unix
   --- Allows isatty, tiocgwinsz, tcgets, tcsets, tcsetsw, tcsetsf.
   --- ### inet
   --- Allows socket (AF_INET), listen, bind, connect, accept,
-  --- getpeername, getsockname, setsockopt, getsockopt.
+  --- getpeername, getsockname, setsockopt, getsockopt, plus the
+  --- read-only interface ioctls used by siocgifconf() and
+  --- siocgifflags() (SIOCGIFCONF, SIOCGIFFLAGS, SIOCGIFNETMASK) on
+  --- Linux.
   --- ### unix
   --- Allows socket (AF_UNIX), listen, bind, connect, accept,
   --- getpeername, getsockname, setsockopt, getsockopt.
@@ -2802,7 +2805,9 @@ local record unix
   --- ### unveil
   --- Allows unveil().
   --- ### exec
-  --- Allows execve.
+  --- Allows execve, and on Linux memfd_create, which is needed to spawn
+  --- programs embedded in the zip filesystem (e.g.
+  --- `unix.execve("/zip/foo.com", ...)`).
   --- If the executable in question needs a loader, then you will need
   --- "rpath prot_exec" too. With APE, security is strongest when you
   --- assimilate your binaries beforehand, using the --assimilate flag,


### PR DESCRIPTION
First PR of the #756 series — item 6 (pin unification), which the issue sequences first because it rides a cosmos bump. The prerequisite landed this morning: release `2026.07.24-e95cebe09` ships a `cosmos.zip` whose `make` member is byte-identical to the separately pinned landlock-make asset (`186e4c9b…`), i.e. it carries the #744 scope fix.

## What changed

**Commit 1 — routine cosmos bump** to `2026.07.24-e95cebe09`. `regen-types` produced doc-comment-only drift in `unix.d.tl`; gentype tests green.

**Commit 2 — pin unification.** `bin/make` no longer downloads a separate landlock-make release asset:

1. It obtains the sha-pinned **bootstrap cosmic** first (url + sha parsed from `cook.mk` with `sed`, so the pin still has a single source; download, verify, `--assimilate`, ELF check, `lua` symlink — mirroring the Makefile's `$(bootstrap_cosmic)` rule, which stays for the cleaned-`o/` case; a cross-reference comment ties the two).
2. It then runs the new **`lib/build/make-boot.tl`** under that bootstrap (`LUA_PATH=";;"`, embedded stdlib only): read the `3p/cosmos/version.lua` pin, fetch cosmos.zip in-memory with retries, verify its sha256, extract the `make` member via `cosmic.zip`, install it atomically as `bin/cosmo-make` (0755).

The trust root becomes exactly the shape sketched in the issue comment: kernel → committed `bin/make` (POSIX sh + curl + sha256sum) → **two** pinned artifacts (bootstrap cosmic, cosmos.zip) → everything else. No host unzip anywhere; the extraction logic is typed, tested, and coverage-ratcheted like every other build script.

Also updated: the no-network-gate comment and the stale host-unzip container rationale in `pr.yml`, AGENTS.md, `docs/contributing.md`, and the coverage baseline (new file's row only — every committed floor is untouched, since this container's privileged environment covers more than CI in env-sensitive files and re-recording those floors here would be wrong in both directions).

## Verification

- Extracted `make` sha `186e4c9b65ec…` — byte-identical to the previous landlock-make pin; `--version` runs.
- Cold tree (`rm -rf o bin/cosmo-make`): `bin/make -j ci` → `ci: PASS` end-to-end through the new path (bootstrap download → assimilation → cosmos.zip fetch/verify/extract → full build/test).
- `bin/make -j enforce` 3/3; sandbox-canary skips here (no Landlock in this container) — CI's privileged job exercises it.

## Proposed PR series for the rest of #756

Per the issue's sequencing (6 → 2 → 1 → 3 → 5 → 4 → 7):

2. **Item 2 — invert the default**: poison `SHELL` globally, real shell becomes the per-rule exception (`$(build_recipe)` self-bootstrap, the bootstrap/flag-stamp rules, version.lua, test apparatus); plus the hostx ratchet — a makefile_test assertion enumerating exactly which rules may carry `$(unveil_hostx)`/a real shell, failing when the set grows.
3. **Item 1 — residue**, 2–3 small PRs shrinking the ratchet list from PR 2: flag-stamp probe + ape-loader extraction → driver modes; gendoc/docs rules de-shelled + a docs CI gate; version.lua/`help` documented as permanent exceptions or converted.
4. **Item 3 — CLI consolidation**, two-phase: add capture/tee/write-if-changed primitives to the cosmic CLI in-tree (tested, additive), then after a release, bump the bootstrap pin and shrink `build-recipe` — possibly to nothing.
5. **Item 5 — env allowlist** (`.ENV` beside `.PLEDGE`/`.UNVEIL`): upstream landlock-make half in whilp/cosmopolitan (sibling issue when picked up), then adoption + hostile-env canary gate here.
6. **Item 4 — grants derived from the graph**: upstream default-deny mode + unused-grant audit in landlock-make, then delete hand-curated `.UNVEIL` sets here with evidence.
7. **Item 7 — ADR** in docs/decisions.md recording the (now two-artifact) trust root, the deliberate exceptions (host curl for the first fetch, git for version stamping), and the settled no-self-hosting decision.

Closes nothing yet — #756 stays open as the tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13

---
_Generated by [Claude Code](https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13)_