### PR TITLE
test: keep the --make test's build artifacts inside its temp dir (#504)

### DIFF
--- a/lib/cosmic/cli/main_handlers_test.tl
+++ b/lib/cosmic/cli/main_handlers_test.tl
@@ -13,7 +13,9 @@ local check = require("cosmic.check")
 local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
 
-local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
+-- Absolute: TEST_BIN is relative to the repo root under `make test`,
+-- and the --make test below runs a child with a different cwd.
+local cosmic = fs.abspath(fs.join(os.getenv("TEST_BIN"), "cosmic"))
 local tmpdir = os.getenv("TEST_TMPDIR")
 
 local record Run
@@ -153,9 +155,13 @@ local function test_make_builds_a_scanned_directory()
   local dir = fs.join(tmpdir, "mk-src")
   fs.makedirs(dir)
   fs.write(fs.join(dir, "a.tl"), "local x = 1\nprint(x)\n")
+  -- cwd is the scanned directory so the generated BUILD_DIR (o/) lands
+  -- under it; without this the recipes run with the repo as cwd and
+  -- write their artifacts into the repo's own o/.
   local argv = {cosmic, "--make", dir}
   local h = check.must(spawn.spawn(argv, {
         env = {"PATH=" .. os.getenv("PATH"), "COSMIC=" .. cosmic},
+        cwd = dir,
       }))
   local r = check.must(h:wait())
   assert(r.code == 0,


### PR DESCRIPTION
Follow-up to #791, which was squash-merged before this fix was pushed — so the defect it corrects is currently on `main`.

## The problem

The `--make` scanned-directory test added in #791 spawns the child with the repo as cwd. `cosmic --make DIR` generates a Makefile whose `BUILD_DIR` is `o/`, resolved against the *child's* cwd — so the recipes wrote into the repo's own build directory, at paths derived from the absolute test tmpdir:

```
o//tmp/.../TEST_TMPDIR/mk-src/a.lua
```

Harmless in that `o/` is gitignored and inside the sandbox's write grant, but a test should not be writing into the tree's build output at all.

## The fix

Run the child with `cwd` set to the scanned directory, so the generated `BUILD_DIR` lands under the test's own temp dir.

That change immediately exposed a latent assumption in the same file: `TEST_BIN` is relative to the repo root under `make test`, so `fs.join(TEST_BIN, "cosmic")` only resolved while cwd was unchanged. With a child cwd it became `exec failed: ENOENT`. The path is absolute now, which is what a test spawning children with their own cwd needs.

Worth noting how this was missed the first time: my direct runs used `TEST_BIN=$PWD/o/bin`, an absolute path, which masked the relative-path assumption. Only the full `bin/make test` run surfaced it.

## Verification

- `bin/make ci` → `ci: PASS`
- the repo's `o/` is clean afterwards (previously `o/tmp/...` appeared)
- the artifact now lands under the test tmpdir, confirmed by locating the generated `a.lua` inside `TEST_TMPDIR/mk-src/o/`

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSajNo281T9W53fQN41Ef9)_