### PR TITLE
feat: add an inherit stdio disposition to cosmic.child (#797)

### DIFF
--- a/lib/cosmic/child/init.tl
+++ b/lib/cosmic/child/init.tl
@@ -66,10 +66,12 @@ end
 --- your end when you are done with it (see Example_run_pipe). Raw integer
 --- fds are not part of this surface (api-review-2, #602); wrap one with
 --- fd.wrap() if it comes from outside the fd module.
+--- stdout/stderr also accept "inherit" (#797): the child writes to THIS
+--- process's fd 1/2 so output streams as it runs; Result then stays "".
 local record Options
   stdin: string | cfd.Handle -- string piped to stdin, or Handle -> fd 0
-  stdout: cfd.Handle -- child's fd 1
-  stderr: cfd.Handle -- child's fd 2
+  stdout: cfd.Handle | childio.StdioMode -- child's fd 1, or "inherit"
+  stderr: cfd.Handle | childio.StdioMode -- child's fd 2, or "inherit"
   env: {string}
   cwd: string
 end

--- a/lib/cosmic/child/io.tl
+++ b/lib/cosmic/child/io.tl
@@ -45,17 +45,29 @@ local record Stdio
   stderr_fd: integer
 end
 
+--- Non-Handle stdio dispositions (#797). "inherit" hands the child this
+--- process's own fd 1 / 2, so its output streams straight to wherever
+--- ours goes instead of being captured and withheld until exit.
+---
+--- It resolves to the same "caller supplied this descriptor" path a
+--- Handle takes, which spawn never closes -- so callers no longer have
+--- to reach for fd.wrap(1), which cosmic.fd explicitly does not model.
+local enum StdioMode
+  "inherit"
+end
+
 --- Resolve the caller's stdio options to raw descriptors, once, at the
 --- boundary. A string stdin passes through as pump data; a Handle
 --- contributes its descriptor. A closed Handle is a caller bug surfaced
 --- here, not a confusing EBADF from deep inside the spawn plumbing.
 --- @param stdin string | cfd.Handle | nil string to pipe, or the child's fd 0
---- @param stdout cfd.Handle | nil the child's fd 1
---- @param stderr cfd.Handle | nil the child's fd 2
+--- @param stdout cfd.Handle | StdioMode | nil the child's fd 1
+--- @param stderr cfd.Handle | StdioMode | nil the child's fd 2
 --- @return Stdio | nil resolved descriptors
 --- @return string error message on a closed Handle
-local function resolve_stdio(stdin?: string | cfd.Handle, stdout?: cfd.Handle,
-    stderr?: cfd.Handle): Stdio | nil, string
+local function resolve_stdio(stdin?: string | cfd.Handle,
+    stdout?: cfd.Handle | StdioMode,
+    stderr?: cfd.Handle | StdioMode): Stdio | nil, string
   local s: Stdio = {}
   if stdin is string then
     s.stdin_data = stdin
@@ -63,11 +75,18 @@ local function resolve_stdio(stdin?: string | cfd.Handle, stdout?: cfd.Handle,
     s.stdin_fd = (stdin):fd()
     if s.stdin_fd < 0 then return nil, "spawn: stdin handle is closed" end
   end
-  if stdout then
+  -- "inherit" resolves to our own descriptor, which then travels the
+  -- identical path a caller-supplied Handle does: spawn dups it onto
+  -- the child's fd and never closes our end (#797).
+  if stdout is StdioMode then
+    s.stdout_fd = 1
+  elseif stdout ~= nil then
     s.stdout_fd = stdout:fd()
     if s.stdout_fd < 0 then return nil, "spawn: stdout handle is closed" end
   end
-  if stderr then
+  if stderr is StdioMode then
+    s.stderr_fd = 2
+  elseif stderr ~= nil then
     s.stderr_fd = stderr:fd()
     if s.stderr_fd < 0 then return nil, "spawn: stderr handle is closed" end
   end
@@ -222,14 +241,16 @@ local function pump(state: PumpState, deadline_ms: number): boolean
 end
 
 local record ChildIoModule
+  StdioMode: StdioMode
   PumpState: PumpState
   Stdio: Stdio
   pump: function(state: PumpState, deadline_ms: number): boolean
   now_ms: function(): number
   read_retry: function(fd: integer, bufsiz: integer): string | nil, string | nil
   wait_retry: function(pid: integer): integer | nil, integer
-  resolve_stdio: function(stdin?: string | cfd.Handle, stdout?: cfd.Handle,
-  stderr?: cfd.Handle): Stdio | nil, string
+  resolve_stdio: function(stdin?: string | cfd.Handle,
+  stdout?: cfd.Handle | StdioMode,
+  stderr?: cfd.Handle | StdioMode): Stdio | nil, string
 end
 
 local M: ChildIoModule = {

--- a/lib/cosmic/child/stdio_test.tl
+++ b/lib/cosmic/child/stdio_test.tl
@@ -13,13 +13,11 @@ local check = require("cosmic.check")
 local child = require("cosmic.child")
 local cfd = require("cosmic.fd")
 local fs = require("cosmic.fs")
--- O_* flags for the capture file; no cosmic wrapper exposes them.
-local unix = require("cosmo.unix")
 
 local lua_bin = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
 
-local WRONLY_CREAT_TRUNC = unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC
+local WRONLY_CREAT_TRUNC = cfd.O_WRONLY | cfd.O_CREAT | cfd.O_TRUNC
 
 --- Run `script` under a fresh cosmic with its stdout redirected to
 --- `outfile`, and return (result, file contents). The script receives
@@ -28,7 +26,7 @@ local function run_capturing(name: string, src: string): child.Result, string
   local script = fs.join(TEST_TMPDIR, name .. ".lua")
   fs.write(script, src)
   local outfile = fs.join(TEST_TMPDIR, name .. ".out")
-  local out_h = check.must(cfd.open(outfile, WRONLY_CREAT_TRUNC, 0x1a4))
+  local out_h = check.must(cfd.open(outfile, WRONLY_CREAT_TRUNC, tonumber("644", 8)))
   local h = check.must(child.spawn({lua_bin, script, lua_bin},
       {stdout = out_h}))
   local r = check.must(h:wait())

--- a/lib/cosmic/child/stdio_test.tl
+++ b/lib/cosmic/child/stdio_test.tl
@@ -1,0 +1,121 @@
+#!/usr/bin/env cosmic
+--- Tests for spawn's "inherit" stdio disposition (#797).
+---
+--- Proving inherit works needs a vantage point OUTSIDE this process,
+--- because this process's own stdout is the thing under test. Every
+--- test here therefore runs a helper cosmic whose stdout is redirected
+--- to a file (with a Handle, the already-supported disposition), has
+--- that helper spawn a grandchild with stdout = "inherit", and then
+--- reads the file. The grandchild's bytes can only reach the file by
+--- travelling through the helper's real fd 1.
+
+local check = require("cosmic.check")
+local child = require("cosmic.child")
+local cfd = require("cosmic.fd")
+local fs = require("cosmic.fs")
+-- O_* flags for the capture file; no cosmic wrapper exposes them.
+local unix = require("cosmo.unix")
+
+local lua_bin = fs.join(os.getenv("TEST_BIN"), "cosmic")
+local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
+
+local WRONLY_CREAT_TRUNC = unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC
+
+--- Run `script` under a fresh cosmic with its stdout redirected to
+--- `outfile`, and return (result, file contents). The script receives
+--- the cosmic path as arg[1] so it can spawn a grandchild.
+local function run_capturing(name: string, src: string): child.Result, string
+  local script = fs.join(TEST_TMPDIR, name .. ".lua")
+  fs.write(script, src)
+  local outfile = fs.join(TEST_TMPDIR, name .. ".out")
+  local out_h = check.must(cfd.open(outfile, WRONLY_CREAT_TRUNC, 0x1a4))
+  local h = check.must(child.spawn({lua_bin, script, lua_bin},
+      {stdout = out_h}))
+  local r = check.must(h:wait())
+  out_h:close()
+  -- parenthesised: must forwards extra returns, which would overflow
+  -- this function's declared two
+  return r, (check.must(fs.read(outfile)))
+end
+
+--- The core claim: an inherited stream reaches the real descriptor, and
+--- precisely because it does, spawn cannot also capture it -- so the
+--- matching Result field is empty. Both halves are asserted together
+--- so neither can drift from the documented contract.
+local function test_inherit_reaches_the_real_descriptor()
+  local r, written = run_capturing("inherit_child", [[
+local child = require("cosmic.child")
+local h = assert(child.spawn({arg[1], "-e", "print('MARKER')"},
+  {stdout = "inherit"}))
+local r = assert(h:wait())
+io.stderr:write("captured=[" .. (r.stdout or "") .. "]\n")
+]])
+  assert(r.ok, "helper failed: " .. (r.stderr or ""))
+  assert(written:find("MARKER", 1, true),
+    "inherited stdout must reach the real descriptor, file was: " .. written)
+  assert(r.stderr:find("captured=[]", 1, true),
+    "an inherited stream must leave Result.stdout empty, got: " .. r.stderr)
+end
+test_inherit_reaches_the_real_descriptor()
+
+--- spawn must not close an inherited descriptor. This is the hazard the
+--- old fd.wrap(1) workaround carried: if spawn closed what it was
+--- handed, the parent's next write would hit a closed fd -- and worse,
+--- a later open() could recycle fd 1. The second write below is the
+--- observable.
+local function test_inherit_leaves_our_descriptor_open()
+  local r, written = run_capturing("inherit_reuse", [[
+local child = require("cosmic.child")
+local h = assert(child.spawn({arg[1], "-e", "print('FIRST')"},
+  {stdout = "inherit"}))
+assert(h:wait())
+io.write("STILL_OPEN\n")
+io.stdout:flush()
+]])
+  assert(r.ok, "helper failed: " .. (r.stderr or ""))
+  assert(written:find("FIRST", 1, true),
+    "the child's inherited write is missing: " .. written)
+  assert(written:find("STILL_OPEN", 1, true),
+    "spawn must not close an inherited descriptor, file was: " .. written)
+end
+test_inherit_leaves_our_descriptor_open()
+
+--- stderr = "inherit" is wired to fd 2, not fd 1. A copy-paste that
+--- resolved both to 1 would still pass the tests above, so this one
+--- checks the streams stay distinct: the grandchild writes only to
+--- stderr, and that must NOT land in the helper's redirected stdout.
+local function test_inherit_stderr_is_separate_from_stdout()
+  local r, written = run_capturing("inherit_stderr", [[
+local child = require("cosmic.child")
+local h = assert(child.spawn(
+  {arg[1], "-e", "io.stderr:write('ERRMARK')"},
+  {stderr = "inherit"}))
+local r = assert(h:wait())
+io.stderr:write("captured=[" .. (r.stderr or "") .. "]\n")
+]])
+  assert(r.ok, "helper failed: " .. (r.stderr or ""))
+  assert(not written:find("ERRMARK", 1, true),
+    "inherited stderr must not reach fd 1, stdout file was: " .. written)
+  assert(r.stderr:find("ERRMARK", 1, true),
+    "inherited stderr should reach our stderr, got: " .. r.stderr)
+  assert(r.stderr:find("captured=[]", 1, true),
+    "an inherited stream must leave Result.stderr empty, got: " .. r.stderr)
+end
+test_inherit_stderr_is_separate_from_stdout()
+
+--- The default is unchanged: with no disposition given, spawn still
+--- captures into Result rather than leaking to our streams.
+local function test_default_still_captures()
+  local r, written = run_capturing("inherit_default", [[
+local child = require("cosmic.child")
+local h = assert(child.spawn({arg[1], "-e", "print('CAPTURED')"}))
+local r = assert(h:wait())
+io.stderr:write("got=[" .. (r.stdout or ""):gsub("%s+$", "") .. "]\n")
+]])
+  assert(r.ok, "helper failed: " .. (r.stderr or ""))
+  assert(not written:find("CAPTURED", 1, true),
+    "a captured stream must not reach fd 1, file was: " .. written)
+  assert(r.stderr:find("got=[CAPTURED]", 1, true),
+    "the default must still capture into Result.stdout, got: " .. r.stderr)
+end
+test_default_still_captures()

--- a/lib/cosmic/make.tl
+++ b/lib/cosmic/make.tl
@@ -5,7 +5,6 @@
 
 local fs = require("cosmic.fs")
 local child = require("cosmic.child")
-local fd = require("cosmic.fd")
 
 --- Configuration for Makefile generation.
 local record Config
@@ -223,16 +222,11 @@ local function run(dir?: string, target?: string): boolean, string
   end
   local cmd = table.concat(argv, " ")
 
-  -- Hand make our own stdout/stderr so a build streams to the terminal
-  -- as it runs, the way it did under io.popen. spawn would otherwise
-  -- pipe both and hold them until exit. Wrapping fds 1 and 2 is safe
-  -- here specifically because spawn never closes caller-supplied
-  -- stdio (child/init.tl:317,445 keep them out of the pump state and
-  -- close only fds it opened), and Handle has no __gc -- only __close,
-  -- which needs a <close> variable.
-  local out, errout = fd.wrap(1), fd.wrap(2)
+  -- "inherit" so a build streams to the terminal as it runs, the way it
+  -- did under io.popen; spawn's default would pipe both streams and
+  -- hold them until exit (#797).
   local h, serr = child.spawn(argv,
-    {stdin = content, cwd = dir, stdout = out, stderr = errout})
+    {stdin = content, cwd = dir, stdout = "inherit", stderr = "inherit"})
   if not (h is child.Handle) then
     return false, "failed to start make: " .. (serr or "unknown error")
   end


### PR DESCRIPTION
Closes #797.

## The gap

`spawn` modelled two stdio dispositions — **capture** (open a pipe, buffer into `Result`, release at exit) and **redirect to a `Handle`** — with no way to say *inherit mine*. A child whose output the user should watch **while it runs** is badly served by capture, which withholds everything until exit.

`make.run` needed exactly that, and got it by wrapping fds 1 and 2:

```teal
local out, errout = fd.wrap(1), fd.wrap(2)
```

That worked, but only by knowing three things no doc promised: that `spawn` keeps caller-supplied stdio out of the pump state (`child/init.tl:317-318`), that it closes only fds it opened (`:310-311, 445-446, 457-458`), and that `fd.Handle` has no `__gc`. It also ran against `cosmic.fd`'s own header — "cosmic.fd has NO stderr, stdout, or stdin handles" — and `fd.wrap`'s contract, "the Handle takes ownership: closing it closes the fd." If any of those changed it became a double close on the process's own stdout, surfacing far from the call site.

## The change

`stdout`/`stderr` now also accept `"inherit"`:

```teal
child.spawn(argv, {stdin = content, cwd = dir, stdout = "inherit", stderr = "inherit"})
```

It is a `StdioMode` enum rather than a bare string, so the literal is checked at compile time and a typo is a type error, not a silent capture.

The implementation is deliberately small: `resolve_stdio` maps the mode to fd 1/2 **at the same boundary** where a `Handle` is mapped to its descriptor. From there it travels the already-proven caller-supplied path — no new branch in the spawn plumbing, and the "never closed" property is inherited rather than reimplemented.

`make.run` drops the `fd.wrap` pair, its paragraph of justification, and the now-unused `cosmic.fd` import. It is again the **only** caller that wanted this, which is why fixing the API now was cheap — the point #797 made.

## Tests

Proving inherit works needs a vantage point **outside** the process under test, because this process's own stdout is the thing being asserted about. So each test runs a helper cosmic whose stdout is redirected to a file (via a `Handle`, the already-supported disposition), has that helper spawn a grandchild with `"inherit"`, then reads the file — the grandchild's bytes can only get there through the helper's real fd 1.

Four cases:

- bytes reach the real descriptor, **and** `Result.stdout` is `""` — both halves together, so neither can drift from the documented contract
- the descriptor is still writable after the child is reaped — the double-close hazard the old workaround carried
- `stderr = "inherit"` resolves to fd **2**, not fd 1 — a copy-paste resolving both to 1 would pass the first two tests
- the default still captures, so this is additive

Each was mutation-checked by swapping `inherit` for the default and back; all three swaps fail the suite.

## Notes for review

**Nested escapes.** The `-e` snippets in the helper scripts are parsed by two Lua parsers, so they use `print('X')` rather than `io.write('X\n')` — a single-escaped `\n` becomes a literal newline inside the inner string and a syntax error. Worth knowing before editing them.

**`init.tl` is at 499 lines**, three under the cap. I trimmed the doc comment to keep headroom and put the full contract on `StdioMode` in `child/io.tl`, which has room. That file is a candidate for splitting before it takes much more.

## Verification

- `bin/make ci` → `ci: PASS`
- `--make` re-verified end to end: output still streams live, artifact lands under the scanned dir, repo `o/` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSajNo281T9W53fQN41Ef9)_