### PR TITLE
quicksand: drop the dead CLONE_* integer casts (cosmopolitan#142)

### DIFF
--- a/lib/cosmic/quicksand/box/run.tl
+++ b/lib/cosmic/quicksand/box/run.tl
@@ -42,12 +42,11 @@ local cenv = require("cosmic.env")
 
 local type BoxOptions = types.BoxOptions
 
--- The CLONE_* constants are declared `number` in the binding types.
-local NEWUSER < const > = unix.CLONE_NEWUSER as integer -- cast: bitop needs integer
-local NEWNET < const > = unix.CLONE_NEWNET as integer -- cast: bitop needs integer
-local NEWNS < const > = unix.CLONE_NEWNS as integer -- cast: bitop needs integer
-local NEWUTS < const > = unix.CLONE_NEWUTS as integer -- cast: bitop needs integer
-local NEWPID < const > = unix.CLONE_NEWPID as integer -- cast: bitop needs integer
+local NEWUSER < const > = unix.CLONE_NEWUSER
+local NEWNET < const > = unix.CLONE_NEWNET
+local NEWNS < const > = unix.CLONE_NEWNS
+local NEWUTS < const > = unix.CLONE_NEWUTS
+local NEWPID < const > = unix.CLONE_NEWPID
 
 local record CapsModule
   capabilities: function(): types.Capabilities


### PR DESCRIPTION
The cosmic-side residue of whilp/cosmopolitan#142.

`lib/cosmic/quicksand/box/run.tl` pinned the five `CLONE_*` namespace flags through `as integer`:

```teal
-- The CLONE_* constants are declared `number` in the binding types.
local NEWUSER < const > = unix.CLONE_NEWUSER as integer -- cast: bitop needs integer
```

That comment stopped being true when gentype started emitting `integer` for constants. `lib/types/cosmo/unix.d.tl` declares `CLONE_NEWUSER` and its siblings `integer` today, so the five casts are no-ops and the note is stale. The flags feed the bit-or in `clone_flags()`, which is the call-site family cosmopolitan#142 was filed about.

This is the only cosmic-side change #142 leaves that does not need a pin bump. The upstream half — an annotation ratchet that keeps constants declared `integer`, plus a `number` → `integer` fix on `lsqlite3.VM:bind_parameter_name` — is whilp/cosmopolitan#215; regenerating `.d.tl` has to wait for that release, since `gentype_test` compares the committed files against the *pinned* definitions.

## Gate

`bin/make ci` → `ci: PASS` (308 teal checks). The type checker passing with the casts removed is itself the proof they were dead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSBubiRnYiy8SoYPqA48MB)_