### PR TITLE
build: one .got status contract, shared by both reporters (#779)

### DIFF
--- a/cook.mk
+++ b/cook.mk
@@ -136,6 +136,12 @@ $(reporter_summaries): .UNVEIL := $(unveil_dev)
 # REPORTER_NOTE: the lint summary's deleted-files note rides the env
 $(reporter_summaries): .ENV := LUA_PATH REPORTER_NOTE LC_ALL TZ NO_COLOR
 $(reporter_summaries): export LUA_PATH = $(tree_lua_path)
+# reporter.tl reads the .got status contract from cosmic.testrun (#779).
+# Declare the compiled module: tree_lua_path ends in `;;`, so without this
+# a lane that has not built the stdlib yet (bin/make lint on a cold tree)
+# would silently resolve it from the bootstrap's embedded, older copy —
+# the #666/#608 stale-stdlib class.
+$(reporter_summaries): $(o)/lib/cosmic/testrun.lua
 
 # Third ENFORCED family (#729): the teal/format check rules, which exec
 # the assimilated $(cosmic_check_bin) duplicate (see lib/cosmic/cook.mk)

--- a/lib/build/reporter.tl
+++ b/lib/build/reporter.tl
@@ -3,6 +3,10 @@
 local getopt = require("cosmic.getopt")
 local proc = require("cosmic.proc")
 local fs = require("cosmic.fs")
+-- The .got exit-code contract and its icons live in cosmic.testrun (#779):
+-- both reporters feed cosmic.build's ci verdict, so they must agree on what
+-- an exit code means. See status_of there.
+local testrun = require("cosmic.testrun")
 
 local record CheckResult
   status: string
@@ -19,13 +23,6 @@ local record CategorizedResults
   ignore: {CheckResult}
 end
 
-local status_icons: {string: string} = {
-  pass = "✓",
-  fail = "✗",
-  skip = "→",
-  ignore = "○",
-}
-
 local function extract_checker(filename: string): string
   return filename:match("%.([^%.]+)%.got$")
 end
@@ -34,7 +31,7 @@ local function format_results(results: {CheckResult}): string
   local lines: {string} = {}
   for _, result in ipairs(results) do
     local status = string.upper(result.status)
-    local icon = status_icons[result.status] or " "
+    local icon = testrun.STATUS_ICONS[result.status] or " "
     local checker = result.checker or ""
     local line = string.format("%s %-6s %-8s %s", icon, status, checker, result.name)
     if result.status ~= "pass" and result.message and result.message ~= "" then
@@ -162,15 +159,9 @@ local function main(...: string): integer, string
     for _, file in ipairs(result_files) do
       local content = fs.read(file)
       if content then
-        local exit_code = tonumber(string.match(content, "^(%d+)"))
-        local status_str: string
-        if exit_code == 0 then
-          status_str = "pass"
-        elseif exit_code == 2 then
-          status_str = "skip"
-        else
-          status_str = "fail"
-        end
+        -- cast: tonumber returns number, status_of takes integer
+        local exit_code = (tonumber(string.match(content, "^(%d+)")) or -1) as integer
+        local status_str = testrun.status_of(exit_code)
         local base = string.gsub(file, "%.got$", "")
         -- cast: or fallback does not narrow
         local out_content = (fs.read(base .. ".out") or "") as string

--- a/lib/build/reporter_test.tl
+++ b/lib/build/reporter_test.tl
@@ -182,3 +182,71 @@ local function test_reporter_note()
   assert(written:match("gone%.tl"), "expected note in summary file")
 end
 test_reporter_note()
+
+-- The ci verdict (cosmic.build's do_verdict) grades a stage by matching
+-- this pattern against whatever summary the stage produced — and the build
+-- has TWO producers: this reporter, for the teal/format/lint/example/
+-- benchmark stages, and `cosmic --report` (cosmic.testrun) for the
+-- test/coverage/enforce lanes. They format differently ON PURPOSE (the
+-- reporter always prints "0 failed"; testrun omits the clause at zero), so
+-- the shared contract is narrow but load-bearing: a summary WITH failures
+-- must carry a matching clause, one WITHOUT must not. Pin it for both, or
+-- a format tweak on either side silently makes ci grade a red stage green
+-- — the #714 laundering class, one layer up (#779).
+local VERDICT_PATTERN <const> = "[1-9]%d* failed"
+
+local function run_report(...: string): integer, string
+  local child = require("cosmic.child")
+  local args: {string} = {fs.join(os.getenv("TEST_BIN") or "", "cosmic"), "--report"}
+  for _, a in ipairs({...}) do
+    table.insert(args, a)
+  end
+  local result, serr = child.run(args)
+  assert(result, "spawn cosmic --report failed: " .. tostring(serr))
+  local r = result as child.Result -- cast: record union after guard
+  return (r.code or 1), r.stdout
+end
+
+local function test_verdict_pattern_agrees_across_both_reporters()
+  local dir = fs.join(tmpdir, "verdict")
+  fs.makedirs(dir)
+  write_test_result(fs.join(dir, "red.test"), 1, "", "boom\n")
+  write_test_result(fs.join(dir, "green.test"), 0, "ok\n", "")
+
+  -- lib/build/reporter: the check stages
+  local rc, rout = run_reporter("--dir", dir, fs.join(dir, "red.test.got"))
+  assert(rc ~= 0, "reporter must exit nonzero on a failure")
+  assert(rout:match(VERDICT_PATTERN),
+    "reporter failure summary must carry the clause ci grades on:\n" .. rout)
+  local _, rpass = run_reporter("--dir", dir, fs.join(dir, "green.test.got"))
+  assert(not rpass:match(VERDICT_PATTERN),
+    "reporter all-pass summary must NOT match the failure clause:\n" .. rpass)
+
+  -- cosmic --report (cosmic.testrun): the test lanes
+  local tc, tout = run_report(fs.join(dir, "red.test.got"))
+  assert(tc ~= 0, "cosmic --report must exit nonzero on a failure")
+  assert(tout:match(VERDICT_PATTERN),
+    "testrun failure summary must carry the clause ci grades on:\n" .. tout)
+  local _, tpass = run_report(fs.join(dir, "green.test.got"))
+  assert(not tpass:match(VERDICT_PATTERN),
+    "testrun all-pass summary must NOT match the failure clause:\n" .. tpass)
+end
+test_verdict_pattern_agrees_across_both_reporters()
+
+-- test: both reporters read the exit-code contract from one place (#779)
+local function test_status_contract_is_shared()
+  local testrun = require("cosmic.testrun")
+  assert(testrun.status_of(0) == "pass", "0 is a pass")
+  assert(testrun.status_of(2) == "skip", "2 is a skip")
+  assert(testrun.status_of(1) == "fail", "1 is a failure")
+  assert(testrun.status_of(127) == "fail", "127 is a failure")
+
+  -- and the reporter classifies through it: a .got of 2 reports as a skip
+  local dir = fs.join(tmpdir, "skipstatus")
+  fs.makedirs(dir)
+  write_test_result(fs.join(dir, "s.test"), 2, "", "")
+  local code, out = run_reporter("--dir", dir, fs.join(dir, "s.test.got"))
+  assert(code == 0, "a skip must not fail the stage, got: " .. tostring(code))
+  assert(out:match("1 skipped"), "reporter should count exit 2 as a skip:\n" .. out)
+end
+test_status_contract_is_shared()

--- a/lib/cosmic/testrun.tl
+++ b/lib/cosmic/testrun.tl
@@ -5,6 +5,33 @@ local env = require("cosmic.env")
 local fs = require("cosmic.fs")
 local instrument = require("cosmic.cli.instrument")
 
+--- Display icons for a `.got` status.
+local STATUS_ICONS: {string: string} = {
+  pass = "✓",
+  fail = "✗",
+  skip = "→",
+  ignore = "○",
+}
+
+--- Classify the exit code recorded in a `.got` file.
+---
+--- ONE definition of the contract (#779). The build has two reporters —
+--- this module covers the test/coverage/enforce lanes, lib/build/reporter
+--- covers teal/format/lint/example/benchmark — and cosmic.build's
+--- `--build verdict` grades whichever of them wrote a stage's summary. A
+--- silent disagreement about what exit 2 means would mis-grade `ci`, the
+--- same failure class as #714 one layer up, so both read it from here.
+--- @param exit_code integer Exit code from the .got file
+--- @return string "pass" (0), "skip" (2), or "fail" (anything else)
+local function status_of(exit_code: integer): string
+  if exit_code == 0 then
+    return "pass"
+  elseif exit_code == 2 then
+    return "skip"
+  end
+  return "fail"
+end
+
 --- Run a test executable and capture output.
 --- Creates a temporary directory (TEST_TMPDIR) for the test and cleans up after.
 --- @param argv {string} Command and arguments
@@ -200,15 +227,12 @@ local function report(paths: {string}): integer
         end
       end
 
-      local status: string
-      if exit_code == 0 then
-        status = "pass"
+      local status = status_of(exit_code)
+      if status == "pass" then
         passed = passed + 1
-      elseif exit_code == 2 then
-        status = "skip"
+      elseif status == "skip" then
         skipped = skipped + 1
       else
-        status = "fail"
         failed = failed + 1
       end
 
@@ -229,14 +253,7 @@ local function report(paths: {string}): integer
   local slowest_ms = 0
 
   for _, result in ipairs(results) do
-    local icon: string
-    if result.status == "pass" then
-      icon = "✓"
-    elseif result.status == "skip" then
-      icon = "→"
-    else
-      icon = "✗"
-    end
+    local icon = STATUS_ICONS[result.status] or STATUS_ICONS.fail
     -- extract timing from stderr instrumentation lines
     local timing = ""
     if result.stderr ~= "" then
@@ -340,11 +357,15 @@ local _ = Example_makefile
 local record TestrunModule
   run: function(argv: {string}, output_base: string): integer
   report: function(paths: {string}): integer
+  status_of: function(exit_code: integer): string
+  STATUS_ICONS: {string: string}
 end
 
 local M: TestrunModule = {
   run = run,
   report = report,
+  status_of = status_of,
+  STATUS_ICONS = STATUS_ICONS,
 }
 
 return M


### PR DESCRIPTION
Fifth group of the post-#756 build simplification pass, following #782–#785. Closes #779.

## The coupling

The build has **two** reporters — `cosmic.testrun` for the test/coverage/enforce lanes, `lib/build/reporter` for teal/format/lint/example/benchmark — and each carried its own copy of the `.got` exit-code contract:

```lua
if exit_code == 0 then "pass" elseif exit_code == 2 then "skip" else "fail"
```

plus its own icon table, written independently. `cosmic.build`'s `--build verdict` then grades a stage by matching `[1-9]%d* failed` against **whichever of them wrote that stage's summary**. A silent disagreement about what exit 2 means would mis-grade `ci` — the #714 laundering class, one layer up.

Both now read `status_of()` and `STATUS_ICONS` from `cosmic.testrun`, which already owns the `.got` format.

**No new module.** Adding one under `lib/cosmic` would have dragged in public-manifest, doc-index, and coverage-ratchet churn to share five lines. `testrun` is where this belongs.

## What I deliberately did not change

**The summary formats stay different.** The reporter always prints `0 failed, 0 skipped, 0 ignored`; testrun omits a clause at zero. Unifying them would change CI log output for no correctness gain — and they satisfy the verdict regex *for different reasons*, which is precisely why the contract needed **pinning** rather than assuming:

```
reporter (all pass):  teal: 2 checks: 2 passed, 0 failed, 0 skipped, 0 ignored
testrun  (all pass):  150 checks: 150 passed
```

`0 failed` doesn't match `[1-9]…`, and testrun omits the clause entirely. Two independent accidents, both correct. The new test asserts for **both** producers that a summary *with* failures carries a matching clause and one *without* does not.

**Declined the second half of the issue.** I claimed five identical summary rules wanted an `$(eval)` template. Looking at them: four are two lines each, they already share every annotation through the `$(reporter_summaries)` list, and lint differs legitimately (guards + explicit file list). A template costs about as many lines as it saves and reads worse. The duplication I described isn't really there.

**Deferred: `do_verdict` grading on prose at all.** It already reads the per-stage `ci-ok` exit marker that #714 made authoritative, so the text match is redundant belt-and-braces. But `do_verdict` ships **embedded in the pinned bootstrap**, so changing it needs a release plus a pin bump — same two-phase constraint as #776's phase 2.

## One hazard closed on the way

Declared `$(o)/lib/cosmic/testrun.lua` as a prerequisite of the reporter summaries. `tree_lua_path` ends in `;;`, so a lane that hadn't built the stdlib yet (`bin/make lint` on a cold tree) would have resolved the shared module from the bootstrap's embedded *older* copy rather than failing — the #666/#608 stale-stdlib class. Sharing code across the bootstrap boundary is exactly where that bites.

## Falsifiability

Checked by hand, not assumed. Making `status_of(2)` return `"fail"`:

```
reporter_test exit: 1
  o/lib/build/reporter_test.lua:241: in local 'test_status_contract_is_shared'
```

Reverting → exit 0.

## Gate

`bin/make -j ci` → `ci: PASS`, exit status read from `make` directly.

## Remaining

#781 (cost/value review of `audit-unveil` and the test-lane sandbox) — a decision issue, yours to make. #786 (split the `Makefile`, now at its 500-line cap) is filed and unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bQu6RAxLxnv7WFYqyre5b

---
_Generated by [Claude Code](https://claude.ai/code/session_014bQu6RAxLxnv7WFYqyre5b)_