### PR TITLE
build: declare the build/docs/types sources so the check gates see them (#800)

### DIFF
--- a/lib/build/cook.mk
+++ b/lib/build/cook.mk
@@ -35,6 +35,12 @@ build_stage_files := $(build_stage) $(build_untar) $(build_portable)
 # entire runtime and no tree .lua is required first. The old compiled
 # driver — and the self-bootstrap shell exception rule that built it,
 # the last real-shell + host-grant build rule — is gone.
+# _srcs (not _tl) so these are type- and format-checked without also
+# entering the docs/benchmark pipelines, which key off _tl (#800). They
+# were previously checked only incidentally, by --compile-strict when
+# build_files were compiled -- which never covered formatting at all.
+build_srcs := $(wildcard lib/build/*.tl)
+
 build_tests := $(wildcard lib/build/*_test.tl)
 
 # lint.lua delegates its shared checks to cosmic.cli.style; LUA_PATH points

--- a/lib/build/makefile_test.tl
+++ b/lib/build/makefile_test.tl
@@ -265,3 +265,47 @@ local function test_check_gates_terminate_the_outer_parse()
   end
 end
 test_check_gates_terminate_the_outer_parse()
+
+-- Every .tl the build knows about must be reachable by the check gates
+-- (#800). teal/format enumerate through per-directory $(wildcard ...)
+-- lists hand-written in each cook.mk, and make has no recursive glob --
+-- $(wildcard lib/**/*.tl) returns a fraction of the tree -- so a
+-- directory nobody remembers to declare is silently unchecked,
+-- unformatted and untested. Not just locally: CI runs the same
+-- wildcards, so nothing anywhere catches it.
+--
+-- Both sides come from the make database, so this needs no git call and
+-- no extra sandbox grant: lint_files is git's view (#799) and
+-- all_source_files is what the gates enumerate.
+--
+-- .d.tl is the one deliberate exclusion: those are generated
+-- declarations that gentype_test asserts byte-for-byte against
+-- generator output, so formatting them would fight the generator.
+local function db_tl_set(db: string, name: string): {string: boolean}
+  local line = db:match("\n" .. name .. " :=([^\n]*)")
+  assert(line, "expected " .. name .. " in the make database")
+  local set: {string: boolean} = {}
+  for word in line:gmatch("%S+") do
+    if word:match("%.tl$") then
+      set[word] = true
+    end
+  end
+  return set
+end
+
+local function test_every_tl_is_reachable_by_the_check_gates()
+  local db = read_make_output("database.out").output
+  local declared = db_tl_set(db, "all_source_files")
+  local missing: {string} = {}
+  for path in pairs(db_tl_set(db, "lint_files")) do
+    if not path:match("%.d%.tl$") and not declared[path] then
+      missing[#missing + 1] = path
+    end
+  end
+  table.sort(missing)
+  assert(#missing == 0,
+    "these .tl files are in the tree but no cook.mk declares them, so "
+    .. "teal/format/test never see them -- add the directory to the "
+    .. "module's _srcs:\n  " .. table.concat(missing, "\n  "))
+end
+test_every_tl_is_reachable_by_the_check_gates()

--- a/lib/docs/cook.mk
+++ b/lib/docs/cook.mk
@@ -2,6 +2,11 @@ modules += docs
 # no docs_tl - avoid inclusion in all_example_srcs (these are build tools, not library code)
 docs_publish := $(o)/lib/docs/publish.lua
 docs_files := $(docs_publish)
+# _srcs, not _tl: _tl would pull these build tools into the pipelines
+# the comment above rules out, while _srcs only adds them to the type
+# and format gates (#800).
+docs_srcs := $(wildcard lib/docs/*.tl)
+
 docs_tests := lib/docs/publish_test.tl
 docs_deps := cosmic
 

--- a/lib/types/cook.mk
+++ b/lib/types/cook.mk
@@ -3,6 +3,12 @@ modules += types
 # binary via cosmos) and the committed lib/types/cosmo/*.d.tl, so it runs as a
 # normal test under $(cosmic_bin). It guards the generator against drift, e.g.
 # the errno-return contract in unix.d.tl (see test_errno_drift_unix).
+# The generators are checked; the generated .d.tl declarations are not.
+# gentype_test asserts those byte-for-byte against generator output, so
+# formatting them would fight the generator rather than the source
+# (#800). Same _srcs-not-_tl reasoning as the other build-tool modules.
+types_srcs := $(filter-out %.d.tl,$(wildcard lib/types/*.tl))
+
 types_tests := lib/types/gentype_test.tl lib/types/gentype_alias_test.tl lib/types/gentype_return_test.tl lib/types/gentl_test.tl lib/types/tl_conformance_test.tl
 # types_deps is intentionally not set - types_files are source files (.d.tl),
 # not built outputs. The regen-types target uses bootstrap_cosmic directly.

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -76,6 +76,16 @@ lint_deleted := $(filter-out $(lint_present),$(lint_files))
 all_linted := $(patsubst %,$(o)/%.lint.got,$(lint_present))
 
 lint_list_stamp := $(o)/lint-files.stamp
+# The makefile fixtures snapshot this very list (makefile_test's #800
+# ratchet compares lint_files against all_source_files), but they
+# otherwise depend only on the makefiles -- so adding a .tl WITHOUT the
+# cook.mk edit, which is exactly the mistake the ratchet exists to
+# catch, would leave the fixture stale and the ratchet green. The stamp
+# is write-if-changed, so this rebuilds the fixture when the file set
+# moves and never otherwise. build_make_out comes from lib/build/cook.mk,
+# included well before this file.
+$(build_make_out)/database.out: $(lint_list_stamp)
+
 $(lint_list_stamp): .FORCE
 	@$(bootstrap_cosmic) --build list $@ $(lint_present)
 


### PR DESCRIPTION
Closes #800. Step 2 of the sequence — #802 made the gates actually run; this makes them cover everything.

## The hole

`teal`/`format` enumerate through per-directory `$(wildcard ...)` lists hand-written in each `cook.mk`. Make has no recursive glob — `$(wildcard lib/**/*.tl)` returns **181** files against **333** present, because `**` behaves as a single `*` — so the lists are hand-maintained per directory and anything unlisted is silently skipped.

Unlike #799's lint hole, this one was invisible **in CI too**: CI runs the same wildcards. Nothing anywhere caught it.

The `build`, `docs` and `types` modules declared `_files` and `_tests` but no `_srcs`, so **16 real source files** — the whole build toolchain (`lint.tl`, `reporter.tl`, `build-stage.tl`, …) and the type generators (`gentype*.tl`, `gentl.tl`) — were never type- or format-checked.

They *were* compiled, and `--compile-strict` type-checks, which is why type errors still failed the build. Formatting had nothing, and #802 found 2 of these 16 genuinely misformatted.

## The change

`_srcs` on the three modules. Deliberately **not** `_tl`: that feeds the docs and benchmark pipelines which `lib/docs/cook.mk` explicitly does not want these build tools in —

```make
# no docs_tl - avoid inclusion in all_example_srcs (these are build tools, not library code)
```

— while `_srcs` feeds only `all_source_files`, i.e. the check gates. That distinction is now written down at each of the three sites so the next person doesn't have to re-derive it.

`.d.tl` stays out: `gentype_test` asserts those byte-for-byte against generator output, so formatting them would fight the generator rather than the source.

**teal and format go 310 → 326 checks, all passing.** Both numbers mean something they didn't before #802, when the gates were reporting on checks that never ran.

## The ratchet, and the flaw I had to fix in it

The ratchet compares `lint_files` (git's view, from #799) against `all_source_files`, both read from the make database fixture — so no git call and no extra sandbox grant.

But that fixture otherwise depends only on the makefiles, which would have made the ratchet **useless for its own purpose**: adding a `.tl` *without* the `cook.mk` edit — precisely the mistake being guarded — changes no makefile, so the fixture stays stale and the ratchet stays green.

I found this because a stale fixture failed CI on a probe file I had already deleted. The fixture now also depends on the write-if-changed lint-files stamp, so it rebuilds when the file set moves and not otherwise.

Verified in the shape that matters: a new undeclared `.tl`, **with no makefile touched**, fails with

```
these .tl files are in the tree but no cook.mk declares them, so
teal/format/test never see them -- add the directory to the module's _srcs:
  lib/cosmic/newdir/probe.tl
```

and passes once removed. Removing `types_srcs` also fails it.

## Verification

- `bin/make ci` → `ci: PASS`, with `.teal.got`/`.format.got` deleted first
- teal 326/326, format 326/326
- ratchet negative-controlled two ways (undeclared new file; removed `_srcs`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSajNo281T9W53fQN41Ef9)_