### PR TITLE
fix: the teal and format gates never ran the check they report (#801)

### DIFF
--- a/lib/build/make-boot.tl
+++ b/lib/build/make-boot.tl
@@ -34,7 +34,7 @@ end
 --- @return string? Error message if loading failed
 local function load_spec(path: string): VersionSpec | nil, string
   -- cast: pcall returns any
-  local ok, spec = pcall(dofile, path) as (boolean, VersionSpec)
+  local ok, spec = pcall(dofile, path) as(boolean, VersionSpec)
   if not ok then
     return nil, "failed to load " .. path .. ": " .. tostring(spec)
   end

--- a/lib/build/makefile_ratchet_test.tl
+++ b/lib/build/makefile_ratchet_test.tl
@@ -228,7 +228,7 @@ local sandboxed_exempt: {string} = {
 --- @param label string What the value means, for the failure message
 --- @param problems {string} Accumulator for failures
 local function diff_owners(actual: {string: boolean}, allowed: {string},
-                           label: string, problems: {string})
+    label: string, problems: {string})
   local declared: {string: boolean} = {}
   for _, owner in ipairs(allowed) do
     declared[owner] = true

--- a/lib/build/makefile_test.tl
+++ b/lib/build/makefile_test.tl
@@ -236,3 +236,32 @@ local function test_lint_lists_untracked_files()
     .. "stays out of the lint set")
 end
 test_lint_lists_untracked_files()
+
+-- Both check gates must terminate the outer option parse with `--`
+-- before the child command (#801).
+--
+-- `cosmic --test <out> <cmd...>` hands <cmd...> to a child, but the
+-- OUTER getopt parses the whole argv first, so a child command that
+-- begins with flags loses them: the child runs argument-less, drops
+-- into the REPL, exits 0, and --test records a pass for a check that
+-- never ran. Every teal and format .got was a 0 for exactly this
+-- reason, on every file, indefinitely.
+--
+-- lint (mk/check.mk) already had its `--`; the test rules have no
+-- inner flags to lose. These two are the ones that were wrong, so
+-- they are the ones pinned here.
+local function test_check_gates_terminate_the_outer_parse()
+  local src = check.must(fs.read("mk/check.mk"), "failed to read mk/check.mk")
+  for _, gate in ipairs({"check%-types", "check%-format"}) do
+    local recipe = src:match("[^\n]*%-%-test[^\n]*" .. gate .. "[^\n]*")
+    assert(recipe,
+      "expected a --test recipe invoking --" .. gate:gsub("%%", ""))
+    -- non-greedy to a standalone `--`: the out path is $(basename $@),
+    -- which itself contains a space, so a %S+ span does not reach it
+    assert(recipe:match("%-%-test.-%s%-%-%s"),
+      "the " .. gate:gsub("%%", "") .. " recipe must pass `--` after the "
+      .. "out path, or the child loses its flags and the gate always "
+      .. "passes; got: " .. recipe)
+  end
+end
+test_check_gates_terminate_the_outer_parse()

--- a/lib/build/reporter_test.tl
+++ b/lib/build/reporter_test.tl
@@ -193,7 +193,7 @@ test_reporter_note()
 -- must carry a matching clause, one WITHOUT must not. Pin it for both, or
 -- a format tweak on either side silently makes ci grade a red stage green
 -- — the #714 laundering class, one layer up (#779).
-local VERDICT_PATTERN <const> = "[1-9]%d* failed"
+local VERDICT_PATTERN < const > = "[1-9]%d* failed"
 
 local function run_report(...: string): integer, string
   local child = require("cosmic.child")

--- a/lib/cosmic/cli/main_handlers_test.tl
+++ b/lib/cosmic/cli/main_handlers_test.tl
@@ -189,3 +189,35 @@ local function test_make_target_never_reaches_a_shell()
     "the injected command must never run, stdout was: " .. r.out)
 end
 test_make_target_never_reaches_a_shell()
