### PR TITLE
build: unused-grant audit by leave-one-out (#756 item 4)

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -92,6 +92,22 @@ makefile ratchet tests enumerate the exception set, the
 `$(unveil_hostx)` carriers, and statically scan recipe text for shell
 syntax — all three fail when a set grows without a declared reason.
 
+most grants are not written by hand at all: landlock-make derives them
+from the declared graph (prerequisites readable, the target's directory
+writable, plus the global base), so a rule declares only genuinely-extra
+paths. that derivation is gated upstream in
+`test/tool/build/make_sandbox_test.sh` (whilp/cosmopolitan#210).
+
+`bin/make audit-unveil` shrinks the hand-written remainder with evidence
+instead of guesswork (#756 item 4): it rebuilds a representative target
+per enforced family with one grant entry withheld, and reports the
+entries that rule did not need. two limits are structural — it needs
+Landlock (it refuses to run without it, since every verdict would read
+UNUSED for the wrong reason), and it only reaches grants composed from a
+shared variable, not per-rule literals. its verdicts are scoped to the
+targets it audited; a rule outside that list may still need an entry it
+reports.
+
 ### Building the cosmic Binary
 
 the cosmic binary is assembled in `lib/cosmic/cook.mk`:

--- a/lib/build/audit-unveil.tl
+++ b/lib/build/audit-unveil.tl
@@ -1,0 +1,363 @@
+#!/usr/bin/env lua
+
+-- Unused-grant audit by leave-one-out (whilp/cosmopolitan#210 item 3,
+-- #756 item 4).
+--
+-- The question worth answering is not "was this path touched?" but
+-- "would removing this grant break the rule?" — the second is what you
+-- act on, and the kernel answers it directly. So: rebuild a target with
+-- one grant entry withheld. If it still succeeds, that entry was not
+-- needed for that target, and the shared set can shrink with evidence
+-- instead of guesswork.
+--
+-- Withholding needs no makefile edits. The grant sets are composed from
+-- make variables (`unveil_base`, `unveil_dev`, `unveil_hostx`, ...), and
+-- a command-line assignment overrides the makefile's, so passing
+-- `unveil_hostx=<all entries but one>` reaches every rule that composes
+-- it. Note that a target-specific `.UNVEIL` can NOT be used for this:
+-- landlock-make unveils the global, pattern, and target sets additively,
+-- so a narrower per-target assignment adds grants rather than replacing
+-- them.
+--
+-- Two things this deliberately does not do. It never edits a makefile —
+-- it reports candidates, a human removes them. And its verdicts are
+-- scoped to the targets it audited: an entry unused by every audited
+-- target may still be needed by a rule that was not audited, so the
+-- report names its own coverage rather than implying the set is safe to
+-- empty.
+
+local child = require("cosmic.child")
+local fs = require("cosmic.fs")
+local proc = require("cosmic.proc")
+local unveil = require("cosmic.unveil")
+
+local record Entry
+  perm: string
+  path: string
+  raw: string
+end
+
+local record Verdict
+  target: string
+  var: string
+  entry: string
+  needed: boolean
+end
+
+local record Options
+  make: string
+  targets: {string}
+  vars: {string}
+  allow_no_enforcement: boolean
+end
+
+local record Report
+  verdicts: {Verdict}
+  unused: {string: {string}} -- var -> entries no audited target needed
+  skipped: {string}
+end
+
+--- Split a grant set value ("rx:/usr r:/etc") into entries.
+--- @param value string Whitespace-separated grant entries
+--- @return {Entry} Parsed entries; malformed ones are dropped
+local function parse_entries(value: string): {Entry}
+  local out: {Entry} = {}
+  for raw in value:gmatch("%S+") do
+    local perm, path = raw:match("^([rwcx]+):(.+)$")
+    if perm and path then
+      out[#out + 1] = { perm = perm, path = path, raw = raw }
+    end
+  end
+  return out
+end
+
+--- Read the expanded value of each named variable from make's database.
+--- `-p -n -q` prints the database without running anything.
+--- @param make string make binary to invoke
+--- @param vars {string} Variable names to look up
+--- @return {string: string} | nil Map of name to expanded value
+--- @return string Error message on failure
+local function read_vars(make: string, vars: {string}): {string: string} | nil, string
+  local res, serr = child.run({ make, "-p", "-n", "-q" })
+  if not res then
+    return nil, "could not run " .. make .. ": " .. tostring(serr)
+  end
+  local r = res as child.Result -- cast: record union after guard
+  local wanted: {string: boolean} = {}
+  for _, v in ipairs(vars) do
+    wanted[v] = true
+  end
+  local found: {string: string} = {}
+  for line in (r.stdout .. "\n" .. r.stderr):gmatch("[^\n]+") do
+    local name, value = line:match("^([%w_]+)%s*:?=%s*(.*)$")
+    if name and wanted[name] and not found[name] then
+      found[name] = value
+    end
+  end
+  for _, v in ipairs(vars) do
+    if not found[v] then
+      return nil, "variable not found in make database: " .. v
+    end
+  end
+  return found
+end
+
+--- Rebuild a target from scratch, returning whether it succeeded and the
+--- set of grant paths landlock-make applied to it.
+--- Removing the target first is what forces the rule to run; --debug=j is
+--- what makes the grants observable.
+--- @param make string make binary to invoke
+--- @param target string Target path to rebuild
+--- @param override string Extra `var=value` argument, or nil
+--- @return boolean Whether the rebuild succeeded
+--- @return {string: boolean} Set of paths unveiled for the target
+local function rebuild(make: string, target: string, override?: string): boolean, {string: boolean}
+  fs.rmrf(target)
+  local argv = { make, target, "--debug=j" }
+  if override then
+    argv[#argv + 1] = override
+  end
+  local res = child.run(argv)
+  local paths: {string: boolean} = {}
+  if not res then
+    return false, paths
+  end
+  local r = res as child.Result -- cast: record union after guard
+  for line in (r.stdout .. "\n" .. r.stderr):gmatch("[^\n]+") do
+    local path = line:match("^Unveil (.+) with permissions ")
+    if path and path ~= "(null)" then
+      paths[path] = true
+    end
+  end
+  return r.ok, paths
+end
+
+--- Whether a target's rule actually composes a grant variable.
+--- Blanking the variable entirely and comparing the applied grant set is
+--- the only reliable test: entries overlap between sets (unveil_hostx
+--- repeats unveil_dev's device nodes), so matching an entry's PATH
+--- against the applied set would credit a rule with using a variable it
+--- never referenced — and report the entry as removable on that
+--- rule's evidence.
+--- @param make string make binary to invoke
+--- @param target string Target path to rebuild
+--- @param var string Grant variable to blank
+--- @param baseline {string: boolean} Grants applied with the full sets
+--- @return boolean Whether blanking the variable changed the grants
+local function var_referenced(make: string, target: string, var: string,
+                              baseline: {string: boolean}): boolean
+  local _, applied = rebuild(make, target, var .. "=")
+  for path in pairs(baseline) do
+    if not applied[path] then
+      return true
+    end
+  end
+  return false
+end
+
+--- Rebuild with one entry withheld from a grant variable.
+--- @param make string make binary to invoke
+--- @param target string Target path to rebuild
+--- @param var string Grant variable to shrink
+--- @param entries {Entry} The variable's full entry list
+--- @param drop integer Index of the entry to withhold
+--- @return boolean Whether the target still built without that grant
+local function rebuild_without(make: string, target: string, var: string,
+                               entries: {Entry}, drop: integer): boolean
+  local kept: {string} = {}
+  for i, e in ipairs(entries) do
+    if i ~= drop then
+      kept[#kept + 1] = e.raw
+    end
+  end
+  local ok = rebuild(make, target, var .. "=" .. table.concat(kept, " "))
+  return ok
+end
+
+--- Audit every (target, variable, entry) triple.
+--- An entry the target never had applied is not reported at all: the rule
+--- does not compose that variable, so withholding it proves nothing.
+--- @param opts Options Audit configuration
+--- @return Report | nil Findings, or nil if a baseline rebuild failed
+--- @return string Error message on failure
+local function audit(opts: Options): Report | nil, string
+  local found, err = read_vars(opts.make, opts.vars)
+  if not found then
+    return nil, err
+  end
+  local values = found as {string: string} -- cast: map union after guard
+  local report: Report = { verdicts = {}, unused = {}, skipped = {} }
+  local needed_anywhere: {string: {string: boolean}} = {}
+  local seen_anywhere: {string: {string: boolean}} = {}
+  for _, var in ipairs(opts.vars) do
+    needed_anywhere[var] = {}
+    seen_anywhere[var] = {}
+  end
+
+  for _, target in ipairs(opts.targets) do
+    local ok, applied = rebuild(opts.make, target)
+    if not ok then
+      -- A target that cannot build with its full grants tells us nothing
+      -- about which of them matter.
+      report.skipped[#report.skipped + 1] = target
+      io.stderr:write("audit-unveil: baseline build failed, skipping: ",
+        target, "\n")
+    else
+      for _, var in ipairs(opts.vars) do
+        if var_referenced(opts.make, target, var, applied) then
+          local entries = parse_entries(values[var])
+          for i, e in ipairs(entries) do
+            if applied[e.path] then
+              seen_anywhere[var][e.raw] = true
+              local still = rebuild_without(opts.make, target, var, entries, i)
+              report.verdicts[#report.verdicts + 1] = {
+                target = target, var = var, entry = e.raw, needed = not still,
+              }
+              if not still then
+                needed_anywhere[var][e.raw] = true
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  for _, var in ipairs(opts.vars) do
+    local unused: {string} = {}
+    for entry in pairs(seen_anywhere[var]) do
+      if not needed_anywhere[var][entry] then
+        unused[#unused + 1] = entry
+      end
+    end
+    table.sort(unused)
+    report.unused[var] = unused
+  end
+  return report
+end
+
+--- Render the report. Candidates are per-audited-target evidence, not a
+--- license to empty the set — the coverage line says so explicitly.
+--- @param report Report Findings to print
+--- @param opts Options Audit configuration, for the coverage note
+local function render(report: Report, opts: Options)
+  local by_target: {string: {Verdict}} = {}
+  for _, v in ipairs(report.verdicts) do
+    by_target[v.target] = by_target[v.target] or {}
+    local list = by_target[v.target]
+    list[#list + 1] = v
+  end
+  for _, target in ipairs(opts.targets) do
+    local list = by_target[target]
+    if list then
+      print(target)
+      for _, v in ipairs(list) do
+        print(("  %-8s %-28s %s"):format(
+          v.needed and "needed" or "UNUSED", v.entry, v.var))
+      end
+    end
+  end
+  print("")
+  print("candidates for removal (unused by every audited target):")
+  local any = false
+  for _, var in ipairs(opts.vars) do
+    local unused = report.unused[var]
+    if #unused > 0 then
+      any = true
+      print(("  %s: %s"):format(var, table.concat(unused, " ")))
+    end
+  end
+  if not any then
+    print("  (none)")
+  end
+  print("")
+  print(("coverage: %d target(s) audited; entries are candidates for THESE "):format(#opts.targets)
+    .. "rules only —")
+  print("a rule outside this list may still need them. Per-rule literal")
+  print("grants (not composed from a variable) are not covered.")
+  if #report.skipped > 0 then
+    print("skipped (baseline build failed): " .. table.concat(report.skipped, " "))
+  end
+end
+
+--- Parse argv into Options.
+--- @param argv {string} Command-line arguments
+--- @return Options | nil Parsed options
+--- @return string Error message on failure
+local function parse_args(argv: {string}): Options | nil, string
+  local opts: Options = {
+    make = "bin/cosmo-make", targets = {}, vars = {},
+    allow_no_enforcement = false,
+  }
+  local i = 1
+  while i <= #argv do
+    local a = argv[i]
+    if a == "--make" then
+      i = i + 1
+      opts.make = argv[i]
+    elseif a == "--target" then
+      i = i + 1
+      opts.targets[#opts.targets + 1] = argv[i]
+    elseif a == "--var" then
+      i = i + 1
+      opts.vars[#opts.vars + 1] = argv[i]
+    elseif a == "--allow-no-enforcement" then
+      opts.allow_no_enforcement = true
+    else
+      return nil, "unknown argument: " .. a
+    end
+    if i > #argv then
+      return nil, "missing value for " .. a
+    end
+    i = i + 1
+  end
+  if #opts.vars == 0 then
+    opts.vars = { "unveil_base", "unveil_dev", "unveil_hostx" }
+  end
+  if #opts.targets == 0 then
+    return nil, "no --target given"
+  end
+  return opts
+end
+
+local function main(argv: {string}): integer
+  local parsed, err = parse_args(argv)
+  if not parsed then
+    io.stderr:write("audit-unveil: ", err, "\n")
+    return 2
+  end
+  local opts = parsed as Options -- cast: record union after guard
+  -- Without enforcement every withheld grant "passes" and the whole
+  -- report reads as "remove everything" — the exact wrong answer,
+  -- delivered confidently.
+  if not unveil.available() then
+    if not opts.allow_no_enforcement then
+      io.stderr:write(
+        "audit-unveil: Landlock unavailable — every verdict would be\n",
+        "  UNUSED for the wrong reason. Run on a Landlock host, or pass\n",
+        "  --allow-no-enforcement to exercise the harness anyway.\n")
+      return 1
+    end
+    io.stderr:write("audit-unveil: WARNING — no enforcement; verdicts are ",
+      "meaningless, harness exercise only\n")
+  end
+  local report, aerr = audit(opts)
+  if not report then
+    io.stderr:write("audit-unveil: ", aerr, "\n")
+    return 1
+  end
+  render(report, opts)
+  return 0
+end
+
+if proc.is_main() then
+  os.exit(main(arg))
+end
+
+return {
+  parse_entries = parse_entries,
+  parse_args = parse_args,
+  audit = audit,
+  render = render,
+  main = main,
+}

--- a/lib/build/audit-unveil_test.tl
+++ b/lib/build/audit-unveil_test.tl
@@ -1,0 +1,72 @@
+local audit = require("build.audit-unveil")
+local check = require("cosmic.check")
+
+local function test_parse_entries()
+  local e = audit.parse_entries("rx:/usr r:/etc rw:/dev/null")
+  assert(#e == 3, "got: " .. tostring(#e))
+  assert(e[1].perm == "rx", "got: " .. e[1].perm)
+  assert(e[1].path == "/usr", "got: " .. e[1].path)
+  assert(e[3].raw == "rw:/dev/null", "got: " .. e[3].raw)
+end
+
+local function test_parse_entries_skips_malformed()
+  -- A bare path with no permission prefix is not a grant entry; dropping
+  -- it keeps the leave-one-out override faithful to what make composes.
+  local e = audit.parse_entries("rx:/usr notagrant r:/etc")
+  assert(#e == 2, "got: " .. tostring(#e))
+  assert(e[2].path == "/etc", "got: " .. e[2].path)
+end
+
+local function test_parse_entries_keeps_colons_in_path()
+  local e = audit.parse_entries("r:/weird:path")
+  assert(#e == 1, "got: " .. tostring(#e))
+  assert(e[1].path == "/weird:path", "got: " .. e[1].path)
+end
+
+local function test_parse_args_defaults()
+  local opts = check.must(audit.parse_args({ "--target", "o/x.lua" }))
+  assert(#opts.targets == 1, "got: " .. tostring(#opts.targets))
+  assert(opts.targets[1] == "o/x.lua", "got: " .. opts.targets[1])
+  assert(#opts.vars == 3, "got: " .. tostring(#opts.vars))
+  assert(opts.vars[1] == "unveil_base", "got: " .. opts.vars[1])
+  assert(not opts.allow_no_enforcement, "default must require enforcement")
+end
+
+local function test_parse_args_explicit()
+  local opts = check.must(audit.parse_args({
+    "--make", "m", "--target", "a", "--target", "b",
+    "--var", "unveil_hostx", "--allow-no-enforcement",
+  }))
+  assert(opts.make == "m", "got: " .. opts.make)
+  assert(#opts.targets == 2, "got: " .. tostring(#opts.targets))
+  assert(#opts.vars == 1, "got: " .. opts.vars[1])
+  assert(opts.allow_no_enforcement, "flag must parse")
+end
+
+local function test_parse_args_requires_target()
+  local opts, err = audit.parse_args({ "--var", "unveil_dev" })
+  assert(opts == nil, "must reject an audit with nothing to audit")
+  assert(err:match("no %-%-target"), "got: " .. err)
+end
+
+local function test_parse_args_rejects_unknown()
+  local opts, err = audit.parse_args({ "--nope" })
+  assert(opts == nil, "must reject unknown arguments")
+  assert(err:match("unknown"), "got: " .. err)
+end
+
+local function test_parse_args_rejects_dangling_value()
+  -- `--target` with nothing after it must not silently audit nothing.
+  local opts, err = audit.parse_args({ "--target" })
+  assert(opts == nil, "must reject a flag with no value")
+  assert(err ~= nil, "must explain why")
+end
+
+test_parse_entries()
+test_parse_entries_skips_malformed()
+test_parse_entries_keeps_colons_in_path()
+test_parse_args_defaults()
+test_parse_args_explicit()
+test_parse_args_requires_target()
+test_parse_args_rejects_unknown()
+test_parse_args_rejects_dangling_value()

--- a/lib/build/audit-unveil_test.tl
+++ b/lib/build/audit-unveil_test.tl
@@ -1,5 +1,50 @@
 local audit = require("build.audit-unveil")
 local check = require("cosmic.check")
+local fs = require("cosmic.fs")
+
+-- A stand-in for make, so the engine is exercised without Landlock (and
+-- without a real build). It models ONE rule: the target composes
+-- unveil_dev and its own target directory, and it fails when
+-- rw:/dev/null is withheld — i.e. exactly one entry is genuinely needed,
+-- the other two are not, and unveil_hostx is never referenced at all.
+local fake_make = [[#!/bin/sh
+for a in "$@"; do
+  case "$a" in
+    -p) echo 'unveil_dev := rw:/dev/null r:/dev/random r:/dev/urandom'
+        echo 'unveil_hostx := rx:/usr rx:/bin'
+        echo 'unveil_base := r:lib'
+        exit 0 ;;
+  esac
+done
+dev='rw:/dev/null r:/dev/random r:/dev/urandom'
+base='r:lib'
+broken=
+for a in "$@"; do
+  case "$a" in
+    unveil_dev=*) dev=${a#unveil_dev=} ;;
+    unveil_base=*) base=${a#unveil_base=} ;;
+    o/out/broken) broken=1 ;;
+  esac
+done
+echo "Unveil o/out with permissions rwc" >&2
+for e in $dev $base; do
+  echo "Unveil ${e#*:} with permissions ${e%%:*}" >&2
+done
+if [ -n "$broken" ]; then exit 1; fi
+case " $dev " in
+  *" rw:/dev/null "*) exit 0 ;;
+  *) exit 1 ;;
+esac
+]]
+
+--- Write the fake make into TEST_TMPDIR and return its path.
+local function write_fake_make(): string
+  local tmpdir = check.must(os.getenv("TEST_TMPDIR"))
+  local path = fs.join(tmpdir, "fake-make")
+  check.must(fs.write(path, fake_make))
+  fs.chmod(path, 493) -- 0755
+  return path
+end
 
 local function test_parse_entries()
   local e = audit.parse_entries("rx:/usr r:/etc rw:/dev/null")
@@ -62,6 +107,72 @@ local function test_parse_args_rejects_dangling_value()
   assert(err ~= nil, "must explain why")
 end
 
+local function test_audit_separates_needed_from_unused()
+  local opts = check.must(audit.parse_args({
+    "--make", write_fake_make(), "--target", "o/out/thing",
+    "--var", "unveil_dev",
+  }))
+  local report = check.must(audit.audit(opts))
+  local by_entry: {string: boolean} = {}
+  for _, v in ipairs(report.verdicts) do
+    by_entry[v.entry] = v.needed
+  end
+  assert(by_entry["rw:/dev/null"] == true,
+    "the entry the rule cannot build without must read needed")
+  assert(by_entry["r:/dev/random"] == false, "unneeded entry must read UNUSED")
+  assert(by_entry["r:/dev/urandom"] == false, "unneeded entry must read UNUSED")
+  local unused = report.unused["unveil_dev"]
+  assert(#unused == 2, "got: " .. tostring(#unused))
+  assert(#report.skipped == 0, "baseline built, nothing should be skipped")
+end
+
+local function test_audit_skips_unreferenced_variable()
+  -- unveil_hostx is not composed by this rule. Withholding its entries
+  -- changes nothing, so reporting them as removable would credit this
+  -- rule with evidence it never produced.
+  local opts = check.must(audit.parse_args({
+    "--make", write_fake_make(), "--target", "o/out/thing",
+    "--var", "unveil_hostx",
+  }))
+  local report = check.must(audit.audit(opts))
+  assert(#report.verdicts == 0,
+    "an unreferenced variable must yield no verdicts, got: "
+    .. tostring(#report.verdicts))
+  assert(#report.unused["unveil_hostx"] == 0, "and no removal candidates")
+end
+
+local function test_audit_skips_target_whose_baseline_fails()
+  -- o/out/broken fails in the fake even with its FULL grants, standing in
+  -- for a target that cannot build at all: it can say nothing about which
+  -- of its grants matter, so withholding them proves nothing.
+  local broken = check.must(audit.parse_args({
+    "--make", write_fake_make(), "--target", "o/out/broken",
+    "--var", "unveil_dev",
+  }))
+  local report = check.must(audit.audit(broken))
+  assert(#report.skipped == 1, "an unbuildable target must be skipped")
+  assert(#report.verdicts == 0, "and must produce no verdicts")
+end
+
+local function test_read_vars_reports_missing_variable()
+  local opts = check.must(audit.parse_args({
+    "--make", write_fake_make(), "--target", "o/out/thing",
+    "--var", "unveil_nonexistent",
+  }))
+  local report, err = audit.audit(opts)
+  assert(report == nil, "a variable make does not define must be an error")
+  assert(err:match("unveil_nonexistent"), "got: " .. tostring(err))
+end
+
+local function test_render_does_not_throw()
+  local opts = check.must(audit.parse_args({
+    "--make", write_fake_make(), "--target", "o/out/thing",
+    "--var", "unveil_dev",
+  }))
+  local report = check.must(audit.audit(opts))
+  audit.render(report, opts)
+end
+
 test_parse_entries()
 test_parse_entries_skips_malformed()
 test_parse_entries_keeps_colons_in_path()
@@ -70,3 +181,8 @@ test_parse_args_explicit()
 test_parse_args_requires_target()
 test_parse_args_rejects_unknown()
 test_parse_args_rejects_dangling_value()
+test_audit_separates_needed_from_unused()
+test_audit_skips_unreferenced_variable()
+test_audit_skips_target_whose_baseline_fails()
+test_read_vars_reports_missing_variable()
+test_render_does_not_throw()

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -13,7 +13,8 @@ build_pack := $(o)/lib/build/build-pack.lua
 # before any make exists); the compiled copy is built so it gets the
 # strict-compile type gate like every other build script.
 build_makeboot := $(o)/lib/build/make-boot.lua
-build_files := $(build_fetch) $(build_stage) $(build_untar) $(build_pack) $(build_portable) $(build_reporter) $(build_help) $(build_lint) $(build_makeboot)
+build_audit := $(o)/lib/build/audit-unveil.lua
+build_files := $(build_fetch) $(build_stage) $(build_untar) $(build_pack) $(build_portable) $(build_reporter) $(build_help) $(build_lint) $(build_makeboot) $(build_audit)
 
 # Self-bootstrap exception (#732): build-recipe drives the shell-free
 # compile/copy/link recipes, so it cannot be compiled by them — this one
@@ -215,3 +216,29 @@ build_help_test_got := \
   $(o)/lib/build/help_test.tl.test.got \
   $(o)/coverage/lib/build/help_test.tl.test.got
 $(build_help_test_got): .UNVEIL := $(unveil_test) r:Makefile
+
+# Unused-grant audit (whilp/cosmopolitan#210 item 3, #756 item 4).
+# Leave-one-out: rebuild a target with one grant entry withheld from a
+# shared set; if it still builds, that entry was not needed for that
+# rule. Withholding rides make's command-line variable override, so no
+# rule here changes — but it also means the audit only reaches grants
+# composed from a variable, not per-rule literals.
+#
+# One representative target per enforced family. They are deliberately
+# small and deterministic: the audit rebuilds each one once per grant
+# entry, so a slow target multiplies.
+audit_targets := \
+  $(o)/lib/cosmic/uuid.lua \
+  $(o)/lib/cosmic/uuid.tl.teal.got \
+  $(o)/lib/cosmic/uuid.tl.format.got \
+  $(o)/lib/cosmic/uuid.tl.lint.got \
+  $(o)/lib/cosmic/uuid_test.tl.test.got
+
+.PHONY: audit-unveil
+## Report .UNVEIL grants no audited rule needs (leave-one-out; needs Landlock)
+# Apparatus, not build logic: it execs nested makes and deletes targets,
+# so it runs outside the sandbox like the canary and the fixtures.
+audit-unveil: .SANDBOXED := 0
+audit-unveil: export LUA_PATH = $(tree_lua_path)
+audit-unveil: $(build_audit) $$(cosmic_bin)
+	@$(cosmic_bin) -- $(build_audit) --make $(MAKE) $(audit_targets:%=--target %)

--- a/lib/cosmic/coverage/baseline.txt
+++ b/lib/cosmic/coverage/baseline.txt
@@ -1,5 +1,6 @@
 # coverage ratchet baseline: `bin/make coverage-baseline` rewrites this file.
 # columns: path covered-lines total-lines
+lib/build/audit-unveil.tl 172 193
 lib/build/build-fetch.tl 23 95
 lib/build/build-pack.tl 97 132
 lib/build/build-recipe.tl 172 206


### PR DESCRIPTION
Downstream half of whilp/cosmopolitan#210 item 3. The design settled on **leave-one-out** rather than the `--strace` intersect: rebuild a target with one grant entry withheld and see whether it still builds.

That answers the question you act on — *would removing this break the rule?* — instead of a proxy for it (*was this path touched?*). It uses the kernel as the oracle, needs no tracing, does no path reasoning across symlinks / `*at()` dirfds / `/proc` indirection, and works for children that aren't cosmo binaries (which is where `--strace` would have been blind — exactly the shell-using exception rules carrying the largest `unveil_hostx` grants).

## Usage

```
bin/make audit-unveil
```

One representative target per enforced family (compile, teal, format, lint, test). Output is a per-target `needed`/`UNUSED` table plus removal candidates, and it **never edits a makefile** — a human removes the entry.

## How withholding works without touching any rule

Grant sets are composed from make variables, and a command-line assignment overrides the makefile's, so `unveil_hostx=<all entries but one>` reaches every rule that composes it.

Worth recording: a target-specific `.UNVEIL` **cannot** be used for this. landlock-make unveils the global, pattern, and target sets *additively*, so a narrower per-target assignment adds grants rather than replacing them. The command-line override is the only lever that actually withholds.

## The attribution bug this caught

Entries overlap between sets — `unveil_hostx` repeats `unveil_dev`'s device nodes. Matching an entry's *path* against the applied grants therefore credited a rule with using a variable it never referenced, and the first end-to-end run duly reported `unveil_hostx` entries as removable **on the evidence of a compile rule that does not compose `unveil_hostx` at all**.

Each variable is now probed by blanking it entirely and comparing the applied grant set; a rule that does not reference it is skipped rather than counted. That is now a test, not a comment.

## Limits, stated in the report rather than hidden

- **Needs Landlock.** It refuses to run without it (exit 1), because with `unveil()` no-opping every verdict reads `UNUSED` for the wrong reason — a confident "remove everything". `--allow-no-enforcement` exists only to exercise the harness, and says so loudly.
- **Only reaches variable-composed grants**, never per-rule literals (`r:tlconfig.lua`, `rw:/dev/ptmx`).
- **Verdicts are scoped to the audited targets.** An entry unused by every audited target may still be needed by a rule that was not audited, so the report prints its own coverage instead of implying the set is safe to empty.

## Verification

- `bin/make ci: PASS` locally; all CI checks green (including `enforce`).
- Engine covered end to end against a fake `make` — it answers `-p` with a small variable database and models one rule that composes `unveil_dev` and fails when `rw:/dev/null` is withheld. Pins that a needed entry reads `needed`, unneeded ones read `UNUSED`, and an unreferenced variable yields no verdicts, plus the unbuildable-target and missing-variable paths.
- Coverage 31.4% → 89.1%. The first push failed the ratchet at 31% — the tests reached parsing but not a single line that decides a verdict. Rebaselining there would have recorded that as acceptable; testing the engine was the fix.
- Baseline gains **one per-file entry** rather than a `bin/make coverage-baseline` rewrite, which would have reset every other file's floor from a local run that skips the Landlock-dependent paths.
- Refusal path exits 1 on a Landlock-less host.

## What is still unproven

**The audit has never produced a real verdict.** Every check above ran against the fake make, because Landlock is `ENOSYS` in the container this was written in. The tool is not wired into CI — it is a human-run ratchet like `perf-baseline`, not a gate — so the first meaningful run is a maintainer's Landlock host. Wiring it into the `enforce` job is a reasonable follow-up, but turning it into a gate is a separate decision: it would fail the build whenever a grant *becomes* unnecessary, which is a policy choice, not a bug fix.