### PR TITLE
build: no-shell is the default — poison SHELL globally, ratchet the exceptions (#756 item 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 .SECONDEXPANSION:
 .SECONDARY:
+# Parse-time shell: $(shell) queries here and in the includes (nproc,
+# uname, git) read this value DURING parsing — poisoning it here empties
+# them silently (witnessed: an empty SOURCE_DATE_EPOCH in the pack).
+# Recipes get the no-shell default at the BOTTOM of this file (#756).
 SHELL := /bin/bash
 .SHELLFLAGS := -o pipefail -c
 .DEFAULT_GOAL := help
@@ -50,8 +54,6 @@ include 3p/tl/cook.mk
 .PHONY: help
 ## Show this help message
 help: export LUA_PATH = $(tree_lua_path)
-help: private SHELL := /dev/null/enoshell
-help: private .SHELLFLAGS := -c
 help: $(build_files) | $(bootstrap_cosmic)
 	@$(bootstrap_cosmic) $(build_help) $(MAKEFILE_LIST)
 
@@ -64,8 +66,6 @@ filter-only = $(if $(only),$(foreach f,$1,$(if $(findstring $(only),$(f)),$(f)))
 # copies after o/ exists (unveil skips missing paths silently).
 $(o)/%: % $(build_recipe) | $(o)/.exists $(bootstrap_cosmic)
 	@$(bootstrap_cosmic) -- $(build_recipe) copy $< $@
-$(o)/.exists: private SHELL := /dev/null/enoshell
-$(o)/.exists: private .SHELLFLAGS := -c
 $(o)/.exists: $(build_recipe) | $(bootstrap_cosmic)
 	@$(bootstrap_cosmic) -- $(build_recipe) list $@
 
@@ -139,8 +139,6 @@ all_tested := $(patsubst %,$(o)/%.test.got,$(all_tests))
 test: $(o)/test-summary.txt
 
 $(o)/test-summary.txt: export LUA_PATH := ;;
-$(o)/test-summary.txt: private SHELL := /dev/null/enoshell
-$(o)/test-summary.txt: private .SHELLFLAGS := -c
 $(o)/test-summary.txt: $(all_tested) | $(cosmic_bin) $(build_recipe)
 	@$(bootstrap_cosmic) -- $(build_recipe) tee $@ $(cosmic_bin) --report $^
 
@@ -222,6 +220,9 @@ $(o)/coverage/%.tl.test.got: $(o)/%.lua $(cosmic_bin) $(ape_loader)
 coverage_baseline := lib/cosmic/coverage/baseline.txt
 coverage_baseline_tool := $(o)/lib/cosmic/coverage/baseline.lua
 
+# Shell exception (#756 item 2): the ratchet conditional (item-1 residue).
+$(o)/coverage-summary.txt: private SHELL := /bin/bash
+$(o)/coverage-summary.txt: private .SHELLFLAGS := -o pipefail -c
 $(o)/coverage-summary.txt: .PLEDGE := $(pledge_build)
 $(o)/coverage-summary.txt: .UNVEIL := $(unveil_base) rwcx:$(o)
 $(o)/coverage-summary.txt: $(coverage_got) | $(cosmic_bin) $(build_recipe)
@@ -239,9 +240,8 @@ $(o)/coverage-summary.txt: $(coverage_got) | $(cosmic_bin) $(build_recipe)
 ## Rewrite the committed coverage ratchet baseline from the last coverage run
 coverage-baseline: .PLEDGE := $(pledge_build)
 coverage-baseline: .UNVEIL := $(unveil_base) rwcx:$(o) rwc:lib/cosmic/coverage
-coverage-baseline: $(coverage_got) | $(cosmic_bin)
-	@$(cosmic_bin) $(coverage_baseline_tool) write $(o)/coverage lib > $(coverage_baseline).tmp
-	@mv $(coverage_baseline).tmp $(coverage_baseline)
+coverage-baseline: $(coverage_got) | $(cosmic_bin) $(build_recipe)
+	@$(bootstrap_cosmic) -- $(build_recipe) capture $(cosmic_bin) $(coverage_baseline) $(coverage_baseline_tool) write $(o)/coverage lib
 	@echo "wrote $(coverage_baseline)"
 
 # Privileged enforcement lane (Phase 1 step 8 prerequisite, audit §5.1).
@@ -275,8 +275,6 @@ $(o)/enforce/%.tl.test.got: $(o)/%.lua $(cosmic_bin)
 # The require-marker line is the tripwire: it fails the lane when no
 # enforcement ran (every sandbox test skipped — outer sandbox active?).
 $(o)/enforce-summary.txt: export LUA_PATH := ;;
-$(o)/enforce-summary.txt: private SHELL := /dev/null/enoshell
-$(o)/enforce-summary.txt: private .SHELLFLAGS := -c
 $(o)/enforce-summary.txt: $(enforce_got) | $(cosmic_bin) $(build_recipe)
 	@$(bootstrap_cosmic) -- $(build_recipe) tee $@ $(cosmic_bin) --report $^
 	@$(bootstrap_cosmic) -- $(build_recipe) require-marker enforce-ran: $(o)/enforce
@@ -418,13 +416,13 @@ all_docs += $(dtl_docs)
 ## Generate documentation from source
 docs: $(all_docs)
 
-$(o)/docs/%.md: %.tl $(cosmic_bin) | $(bootstrap_files)
-	@mkdir -p $(@D)
-	@$(cosmic_bin) lib/cosmic/doc/gendoc.tl $< > $@
+# De-shelled (#756 item 2): the driver's capture mode owns the output
+# file (and its parent directory) — no mkdir, no redirect.
+$(o)/docs/%.md: %.tl $(cosmic_bin) $(build_recipe) | $(bootstrap_files)
+	@$(bootstrap_cosmic) -- $(build_recipe) capture $(cosmic_bin) $@ lib/cosmic/doc/gendoc.tl $<
 
-$(o)/docs/cosmo/%.md: lib/types/cosmo/%.d.tl $(cosmic_bin) | $(bootstrap_files)
-	@mkdir -p $(@D)
-	@$(cosmic_bin) lib/cosmic/doc/gendoc.tl $< > $@
+$(o)/docs/cosmo/%.md: lib/types/cosmo/%.d.tl $(cosmic_bin) $(build_recipe) | $(bootstrap_files)
+	@$(bootstrap_cosmic) -- $(build_recipe) capture $(cosmic_bin) $@ lib/cosmic/doc/gendoc.tl $<
 
 # Generate serialized doc index for embedding (uses bootstrap cosmic to avoid circular dep)
 # Include both module sources and example files for the index
@@ -456,6 +454,9 @@ doc-index: $(doc_index)
 
 .PHONY: doc-publish
 ## Publish docs to git branch (SOURCE_SHA required, uses $(o)/docs)
+# Shell exception (#756 item 2): SOURCE_SHA guard + env prefix; git anyway.
+doc-publish: private SHELL := /bin/bash
+doc-publish: private .SHELLFLAGS := -o pipefail -c
 doc-publish: .PLEDGE := $(pledge_build) inet dns
 doc-publish: .UNVEIL := $(unveil_run) rwc:.git rwc:. r:/home r:/root
 doc-publish: $(all_docs) $(docs_publish) | $(bootstrap_cosmic)
@@ -473,8 +474,6 @@ ci_marks := $(foreach s,$(ci_stages),$(o)/ci-ok-$(s))
 # laundered its exit status through the already-tee'd summary). All
 # markers build in ONE sub-make, so stages keep sharing the target graph
 # and run in parallel without racing on common prerequisites.
-$(o)/ci-ok-%: private SHELL := /dev/null/enoshell
-$(o)/ci-ok-%: private .SHELLFLAGS := -c
 $(o)/ci-ok-%: %
 	@$(bootstrap_cosmic) -- $(build_recipe) list $@
 
@@ -483,10 +482,19 @@ $(o)/ci-ok-%: %
 # De-hosted (#732): the grading loop lives in the driver's verdict mode
 # (same #714 semantics — summary text AND exit marker — gated by the
 # ci-launder fixture); `-` on the sub-make replaces `|| true`.
-ci: private SHELL := /dev/null/enoshell
-ci: private .SHELLFLAGS := -c
 ci: export LUA_PATH := ;;
 ci: | $(bootstrap_cosmic) $(build_recipe)
 	@$(bootstrap_cosmic) -- $(build_recipe) remove $(ci_summaries) $(ci_marks)
 	-@$(MAKE) --keep-going $(ci_marks)
 	@$(bootstrap_cosmic) -- $(build_recipe) verdict $(o) $(ci_stages)
+
+# No-shell DEFAULT (#756 item 2, inverting #732's per-family opt-in).
+# Set LAST so the parse-time $(shell) queries above ran under the real
+# shell; recipes read SHELL's FINAL value, so the poison reaches every
+# rule. A recipe is a shell-free argv line (make's direct-exec fast
+# path spawns no shell); one that regresses to shell syntax fails
+# loudly on every host, Landlock or not. Rules that genuinely need a
+# shell override SHELL/.SHELLFLAGS per rule with `private` (the grant
+# must not leak to prerequisites); makefile_test ratchets that list.
+SHELL := /dev/null/enoshell
+.SHELLFLAGS := -c

--- a/cook.mk
+++ b/cook.mk
@@ -64,8 +64,6 @@ $(o)/%.lua: .PLEDGE := $(pledge_build) fattr
 # fast path + poisoned-SHELL tripwire as fetch/stage. The driver's own
 # compile opts back out in lib/build/cook.mk (self-bootstrap exception).
 $(o)/%.lua: .UNVEIL := rwc:$(o) r:tlconfig.lua $(unveil_dev)
-$(o)/%.lua: private SHELL := /dev/null/enoshell
-$(o)/%.lua: private .SHELLFLAGS := -c
 # LUA_PATH=;; pins the DRIVER to the bootstrap's embedded stdlib (a
 # caller's LUA_PATH must not redirect its requires); the compile child
 # gets ";;" (strict) or TREE_LUA_PATH — the #666 axis, one layer down.
@@ -82,19 +80,16 @@ $(o)/%.lua: export TL_PATH = $(tree_tl_path)
 # the grant sets.
 $(o)/%/.fetched: .SANDBOXED := 1
 $(o)/%/.staged: .SANDBOXED := 1
-# De-hosted (#732): these recipes are metacharacter-free argv, so a
-# plain -c re-enables make's direct-exec fast path (the global pipefail
-# .SHELLFLAGS forces the shell; these recipes have no pipes) and no
-# shell runs at all — the poisoned SHELL is the tripwire that fails
-# loudly if a recipe ever regresses to shell syntax. private: cold-tree
-# prerequisites (stdlib compiles) must not inherit either override —
-# but NOT on the export: a private export never reaches the recipe env
-# (witnessed: bootstrap fell back to its embedded stdlib); inheritance
-# is benign because every compile recipe sets LUA_PATH explicitly.
-# Recursive (=): tree_lua_path is computed after the includes (#720).
+# De-hosted (#732): these recipes are metacharacter-free argv, so
+# make's direct-exec fast path runs them with no shell at all; the
+# GLOBAL poisoned SHELL (#756 item 2, set at the bottom of the
+# Makefile) is the tripwire that fails loudly if any recipe regresses
+# to shell syntax. The LUA_PATH export is deliberately NOT private: a
+# private export never reaches the recipe env (witnessed: bootstrap
+# fell back to its embedded stdlib); inheritance is benign because
+# every compile recipe sets LUA_PATH explicitly. Recursive (=):
+# tree_lua_path is computed after the includes (#720).
 $(o)/%/.fetched $(o)/%/.staged: export LUA_PATH = $(tree_lua_path)
-$(o)/%/.fetched $(o)/%/.staged: private SHELL := /dev/null/enoshell
-$(o)/%/.fetched $(o)/%/.staged: private .SHELLFLAGS := -c
 # De-hosted (#732): lint runs through the pinned bootstrap's --test
 # capture (which mkdtemps under $(TMP)); the .ok alias file is retired —
 # the .got IS the target. LUA_PATH points the lint child at this tree's
@@ -104,8 +99,6 @@ $(o)/%.lint.got: .SANDBOXED := 1
 $(o)/%.lint.got: .PLEDGE := $(pledge_build)
 $(o)/%.lint.got: .UNVEIL := rwc:$(o) rwc:$(TMP) $(unveil_dev)
 $(o)/%.lint.got: export LUA_PATH = $(o)/lib/?.lua;$(o)/lib/?/init.lua;;
-$(o)/%.lint.got: private SHELL := /dev/null/enoshell
-$(o)/%.lint.got: private .SHELLFLAGS := -c
 # Reporter summaries (bootstrap + tee). test/coverage/enforce summaries
 # exec $(cosmic_bin) and stay unsandboxed with the test lanes.
 reporter_summaries := $(o)/teal-summary.txt $(o)/format-summary.txt \
@@ -117,8 +110,6 @@ $(reporter_summaries): .PLEDGE := $(pledge_build)
 # fast path + tripwire as fetch/stage above.
 $(reporter_summaries): .UNVEIL := rwc:$(o) $(unveil_dev)
 $(reporter_summaries): export LUA_PATH = $(tree_lua_path)
-$(reporter_summaries): private SHELL := /dev/null/enoshell
-$(reporter_summaries): private .SHELLFLAGS := -c
 
 # Third ENFORCED family (#729): the teal/format check rules, which exec
 # the assimilated $(cosmic_check_bin) duplicate (see lib/cosmic/cook.mk)
@@ -131,13 +122,9 @@ $(o)/%.teal.got: .SANDBOXED := 1
 $(o)/%.teal.got: .PLEDGE := $(pledge_build)
 $(o)/%.teal.got: .UNVEIL := rwc:$(o) r:tlconfig.lua rwc:$(TMP) $(unveil_dev)
 $(o)/%.teal.got: export TL_PATH = $(tree_tl_path)
-$(o)/%.teal.got: private SHELL := /dev/null/enoshell
-$(o)/%.teal.got: private .SHELLFLAGS := -c
 $(o)/%.format.got: .SANDBOXED := 1
 $(o)/%.format.got: .PLEDGE := $(pledge_build)
 $(o)/%.format.got: .UNVEIL := rwc:$(o) r:tlconfig.lua rwc:$(TMP) $(unveil_dev)
-$(o)/%.format.got: private SHELL := /dev/null/enoshell
-$(o)/%.format.got: private .SHELLFLAGS := -c
 
 # Fifth ENFORCED family (#729): examples. Same grant sets as the test
 # lanes — examples exercise the same modules (sockets, tty, chmod) and
@@ -147,8 +134,6 @@ $(o)/%.format.got: private .SHELLFLAGS := -c
 $(o)/%.tl.example.got: .SANDBOXED := 1
 $(o)/%.tl.example.got: .PLEDGE := $(pledge_test)
 $(o)/%.tl.example.got: .UNVEIL := $(unveil_test)
-$(o)/%.tl.example.got: private SHELL := /dev/null/enoshell
-$(o)/%.tl.example.got: private .SHELLFLAGS := -c
 
 # Fourth ENFORCED family (#729): the plain and coverage test lanes,
 # running the real fat-APE $(cosmic_bin) via the staged o/bin/ape
@@ -166,13 +151,9 @@ $(o)/%.tl.example.got: private .SHELLFLAGS := -c
 # tools (sh, etc.) under $(unveil_test).
 $(o)/%.tl.test.got: .SANDBOXED := 1
 $(o)/%.tl.test.got: export LUA_PATH = $(tree_lua_path)
-$(o)/%.tl.test.got: private SHELL := /dev/null/enoshell
-$(o)/%.tl.test.got: private .SHELLFLAGS := -c
 $(o)/coverage/%.tl.test.got: .SANDBOXED := 1
 $(o)/enforce/%.tl.test.got: export LUA_PATH = $(tree_lua_path)
 $(o)/%.tl.benchmark.got: export LUA_PATH = $(tree_lua_path)
-$(o)/%.tl.benchmark.got: private SHELL := /dev/null/enoshell
-$(o)/%.tl.benchmark.got: private .SHELLFLAGS := -c
 
 # Type definition generation (define early so it's available to all modules).
 # Must match MODULES in lib/types/gentype.tl: "cosmo" renders the top-level
@@ -198,6 +179,10 @@ bootstrap_sha256 := 6c2a0afe6c942560ce2a0d796ddf8f8df096ce2c92b8ce142c28da59ecac
 
 # bin/make mirrors this rule (ensure_bootstrap, parsing the pin above via
 # sed) for the cold-tree case where no make exists yet — keep them in sync.
+# Shell exception (#756 item 2): the trust-root download — curl, the
+# sha256sum pipe, and the ELF check predate everything the driver needs.
+$(bootstrap_cosmic): private SHELL := /bin/bash
+$(bootstrap_cosmic): private .SHELLFLAGS := -o pipefail -c
 $(bootstrap_cosmic):
 	@mkdir -p $(@D)
 	curl -fsSL -o $@ $(bootstrap_url)
@@ -216,6 +201,8 @@ $(bootstrap_cosmic):
 # driver's own compile READS this stamp, so probing through the driver
 # would cycle. It stays shell, grouped with the bootstrap download.
 compile_flag_stamp := $(o)/bootstrap/compile-flag
+$(compile_flag_stamp): private SHELL := /bin/bash
+$(compile_flag_stamp): private .SHELLFLAGS := -o pipefail -c
 $(compile_flag_stamp): $(bootstrap_files)
 	@mkdir -p $(@D)
 	@printf 'print("probe")\n' > $@.probe.tl
@@ -260,6 +247,10 @@ gentype_closure_lua := $(patsubst %.tl,$(o)/%.lua,$(gentype_closure_tl))
 
 .PHONY: regen-types
 ## Regenerate .d.tl type definitions from the pinned cosmos definitions.lua
+# Shell exception (#756 item 2): dev-facing regen loop (for/case/redirect);
+# the gentype drift test gates its output, not this recipe.
+regen-types: private SHELL := /bin/bash
+regen-types: private .SHELLFLAGS := -o pipefail -c
 regen-types: $(gentype_closure_lua)
 	@test -x $(cosmos_lua_bin) || { echo "regen-types: staged cosmos missing; run 'bin/make staged' first"; exit 1; }
 	@test -f $(tl_dir)/tl.lua || { echo "regen-types: staged tl missing; run 'bin/make staged' first"; exit 1; }

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -21,8 +21,8 @@ build_files := $(build_fetch) $(build_stage) $(build_untar) $(build_pack) $(buil
 # needs), and everything else compiles through the driver. The driver
 # runs against the bootstrap's EMBEDDED stdlib (see its header), so the
 # bootstrap sha covers its runtime and no tree .lua is required first.
-$(build_recipe): SHELL := /bin/bash
-$(build_recipe): .SHELLFLAGS := -o pipefail -c
+$(build_recipe): private SHELL := /bin/bash
+$(build_recipe): private .SHELLFLAGS := -o pipefail -c
 $(build_recipe): export LUA_PATH := ;;
 $(build_recipe): .UNVEIL := rwc:$(o) r:tlconfig.lua $(unveil_hostx)
 $(build_recipe): lib/build/build-recipe.tl $(types_files) $(tl_files) $(bootstrap_files) $(compile_flag_stamp)
@@ -47,8 +47,6 @@ $(build_test_got): $(build_files)
 # make-help snapshot: generate actual help output (driver capture, #732)
 $(o)/lib/build/make-help.snap: export LUA_PATH := ;;
 $(o)/lib/build/make-help.snap: export TREE_LUA_PATH = $(tree_lua_path)
-$(o)/lib/build/make-help.snap: private SHELL := /dev/null/enoshell
-$(o)/lib/build/make-help.snap: private .SHELLFLAGS := -c
 $(o)/lib/build/make-help.snap: Makefile $(build_help) $(build_recipe) | $(bootstrap_cosmic)
 	@$(bootstrap_cosmic) -- $(build_recipe) capture $(bootstrap_cosmic) $@ $(build_help) Makefile
 
@@ -92,6 +90,10 @@ $(build_make_out)/only-database.out: $(build_make_srcs)
 # Every enforcement-bound .UNVEIL carrying $(...) needs this spelling.
 canary_dir := $(o)/sandbox-canary
 canary_escape := $(o)/sandbox-canary-escape.txt
+# Shell exceptions (#756 item 2): the probe's out-of-grant write attempt
+# and the canary's verdict branching are the enforcement test itself.
+$(canary_dir)/probe.got sandbox-canary: private SHELL := /bin/bash
+$(canary_dir)/probe.got sandbox-canary: private .SHELLFLAGS := -o pipefail -c
 $(canary_dir)/probe.got: .SANDBOXED := 1
 $(canary_dir)/probe.got: .PLEDGE := $(pledge_build)
 $(canary_dir)/probe.got: .UNVEIL := rwc:$(canary_dir) $(unveil_hostx)
@@ -128,6 +130,10 @@ sandbox-canary: $$(cosmic_bin)
 .PHONY: ci-selftest-launder
 ci-selftest-launder: $(o)/ci-selftest-launder-summary.txt
 
+# Shell exception (#756 item 2): deliberately tees a clean summary and
+# then fails — the laundering the ci grading gate must catch.
+$(o)/ci-selftest-launder-summary.txt: private SHELL := /bin/bash
+$(o)/ci-selftest-launder-summary.txt: private .SHELLFLAGS := -o pipefail -c
 $(o)/ci-selftest-launder-summary.txt:
 	@mkdir -p $(@D)
 	@echo "ci grading selftest: 1 passed" | tee $@
@@ -147,6 +153,10 @@ $(build_make_out)/ci-launder.out: $(build_make_srcs)
 # Environment clamp probe (#731): echoes the env a recipe actually sees.
 # Test apparatus like ci-selftest-launder above, not a help target.
 .PHONY: env-probe
+# Shell exception (#756 item 2): the probe exists to show the env a
+# recipe's shell actually sees.
+env-probe: private SHELL := /bin/bash
+env-probe: private .SHELLFLAGS := -o pipefail -c
 env-probe:
 	@echo "LC_ALL=$$LC_ALL"; echo "TZ=$$TZ"; echo "PATH=$$PATH"
 
@@ -160,6 +170,12 @@ $(build_make_out)/env-clamp.out: $(build_make_srcs)
 	@code=0; LC_ALL=tr_TR.UTF-8 TZ=Pacific/Kiritimati PATH="/hostile/bin:$$PATH" $(MAKE) -s env-probe >$@.tmp 2>&1 || code=$$?; echo "exit:$$code" >> $@.tmp; mv $@.tmp $@
 
 build_make_outputs := $(build_make_out)/dry-run.out $(build_make_out)/database.out $(build_make_out)/only-database.out $(build_make_out)/ci-launder.out $(build_make_out)/env-clamp.out
+
+# Shell exceptions (#756 item 2): the fixture rules above run nested
+# makes with exit-code capture and redirects — test apparatus, not build
+# logic.
+$(build_make_outputs): private SHELL := /bin/bash
+$(build_make_outputs): private .SHELLFLAGS := -o pipefail -c
 
 # makefile_test consumes the fixtures in both test lanes
 build_makefile_test_got := \

--- a/lib/build/makefile_test.tl
+++ b/lib/build/makefile_test.tl
@@ -163,3 +163,170 @@ local function test_compile_pins_tree_only_tl_path()
   end
 end
 test_compile_pins_tree_only_tl_path()
+
+-- #756 item 2: the no-shell default and its two ratchets. The database
+-- fixture renders target-specific variables as "<owner>: VAR := value"
+-- lines and pattern-specific ones as a "<pattern> :" header followed by
+-- "# VAR := value" comment lines (blank line ends the block); the
+-- parser below reads both shapes plus the uncommented global.
+local record VarOverrides
+  global: string
+  owners: {string: string}
+end
+
+--- @param db string The database.out fixture text
+--- @param var string Variable name as a Lua pattern (e.g. "%.UNVEIL")
+--- @return VarOverrides Global value and per-owner override values
+local function parse_var_overrides(db: string, var: string): VarOverrides
+  local owners: {string: string} = {}
+  local global_value: string = nil
+  local pattern: string = nil
+  for line in (db .. "\n"):gmatch("([^\n]*)\n") do
+    local header = line:match("^(%S+) :$")
+    if header then
+      pattern = header
+    elseif line == "" then
+      pattern = nil
+    else
+      local owner, value = line:match("^([^#%s][^:]*): " .. var .. " := (.*)$")
+      if owner then
+        owners[owner] = value:match("^(.-)%s*$")
+      elseif pattern then
+        local pvalue = line:match("^# " .. var .. " := (.*)$")
+        if pvalue then
+          owners[pattern] = pvalue:match("^(.-)%s*$")
+        end
+      end
+      local gvalue = line:match("^" .. var .. " := (.*)$")
+      if gvalue then
+        global_value = gvalue:match("^(.-)%s*$")
+      end
+    end
+  end
+  return {global = global_value, owners = owners}
+end
+
+local poison_shell < const > = "/dev/null/enoshell"
+local real_shell < const > = "/bin/bash"
+
+-- The complete set of rules allowed a real shell. Growing this list is
+-- a design decision (#756 item 2): a new entry needs a "Shell
+-- exception" comment at the rule stating why the recipe cannot be a
+-- shell-free argv line (or a driver/CLI conversion instead).
+local real_shell_allowed: {string} = {
+  "doc-publish", -- SOURCE_SHA guard + git publishing
+  "env-probe", -- shows the env a recipe shell sees
+  "o/bin/ape", -- APE loader extraction IS the stub flow
+  "o/bootstrap/compile-flag", -- pre-driver strict-compile probe
+  "o/bootstrap/cosmic", -- trust-root download (curl + sha pipe)
+  "o/ci-selftest-launder-summary.txt", -- deliberately laundering fixture
+  "o/cosmic/version.lua", -- git describe interpolation
+  "o/coverage-summary.txt", -- ratchet conditional (item-1 residue)
+  "o/lib/build/build-recipe.lua", -- driver self-bootstrap compile
+  "o/lib/build/make/ci-launder.out", -- nested-make fixture
+  "o/lib/build/make/database.out", -- nested-make fixture
+  "o/lib/build/make/dry-run.out", -- nested-make fixture
+  "o/lib/build/make/env-clamp.out", -- nested-make fixture
+  "o/lib/build/make/only-database.out", -- nested-make fixture
+  "o/sandbox-canary/probe.got", -- out-of-grant write attempt
+  "perf", -- perf_cmd env prefixes
+  "perf-baseline", -- perf_cmd env prefixes
+  "perf-bin", -- COSMO_LUA guard
+  "perf-compare", -- retry/triage chain
+  "perf-selfcheck", -- A/A chain
+  "regen-tl-types", -- dev regen (redirect + mv)
+  "regen-types", -- dev regen loop
+  "sandbox-canary", -- verdict branching
+}
+
+-- test: the global SHELL is poisoned, every real-shell override is on
+-- the allowlist above, and every allowlist entry still exists (a stale
+-- entry means the exception was retired — remove it here too).
+local function test_no_shell_default_ratchet()
+  local db = read_make_output("database.out").output
+  local sh = parse_var_overrides(db, "SHELL")
+  assert(sh.global == poison_shell,
+    "global SHELL must be the poison, got: " .. tostring(sh.global))
+  local allowed: {string: boolean} = {}
+  for _, owner in ipairs(real_shell_allowed) do
+    allowed[owner] = true
+  end
+  local problems: {string} = {}
+  for owner, value in pairs(sh.owners) do
+    if value ~= poison_shell then
+      if not allowed[owner] then
+        problems[#problems + 1] = owner .. " overrides SHELL to " .. value ..
+        " but is not on the exception allowlist"
+      elseif value ~= real_shell then
+        problems[#problems + 1] = owner .. " overrides SHELL to unexpected " .. value
+      end
+    end
+  end
+  for _, owner in ipairs(real_shell_allowed) do
+    local value = sh.owners[owner]
+    if not value or value == poison_shell then
+      problems[#problems + 1] = owner ..
+      " is allowlisted but carries no real-shell override (stale entry)"
+    end
+  end
+  assert(#problems == 0,
+    "shell-exception ratchet:\n  " .. table.concat(problems, "\n  "))
+end
+test_no_shell_default_ratchet()
+
+-- The complete set of rules whose .UNVEIL carries the host-exec grant
+-- set ($(unveil_hostx), marker rx:/usr). Same ratchet contract: a new
+-- carrier is a design decision, not a default (#756 items 2/4).
+local hostx_marker < const > = "rx:/usr"
+local hostx_allowed: {string} = {
+  "doc-publish", -- unveil_run (git, network)
+  "o/%.tl.benchmark.got", -- unveil_run test lane
+  "o/%.tl.example.got", -- unveil_test lane
+  "o/%.tl.test.got", -- unveil_test lane
+  "o/coverage/%.tl.test.got", -- unveil_test lane
+  "o/coverage/lib/build/help_test.tl.test.got", -- unveil_test + Makefile
+  "o/coverage/lib/cosmic/teal_config_test.tl.test.got", -- unveil_test + tlconfig
+  "o/coverage/lib/cosmic/tty_test.tl.test.got", -- unveil_test + pty devs
+  "o/lib/build/build-recipe.lua", -- self-bootstrap shell
+  "o/lib/build/help_test.tl.test.got", -- unveil_test + Makefile
+  "o/lib/cosmic/teal_config_test.tl.test.got", -- unveil_test + tlconfig
+  "o/lib/cosmic/tty_test.tl.test.got", -- unveil_test + pty devs
+  "o/sandbox-canary/probe.got", -- canary needs its shell
+  "perf", -- unveil_test lane
+  "perf-baseline", -- unveil_test lane
+  "perf-bin", -- unveil_test lane
+  "perf-compare", -- unveil_test lane
+  "perf-selfcheck", -- unveil_test lane
+}
+
+-- test: the global .UNVEIL carries no host-exec grants, and the set of
+-- rules that do is exactly the allowlist above, both directions.
+local function test_hostx_ratchet()
+  local db = read_make_output("database.out").output
+  local uv = parse_var_overrides(db, "%.UNVEIL")
+  assert(uv.global, "expected a global .UNVEIL in the database")
+  assert(not uv.global:find(hostx_marker, 1, true),
+    "global .UNVEIL must not carry the host-exec set, got: " .. uv.global)
+  local allowed: {string: boolean} = {}
+  for _, owner in ipairs(hostx_allowed) do
+    allowed[owner] = true
+  end
+  local problems: {string} = {}
+  for owner, value in pairs(uv.owners) do
+    if value:find(hostx_marker, 1, true) and not allowed[owner] then
+      problems[#problems + 1] = owner .. " carries " .. hostx_marker ..
+      " but is not on the hostx allowlist"
+    end
+  end
+  for _, owner in ipairs(hostx_allowed) do
+    local value = uv.owners[owner]
+    if not value or not value:find(hostx_marker, 1, true) then
+      problems[#problems + 1] = owner ..
+      " is allowlisted for hostx but carries no " .. hostx_marker ..
+      " grant (stale entry)"
+    end
+  end
+  assert(#problems == 0,
+    "hostx ratchet:\n  " .. table.concat(problems, "\n  "))
+end
+test_hostx_ratchet()

--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -72,11 +72,11 @@ pack = $(bootstrap_cosmic) -- $(build_pack) --built $(cosmic_built) \
 # fallback would swallow the denial into a silently version-less
 # artifact. Target-specific wins over pattern-specific.
 $(cosmic_version_lua): .SANDBOXED := 0
-# a .lua-named target inherits the compile family's poisoned no-shell
-# SHELL (#732); this recipe is a deliberate host exception (git) and
-# keeps the real shell alongside its sandbox opt-out above
-$(cosmic_version_lua): SHELL := /bin/bash
-$(cosmic_version_lua): .SHELLFLAGS := -o pipefail -c
+# Shell exception (#732/#756 item 2): git describe + cosmos version
+# interpolation; a deliberate host dependency, alongside its sandbox
+# opt-out above.
+$(cosmic_version_lua): private SHELL := /bin/bash
+$(cosmic_version_lua): private .SHELLFLAGS := -o pipefail -c
 $(cosmic_version_lua): .FORCE | $$(cosmos_staged)
 	@mkdir -p $(@D)
 	@echo "return { cosmic = \"$$(git describe --tags --always --dirty 2>/dev/null || echo unknown)\", cosmos = \"$$($(cosmos_lua_bin) -e "print(dofile('3p/cosmos/version.lua').version)")\" }" > $@.tmp
@@ -85,8 +85,6 @@ $(cosmic_version_lua): .FORCE | $$(cosmos_staged)
 .PHONY: .FORCE
 
 $(cosmic_bin) $(cosmic_debug_bin): export LUA_PATH = $(tree_lua_path)
-$(cosmic_bin) $(cosmic_debug_bin): private SHELL := /dev/null/enoshell
-$(cosmic_bin) $(cosmic_debug_bin): private .SHELLFLAGS := -c
 $(cosmic_bin): $$(cosmic_lua) $(cosmic_main) $(cosmic_args) $$(tl_staged) $$(doc_index) $(cosmic_version_lua) $(cosmic_sys) $(cosmic_skills) $(cosmic_types) $(build_pack) | $(bootstrap_cosmic)
 	@$(pack) --out $@ --base $(cosmos_lua_bin)
 
@@ -100,8 +98,6 @@ $(cosmic_debug_bin): $(cosmic_bin) $(build_pack)
 # ELF like the bootstrap; the shipped $(cosmic_bin) stays a fat APE
 # (the cross-OS smoke lanes cover real-APE behavior).
 cosmic_check_bin := $(o)/bin/cosmic-check
-$(cosmic_check_bin): private SHELL := /dev/null/enoshell
-$(cosmic_check_bin): private .SHELLFLAGS := -c
 # --assimilate is handled by the APE shell stub, which a direct (no
 # shell) exec bypasses — the pinned cosmos assimilate tool converts in
 # place instead, keeping this recipe shell-free (#732).
@@ -126,6 +122,8 @@ $(cosmic_check_bin): $(cosmic_bin) $(build_recipe) | $$(cosmos_staged)
 # direct cosmopolitan exec maps the binary and never writes the .ape-*
 # cache (witnessed), so this recipe must go through a real shell.
 ape_loader := $(o)/bin/ape
+$(ape_loader): private SHELL := /bin/bash
+$(ape_loader): private .SHELLFLAGS := -o pipefail -c
 $(ape_loader): $(cosmic_bin)
 	@t=$$(mktemp -d) && PATH="$(HOST_PATH)" TMPDIR=$$t $(CURDIR)/$< -e 'return' >/dev/null && \
 	  set -- $$t/.ape-*; [ -x "$$1" ] || { echo "ape loader extraction failed" >&2; exit 1; }; \

--- a/lib/perf/cook.mk
+++ b/lib/perf/cook.mk
@@ -46,17 +46,26 @@ perf-bin: .PLEDGE := $(pledge_build)
 perf-bin: .UNVEIL := $(unveil_test) $(if $(COSMO_LUA),r:$(COSMO_LUA))
 
 ## Build o/perf/cosmic-local: the cosmic payload on a local cosmopolitan lua (COSMO_LUA=...)
-perf-bin: $(cosmic_bin)
+# The payload rides build-pack like the shipped binaries (#755 moved the
+# pack there but left a call to the deleted pack-cosmic define here, so
+# perf-bin silently produced a payload-less binary).
+# Shell exception (#756 item 2): the COSMO_LUA guard.
+perf-bin: private SHELL := /bin/bash
+perf-bin: private .SHELLFLAGS := -o pipefail -c
+perf-bin: $(cosmic_bin) $(build_pack)
 	@test -n "$(COSMO_LUA)" || { \
 		echo "perf-bin: set COSMO_LUA=/path/to/cosmopolitan/o/tool/lua/lua" >&2; \
 		echo "perf-bin: see lib/perf/optimize/cosmopolitan.md" >&2; exit 1; }
 	@mkdir -p $(perf_sandbox)
-	@cp $(COSMO_LUA) $(cosmic_local_bin)
-	@chmod +x $(cosmic_local_bin)
-	$(call pack-cosmic,$(cosmic_local_bin))
+	@$(pack) --out $(cosmic_local_bin) --base $(COSMO_LUA)
 	@echo "built $(cosmic_local_bin) from $(COSMO_LUA)"
 	@echo "measure it with: PERF_BIN=$(cosmic_local_bin) bin/make perf-compare"
 
+# Shell exceptions (#756 item 2): every perf recipe runs $(perf_cmd),
+# whose PERF_BIN/LUA_PATH env prefixes need a shell (and perf-compare's
+# retry/triage chain branches); measurement apparatus, not build logic.
+perf perf-baseline perf-compare perf-selfcheck: private SHELL := /bin/bash
+perf perf-baseline perf-compare perf-selfcheck: private .SHELLFLAGS := -o pipefail -c
 perf perf-baseline: .PLEDGE := $(pledge_build)
 perf perf-baseline: .UNVEIL := $(unveil_test)
 

--- a/lib/types/cook.mk
+++ b/lib/types/cook.mk
@@ -13,6 +13,10 @@ $(o)/lib/types/gentl_test.tl.test.got $(o)/coverage/lib/types/gentl_test.tl.test
 
 .PHONY: regen-tl-types
 ## Regenerate lib/types/tl.d.tl from the staged tl source
+# Shell exception (#756 item 2): dev-facing regen (redirect + mv); the
+# gentl drift test gates its output, not this recipe.
+regen-tl-types: private SHELL := /bin/bash
+regen-tl-types: private .SHELLFLAGS := -o pipefail -c
 regen-tl-types: .PLEDGE := $(pledge_build)
 regen-tl-types: .UNVEIL := $(unveil_base) rwcx:$(o) rwc:lib/types
 regen-tl-types: $(o)/lib/types/gentl.lua $$(tl_staged) | $(bootstrap_cosmic)


### PR DESCRIPTION
PR 2 of the #756 series — item 2, the default inversion the issue sequences right after the pin unification (#758, merged).

## What changed

**The flip.** `SHELL` is poisoned globally and every per-family poison pair (the #732 opt-ins) is deleted. One subtlety surfaced immediately: parse-time `$(shell)` queries (nproc, uname, git ls-files, git log) read `SHELL` too, and poisoning it at the top silently emptied them — including `SOURCE_DATE_EPOCH`, which would have broken reproducibility invisibly. So the top of the Makefile keeps the real shell for parsing, and the poison is set at the **bottom**, after the last parse-time `$(shell)`; recipes read the final value, so the tripwire still reaches every rule. Both ends carry comments explaining the split.

**The exceptions.** 23 rules keep a real shell, each with a `Shell exception` comment stating why, and each `private` so the grant can't leak into its prerequisite subtree: the trust-root bootstrap download, the compile-flag probe, the `build-recipe` self-bootstrap, the version stamp (git), the APE-loader extraction, `doc-publish`, the coverage-summary ratchet conditional, the two dev regens, the five perf lanes, and the test apparatus (the five nested-make fixtures, the sandbox canary pair, the launder selftest, env-probe).

**Two conversions instead of exceptions** (they were free wins with the existing driver): the gendoc `.md` rules and `coverage-baseline` now run through `build-recipe capture` — mkdir/redirect/mv subsumed, write-if-changed, and no write when the child fails.

**The ratchets** (the issue's "the flip itself is the tripwire… pair it with a hostx ratchet"). Two new makefile_test gates parse the `make -p` database fixture, both directions (a new entry fails, and a stale allowlist entry fails too):
- global `SHELL` must be the poison, and the set of rules overriding it to a real shell must equal the committed 23-entry allowlist;
- the global `.UNVEIL` must carry no host-exec grants, and the set of rules whose `.UNVEIL` carries `$(unveil_hostx)` (marker `rx:/usr`) must equal its own 18-entry allowlist (the test/coverage/example/benchmark lanes, the canary, build-recipe, doc-publish, the perf lanes, and the tty/tlconfig/help-test specials).

Red-tested: a rogue `SHELL := /bin/bash` rule fails the ratchet by name with an actionable message.

**Drive-by fix (caught by the survey):** #755 deleted the `pack-cosmic` define but left its `$(call …)` in `perf-bin`, which since then silently produced a payload-less binary (an undefined `call` expands to an empty recipe line). `perf-bin` now packs through `build-pack` exactly like the shipped binaries; verified end to end using the staged cosmos lua as `COSMO_LUA` — the produced binary loads `cosmic.*` from its payload — and the missing-`COSMO_LUA` guard still fails loudly.

## Verification

- `bin/make -j ci` → `ci: PASS` (includes the regenerated fixtures and both new ratchets; format/teal/lint all green, Makefile at exactly the 500-line cap)
- `bin/make -j enforce` → 3/3
- ratchet red test: rogue exception → named failure; revert → green
- `bin/make -j docs`, `coverage-baseline` conversion exercised (output identical, then restored)
- `perf-bin` end-to-end as above

Remaining series (unchanged from #758's plan): item 1 residue next (each conversion shrinks these allowlists), then item 3 (CLI consolidation across a pin bump), items 5/4 (upstream `.ENV` allowlist and grant derivation), item 7 (the trust-root ADR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13

---
_Generated by [Claude Code](https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13)_