### PR TITLE
build: retire the source-copy layer and the strict-compile probe (#774, #775, #776)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,21 +354,6 @@ bootstrap: $(bootstrap_files)
 ## Build cosmic binary
 build: cosmic
 
-# MANUAL two-stage self-host check — no workflow runs these (#774); run
-# them before a bootstrap pin bump to prove the tree rebuilds and re-checks
-# itself under the binary it produced. stage1 overwrites the binary without
-# touching the .pin stamp bin/make compares, so it leaves the tree on an
-# UNPINNED bootstrap until `rm -rf o/bootstrap` restores the pinned one.
-.PHONY: stage1
-## Manual self-host step 1: build cosmic and overwrite the local bootstrap
-stage1: $(cosmic_bin)
-	@cp $(cosmic_bin) $(bootstrap_cosmic)
-	@echo Bootstrap refreshed from $(cosmic_bin)
-
-.PHONY: stage2
-## Manual self-host step 2: re-run the full gate under it (alias for ci)
-stage2: ci
-
 # Example testing - run Example_* functions in _example.tl files
 all_example_srcs := $(call filter-only,$(foreach m,$(modules),$($(m)_examples)))
 all_examples := $(patsubst %.tl,$(o)/%.tl.example.got,$(all_example_srcs))

--- a/Makefile
+++ b/Makefile
@@ -60,16 +60,13 @@ help: $(build_files) | $(bootstrap_cosmic)
 ## Filter targets by substring (make test only=teal; also narrows fetch/stage)
 filter-only = $(if $(only),$(foreach f,$1,$(if $(findstring $(only),$(f)),$(f))),$1)
 
-# Copies and compiles are the pinned bootstrap's --build steps (#732,
-# #756 item 3): no shell, no host mkdir/cp/cat/cmp/mv (LUA_PATH pins
-# live in cook.mk with the family's other pattern vars). .exists orders
-# cold-tree copies after o/ exists (unveil skips missing paths).
-$(o)/%: % | $(o)/.exists $(bootstrap_cosmic)
-	@$(bootstrap_cosmic) --build copy $< $@
-$(o)/.exists: | $(bootstrap_cosmic)
-	@$(bootstrap_cosmic) --build list $@
-
-$(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files) $(compile_flag_stamp)
+# Compiles are the pinned bootstrap's --build steps (#732, #756 item 3):
+# no shell, no host mkdir/cat/cmp/mv (LUA_PATH pins live in cook.mk with
+# the family's other pattern vars). The `$(o)/%: %` source-copy rule that
+# used to sit here is retired (#775): teal/format read sources directly
+# now, as lint always has. tl resolves through $(bootstrap_files)'s
+# embedded copy; the old $(tl_files) prereq was never defined, ever empty.
+$(o)/%.lua: %.tl $(types_files) $(bootstrap_files) $(compile_flag_stamp)
 	@$(bootstrap_cosmic) --build compile $(compile_flag_stamp) $(bootstrap_cosmic) $< $@ $(include_dir_flags)
 
 # tl files: modules declare _tl, derive compiled .lua outputs
@@ -91,8 +88,6 @@ $(foreach m,$(filter-out $(default_deps),$(modules)),\
     $(eval $($(m)_files): $($(d)_files))\
     $(if $($(d)_staged),\
       $(eval $($(m)_files): $($(d)_staged)))))
