### PR TITLE
fix: lint untracked files too, so a new file is checked before it is staged

### DIFF
--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -211,6 +211,15 @@ build_makefile_test_got := $(call test_got,\
 $(build_makefile_test_got): $(build_make_outputs)
 $(build_makefile_test_got): TEST_DIR := $(build_make_out)
 
+# The lint-file-list ratchet in makefile_test reads mk/check.mk SOURCE,
+# which the test unveil set does not cover. It cannot use the database
+# fixture like its neighbours: lint_files is :=, so the database records
+# the expanded file list rather than the git flags being guarded. Only
+# makefile_test needs this, not the ratchet test beside it, so the grant
+# stays as narrow as the allowlist entries it costs.
+build_makefile_src_test_got := $(call test_got,lib/build/makefile_test.tl)
+$(build_makefile_src_test_got): .UNVEIL := $(unveil_test) r:mk
+
 # help_test parses the real Makefile, which the test unveil set does
 # not cover (#729 test family)
 build_help_test_got := $(call test_got,lib/build/help_test.tl)

--- a/lib/build/makefile_ratchet_test.tl
+++ b/lib/build/makefile_ratchet_test.tl
@@ -127,9 +127,11 @@ local hostx_allowed: {string} = {
   "o/%.tl.test.got", -- unveil_test lane
   "o/coverage/%.tl.test.got", -- unveil_test lane
   "o/coverage/lib/build/help_test.tl.test.got", -- unveil_test + Makefile
+  "o/coverage/lib/build/makefile_test.tl.test.got", -- unveil_test + mk
   "o/coverage/lib/cosmic/teal_config_test.tl.test.got", -- unveil_test + tlconfig
   "o/coverage/lib/cosmic/tty_test.tl.test.got", -- unveil_test + pty devs
   "o/lib/build/help_test.tl.test.got", -- unveil_test + Makefile
+  "o/lib/build/makefile_test.tl.test.got", -- unveil_test + mk
   "o/lib/cosmic/teal_config_test.tl.test.got", -- unveil_test + tlconfig
   "o/lib/cosmic/tty_test.tl.test.got", -- unveil_test + pty devs
   "o/sandbox-canary/probe.got", -- canary needs its shell

--- a/lib/build/makefile_test.tl
+++ b/lib/build/makefile_test.tl
@@ -209,3 +209,30 @@ local function test_compile_pins_tree_only_tl_path()
   end
 end
 test_compile_pins_tree_only_tl_path()
+
+-- The lint file list must include untracked-but-not-ignored files.
+--
+-- lint is the only gate whose file list comes from git rather than from
+-- a wildcard: teal/format/test enumerate via $(wildcard ...) in each
+-- cook.mk and so see a file the moment it exists, but lint asks git.
+-- With a bare `git ls-files` that meant a brand-new file was linted
+-- ZERO times locally -- `bin/make lint` reported green on a file it had
+-- never opened -- and first failed in CI, where the checkout has it
+-- tracked. --others is what closes that; --exclude-standard is what
+-- keeps o/ and other ignored build output out of the list.
+--
+-- Asserted against the makefile source because both flags vanish from
+-- make's database: lint_files is `:=`, so the database records the
+-- expanded file list, not the command that produced it.
+local function test_lint_lists_untracked_files()
+  local src = check.must(fs.read("mk/check.mk"), "failed to read mk/check.mk")
+  local cmd = src:match("lint_files%s*:=[^\n]*\n?[^\n]*")
+  assert(cmd, "mk/check.mk should define lint_files from git ls-files")
+  assert(cmd:find("ls%-files"), "lint_files should come from git ls-files")
+  assert(cmd:find("%-%-others"),
+    "lint_files must pass --others or new files go unlinted until staged")
+  assert(cmd:find("%-%-exclude%-standard"),
+    "lint_files must pass --exclude-standard so ignored build output "
+    .. "stays out of the lint set")
+end
+test_lint_lists_untracked_files()

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -43,17 +43,28 @@ $(o)/format-summary.txt: $(all_formats) | $(build_reporter)
 $(o)/%.format.got: % $(cosmic_check_bin) | $(bootstrap_files)
 	@$(cosmic_check_bin) --test $(basename $@) $(cosmic_check_bin) --check-format $<
 
-# Lint every tracked file (#719). git ls-files fails SILENTLY outside
-# a git checkout — an empty list would lint nothing and report green,
-# so the summary recipe fails loudly instead. Tracked-but-deleted files
-# appear in ls-files but cannot be made: lint what exists, surface the
-# skips in the summary, fail if the filter collapses the list. The
-# stamp records the linted set so a deletion (which only SHRINKS the
-# prerequisite list) still rebuilds the summary instead of staying
-# stale-green "up to date".
-lint_tracked := $(shell git ls-files 2>/dev/null)
-lint_present := $(wildcard $(lint_tracked))
-lint_deleted := $(filter-out $(lint_present),$(lint_tracked))
+# Lint every file that will land (#719): tracked, PLUS untracked ones
+# git does not ignore. --others is what makes a brand-new file linted
+# before it is staged; without it `git ls-files` alone reported green on
+# a file it had never opened, so a new module or test got no lint at all
+# locally and first failed in CI, where the checkout has it tracked.
+# (teal/format/test never had that gap — their lists come from wildcards
+# in each cook.mk, which see a file the moment it exists.)
+# --exclude-standard keeps .gitignore honoured, so o/ and other build
+# output stay out; a build leaves nothing untracked outside it.
+#
+# git ls-files fails SILENTLY outside a git checkout — an empty list
+# would lint nothing and report green, so the summary recipe fails
+# loudly instead. Tracked-but-deleted files appear in ls-files but
+# cannot be made: lint what exists, surface the skips in the summary,
+# fail if the filter collapses the list. The stamp records the linted
+# set so a deletion (which only SHRINKS the prerequisite list) still
+# rebuilds the summary instead of staying stale-green "up to date".
+# sort dedupes, since --cached and --others are assembled separately.
+lint_files := $(sort $(shell git ls-files --cached --others \
+  --exclude-standard 2>/dev/null))
+lint_present := $(wildcard $(lint_files))
+lint_deleted := $(filter-out $(lint_present),$(lint_files))
 all_linted := $(patsubst %,$(o)/%.lint.got,$(lint_present))
 
 lint_list_stamp := $(o)/lint-files.stamp
@@ -65,7 +76,7 @@ lint: $(o)/lint-summary.txt
 
 $(o)/lint-summary.txt: export REPORTER_NOTE = $(if $(lint_deleted),lint: skipped deleted tracked file(s): $(lint_deleted))
 $(o)/lint-summary.txt: $(all_linted) $(lint_list_stamp) | $(build_reporter)
-	$(if $(strip $(lint_tracked)),,$(error lint: git ls-files found nothing — not a git checkout?))
+	$(if $(strip $(lint_files)),,$(error lint: git ls-files found nothing — not a git checkout?))
 	$(if $(strip $(lint_present)),,$(error lint: no tracked file exists on disk — filter collapsed the list?))
 	@$(bootstrap_cosmic) -- $(build_reporter) --dir $(o) --out $@ $(all_linted)
 


### PR DESCRIPTION
Found while diagnosing why #798's first CI run failed on a lint rule that `bin/make ci` had reported **PASS** on locally, minutes earlier, with the same file on disk.

## The hole

`mk/check.mk:54` built the lint file list from tracked files only:

```make
lint_tracked := $(shell git ls-files 2>/dev/null)
```

`git ls-files` lists **tracked** files. A file you have just written is untracked, so it was not in the list — lint reported green on a file it had never opened. It only got linted after `git add`, which for most workflows is *after* you have run the gate and believed it.

That is the worst shape a gate can have: green locally, red only after pushing, on the machine with less information than you.

**lint is the only gate with this hole.** `teal`, `format`, and `test` enumerate through `$(wildcard ...)` in each `cook.mk`, so they see a file the moment it exists — which is exactly why #798's new test file was type-checked and executed, but not linted.

## Reproduction

Same file, same content, on `main` before the fix:

| state | `bin/make lint` |
|---|---|
| untracked file with a forbidden `require("cosmo.unix")` | **exit 0**, 390 checks — the file is not among them |
| after `git add`, no edit to the file | exit 1, `cosmo-require` violation reported |

After the fix the untracked case exits 2, and a clean tree still passes 390 checks.

## The fix

```make
lint_files := $(sort $(shell git ls-files --cached --others \
  --exclude-standard 2>/dev/null))
```

- `--others` adds untracked files — the actual fix
- `--exclude-standard` honours `.gitignore`, keeping `o/` and other build output out. Verified a build leaves nothing untracked outside `o/`, so the linted set grows by exactly the files a commit would add
- `sort` dedupes, since the two lists are assembled separately
- renamed `lint_tracked` → `lint_files`, since "tracked" is no longer what it means

The existing not-a-git-checkout and deleted-file guards are untouched; the original comment already reasoned carefully about both, so this only adds the case it missed.

## Regression guard

A ratchet in `makefile_test.tl` asserts both flags are still present. It reads `mk/check.mk` **source** rather than make's database, because `lint_files` is `:=` — the database records the expanded file list, not the command that produced it, so both flags are invisible there.

Negative control: reverting to a bare `git ls-files` fails the test (exit 2).

## Note on scope

This makes local lint stricter in one visible way: an untracked file that is not gitignored now gets linted. That is the intent — if it is not ignored, it is on its way into a commit — but it does mean a stray scratch file in the tree will be checked rather than ignored.

## Verification

- `bin/make ci` → `ci: PASS`
- before/after reproduction above, both directions
- ratchet negative control

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSajNo281T9W53fQN41Ef9)_