### PR TITLE
build: recipes call the bootstrap's own --build surface (#756 item 3, phase 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,17 +60,17 @@ help: $(build_files) | $(bootstrap_cosmic)
 ## Filter targets by substring (make test only=teal; also narrows fetch/stage)
 filter-only = $(if $(only),$(foreach f,$1,$(if $(findstring $(only),$(f)),$(f))),$1)
 
-# Copies and compiles run through the build-recipe driver (#732): no
-# shell, no host mkdir/cp/cat/cmp/mv (LUA_PATH pins live in cook.mk
-# with the family's other pattern vars). .exists orders cold-tree
-# copies after o/ exists (unveil skips missing paths silently).
-$(o)/%: % $(build_recipe) | $(o)/.exists $(bootstrap_cosmic)
-	@$(bootstrap_cosmic) -- $(build_recipe) copy $< $@
-$(o)/.exists: $(build_recipe) | $(bootstrap_cosmic)
-	@$(bootstrap_cosmic) -- $(build_recipe) list $@
+# Copies and compiles are the pinned bootstrap's --build steps (#732,
+# #756 item 3): no shell, no host mkdir/cp/cat/cmp/mv (LUA_PATH pins
+# live in cook.mk with the family's other pattern vars). .exists orders
+# cold-tree copies after o/ exists (unveil skips missing paths).
+$(o)/%: % | $(o)/.exists $(bootstrap_cosmic)
+	@$(bootstrap_cosmic) --build copy $< $@
+$(o)/.exists: | $(bootstrap_cosmic)
+	@$(bootstrap_cosmic) --build list $@
 
-$(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files) $(compile_flag_stamp) $(build_recipe)
-	@$(bootstrap_cosmic) -- $(build_recipe) compile $(compile_flag_stamp) $(bootstrap_cosmic) $< $@ $(include_dir_flags)
+$(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files) $(compile_flag_stamp)
+	@$(bootstrap_cosmic) --build compile $(compile_flag_stamp) $(bootstrap_cosmic) $< $@ $(include_dir_flags)
 
 # tl files: modules declare _tl, derive compiled .lua outputs
 all_tl := $(call filter-only,$(foreach x,$(modules),$($(x)_tl)))
@@ -96,7 +96,7 @@ all_versions := $(call filter-only,$(foreach x,$(modules),$($(x)_version)))
 
 # versioned modules: o/module/.versioned -> version.lua
 $(foreach m,$(modules),$(if $($(m)_version),\
-  $(eval $(o)/$(m)/.versioned: $($(m)_version) $(build_recipe) | $(bootstrap_cosmic) ; @$(bootstrap_cosmic) -- $(build_recipe) link $(CURDIR)/$$< $$@)))
+  $(eval $(o)/$(m)/.versioned: $($(m)_version) | $(bootstrap_cosmic) ; @$(bootstrap_cosmic) --build link $(CURDIR)/$$< $$@)))
 all_versioned := $(call filter-only,$(foreach m,$(modules),$(if $($(m)_version),$(o)/$(m)/.versioned)))
 
 # versions get fetched: o/module/.fetched -> o/fetched/module/<ver>-<sha>/<archive>
