### PR TITLE
perf: the compare retry and A/A triage move into perf.gate (#756 cleanup 3/4)

### DIFF
--- a/lib/build/makefile_ratchet_test.tl
+++ b/lib/build/makefile_ratchet_test.tl
@@ -79,8 +79,6 @@ local real_shell_allowed: {string} = {
   "o/lib/build/make/only-database.out", -- nested-make fixture
   "o/sandbox-canary/probe.got", -- out-of-grant write attempt
   "perf-bin", -- COSMO_LUA guard
-  "perf-compare", -- retry/triage chain
-  "perf-selfcheck", -- A/A chain
   "regen-types", -- dev regen loop
   "sandbox-canary", -- verdict branching
 }

--- a/lib/cosmic/coverage/baseline.txt
+++ b/lib/cosmic/coverage/baseline.txt
@@ -131,6 +131,7 @@ lib/perf/bench/startup_bench.tl 74 86
 lib/perf/bench/stream_bench.tl 0 80
 lib/perf/bench/time_bench.tl 0 14
 lib/perf/compare.tl 104 107
+lib/perf/gate.tl 95 115
 lib/perf/harness.tl 138 149
 lib/perf/perf_types.tl 2 2
 lib/perf/run.tl 93 182
@@ -142,4 +143,4 @@ lib/types/gentype_parse.tl 267 288
 lib/types/gentype_render.tl 309 312
 lib/types/gentype_types.tl 2 2
 tlconfig.lua 7 7
-total 11675 15311
+total 11770 15426

--- a/lib/perf/cook.mk
+++ b/lib/perf/cook.mk
@@ -68,12 +68,6 @@ perf-bin: $(cosmic_bin) $(build_pack)
 	@echo "built $(cosmic_local_bin) from $(COSMO_LUA)"
 	@echo "measure it with: PERF_BIN=$(cosmic_local_bin) bin/make perf-compare"
 
-# Shell exceptions (#756 item 2): the compare/selfcheck retry and
-# triage chains branch on exit codes; measurement apparatus, not build
-# logic. perf and perf-baseline are argv-only since the export
-# conversion above.
-perf-compare perf-selfcheck: private SHELL := /bin/bash
-perf-compare perf-selfcheck: private .SHELLFLAGS := -o pipefail -c
 perf perf-baseline: .PLEDGE := $(pledge_build)
 perf perf-baseline: .UNVEIL := $(unveil_test)
 
@@ -90,40 +84,25 @@ perf-baseline: $$(perf_lua) $(cosmic_bin)
 perf-compare: .PLEDGE := $(pledge_build)
 perf-compare: .UNVEIL := $(unveil_test)
 
-perf_compare_cmd = $(PERF_BIN) -- $(perf_run) --compare \
-	$(perf_sandbox)/baseline.json $(perf_sandbox)/current.json \
-	--threshold $(PERF_THRESHOLD)
-
-# Final stage: reclassify any surviving regression the current binary
-# cannot reproduce against itself (selfcheck-b vs the current run) as
-# "noise" rather than a failure — the A/A control, run automatically.
-perf_triage_cmd = $(PERF_BIN) -- $(perf_run) --compare \
-	$(perf_sandbox)/baseline.json $(perf_sandbox)/current.json \
-	--threshold $(PERF_THRESHOLD) \
-	--selfcheck-a $(perf_sandbox)/current.json \
-	--selfcheck-b $(perf_sandbox)/selfcheck-b.json
+# De-shelled (#756 cleanup): the retry and A/A-triage orchestration
+# lives in perf.gate (tested with injected measurements); the recipe is
+# one argv line. After the positional results paths, everything but
+# --threshold is handed to perf.run per re-measurement pass (no `--`
+# separator — the cosmic dispatcher consumes a standalone one).
+perf_gate := $(o)/lib/perf/gate.lua
+perf_gate_run_args = --samples $(PERF_SAMPLES) --min-secs $(PERF_MIN_SECS) \
+	$(perf_only_flag) $(perf_bench_mods)
 
 ## Re-run scenarios and fail on any regression vs the saved baseline
-# A failed comparison retries once with fresh measurements so machine
-# noise has to strike twice in the same direction. If a regression still
-# stands, one more pass of the same binary drives an automatic A/A
-# triage: scenarios that swing past the bar against themselves are
-# reclassified "noise" and the gate passes iff a real regression remains.
+# A flagged regression re-measures once (noise must strike twice in the
+# same direction); if it persists, an automatic A/A self-check
+# reclassifies swings the binary shows against itself as "noise", and
+# the gate fails iff a real regression remains.
 perf-compare: perf
-	@$(perf_compare_cmd) || { \
-		echo "perf-compare: regression flagged; re-measuring once to filter noise"; \
-		$(perf_cmd) --out $(perf_sandbox)/current.json $(perf_bench_mods) \
-			&& $(perf_compare_cmd); } || { \
-		echo "perf-compare: regression persists; running A/A self-check to separate real regressions from machine noise"; \
-		$(perf_cmd) --out $(perf_sandbox)/selfcheck-b.json $(perf_bench_mods) \
-			&& $(perf_triage_cmd); }
+	@$(PERF_BIN) -- $(perf_gate) compare $(perf_sandbox)/baseline.json $(perf_sandbox)/current.json $(perf_sandbox)/selfcheck-b.json --threshold $(PERF_THRESHOLD) $(perf_gate_run_args)
 
 perf-selfcheck: .PLEDGE := $(pledge_build)
 perf-selfcheck: .UNVEIL := $(unveil_test)
-
-perf_selfcheck_cmd = $(PERF_BIN) -- $(perf_run) --compare \
-	$(perf_sandbox)/selfcheck-a.json $(perf_sandbox)/selfcheck-b.json \
-	--threshold $(PERF_THRESHOLD)
 
 ## A/A control: measure this machine's noise floor by comparing the SAME
 ## binary against itself. Anything flagged here moves more than the bar on
@@ -134,8 +113,4 @@ perf_selfcheck_cmd = $(PERF_BIN) -- $(perf_run) --compare \
 # fast focused check on just the scenario perf-compare flagged.
 perf-selfcheck: $$(perf_lua) $(cosmic_bin)
 	@mkdir -p $(perf_sandbox)
-	@$(perf_cmd) --out $(perf_sandbox)/selfcheck-a.json $(perf_bench_mods)
-	@$(perf_cmd) --out $(perf_sandbox)/selfcheck-b.json $(perf_bench_mods)
-	@$(perf_selfcheck_cmd) && \
-		echo "perf-selfcheck: nothing exceeded the bar — the machine is quiet at this threshold" || \
-		echo "perf-selfcheck: the scenarios flagged above vary by more than the bar on noise alone; discount same-named perf-compare regressions"
+	@$(PERF_BIN) -- $(perf_gate) selfcheck $(perf_sandbox)/selfcheck-a.json $(perf_sandbox)/selfcheck-b.json --threshold $(PERF_THRESHOLD) $(perf_gate_run_args)

--- a/lib/perf/gate.tl
+++ b/lib/perf/gate.tl
@@ -1,0 +1,221 @@
+#!/usr/bin/env lua
+--- Perf gate orchestration (#756 cleanup): the compare retry and the
+--- A/A triage that used to live as ||-chains in the perf-compare and
+--- perf-selfcheck recipes. A flagged regression re-measures once (noise
+--- must strike twice in the same direction); if it persists, an A/A
+--- self-check reclassifies swings the current binary shows against
+--- itself as noise. Measurement is injected so the orchestration is
+--- testable without running real benchmarks; main wires perf.run.
+local compare = require("perf.compare")
+local proc = require("cosmic.proc")
+
+local type Measure = function(out: string): integer
+
+local record GateOptions
+  baseline: string
+  current: string
+  selfcheck_b: string
+  threshold: number
+  measure: Measure
+end
+
+local record SelfcheckOptions
+  a: string
+  b: string
+  threshold: number
+  measure: Measure
+end
+
+local usage < const > = [[
+usage: gate.lua compare BASE.json CUR.json SELFB.json [--threshold PCT] <run args...>
+       gate.lua selfcheck A.json B.json [--threshold PCT] <run args...>
+]]
+
+--- Load, compare (optionally triaged), and print one comparison.
+--- @param base_path string Baseline results path
+--- @param cur_path string Current results path
+--- @param threshold number? Noise bar in percent
+--- @param na_path string? A/A control A (triage mode when both set)
+--- @param nb_path string? A/A control B
+--- @return integer Failure count, or -1 on a load error
+--- @return string? Error message when loading failed
+local function compare_once(base_path: string, cur_path: string,
+    threshold: number, na_path?: string, nb_path?: string): integer, string
+  local base, berr = compare.load_results(base_path)
+  if base == nil then
+    return -1, berr
+  end
+  local cur, cerr = compare.load_results(cur_path)
+  if cur == nil then
+    return -1, cerr
+  end
+  local deltas, failures = compare.diff(base, cur, threshold)
+  if na_path and nb_path then
+    local na, naerr = compare.load_results(na_path)
+    if na == nil then
+      return -1, naerr
+    end
+    local nb, nberr = compare.load_results(nb_path)
+    if nb == nil then
+      return -1, nberr
+    end
+    deltas, failures = compare.triage(base, cur, na, nb, threshold)
+  end
+  print(compare.format(deltas))
+  return failures
+end
+
+--- Run the compare gate over an already-measured current file.
+--- @param opts GateOptions Paths, threshold, and the measure function
+--- @return integer Exit code: 0 clean or noise, 1 on a real regression
+local function gate(opts: GateOptions): integer
+  local failures, err = compare_once(opts.baseline, opts.current, opts.threshold)
+  if failures < 0 then
+    io.stderr:write(tostring(err) .. "\n")
+    return 1
+  end
+  if failures == 0 then
+    return 0
+  end
+  print("perf-compare: regression flagged; re-measuring once to filter noise")
+  local rc = opts.measure(opts.current)
+  if rc ~= 0 then
+    return rc
+  end
+  failures, err = compare_once(opts.baseline, opts.current, opts.threshold)
+  if failures < 0 then
+    io.stderr:write(tostring(err) .. "\n")
+    return 1
+  end
+  if failures == 0 then
+    return 0
+  end
+  print("perf-compare: regression persists; running A/A self-check to separate" ..
+    " real regressions from machine noise")
+  rc = opts.measure(opts.selfcheck_b)
+  if rc ~= 0 then
+    return rc
+  end
+  failures, err = compare_once(opts.baseline, opts.current, opts.threshold,
+    opts.current, opts.selfcheck_b)
+  if failures < 0 then
+    io.stderr:write(tostring(err) .. "\n")
+    return 1
+  end
+  if failures > 0 then
+    io.stderr:write("perf: " .. failures ..
+      " scenario(s) regressed, errored, or went missing\n")
+    return 1
+  end
+  return 0
+end
+
+--- Measure the same binary twice and report the machine's noise floor.
+--- Informational: always exits 0 (the verdict text is the product).
+--- @param opts SelfcheckOptions Paths, threshold, and the measure function
+--- @return integer Exit code: 0 unless measurement or loading failed
+local function selfcheck(opts: SelfcheckOptions): integer
+  local rc = opts.measure(opts.a)
+  if rc ~= 0 then
+    return rc
+  end
+  rc = opts.measure(opts.b)
+  if rc ~= 0 then
+    return rc
+  end
+  local failures, err = compare_once(opts.a, opts.b, opts.threshold)
+  if failures < 0 then
+    io.stderr:write(tostring(err) .. "\n")
+    return 1
+  end
+  if failures == 0 then
+    print("perf-selfcheck: nothing exceeded the bar — the machine is quiet" ..
+      " at this threshold")
+  else
+    print("perf-selfcheck: the scenarios flagged above vary by more than the" ..
+      " bar on noise alone; discount same-named perf-compare regressions")
+  end
+  return 0
+end
+
+--- CLI entry point. The results paths are positional (right after the
+--- mode); every remaining argument except --threshold is handed to
+--- perf.run per measurement pass (with --out prepended). Deliberately
+--- no `--` separator: the cosmic dispatcher consumes a standalone `--`
+--- before the script ever sees its arguments (witnessed).
+--- @param ... string Command-line arguments
+--- @return integer Exit code
+local function main(...: string): integer
+  local argv = {...}
+  local mode = argv[1]
+  local want = 0
+  if mode == "compare" then
+    want = 3
+  elseif mode == "selfcheck" then
+    want = 2
+  end
+  if want == 0 or #argv < 1 + want then
+    io.stderr:write(usage)
+    return 2
+  end
+  local paths: {string} = {}
+  for i = 2, 1 + want do
+    paths[#paths + 1] = argv[i]
+  end
+  local threshold: number = nil
+  local runargs: {string} = {}
+  local i = want + 2
+  while i <= #argv do
+    local v = argv[i]
+    if v == "--threshold" then
+      i = i + 1
+      threshold = tonumber(argv[i])
+    else
+      runargs[#runargs + 1] = v
+    end
+    i = i + 1
+  end
+  local run = require("perf.run")
+  local function measure(out: string): integer
+    local margs: {string} = {"--out", out}
+    for _, r in ipairs(runargs) do
+      margs[#margs + 1] = r
+    end
+    return run.main(table.unpack(margs))
+  end
+  if mode == "compare" then
+    return gate({
+        baseline = paths[1],
+        current = paths[2],
+        selfcheck_b = paths[3],
+        threshold = threshold,
+        measure = measure,
+      })
+  end
+  return selfcheck({
+      a = paths[1],
+      b = paths[2],
+      threshold = threshold,
+      measure = measure,
+    })
+end
+
+if proc.is_main() then
+  os.exit(main(...))
+end
+
+local record gate_module
+  type GateOptions = GateOptions
+  type SelfcheckOptions = SelfcheckOptions
+  gate: function(opts: GateOptions): integer
+  selfcheck: function(opts: SelfcheckOptions): integer
+  main: function(...: string): integer
+end
+
+local M: gate_module = {
+  gate = gate,
+  selfcheck = selfcheck,
+  main = main,
+}
+
+return M

--- a/lib/perf/gate_test.tl
+++ b/lib/perf/gate_test.tl
@@ -1,0 +1,173 @@
+#!/usr/bin/env cosmic
+--- Tests for the perf gate orchestration: the retry and A/A triage
+--- flows that used to be untestable ||-chains in make recipes. The
+--- measure function is injected, so each path is exercised with
+--- fabricated results files and no real benchmarks.
+
+local fs = require("cosmic.fs")
+local gate = require("perf.gate")
+local json = require("cosmic.json")
+
+local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
+
+local function write_results(path: string, wall_ns: number)
+  local payload = {
+    meta = {},
+    results = {
+      {
+        name = "scenario",
+        wall_ns = wall_ns,
+        spread_pct = 2,
+        samples_ns = {},
+        iterations = 1,
+      },
+    },
+  }
+  local encoded = json.encode(payload)
+  assert(fs.write(path, encoded))
+end
+
+local function paths(prefix: string): string, string, string
+  return fs.join(tmpdir, prefix .. "-base.json"),
+    fs.join(tmpdir, prefix .. "-cur.json"),
+    fs.join(tmpdir, prefix .. "-selfb.json")
+end
+
+local function test_clean_compare_measures_nothing()
+  local base, cur, selfb = paths("clean")
+  write_results(base, 1000)
+  write_results(cur, 1010)
+  local calls = 0
+  local code = gate.gate({
+      baseline = base, current = cur, selfcheck_b = selfb, threshold = 10,
+      measure = function(_out: string): integer
+        calls = calls + 1
+        return 0
+      end,
+    })
+  assert(code == 0, "clean compare must pass, got " .. code)
+  assert(calls == 0, "clean compare must not re-measure, got " .. calls)
+end
+test_clean_compare_measures_nothing()
+
+local function test_flagged_regression_retries_then_passes()
+  local base, cur, selfb = paths("retry")
+  write_results(base, 1000)
+  write_results(cur, 1300)
+  local calls = 0
+  local code = gate.gate({
+      baseline = base, current = cur, selfcheck_b = selfb, threshold = 10,
+      measure = function(out: string): integer
+        calls = calls + 1
+        write_results(out, 1010) -- the re-measurement comes back quiet
+        return 0
+      end,
+    })
+  assert(code == 0, "noise filtered by the retry must pass, got " .. code)
+  assert(calls == 1, "expected exactly one re-measurement, got " .. calls)
+end
+test_flagged_regression_retries_then_passes()
+
+local function test_persistent_regression_triaged_as_noise_passes()
+  local base, cur, selfb = paths("noise")
+  write_results(base, 1000)
+  write_results(cur, 1300)
+  local calls = 0
+  local code = gate.gate({
+      baseline = base, current = cur, selfcheck_b = selfb, threshold = 10,
+      measure = function(out: string): integer
+        calls = calls + 1
+        if calls == 1 then
+          write_results(out, 1300) -- regression persists on re-measurement
+        else
+          write_results(out, 1800) -- A/A control swings just as hard: noise
+        end
+        return 0
+      end,
+    })
+  assert(code == 0, "A/A-reclassified noise must pass, got " .. code)
+  assert(calls == 2, "expected re-measure + selfcheck-b, got " .. calls)
+end
+test_persistent_regression_triaged_as_noise_passes()
+
+local function test_real_regression_survives_triage_and_fails()
+  local base, cur, selfb = paths("real")
+  write_results(base, 1000)
+  write_results(cur, 1300)
+  local calls = 0
+  local code = gate.gate({
+      baseline = base, current = cur, selfcheck_b = selfb, threshold = 10,
+      measure = function(out: string): integer
+        calls = calls + 1
+        if calls == 1 then
+          write_results(out, 1300) -- persists
+        else
+          write_results(out, 1310) -- A/A control is quiet: it is real
+        end
+        return 0
+      end,
+    })
+  assert(code == 1, "a real regression must fail the gate, got " .. code)
+  assert(calls == 2, "expected re-measure + selfcheck-b, got " .. calls)
+end
+test_real_regression_survives_triage_and_fails()
+
+local function test_measure_failure_propagates()
+  local base, cur, selfb = paths("mfail")
+  write_results(base, 1000)
+  write_results(cur, 1300)
+  local code = gate.gate({
+      baseline = base, current = cur, selfcheck_b = selfb, threshold = 10,
+      measure = function(_out: string): integer
+        return 3
+      end,
+    })
+  assert(code == 3, "a failed measurement must propagate its code, got " .. code)
+end
+test_measure_failure_propagates()
+
+local function test_selfcheck_reports_quiet_and_noisy()
+  local a, b, _ = paths("self")
+  local code = gate.selfcheck({
+      a = a, b = b, threshold = 10,
+      measure = function(out: string): integer
+        write_results(out, out == a and 1000 or 1010)
+        return 0
+      end,
+    })
+  assert(code == 0, "quiet selfcheck exits 0, got " .. code)
+  code = gate.selfcheck({
+      a = a, b = b, threshold = 10,
+      measure = function(out: string): integer
+        write_results(out, out == a and 1000 or 1500)
+        return 0
+      end,
+    })
+  assert(code == 0, "noisy selfcheck is informational and exits 0, got " .. code)
+end
+test_selfcheck_reports_quiet_and_noisy()
+
+local function test_missing_baseline_fails_loudly()
+  local base, cur, selfb = paths("missing")
+  write_results(cur, 1000)
+  local code = gate.gate({
+      baseline = base, current = cur, selfcheck_b = selfb, threshold = 10,
+      measure = function(_out: string): integer
+        return 0
+      end,
+    })
+  assert(code == 1, "a missing baseline must fail, got " .. code)
+end
+test_missing_baseline_fails_loudly()
+
+local function test_main_parses_positionals_without_separator()
+  -- the cosmic dispatcher consumes a standalone "--", so main takes its
+  -- paths positionally; a missing file must reach the gate (exit 1),
+  -- never the usage error (exit 2)
+  local code = gate.main("compare", "no.json", "such.json", "file.json",
+    "--threshold", "10", "--samples", "1")
+  assert(code == 1, "positional parse must reach the gate, got " .. code)
+  code = gate.main("bogus-mode")
+  assert(code == 2, "unknown mode must print usage, got " .. code)
+end
+test_main_parses_positionals_without_separator()


### PR DESCRIPTION
Third PR of the pre-ADR cleanup pass (https://github.com/whilp/cosmic/issues/756#issuecomment-5071082662).

## What changed

`perf-compare`'s `||`-chain (compare → re-measure once so noise must strike twice in the same direction → automatic A/A triage) and `perf-selfcheck`'s verdict logic were shell recipes — the most intricate control flow left in any recipe, and completely untested. They now live in **`lib/perf/gate.tl`** with the measurement function *injected*, which makes every path testable without running a benchmark:

- clean first compare measures nothing;
- a flagged regression re-measures exactly once and passes when the retry comes back quiet;
- a persistent regression triages against the A/A control — reclassified noise passes, a real regression fails;
- measurement failures propagate their exit code;
- selfcheck prints quiet/noisy verdicts and stays informational (exit 0) either way;
- a missing baseline fails loudly.

Both recipes are now single argv lines; their shell exceptions retire — **ratchet allowlist 18 → 16**, enforced both directions.

**One dispatcher discovery**, regression-tested: the cosmic CLI consumes a standalone `--` before a script ever sees its arguments (verified with an argv probe — the separator simply vanishes from the script's varargs). `gate.main` therefore takes its results paths positionally and forwards everything except `--threshold` to `perf.run` per measurement pass; the test pins the behavior so a future parser can't quietly regress it.

## Verification

- `gate_test.tl`: 8 tests over the injected-measurement flows, all green.
- Live: `PERF_ONLY=json bin/make perf-compare` runs through the gate (4 scenarios ok) and `perf-selfcheck` prints the quiet-machine verdict.
- Coverage baseline gains `gate.tl`'s row (95/115); makefile ratchets green at 16; full `bin/make -j ci` → `ci: PASS`.

Last in the pass: the comment/doc sweep (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13

---
_Generated by [Claude Code](https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13)_