-
-all_versions := $(call filter-only,$(foreach x,$(modules),$($(x)_version)))
 
 # versioned modules: o/module/.versioned -> version.lua
 $(foreach m,$(modules),$(if $($(m)_version),\
@@ -118,8 +113,8 @@ fetched: $(all_fetched)
 stdlib_lua := $(patsubst %.tl,$(o)/%.lua,$(filter lib/cosmic/%,$(foreach x,$(modules),$($(x)_tl))))
 # The fetch/stage trees must EXIST before their sandboxed rules launch
 # (unveil silently skips missing paths — the same trap the target-dir
-# derivation closed upstream, one level up); the driver's list mode
-# mints them like $(o)/.exists.
+# derivation closed upstream, one level up); the driver's list mode mints
+# them as a stamp.
 $(FETCH_O)/.exists $(STAGE_O)/.exists: | $(bootstrap_cosmic)
 	@$(bootstrap_cosmic) --build list $@
 $(o)/%/.fetched: export SSL_USE_SYSTEM_CERTS = 1
@@ -285,13 +280,13 @@ all_source_files := $(call filter-only,$(foreach x,$(modules),$($(x)_tests)))
 all_source_files += $(call filter-only,$(filter-out ,$(foreach x,$(modules),$($(x)_version))))
 all_source_files += $(call filter-only,$(foreach x,$(modules),$($(x)_srcs)))
 all_source_files += $(all_tl)
-all_checkable_files := $(addprefix $(o)/,$(all_source_files))
 
 .PHONY: files
 ## Build all module files
 files: $(all_built_files)
 
-all_teals := $(patsubst %,%.teal.got,$(all_checkable_files))
+# .got NAMES are $(o)-prefixed; the PREREQUISITE is the source (#775).
+all_teals := $(patsubst %,$(o)/%.teal.got,$(all_source_files))
 
 .PHONY: check
 ## Run Teal type checking
@@ -303,10 +298,10 @@ teal: $(o)/teal-summary.txt
 $(o)/teal-summary.txt: $(all_teals) | $(build_reporter)
 	@$(bootstrap_cosmic) -- $(build_reporter) --dir $(o) --out $@ $^
 
-$(o)/%.teal.got: $(o)/% $(cosmic_check_bin) | $(bootstrap_files)
+$(o)/%.teal.got: % $(cosmic_check_bin) | $(bootstrap_files)
 	@$(cosmic_check_bin) --test $(basename $@) $(cosmic_check_bin) $(include_dir_flags) --check-types $<
 
-all_formats := $(patsubst %,%.format.got,$(all_checkable_files))
+all_formats := $(patsubst %,$(o)/%.format.got,$(all_source_files))
 
 ## Check formatting on all files
 format: $(o)/format-summary.txt
@@ -314,7 +309,7 @@ format: $(o)/format-summary.txt
 $(o)/format-summary.txt: $(all_formats) | $(build_reporter)
 	@$(bootstrap_cosmic) -- $(build_reporter) --dir $(o) --out $@ $^
 
-$(o)/%.format.got: $(o)/% $(cosmic_check_bin) | $(bootstrap_files)
+$(o)/%.format.got: % $(cosmic_check_bin) | $(bootstrap_files)
 	@$(cosmic_check_bin) --test $(basename $@) $(cosmic_check_bin) --check-format $<
 
 # Lint every tracked file (#719). git ls-files fails SILENTLY outside
@@ -359,14 +354,19 @@ bootstrap: $(bootstrap_files)
 ## Build cosmic binary
 build: cosmic
 
+# MANUAL two-stage self-host check — no workflow runs these (#774); run
+# them before a bootstrap pin bump to prove the tree rebuilds and re-checks
+# itself under the binary it produced. stage1 overwrites the binary without
+# touching the .pin stamp bin/make compares, so it leaves the tree on an
+# UNPINNED bootstrap until `rm -rf o/bootstrap` restores the pinned one.
 .PHONY: stage1
-## CI stage 1: build cosmic and refresh bootstrap with updated bundled types
+## Manual self-host step 1: build cosmic and overwrite the local bootstrap
 stage1: $(cosmic_bin)
 	@cp $(cosmic_bin) $(bootstrap_cosmic)
 	@echo Bootstrap refreshed from $(cosmic_bin)
 
 .PHONY: stage2
-## CI stage 2: type check and test with refreshed bootstrap (alias for ci)
+## Manual self-host step 2: re-run the full gate under it (alias for ci)
 stage2: ci
 
 # Example testing - run Example_* functions in _example.tl files
@@ -478,7 +478,7 @@ $(o)/ci-ok-%: %
 	@$(bootstrap_cosmic) --build list $@
 
 .PHONY: ci
-## Run CI checks (format, teal, test, example, lint) in parallel
+## Run the full gate in parallel (format, teal, test, example, lint, coverage)
 # De-hosted (#732): the grading loop lives in the driver's verdict mode
 # (same #714 semantics — summary text AND exit marker — gated by the
 # ci-launder fixture); `-` on the sub-make replaces `|| true`.

--- a/cook.mk
+++ b/cook.mk
@@ -60,9 +60,11 @@ pledge_test := $(pledge_build) fattr inet dns unix tty id flock
 # build job has it, the canary proves it). Requires the assimilated
 # bootstrap below: a raw APE exec falls back to extracting a loader into
 # $HOME/.ape-*, which no grant covers. Pattern variables attach by
-# target NAME, so every *.lua target under $(o) is enforced — including
-# the `$(o)/%: %` copies (their `cp -p` needs the fattr promise) and
-# the doc index. version.lua opts back out where it is defined: its
+# target NAME, so every *.lua target under $(o) is enforced — the
+# compiles and the doc index. (Before #775 this also swept up whichever
+# `$(o)/%: %` source copies happened to end in .lua — two of 308 — and
+# left the rest unenforced; retiring that rule made the family's
+# membership deliberate.) version.lua opts back out where it is defined: its
 # recipe needs git + .git, and its `|| echo unknown` fallback would
 # otherwise silently mint an artifact with no version.
 $(o)/%.lua: .SANDBOXED := 1
@@ -225,26 +227,28 @@ $(bootstrap_cosmic): o/bootstrap/cosmic
 	@ln -sf cosmic $(@D)/lua
 endif
 
-# Strict-compile capability probe: newer bootstraps ship --compile-strict
-# (strict type check, then generate from that same checked AST, so nothing
-# ships that did not typecheck); the pinned bootstrap may predate the flag.
-# Probe once and use the best flag it supports — after a bootstrap pin bump
-# (or CI's stage1 refresh) in-tree compiles become strict automatically.
-# Shell exception (#732): the probe is pre-driver trust machinery — the
-# driver's own compile READS this stamp, so probing through the driver
-# would cycle. It stays shell, grouped with the bootstrap download.
+# In-tree compiles are strict, always (#776). --compile-strict type checks
+# and then generates from that same checked AST, so nothing ships that did
+# not typecheck; LUA_PATH=";;" for those compiles is also a #733
+# reproducibility requirement, since the non-strict tree-LUA_PATH path made
+# output depend on parallel build order.
+#
+# This used to PROBE the pinned bootstrap for the flag and fall back to
+# plain --compile when it was absent — bridging a bootstrap that predated
+# it. Every pin since ships the flag, and the fallback was the one place
+# in this build where a stale input degraded SILENTLY (into exactly the
+# non-reproducible compile #733 exists to prevent) instead of failing.
+# The flag is pinned here instead: a bootstrap that cannot honor it now
+# fails at the first compile with the compiler's own error.
+#
+# The stamp file stays because the recipe steps run the PINNED bootstrap's
+# embedded --build surface, whose do_compile reads it (and validates the
+# contents) — dropping the argument needs a release first. Writing it
+# through `--build list` is shell-free and write-if-changed, so the rule's
+# old shell exception is retired.
 compile_flag_stamp := $(o)/bootstrap/compile-flag
-$(compile_flag_stamp): private SHELL := /bin/bash
-$(compile_flag_stamp): private .SHELLFLAGS := -o pipefail -c
 $(compile_flag_stamp): $(bootstrap_files)
-	@mkdir -p $(@D)
-	@printf 'print("probe")\n' > $@.probe.tl
-	@if LUA_PATH=";;" $(bootstrap_cosmic) --compile-strict $@.probe.tl >/dev/null 2>&1; then \
-		echo --compile-strict > $@; \
-	else \
-		echo --compile > $@; \
-	fi
-	@rm -f $@.probe.tl
+	@$(bootstrap_cosmic) --build list $@ --compile-strict
 
 # Type definition regeneration.
 # The generated .d.tl files are a pure function of (lib/types/gentype*.tl, the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,7 @@ users import `cosmic.*` modules. `cosmo.*` bindings are available but undocument
 .tl source → cosmic --compile → .lua → zip into binary
 ```
 
-the bootstrap problem: compiling `.tl` requires a working cosmic binary. this is solved by a pre-built bootstrap binary, pinned by url + sha256 in `cook.mk` and fetched by `bin/make`. the pin is bumped **by hand**; no workflow refreshes it (`make stage1`/`stage2` are manual self-host checks — see [build.md](build.md)).
+the bootstrap problem: compiling `.tl` requires a working cosmic binary. this is solved by a pre-built bootstrap binary, pinned by url + sha256 in `cook.mk` and fetched by `bin/make`. the pin is bumped **by hand**; no workflow refreshes it, and no lane verifies the self-host property (see [build.md](build.md)).
 
 dependency chain:
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,17 +32,15 @@ users import `cosmic.*` modules. `cosmo.*` bindings are available but undocument
 .tl source → cosmic --compile → .lua → zip into binary
 ```
 
-the bootstrap problem: compiling `.tl` requires a working cosmic binary. this is solved by checking in a pre-built bootstrap binary that gets refreshed during CI (`make stage1`).
+the bootstrap problem: compiling `.tl` requires a working cosmic binary. this is solved by a pre-built bootstrap binary, pinned by url + sha256 in `cook.mk` and fetched by `bin/make`. the pin is bumped **by hand**; no workflow refreshes it (`make stage1`/`stage2` are manual self-host checks — see [build.md](build.md)).
 
 dependency chain:
 ```
-bootstrap cosmic (pre-built)
+bootstrap cosmic (pinned url + sha256, fetched by bin/make)
   → compiles build scripts (build-fetch.lua, build-stage.lua)
   → fetches/stages 3p deps (cosmos, tl)
   → compiles cosmic modules (.tl → .lua)
   → builds cosmic binary (link lua + zip modules)
-  → stage1: refreshed bootstrap = new cosmic
-  → stage2: type check + test with refreshed bootstrap
 ```
 
 ### Sandboxed Build

--- a/docs/build.md
+++ b/docs/build.md
@@ -35,12 +35,19 @@ the top-level Makefile aggregates all modules and derives:
 
 ### Compilation
 
-Teal files compile to Lua via the bootstrap cosmic binary:
+Teal files compile to Lua through the pinned bootstrap's own shell-free
+recipe surface (`cosmic --build`, #732/#756 item 3) — no redirect, no host
+`cat`/`cmp`/`mv`:
 
 ```makefile
-$(o)/%.lua: %.tl $(types_files) $(tl_files) $(bootstrap_files)
-    @$(bootstrap_cosmic) --compile $< > $@
+$(o)/%.lua: %.tl $(types_files) $(bootstrap_files) $(compile_flag_stamp)
+    @$(bootstrap_cosmic) --build compile $(compile_flag_stamp) $(bootstrap_cosmic) $< $@ $(include_dir_flags)
 ```
+
+compiles are strict (`--compile-strict`: type check, then generate from
+that same checked AST) with `LUA_PATH=";;"`, which is what makes the
+output independent of parallel build order (#733). the flag is pinned in
+`cook.mk`, not probed (#776).
 
 ### Versioned Dependencies (3p/)
 
@@ -59,16 +66,22 @@ symlinks connect `o/<module>/.staged` to the extracted directory.
 ### Test Execution
 
 ```makefile
-$(o)/%.tl.test.got: $(o)/%.lua ...
-    @TEST_TMPDIR=$$(mktemp -d) $< > $(basename $@).out 2> $(basename $@).err
-    @echo $$? > $@
+$(o)/%.tl.test.got: $(o)/%.lua $(cosmic_bin) $(ape_loader)
+    @$(cosmic_bin) --test $(basename $@) $(cosmic_bin) $<
 ```
 
-each test:
+`cosmic --test` owns the capture — the recipe is a single argv line with
+no shell, no `mktemp`, and no redirects. each test:
 - runs as a standalone script (compiled `.lua` with shebang)
-- gets its own `TEST_TMPDIR`
+- gets its own `TEST_TMPDIR`, created and cleaned up by the runner
 - captures stdout to `.out`, stderr to `.err`, exit code to `.got`
-- `reporter.tl` aggregates `.got` files into a summary
+- is aggregated into a summary: `cosmic --report` for the test, coverage,
+  and enforce lanes; `lib/build/reporter.tl --out` for teal, format,
+  lint, example, and benchmark
+
+type and format checks follow the same shape but read the **source**
+directly (`$(o)/%.teal.got: %`), as lint always has — there is no copy of
+the tree under `o/` (#775).
 
 ### Sandboxing
 
@@ -146,14 +159,21 @@ the result is a single executable with all modules accessible at `/zip/.lua/`.
 
 ## CI Pipeline
 
-`make ci` runs four stages with `--keep-going`:
+`make ci` runs six stages with `--keep-going`:
 
 1. **format**: check all files with `cosmic --check-format`
 2. **teal**: type check all files with `cosmic --check-types`
 3. **test**: run all `*_test.tl` files
 4. **example**: run all `Example_*` functions in `*_example.tl` files
+5. **lint**: file length, cast justifications, and shared style checks on
+   every tracked file
+6. **coverage**: the tests again in a separate output tree with collection
+   on, ratcheted against `lib/cosmic/coverage/baseline.txt`
 
-failures in any stage are collected and reported at the end.
+each stage gets a `ci-ok-<stage>` exit marker, made only after its entire
+subtree succeeded. grading reads the marker as well as the summary text,
+so a recipe that fails *after* writing a clean summary still fails the
+stage (#714). the run ends with a `ci: PASS` / `ci: FAIL (stages)` line.
 
 ## Filtering
 
@@ -169,12 +189,18 @@ bin/make files only=cosmic    # only build cosmic files
 
 the bootstrap avoids circular dependency (need cosmic to compile cosmic):
 
-1. a pre-built `cosmic` binary is downloaded to `o/bootstrap/cosmic`
-2. it compiles all `.tl` → `.lua` and builds the new cosmic binary
-3. `make stage1` copies the new binary over the bootstrap
-4. `make stage2` (alias for `make ci`) re-checks everything with the refreshed bootstrap
+1. `bin/make` downloads a pre-built `cosmic` to `o/bootstrap/cosmic`,
+   verifies it against the sha in `cook.mk`, and assimilates it to a
+   native ELF. it is the *sole* provisioner — the Makefile's rule only
+   errors, and a pin bump re-downloads via the `.pin` stamp.
+2. it compiles all `.tl` → `.lua` and builds the new cosmic binary.
 
-the bootstrap URL is pinned in `cook.mk`.
+the bootstrap URL and sha are pinned in `cook.mk` and bumped **by hand**;
+no workflow refreshes them. `make stage1` (overwrite the local bootstrap
+with the binary you just built) and `make stage2` (re-run the gate under
+it) are manual self-host checks worth running before a pin bump — nothing
+in CI runs them, and `stage1` deliberately leaves the tree on an unpinned
+bootstrap until you delete `o/bootstrap`.
 
 the build's trust root — what `bin/make` fetches, what stays outside
 the root, and the settled decision that pinned make is permanent — is

--- a/docs/build.md
+++ b/docs/build.md
@@ -196,11 +196,11 @@ the bootstrap avoids circular dependency (need cosmic to compile cosmic):
 2. it compiles all `.tl` → `.lua` and builds the new cosmic binary.
 
 the bootstrap URL and sha are pinned in `cook.mk` and bumped **by hand**;
-no workflow refreshes them. `make stage1` (overwrite the local bootstrap
-with the binary you just built) and `make stage2` (re-run the gate under
-it) are manual self-host checks worth running before a pin bump — nothing
-in CI runs them, and `stage1` deliberately leaves the tree on an unpinned
-bootstrap until you delete `o/bootstrap`.
+no workflow refreshes them, and nothing verifies that the tree can rebuild
+itself under a binary it just produced. `make stage1`/`stage2` used to
+gesture at that check but no lane ever ran them, so they were removed
+(#774) rather than left as a gate that never fires. if the self-host
+property is worth guaranteeing, it wants a CI lane, not a manual target.
 
 the build's trust root — what `bin/make` fetches, what stays outside
 the root, and the settled decision that pinned make is permanent — is

--- a/lib/build/makefile_ratchet_test.tl
+++ b/lib/build/makefile_ratchet_test.tl
@@ -269,8 +269,9 @@ end
 test_sandboxed_ratchet()
 
 -- Static no-shell gate (#756 cleanup): the poisoned SHELL only trips
--- when a rule RUNS, and cold rules can sit broken unnoticed (stage1
--- after the #759 flip, found days later in #760). Scan every recipe in
+-- when a rule RUNS, and cold rules can sit broken unnoticed (the
+-- since-retired stage1 broke at the #759 flip and was found days later
+-- in #760 — exactly the class this catches). Scan every recipe in
 -- the database dump: a rule not on the shell-exception allowlist must
 -- carry no shell syntax in its recipe text. The dump is UNEXPANDED, so
 -- a $(var) hiding metacharacters still needs the runtime poison — this

--- a/lib/build/makefile_ratchet_test.tl
+++ b/lib/build/makefile_ratchet_test.tl
@@ -68,7 +68,6 @@ local real_shell_allowed: {string} = {
   "env-probe", -- shows the env a recipe shell sees
   "env-probe-clamped", -- .ENV canary probe (#756 item 5)
   "o/bin/ape", -- APE loader extraction IS the stub flow
-  "o/bootstrap/compile-flag", -- pre-driver strict-compile probe
   "o/ci-selftest-launder-summary.txt", -- deliberately laundering fixture
   "o/cosmic/version.lua", -- git describe interpolation
   "o/lib/build/make/ci-launder.out", -- nested-make fixture

--- a/lib/cook.mk
+++ b/lib/cook.mk
@@ -12,8 +12,8 @@ include lib/types/cook.mk
 
 # A committed foo.lua beside a module's foo.tl would shadow the .tl at
 # require time (package.path tries .lua first), and invites stale-copy
-# confusion in o/ — refuse to configure (#721). Note make itself is NOT
-# the hazard: shortest-stem selection picks the %.tl compile rule over
-# the $(o)/%: % copy rule (verified against cosmo-make).
+# confusion in o/ — refuse to configure (#721). (The make-side half of
+# this hazard — a $(o)/%: % copy rule competing with the %.tl compile
+# rule for the same target — is gone with the copy rule itself, #775.)
 tl_shadowed := $(wildcard $(patsubst %.tl,%.lua,$(foreach m,$(modules),$($(m)_tl))))
 $(if $(tl_shadowed),$(error committed .lua beside .tl source: $(tl_shadowed)))


### PR DESCRIPTION
First group of the post-#756 build simplification pass. Three independent changes, each removing apparatus that no longer earns its keep. Closes #774, #775, #776.

Two commits: the main change, then a review follow-up deleting `stage1`/`stage2` outright.

## #775 — the `$(o)/%: %` source-copy layer

Every checkable source was copied into the output tree solely so `$(o)/%.teal.got` and `$(o)/%.format.got` had a prerequisite under `$(o)`. Measured on this tree:

| | before | after |
|---|---|---|
| `make -n teal` → `--build copy` | 309 | 1 (`cosmic-check`, its own explicit rule) |
| `make -n files` → `--build copy` | 0 | 0 |

The checks read the sources directly now, exactly as lint always has (`$(o)/%.lint.got: %`). Target names are unchanged, and the check set is identical — **308 teal + 308 format before and after**.

Deleting the rule also retires `$(o)/.exists` (its only consumer) and makes the enforced sandbox family deliberate. Pattern variables attach by target *name*, so `$(o)/%.lua: .SANDBOXED := 1` had been sweeping up whichever copies happened to end in `.lua` — two of 308, the `version.lua` files — and leaving the other 306 unenforced. The comment in `cook.mk` claiming the copies were covered is corrected.

Side benefit: diagnostics now name the real source path instead of the `o/` copy.

## #776 — the strict-compile probe

The probe shelled out to detect whether the pinned bootstrap supports `--compile-strict`, falling back to plain `--compile` when absent. Every pin since ships the flag, and the fallback was the one place in this build where a stale input degraded **silently** — into precisely the order-dependent compile that #733 exists to prevent.

The flag is pinned instead: a bootstrap that cannot honor it now fails at the first compile with the compiler's own error. The stamp file stays (the pinned bootstrap's embedded `do_compile` reads and validates it, so dropping the argument needs a release first) but is written through `--build list`, which is shell-free — so the rule's shell exception is retired and `o/bootstrap/compile-flag` drops off `real_shell_allowed`. That ratchet is bidirectional, so the removal is checked in both directions.

Phase 2 (dropping the stamp argument from `do_compile` and the `TREE_LUA_PATH` axis) is deferred to whenever a bootstrap pin bump lands anyway, per #776.

## #774 — dead references, deleted targets, honest docs

- `all_versions` — defined, never used.
- `$(tl_files)` in the compile rule — **never defined anywhere**; always expanded empty, so the rule read as though compiles depended on the staged tl tree when they resolve tl through the bootstrap's embedded copy.
- **`stage1`/`stage2` deleted.** `stage2` was a bare alias for `ci`. `stage1` was `cp o/bin/cosmic o/bootstrap/cosmic` plus an echo, and needed a five-line comment warning that it leaves the tree on an unpinned bootstrap — a hazard note longer than the recipe. Together they cost two `.PHONY` entries, two lines of `bin/make help` clutter, and 15 lines against the 500-line lint cap.

  The clinching evidence is in `makefile_ratchet_test`'s own comment: **`stage1` is the cold rule that broke at the #759 no-shell flip and sat broken for days until #760 found it.** A target no lane runs is a target that rots silently — which is the argument for the static recipe scan, and equally the argument against keeping this one. If the self-host property is worth guaranteeing it wants a CI lane (option 1 in #774), not a manual target standing in for one; the docs now say that instead of describing a procedure nobody follows.

- `docs/build.md` presented **pre-#732 recipes** as how the build works (a `> $@` compile, a `mktemp -d` test recipe) and said `make ci` runs four stages when `ci_stages` is six. `docs/architecture.md` claimed CI refreshes the bootstrap. Both corrected; the `ci` help description now names all six stages.

## Gate

`bin/make -j ci` on warm and **cold** (`rm -rf o`) trees, exit status read from `make` directly, never through a pipe:

```
ci: PASS
teal:     308 checks: 308 passed, 0 failed
format:   308 checks: 308 passed, 0 failed
test:     150 checks: 150 passed
example:   30 checks:  30 passed, 0 failed
lint:     384 checks: 384 passed, 0 failed
coverage: ratchet ok
```

CI on the first commit: **all 7 jobs green.** The `build` job matters most here — it ran the full gate cold in the privileged container and ended `ci: PASS`, and the `enforce` job in the same image reported `sandbox-canary: PASS — out-of-grant write was blocked`, so Landlock enforcement was live for that run. Together those answer #775's one open question: the sandboxed teal/format rules build fine without the copy layer minting their output directories first. (The dev host has no Landlock — `sandbox-canary` SKIPs there — so this could only be settled in CI. Note `make enforce` alone does *not* cover it; it only builds the three sandbox test files.)

## Note for a follow-up

The `Makefile` was at **exactly 500 lines** before this change — zero headroom against the lint cap, and my first gate run failed on exactly that after I added comments. Deleting `stage1`/`stage2` brought it to **485**, so there is room again, but it is worth splitting before the remaining groups land, since #778 and #779 both add rules.

Remaining groups: #777 (`only=` artifact completeness), #778 (collapse the three test lanes), #779 (one report implementation), #780 (`build_files` split), #781 (cost/value review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bQu6RAxLxnv7WFYqyre5b