@@ -120,8 +120,8 @@ stdlib_lua := $(patsubst %.tl,$(o)/%.lua,$(filter lib/cosmic/%,$(foreach x,$(mod
 # (unveil silently skips missing paths — the same trap the target-dir
 # derivation closed upstream, one level up); the driver's list mode
 # mints them like $(o)/.exists.
-$(FETCH_O)/.exists $(STAGE_O)/.exists: $(build_recipe) | $(bootstrap_cosmic)
-	@$(bootstrap_cosmic) -- $(build_recipe) list $@
+$(FETCH_O)/.exists $(STAGE_O)/.exists: | $(bootstrap_cosmic)
+	@$(bootstrap_cosmic) --build list $@
 $(o)/%/.fetched: export SSL_USE_SYSTEM_CERTS = 1
 $(o)/%/.fetched: .PLEDGE := $(pledge_build) inet dns
 $(o)/%/.fetched: .UNVEIL := $(unveil_fetch) $(unveil_dev) r:/etc/resolv.conf r:/etc/hosts r:/etc/ssl $(if $(SSL_CERT_FILE),r:$(SSL_CERT_FILE))
@@ -145,8 +145,8 @@ all_tested := $(patsubst %,$(o)/%.test.got,$(all_tests))
 test: $(o)/test-summary.txt
 
 $(o)/test-summary.txt: export LUA_PATH := ;;
-$(o)/test-summary.txt: $(all_tested) | $(cosmic_bin) $(build_recipe)
-	@$(bootstrap_cosmic) -- $(build_recipe) tee $@ $(cosmic_bin) --report $^
+$(o)/test-summary.txt: $(all_tested) | $(cosmic_bin)
+	@$(bootstrap_cosmic) --build tee $@ $(cosmic_bin) --report $^
 
 export TEST_O := $(o)
 export TEST_PLATFORM := $(platform)
@@ -231,17 +231,17 @@ coverage_baseline_tool := $(o)/lib/cosmic/coverage/baseline.lua
 # when the filter is empty, so no quoting and no shell.
 $(o)/coverage-summary.txt: .PLEDGE := $(pledge_build)
 $(o)/coverage-summary.txt: .UNVEIL := $(unveil_base) rwcx:$(o)
-$(o)/coverage-summary.txt: $(coverage_got) | $(cosmic_bin) $(build_recipe)
-	@$(bootstrap_cosmic) -- $(build_recipe) capture $(cosmic_bin) $(o)/coverage-tests.txt --report $(coverage_got)
-	@$(bootstrap_cosmic) -- $(build_recipe) tee $@ $(cosmic_bin) --coverage-report $(o)/coverage lib
+$(o)/coverage-summary.txt: $(coverage_got) | $(cosmic_bin)
+	@$(bootstrap_cosmic) --build capture $(cosmic_bin) $(o)/coverage-tests.txt --report $(coverage_got)
+	@$(bootstrap_cosmic) --build tee $@ $(cosmic_bin) --coverage-report $(o)/coverage lib
 	@$(cosmic_bin) $(coverage_baseline_tool) gate $(coverage_baseline) --only=$(only) $(o)/coverage lib
 
 .PHONY: coverage-baseline
 ## Rewrite the committed coverage ratchet baseline from the last coverage run
 coverage-baseline: .PLEDGE := $(pledge_build)
 coverage-baseline: .UNVEIL := $(unveil_base) rwcx:$(o) rwc:lib/cosmic/coverage
-coverage-baseline: $(coverage_got) | $(cosmic_bin) $(build_recipe)
-	@$(bootstrap_cosmic) -- $(build_recipe) capture $(cosmic_bin) $(coverage_baseline) $(coverage_baseline_tool) write $(o)/coverage lib
+coverage-baseline: $(coverage_got) | $(cosmic_bin)
+	@$(bootstrap_cosmic) --build capture $(cosmic_bin) $(coverage_baseline) $(coverage_baseline_tool) write $(o)/coverage lib
 	@echo wrote $(coverage_baseline)
 
 # Privileged enforcement lane (Phase 1 step 8 prerequisite, audit §5.1).
@@ -275,9 +275,9 @@ $(o)/enforce/%.tl.test.got: $(o)/%.lua $(cosmic_bin)
 # The require-marker line is the tripwire: it fails the lane when no
 # enforcement ran (every sandbox test skipped — outer sandbox active?).
 $(o)/enforce-summary.txt: export LUA_PATH := ;;
-$(o)/enforce-summary.txt: $(enforce_got) | $(cosmic_bin) $(build_recipe)
-	@$(bootstrap_cosmic) -- $(build_recipe) tee $@ $(cosmic_bin) --report $^
-	@$(bootstrap_cosmic) -- $(build_recipe) require-marker enforce-ran: $(o)/enforce
+$(o)/enforce-summary.txt: $(enforce_got) | $(cosmic_bin)
+	@$(bootstrap_cosmic) --build tee $@ $(cosmic_bin) --report $^
+	@$(bootstrap_cosmic) --build require-marker enforce-ran: $(o)/enforce
 
 all_built_files := $(call filter-only,$(foreach x,$(modules),$($(x)_files)))
 all_built_files += $(all_lua)
@@ -331,8 +331,8 @@ lint_deleted := $(filter-out $(lint_present),$(lint_tracked))
 all_linted := $(patsubst %,$(o)/%.lint.got,$(lint_present))
 
 lint_list_stamp := $(o)/lint-files.stamp
-$(lint_list_stamp): .FORCE $(build_recipe)
-	@$(bootstrap_cosmic) -- $(build_recipe) list $@ $(lint_present)
+$(lint_list_stamp): .FORCE
+	@$(bootstrap_cosmic) --build list $@ $(lint_present)
 
 ## Check file length limits on all files
 lint: $(o)/lint-summary.txt
@@ -418,11 +418,11 @@ docs: $(all_docs)
 
 # De-shelled (#756 item 2): the driver's capture mode owns the output
 # file (and its parent directory) — no mkdir, no redirect.
-$(o)/docs/%.md: %.tl $(cosmic_bin) $(build_recipe) | $(bootstrap_files)
-	@$(bootstrap_cosmic) -- $(build_recipe) capture $(cosmic_bin) $@ lib/cosmic/doc/gendoc.tl $<
+$(o)/docs/%.md: %.tl $(cosmic_bin) | $(bootstrap_files)
+	@$(bootstrap_cosmic) --build capture $(cosmic_bin) $@ lib/cosmic/doc/gendoc.tl $<
 
-$(o)/docs/cosmo/%.md: lib/types/cosmo/%.d.tl $(cosmic_bin) $(build_recipe) | $(bootstrap_files)
-	@$(bootstrap_cosmic) -- $(build_recipe) capture $(cosmic_bin) $@ lib/cosmic/doc/gendoc.tl $<
+$(o)/docs/cosmo/%.md: lib/types/cosmo/%.d.tl $(cosmic_bin) | $(bootstrap_files)
+	@$(bootstrap_cosmic) --build capture $(cosmic_bin) $@ lib/cosmic/doc/gendoc.tl $<
 
 # Generate serialized doc index for embedding (uses bootstrap cosmic to avoid circular dep)
 # Include both module sources and example files for the index
@@ -445,8 +445,8 @@ doc_index_script := lib/cosmic/doc/index.tl
 # cook.mk edits (#717). The write-if-changed dance below keeps the
 # binary from re-embedding when the regenerated content is identical
 $(doc_index): export TREE_LUA_PATH = $(o)/lib/?.lua;$(o)/lib/?/init.lua;;
-$(doc_index): $(doc_index_srcs) $(doc_index_lua) $(doc_index_script) $(build_recipe) $(MAKEFILE_LIST) | $(bootstrap_cosmic)
-	@$(bootstrap_cosmic) -- $(build_recipe) capture $(bootstrap_cosmic) $@ $(doc_index_script) $(doc_index_srcs)
+$(doc_index): $(doc_index_srcs) $(doc_index_lua) $(doc_index_script) $(MAKEFILE_LIST) | $(bootstrap_cosmic)
+	@$(bootstrap_cosmic) --build capture $(bootstrap_cosmic) $@ $(doc_index_script) $(doc_index_srcs)
 
 .PHONY: doc-index
 ## Generate serialized documentation index
@@ -475,7 +475,7 @@ ci_marks := $(foreach s,$(ci_stages),$(o)/ci-ok-$(s))
 # markers build in ONE sub-make, so stages keep sharing the target graph
 # and run in parallel without racing on common prerequisites.
 $(o)/ci-ok-%: %
-	@$(bootstrap_cosmic) -- $(build_recipe) list $@
+	@$(bootstrap_cosmic) --build list $@
 
 .PHONY: ci
 ## Run CI checks (format, teal, test, example, lint) in parallel
@@ -483,10 +483,10 @@ $(o)/ci-ok-%: %
 # (same #714 semantics — summary text AND exit marker — gated by the
 # ci-launder fixture); `-` on the sub-make replaces `|| true`.
 ci: export LUA_PATH := ;;
-ci: | $(bootstrap_cosmic) $(build_recipe)
-	@$(bootstrap_cosmic) -- $(build_recipe) remove $(ci_summaries) $(ci_marks)
+ci: | $(bootstrap_cosmic)
+	@$(bootstrap_cosmic) --build remove $(ci_summaries) $(ci_marks)
 	-@$(MAKE) --keep-going $(ci_marks)
-	@$(bootstrap_cosmic) -- $(build_recipe) verdict $(o) $(ci_stages)
+	@$(bootstrap_cosmic) --build verdict $(o) $(ci_stages)
 
 # No-shell DEFAULT (#756 item 2, inverting #732's per-family opt-in).
 # Set LAST so the parse-time $(shell) queries above ran under the real

--- a/cook.mk
+++ b/cook.mk
@@ -68,18 +68,18 @@ pledge_test := $(pledge_build) fattr inet dns unix tty id flock
 $(o)/%.lua: .SANDBOXED := 1
 $(o)/%.lua: .PLEDGE := $(pledge_build) fattr
 # De-hosted (#732): compiles and the $(o)/%: % copies run through the
-# build-recipe driver — direct bootstrap execs under the global
-# no-shell default. The driver's own compile opts back out in
-# lib/build/cook.mk (self-bootstrap exception).
+# pinned bootstrap's own --build recipe steps (#756 item 3) — direct
+# bootstrap execs under the global no-shell default.
 $(o)/%.lua: .UNVEIL := r:tlconfig.lua $(unveil_dev)
 # .ENV (#756 item 5): the compile child sees ONLY the declared set —
 # the three path axes below plus the pinned locale/tz and NO_COLOR
 # (deterministic output). A hostile caller variable cannot reach it;
 # gate: the env-clamp fixture's clamped probe in lib/build/cook.mk.
 $(o)/%.lua: .ENV := LUA_PATH TREE_LUA_PATH TL_PATH LC_ALL TZ NO_COLOR
-# LUA_PATH=;; pins the DRIVER to the bootstrap's embedded stdlib (a
-# caller's LUA_PATH must not redirect its requires); the compile child
-# gets ";;" (strict) or TREE_LUA_PATH — the #666 axis, one layer down.
+# LUA_PATH=;; pins the --build dispatcher to the bootstrap's embedded
+# stdlib (a caller's LUA_PATH must not redirect its requires); the
+# compile child gets ";;" (strict) or TREE_LUA_PATH — the #666 axis,
+# one layer down.
 $(o)/%.lua: export LUA_PATH := ;;
 $(o)/%.lua: export TREE_LUA_PATH = $(tree_lua_path)
 $(o)/%.lua: export TL_PATH = $(tree_tl_path)
@@ -190,18 +190,21 @@ type_modules := cosmo unix path getopt lsqlite3 re argon2 zip repl
 modules += bootstrap
 bootstrap_cosmic := $(o)/bootstrap/cosmic
 bootstrap_files := $(bootstrap_cosmic)
-bootstrap_url := https://github.com/whilp/cosmic/releases/download/2026-07-19-5c6bce5/cosmic-lua
+bootstrap_url := https://github.com/whilp/cosmic/releases/download/2026-07-24-45acffa/cosmic-lua
 # SHA-256 of the bootstrap cosmic binary. It compiles the entire project, so
 # verify it before executing. Update this when bumping bootstrap_url.
-# This pin ships --compile-strict, so the probe selects hermetic
-# LUA_PATH=";;" compiles — a reproducibility requirement (#733): the
-# pre-strict tree-LUA_PATH path made compiled output depend on parallel
-# build order (bootstrap's embedded stdlib vs the tree's, whichever
-# existed first). LUA_PATH governs runtime require; the TYPE-resolution
-# axis (tl.search_module) is pinned separately to the tree via TL_PATH in
-# the compile/check recipes, so a compile can never type-check against the
-# bootstrap's stale embedded source (#744 — see tree_tl_path).
-bootstrap_sha256 := 6c2a0afe6c942560ce2a0d796ddf8f8df096ce2c92b8ce142c28da59ecac6dc6
+# This pin ships --build (#756 item 3), so every recipe step — compile,
+# copy, link, capture, tee, list, remove, require-*, verdict — is the
+# bootstrap's own surface and the compiled driver is gone. It also ships
+# --compile-strict, so the probe selects hermetic LUA_PATH=";;" compiles
+# — a reproducibility requirement (#733): the pre-strict tree-LUA_PATH
+# path made compiled output depend on parallel build order (bootstrap's
+# embedded stdlib vs the tree's, whichever existed first). LUA_PATH
+# governs runtime require; the TYPE-resolution axis (tl.search_module)
+# is pinned separately to the tree via TL_PATH in the compile/check
+# recipes, so a compile can never type-check against the bootstrap's
+# stale embedded source (#744 — see tree_tl_path).
+bootstrap_sha256 := 2469fb2f5a9197d8bacdeefd6b99366f318b813a2de48578b047e43c5954158e
 
 # bin/make is the SOLE provisioner of the bootstrap (#756 cleanup): it
 # runs before every make invocation, parses the pin above via sed,

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -7,7 +7,6 @@ build_portable := $(o)/lib/build/portable.lua
 build_reporter := $(o)/lib/build/reporter.lua
 build_help := $(o)/lib/build/make-help.lua
 build_lint := $(o)/lib/build/lint.lua
-build_recipe := $(o)/lib/build/build-recipe.lua
 build_pack := $(o)/lib/build/build-pack.lua
 # make-boot runs from SOURCE under the bootstrap (bin/make invokes it
 # before any make exists); the compiled copy is built so it gets the
@@ -15,24 +14,12 @@ build_pack := $(o)/lib/build/build-pack.lua
 build_makeboot := $(o)/lib/build/make-boot.lua
 build_files := $(build_fetch) $(build_stage) $(build_untar) $(build_pack) $(build_portable) $(build_reporter) $(build_help) $(build_lint) $(build_makeboot)
 
-# Self-bootstrap exception (#732): the driver drives the shell-free
-# compile/copy/link recipes, so it cannot be compiled by them — this one
-# target keeps the old shell recipe (and the host grants + real shell it
-# needs), and everything else compiles through the driver. The source is
-# lib/cosmic/build.tl (#756 item 3): the same module the cosmic binary
-# embeds behind `--build`; this compiled copy exists only until a
-# bootstrap pin ships that flag, at which point the recipes call
-# `$(bootstrap_cosmic) --build ...` and this rule disappears. The driver
-# runs against the bootstrap's EMBEDDED stdlib (see its header), so the
-# bootstrap sha covers its runtime and no tree .lua is required first.
-$(build_recipe): private SHELL := /bin/bash
-$(build_recipe): private .SHELLFLAGS := -o pipefail -c
-$(build_recipe): export LUA_PATH := ;;
-$(build_recipe): .UNVEIL := rwc:$(o) r:tlconfig.lua $(unveil_hostx)
-$(build_recipe): lib/cosmic/build.tl $(types_files) $(tl_files) $(bootstrap_files) $(compile_flag_stamp)
-	@mkdir -p $(@D)
-	@f=$$(cat $(compile_flag_stamp)); if [ "$$f" = "--compile-strict" ]; then export LUA_PATH=";;"; else export LUA_PATH="$(tree_lua_path)"; fi; export TL_PATH="$(tree_tl_path)"; $(bootstrap_cosmic) $(include_dir_flags) $$f $< > $@.tmp
-	@if cmp -s $@.tmp $@ 2>/dev/null; then rm $@.tmp; else mv $@.tmp $@; fi
+# The recipe steps (copy/compile/capture/tee/...) are the pinned
+# bootstrap's own `--build` surface (#756 item 3): cosmic.build ships
+# EMBEDDED in the bootstrap, so the bootstrap sha covers the driver's
+# entire runtime and no tree .lua is required first. The old compiled
+# driver — and the self-bootstrap shell exception rule that built it,
+# the last real-shell + host-grant build rule — is gone.
 build_tests := $(wildcard lib/build/*_test.tl)
 
 # lint.lua delegates its shared checks to cosmic.cli.style; LUA_PATH points
@@ -51,8 +38,8 @@ $(build_test_got): $(build_files)
 # make-help snapshot: generate actual help output (driver capture, #732)
 $(o)/lib/build/make-help.snap: export LUA_PATH := ;;
 $(o)/lib/build/make-help.snap: export TREE_LUA_PATH = $(tree_lua_path)
-$(o)/lib/build/make-help.snap: Makefile $(build_help) $(build_recipe) | $(bootstrap_cosmic)
-	@$(bootstrap_cosmic) -- $(build_recipe) capture $(bootstrap_cosmic) $@ $(build_help) Makefile
+$(o)/lib/build/make-help.snap: Makefile $(build_help) | $(bootstrap_cosmic)
+	@$(bootstrap_cosmic) --build capture $(bootstrap_cosmic) $@ $(build_help) Makefile
 
 # makefile validation outputs
 build_make_out := $(o)/lib/build/make
@@ -152,21 +139,17 @@ $(o)/ci-selftest-launder-summary.txt:
 # above; the graded verdict must be FAIL. o= points the nested run at
 # its own output tree so its failed/summary/marker files never collide
 # with the real ci run that builds this fixture.
-# The nested tree has no bootstrap/driver of its own; the ci recipe's
-# remove/verdict steps exec them, so the fixture hands in the parent's
-# by absolute path (#732) — and marks them -o (old-file: use, never
-# remake): without that, a parent-tree bootstrap refresh makes them
-# look stale INSIDE the nested run, which then rebuilds the parent's
-# own driver in a race against the outer make (witnessed: the nested
-# compile's cmp/mv losing its .tmp mid-flight).
-# Order-only on the driver: -o means "use, never remake", so on a COLD
-# tree the fixture must not start until the parent's driver exists —
-# without this the nested remove step dies on the missing .lua and the
-# fixture records an exec error instead of the graded ci: FAIL verdict
-# (witnessed: the release build's cold `make test`, 2026-07-24).
-$(build_make_out)/ci-launder.out: $(build_make_srcs) | $(build_recipe) $(bootstrap_cosmic)
+# The nested tree has no bootstrap of its own; the ci recipe's --build
+# steps exec it, so the fixture hands in the parent's by absolute path
+# (#732) — and marks it -o (old-file: use, never remake): without that,
+# a parent-tree bootstrap refresh makes it look stale INSIDE the nested
+# run, racing the outer make. The old compiled-driver handoff (and its
+# cold-tree ENOENT ordering hazard) is gone with the driver itself
+# (#756 item 3): bin/make provisions the bootstrap before any rule
+# runs, so it always exists.
+$(build_make_out)/ci-launder.out: $(build_make_srcs) | $(bootstrap_cosmic)
 	@mkdir -p $(@D)
-	@code=0; $(MAKE) ci o=$(o)/citest ci_stages=ci-selftest-launder bootstrap_cosmic=$(CURDIR)/$(bootstrap_cosmic) build_recipe=$(CURDIR)/$(build_recipe) -o $(CURDIR)/$(bootstrap_cosmic) -o $(CURDIR)/$(build_recipe) >$@.tmp 2>&1 || code=$$?; echo "exit:$$code" >> $@.tmp; mv $@.tmp $@
+	@code=0; $(MAKE) ci o=$(o)/citest ci_stages=ci-selftest-launder bootstrap_cosmic=$(CURDIR)/$(bootstrap_cosmic) -o $(CURDIR)/$(bootstrap_cosmic) >$@.tmp 2>&1 || code=$$?; echo "exit:$$code" >> $@.tmp; mv $@.tmp $@
 
 # Environment clamp probe (#731): echoes the env a recipe actually sees.
 # Test apparatus like ci-selftest-launder above, not a help target.

--- a/lib/build/makefile_ratchet_test.tl
+++ b/lib/build/makefile_ratchet_test.tl
@@ -71,7 +71,6 @@ local real_shell_allowed: {string} = {
   "o/bootstrap/compile-flag", -- pre-driver strict-compile probe
   "o/ci-selftest-launder-summary.txt", -- deliberately laundering fixture
   "o/cosmic/version.lua", -- git describe interpolation
-  "o/lib/build/build-recipe.lua", -- driver self-bootstrap compile
   "o/lib/build/make/ci-launder.out", -- nested-make fixture
   "o/lib/build/make/database.out", -- nested-make fixture
   "o/lib/build/make/dry-run.out", -- nested-make fixture
@@ -131,7 +130,6 @@ local hostx_allowed: {string} = {
   "o/coverage/lib/build/help_test.tl.test.got", -- unveil_test + Makefile
   "o/coverage/lib/cosmic/teal_config_test.tl.test.got", -- unveil_test + tlconfig
   "o/coverage/lib/cosmic/tty_test.tl.test.got", -- unveil_test + pty devs
-  "o/lib/build/build-recipe.lua", -- self-bootstrap shell
   "o/lib/build/help_test.tl.test.got", -- unveil_test + Makefile
   "o/lib/cosmic/teal_config_test.tl.test.got", -- unveil_test + tlconfig
   "o/lib/cosmic/tty_test.tl.test.got", -- unveil_test + pty devs

--- a/lib/build/makefile_test.tl
+++ b/lib/build/makefile_test.tl
@@ -162,9 +162,15 @@ test_lint_guard_present()
 -- CURDIR-anchored so a mis-rooted recipe still resolves.
 local function test_compile_pins_tree_only_tl_path()
   local out = read_make_output("database.out").output
-  -- the recipe must wire type resolution to the tree-only path
-  assert(out:find('export TL_PATH="$(tree_tl_path)"', 1, true),
-    "expected the compile recipe to export TL_PATH=$(tree_tl_path)")
+  -- the compile family must wire type resolution to the tree-only path:
+  -- the o/%.lua pattern's target-specific export shows in the database
+  -- as a target block whose variable line carries the raw reference
+  local pinned = false
+  for value in out:gmatch("o/%%%.lua :\n[^\n]*\n# TL_PATH := ([^\n]*)") do
+    pinned = value == "$$(tree_tl_path)"
+  end
+  assert(pinned,
+    "expected the o/%.lua family to export TL_PATH=$(tree_tl_path)")
   -- and the resolved value must be absolute, tree-only, no /zip fallback
   local tl_path = out:match("\ntree_tl_path := ([^\n]*)")
   assert(tl_path, "expected tree_tl_path definition in database output")

--- a/lib/cosmic/build.tl
+++ b/lib/cosmic/build.tl
@@ -3,15 +3,12 @@
 --- `link` replaces mkdir+ln -sfn, `capture` and `tee` replace redirects
 --- with cmp/mv or tee, plus list/remove/require-*/verdict.
 ---
---- Dual life (#756 item 3): embedded in the cosmic binary behind the
---- greedy `--build <mode> <args>...` CLI flag — the surface recipes
---- call once the bootstrap pin ships it — AND compiled to
---- o/lib/build/build-recipe.lua by the self-bootstrap exception rule in
---- lib/build/cook.mk, because today's PINNED bootstrap predates
---- `--build` and the compile rule cannot compile its own driver. When a
---- release carrying `--build` is pinned, the recipes become
---- `$(bootstrap_cosmic) --build ...` and the compiled driver (and its
---- exception rule) disappears.
+--- Embedded in the cosmic binary behind the greedy `--build <mode>
+--- <args>...` CLI flag (#756 item 3). The build's make recipes exec the
+--- PINNED bootstrap's copy (`$(bootstrap_cosmic) --build ...`), so
+--- changes here reach the recipes only through a release + bootstrap
+--- pin bump — an edit to this file cannot affect the build that
+--- compiles it.
 ---
 --- Requires the EMBEDDED stdlib only — deliberately no tree modules:
 --- the compile rule is what BUILDS the tree's .lua files, so a tree

--- a/lib/cosmic/build_test.tl
+++ b/lib/cosmic/build_test.tl
@@ -1,8 +1,8 @@
 #!/usr/bin/env cosmic
 -- Tests for cosmic.build (#732, #756 item 3): the shell-free recipe
--- steps behind `--build`, spawned the way make will spawn them, with
--- the test cosmic binary standing in as the pinned bootstrap for
--- compile mode.
+-- steps behind `--build`, spawned the way make spawns them, with the
+-- test cosmic binary standing in as the pinned bootstrap for compile
+-- mode.
 
 local child = require("cosmic.child")
 local env = require("cosmic.env")

--- a/lib/cosmic/cook.mk
+++ b/lib/cosmic/cook.mk
@@ -104,11 +104,11 @@ cosmic_check_bin := $(o)/bin/cosmic-check
 # remove the previous run's backup first: assimilate writes $@.bak and
 # refuses to overwrite one, so a rebuild over yesterday's assimilation
 # failed with "File exists" (witnessed after a bootstrap refresh).
-$(cosmic_check_bin): $(cosmic_bin) $(build_recipe) | $$(cosmos_staged)
-	@$(bootstrap_cosmic) -- $(build_recipe) copy $< $@
-	@$(bootstrap_cosmic) -- $(build_recipe) remove $@.bak
+$(cosmic_check_bin): $(cosmic_bin) | $$(cosmos_staged)
+	@$(bootstrap_cosmic) --build copy $< $@
+	@$(bootstrap_cosmic) --build remove $@.bak
 	@$(cosmos_dir)/assimilate $@
-	@$(bootstrap_cosmic) -- $(build_recipe) require-elf $@
+	@$(bootstrap_cosmic) --build require-elf $@
 
 # The APE loader, staged where the clamped PATH can see it (#729 test
 # family): the APE shell stub prefers `exec ape "$o" "$@"` for any

--- a/lib/types/cook.mk
+++ b/lib/types/cook.mk
@@ -17,6 +17,6 @@ $(o)/lib/types/gentl_test.tl.test.got $(o)/coverage/lib/types/gentl_test.tl.test
 # write-if-changed, nothing written when the generator fails.
 regen-tl-types: .PLEDGE := $(pledge_build)
 regen-tl-types: .UNVEIL := $(unveil_base) rwcx:$(o) rwc:lib/types
-regen-tl-types: $(o)/lib/types/gentl.lua $$(tl_staged) $(build_recipe) | $(bootstrap_cosmic)
-	@$(bootstrap_cosmic) -- $(build_recipe) capture $(bootstrap_cosmic) lib/types/tl.d.tl $(o)/lib/types/gentl.lua $(o)/tl/.staged/tl.tl
+regen-tl-types: $(o)/lib/types/gentl.lua $$(tl_staged) | $(bootstrap_cosmic)
+	@$(bootstrap_cosmic) --build capture $(bootstrap_cosmic) lib/types/tl.d.tl $(o)/lib/types/gentl.lua $(o)/tl/.staged/tl.tl
 	@echo wrote lib/types/tl.d.tl


### PR DESCRIPTION
The pin-bump half of #756 item 3, and the last change of the arc. Bootstrap pin → `2026-07-24-45acffa` (the release you just cut — the first carrying `--build`), and the recipes now call the bootstrap's own surface.

## What changed

- **Every recipe step is `$(bootstrap_cosmic) --build <mode> ...`** — copy, compile, link, capture, tee, list, remove, require-marker, require-elf, verdict — a direct exec of the pinned bootstrap's embedded `cosmic.build`. Same argv shapes as the old driver invocations, minus the `-- $(build_recipe)` indirection.
- **The compiled driver is gone**: `o/lib/build/build-recipe.lua`, its `build_recipe` variable, and the **self-bootstrap exception rule** — the last real-shell + `$(unveil_hostx)` build rule — are deleted, along with the driver's entries in both ratchet allowlists (real-shell and hostx). The "embedded-stdlib driver" special case from #732 no longer exists; the bootstrap sha covers the recipe runtime directly.
- **The ci-launder fixture hands the nested make only the bootstrap**, which `bin/make` provisions before any rule runs — permanently retiring the cold-tree ENOENT ordering hazard that #768's fixture fix worked around (that ordering prereq is gone too, no longer needed).
- **`makefile_test`'s #744 assertion** ("compiles pin tree-only TL_PATH") moves off the deleted rule's recipe text and now pins the `o/%.lua` pattern's target-specific `TL_PATH := $$(tree_tl_path)` export in the database dump — the mechanism that actually carries the property.
- Comment updates in `Makefile`/`cook.mk`/`lib/build/cook.mk` and the `cosmic.build` header, which now describes the end state: recipes exec the pinned copy, so an edit to the module cannot affect the build that compiles it.

## Verification

- **Cold tree, real pin**: `rm -rf o` → `bin/make` provisions `2026-07-24-45acffa` (sha verified against the release's SHA256SUMS, `--build` smoke-tested on the downloaded artifact before pinning) → `bin/make -j8 ci` → `ci: PASS`.
- Also validated ahead of the release by standing in a locally built assimilated binary as the bootstrap and running full ci through the converted recipes.

## Where this leaves #756

All seven items are done: 6 (#758), 2 (#759/#760), 1 (#761), 5 (#209 + #762), 4 (#211/#212 + #766), 3 (#767 + this), 7 (#768). The remaining shell surface is exactly the enumerated per-rule exceptions (test apparatus, probes, version stamping), the ratchets hold the boundary, and the grant-derivation endgame stays tracked upstream in whilp/cosmopolitan#210. #756 can close when this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13

---
_Generated by [Claude Code](https://claude.ai/code/session_019QFxKwtwGcsCYYbqY1dh13)_