### PR TITLE
docs: describe the post-#756 build in comments, docs, and the skill (#756 cleanup 4/4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,7 +214,8 @@ bin/make clean          # remove build artifacts
 key concepts:
 - **modules**: each directory declares a module via `cook.mk` with `_tl`, `_tests`, `_files`, `_deps`
 - **versioned deps**: 3p modules use `version.lua` → fetch → stage pipeline
-- **bootstrap**: a pre-built cosmic binary bootstraps compilation of `.tl` → `.lua`
+- **bootstrap**: a pre-built cosmic binary bootstraps compilation of `.tl` → `.lua`; `bin/make` is its sole provisioner (sha-pinned, re-fetched on pin bumps)
+- **no-shell default**: `SHELL` is poisoned globally — recipes are single argv lines, the real shell is a per-rule exception, and the makefile ratchet tests enumerate the exceptions, the host-exec grants, and statically scan recipe text (#756 item 2)
 - **sandboxing**: per-rule `.PLEDGE`/`.UNVEIL` annotations document each rule's intended access; landlock-make enforces them only for rules that set `.SANDBOXED = 1` (today just the `sandbox-canary` probe, which CI runs to prove the mechanism works). `.ENV` clamps a rule's child environment to the named variables (#756 item 5) — the driver-exec families declare theirs in cook.mk, gated by the env-clamp fixture's canary probe
 - **output directory**: all build artifacts go to `o/`
 

--- a/Makefile
+++ b/Makefile
@@ -110,11 +110,11 @@ fetched: $(all_fetched)
 # operator SSL_CERT_FILE bundle is unveiled). The scripts run under the
 # pinned bootstrap against THIS tree's cosmic.* APIs — the compiled
 # stdlib is a prerequisite (a cold parallel build once fell back to the
-# bootstrap's embedded stdlib; only= must not shrink it). De-hosted
-# (#732): symlink resolution and extraction are in-process, and the
-# no-shell/LUA_PATH target variables in cook.mk (with the .SANDBOXED
-# flips) make each recipe a direct bootstrap exec — no $(unveil_hostx):
-# ONLY the pinned bootstrap executes under these grants.
+# bootstrap's embedded stdlib; only= must not shrink it). Extraction is
+# in-process (#732) and each recipe is a direct bootstrap exec under
+# the global no-shell default — no $(unveil_hostx): ONLY the pinned
+# bootstrap executes under these grants, with .ENV/.SANDBOXED/LUA_PATH
+# for the family living in cook.mk.
 stdlib_lua := $(patsubst %.tl,$(o)/%.lua,$(filter lib/cosmic/%,$(foreach x,$(modules),$($(x)_tl))))
 $(o)/%/.fetched: export SSL_USE_SYSTEM_CERTS = 1
 $(o)/%/.fetched: .PLEDGE := $(pledge_build) inet dns

--- a/cook.mk
+++ b/cook.mk
@@ -60,9 +60,9 @@ pledge_test := $(pledge_build) fattr inet dns unix tty id flock
 $(o)/%.lua: .SANDBOXED := 1
 $(o)/%.lua: .PLEDGE := $(pledge_build) fattr
 # De-hosted (#732): compiles and the $(o)/%: % copies run through the
-# build-recipe driver — direct bootstrap execs under the same no-shell
-# fast path + poisoned-SHELL tripwire as fetch/stage. The driver's own
-# compile opts back out in lib/build/cook.mk (self-bootstrap exception).
+# build-recipe driver — direct bootstrap execs under the global
+# no-shell default. The driver's own compile opts back out in
+# lib/build/cook.mk (self-bootstrap exception).
 $(o)/%.lua: .UNVEIL := rwc:$(o) r:tlconfig.lua $(unveil_dev)
 # .ENV (#756 item 5): the compile child sees ONLY the declared set —
 # the three path axes below plus the pinned locale/tz and NO_COLOR

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,11 +47,19 @@ bootstrap cosmic (pre-built)
 
 ### Sandboxed Build
 
-when using landlock-make (the default via `bin/make`), each build rule gets:
+`bin/make` is the trust root: it fetches the sha-pinned bootstrap cosmic,
+which extracts `make` from the sha-pinned cosmos.zip — two pinned
+artifacts, one committed fetcher, no other host downloads (#756).
+
+under landlock-make, each build rule declares its access:
 - **pledge**: restricts available system calls (e.g., `stdio rpath`)
 - **unveil**: restricts filesystem visibility (e.g., `r:lib rwc:o/`)
+- **.ENV**: clamps the child environment to named variables
 
-this ensures build rules only access declared inputs and outputs.
+recipes are shell-free by default: `SHELL` is poisoned globally and a
+recipe is a single argv line, with the real shell a per-rule exception.
+makefile ratchet tests enumerate the exceptions and the host-exec
+grants, and fail when either set grows (#756 item 2).
 
 ## Directory Structure
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -75,12 +75,22 @@ each test:
 with landlock-make (`bin/make`), each rule declares security constraints:
 
 ```makefile
-$(o)/%.tl.test.got: .PLEDGE = stdio rpath wpath cpath proc exec
-$(o)/%.tl.test.got: .UNVEIL = rx:$(o)/bootstrap r:lib rwc:$(o) rwc:$(TMP)
+$(o)/%.tl.test.got: .PLEDGE := stdio rpath wpath cpath proc exec
+$(o)/%.tl.test.got: .UNVEIL := rx:$(o)/bootstrap r:lib rwc:$(o) rwc:$(TMP)
+$(o)/%.lua: .ENV := LUA_PATH TREE_LUA_PATH TL_PATH LC_ALL TZ NO_COLOR
 ```
 
 - `.PLEDGE` restricts system calls (OpenBSD pledge semantics)
 - `.UNVEIL` restricts filesystem paths and permissions
+- `.ENV` clamps the child environment to the named variables (#756 item
+  5); the env-clamp fixture's canary probe gates it
+
+recipes are shell-free by default (#756 item 2): the global `SHELL` is
+poisoned, recipes are single argv lines run via make's direct-exec
+path, and the real shell is a per-rule `private` exception. The
+makefile ratchet tests enumerate the exception set, the
+`$(unveil_hostx)` carriers, and statically scan recipe text for shell
+syntax — all three fail when a set grows without a declared reason.
 
 ### Building the cosmic Binary
 

--- a/skills/cosmic/testing.md
+++ b/skills/cosmic/testing.md
@@ -92,7 +92,7 @@ test_write_file()
 
 ## The Test Sandbox
 
-`bin/make test` runs every test under a landlock-make sandbox. the default grants (the test lane at `Makefile:142-143`; the coverage lane at `Makefile:195-196` is identical) are:
+`bin/make test` runs every test under a landlock-make sandbox. the default grants (the `$(o)/%.tl.test.got` pledge/unveil lines in the Makefile; the coverage lane is identical) are:
 
 - `.PLEDGE = stdio rpath wpath cpath proc exec`
 - `.UNVEIL = rx:o/bootstrap r:lib r:3p rwcx:o rwc:$TMP rx:/usr rx:/proc r:/etc r:/dev/null`
@@ -108,8 +108,8 @@ what that means for a test author:
 
 two escalation paths exist; prefer the tight default whenever the test can live with it:
 
-- **namespace tests** (anything calling `unshare(2)` or writing `/proc/self/*_map` — the quicksand netns/proxy/box suites): no pledge promise covers unshare, so these tests are listed in `quicksand_sandbox_tests` (`Makefile:150-158`) which sets empty `.PLEDGE`/`.UNVEIL` for exactly those `.got` targets. to add one, append its plain and `coverage/` target paths to that list.
-- **enforcement tests** (pledge/unveil/landlock primitives asserting that restriction *actually* blocks): under the outer sandbox their assertions degrade to visible skips. the separate privileged `enforce` lane (`Makefile:236-270`, `bin/make enforce`) reruns them unsandboxed with `COSMIC_ENFORCE=1`, where a skip becomes a loud failure, plus a tripwire that fails the lane if nothing enforced at all.
+- **namespace tests** (anything calling `unshare(2)` or writing `/proc/self/*_map` — the quicksand netns/proxy/box suites): no pledge promise covers unshare, so these tests are listed in `quicksand_sandbox_tests` in the Makefile, which sets empty `.PLEDGE`/`.UNVEIL` for exactly those `.got` targets. to add one, append its plain and `coverage/` target paths to that list.
+- **enforcement tests** (pledge/unveil/landlock primitives asserting that restriction *actually* blocks): under the outer sandbox their assertions degrade to visible skips. the separate privileged `enforce` lane (`bin/make enforce`) reruns them unsandboxed with `COSMIC_ENFORCE=1`, where a skip becomes a loud failure, plus a tripwire that fails the lane if nothing enforced at all.
 
 a per-rule override (custom `.PLEDGE`/`.UNVEIL` for one `.got` target) is possible but rare; reach for it only when a test needs one extra grant (say, an additional read path) and neither list above fits.
 


### PR DESCRIPTION
Last PR of the pre-ADR cleanup pass (https://github.com/whilp/cosmic/issues/756#issuecomment-5071082662). Pure narration — no behavior changes — so everything describes the present design rather than its history:

- **docs/architecture.md, docs/build.md**: the Sandboxed Build / Sandboxing sections gain the trust root (`bin/make` → two pinned artifacts), the `.ENV` axis with its canary gate, and the no-shell default with its three ratchets (exception set, hostx carriers, static recipe scan). The build.md example also drops its stale `=` spellings for the `:=` the enforcement path requires.
- **AGENTS.md**: key concepts gain the no-shell default and `bin/make`'s sole-provisioner role.
- **Makefile / cook.mk**: the fetch block and the compile-family comment stop describing the poisoned-SHELL tripwire as a per-family arrangement — it has been the global default since #759.
- **skills/cosmic/testing.md** (embedded in the binary): hard-coded `Makefile:NNN` line references — already rotted several PRs ago — become durable anchors (rule and variable names).

Gate: full `bin/make -j ci` → `ci: PASS`.

With this, the cleanup pass is complete. Remaining on #756: item 4 downstream (`.UNVEIL` shrinkage against the target-dir auto-grant, riding the next cosmos release), item 3 (CLI consolidation across a pin-bump cycle), and the item 7 ADR recording the trust root and the no-self-hosting decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13

---
_Generated by [Claude Code](https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13)_