### PR TITLE
build: retire the compile flag stamp from the driver (#776 phase 2)

### DIFF
--- a/lib/cosmic/build.tl
+++ b/lib/cosmic/build.tl
@@ -63,35 +63,28 @@ local function child_tree_lua_path(): string
   return tree
 end
 
---- compile <flag_stamp> <bootstrap> <src> <out> [compiler flags...]
---- Reads the probed flag and sets the child's LUA_PATH (";;" for
---- strict compiles, $TREE_LUA_PATH otherwise; TL_PATH passes through
---- from the rule's export).
+--- compile <bootstrap> <src> <out> [compiler flags...]
+--- Always a STRICT compile (#776): --compile-strict type checks and then
+--- generates from that same checked AST, so nothing ships that did not
+--- typecheck, under LUA_PATH=";;" so output cannot depend on parallel
+--- build order (#733). TL_PATH passes through from the rule's export.
+---
+--- The pre-#776 driver took a flag-stamp path as its first argument and
+--- read a probed flag out of it, falling back to a non-strict,
+--- order-dependent compile when the pinned bootstrap predated the flag.
+--- That fallback was the one place a stale input degraded silently; the
+--- flag was pinned in #776 and the stamp is retired here.
 local function do_compile(args: {string}): integer
-  local stamp, bootstrap, src, out = args[1], args[2], args[3], args[4]
+  local bootstrap, src, out = args[1], args[2], args[3]
   if not out then
-    return fail("usage: compile <flag_stamp> <bootstrap> <src> <out> [flags...]")
+    return fail("usage: compile <bootstrap> <src> <out> [flags...]")
   end
-  -- cast: or fallback does not narrow
-  local flag = ((fs.read(stamp) or "") as string):match("%S+")
-  if flag ~= "--compile-strict" and flag ~= "--compile" then
-    return fail("bad compile flag in " .. stamp .. ": " .. tostring(flag))
-  end
-  if flag == "--compile-strict" then
-    env.set("LUA_PATH", ";;")
-  else
-    local tree = child_tree_lua_path()
-    if not tree then
-      return fail("TREE_LUA_PATH required for non-strict compiles")
-    end
-    env.set("LUA_PATH", tree)
-  end
-
+  env.set("LUA_PATH", ";;")
   local argv: {string} = {bootstrap}
-  for i = 5, #args do
+  for i = 4, #args do
     table.insert(argv, args[i])
   end
-  table.insert(argv, flag)
+  table.insert(argv, "--compile-strict")
   table.insert(argv, src)
   return run_into(argv, out)
 end

--- a/lib/cosmic/build_test.tl
+++ b/lib/cosmic/build_test.tl
@@ -55,21 +55,21 @@ local function test_link_replaces()
 end
 test_link_replaces()
 
-local function compile_fixture(name: string, content: string): string, string, string
+-- #776 retired the flag-stamp argument: compiles are unconditionally
+-- strict, so the fixture is just a source and an output path.
+local function compile_fixture(name: string, content: string): string, string
   local dir = fs.join(tmpdir, name)
   fs.makedirs(dir)
-  local stamp = fs.join(dir, "compile-flag")
   local src = fs.join(dir, "mod.tl")
   local out = fs.join(dir, "mod.lua")
-  assert(fs.write(stamp, "--compile\n"))
   assert(fs.write(src, content))
-  return stamp, src, out
+  return src, out
 end
 
 local function test_compile_writes_output()
-  local stamp, src, out = compile_fixture("c-ok", "local x: number = 1\nprint(x)\n")
+  local src, out = compile_fixture("c-ok", "local x: number = 1\nprint(x)\n")
   env.set("TREE_LUA_PATH", ";;")
-  local code, _out, err = run_driver("compile", stamp, test_bin, src, out)
+  local code, _out, err = run_driver("compile", test_bin, src, out)
   assert(code == 0, "compile failed (" .. tostring(code) .. "): " .. err)
   -- cast: or fallback does not narrow
   local lua = (fs.read(out) or "") as string
@@ -78,16 +78,16 @@ end
 test_compile_writes_output()
 
 local function test_compile_unchanged_keeps_mtime()
-  local stamp, src, out = compile_fixture("c-mtime", "print(1)\n")
+  local src, out = compile_fixture("c-mtime", "print(1)\n")
   env.set("TREE_LUA_PATH", ";;")
-  local code = run_driver("compile", stamp, test_bin, src, out)
+  local code = run_driver("compile", test_bin, src, out)
   assert(code == 0, "first compile failed")
   local st1 = fs.stat(out)
   assert(st1, "output should exist")
   local s1, n1 = (st1 as fs_types.Stat):mtim() -- cast: mixed-representation Stat
   -- second run with identical content must not rewrite the output
   fs.chmod(out, tonumber("444", 8) as integer) -- cast: octal is integral
-  code = run_driver("compile", stamp, test_bin, src, out)
+  code = run_driver("compile", test_bin, src, out)
   assert(code == 0, "second compile failed")
   local st2 = fs.stat(out)
   local s2, n2 = (st2 as fs_types.Stat):mtim() -- cast: mixed-representation Stat
@@ -95,24 +95,25 @@ local function test_compile_unchanged_keeps_mtime()
 end
 test_compile_unchanged_keeps_mtime()
 
+-- strictness (#776): a type error must fail AND leave no output, so a
+-- file that did not typecheck can never be packed into the binary
 local function test_compile_failure_no_output()
-  local stamp, src, out = compile_fixture("c-bad", "local x: number = \"not a number\"\n")
+  local src, out = compile_fixture("c-bad", "local x: number = \"not a number\"\n")
   env.set("TREE_LUA_PATH", ";;")
-  local code, _out, err = run_driver("compile", stamp, test_bin, src, out)
+  local code, _out, err = run_driver("compile", test_bin, src, out)
   assert(code ~= 0, "type error must fail the compile")
   assert(err ~= "", "compiler stderr must pass through")
   assert(not fs.stat(out), "failed compile must not write output")
 end
 test_compile_failure_no_output()
 
-local function test_compile_rejects_bad_stamp()
-  local stamp, src, out = compile_fixture("c-stamp", "print(1)\n")
-  assert(fs.write(stamp, "--rm -rf\n"))
-  local code, _out, err = run_driver("compile", stamp, test_bin, src, out)
-  assert(code ~= 0, "bad stamp must fail")
-  assert(err:match("bad compile flag"), "expected stamp error, got: " .. err)
+local function test_compile_requires_all_paths()
+  local src, _out = compile_fixture("c-usage", "print(1)\n")
+  local code, _stdout, err = run_driver("compile", test_bin, src)
+  assert(code ~= 0, "a missing output path must fail")
+  assert(err:match("usage: compile"), "expected a usage error, got: " .. err)
 end
-test_compile_rejects_bad_stamp()
+test_compile_requires_all_paths()
 
 local function test_unknown_mode()
   local code, _out, err = run_driver("explode")


### PR DESCRIPTION
Phase 2 of #776. **Driver only** — the recipes and the bootstrap pin are deliberately untouched, because this is the half that has to ship in a release before it can be used.

## The change

`do_compile` now takes `<bootstrap> <src> <out> [flags...]` and always compiles strict under `LUA_PATH=";;"`. Gone with the stamp:

- reading and validating a flag out of a file;
- the **non-strict branch** that set `LUA_PATH` from `TREE_LUA_PATH` — the order-dependent compile #733 exists to prevent.

`child_tree_lua_path` stays; `do_capture` still uses it.

## Sequencing — the awkward part

`lib/cosmic/build.tl` is compiled and embedded in the binary it builds, but **nothing in the build invokes it**: every recipe step goes through `$(bootstrap_cosmic)`, i.e. the *pinned* bootstrap's older copy. `build_test` spawns the *freshly built* binary, so it exercises the new signature.

Both halves are green in the same run precisely because they are different binaries:

```
Makefile:86   @$(bootstrap_cosmic) --build compile $(compile_flag_stamp) ...   # legacy form, old driver
build_test    <TEST_BIN>/cosmic --build compile <bootstrap> <src> <out>        # new form, new driver
```

**Next steps, in order:**

1. merge this
2. cut a release (builds `cosmic-lua` from `main`, so the released binary carries the new driver)
3. one atomic commit: bump `bootstrap_url` + `bootstrap_sha256` to that release **and** switch the recipe to the new form, drop the `$(compile_flag_stamp)` target and prerequisite, and drop `TREE_LUA_PATH` from the compile family's `.ENV`/exports

Step 3 is safe as a single commit because `bin/make` re-provisions the bootstrap from the pin *before* make parses anything — there is no window where a new recipe meets an old driver.

## Not doing the `ci-ok` half — it would remove a real check

The plan was to have `do_verdict` grade on the per-stage exit marker alone and stop matching summary prose. `build_test`'s existing `test_verdict` fixtures show the two checks are **complementary, not redundant**:

| fixture | state | caught by |
|---|---|---|
| `launder` | clean summary, **no** marker | the marker (#714) |
| `bad` | **failing** summary, marker **present** | the prose |

Marker-only grading would grade `bad` **green**. That fixture models a reporter that reports failures but exits 0 — narrow, but a genuine second check on a path where the first one lies.

The reason to drop the prose match was that two independently-formatted reporters made it fragile. **#779 closed that** by pinning both producers' failure clauses with a test. The fragility is gone; the check is worth keeping. Happy to do it anyway if you disagree — it's a one-line change — but I'd be knowingly narrowing the gate.

## Gate

`bin/make -j ci` → `ci: PASS`, `build_test` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bQu6RAxLxnv7WFYqyre5b

---
_Generated by [Claude Code](https://claude.ai/code/session_014bQu6RAxLxnv7WFYqyre5b)_