+
+-- The check gates run `cosmic --test <out> -- cosmic --check-format F`.
+-- That `--` is load-bearing: without it the OUTER getopt consumes the
+-- child's --check-format, the child runs argument-less, drops into the
+-- REPL, reads EOF and exits 0 -- so --test faithfully records a pass
+-- for a check that never ran, and every teal/format .got was a 0
+-- regardless of the file (#801).
+--
+-- This pins the propagation in both directions, so a gate that cannot
+-- fail is caught here rather than by noticing, months later, that
+-- nothing has ever gone red.
+local function test_test_wrapper_propagates_child_exit_code()
+  local bad = fs.join(tmpdir, "wrap_bad.tl")
+  fs.write(bad, 'local function f()\n        return 1\nend\nprint(f())\n')
+  local good = fs.join(tmpdir, "wrap_good.tl")
+  fs.write(good, 'local x = 1\nprint(x)\n')
+
+  local base_bad = fs.join(tmpdir, "wrap_bad.fmt")
+  cli("--test", base_bad, "--", cosmic, "--check-format", bad)
+  local got_bad = check.must(fs.read(base_bad .. ".got"),
+    "--test should record an exit code for the failing check")
+  assert(got_bad:gsub("%s+$", "") ~= "0",
+    "a failing check must be recorded as non-zero, got: " .. got_bad)
+
+  local base_good = fs.join(tmpdir, "wrap_good.fmt")
+  cli("--test", base_good, "--", cosmic, "--check-format", good)
+  local got_good = check.must(fs.read(base_good .. ".got"),
+    "--test should record an exit code for the passing check")
+  assert(got_good:gsub("%s+$", "") == "0",
+    "a passing check must be recorded as 0, got: " .. got_good)
+end
+test_test_wrapper_propagates_child_exit_code()

--- a/lib/cosmic/quicksand/proxy/serve_test.tl
+++ b/lib/cosmic/quicksand/proxy/serve_test.tl
@@ -169,7 +169,7 @@ local function test_allowlist_does_not_bypass_the_ssrf_guard()
   local sock = check.must(net.connect_tcp("127.0.0.1", srv.port()),
     "client connect failed")
   assert(sock:send("GET http://127.0.0.1:" .. port .. "/hi HTTP/1.1\r\n"
-    .. "Host: 127.0.0.1:" .. port .. "\r\n\r\n"))
+      .. "Host: 127.0.0.1:" .. port .. "\r\n\r\n"))
   local cfd = check.must(srv.accept(), "proxy accept failed")
 
   local worker = proc.fork()

--- a/lib/perf/gate_test.tl
+++ b/lib/perf/gate_test.tl
@@ -29,8 +29,8 @@ end
 
 local function paths(prefix: string): string, string, string
   return fs.join(tmpdir, prefix .. "-base.json"),
-    fs.join(tmpdir, prefix .. "-cur.json"),
-    fs.join(tmpdir, prefix .. "-selfb.json")
+  fs.join(tmpdir, prefix .. "-cur.json"),
+  fs.join(tmpdir, prefix .. "-selfb.json")
 end
 
 local function test_clean_compare_measures_nothing()

