### PR TITLE
build: split build_files into per-consumer runtime closures (#780)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ include 3p/tl/cook.mk
 .PHONY: help
 ## Show this help message
 help: export LUA_PATH = $(tree_lua_path)
-help: $(build_files) | $(bootstrap_cosmic)
+help: $(build_help) | $(bootstrap_cosmic)
 	@$(bootstrap_cosmic) $(build_help) $(MAKEFILE_LIST)
 
 ## Filter targets by substring (make test only=teal; also narrows fetch/stage)
@@ -128,7 +128,7 @@ $(FETCH_O)/.exists $(STAGE_O)/.exists: | $(bootstrap_cosmic)
 $(o)/%/.fetched: export SSL_USE_SYSTEM_CERTS = 1
 $(o)/%/.fetched: .PLEDGE := $(pledge_build) inet dns
 $(o)/%/.fetched: .UNVEIL := $(unveil_fetch) $(unveil_dev) r:/etc/resolv.conf r:/etc/hosts r:/etc/ssl $(if $(SSL_CERT_FILE),r:$(SSL_CERT_FILE))
-$(o)/%/.fetched: $(o)/%/.versioned $(build_files) $(stdlib_lua) | $(bootstrap_cosmic) $(FETCH_O)/.exists
+$(o)/%/.fetched: $(o)/%/.versioned $(build_fetch_files) $(stdlib_lua) | $(bootstrap_cosmic) $(FETCH_O)/.exists
 	@$(bootstrap_cosmic) -- $(build_fetch) $< $(platform) $@
 
 # versions get staged: o/module/.staged -> o/staged/module/<ver>-<sha>
@@ -138,7 +138,7 @@ all_staged := $(patsubst %/.fetched,%/.staged,$(all_fetched))
 staged: $(all_staged)
 $(o)/%/.staged: .PLEDGE := $(pledge_build)
 $(o)/%/.staged: .UNVEIL := $(unveil_stage) $(unveil_dev)
-$(o)/%/.staged: $(o)/%/.fetched $(build_files) $(stdlib_lua) | $(STAGE_O)/.exists
+$(o)/%/.staged: $(o)/%/.fetched $(build_stage_files) $(stdlib_lua) | $(STAGE_O)/.exists
 	@$(bootstrap_cosmic) -- $(build_stage) $(o)/$*/.versioned $(platform) $< $@
 
 all_tests := $(foreach x,$(modules),$($(x)_tests))

--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -13,7 +13,22 @@ build_pack := $(o)/lib/build/build-pack.lua
 # strict-compile type gate like every other build script.
 build_makeboot := $(o)/lib/build/make-boot.lua
 build_audit := $(o)/lib/build/audit-unveil.lua
+# The module's _files: everything under lib/build compiled, which is what
+# `make files` builds and what the build tests exercise at runtime.
 build_files := $(build_fetch) $(build_stage) $(build_untar) $(build_pack) $(build_portable) $(build_reporter) $(build_help) $(build_lint) $(build_makeboot) $(build_audit)
+
+# Per-consumer runtime closures (#780). build_files conflates "what a
+# recipe execs" with "everything here, compiled so it gets the strict
+# type gate" — so `make help` compiled ten scripts to run one, and an
+# edit to audit-unveil.tl invalidated the fetch and stage rules. These
+# are the actual require closures (build.* only; the cosmic.* halves ride
+# $(stdlib_lua), already a prerequisite of both rules):
+#   build-fetch -> build.portable
+#   build-stage -> build.portable, build.build-untar
+# make-boot is deliberately in NEITHER: bin/make runs it from SOURCE
+# before any make exists, so its compiled copy exists only for the gate.
+build_fetch_files := $(build_fetch) $(build_portable)
+build_stage_files := $(build_stage) $(build_untar) $(build_portable)
 
 # The recipe steps (copy/compile/capture/tee/...) are the pinned
 # bootstrap's own `--build` surface (#756 item 3): cosmic.build ships


### PR DESCRIPTION
Third group of the post-#756 build simplification pass, following #782 and #783. Closes #780. Small and self-contained.

## The bucket

`build_files` conflated two unrelated sets — **what a recipe execs** and **everything under `lib/build` compiled so it gets the strict type gate** — and three rules depended on the union:

```make
help: $(build_files)                          # ten scripts compiled to run one
$(o)/%/.fetched: ... $(build_files) ...
$(o)/%/.staged:  ... $(build_files) ...
```

So an edit to `audit-unveil.tl` — which only the `audit-unveil` target ever runs — invalidated the fetch and stage rules.

## The actual closures

Read from the sources rather than assumed:

| script | `build.*` requires |
|---|---|
| `build-fetch` | `build.portable` |
| `build-stage` | `build.portable`, `build.build-untar` |
| `build-untar` | `build.portable` |
| `reporter`, `make-help`, `build-pack`, `make-boot`, `audit-unveil` | none |

The `cosmic.*` halves ride `$(stdlib_lua)`, already a prerequisite of both rules.

`make-boot` is deliberately in **neither** closure: `bin/make` runs it from *source* before any make exists, so its compiled copy exists only for the type gate. That is now stated at the definition instead of being implicit.

`build_files` stays as the module's `_files` — what `make files` builds and what the build tests exercise at runtime via `LUA_PATH`. Only `help`/`fetch`/`stage` change, to name what they use.

## Verification

**Measured, not asserted.** With `o/lib/build` removed:

```
$ bin/make -n help | grep 'build compile'
... lib/build/make-help.tl
$ bin/make -n help | grep -c 'build compile'
1
```

Ten compiles → one.

**The narrowing was checked by forcing the rules to actually re-run**, rather than letting an up-to-date tree prove nothing:

```
$ rm -rf o/cosmos o/tl o/staged o/fetched && bin/make -j staged
↓ FETCH  .../v0.24.8.tar.gz
□ STAGE  tl @ 0.24.8-8d7a143
↓ FETCH  .../cosmos.zip
□ STAGE  cosmos @ 2026.07.25-479c2e2c6-61ec9b6
STAGED_EXIT=0
```

A missing runtime dep would have surfaced as a loud `module not found` from the recipe — that is the failure mode this change could plausibly introduce, so it is the one I exercised.

## Gate

`bin/make -j ci` → `ci: PASS`, exit status read from `make` directly.

## Remaining

#778 (collapse the three test lanes), #779 (one report implementation), #781 (cost/value review).

**Recommended before #778/#779:** split the `Makefile`. It is at 488 lines against the 500-line lint cap, both of those issues add rules, and a gate run has already failed on exactly that during this pass. Not currently a filed issue — happy to open one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bQu6RAxLxnv7WFYqyre5b

---
_Generated by [Claude Code](https://claude.ai/code/session_014bQu6RAxLxnv7WFYqyre5b)_