### PR TITLE
fix: report a failing make as a failure, and say how it failed

### DIFF
--- a/lib/cosmic/make.tl
+++ b/lib/cosmic/make.tl
@@ -217,8 +217,17 @@ local function run(dir?: string, target?: string): boolean, string
     return false, "failed to start make"
   end
   p:write(content)
-  local ok = p:close()
-  return ok ~= nil, cmd
+  -- close() on a popen'd file reports (true|fail, "exit"|"signal", n).
+  -- Branch on truthiness, not on `ok ~= nil`: Lua 5.4's `fail` is nil
+  -- today, but the manual only says it "is currently nil" -- a `false`
+  -- would make a `~= nil` test read a FAILED make as success, which is
+  -- the one shape of bug this build works hardest to avoid.
+  local ok, how, code = p:close()
+  if ok then
+    return true, cmd
+  end
+  return false, string.format("%s failed: %s %s", cmd,
+    how or "unknown", tostring(code))
 end
 
 local record MakeModule

--- a/lib/cosmic/make_test.tl
+++ b/lib/cosmic/make_test.tl
@@ -3,6 +3,8 @@
 
 local make = require("cosmic.make")
 local fs = require("cosmic.fs")
+local env = require("cosmic.env")
+local check = require("cosmic.check")
 
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
 
@@ -184,6 +186,45 @@ test_generate_custom_config()
 -- interpolated into a shell command, so a value like "; rm -rf ~" must be
 -- refused rather than executed.
 local function test_run_rejects_unsafe_target()
+
+-- run() pipes the generated makefile through io.popen, which inherits
+-- THIS process's cwd -- so the generated BUILD_DIR would otherwise
+-- resolve against the repo root and write build output into it. Both
+-- tests below chdir into the scanned directory and restore afterwards.
+
+-- Test run reports a failing make as a failure, with the exit status.
+-- The generated makefile compiles sources with $(COSMIC), so pointing
+-- that at a nonexistent binary fails the build deterministically --
+-- without depending on whether a real `cosmic` is on PATH.
+local function test_run_reports_make_failure()
+  local test_dir = setup()
+  touch(fs.join(test_dir, "a.tl"), "local x = 1\nprint(x)\n")
+  local prev = check.must(fs.getcwd())
+  assert(fs.chdir(test_dir))
+  env.set("COSMIC", fs.join(test_dir, "no-such-cosmic"))
+  local ok, err = make.run(test_dir)
+  env.unset("COSMIC")
+  assert(fs.chdir(prev))
+  assert(not ok, "a failing make must be reported as a failure")
+  assert(err:match("exit"),
+    "the failure should name how make ended, got: " .. tostring(err))
+  teardown(test_dir)
+end
+test_run_reports_make_failure()
+
+-- Test run reports a clean make as success. An empty project generates
+-- rules with nothing to do, which is enough to exercise the success
+-- branch without needing a working compiler on PATH.
+local function test_run_reports_make_success()
+  local test_dir = setup()
+  local prev = check.must(fs.getcwd())
+  assert(fs.chdir(test_dir))
+  local ok, err = make.run(test_dir)
+  assert(fs.chdir(prev))
+  assert(ok, "an empty project should build cleanly, got: " .. tostring(err))
+  teardown(test_dir)
+end
+test_run_reports_make_success()
   local test_dir = setup()
   local ok, err = make.run(test_dir, "all; touch /tmp/pwned")
   assert(not ok, "run should reject unsafe target")


### PR DESCRIPTION
Closes the loose end noted in #791's description.

## What was wrong

`make.run` ended in:

```teal
local ok = p:close()
return ok ~= nil, cmd
```

**It tests the wrong property.** Verified empirically against the pinned runtime: `io.popen(...):close()` returns `true, "exit", 0` on success and `nil, "exit", 3` on failure, so `ok ~= nil` is correct *today*. But the Lua 5.4 manual only says `fail` "is currently nil". If it ever became `false`, `false ~= nil` is true and a **failed make would be reported as success** — silently. That is the exact failure shape the rest of this build goes out of its way to make impossible (cf. #776, where a silent downgrade was the whole reason to delete a probe).

**The failure message was the command, not the diagnosis.** On failure `run` returned `cmd`, so `handle_make` printed a bare `make -f -` to stderr — after make's own error had already scrolled past. The output read as noise repeating what was run.

## The fix

Branch on truthiness, and report how make ended:

```teal
local ok, how, code = p:close()
if ok then
  return true, cmd
end
return false, string.format("%s failed: %s %s", cmd, how or "unknown", tostring(code))
```

`make -f - failed: exit 2` instead of `make -f -`.

## Coverage

Two tests, one per branch. The failure case points `$(COSMIC)` at a nonexistent binary, which fails the generated build deterministically rather than depending on whether a real `cosmic` happens to be on PATH.

The failure test asserts the message names *how* make ended, which is what makes it a regression test for the changed line rather than decoration — the old message was `make -f -`, and `("make -f -"):match("exit")` is nil, so it fails against the old code. Both tests are mutation-checked: flipping either expectation fails the suite.

## A workaround in the tests, and why

Both tests `chdir` into the scanned directory before calling `run`, and restore afterwards. `run` pipes through `io.popen`, which has no cwd parameter and inherits the caller's — so the generated `BUILD_DIR` resolves against the *caller's* cwd, and calling `run` from the repo root writes build output into the tree's own `o/`. Without the chdir, these tests would pollute `o/` exactly as #792 fixed for the `--make` CLI test.

That is a real limitation in the library rather than in the tests, but giving `run` cwd control is an API change and not this PR's business. Filed separately as #795, which also covers dropping this workaround and #792's once it lands.

## Verification

- `bin/make ci` → `ci: PASS`
- repo `o/` clean afterwards
- failure path manually confirmed: `make -f - failed: exit 2`, exit 1
- success path manually confirmed: exit 0