### PR TITLE
build: adopt .ENV on the driver-exec families + canary gate (#756 item 5)

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "31418749959219e71c3dbfdf0cfa0a3e36aa9fe88868716c138d94cf418d5a27"}},
+  platforms = {["*"] = {sha = "abfbe5ea59d515a9b1ff69a32ea6c5de7dc17314ffdf427402222a86596a6b50"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.24-e95cebe09"
+  version = "2026.07.24-67f462c42"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,7 +215,7 @@ key concepts:
 - **modules**: each directory declares a module via `cook.mk` with `_tl`, `_tests`, `_files`, `_deps`
 - **versioned deps**: 3p modules use `version.lua` → fetch → stage pipeline
 - **bootstrap**: a pre-built cosmic binary bootstraps compilation of `.tl` → `.lua`
-- **sandboxing**: per-rule `.PLEDGE`/`.UNVEIL` annotations document each rule's intended access; landlock-make enforces them only for rules that set `.SANDBOXED = 1` (today just the `sandbox-canary` probe, which CI runs to prove the mechanism works)
+- **sandboxing**: per-rule `.PLEDGE`/`.UNVEIL` annotations document each rule's intended access; landlock-make enforces them only for rules that set `.SANDBOXED = 1` (today just the `sandbox-canary` probe, which CI runs to prove the mechanism works). `.ENV` clamps a rule's child environment to the named variables (#756 item 5) — the driver-exec families declare theirs in cook.mk, gated by the env-clamp fixture's canary probe
 - **output directory**: all build artifacts go to `o/`
 
 ## Type Generation

--- a/bin/make
+++ b/bin/make
@@ -85,7 +85,10 @@ ensure_bootstrap() {
     ln -sf cosmic "${ROOT}/o/bootstrap/lua"
 }
 
-if [ ! -f "${MAKE_BIN}" ]; then
+# Re-extract when the cosmos pin moved (-nt: version.lua newer than the
+# extracted make), not only when the binary is missing — a pin bump must
+# refresh local trees' make, or they keep running the previous release's.
+if [ ! -f "${MAKE_BIN}" ] || [ "${ROOT}/3p/cosmos/version.lua" -nt "${MAKE_BIN}" ]; then
     ensure_bootstrap
     # SSL_USE_SYSTEM_CERTS: the bootstrap's embedded CAs are too narrow
     # for github.com (same knob as the Makefile's fetch rule); the sha

--- a/cook.mk
+++ b/cook.mk
@@ -64,6 +64,11 @@ $(o)/%.lua: .PLEDGE := $(pledge_build) fattr
 # fast path + poisoned-SHELL tripwire as fetch/stage. The driver's own
 # compile opts back out in lib/build/cook.mk (self-bootstrap exception).
 $(o)/%.lua: .UNVEIL := rwc:$(o) r:tlconfig.lua $(unveil_dev)
+# .ENV (#756 item 5): the compile child sees ONLY the declared set —
+# the three path axes below plus the pinned locale/tz and NO_COLOR
+# (deterministic output). A hostile caller variable cannot reach it;
+# gate: the env-clamp fixture's clamped probe in lib/build/cook.mk.
+$(o)/%.lua: .ENV := LUA_PATH TREE_LUA_PATH TL_PATH LC_ALL TZ NO_COLOR
 # LUA_PATH=;; pins the DRIVER to the bootstrap's embedded stdlib (a
 # caller's LUA_PATH must not redirect its requires); the compile child
 # gets ";;" (strict) or TREE_LUA_PATH — the #666 axis, one layer down.
@@ -89,6 +94,14 @@ $(o)/%/.staged: .SANDBOXED := 1
 # fell back to its embedded stdlib); inheritance is benign because
 # every compile recipe sets LUA_PATH explicitly. Recursive (=):
 # tree_lua_path is computed after the includes (#720).
+# .ENV (#756 item 5): fetch declares the network extras — operator
+# proxy/CA variables (both cases; this is exactly the "per-rule
+# declared extras" shape) — stage only the tree paths. SSL_USE_
+# SYSTEM_CERTS rides the fetch rule's own export in the Makefile.
+$(o)/%/.fetched: .ENV := LUA_PATH FETCH_O SSL_USE_SYSTEM_CERTS SSL_CERT_FILE \
+  HTTPS_PROXY https_proxy HTTP_PROXY http_proxy NO_PROXY no_proxy \
+  LC_ALL TZ NO_COLOR TMPDIR
+$(o)/%/.staged: .ENV := LUA_PATH STAGE_O FETCH_O LC_ALL TZ NO_COLOR TMPDIR
 $(o)/%/.fetched $(o)/%/.staged: export LUA_PATH = $(tree_lua_path)
 # De-hosted (#732): lint runs through the pinned bootstrap's --test
 # capture (which mkdtemps under $(TMP)); the .ok alias file is retired —
@@ -98,6 +111,7 @@ $(o)/%/.fetched $(o)/%/.staged: export LUA_PATH = $(tree_lua_path)
 $(o)/%.lint.got: .SANDBOXED := 1
 $(o)/%.lint.got: .PLEDGE := $(pledge_build)
 $(o)/%.lint.got: .UNVEIL := rwc:$(o) rwc:$(TMP) $(unveil_dev)
+$(o)/%.lint.got: .ENV := LUA_PATH TMPDIR LC_ALL TZ NO_COLOR
 $(o)/%.lint.got: export LUA_PATH = $(o)/lib/?.lua;$(o)/lib/?/init.lua;;
 # Reporter summaries (bootstrap + tee). test/coverage/enforce summaries
 # exec $(cosmic_bin) and stay unsandboxed with the test lanes.
@@ -109,6 +123,8 @@ $(reporter_summaries): .PLEDGE := $(pledge_build)
 # `| tee`), so these recipes are direct bootstrap execs — same no-shell
 # fast path + tripwire as fetch/stage above.
 $(reporter_summaries): .UNVEIL := rwc:$(o) $(unveil_dev)
+# REPORTER_NOTE: the lint summary's deleted-files note rides the env
+$(reporter_summaries): .ENV := LUA_PATH REPORTER_NOTE LC_ALL TZ NO_COLOR
 $(reporter_summaries): export LUA_PATH = $(tree_lua_path)
 
 # Third ENFORCED family (#729): the teal/format check rules, which exec
@@ -121,10 +137,12 @@ $(reporter_summaries): export LUA_PATH = $(tree_lua_path)
 $(o)/%.teal.got: .SANDBOXED := 1
 $(o)/%.teal.got: .PLEDGE := $(pledge_build)
 $(o)/%.teal.got: .UNVEIL := rwc:$(o) r:tlconfig.lua rwc:$(TMP) $(unveil_dev)
+$(o)/%.teal.got: .ENV := TL_PATH TMPDIR LC_ALL TZ NO_COLOR
 $(o)/%.teal.got: export TL_PATH = $(tree_tl_path)
 $(o)/%.format.got: .SANDBOXED := 1
 $(o)/%.format.got: .PLEDGE := $(pledge_build)
 $(o)/%.format.got: .UNVEIL := rwc:$(o) r:tlconfig.lua rwc:$(TMP) $(unveil_dev)
+$(o)/%.format.got: .ENV := TMPDIR LC_ALL TZ NO_COLOR
 
 # Fifth ENFORCED family (#729): examples. Same grant sets as the test
 # lanes — examples exercise the same modules (sockets, tty, chmod) and

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -164,14 +164,28 @@ env-probe: private .SHELLFLAGS := -o pipefail -c
 env-probe:
 	@echo "LC_ALL=$$LC_ALL"; echo "TZ=$$TZ"; echo "PATH=$$PATH"
 
+# Clamped twin (#756 item 5): .ENV must strip everything undeclared.
+# The env-clamp fixture sends a hostile CANARY through make; this
+# recipe proves it never reaches a clamped child (env-probe above stays
+# unclamped, showing the passthrough behavior for comparison).
+# Shell exception: probe apparatus, like env-probe.
+.PHONY: env-probe-clamped
+env-probe-clamped: .ENV := LC_ALL TZ PATH
+env-probe-clamped: private SHELL := /bin/bash
+env-probe-clamped: private .SHELLFLAGS := -o pipefail -c
+env-probe-clamped:
+	@echo "CANARY=$${CANARY:-unset}"; echo "CLAMPED_LC_ALL=$$LC_ALL"
+
 # Gate for the clamp: run a nested make under a hostile caller env — a
-# non-C locale, a non-UTC timezone, a poisoned PATH head — and record
-# what the probe recipe saw. makefile_test asserts the clamp held; if
-# someone reverts the exports in cook.mk this fixture goes hostile and
-# the test fails, so the property stays falsifiable (#728).
+# non-C locale, a non-UTC timezone, a poisoned PATH head, and a CANARY
+# variable — and record what both probe recipes saw. makefile_test
+# asserts the axis clamp held (#731) AND that the CANARY never reached
+# the .ENV-clamped probe (#756 item 5); if someone reverts the exports
+# in cook.mk or the clamp, this fixture goes hostile and the test
+# fails, so both properties stay falsifiable (#728).
 $(build_make_out)/env-clamp.out: $(build_make_srcs)
 	@mkdir -p $(@D)
-	@code=0; LC_ALL=tr_TR.UTF-8 TZ=Pacific/Kiritimati PATH="/hostile/bin:$$PATH" $(MAKE) -s env-probe >$@.tmp 2>&1 || code=$$?; echo "exit:$$code" >> $@.tmp; mv $@.tmp $@
+	@code=0; LC_ALL=tr_TR.UTF-8 TZ=Pacific/Kiritimati PATH="/hostile/bin:$$PATH" CANARY=evil $(MAKE) -s env-probe env-probe-clamped >$@.tmp 2>&1 || code=$$?; echo "exit:$$code" >> $@.tmp; mv $@.tmp $@
 
 build_make_outputs := $(build_make_out)/dry-run.out $(build_make_out)/database.out $(build_make_out)/only-database.out $(build_make_out)/ci-launder.out $(build_make_out)/env-clamp.out
 

--- a/lib/build/makefile_test.tl
+++ b/lib/build/makefile_test.tl
@@ -115,6 +115,23 @@ local function test_env_clamp_holds_under_hostile_env()
 end
 test_env_clamp_holds_under_hostile_env()
 
+-- test: .ENV strips undeclared variables (#756 item 5). The same
+-- fixture sends CANARY=evil through the nested make; the clamped probe
+-- must never see it, while its declared LC_ALL still flows through.
+local function test_env_allowlist_strips_canary()
+  local out = read_make_output("env-clamp.out").output
+  assert(out:find("CANARY=unset", 1, true),
+    "expected the .ENV-clamped probe to report CANARY=unset\noutput: " ..
+    out:sub(1, 500))
+  assert(not out:find("CANARY=evil", 1, true),
+    "hostile CANARY leaked into an .ENV-clamped recipe\noutput: " ..
+    out:sub(1, 500))
+  assert(out:find("CLAMPED_LC_ALL=C", 1, true),
+    "declared LC_ALL should still reach the clamped probe\noutput: " ..
+    out:sub(1, 500))
+end
+test_env_allowlist_strips_canary()
+
 -- test: the lint stage is guarded against a silently-empty file list
 -- (#719). Outside a git checkout `git ls-files` fails silently and
 -- lint would green-light zero checks; the summary recipe must carry
@@ -216,6 +233,7 @@ local real_shell < const > = "/bin/bash"
 local real_shell_allowed: {string} = {
   "doc-publish", -- SOURCE_SHA guard + git publishing
   "env-probe", -- shows the env a recipe shell sees
+  "env-probe-clamped", -- .ENV canary probe (#756 item 5)
   "o/bin/ape", -- APE loader extraction IS the stub flow
   "o/bootstrap/compile-flag", -- pre-driver strict-compile probe
   "o/bootstrap/cosmic", -- trust-root download (curl + sha pipe)

--- a/lib/cosmic/tl_loader_test.tl
+++ b/lib/cosmic/tl_loader_test.tl
@@ -134,8 +134,12 @@ return { x = x }
 local badmod = require("badmod")
 print("should not get here: " .. tostring(badmod))
 ]])
+  -- keep PATH (same trap as test_tl_loader_still_available above): a
+  -- replacement env without it strands the APE stub away from the
+  -- staged `ape` loader, and its ./.ape-* fallback is denied under the
+  -- test sandbox
   local h = check.must(spawn.spawn({cosmic, script}, {
-        env = {"TL_PATH=" .. baddir .. "/?.tl"},
+        env = {"TL_PATH=" .. baddir .. "/?.tl", "PATH=" .. os.getenv("PATH")},
       }))
   local r = check.must(h:wait())
   assert(not r.ok, "require of a broken .tl module must fail")
@@ -165,6 +169,7 @@ print("value=" .. require("goodmod").value)
         env = {
           "TL_PATH=" .. gooddir .. "/?.tl",
           "COSMIC_TL_CACHE_DIR=" .. cachedir,
+          "PATH=" .. os.getenv("PATH"), -- APE stub needs the staged loader
         },
       }))
   local r = check.must(h:wait())


### PR DESCRIPTION
PR 4 of the #756 series in this repo — item 5's downstream half, completing the arc opened by whilp/cosmopolitan#208/#209 (`.ENV` in landlock-make, merged and released this afternoon as `2026.07.24-67f462c42`).

## What changed

**Cosmos bump** to `2026.07.24-67f462c42` — the first release whose `make` carries `.ENV`. `regen-types` produced zero drift.

**`bin/make` staleness fix.** The item-6 design only extracted `cosmo-make` when the binary was *missing*, so a pin bump would leave local trees running the previous release's make indefinitely — the new `.ENV` support would never arrive outside cold checkouts. `bin/make` now re-extracts when `3p/cosmos/version.lua` is newer than the extracted binary (POSIX `-nt`, no new tooling). Verified: the bump alone re-fetched cosmos.zip and produced a make matching the release's asset digest, `.ENV`-capable.

**`.ENV` on the six driver-exec families**, declared beside each family's `.PLEDGE`/`.UNVEIL`:

- **compile** — the three path axes (`LUA_PATH`, `TREE_LUA_PATH`, `TL_PATH`) + locale/`NO_COLOR`;
- **fetch** — the network extras as *per-rule declared extras*, exactly the issue's shape: `FETCH_O`, `SSL_USE_SYSTEM_CERTS`, `SSL_CERT_FILE`, and the operator proxy variables in both cases (verified live in this proxied environment);
- **stage**, **lint**, **reporter summaries** (`REPORTER_NOTE` rides the env for the lint note), **teal/format checks** — each their own minimal set.

Children of these rules now see only the declared set plus make's protocol variables. The **test/example lanes stay unclamped** for now — their children legitimately use a much broader env (host tools, HOME, pty vars); clamping them is follow-up work once the audit tooling from whilp/cosmopolitan#210 can measure what they actually need.

**The gate**, generalizing the #731 axis clamp exactly as the issue describes: the env-clamp fixture now sends `CANARY=evil` through the nested make alongside the hostile locale/tz/PATH, and a new `.ENV`-clamped probe (`env-probe-clamped`, shell-exception apparatus like its unclamped twin) must report `CANARY=unset` while its *declared* `LC_ALL` still flows through. makefile_test asserts both directions, so the property is falsifiable: revert a clamp or an export and the fixture goes hostile.

## Verification

- Cold tree (`rm -rf o bin/cosmo-make`): `bin/make -j ci` → `ci: PASS` with all six families clamped — every undeclared-but-needed variable would have failed its family loudly.
- Clamped probe: `CANARY=unset`, `CLAMPED_LC_ALL=C`.
- `bin/make test only=gentype` 3/3; makefile_test green with the new assertions and the `env-probe-clamped` allowlist entry.

Remaining in the series: item 4 downstream (`.UNVEIL` shrinkage against the target-dir auto-grant from whilp/cosmopolitan#211 — next cosmos release), item 3 (CLI consolidation across a pin-bump cycle), and the item 7 ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13

---
_Generated by [Claude Code](https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13)_