### PR TITLE
build: convert item-1 residue off the shell; shrink the exception ratchet 23 → 19 (#756 item 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,21 +220,15 @@ $(o)/coverage/%.tl.test.got: $(o)/%.lua $(cosmic_bin) $(ape_loader)
 coverage_baseline := lib/cosmic/coverage/baseline.txt
 coverage_baseline_tool := $(o)/lib/cosmic/coverage/baseline.lua
 
-# Shell exception (#756 item 2): the ratchet conditional (item-1 residue).
-$(o)/coverage-summary.txt: private SHELL := /bin/bash
-$(o)/coverage-summary.txt: private .SHELLFLAGS := -o pipefail -c
+# De-shelled (#756 item 1): the skip/check branching lives in the
+# baseline tool's gate mode; --only=$(only) stays one argv token even
+# when the filter is empty, so no quoting and no shell.
 $(o)/coverage-summary.txt: .PLEDGE := $(pledge_build)
 $(o)/coverage-summary.txt: .UNVEIL := $(unveil_base) rwcx:$(o)
 $(o)/coverage-summary.txt: $(coverage_got) | $(cosmic_bin) $(build_recipe)
 	@$(bootstrap_cosmic) -- $(build_recipe) capture $(cosmic_bin) $(o)/coverage-tests.txt --report $(coverage_got)
 	@$(bootstrap_cosmic) -- $(build_recipe) tee $@ $(cosmic_bin) --coverage-report $(o)/coverage lib
-	@if [ -n "$(only)" ]; then \
-	  echo "coverage ratchet skipped (only=$(only))"; \
-	elif [ -f $(coverage_baseline) ]; then \
-	  $(cosmic_bin) $(coverage_baseline_tool) check $(coverage_baseline) $(o)/coverage lib; \
-	else \
-	  echo "coverage ratchet skipped: no $(coverage_baseline); run 'bin/make coverage-baseline' to start it"; \
-	fi
+	@$(cosmic_bin) $(coverage_baseline_tool) gate $(coverage_baseline) --only=$(only) $(o)/coverage lib
 
 .PHONY: coverage-baseline
 ## Rewrite the committed coverage ratchet baseline from the last coverage run
@@ -242,7 +236,7 @@ coverage-baseline: .PLEDGE := $(pledge_build)
 coverage-baseline: .UNVEIL := $(unveil_base) rwcx:$(o) rwc:lib/cosmic/coverage
 coverage-baseline: $(coverage_got) | $(cosmic_bin) $(build_recipe)
 	@$(bootstrap_cosmic) -- $(build_recipe) capture $(cosmic_bin) $(coverage_baseline) $(coverage_baseline_tool) write $(o)/coverage lib
-	@echo "wrote $(coverage_baseline)"
+	@echo wrote $(coverage_baseline)
 
 # Privileged enforcement lane (Phase 1 step 8 prerequisite, audit §5.1).
 # The sandbox tests carry "outer sandbox blocked this -> skip" escape hatches,
@@ -363,7 +357,7 @@ build: cosmic
 ## CI stage 1: build cosmic and refresh bootstrap with updated bundled types
 stage1: $(cosmic_bin)
 	@cp $(cosmic_bin) $(bootstrap_cosmic)
-	@echo "Bootstrap refreshed from $(cosmic_bin)"
+	@echo Bootstrap refreshed from $(cosmic_bin)
 
 .PHONY: stage2
 ## CI stage 2: type check and test with refreshed bootstrap (alias for ci)

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -145,10 +145,14 @@ $(o)/ci-selftest-launder-summary.txt:
 # with the real ci run that builds this fixture.
 # The nested tree has no bootstrap/driver of its own; the ci recipe's
 # remove/verdict steps exec them, so the fixture hands in the parent's
-# by absolute path (#732).
+# by absolute path (#732) — and marks them -o (old-file: use, never
+# remake): without that, a parent-tree bootstrap refresh makes them
+# look stale INSIDE the nested run, which then rebuilds the parent's
+# own driver in a race against the outer make (witnessed: the nested
+# compile's cmp/mv losing its .tmp mid-flight).
 $(build_make_out)/ci-launder.out: $(build_make_srcs)
 	@mkdir -p $(@D)
-	@code=0; $(MAKE) ci o=$(o)/citest ci_stages=ci-selftest-launder bootstrap_cosmic=$(CURDIR)/$(bootstrap_cosmic) build_recipe=$(CURDIR)/$(build_recipe) >$@.tmp 2>&1 || code=$$?; echo "exit:$$code" >> $@.tmp; mv $@.tmp $@
+	@code=0; $(MAKE) ci o=$(o)/citest ci_stages=ci-selftest-launder bootstrap_cosmic=$(CURDIR)/$(bootstrap_cosmic) build_recipe=$(CURDIR)/$(build_recipe) -o $(CURDIR)/$(bootstrap_cosmic) -o $(CURDIR)/$(build_recipe) >$@.tmp 2>&1 || code=$$?; echo "exit:$$code" >> $@.tmp; mv $@.tmp $@
 
 # Environment clamp probe (#731): echoes the env a recipe actually sees.
 # Test apparatus like ci-selftest-launder above, not a help target.

--- a/lib/build/makefile_test.tl
+++ b/lib/build/makefile_test.tl
@@ -221,7 +221,6 @@ local real_shell_allowed: {string} = {
   "o/bootstrap/cosmic", -- trust-root download (curl + sha pipe)
   "o/ci-selftest-launder-summary.txt", -- deliberately laundering fixture
   "o/cosmic/version.lua", -- git describe interpolation
-  "o/coverage-summary.txt", -- ratchet conditional (item-1 residue)
   "o/lib/build/build-recipe.lua", -- driver self-bootstrap compile
   "o/lib/build/make/ci-launder.out", -- nested-make fixture
   "o/lib/build/make/database.out", -- nested-make fixture
@@ -229,12 +228,9 @@ local real_shell_allowed: {string} = {
   "o/lib/build/make/env-clamp.out", -- nested-make fixture
   "o/lib/build/make/only-database.out", -- nested-make fixture
   "o/sandbox-canary/probe.got", -- out-of-grant write attempt
-  "perf", -- perf_cmd env prefixes
-  "perf-baseline", -- perf_cmd env prefixes
   "perf-bin", -- COSMO_LUA guard
   "perf-compare", -- retry/triage chain
   "perf-selfcheck", -- A/A chain
-  "regen-tl-types", -- dev regen (redirect + mv)
   "regen-types", -- dev regen loop
   "sandbox-canary", -- verdict branching
 }

--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -101,8 +101,12 @@ cosmic_check_bin := $(o)/bin/cosmic-check
 # --assimilate is handled by the APE shell stub, which a direct (no
 # shell) exec bypasses — the pinned cosmos assimilate tool converts in
 # place instead, keeping this recipe shell-free (#732).
+# remove the previous run's backup first: assimilate writes $@.bak and
+# refuses to overwrite one, so a rebuild over yesterday's assimilation
+# failed with "File exists" (witnessed after a bootstrap refresh).
 $(cosmic_check_bin): $(cosmic_bin) $(build_recipe) | $$(cosmos_staged)
 	@$(bootstrap_cosmic) -- $(build_recipe) copy $< $@
+	@$(bootstrap_cosmic) -- $(build_recipe) remove $@.bak
 	@$(cosmos_dir)/assimilate $@
 	@$(bootstrap_cosmic) -- $(build_recipe) require-elf $@
 

--- a/lib/cosmic/coverage/baseline.tl
+++ b/lib/cosmic/coverage/baseline.tl
@@ -183,6 +183,26 @@ local function check(baseline_path: string, paths: {string}): integer
   return 0
 end
 
+--- Gate mode for the coverage-summary recipe (shell-free, #756 item 1):
+--- skip under a test filter (partial data would read as a huge decline)
+--- or when no baseline is committed; otherwise run the ratchet check.
+--- @param baseline_path string Path to the committed baseline
+--- @param only string The active only= filter ("" when unset)
+--- @param paths {string} Report inputs (see report.compute)
+--- @return integer Exit code: 0 when skipped or the ratchet holds
+local function gate(baseline_path: string, only: string, paths: {string}): integer
+  if only ~= "" then
+    io.write("coverage ratchet skipped (only=" .. only .. ")\n")
+    return 0
+  end
+  if not fs.isfile(baseline_path) then
+    io.write("coverage ratchet skipped: no " .. baseline_path ..
+      "; run 'bin/make coverage-baseline' to start it\n")
+    return 0
+  end
+  return check(baseline_path, paths)
+end
+
 --- Write a fresh baseline for the given report inputs to stdout.
 --- @param paths {string} Report inputs (see report.compute)
 --- @return integer Exit code: 0 on success
@@ -210,8 +230,21 @@ local function main(argv: {string}): integer
       paths[#paths + 1] = argv[i]
     end
     return check(argv[2], paths)
+  elseif mode == "gate" and argv[2] and argv[3] and argv[4] then
+    -- --only=<str> stays one argv token even when the filter is empty,
+    -- so the no-shell recipe needs no quoting
+    local only = argv[3]:match("^%-%-only=(.*)$")
+    if only then
+      local paths: {string} = {}
+      for i = 4, #argv do
+        paths[#paths + 1] = argv[i]
+      end
+      return gate(argv[2], only, paths)
+    end
   end
-  io.stderr:write("usage: baseline.lua write <paths...> | check <baseline> <paths...>\n")
+  io.stderr:write("usage: baseline.lua write <paths...>" ..
+    " | check <baseline> <paths...>" ..
+    " | gate <baseline> --only=<str> <paths...>\n")
   return 2
 end
 
@@ -225,6 +258,7 @@ local record BaselineModule
   parse: function(text: string): {string: Entry} | nil, Entry, string
   compare: function(reports: {FileReport}, entries: {string: Entry}, total: Entry): {string}
   check: function(baseline_path: string, paths: {string}): integer
+  gate: function(baseline_path: string, only: string, paths: {string}): integer
   write: function(paths: {string}): integer
 end
 
@@ -233,6 +267,7 @@ local M: BaselineModule = {
   parse = parse,
   compare = compare,
   check = check,
+  gate = gate,
   write = write,
 }
 

--- a/lib/cosmic/coverage/baseline_test.tl
+++ b/lib/cosmic/coverage/baseline_test.tl
@@ -109,3 +109,29 @@ local function test_total_ratchet_catches_masked_decline()
     #probs .. ": " .. tostring(probs[1]))
 end
 test_total_ratchet_catches_masked_decline()
+
+local function test_gate_skips_under_only_filter()
+  local code = baseline.gate("/no/such/baseline.txt", "sqlite", {})
+  assert(code == 0, "gate must skip (exit 0) under an only= filter")
+end
+test_gate_skips_under_only_filter()
+
+local function test_gate_skips_without_baseline()
+  local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
+  local code = baseline.gate(tmpdir .. "/absent-baseline.txt", "", {})
+  assert(code == 0, "gate must skip (exit 0) when no baseline is committed")
+end
+test_gate_skips_without_baseline()
+
+local function test_gate_checks_when_baseline_present()
+  local fs = require("cosmic.fs")
+  local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
+  local path = fs.join(tmpdir, "gate-baseline.txt")
+  assert(fs.write(path, baseline.render(reports({{"lib/a.tl", 9, 10}}))))
+  -- an empty report set makes every baseline entry stale: the gate must
+  -- delegate to check and FAIL, proving it does not skip when it
+  -- should be checking
+  local code = baseline.gate(path, "", {})
+  assert(code == 1, "gate must run the real check when a baseline exists")
+end
+test_gate_checks_when_baseline_present()

--- a/lib/perf/cook.mk
+++ b/lib/perf/cook.mk
@@ -34,8 +34,15 @@ PERF_ONLY ?=
 PERF_THRESHOLD ?= 10
 
 perf_only_flag = $(if $(PERF_ONLY),--only $(PERF_ONLY))
-perf_cmd = PERF_BIN=$(PERF_BIN) LUA_PATH="$(tree_lua_path)" $(PERF_BIN) -- $(perf_run) \
+# De-shelled (#756 item 1): PERF_BIN/LUA_PATH reach the children as
+# target exports on the perf lanes below, not shell env prefixes, so
+# perf and perf-baseline are plain argv recipes.
+perf_cmd = $(PERF_BIN) -- $(perf_run) \
 	--samples $(PERF_SAMPLES) --min-secs $(PERF_MIN_SECS) $(perf_only_flag)
+
+perf_lanes := perf perf-baseline perf-compare perf-selfcheck
+$(perf_lanes): export PERF_BIN := $(PERF_BIN)
+$(perf_lanes): export LUA_PATH = $(tree_lua_path)
 
 perf_sandbox := $(o)/perf
 cosmic_local_bin := $(perf_sandbox)/cosmic-local
@@ -61,11 +68,12 @@ perf-bin: $(cosmic_bin) $(build_pack)
 	@echo "built $(cosmic_local_bin) from $(COSMO_LUA)"
 	@echo "measure it with: PERF_BIN=$(cosmic_local_bin) bin/make perf-compare"
 
-# Shell exceptions (#756 item 2): every perf recipe runs $(perf_cmd),
-# whose PERF_BIN/LUA_PATH env prefixes need a shell (and perf-compare's
-# retry/triage chain branches); measurement apparatus, not build logic.
-perf perf-baseline perf-compare perf-selfcheck: private SHELL := /bin/bash
-perf perf-baseline perf-compare perf-selfcheck: private .SHELLFLAGS := -o pipefail -c
+# Shell exceptions (#756 item 2): the compare/selfcheck retry and
+# triage chains branch on exit codes; measurement apparatus, not build
+# logic. perf and perf-baseline are argv-only since the export
+# conversion above.
+perf-compare perf-selfcheck: private SHELL := /bin/bash
+perf-compare perf-selfcheck: private .SHELLFLAGS := -o pipefail -c
 perf perf-baseline: .PLEDGE := $(pledge_build)
 perf perf-baseline: .UNVEIL := $(unveil_test)
 
@@ -82,14 +90,14 @@ perf-baseline: $$(perf_lua) $(cosmic_bin)
 perf-compare: .PLEDGE := $(pledge_build)
 perf-compare: .UNVEIL := $(unveil_test)
 
-perf_compare_cmd = LUA_PATH="$(tree_lua_path)" $(PERF_BIN) -- $(perf_run) --compare \
+perf_compare_cmd = $(PERF_BIN) -- $(perf_run) --compare \
 	$(perf_sandbox)/baseline.json $(perf_sandbox)/current.json \
 	--threshold $(PERF_THRESHOLD)
 
 # Final stage: reclassify any surviving regression the current binary
 # cannot reproduce against itself (selfcheck-b vs the current run) as
 # "noise" rather than a failure — the A/A control, run automatically.
-perf_triage_cmd = LUA_PATH="$(tree_lua_path)" $(PERF_BIN) -- $(perf_run) --compare \
+perf_triage_cmd = $(PERF_BIN) -- $(perf_run) --compare \
 	$(perf_sandbox)/baseline.json $(perf_sandbox)/current.json \
 	--threshold $(PERF_THRESHOLD) \
 	--selfcheck-a $(perf_sandbox)/current.json \
@@ -113,7 +121,7 @@ perf-compare: perf
 perf-selfcheck: .PLEDGE := $(pledge_build)
 perf-selfcheck: .UNVEIL := $(unveil_test)
 
-perf_selfcheck_cmd = LUA_PATH="$(tree_lua_path)" $(PERF_BIN) -- $(perf_run) --compare \
+perf_selfcheck_cmd = $(PERF_BIN) -- $(perf_run) --compare \
 	$(perf_sandbox)/selfcheck-a.json $(perf_sandbox)/selfcheck-b.json \
 	--threshold $(PERF_THRESHOLD)
 

--- a/lib/types/cook.mk
+++ b/lib/types/cook.mk
@@ -13,13 +13,10 @@ $(o)/lib/types/gentl_test.tl.test.got $(o)/coverage/lib/types/gentl_test.tl.test
 
 .PHONY: regen-tl-types
 ## Regenerate lib/types/tl.d.tl from the staged tl source
-# Shell exception (#756 item 2): dev-facing regen (redirect + mv); the
-# gentl drift test gates its output, not this recipe.
-regen-tl-types: private SHELL := /bin/bash
-regen-tl-types: private .SHELLFLAGS := -o pipefail -c
+# De-shelled (#756 item 1): the driver's capture mode owns the output —
+# write-if-changed, nothing written when the generator fails.
 regen-tl-types: .PLEDGE := $(pledge_build)
 regen-tl-types: .UNVEIL := $(unveil_base) rwcx:$(o) rwc:lib/types
-regen-tl-types: $(o)/lib/types/gentl.lua $$(tl_staged) | $(bootstrap_cosmic)
-	@$(bootstrap_cosmic) $(o)/lib/types/gentl.lua $(o)/tl/.staged/tl.tl > lib/types/tl.d.tl.tmp
-	@mv lib/types/tl.d.tl.tmp lib/types/tl.d.tl
-	@echo "wrote lib/types/tl.d.tl"
+regen-tl-types: $(o)/lib/types/gentl.lua $$(tl_staged) $(build_recipe) | $(bootstrap_cosmic)
+	@$(bootstrap_cosmic) -- $(build_recipe) capture $(bootstrap_cosmic) lib/types/tl.d.tl $(o)/lib/types/gentl.lua $(o)/tl/.staged/tl.tl
+	@echo wrote lib/types/tl.d.tl


### PR DESCRIPTION
PR 3 of the #756 series — item 1, the opportunistic residue conversions that shrink the #759 ratchet's allowlists.

## Conversions (each deletes a real-shell exception)

- **coverage-summary** — the `only=`/baseline-exists branching moves into the baseline tool's new `gate` mode (`gate <baseline> --only=<str> <paths…>`). `--only=$(only)` stays a single argv token even when the filter is empty, so the recipe needs no quoting and no shell. New `baseline_test` cases cover all three branches (skip under a filter, skip without a baseline, delegate to the real check).
- **regen-tl-types** — redirect + `mv` becomes the driver's `capture` (write-if-changed; nothing written when the generator fails).
- **perf / perf-baseline** — `PERF_BIN`/`LUA_PATH` reach children as target exports instead of shell env prefixes, making both recipes plain argv. `perf-compare`/`perf-selfcheck` keep their exception (exit-code retry/triage chains) but share the exports; a command-line `PERF_BIN=` still wins (command-line vars auto-export).

Shell allowlist: 23 → 19. The remaining 19 are trust-root machinery, git/dev regens, and test apparatus — candidates for "documented permanent exception" status in the item-7 ADR.

## Bug class found and fixed: quotes force the shell

The #759 flip left a latent trap: make's direct-exec fast path rejects **quoted** arguments, so an otherwise-argv recipe with `@echo "…"` dies on the poisoned shell. `stage1` has been broken this way since the flip — no gate runs it — and my two new echo lines had the same flaw, initially masked by an exit-status-laundering `| tail` in local validation (exactly the trap AGENTS.md documents; re-verified with `pipefail`). All three lines are now unquoted, and a sweep confirms every remaining quoted recipe line sits inside an excepted rule.

A possible follow-up gate (not in this PR): a makefile_test assertion that no non-allowlisted rule's recipe text contains shell metacharacters, which would catch never-run rules like `stage1` statically. Its blind spot (variables that expand into metachars) is the same one the runtime poison covers, so the two compose.

## Verification

- Targeted, with `set -o pipefail`: baseline/makefile/perf test lanes green; `regen-tl-types` reproduces `tl.d.tl` with zero drift; `coverage-baseline` writes correctly (then restored); `stage1` refreshes; `PERF_ONLY=json` `perf`, `perf-baseline`, and the full `perf-compare` chain run end to end through the export conversion.
- Full `bin/make -j ci` was still finishing locally at push time; this PR's own CI runs the same gate, and I'm subscribed to drive it to green.

Remaining series: item 5 downstream (`.ENV` adoption + hostile-env canary gate — needs the next cosmos release, which now carries both whilp/cosmopolitan#209 and #211), item 4 downstream (grant shrinkage against the auto target-dir grant), item 3 (CLI consolidation across a pin bump), item 7 (the ADR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13

---
_Generated by [Claude Code](https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13)_