### PR TITLE
build: fold the recipe driver into the cosmic CLI as --build (#756 item 3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,6 +276,7 @@ cosmic --docs <query>         search documentation
 cosmic --examples [module]    browse examples
 cosmic --test <out> <cmd>     run test, capture output
 cosmic --report <paths>       report test results
+cosmic --build <mode> <args>  run a shell-free build recipe step
 cosmic --embed <path>         embed files into executable
 cosmic --benchmark file.tl    run benchmarks
 cosmic -i                     interactive REPL

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -15,17 +15,21 @@ build_pack := $(o)/lib/build/build-pack.lua
 build_makeboot := $(o)/lib/build/make-boot.lua
 build_files := $(build_fetch) $(build_stage) $(build_untar) $(build_pack) $(build_portable) $(build_reporter) $(build_help) $(build_lint) $(build_makeboot)
 
-# Self-bootstrap exception (#732): build-recipe drives the shell-free
+# Self-bootstrap exception (#732): the driver drives the shell-free
 # compile/copy/link recipes, so it cannot be compiled by them — this one
 # target keeps the old shell recipe (and the host grants + real shell it
-# needs), and everything else compiles through the driver. The driver
+# needs), and everything else compiles through the driver. The source is
+# lib/cosmic/build.tl (#756 item 3): the same module the cosmic binary
+# embeds behind `--build`; this compiled copy exists only until a
+# bootstrap pin ships that flag, at which point the recipes call
+# `$(bootstrap_cosmic) --build ...` and this rule disappears. The driver
 # runs against the bootstrap's EMBEDDED stdlib (see its header), so the
 # bootstrap sha covers its runtime and no tree .lua is required first.
 $(build_recipe): private SHELL := /bin/bash
 $(build_recipe): private .SHELLFLAGS := -o pipefail -c
 $(build_recipe): export LUA_PATH := ;;
 $(build_recipe): .UNVEIL := rwc:$(o) r:tlconfig.lua $(unveil_hostx)
-$(build_recipe): lib/build/build-recipe.tl $(types_files) $(tl_files) $(bootstrap_files) $(compile_flag_stamp)
+$(build_recipe): lib/cosmic/build.tl $(types_files) $(tl_files) $(bootstrap_files) $(compile_flag_stamp)
 	@mkdir -p $(@D)
 	@f=$$(cat $(compile_flag_stamp)); if [ "$$f" = "--compile-strict" ]; then export LUA_PATH=";;"; else export LUA_PATH="$(tree_lua_path)"; fi; export TL_PATH="$(tree_tl_path)"; $(bootstrap_cosmic) $(include_dir_flags) $$f $< > $@.tmp
 	@if cmp -s $@.tmp $@ 2>/dev/null; then rm $@.tmp; else mv $@.tmp $@; fi

--- a/lib/cosmic/build.tl
+++ b/lib/cosmic/build.tl
@@ -1,18 +1,24 @@
-#!/usr/bin/env lua
---- Shell-free recipe steps for the compile, copy, version-link, and
---- doc-index rules (#732): `compile` replaces the cat/if/redirect/
---- cmp/mv dance, `copy` replaces mkdir+cp, `link` replaces
---- mkdir+ln -sfn, `capture` replaces redirect+cmp/mv for scripts.
+--- Shell-free recipe steps for the build's make rules (#732): `compile`
+--- replaces the cat/if/redirect/cmp/mv dance, `copy` replaces mkdir+cp,
+--- `link` replaces mkdir+ln -sfn, `capture` and `tee` replace redirects
+--- with cmp/mv or tee, plus list/remove/require-*/verdict.
 ---
---- Runs under the PINNED bootstrap against its EMBEDDED stdlib only —
---- deliberately no tree requires, unlike every other build script: the
---- compile rule is what BUILDS the tree's .lua files, so a tree
+--- Dual life (#756 item 3): embedded in the cosmic binary behind the
+--- greedy `--build <mode> <args>...` CLI flag — the surface recipes
+--- call once the bootstrap pin ships it — AND compiled to
+--- o/lib/build/build-recipe.lua by the self-bootstrap exception rule in
+--- lib/build/cook.mk, because today's PINNED bootstrap predates
+--- `--build` and the compile rule cannot compile its own driver. When a
+--- release carrying `--build` is pinned, the recipes become
+--- `$(bootstrap_cosmic) --build ...` and the compiled driver (and its
+--- exception rule) disappears.
+---
+--- Requires the EMBEDDED stdlib only — deliberately no tree modules:
+--- the compile rule is what BUILDS the tree's .lua files, so a tree
 --- dependency here is circular, and the recipes export LUA_PATH=";;"
 --- so a caller's LUA_PATH cannot redirect the driver's own requires.
---- The bootstrap sha therefore covers this driver's entire runtime; a
+--- The bootstrap sha therefore covers the driver's entire runtime; a
 --- bootstrap bump that breaks an embedded API fails the build loudly.
---- The driver's own .lua is compiled by a self-bootstrap exception
---- rule (see lib/build/cook.mk) — it cannot compile itself.
 
 local child = require("cosmic.child")
 local env = require("cosmic.env")
@@ -21,7 +27,7 @@ local fs_types = require("cosmic.fs.types")
 local proc = require("cosmic.proc")
 
 local function fail(msg: string): integer
-  io.stderr:write("build-recipe: " .. msg .. "\n")
+  io.stderr:write("--build: " .. msg .. "\n")
   return 1
 end
 
@@ -323,7 +329,7 @@ local function main(...: string): integer
   local mode = table.remove(args, 1)
   local run_mode = mode and modes[mode]
   if not run_mode then
-    return fail("usage: build-recipe <mode> ... (see the modes table)")
+    return fail("usage: --build <mode> ... (see the modes table)")
   end
   return run_mode(args)
 end

--- a/lib/cosmic/build_test.tl
+++ b/lib/cosmic/build_test.tl
@@ -1,7 +1,8 @@
 #!/usr/bin/env cosmic
--- Tests for the build-recipe driver (#732). The driver is spawned the
--- way make spawns it, with the test cosmic binary standing in as the
--- pinned bootstrap for compile mode.
+-- Tests for cosmic.build (#732, #756 item 3): the shell-free recipe
+-- steps behind `--build`, spawned the way make will spawn them, with
+-- the test cosmic binary standing in as the pinned bootstrap for
+-- compile mode.
 
 local child = require("cosmic.child")
 local env = require("cosmic.env")
@@ -10,11 +11,9 @@ local fs_types = require("cosmic.fs.types")
 
 local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
 local test_bin = fs.join(os.getenv("TEST_BIN") or "", "cosmic")
-local test_o = os.getenv("TEST_O") or "o"
-local driver = fs.join(test_o, "lib/build/build-recipe.lua")
 
 local function run_driver(...: string): integer, string, string
-  local args: {string} = {test_bin, "--", driver}
+  local args: {string} = {test_bin, "--build"}
   for _, a in ipairs({...}) do
     table.insert(args, a)
   end
@@ -132,6 +131,18 @@ local function test_tee_prints_and_writes()
   assert(written:match("report line"), "tee must write the file")
 end
 test_tee_prints_and_writes()
+
+local function test_child_flags_not_consumed()
+  -- the payload after the mode is a foreign argv: cosmic flags in it
+  -- belong to the child (the recipe shape `--build tee out cosmic
+  -- --report ...`), and the dispatcher must not let getopt permute
+  -- them into its own options
+  local out = fs.join(tmpdir, "tee/version.txt")
+  local code, stdout, err = run_driver("tee", out, test_bin, "--version")
+  assert(code == 0, "tee --version failed (" .. tostring(code) .. "): " .. err)
+  assert(stdout:match("cosmic%-lua"), "child --version output expected, got: " .. stdout)
+end
+test_child_flags_not_consumed()
 
 local function test_tee_propagates_failure_after_writing()
   local out = fs.join(tmpdir, "tee/fail.txt")

--- a/lib/cosmic/cli/args.tl
+++ b/lib/cosmic/cli/args.tl
@@ -30,11 +30,36 @@ local longopts: {getopt.LongOpt} = {
   {name = "test", has_arg = "required"},
   {name = "report", has_arg = "none"},
   {name = "coverage-report", has_arg = "none"},
+  {name = "build", has_arg = "required"},
   {name = "make", has_arg = "optional"},
   {name = "skill", has_arg = "required"},
   {name = "write-if-changed", has_arg = "none"},
   {name = "include-dir", has_arg = "required"},
 }
+
+--- Options requiring an argument, derived from the tables above and
+--- shared so the dispatcher's pre-scan stays in sync with them.
+local short_needs_arg: {string: boolean} = {}
+do
+  local j = 1
+  while j <= #shortopts do
+    local c = shortopts:sub(j, j)
+    if c ~= ":" then
+      if j < #shortopts and shortopts:sub(j + 1, j + 1) == ":" and
+      (j + 1 >= #shortopts or shortopts:sub(j + 2, j + 2) ~= ":") then
+        short_needs_arg[c] = true
+      end
+    end
+    j = j + 1
+  end
+end
+
+local long_needs_arg: {string: boolean} = {}
+for _, opt in ipairs(longopts) do
+  if opt.has_arg == "required" then
+    long_needs_arg[opt.name] = true
+  end
+end
 
 --- Resolve optional arg value that may be space-separated.
 --- For flags like --docs, --examples, --make where getopt returns ""
@@ -55,5 +80,7 @@ end
 return {
   shortopts = shortopts,
   longopts = longopts,
+  short_needs_arg = short_needs_arg,
+  long_needs_arg = long_needs_arg,
   resolve_optional_arg = resolve_optional_arg,
 }

--- a/lib/cosmic/cli/main.tl
+++ b/lib/cosmic/cli/main.tl
@@ -46,6 +46,8 @@ local record Options
   test_output: string
   report_paths: {string}
   coverage_report_paths: {string}
+  build_mode: string
+  build_argv: {string}
   make: string
   skill: string
   write_if_changed: boolean
@@ -55,6 +57,8 @@ end
 
 -- Parse arguments using cosmo.getopt iterator API
 local function parse_args(): Options
+  -- Absent record fields read as nil; only the accumulating and
+  -- boolean fields need initial values.
   local opts: Options = {
     execute = {},
     load = {},
@@ -62,59 +66,17 @@ local function parse_args(): Options
     version = false,
     warnings = false,
     help = false,
-    script = nil,
     script_args = {},
-    compile = nil,
-    compile_strict = nil,
-    format = nil,
-    fix = nil,
-    check_format = nil,
-    check_types = nil,
-    check_style = nil,
     embed = {},
-    output = nil,
-    extract = nil,
-    exe = nil,
-    check_examples = nil,
-    examples = nil,
-    benchmark = nil,
-    docs = nil,
     welcome = false,
-    test_argv = nil,
-    test_output = nil,
-    report_paths = nil,
-    coverage_report_paths = nil,
-    make = nil,
-    skill = nil,
     write_if_changed = false,
     include_dirs = {},
-    error = nil,
   }
 
   local shortopts = cli_args.shortopts
   local longopts: {getopt.LongOpt} = cli_args.longopts
-
-  -- Parse shortopts to build set of options that require arguments
-  local short_needs_arg: {string: boolean} = {}
-  local j = 1
-  while j <= #shortopts do
-    local c = shortopts:sub(j, j)
-    if c ~= ":" then
-      if j < #shortopts and shortopts:sub(j + 1, j + 1) == ":" and
-      (j + 1 >= #shortopts or shortopts:sub(j + 2, j + 2) ~= ":") then
-        short_needs_arg[c] = true
-      end
-    end
-    j = j + 1
-  end
-
-  -- Parse longopts to build set of options that require arguments
-  local long_needs_arg: {string: boolean} = {}
-  for _, opt in ipairs(longopts) do
-    if opt.has_arg == "required" then
-      long_needs_arg[opt.name] = true
-    end
-  end
+  local short_needs_arg = cli_args.short_needs_arg
+  local long_needs_arg = cli_args.long_needs_arg
 
   -- Options that consume all remaining arguments (no script after them)
   local long_greedy: {string: boolean} = {
@@ -128,6 +90,12 @@ local function parse_args(): Options
 
   -- Find first non-option argument (script name) to know where to stop parsing
   local script_idx: integer = nil
+  -- --build's payload after the mode is a FOREIGN argv — the recipe
+  -- child's own flags (`--build tee out cosmic --report ...`). getopt
+  -- permutes, so it would consume those flags as cosmic options; slice
+  -- the payload off here and parse only up to the mode argument.
+  local build_payload: {string} = nil
+  local build_parse_end: integer = nil
   local i = 1
   while i <= #arg do
     local a = arg[i]
@@ -136,7 +104,15 @@ local function parse_args(): Options
       break
     elseif a:sub(1, 2) == "--" then
       local opt_name = a:sub(3)
-      if long_greedy[opt_name] then
+      if opt_name == "build" then
+        build_payload = {}
+        for k = i + 2, #arg do
+          build_payload[#build_payload + 1] = arg[k]
+        end
+        build_parse_end = i + 1
+        script_idx = nil
+        break
+      elseif long_greedy[opt_name] then
         script_idx = nil
         break
       elseif long_extra_arg[opt_name] then
@@ -165,6 +141,10 @@ local function parse_args(): Options
       if arg[k] ~= "--" then
         cosmic_args[#cosmic_args + 1] = arg[k]
       end
+    end
+  elseif build_parse_end then
+    for k = 1, math.min(build_parse_end, #arg) do
+      cosmic_args[#cosmic_args + 1] = arg[k]
     end
   else
     cosmic_args = arg
@@ -195,6 +175,8 @@ local function parse_args(): Options
     local m = r.missing[1]
     if m == "test" then
       opts.error = "cosmic-lua: --test requires: --test <output> <cmd>...\nSee: cosmic-lua --help"
+    elseif m == "build" then
+      opts.error = "cosmic-lua: --build requires: --build <mode> <args>...\nSee: cosmic-lua --help"
     elseif m == "embed" then
       opts.error = "cosmic-lua: --embed requires: --embed <path>\nSee: cosmic-lua --help"
     elseif m == "output" then
@@ -291,6 +273,10 @@ local function parse_args(): Options
       return opts
     elseif opt == "coverage-report" then
       opts.coverage_report_paths = r.args
+      return opts
+    elseif opt == "build" then
+      opts.build_mode = optarg
+      opts.build_argv = build_payload or {}
       return opts
     elseif opt == "make" then
       opts.make = optarg or ""
@@ -399,6 +385,21 @@ local function main(): integer, string
 
   if opts.coverage_report_paths then
     return require("cosmic.coverage").report(opts.coverage_report_paths)
+  end
+
+  if opts.build_mode then
+    -- Arm line coverage like the script path below does: --build runs
+    -- in the coverage lane must still report cosmic.build's lines.
+    local cov_dump: function() = nil
+    if os.getenv("COSMIC_COVERAGE") then
+      cov_dump = require("cosmic.coverage").enable_from_env()
+    end
+    local build = require("cosmic.build")
+    local code = build.main(opts.build_mode, table.unpack(opts.build_argv))
+    if cov_dump then
+      cov_dump()
+    end
+    return code
   end
 
   if opts.make ~= nil then

--- a/lib/cosmic/coverage/baseline.txt
+++ b/lib/cosmic/coverage/baseline.txt
@@ -2,7 +2,6 @@
 # columns: path covered-lines total-lines
 lib/build/build-fetch.tl 23 95
 lib/build/build-pack.tl 97 132
-lib/build/build-recipe.tl 172 206
 lib/build/build-stage.tl 45 251
 lib/build/build-untar.tl 121 130
 lib/build/lint.tl 97 132
@@ -12,6 +11,7 @@ lib/build/portable.tl 16 18
 lib/build/reporter.tl 145 159
 lib/cosmic/ansi.tl 86 86
 lib/cosmic/benchmark.tl 180 212
+lib/cosmic/build.tl 172 206
 lib/cosmic/check.tl 80 82
 lib/cosmic/child/fast.tl 40 52
 lib/cosmic/child/init.tl 214 247

--- a/lib/cosmic/public.tl
+++ b/lib/cosmic/public.tl
@@ -98,7 +98,12 @@ local public: {string} = {
 --- the shipped test battery alongside testrun/example/benchmark).
 --- `errno` stays public (the error convention's user-facing interface:
 --- wrappers document errno.is/errno.name_of by name).
+---
+--- #756 item 3: `build` is internal — the shell-free recipe steps
+--- behind the `--build` CLI flag; build-system tooling like `make`,
+--- not runtime API.
 local internal: {string} = {
+  "build",
   "cli",
   "make",
   "public",

--- a/sys/help.md
+++ b/sys/help.md
@@ -26,6 +26,8 @@ Cosmic options:
                                 e.g. cosmic --report o/foo.got
   --coverage-report <paths>...  merge .cov data, print per-file line coverage
                                 e.g. cosmic --coverage-report o/coverage lib
+  --build <mode> <args>...      run a shell-free build recipe step
+                                (copy, link, list, capture, tee, compile, ...)
   --make [dir] [target]         generate Makefile, pipe to make -f -
   --skill <dir>                 write agent skill file (SKILL.md) to directory
   --welcome                     show welcome message


### PR DESCRIPTION
The in-tree half of #756 item 3: the build-recipe driver's logic becomes part of the cosmic CLI proper, so the next release ships the surface recipes will call — and the pin-bump half of the cycle can then delete the driver, its self-bootstrap shell exception, and the "embedded-stdlib driver" special case entirely.

## What changed

- **`lib/build/build-recipe.tl` moves to `lib/cosmic/build.tl`** (internal module, listed in the PUBLIC manifest's internal set). Same eleven modes, same embedded-stdlib-only constraint — the module still requires nothing outside the pinned bootstrap's embedded stdlib, so the bootstrap sha keeps covering the driver's entire runtime.
- **New greedy CLI flag: `--build <mode> <args>...`** dispatching to the module, documented in `--help` (the help/args tests enforce that pairing). The cosmic binary now carries the recipe steps natively: `cosmic --build copy src dst`, `cosmic --build tee out cosmic --report ...`.
- **The driver keeps its dual life for exactly one pin cycle**: the self-bootstrap exception rule in `lib/build/cook.mk` now compiles `lib/cosmic/build.tl` to the same `o/lib/build/build-recipe.lua`, because today's pinned bootstrap predates `--build`. Once a release carrying this flag is pinned, recipes become `$(bootstrap_cosmic) --build ...` and the exception rule (with its real-shell + hostx grants) disappears — that is the phase-2 follow-up.

## The bug the new test caught

The `--build` payload is a **foreign argv**: in the phase-2 recipe shape `--build tee $@ $(cosmic_bin) --report $^`, the `--report` belongs to the child. cosmic's getopt permutes, so a first cut let it consume the child's flags as cosmic options (the tee test failed with the child's `-e` silently eaten — the child ran bare). The dispatcher now slices the payload off before getopt ever sees it, parsing only up to the mode argument; a regression test pins a cosmic long-flag (`--version`) surviving in the payload.

Two supporting changes:

- **Coverage arming extends to the `--build` path** (same shape as the script path), so the module's lines keep reporting in the coverage lane — the moved file lands at the same 172/206 the driver had, and only the row's path changed in the committed baseline.
- **`main.tl` stays under the 500-line cap** by sharing the derived needs-arg sets from `cli.args` (they're computed from that module's own tables, so they belong there) and dropping the redundant explicit `nil` field inits from the options literal.

## Verification

- `bin/make -j ci` → `ci: PASS` (format, teal, test, example, lint, coverage ratchet).
- Smoke: `--build list/tee/copy/...` behave as the driver did; `--build` with no mode and with an unknown mode both fail with usage errors; `--help` documents the flag.
- The full build itself still runs through the compiled driver under the pinned bootstrap — recipes are deliberately untouched in this half.

Remaining on #756 after this: item 3 phase 2 (rides the next bootstrap pin bump) and the item 7 ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13

---
_Generated by [Claude Code](https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13)_