### PR TITLE
test: cover the PID-1 supervisor, the CLI error/gate paths, and the proxy allow branch (#504)

### DIFF
--- a/lib/cosmic/cli/main_handlers_test.tl
+++ b/lib/cosmic/cli/main_handlers_test.tl
@@ -1,0 +1,184 @@
+#!/usr/bin/env cosmic
+--- Tests for the cosmic.cli.main_handlers surfaces #504 flagged as
+--- zero-coverage: the format gate, --docs lookup (including its
+--- not-found UX), the --examples chain, and --make.
+---
+--- These spawn the built binary rather than calling the handlers
+--- in-process, for two reasons: the handlers write to stdout/stderr
+--- (which would corrupt this test's own output), and #504 asks for the
+--- *chain* -- argument parsing, dispatch, and handler together -- not
+--- just the leaf function.
+
+local check = require("cosmic.check")
+local fs = require("cosmic.fs")
+local spawn = require("cosmic.child")
+
+local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
+local tmpdir = os.getenv("TEST_TMPDIR")
+
+local record Run
+  code: integer
+  out: string
+  err: string
+end
+
+--- Run the cosmic binary with the given arguments and collect its exit
+--- code and streams.
+local function cli(...: string): Run
+  local argv: {string} = {cosmic}
+  for _, a in ipairs({...}) do
+    argv[#argv + 1] = a
+  end
+  local h = check.must(spawn.spawn(argv))
+  local r = check.must(h:wait())
+  -- code is nil when the child was signaled; report that as non-zero
+  -- so callers can treat "did not exit cleanly" uniformly.
+  return {
+    code = r.code or 128,
+    out = r.stdout or "",
+    err = r.stderr or "",
+  }
+end
+
+-- --check-format: the gate that keeps the tree formatted. Exercised in
+-- both directions so a gate that accepted everything would fail here.
+
+local formatted = fs.join(tmpdir, "formatted.tl")
+fs.write(formatted, 'local x = 1\nprint(x)\n')
+
+local misformatted = fs.join(tmpdir, "misformatted.tl")
+fs.write(misformatted, 'local function f()\n        return 1\nend\nprint(f())\n')
+
+local function test_check_format_accepts_formatted_source()
+  local r = cli("--check-format", formatted)
+  assert(r.code == 0,
+    "well-formatted file should pass, got " .. r.code .. ": " .. r.err)
+end
+test_check_format_accepts_formatted_source()
+
+local function test_check_format_rejects_misformatted_source()
+  local r = cli("--check-format", misformatted)
+  assert(r.code ~= 0, "misformatted file must be rejected, got exit 0")
+  assert((r.out .. r.err):find("misformatted", 1, true),
+    "the diagnostic should name the file, got: " .. r.out .. r.err)
+end
+test_check_format_rejects_misformatted_source()
+
+local function test_check_format_reports_missing_file()
+  local r = cli("--check-format", fs.join(tmpdir, "nope-does-not-exist.tl"))
+  assert(r.code ~= 0, "a missing file must not pass the gate")
+  assert(#(r.out .. r.err) > 0,
+    "a missing file should produce a diagnostic, not silence")
+end
+test_check_format_reports_missing_file()
+
+local function test_check_format_rejects_unparseable_source()
+  local broken = fs.join(tmpdir, "broken.tl")
+  fs.write(broken, 'local function f(\n')
+  local r = cli("--check-format", broken)
+  assert(r.code ~= 0, "unparseable source must be rejected, got exit 0")
+end
+test_check_format_rejects_unparseable_source()
+
+-- --docs: the lookup path and, per #504, its not-found UX.
+
+local function test_docs_finds_a_real_module()
+  local r = cli("--docs", "cosmic.fs")
+  assert(r.code == 0, "--docs cosmic.fs should succeed, got: " .. r.err)
+  assert(r.out:find("fs", 1, true), "expected fs docs, got: " .. r.out)
+end
+test_docs_finds_a_real_module()
+
+--- The not-found path must fail loudly and say something useful -- the
+--- specific UX complaint in #504. A miss that exited 0, or exited 1
+--- with an empty message, both regress it.
+local function test_docs_miss_fails_with_a_message()
+  local r = cli("--docs", "zzz-no-such-symbol-anywhere")
+  assert(r.code ~= 0, "a docs miss must not exit 0")
+  local said = r.out .. r.err
+  assert(#said > 0, "a docs miss must explain itself, got empty output")
+  assert(said:find("zzz%-no%-such%-symbol%-anywhere") or
+    said:lower():find("no ") or said:lower():find("not found"),
+    "the miss should reference the query or say not-found, got: " .. said)
+end
+test_docs_miss_fails_with_a_message()
+
+-- --examples: the chain #504 lists as zero-coverage.
+
+local function test_examples_lists_without_argument()
+  local r = cli("--examples")
+  assert(r.code == 0, "bare --examples should succeed, got: " .. r.err)
+  assert(#r.out > 0, "bare --examples should list something")
+end
+test_examples_lists_without_argument()
+
+local function test_examples_shows_a_known_module()
+  -- poll ships poll_example.tl, so this exercises the show-module path
+  -- rather than the listing path.
+  local r = cli("--examples", "poll")
+  assert(r.code == 0, "--examples poll should succeed, got: " .. r.err)
+  assert(r.out:find("poll", 1, true),
+    "expected poll examples, got: " .. r.out)
+end
+test_examples_shows_a_known_module()
+
+local function test_examples_miss_fails()
+  local r = cli("--examples", "zzz-no-such-module")
+  assert(r.code ~= 0, "--examples on an unknown module must not exit 0")
+end
+test_examples_miss_fails()
+
+-- --make: handle_make delegates to cosmic.make, which SCANS a
+-- directory and generates a Makefile rather than running one the user
+-- wrote. With no directory it prints the generated file; with one it
+-- pipes it to make.
+
+local function test_make_prints_the_generated_makefile()
+  local r = cli("--make")
+  assert(r.code == 0, "bare --make should succeed, got: " .. r.err)
+  assert(r.out:find("Generated by cosmic --make", 1, true),
+    "expected the generated-makefile header, got: " .. r.out)
+  for _, target in ipairs({"check:", "format:", "test:", "ci:", "clean:"}) do
+    assert(r.out:find(target, 1, true),
+      "generated makefile should define " .. target .. ", got: " .. r.out)
+  end
+end
+test_make_prints_the_generated_makefile()
+
+--- Scanning a directory and actually running the generated rules. The
+--- generated file uses `COSMIC ?= cosmic`, so without an override the
+--- recipes shell out to a `cosmic` that is not on PATH in a test
+--- environment; point it at the binary under test instead.
+local function test_make_builds_a_scanned_directory()
+  local dir = fs.join(tmpdir, "mk-src")
+  fs.makedirs(dir)
+  fs.write(fs.join(dir, "a.tl"), "local x = 1\nprint(x)\n")
+  local argv = {cosmic, "--make", dir}
+  local h = check.must(spawn.spawn(argv, {
+        env = {"PATH=" .. os.getenv("PATH"), "COSMIC=" .. cosmic},
+      }))
+  local r = check.must(h:wait())
+  assert(r.code == 0,
+    "--make on a scanned dir should build, got " .. tostring(r.code)
+    .. ": " .. (r.stderr or ""))
+end
+test_make_builds_a_scanned_directory()
+
+--- The target name is interpolated into a shell command, so make.run
+--- rejects anything that is not a plain make target. This is a
+--- security boundary: without it, `--make DIR '; rm -rf ~'` would run
+--- arbitrary commands.
+local function test_make_rejects_shell_metacharacters_in_target()
+  local dir = fs.join(tmpdir, "mk-inject")
+  fs.makedirs(dir)
+  local r = cli("--make", dir, "; echo pwned")
+  assert(r.code ~= 0, "an injected target must not exit 0")
+  assert(r.err:find("invalid make target", 1, true),
+    "expected the guard's rejection on stderr, got: " .. r.err)
+  -- The rejection message quotes the offending target, so "pwned"
+  -- legitimately appears on stderr. What must NOT appear is the
+  -- *output* of running it, which `echo` would put on stdout.
+  assert(not r.out:find("pwned", 1, true),
+    "the injected command must never run, stdout was: " .. r.out)
+end
+test_make_rejects_shell_metacharacters_in_target()

--- a/lib/cosmic/cli/run_test.tl
+++ b/lib/cosmic/cli/run_test.tl
@@ -1,0 +1,89 @@
+#!/usr/bin/env cosmic
+--- Tests for cosmic.cli.run -- the two user-facing error-presentation
+--- helpers the CLI wraps every script in (#504, previously zero
+--- coverage). Both are pure string transforms, so they are tested
+--- directly rather than through a spawned binary.
+
+local run = require("cosmic.cli.run")
+local env = require("cosmic.env")
+
+-- augment_module_errors: attach require hints to Teal's compile-time
+-- "module not found" so a typo reads the same whether it was caught at
+-- compile time or run time.
+
+local function test_augment_leaves_unrelated_errors_alone()
+  local err = "foo.tl:3:1: syntax error near 'end'"
+  assert(run.augment_module_errors(err) == err,
+    "an error without a module-not-found match must pass through verbatim")
+end
+test_augment_leaves_unrelated_errors_alone()
+
+local function test_augment_appends_did_you_mean()
+  local err = "s.tl:1:1: module not found: 'cosmic.fss'"
+  local out = run.augment_module_errors(err)
+  assert(out ~= err, "a module-not-found error should be augmented")
+  assert(out:find(err, 1, true) == 1,
+    "the original message must be preserved as the prefix, got: " .. out)
+  assert(out:find("Did you mean?", 1, true),
+    "expected a Did-you-mean block, got: " .. out)
+  assert(out:find("cosmic.fs", 1, true),
+    "expected the near-miss suggestion cosmic.fs, got: " .. out)
+  -- The hint engine's own first two lines ("module 'x' not found" and
+  -- the blank after it) are dropped -- they would duplicate the Teal
+  -- error we are appending to.
+  assert(not out:find("module 'cosmic.fss' not found", 1, true),
+    "the hint's redundant header must be stripped, got: " .. out)
+  assert(not out:match("\n\n$"), "trailing blank lines must be trimmed")
+end
+test_augment_appends_did_you_mean()
+
+local function test_augment_respects_no_require_hints()
+  local err = "s.tl:1:1: module not found: 'cosmic.fss'"
+  env.set("COSMIC_NO_REQUIRE_HINTS", "1")
+  local out = run.augment_module_errors(err)
+  env.unset("COSMIC_NO_REQUIRE_HINTS")
+  assert(out == err,
+    "COSMIC_NO_REQUIRE_HINTS must disable augmentation, got: " .. out)
+end
+test_augment_respects_no_require_hints()
+
+-- trim_traceback: hide the cosmic entry point's frames so a user sees
+-- only their own stack.
+
+local function test_trim_traceback_keeps_the_message()
+  local tb = run.trim_traceback("boom")
+  assert(tb:find("boom", 1, true),
+    "the error message must survive trimming, got: " .. tb)
+end
+test_trim_traceback_keeps_the_message()
+
+local function test_trim_traceback_accepts_non_string_errors()
+  -- The parameter is `any`: a script can error() a table or a number.
+  local tb = run.trim_traceback(42)
+  assert(tb:find("42", 1, true), "expected the tostring'd value, got: " .. tb)
+end
+test_trim_traceback_accepts_non_string_errors()
+
+--- The real contract: running under the cosmic binary, the live stack
+--- passes through /zip/main.lua (the embedded entry point). Trimming
+--- must cut there, and COSMIC_FULL_TRACEBACK must keep it. Comparing
+--- the two in one test means this cannot pass vacuously on a host
+--- where the frame happens to be absent -- if /zip/main.lua is not in
+--- the untrimmed traceback there is nothing to trim, and we skip.
+local function test_trim_traceback_cuts_at_the_cosmic_entry_point()
+  env.set("COSMIC_FULL_TRACEBACK", "1")
+  local full = run.trim_traceback("boom")
+  env.unset("COSMIC_FULL_TRACEBACK")
+  if not full:find("/zip/main%.lua:") then
+    require("cosmic.check").skip(
+      "traceback trimming: no /zip/main.lua frame in this run")
+    return
+  end
+  local trimmed = run.trim_traceback("boom")
+  assert(not trimmed:find("/zip/main%.lua:"),
+    "trimmed traceback must not expose the entry point, got: " .. trimmed)
+  assert(#trimmed < #full,
+    "trimming must shorten the traceback: " .. #trimmed .. " vs " .. #full)
+  assert(trimmed:find("boom", 1, true), "message still required after trim")
+end
+test_trim_traceback_cuts_at_the_cosmic_entry_point()

--- a/lib/cosmic/quicksand/proc_test.tl
+++ b/lib/cosmic/quicksand/proc_test.tl
@@ -154,3 +154,150 @@ io.write("done\n")
   end
 end
 test_barrier_signal_wait()
+
+-- become_init: the PID-1 supervisor loop (#504).
+--
+-- These exercise behavior, not just exports. become_init does NOT
+-- require a PID namespace -- it is a plain wait(2) loop over a pid it
+-- is handed -- so every scenario below runs as an ordinary forking
+-- process and needs no privilege. Each runs in a subprocess because
+-- become_init installs process-wide sigaction handlers and reaps every
+-- child of the calling process.
+--
+-- The scripts use cosmo.unix directly (as the barrier test above does):
+-- fork/wait/kill have no cosmic.* wrapper, since cosmic.child models
+-- spawn-and-collect rather than the raw primitives a supervisor needs.
+
+--- Preamble shared by the become_init scenarios: a fork that reports a
+--- skip instead of failing when an outer sandbox denies it.
+local init_preamble = [[
+local unix = require("cosmo.unix")
+local qproc = require("cosmic.quicksand.proc")
+local time = require("cosmic.time")
+local function forked()
+  local pid, err = unix.fork()
+  if not pid then
+    io.write("skipped: fork: " .. tostring(err) .. "\n")
+    os.exit(0)
+  end
+  return pid
+end
+]]
+
+--- Run a become_init scenario under a fresh cosmic and return its
+--- stdout, or nil when the child died before reporting (an outer
+--- sandbox killing fork/sigaction, which the caller turns into a skip).
+local function run_init(name: string, body: string): string
+  local script = fs.join(tmpdir, name .. ".lua")
+  fs.write(script, init_preamble .. body)
+  local h = check.must(spawn.spawn({cosmic, script}))
+  local r = check.must(h:wait())
+  if not r.ok then
+    return nil
+  end
+  return r.stdout
+end
+
+--- The documented 0..255 case: main exited normally, so become_init
+--- returns that exit status verbatim.
+local function test_become_init_returns_child_exit_status()
+  local out = run_init("init_exit", [[
+local pid = forked()
+if pid == 0 then os.exit(42) end
+io.write("code=" .. tostring(qproc.become_init(pid)) .. "\n")
+]])
+  if not out then
+    check.skip("become_init exit status: child died (outer sandbox)")
+    return
+  end
+  if out:find("skipped") then
+    check.skip("become_init exit status: " .. out:gsub("%s+$", ""))
+    return
+  end
+  assert(out:find("code=42"), "expected code=42, got: " .. out)
+end
+test_become_init_returns_child_exit_status()
+
+--- The documented 128+signum case. SIGKILL is unblockable, so the kill
+--- lands whatever the child is doing -- no sleep/race to lose.
+local function test_become_init_maps_signal_death_to_128_plus_signum()
+  local out = run_init("init_signaled", [[
+local pid = forked()
+if pid == 0 then time.sleep(60) os.exit(0) end
+unix.kill(pid, unix.SIGKILL)
+io.write("code=" .. tostring(qproc.become_init(pid)) .. "\n")
+]])
+  if not out then
+    check.skip("become_init signal death: child died (outer sandbox)")
+    return
+  end
+  if out:find("skipped") then
+    check.skip("become_init signal death: " .. out:gsub("%s+$", ""))
+    return
+  end
+  -- 128 + SIGKILL(9)
+  assert(out:find("code=137"), "expected code=137, got: " .. out)
+end
+test_become_init_maps_signal_death_to_128_plus_signum()
+
+--- Signal forwarding plus the unknown-child reap, in one scenario: a
+--- killer child SIGTERMs the supervisor, whose handler forwards it to
+--- main. Main dies of SIGTERM (143). The killer is NOT a sidecar, so
+--- reaping it must not end the loop -- if the "unknown children keep
+--- the loop waiting" branch regressed, become_init would return early
+--- with 1 and this test would catch it.
+local function test_become_init_forwards_signals_to_main()
+  local out = run_init("init_forward", [[
+local main = forked()
+if main == 0 then time.sleep(60) os.exit(0) end
+local supervisor = unix.getpid()
+local killer = forked()
+if killer == 0 then
+  time.sleep(1)
+  unix.kill(supervisor, unix.SIGTERM)
+  os.exit(0)
+end
+io.write("code=" .. tostring(qproc.become_init(main)) .. "\n")
+]])
+  if not out then
+    check.skip("become_init forwarding: child died (outer sandbox)")
+    return
+  end
+  if out:find("skipped") then
+    check.skip("become_init forwarding: " .. out:gsub("%s+$", ""))
+    return
+  end
+  -- 128 + SIGTERM(15)
+  assert(out:find("code=143"), "expected code=143, got: " .. out)
+end
+test_become_init_forwards_signals_to_main()
+
+--- A sidecar exiting before main: on_sidecar_exit fires with that
+--- sidecar's pid, main is killed, and the supervisor reports 1.
+local function test_become_init_sidecar_exit_kills_main()
+  local out = run_init("init_sidecar", [[
+local main = forked()
+if main == 0 then time.sleep(60) os.exit(0) end
+local side = forked()
+if side == 0 then os.exit(0) end
+local fired = -1
+local code = qproc.become_init(main, {
+  sidecars = {side},
+  on_sidecar_exit = function(pid) fired = pid end,
+})
+io.write("code=" .. tostring(code)
+  .. " fired=" .. tostring(fired == side) .. "\n")
+]])
+  if not out then
+    check.skip("become_init sidecar: child died (outer sandbox)")
+    return
+  end
+  if out:find("skipped") then
+    check.skip("become_init sidecar: " .. out:gsub("%s+$", ""))
+    return
+  end
+  assert(out:find("code=1"), "expected code=1, got: " .. out)
+  assert(out:find("fired=true"),
+    "on_sidecar_exit should fire with the sidecar pid, got: " .. out)
+end
+test_become_init_sidecar_exit_kills_main()

--- a/lib/cosmic/quicksand/proxy/serve_test.tl
+++ b/lib/cosmic/quicksand/proxy/serve_test.tl
@@ -2,11 +2,23 @@
 --- End-to-end tests for the proxy's request-body limits (#497): a
 --- Content-Length over max_body_bytes is refused with 413 and a
 --- malformed one with 400, in both cases before a single body byte is
---- read or buffered. Every request here is refused before the upstream
---- dial, so the tests need only loopback sockets, no DNS or egress.
+--- read or buffered. Those requests are all refused before the
+--- upstream dial, so they need only loopback sockets, no DNS or
+--- egress.
+---
+--- The last test reaches further (#504): it is the one request the
+--- rule engine ALLOWS, so it runs on past the allowlist into the
+--- upstream dial. It stops there by design -- see the note above it
+--- for why a relayed response is not reachable hermetically.
 local check = require("cosmic.check")
 local serve = require("cosmic.quicksand.proxy.serve")
 local net = require("cosmic.net")
+-- cosmic.child models spawn-and-collect, but the upstream here has to
+-- share this process's already-bound listening socket, so this test
+-- forks directly via cosmic.proc.
+local proc = require("cosmic.proc")
+local signal = require("cosmic.signal")
+local fd = require("cosmic.fd")
 
 --- Start a proxy on an ephemeral loopback port with a tiny body cap
 --- and one allowed pass-through host.
@@ -28,8 +40,10 @@ end
 local function roundtrip(srv: serve.Server, request: string): string
   local sock = check.must(net.connect_tcp("127.0.0.1", srv.port()), "connect failed")
   assert(sock:send(request))
-  local fd = check.must(srv.accept(), "accept failed")
-  srv.handle(fd)
+  -- named to match serve.tl's own client_fd, and to leave `fd` to the
+  -- cosmic.fd module imported above
+  local client_fd = check.must(srv.accept(), "accept failed")
+  srv.handle(client_fd)
   local parts: {string} = {}
   while true do
     local chunk = sock:recv(4096)
@@ -97,3 +111,96 @@ local function test_deny_precedes_body_checks()
     "denied host should get 403, got: " .. resp:sub(1, 40))
 end
 test_deny_precedes_body_checks()
+
+-- The allowlist does not override the SSRF guard (#504).
+--
+-- This is as far as the allow path can be driven hermetically. dial()
+-- refuses every non-public IP unconditionally -- loopback included,
+-- with no opt-out -- so a test-local upstream can never be reached,
+-- and a real relayed response would need actual egress. What CAN be
+-- proved here is the security property that makes that so: putting a
+-- loopback address on the allowlist does not get you a connection to
+-- it.
+--
+-- The upstream is real and would answer 200 if it were ever reached,
+-- which is what makes this discriminating: a bypassed guard shows up
+-- as the body below, not as a subtly different error. It is also
+-- distinct from the 403 in the test above -- the rule engine DID
+-- allow this host, so the request reached the dial and came back 502.
+--
+-- handle() runs in a forked worker because the allow path ends in
+-- http.pump(), which is bidirectional and would otherwise wait on a
+-- client half-close that never comes.
+
+local UPSTREAM_BODY = "hello-from-upstream"
+
+local function test_allowlist_does_not_bypass_the_ssrf_guard()
+  local listener, lport = net.listen_tcp("127.0.0.1", 0, 8)
+  local ls = check.must(listener, "upstream listen failed")
+  local port = lport
+
+  local pid = proc.fork()
+  if not pid then
+    ls:close()
+    check.skip("ssrf guard: fork unavailable")
+    return
+  end
+  if pid == 0 then
+    local conn = ls:accept()
+    if conn is net.Socket then
+      conn:recv(65536)
+      conn:send("HTTP/1.1 200 OK\r\nContent-Length: " .. #UPSTREAM_BODY
+        .. "\r\n\r\n" .. UPSTREAM_BODY)
+      conn:close()
+    end
+    ls:close()
+    os.exit(0)
+  end
+  ls:close()
+
+  local srv = check.must(serve.new({
+        bind_port = 0,
+        allowed_hosts = {["127.0.0.1:" .. port] = {}},
+        log_level = "quiet",
+        resolve_timeout_ms = 2000,
+      }), "serve.new failed")
+  assert(srv.listen(), "listen failed")
+
+  local sock = check.must(net.connect_tcp("127.0.0.1", srv.port()),
+    "client connect failed")
+  assert(sock:send("GET http://127.0.0.1:" .. port .. "/hi HTTP/1.1\r\n"
+    .. "Host: 127.0.0.1:" .. port .. "\r\n\r\n"))
+  local cfd = check.must(srv.accept(), "proxy accept failed")
+
+  local worker = proc.fork()
+  if worker == 0 then
+    srv.handle(cfd)
+    os.exit(0)
+  end
+  -- Drop the parent's copy or the client never sees EOF once the
+  -- worker closes its own.
+  fd.wrap(cfd):close()
+
+  local parts: {string} = {}
+  while true do
+    local chunk = sock:recv(4096)
+    if not chunk then break end
+    parts[#parts + 1] = chunk
+  end
+  sock:close()
+  local resp = table.concat(parts)
+  proc.wait(worker)
+  -- The upstream is still parked in accept() and always will be --
+  -- that is the point -- so kill it rather than waiting on it.
+  proc.kill(pid, signal.SIGKILL)
+  proc.wait(pid)
+
+  assert(not resp:find(UPSTREAM_BODY, 1, true),
+    "the allowlist must not reach a loopback upstream, got: " .. resp)
+  assert(not resp:find("^HTTP/1%.1 403 "),
+    "the rule engine should have ALLOWED this host, got a deny: "
+    .. resp:sub(1, 40))
+  assert(resp:find("^HTTP/1%.1 502 "),
+    "a blocked upstream should surface as 502, got: " .. resp:sub(1, 40))
+end
+test_allowlist_does_not_bypass_the_ssrf_guard()


### PR DESCRIPTION
Works through four of the highest-risk zero-coverage areas in #504, replacing the tautological assertions it called out with tests that observe behavior.

Gate: `bin/make ci` → `ci: PASS`.

## `quicksand/proc` — the PID-1 supervisor

`become_init` was covered by `assert(type(proc.become_init) == "function")` and nothing else.

The useful discovery: **it does not need a PID namespace.** It is a plain `wait(2)` loop over a pid it is handed, so every documented outcome can be driven as an ordinary forking subprocess with no privilege and no namespace setup. All four now are:

| case | asserted |
|---|---|
| main exits normally | returns that status verbatim (42) |
| main killed by a signal | `128 + signum` (137 for SIGKILL) |
| supervisor signalled | forwards to main, which dies of it (143) |
| sidecar exits first | `on_sidecar_exit` fires with its pid, main killed, returns 1 |

The forwarding case doubles as coverage of the unknown-child reap: its killer child is *not* a sidecar, so reaping it must not end the loop. If that branch regressed, `become_init` would return 1 early and the test fails.

## `cli/run` — previously zero coverage

Both helpers are pure string transforms, so they are tested directly rather than through a spawned binary:

- `augment_module_errors` — unrelated errors pass through untouched; a `module not found` error gains the Did-you-mean block with the hint engine's redundant header stripped; `COSMIC_NO_REQUIRE_HINTS` disables it
- `trim_traceback` — keeps the message, accepts non-string error values, and (the real contract) cuts at the `/zip/main.lua` entry frame while `COSMIC_FULL_TRACEBACK` keeps it. Verified non-vacuous: the untrimmed traceback contains the frame and is 138 chars, the trimmed one does not and is 57.

## `cli/main_handlers` — the format gate, `--docs`, `--examples`, `--make`

These spawn the built binary, so they cover argument parsing and dispatch as well as the leaf handler — #504 asks for the *chain*.

The format gate is exercised in both directions (formatted → 0, misformatted → 1, missing file → 1, unparseable → 1) so a gate that accepted everything would fail here. `--docs` and `--examples` likewise cover both a hit and a miss, including the not-found UX #504 names.

`--make` needed a correction: it does not run a user's Makefile, it **scans a directory and generates one**, then pipes it to `make`. The tests match the real semantics, including the shell-injection guard on the target name — `--make DIR '; echo pwned'` must be rejected, and the injected command must never run. (The guard's own message quotes the offending target, so that assertion checks stdout, where an executed `echo` would land, not stderr where the rejection goes.)

## `quicksand/proxy/serve` — the allow branch

Every existing test in that file stops at a refusal (413/400/403) *before* the upstream dial, so none of them proved the rule engine's allow branch runs at all. The new test is the one request the engine **allows**, so it runs past the allowlist into `dial()`.

It stops there by design, and this is the part worth reviewing: `dial()` refuses every non-public IP unconditionally, loopback included, with no opt-out (`proxy/dial.tl:72-73`). So a hermetic upstream can never be reached, and a genuinely relayed response would require real egress — not acceptable in this suite. Rather than skip, the test proves the security property that makes it so: **putting a loopback address on the allowlist does not get you a connection to it.**

That is discriminating rather than vacuous because the upstream is real and would answer `200` with a known body if it were ever reached — a bypassed guard shows up as that body, not as a subtly different error. It is also distinct from the neighbouring 403 test: the rule engine *did* allow this host, so the request reached the dial and came back 502.

Its worker is forked because the allow path ends in `http.pump()`, which is bidirectional and would otherwise wait on a client half-close that never comes — `serve.tl` documents `handle` as designed for a forked worker, and running it in-process is what the refusal tests get away with only because `refuse()` returns before the pump.

## Verification

Every new assertion was mutation-checked — flipping the expected value (42→43, 137→138, 143→144, `fired=true`→`fired=nope`) fails the test. None pass vacuously.

## Not covered, and why

The tty `getpass`/`raw`/`restore`/termios paths remain tautological. They need a pty, and `cosmo.unix` exposes none of `openpty`/`forkpty`/`posix_openpt`/`grantpt`/`unlockpt`/`ptsname`. Filed as whilp/cosmopolitan#216 — the libc primitives already exist there (`libc/calls/openpty.c`, `libc/runtime/login_tty.c`), only the Lua binding is missing. #504 cannot be fully closed until that lands.

One incidental note for a follow-up, not changed here: `make.run` ends in `return ok ~= nil` over `p:close()` (`lib/cosmic/make.tl:220-221`). Lua 5.4 returns `fail` (nil) for a failed popen close so this is correct today, but a `false` return would be read as success.

## Unrelated change in the diff

`roundtrip`'s local `fd` in `serve_test.tl` is renamed to `client_fd` — it shadowed the newly imported `cosmic.fd` module, and warnings are errors. The new name matches `serve.tl`'s own.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSajNo281T9W53fQN41Ef9)_