### PR TITLE
docs: trust root + no-self-hosting ADRs (#756 item 7); fix the release build's cold-tree failure

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -135,3 +135,7 @@ the bootstrap avoids circular dependency (need cosmic to compile cosmic):
 4. `make stage2` (alias for `make ci`) re-checks everything with the refreshed bootstrap
 
 the bootstrap URL is pinned in `cook.mk`.
+
+the build's trust root — what `bin/make` fetches, what stays outside
+the root, and the settled decision that pinned make is permanent — is
+recorded in [decisions.md](decisions.md) (D13, D14).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -209,3 +209,69 @@ old one.
   AGENTS.md.
 - **consequences:** the decision log can grow without bloating the
   goals statement; goals stay short enough to actually be read.
+
+## D13 — the build's trust root is two pinned artifacts behind one committed fetcher
+
+- **date:** 2026-07
+- **context:** the #756 arc converged the build on "make as the pinned
+  job graph, cosmic as the only build logic": every recipe is a single
+  argv under a sha-pinned bootstrap, `SHELL` is poisoned globally with
+  per-rule exceptions, sandbox annotations and per-rule env clamps
+  document and (where opted in) enforce each rule's access. that
+  discipline is only as strong as what the build ultimately trusts.
+- **decision:** the chain, stated once: **kernel → committed `bin/make`
+  → two sha-pinned artifacts → everything else.** `bin/make` is POSIX
+  sh with one job — obtain the pinned bootstrap cosmic (release pinned
+  in `cook.mk`), which then extracts the pinned landlock-make from
+  `cosmos.zip` (release pinned in `3p/cosmos/version.lua`); it is the
+  sole provisioner of both, and re-provisions on pin bumps. everything
+  downstream — staged 3p, compiled tree, the cosmic binary, every gate —
+  runs under those two artifacts. deliberately **outside** the root,
+  enumerated: host `sh`/`curl`/`sha256sum` (and `od`/`sed`) for the
+  first fetch; host `git` for version stamping; the digest-pinned CI
+  container image. each link has a gate: the sha checks in `bin/make`
+  refuse a wrong artifact; the makefile ratchet tests enumerate the
+  real-shell exceptions and host-exec grants and statically scan recipe
+  text for shell metacharacters; the sandbox canary plus the enforce
+  lane prove enforcement works; the offline lane proves no undeclared
+  network; the reproducible lane proves double-build determinism; the
+  env-clamp fixture proves the `.ENV` clamp holds against a hostile
+  caller environment.
+- **rejected:** vendoring the binaries into git (the sha pin already
+  fixes the bytes; vendoring adds repo weight, not trust); trusting any
+  host toolchain beyond the first fetch (host make, cc, lua — where
+  host variance lives); collapsing to a single artifact by shipping
+  make inside the cosmic release binary (entangles the two release
+  cycles for no reduction in what must be trusted — one fetcher, two
+  pins is the achievable minimum).
+- **consequences:** `bin/make` is the only place host variance can bite
+  and the only committed shell that is not a per-rule exception; new
+  binaries enter the build only through pin bumps; the ratchets keep
+  the exception sets from regrowing silently. supply-chain review
+  reduces to: read `bin/make`, audit two shas, trust the kernel.
+
+## D14 — no self-hosting: pinned make is permanent
+
+- **date:** 2026-07
+- **context:** with all build logic in `.tl` under the bootstrap,
+  make's remaining roles are the graph itself — pattern rules,
+  `.SECONDEXPANSION`, the module `foreach`/`eval` expansion, staleness,
+  the jobserver — plus sandbox enforcement (`.PLEDGE`/`.UNVEIL`/
+  `.ENV`/`.SANDBOXED` in landlock-make). a cosmic-native graph executor
+  would close the loop and make cosmic fully self-hosting.
+- **decision:** pinned cosmo-make (the landlock-make maintained next
+  door in whilp/cosmopolitan) is a **permanent component, not a
+  waypoint**. the endgame shrinks what make *means* — a job-execution
+  system and dependency graph, nothing else — and that is the end
+  state. build capabilities arrive as landlock-make features upstream
+  plus cosmic-side adoption, both pinned.
+- **rejected:** a cosmic-native graph executor (re-implementing
+  staleness, parallelism, and the jobserver is high-risk scar tissue
+  with no user-facing payoff — cosmic's mission is user tooling, and
+  `--make` project scaffolding already covers users); driving the
+  build from a cosmic script that shells out to make as a library.
+- **consequences:** the build keeps a second pinned binary forever
+  (priced into D13); graph-level features go through an upstream
+  release cycle rather than a tree edit; make syntax remains a
+  reviewed boundary, held small by the no-shell default and the
+  ratchets.

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -159,7 +159,12 @@ $(o)/ci-selftest-launder-summary.txt:
 # look stale INSIDE the nested run, which then rebuilds the parent's
 # own driver in a race against the outer make (witnessed: the nested
 # compile's cmp/mv losing its .tmp mid-flight).
-$(build_make_out)/ci-launder.out: $(build_make_srcs)
+# Order-only on the driver: -o means "use, never remake", so on a COLD
+# tree the fixture must not start until the parent's driver exists —
+# without this the nested remove step dies on the missing .lua and the
+# fixture records an exec error instead of the graded ci: FAIL verdict
+# (witnessed: the release build's cold `make test`, 2026-07-24).
+$(build_make_out)/ci-launder.out: $(build_make_srcs) | $(build_recipe) $(bootstrap_cosmic)
 	@mkdir -p $(@D)
 	@code=0; $(MAKE) ci o=$(o)/citest ci_stages=ci-selftest-launder bootstrap_cosmic=$(CURDIR)/$(bootstrap_cosmic) build_recipe=$(CURDIR)/$(build_recipe) -o $(CURDIR)/$(bootstrap_cosmic) -o $(CURDIR)/$(build_recipe) >$@.tmp 2>&1 || code=$$?; echo "exit:$$code" >> $@.tmp; mv $@.tmp $@
 


### PR DESCRIPTION
Two commits: the last item of #756 (the ADRs), plus the fix for the release run you triggered (https://github.com/whilp/cosmic/actions/runs/30125828482), which failed in `makefile_test` on its cold tree. **Merging this unblocks re-running the release**, which in turn unblocks item 3 phase 2 (the pin bump that deletes the driver) — that's staged and waiting.

## The release failure (second commit)

The ci-launder fixture's nested `make ci` hands in the parent's compiled driver with `-o` (use, never remake), but the fixture rule depended only on the makefiles. On a **cold** tree the driver doesn't exist when the fixture generates: the nested ci's `remove` step dies on the missing `.lua` (`cannot open o/lib/build/build-recipe.lua`), the fixture records an exec error with no `ci: FAIL` verdict line, and `test_ci_grading_catches_exit_after_clean_summary` fails. Warm dev trees never see it, and pr.yml runs had been getting survivable orderings; the release job's `-j teal test build` on a fresh checkout hits it deterministically. (#767 merged before its own cold CI finished, which is why this first surfaced in the release run.)

Fix: order-only prereqs on the driver and bootstrap for the fixture rule. Validated by reproducing the exact failure on a fresh `o/`, then re-running cold to green, then full `bin/make -j ci` → `ci: PASS`. Note this whole hazard class disappears in item 3 phase 2, when the nested ci stops needing a driver handoff at all.

## The ADRs (first commit)

- **D13 — the build's trust root is two pinned artifacts behind one committed fetcher.** States the chain once: kernel → committed `bin/make` (POSIX sh, one job) → the pinned bootstrap cosmic + the pinned cosmos.zip (from which the bootstrap extracts landlock-make) → everything else. Enumerates what is deliberately *outside* the root — host `sh`/`curl`/`sha256sum` for the first fetch, `git` for version stamping, the digest-pinned CI image — and names the gate proving each link. Records the rejected alternatives (vendoring binaries into git, trusting host toolchains beyond the first fetch, single-artifact packaging).
- **D14 — no self-hosting: pinned make is permanent.** The settled decision from the issue's preamble: cosmo-make keeps the graph and the sandbox surface; a cosmic-native graph executor is rejected. Consequences priced in: a second pinned binary forever, graph features via upstream release cycles.
- `docs/build.md`'s bootstrap section points at both entries.

## Verification

`bin/make -j ci` → `ci: PASS`, plus the dedicated cold-tree reproduction above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13