### PR TITLE
build: shrink .UNVEIL to declared extras against the target-dir auto-grant (#756 item 4)

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "86a68875377dbb88e58a87c5535439637b006738a97847912cea9eaff7563953"}},
+  platforms = {["*"] = {sha = "556ac11698e1394e94905dffad4b436c8b4b0513f4d9d02b7efaae6edbc278f8"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.24-28d820234"
+  version = "2026.07.24-5d978d74d"
 }

--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "abfbe5ea59d515a9b1ff69a32ea6c5de7dc17314ffdf427402222a86596a6b50"}},
+  platforms = {["*"] = {sha = "86a68875377dbb88e58a87c5535439637b006738a97847912cea9eaff7563953"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.24-67f462c42"
+  version = "2026.07.24-28d820234"
 }

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ fetched: $(all_fetched)
 stdlib_lua := $(patsubst %.tl,$(o)/%.lua,$(filter lib/cosmic/%,$(foreach x,$(modules),$($(x)_tl))))
 $(o)/%/.fetched: export SSL_USE_SYSTEM_CERTS = 1
 $(o)/%/.fetched: .PLEDGE := $(pledge_build) inet dns
-$(o)/%/.fetched: .UNVEIL := $(unveil_dep) $(unveil_dev) r:/etc/resolv.conf r:/etc/hosts r:/etc/ssl $(if $(SSL_CERT_FILE),r:$(SSL_CERT_FILE))
+$(o)/%/.fetched: .UNVEIL := $(unveil_fetch) $(unveil_dev) r:/etc/resolv.conf r:/etc/hosts r:/etc/ssl $(if $(SSL_CERT_FILE),r:$(SSL_CERT_FILE))
 $(o)/%/.fetched: $(o)/%/.versioned $(build_files) $(stdlib_lua) | $(bootstrap_cosmic)
 	@$(bootstrap_cosmic) -- $(build_fetch) $< $(platform) $@
 
@@ -128,7 +128,7 @@ all_staged := $(patsubst %/.fetched,%/.staged,$(all_fetched))
 ## Fetch and extract all dependencies
 staged: $(all_staged)
 $(o)/%/.staged: .PLEDGE := $(pledge_build)
-$(o)/%/.staged: .UNVEIL := $(unveil_dep) $(unveil_dev)
+$(o)/%/.staged: .UNVEIL := $(unveil_stage) $(unveil_dev)
 $(o)/%/.staged: $(o)/%/.fetched $(build_files) $(stdlib_lua)
 	@$(bootstrap_cosmic) -- $(build_stage) $(o)/$*/.versioned $(platform) $< $@
 

--- a/Makefile
+++ b/Makefile
@@ -116,10 +116,16 @@ fetched: $(all_fetched)
 # bootstrap executes under these grants, with .ENV/.SANDBOXED/LUA_PATH
 # for the family living in cook.mk.
 stdlib_lua := $(patsubst %.tl,$(o)/%.lua,$(filter lib/cosmic/%,$(foreach x,$(modules),$($(x)_tl))))
+# The fetch/stage trees must EXIST before their sandboxed rules launch
+# (unveil silently skips missing paths — the same trap the target-dir
+# derivation closed upstream, one level up); the driver's list mode
+# mints them like $(o)/.exists.
+$(FETCH_O)/.exists $(STAGE_O)/.exists: $(build_recipe) | $(bootstrap_cosmic)
+	@$(bootstrap_cosmic) -- $(build_recipe) list $@
 $(o)/%/.fetched: export SSL_USE_SYSTEM_CERTS = 1
 $(o)/%/.fetched: .PLEDGE := $(pledge_build) inet dns
 $(o)/%/.fetched: .UNVEIL := $(unveil_fetch) $(unveil_dev) r:/etc/resolv.conf r:/etc/hosts r:/etc/ssl $(if $(SSL_CERT_FILE),r:$(SSL_CERT_FILE))
-$(o)/%/.fetched: $(o)/%/.versioned $(build_files) $(stdlib_lua) | $(bootstrap_cosmic)
+$(o)/%/.fetched: $(o)/%/.versioned $(build_files) $(stdlib_lua) | $(bootstrap_cosmic) $(FETCH_O)/.exists
 	@$(bootstrap_cosmic) -- $(build_fetch) $< $(platform) $@
 
 # versions get staged: o/module/.staged -> o/staged/module/<ver>-<sha>
@@ -129,7 +135,7 @@ all_staged := $(patsubst %/.fetched,%/.staged,$(all_fetched))
 staged: $(all_staged)
 $(o)/%/.staged: .PLEDGE := $(pledge_build)
 $(o)/%/.staged: .UNVEIL := $(unveil_stage) $(unveil_dev)
-$(o)/%/.staged: $(o)/%/.fetched $(build_files) $(stdlib_lua)
+$(o)/%/.staged: $(o)/%/.fetched $(build_files) $(stdlib_lua) | $(STAGE_O)/.exists
 	@$(bootstrap_cosmic) -- $(build_stage) $(o)/$*/.versioned $(platform) $< $@
 
 all_tests := $(call filter-only,$(foreach x,$(modules),$($(x)_tests)))

--- a/cook.mk
+++ b/cook.mk
@@ -33,7 +33,15 @@ unveil_dev := rw:/dev/null r:/dev/random r:/dev/urandom
 # Host set proven under real enforcement by the sandbox-canary (#724)
 # and the enforced families' CI runs: shell + coreutils + loaders.
 unveil_hostx := rx:/usr rx:/bin rx:/lib rx:/lib64 rx:/proc r:/etc $(unveil_dev)
-unveil_dep := rx:$(o)/bootstrap r:3p rwc:$(o)
+# Grants derived from the graph (#756 item 4, whilp/cosmopolitan#211):
+# landlock-make auto-grants rx on prerequisites and rwc on the target's
+# directory, so sandboxed families no longer hand-grant the whole
+# output tree — only genuinely-extra paths. fetch writes the archive
+# cache; stage reads it and writes the staged tree (their stamps and
+# symlinks live in the target's own directory, covered by the
+# auto-grant).
+unveil_fetch := rx:$(o)/bootstrap r:3p rwc:$(FETCH_O)
+unveil_stage := rx:$(o)/bootstrap r:3p r:$(FETCH_O) rwc:$(STAGE_O)
 # TMP is x: tests exec what they build there — embed outputs, scripts
 # under TEST_TMPDIR (proven need: embed/child/testrun under Landlock)
 unveil_test := $(unveil_base) rwcx:$(o) rwcx:$(TMP) $(unveil_hostx)
@@ -63,7 +71,7 @@ $(o)/%.lua: .PLEDGE := $(pledge_build) fattr
 # build-recipe driver — direct bootstrap execs under the global
 # no-shell default. The driver's own compile opts back out in
 # lib/build/cook.mk (self-bootstrap exception).
-$(o)/%.lua: .UNVEIL := rwc:$(o) r:tlconfig.lua $(unveil_dev)
+$(o)/%.lua: .UNVEIL := r:tlconfig.lua $(unveil_dev)
 # .ENV (#756 item 5): the compile child sees ONLY the declared set —
 # the three path axes below plus the pinned locale/tz and NO_COLOR
 # (deterministic output). A hostile caller variable cannot reach it;
@@ -110,7 +118,7 @@ $(o)/%/.fetched $(o)/%/.staged: export LUA_PATH = $(tree_lua_path)
 # sees it too, as the old shell prefix already had it.
 $(o)/%.lint.got: .SANDBOXED := 1
 $(o)/%.lint.got: .PLEDGE := $(pledge_build)
-$(o)/%.lint.got: .UNVEIL := rwc:$(o) rwc:$(TMP) $(unveil_dev)
+$(o)/%.lint.got: .UNVEIL := rwc:$(TMP) $(unveil_dev)
 $(o)/%.lint.got: .ENV := LUA_PATH TMPDIR LC_ALL TZ NO_COLOR
 $(o)/%.lint.got: export LUA_PATH = $(o)/lib/?.lua;$(o)/lib/?/init.lua;;
 # Reporter summaries (bootstrap + tee). test/coverage/enforce summaries
@@ -122,7 +130,7 @@ $(reporter_summaries): .PLEDGE := $(pledge_build)
 # De-hosted (#732): the reporter writes its own summary (--out replaces
 # `| tee`), so these recipes are direct bootstrap execs — same no-shell
 # fast path + tripwire as fetch/stage above.
-$(reporter_summaries): .UNVEIL := rwc:$(o) $(unveil_dev)
+$(reporter_summaries): .UNVEIL := $(unveil_dev)
 # REPORTER_NOTE: the lint summary's deleted-files note rides the env
 $(reporter_summaries): .ENV := LUA_PATH REPORTER_NOTE LC_ALL TZ NO_COLOR
 $(reporter_summaries): export LUA_PATH = $(tree_lua_path)
@@ -136,12 +144,12 @@ $(reporter_summaries): export LUA_PATH = $(tree_lua_path)
 # grants. testrun mkdtemps the per-check TEST_TMPDIR under $(TMP).
 $(o)/%.teal.got: .SANDBOXED := 1
 $(o)/%.teal.got: .PLEDGE := $(pledge_build)
-$(o)/%.teal.got: .UNVEIL := rwc:$(o) r:tlconfig.lua rwc:$(TMP) $(unveil_dev)
+$(o)/%.teal.got: .UNVEIL := r:tlconfig.lua rwc:$(TMP) $(unveil_dev)
 $(o)/%.teal.got: .ENV := TL_PATH TMPDIR LC_ALL TZ NO_COLOR
 $(o)/%.teal.got: export TL_PATH = $(tree_tl_path)
 $(o)/%.format.got: .SANDBOXED := 1
 $(o)/%.format.got: .PLEDGE := $(pledge_build)
-$(o)/%.format.got: .UNVEIL := rwc:$(o) r:tlconfig.lua rwc:$(TMP) $(unveil_dev)
+$(o)/%.format.got: .UNVEIL := r:tlconfig.lua rwc:$(TMP) $(unveil_dev)
 $(o)/%.format.got: .ENV := TMPDIR LC_ALL TZ NO_COLOR
 
 # Fifth ENFORCED family (#729): examples. Same grant sets as the test

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -77,8 +77,9 @@ $(build_make_out)/only-database.out: $(build_make_srcs)
 # Makefile's global defaults), and cosmopolitan's unveil() silently
 # no-ops where Landlock is unavailable, so nothing else in this build
 # can prove the enforcement mechanism still works. The probe rule opts
-# in with .SANDBOXED = 1 and a grant limited to its own directory, then
-# attempts a write outside that grant, recording the verdict inside it.
+# in with .SANDBOXED = 1, then attempts a write outside its grants,
+# recording the verdict beside its target (the derived target-dir
+# grant, #756 item 4).
 # ENOENT unveil entries are skipped by landlock-make, so the generous
 # rx list below is safe across hosts; the probe directory must exist
 # BEFORE the sandboxed rule runs (unveil on a missing path is a no-op).
@@ -96,7 +97,11 @@ $(canary_dir)/probe.got sandbox-canary: private SHELL := /bin/bash
 $(canary_dir)/probe.got sandbox-canary: private .SHELLFLAGS := -o pipefail -c
 $(canary_dir)/probe.got: .SANDBOXED := 1
 $(canary_dir)/probe.got: .PLEDGE := $(pledge_build)
-$(canary_dir)/probe.got: .UNVEIL := rwc:$(canary_dir) $(unveil_hostx)
+# The probe's own-directory grant is gone (#756 item 4): the target-dir
+# auto-grant must cover the verdict write, so the canary now ALSO
+# proves the derived grant under real Landlock — if the auto-grant
+# broke, the probe could not record its verdict and the canary fails.
+$(canary_dir)/probe.got: .UNVEIL := $(unveil_hostx)
 $(canary_dir)/probe.got: .FORCE
 	@if echo escaped 2>/dev/null > $(canary_escape); then \
 	  echo escaped > $@; \


### PR DESCRIPTION
Item 4's downstream half — the grant shrinkage the target-dir auto-grant (whilp/cosmopolitan#211, sibling issue #210) was built for. Rides cosmos `2026.07.24-5d978d74d`, which also carries the fix this PR's own CI forced upstream (whilp/cosmopolitan#212 — see below). regen-types: no drift across both bumps.

## What changed

With landlock-make deriving three of the four grant legs itself (rx on prerequisites, **rwc on the target's directory**, the merged global base), the hand grants shrink to genuinely-per-rule extras:

- **compile, lint, teal, format, reporter summaries**: `rwc:$(o)` dropped — each family keeps only `tlconfig.lua`, `$(TMP)`, and the device nodes it actually touches.
- **fetch/stage**: the shared `unveil_dep` (rwc on the *whole* output tree) splits into `unveil_fetch` (writes the archive cache, `rwc:$(FETCH_O)`) and `unveil_stage` (reads it, writes the staged tree, `r:$(FETCH_O) rwc:$(STAGE_O)`) — a real narrowing: fetch can no longer write the staged tree nor stage the cache.
- **the sandbox-canary probe drops its own-directory grant entirely**: the auto-grant must cover the verdict write, so the canary — CI's proof that enforcement works at all — now *also* attests the derived grant under real Landlock on every enforce run.

## What CI caught (twice), and where each fix landed

Local validation could not enforce anything (no Landlock in the dev container — flagged from the start), and the Landlock lanes earned their keep, exposing the same failure class at two levels:

1. **Round 1, all five Linux lanes red**: `unveil` on a nonexistent path is a silent no-op, and on a cold tree the *target's directory* doesn't exist yet at sandbox setup — the auto-grant vanished exactly when needed (compile `ENOENT`, copies `EACCES`). Fixed **upstream** in whilp/cosmopolitan#212: make now creates the target's directory immediately before unveiling it, and this PR's pin bump to `5d978d74d` picks that up.
2. **Round 2, fetch red**: the same trap one level up — `rwc:$(FETCH_O)`/`rwc:$(STAGE_O)` no-op'd because `o/fetched`/`o/staged` don't exist on a cold tree, denying the very writes that would create them. Fixed **here** with the repo's own idiom: the driver's list mode mints each tree (`$(FETCH_O)/.exists`, `$(STAGE_O)/.exists`), order-only, before the sandboxed rules launch — the same pattern as `$(o)/.exists`.

## Verification

- CI green across all lanes on the final head — build/offline exercising the narrowed families under real Landlock, enforce attesting the canary's auto-grant dependence, reproducible double-building through the derived grants.
- Locally: cold fetch/stage through the stamps, the missing-deep-directory probe against the extracted make, full `bin/make -j ci` → `ci: PASS` at each step.

Remaining on #756 after this: item 3 (CLI consolidation across a pin-bump cycle) and the item 7 ADR. Default-deny mode and the unused-grant audit stay tracked upstream in #210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13