### PR TITLE
build: bin/make is the sole bootstrap provisioner (#756 cleanup 2/4)

### DIFF
--- a/bin/make
+++ b/bin/make
@@ -2,14 +2,15 @@
 set -e
 
 # Trust root (#756 item 6). This script is the only host-shell step in the
-# build: with POSIX sh + curl + sha256sum + sed/od it obtains ONE pinned
-# artifact — the bootstrap cosmic (url + sha in cook.mk, single source for
-# this script and the Makefile's own rule) — and everything after runs
+# build and the ONLY provisioner of the trust root (#756 cleanup): with
+# POSIX sh + curl + sha256sum + sed/od it obtains ONE pinned artifact —
+# the bootstrap cosmic (url + sha in cook.mk) — and everything after runs
 # under that pin: the bootstrap extracts `make` from the sha-pinned
 # cosmos.zip (pin in 3p/cosmos/version.lua) via lib/build/make-boot.tl,
 # so no separate landlock-make release asset and no host unzip exist in
-# the chain. Trust root: kernel -> this script -> two pinned artifacts ->
-# everything else.
+# the chain. The Makefile's $(bootstrap_cosmic) rule only errors — it
+# never downloads. Trust root: kernel -> this script -> two pinned
+# artifacts -> everything else.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
@@ -54,16 +55,22 @@ download() {
 }
 
 ensure_bootstrap() {
-    # Mirror of the Makefile's $(bootstrap_cosmic) rule (which still
-    # covers the MAKE_BIN-exists-but-o/-cleaned case): download, verify
-    # against the cook.mk pin, assimilate to a native ELF (sandboxed
-    # rules cannot grant the APE loader's ~/.ape-* extraction), check.
-    [ -x "${BOOTSTRAP}" ] && return 0
+    # Sole provisioner of the bootstrap (#756 cleanup; the Makefile's
+    # rule only errors): download, verify against the cook.mk pin,
+    # assimilate to a native ELF (sandboxed rules cannot grant the APE
+    # loader's ~/.ape-* extraction), check. The stamp beside the binary
+    # records which pin produced it, so a cook.mk pin bump re-downloads
+    # instead of leaving local trees on the previous bootstrap (string
+    # compare on the hot path — no hashing per invocation).
     bootstrap_url="$(sed -n 's/^bootstrap_url := //p' "${ROOT}/cook.mk")"
     bootstrap_sha256="$(sed -n 's/^bootstrap_sha256 := //p' "${ROOT}/cook.mk")"
     if [ -z "${bootstrap_url}" ] || [ -z "${bootstrap_sha256}" ]; then
         echo "could not read bootstrap_url/bootstrap_sha256 from ${ROOT}/cook.mk" >&2
         exit 1
+    fi
+    if [ -x "${BOOTSTRAP}" ] &&
+        [ "$(cat "${BOOTSTRAP}.pin" 2>/dev/null)" = "${bootstrap_sha256}" ]; then
+        return 0
     fi
     echo "Downloading bootstrap cosmic..." >&2
     mkdir -p "${ROOT}/o/bootstrap"
@@ -83,13 +90,17 @@ ensure_bootstrap() {
     fi
     mv -f "${boot_tmp}" "${BOOTSTRAP}"
     ln -sf cosmic "${ROOT}/o/bootstrap/lua"
+    printf '%s\n' "${bootstrap_sha256}" > "${BOOTSTRAP}.pin"
 }
+
+# Always: covers the cleaned-o/ case (the Makefile no longer downloads)
+# and bootstrap pin bumps (the stamp mismatch re-downloads).
+ensure_bootstrap
 
 # Re-extract when the cosmos pin moved (-nt: version.lua newer than the
 # extracted make), not only when the binary is missing — a pin bump must
 # refresh local trees' make, or they keep running the previous release's.
 if [ ! -f "${MAKE_BIN}" ] || [ "${ROOT}/3p/cosmos/version.lua" -nt "${MAKE_BIN}" ]; then
-    ensure_bootstrap
     # SSL_USE_SYSTEM_CERTS: the bootstrap's embedded CAs are too narrow
     # for github.com (same knob as the Makefile's fetch rule); the sha
     # pin is the trust root, TLS is transport. LUA_PATH=";;" pins

--- a/cook.mk
+++ b/cook.mk
@@ -195,20 +195,14 @@ bootstrap_url := https://github.com/whilp/cosmic/releases/download/2026-07-19-5c
 # bootstrap's stale embedded source (#744 — see tree_tl_path).
 bootstrap_sha256 := 6c2a0afe6c942560ce2a0d796ddf8f8df096ce2c92b8ce142c28da59ecac6dc6
 
-# bin/make mirrors this rule (ensure_bootstrap, parsing the pin above via
-# sed) for the cold-tree case where no make exists yet — keep them in sync.
-# Shell exception (#756 item 2): the trust-root download — curl, the
-# sha256sum pipe, and the ELF check predate everything the driver needs.
-$(bootstrap_cosmic): private SHELL := /bin/bash
-$(bootstrap_cosmic): private .SHELLFLAGS := -o pipefail -c
+# bin/make is the SOLE provisioner of the bootstrap (#756 cleanup): it
+# runs before every make invocation, parses the pin above via sed,
+# downloads/verifies/assimilates, and re-downloads when the pin moves
+# (the .pin stamp beside the binary). This rule is only a tripwire for
+# invocations that bypassed bin/make — it never downloads, so the
+# curl/sha256sum/cmp shell exception it carried is retired.
 $(bootstrap_cosmic):
-	@mkdir -p $(@D)
-	curl -fsSL -o $@ $(bootstrap_url)
-	@echo "$(bootstrap_sha256)  $@" | sha256sum -c - || { rm -f $@; echo "bootstrap cosmic checksum verification failed" >&2; exit 1; }
-	chmod +x $@
-	@$@ --assimilate
-	@printf '\177ELF' | cmp -s - <(head -c 4 $@) || { echo "bootstrap assimilation failed: $@ is still an APE — sandboxed rules need a native ELF (no loader grants)" >&2; exit 1; }
-	@ln -sf cosmic $(@D)/lua
+	$(error $(bootstrap_cosmic) missing — run builds via bin/make, which provisions the trust root)
 
 # Strict-compile capability probe: newer bootstraps ship --compile-strict
 # (strict type check, then generate from that same checked AST, so nothing

--- a/cook.mk
+++ b/cook.mk
@@ -198,11 +198,21 @@ bootstrap_sha256 := 6c2a0afe6c942560ce2a0d796ddf8f8df096ce2c92b8ce142c28da59ecac
 # bin/make is the SOLE provisioner of the bootstrap (#756 cleanup): it
 # runs before every make invocation, parses the pin above via sed,
 # downloads/verifies/assimilates, and re-downloads when the pin moves
-# (the .pin stamp beside the binary). This rule is only a tripwire for
-# invocations that bypassed bin/make — it never downloads, so the
-# curl/sha256sum/cmp shell exception it carried is retired.
+# (the .pin stamp beside the binary). Neither rule below downloads, so
+# the curl/sha256sum/cmp shell exception this rule carried is retired.
+ifeq ($(o),o)
+# Canonical tree: only a bypassed bin/make can get here — trip loudly.
 $(bootstrap_cosmic):
 	$(error $(bootstrap_cosmic) missing — run builds via bin/make, which provisions the trust root)
+else
+# Non-default output tree (o=o2, the reproducible double-build):
+# derive the bootstrap from the canonical tree bin/make provisioned —
+# same bytes, argv-only recipe.
+$(bootstrap_cosmic): o/bootstrap/cosmic
+	@mkdir -p $(@D)
+	@cp -p o/bootstrap/cosmic $@
+	@ln -sf cosmic $(@D)/lua
+endif
 
 # Strict-compile capability probe: newer bootstraps ship --compile-strict
 # (strict type check, then generate from that same checked AST, so nothing

--- a/lib/build/makefile_ratchet_test.tl
+++ b/lib/build/makefile_ratchet_test.tl
@@ -69,7 +69,6 @@ local real_shell_allowed: {string} = {
   "env-probe-clamped", -- .ENV canary probe (#756 item 5)
   "o/bin/ape", -- APE loader extraction IS the stub flow
   "o/bootstrap/compile-flag", -- pre-driver strict-compile probe
-  "o/bootstrap/cosmic", -- trust-root download (curl + sha pipe)
   "o/ci-selftest-launder-summary.txt", -- deliberately laundering fixture
   "o/cosmic/version.lua", -- git describe interpolation
   "o/lib/build/build-recipe.lua", -- driver self-bootstrap compile


### PR DESCRIPTION
Second PR of the pre-ADR cleanup pass (https://github.com/whilp/cosmic/issues/756#issuecomment-5071082662).

## What changed

The Makefile's `$(bootstrap_cosmic)` download rule and `bin/make`'s `ensure_bootstrap` were documented mirrors kept in sync by hand — and the survey exposed a shared gap: **neither re-downloaded when the bootstrap pin itself moved**. A `cook.mk` pin bump left local trees running the previous bootstrap until an `rm -rf o`.

Now `bin/make` provisions unconditionally on every invocation:

- a `.pin` stamp beside the binary records which sha produced it, so the hot path is a single string compare (no hashing per run) and a pin bump triggers a re-download — the same `-nt`-style staleness idea #761 gave the extracted make, applied to the bootstrap;
- the Makefile rule collapses to a no-recipe `$(error … run builds via bin/make …)` tripwire for anything that bypassed `bin/make`;
- the rule's curl/sha256sum/cmp shell exception retires — **ratchet allowlist 19 → 18**, checked both directions by the ratchet from #762.

## Verification

All four provisioning paths exercised:
- warm run mints the stamp (matching the cook.mk pin);
- `rm -rf o` → `bin/make` re-provisions (bootstrap + stamp + `lua` symlink), the make rule never fires;
- corrupted stamp → re-download, stamp restored;
- direct `bin/cosmo-make` with a missing bootstrap → `cook.mk:205: *** o/bootstrap/cosmic missing — run builds via bin/make, which provisions the trust root.  Stop.`

Plus `bin/make -j test only=makefile` 2/2 (both ratchet directions green at 18 entries) and full `bin/make -j ci` → `ci: PASS`.

Next: perf chains into the runner (3/4), comment/doc sweep (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13

---
_Generated by [Claude Code](https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13)_