--- a/lib/types/gentype_render.tl
+++ b/lib/types/gentype_render.tl
@@ -239,7 +239,7 @@ local function render_returns(returns: {Return}, fallible: boolean, error_type: 
   for i = 2, #ret_types do
     local n = ret_names[i]
     if (n == "error" or n == "err" or n == "errno")
-      and ret_types[i]:sub(-6) == " | nil" then
+    and ret_types[i]:sub(-6) == " | nil" then
       ret_types[i] = ret_types[i]:sub(1, -7)
     end
   end

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -29,8 +29,13 @@ teal: $(o)/teal-summary.txt
 $(o)/teal-summary.txt: $(all_teals) | $(build_reporter)
 	@$(bootstrap_cosmic) -- $(build_reporter) --dir $(o) --out $@ $^
 
+# The `--` is load-bearing (#801): without it the outer getopt consumes
+# the child's --check-types, the child runs argument-less, drops into
+# the REPL, reads EOF and exits 0 -- so --test faithfully records a pass
+# for a check that never ran. lint gets this right at :84; test/mk has
+# no inner flags to lose.
 $(o)/%.teal.got: % $(cosmic_check_bin) | $(bootstrap_files)
-	@$(cosmic_check_bin) --test $(basename $@) $(cosmic_check_bin) $(include_dir_flags) --check-types $<
+	@$(cosmic_check_bin) --test $(basename $@) -- $(cosmic_check_bin) $(include_dir_flags) --check-types $<
 
 all_formats := $(patsubst %,$(o)/%.format.got,$(call filter-only,$(all_source_files)))
 
@@ -40,8 +45,11 @@ format: $(o)/format-summary.txt
 $(o)/format-summary.txt: $(all_formats) | $(build_reporter)
 	@$(bootstrap_cosmic) -- $(build_reporter) --dir $(o) --out $@ $^
 
+# `--` for the same reason as the teal rule above (#801). This gate had
+# no second line of defence -- teal's work is redone by --compile-strict,
+# but nothing else checks formatting -- so it silently passed everything.
 $(o)/%.format.got: % $(cosmic_check_bin) | $(bootstrap_files)
-	@$(cosmic_check_bin) --test $(basename $@) $(cosmic_check_bin) --check-format $<
+	@$(cosmic_check_bin) --test $(basename $@) -- $(cosmic_check_bin) --check-format $<
 
 # Lint every file that will land (#719): tracked, PLUS untracked ones
 # git does not ignore. --others is what makes a brand-new file linted

--- a/tlconfig.lua
+++ b/tlconfig.lua
@@ -7,7 +7,7 @@
 return {
   gen_target = "5.4",
   gen_compat = "off",
-  include_dir = { "lib", "lib/types" },
+  include_dir = {"lib", "lib/types"},
   source_dir = ".",
   build_dir = "o/teal",
 }


### PR DESCRIPTION
Closes #801. Step 1 of the two-step sequence agreed for #800 — the gate has to work before adding files to it is worth anything.

## What was broken

`cosmic --test <out> <cmd...>` parses the whole argv with the **outer** getopt before handing `<cmd...>` to the child, so a child command beginning with flags loses them. The child ran argument-less, dropped into the REPL, read EOF, exited 0 — and `--test` faithfully recorded that 0.

```
$ o/bin/cosmic-check --test probe o/bin/cosmic-check --check-format lib/build/make-boot.tl
rc=0   probe.got=[0]
probe.out=[Lua 5.4 ... Type help() for docs ... >: ]

$ o/bin/cosmic-check --check-format lib/build/make-boot.tl
rc=1        # the file really is misformatted
```

All 326 `.teal.out` and 326 `.format.out` files in `o/` contain that REPL banner. **The gates have never checked anything.**

End-to-end proof: take a correctly-formatted tracked file, change one line's indentation only, and `bin/make format` still reports `326 checks: 326 passed`, rc=0, while `cosmic --check-format` on the same file exits 1.

## The fix

`--` after the out path, stopping the outer parse:

```make
@$(cosmic_check_bin) --test $(basename $@) -- $(cosmic_check_bin) $(include_dir_flags) --check-types $<
@$(cosmic_check_bin) --test $(basename $@) -- $(cosmic_check_bin) --check-format $<
```

`lint` (`mk/check.mk:84`) already had its `--`; the test rules pass no inner flags. Those two were right by construction and are untouched — which is also why `test` and `lint` have been catching real failures all along while these two never did.

## Fallout

**Type safety survived by accident.** `--compile-strict` type-checks during compilation, and nearly every `.tl` gets compiled, so type errors still failed the build — from the compile rule, not the teal step. I confirmed this by planting a type error: the build fails at `o/lib/cosmic/html.lua`.

**Formatting had no backstop**, so drift accumulated. 7 files were misformatted:

```
lib/build/make-boot.tl              lib/perf/gate_test.tl
lib/build/makefile_ratchet_test.tl  lib/types/gentype_render.tl
lib/build/reporter_test.tl          tlconfig.lua
lib/cosmic/quicksand/proxy/serve_test.tl
```

Fixed with `cosmic --fix`. `git diff -w` shows `mk/check.mk` as the only non-whitespace change in the diff.

`quicksand/proxy/serve_test.tl:172` blames to 1b23b01 (#791) — my own recent work, which merged unformatted precisely because this gate was dead. That is the clearest evidence the gate mattered.

## Guards

Two, each verified in both directions:

- **`main_handlers_test.tl`** — asserts `--test` propagates a child's exit code, for a failing and a passing check. Removing the `--` from its own invocation makes it report `must be recorded as non-zero, got: 0` — the bug itself, in the test's own words.
- **`makefile_test.tl`** — asserts both recipes carry `--` after the out path. Stripping it from the teal recipe fails the test.

## One trap worth knowing

**A recipe change does not invalidate existing targets.** After fixing the recipes, `bin/make format` still reported green because the stale `.got` files were up to date against unchanged prerequisites. The gates only re-ran after deleting them. Anyone verifying this PR should do the same, and the CI checkout is unaffected since it starts with no `o/`.

## Verification

- `bin/make ci` → `ci: PASS`, with all `.teal.got`/`.format.got` deleted first so both gates genuinely executed
- before/after reproduction of the vacuity, both directions
- both guards mutation-checked

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSajNo281T9W53fQN41Ef9)_