### PR TITLE
fix: run make in the scanned directory, via argv instead of a shell (#795)

### DIFF
--- a/lib/cosmic/cli/main_handlers_test.tl
+++ b/lib/cosmic/cli/main_handlers_test.tl
@@ -155,13 +155,12 @@ local function test_make_builds_a_scanned_directory()
   local dir = fs.join(tmpdir, "mk-src")
   fs.makedirs(dir)
   fs.write(fs.join(dir, "a.tl"), "local x = 1\nprint(x)\n")
-  -- cwd is the scanned directory so the generated BUILD_DIR (o/) lands
-  -- under it; without this the recipes run with the repo as cwd and
-  -- write their artifacts into the repo's own o/.
+  -- No cwd needed here: make.run now runs make in the scanned
+  -- directory itself (#795), so the generated BUILD_DIR lands under
+  -- `dir` regardless of where this process happens to be.
   local argv = {cosmic, "--make", dir}
   local h = check.must(spawn.spawn(argv, {
         env = {"PATH=" .. os.getenv("PATH"), "COSMIC=" .. cosmic},
-        cwd = dir,
       }))
   local r = check.must(h:wait())
   assert(r.code == 0,
@@ -170,21 +169,23 @@ local function test_make_builds_a_scanned_directory()
 end
 test_make_builds_a_scanned_directory()
 
---- The target name is interpolated into a shell command, so make.run
---- rejects anything that is not a plain make target. This is a
---- security boundary: without it, `--make DIR '; rm -rf ~'` would run
---- arbitrary commands.
-local function test_make_rejects_shell_metacharacters_in_target()
+--- End-to-end proof that a target never reaches a shell. make.run
+--- passes it as one argv element (#795), so make receives the whole
+--- string as a single target name and fails to find it -- rather than
+--- a shell splitting it into a second command to run.
+local function test_make_target_never_reaches_a_shell()
   local dir = fs.join(tmpdir, "mk-inject")
   fs.makedirs(dir)
   local r = cli("--make", dir, "; echo pwned")
-  assert(r.code ~= 0, "an injected target must not exit 0")
-  assert(r.err:find("invalid make target", 1, true),
-    "expected the guard's rejection on stderr, got: " .. r.err)
-  -- The rejection message quotes the offending target, so "pwned"
-  -- legitimately appears on stderr. What must NOT appear is the
-  -- *output* of running it, which `echo` would put on stdout.
+  assert(r.code ~= 0, "an unfindable target must not exit 0")
+  -- make quoting the ENTIRE string as one target is the observable
+  -- that distinguishes "passed as argv" from "split by a shell".
+  assert(r.err:find("No rule to make target '; echo pwned'", 1, true),
+    "make should report the whole string as one target, got: " .. r.err)
+  -- make's diagnostic quotes the target, so "pwned" legitimately
+  -- appears on stderr. What must NOT appear is the *output* of running
+  -- it, which `echo` would put on stdout.
   assert(not r.out:find("pwned", 1, true),
     "the injected command must never run, stdout was: " .. r.out)
 end
-test_make_rejects_shell_metacharacters_in_target()
+test_make_target_never_reaches_a_shell()

--- a/lib/cosmic/make.tl
+++ b/lib/cosmic/make.tl
@@ -4,6 +4,8 @@
 --- format-check, test, and report.
 
 local fs = require("cosmic.fs")
+local child = require("cosmic.child")
+local fd = require("cosmic.fd")
 
 --- Configuration for Makefile generation.
 local record Config
@@ -202,32 +204,50 @@ local function run(dir?: string, target?: string): boolean, string
     return true, "stdout"
   end
 
-  -- pipe to make. The target name is interpolated into a shell command, so
-  -- reject anything that isn't a plain make target to avoid shell injection
-  -- (e.g. a target of `; rm -rf ~` would otherwise run arbitrary commands).
-  local cmd = "make -f -"
+  -- Feed the generated file to make on stdin, as argv rather than
+  -- through a shell (#795). Two consequences worth stating:
+  --
+  -- cwd is the scanned directory, so the generated `BUILD_DIR ?= o`
+  -- resolves against the project being built. Under io.popen it
+  -- resolved against whatever cwd the CALLER happened to have, so
+  -- building /tmp/x from a checkout wrote into the checkout's own o/.
+  --
+  -- The target reaches make as one argv element, so it is no longer
+  -- interpolated into a shell command. That is what retired the old
+  -- `^[%w._/-]+$` guard here: it existed only because `; rm -rf ~`
+  -- could once be split by a shell, and it also rejected legitimate
+  -- make arguments (`CFLAGS=-g`, `dir/sub:all`).
+  local argv = {"make", "-f", "-"}
   if target then
-    if not target:match("^[%w._/-]+$") then
-      return false, "invalid make target: " .. target
-    end
-    cmd = cmd .. " " .. target
+    argv[#argv + 1] = target
   end
-  local p = io.popen(cmd, "w")
-  if not p then
-    return false, "failed to start make"
+  local cmd = table.concat(argv, " ")
+
+  -- Hand make our own stdout/stderr so a build streams to the terminal
+  -- as it runs, the way it did under io.popen. spawn would otherwise
+  -- pipe both and hold them until exit. Wrapping fds 1 and 2 is safe
+  -- here specifically because spawn never closes caller-supplied
+  -- stdio (child/init.tl:317,445 keep them out of the pump state and
+  -- close only fds it opened), and Handle has no __gc -- only __close,
+  -- which needs a <close> variable.
+  local out, errout = fd.wrap(1), fd.wrap(2)
+  local h, serr = child.spawn(argv,
+    {stdin = content, cwd = dir, stdout = out, stderr = errout})
+  if not (h is child.Handle) then
+    return false, "failed to start make: " .. (serr or "unknown error")
   end
-  p:write(content)
-  -- close() on a popen'd file reports (true|fail, "exit"|"signal", n).
-  -- Branch on truthiness, not on `ok ~= nil`: Lua 5.4's `fail` is nil
-  -- today, but the manual only says it "is currently nil" -- a `false`
-  -- would make a `~= nil` test read a FAILED make as success, which is
-  -- the one shape of bug this build works hardest to avoid.
-  local ok, how, code = p:close()
-  if ok then
+  -- cast: Teal's narrowing does not survive the early-exit guard above
+  local res, werr = (h as child.Handle):wait()
+  if not (res is child.Result) then
+    return false, cmd .. " failed: " .. (werr or "unknown error")
+  end
+  if res.ok then
     return true, cmd
   end
-  return false, string.format("%s failed: %s %s", cmd,
-    how or "unknown", tostring(code))
+  if res.signal then
+    return false, string.format("%s failed: signal %d", cmd, res.signal)
+  end
+  return false, string.format("%s failed: exit %d", cmd, res.code or -1)
 end
 
 local record MakeModule

--- a/lib/cosmic/make_test.tl
+++ b/lib/cosmic/make_test.tl
@@ -4,7 +4,6 @@
 local make = require("cosmic.make")
 local fs = require("cosmic.fs")
 local env = require("cosmic.env")
-local check = require("cosmic.check")
 
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
 
@@ -182,15 +181,24 @@ local function test_generate_custom_config()
 end
 test_generate_custom_config()
 
--- Test run rejects shell metacharacters in the target name. The target is
--- interpolated into a shell command, so a value like "; rm -rf ~" must be
--- refused rather than executed.
-local function test_run_rejects_unsafe_target()
-
--- run() pipes the generated makefile through io.popen, which inherits
--- THIS process's cwd -- so the generated BUILD_DIR would otherwise
--- resolve against the repo root and write build output into it. Both
--- tests below chdir into the scanned directory and restore afterwards.
+-- Test a target carrying shell metacharacters is inert. run() passes
+-- the target as one argv element instead of interpolating it into a
+-- shell command (#795), so "; touch <marker>" is just a target make
+-- cannot find: the build fails and the side effect never happens. The
+-- old `^[%w._/-]+$` guard that used to reject this is gone with the
+-- shell it existed for.
+local function test_run_does_not_let_a_target_reach_a_shell()
+  local test_dir = setup()
+  local marker = fs.join(test_dir, "pwned")
+  local ok, err = make.run(test_dir, "all; touch " .. marker)
+  assert(not ok, "an unfindable target should fail the build")
+  assert(not fs.isfile(marker),
+    "the target must never reach a shell, but " .. marker .. " appeared")
+  assert(err:match("exit"),
+    "expected make's own failure, got: " .. tostring(err))
+  teardown(test_dir)
+end
+test_run_does_not_let_a_target_reach_a_shell()
 
 -- Test run reports a failing make as a failure, with the exit status.
 -- The generated makefile compiles sources with $(COSMIC), so pointing
@@ -199,12 +207,9 @@ local function test_run_rejects_unsafe_target()
 local function test_run_reports_make_failure()
   local test_dir = setup()
   touch(fs.join(test_dir, "a.tl"), "local x = 1\nprint(x)\n")
-  local prev = check.must(fs.getcwd())
-  assert(fs.chdir(test_dir))
   env.set("COSMIC", fs.join(test_dir, "no-such-cosmic"))
   local ok, err = make.run(test_dir)
   env.unset("COSMIC")
-  assert(fs.chdir(prev))
   assert(not ok, "a failing make must be reported as a failure")
   assert(err:match("exit"),
     "the failure should name how make ended, got: " .. tostring(err))
@@ -217,21 +222,11 @@ test_run_reports_make_failure()
 -- branch without needing a working compiler on PATH.
 local function test_run_reports_make_success()
   local test_dir = setup()
-  local prev = check.must(fs.getcwd())
-  assert(fs.chdir(test_dir))
   local ok, err = make.run(test_dir)
-  assert(fs.chdir(prev))
   assert(ok, "an empty project should build cleanly, got: " .. tostring(err))
   teardown(test_dir)
 end
 test_run_reports_make_success()
-  local test_dir = setup()
-  local ok, err = make.run(test_dir, "all; touch /tmp/pwned")
-  assert(not ok, "run should reject unsafe target")
-  assert(err:match("invalid make target"), "expected invalid target error, got: " .. tostring(err))
-  teardown(test_dir)
-end
-test_run_rejects_unsafe_target()
 
 -- Test generate includes cosmic.mk
 local function test_generate_includes_cosmic_mk()


### PR DESCRIPTION
Closes #795. Takes option 1 from that issue.

## The bug

`make.run` piped the generated Makefile through `io.popen`, which has no cwd parameter and inherits the caller's. The generated `BUILD_DIR ?= o` is relative, so build output landed relative to wherever the **caller** happened to be rather than to the directory that was scanned — `--make /tmp/x` from a checkout wrote into the checkout's own `o/`.

It had already cost two workarounds, both removed here: #792 (`cwd = dir` in the CLI test) and #794 (`chdir` in the library tests).

## The change

Spawn make with `cosmic.child.spawn`: argv, the generated file fed on stdin, `cwd` set to the scanned directory.

Verified end to end — the artifact now lands under the scanned dir:

```
/tmp/.../mkcwd/o/tmp/.../mkcwd/a.lua
```

with the repo's `o/` clean afterwards.

## Two consequences worth review

**The shell-injection guard is gone, and its tests are converted rather than deleted.** The target is now one argv element, never interpolated into a shell command, so `^[%w._/-]+$` has nothing left to defend. Deleting the tests with it would have quietly dropped a security property, so both levels now assert the stronger claim directly:

- library: a `"; touch <marker>"` target leaves no marker behind
- CLI: make reports the **entire** string as one target — `No rule to make target '; echo pwned'` — which is precisely the observable distinguishing "passed as argv" from "split by a shell"

The guard also rejected legitimate make arguments (`CFLAGS=-g`, `dir/sub:all`); those now work.

**make's output still streams.** `spawn` pipes stdout/stderr by default and withholds them until exit, which for a build would turn live progress into a post-hoc dump. So make is handed our own fds 1 and 2.

That needs justification, because `cosmic.fd`'s header says the module deliberately has no stdout/stderr handles and `fd.wrap` documents that the Handle takes ownership. It is safe *here specifically*: `spawn` never closes caller-supplied stdio — `child/init.tl:317` keeps them out of the pump state (`stdout_fd = stdout_is_fd and nil or stdout_r`) and `:445` closes only fds it opened — and `Handle` has no `__gc`, only `__close`, which requires a `<close>` variable. If either of those changes, this becomes a double-close on the process's own stdout. I've noted it at the call site.

If you'd rather not lean on that, the alternative is an explicit "inherit" stdio option on `cosmic.child` — a wider API change than this issue called for, so I didn't reach for it unprompted.

## Also in this diff

Flattens the two `make.run` tests added in #794. A bad edit anchor there matched the function *definition* line rather than the trailing call, so they were defined and invoked **inside** `test_run_rejects_unsafe_target`. It parsed, and all three tests ran and asserted — the coverage was real, and the mutation checks I ran on it were valid — but the nesting was not intended. My mistake, corrected here since this PR rewrites that region anyway.

## Verification

- `bin/make ci` → `ci: PASS`, repo `o/` clean afterwards
- streaming confirmed by eye: make's output appears during the run, not after
- all three new/converted assertions mutation-checked — flipping each one fails the suite

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSajNo281T9W53fQN41Ef9)_