### PR TITLE
cosmos 2026.07.25-479c2e2c6; regen types (cosmopolitan#142)

### DIFF
--- a/3p/cosmos/version.lua
+++ b/3p/cosmos/version.lua
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "556ac11698e1394e94905dffad4b436c8b4b0513f4d9d02b7efaae6edbc278f8"}},
+  platforms = {["*"] = {sha = "61ec9b69617a08e04efce3747941723798e9a390cc3e95926eef727aa48e880c"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.24-5d978d74d"
+  version = "2026.07.25-479c2e2c6"
 }

--- a/lib/types/cosmo/lsqlite3.d.tl
+++ b/lib/types/cosmo/lsqlite3.d.tl
@@ -343,7 +343,7 @@ local record VM
   bind_blob: function(self: VM, index: integer, value: string): integer
   bind_names: function(self: VM, names: {string}): integer
   bind_parameter_count: function(self: VM): integer
-  bind_parameter_name: function(self: VM, index: number): string
+  bind_parameter_name: function(self: VM, index: integer): string | nil
   bind_values: function(self: VM, ...: string | number | nil): integer
   columns: function(self: VM): integer
   finalize: function(self: VM): integer

--- a/lib/types/cosmo/unix.d.tl
+++ b/lib/types/cosmo/unix.d.tl
@@ -527,6 +527,7 @@ local record unix
   --- @type integer System-imposed limit on the number of threads was encountered.
   --- Raised by connect, listen, recv.
   ECONNREFUSED: integer
+  --- @type integer Connection reset by client. Raised by `send`.
   ECONNRESET: integer
   --- @type integer Resource deadlock avoided.
   --- Raised by `fcntl`.
@@ -576,6 +577,7 @@ local record unix
   --- `mbind`, `pciconfig_read`, `ptrace`, `read`, `readlink`, `sendfile`, `statfs`,
   --- `symlink`, `sync_file_range`, `truncate`, `unlink`, `write`.
   EIO: integer
+  --- @type integer Socket is connected. Raised by `connect`, `send`.
   EISCONN: integer
   --- @type integer Is a directory.
   --- Raised by `copy_file_range`, `execve`, `open`, `read`, `rename`, `truncate`,


### PR DESCRIPTION
Picks up whilp/cosmopolitan#215, the upstream half of cosmopolitan#142: an annotation ratchet requiring every constant in `definitions.lua` to declare `integer` (all 628 pass, backed by a runtime `math.type()` probe), plus the two annotation bugs that ratchet turned up.

This is the pin bump that #772 said had to wait for a release.

## Pin

`3p/cosmos/version.lua`: `2026.07.24-5d978d74d` → `2026.07.25-479c2e2c6` (built from the merged #215).

## Regenerated types

Three lines move, and only these three:

```diff
-  bind_parameter_name: function(self: VM, index: number): string
+  bind_parameter_name: function(self: VM, index: integer): string | nil
```

Upstream had this declared `@param index number` / `@return string` while its twin over the **same C function** — one `vmlib` metatable documented as both `Statement` and `VM` — declared `integer` / `string?`. The twin was right both times: an index is integral, and the C pushes `sqlite3_bind_parameter_name()` straight through, which is NULL → nil for a positional `?` parameter. No cosmic wrapper calls this method, so the tightening lands with no fallout.

```diff
+  --- @type integer Connection reset by client. Raised by `send`.
   ECONNRESET: integer
+  --- @type integer Socket is connected. Raised by `connect`, `send`.
   EISCONN: integer
```

Two constants regain doc comments that a stray blank line had detached from them upstream.

The diff matches exactly what `GENTYPE_DEFS=<cosmopolitan checkout> bin/make regen-types` predicted before the release was cut, so the release contains what it should.

## Gate

`bin/make ci` → `ci: PASS`. `bin/make test only=gentype` → 3/3, so the committed `.d.tl` match generator output against the new pin byte-for-byte.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSBubiRnYiy8SoYPqA48MB)_