### PR TITLE
fix: --test slices its command vector, so the child keeps its own flags

### DIFF
--- a/lib/cosmic/cli/main.tl
+++ b/lib/cosmic/cli/main.tl
@@ -81,7 +81,6 @@ local function parse_args(): Options
   -- Options that consume all remaining arguments (no script after them)
   local long_greedy: {string: boolean} = {
     ["report"] = true,
-    ["test"] = true,
     ["coverage-report"] = true,
   }
 
@@ -90,12 +89,13 @@ local function parse_args(): Options
 
   -- Find first non-option argument (script name) to know where to stop parsing
   local script_idx: integer = nil
-  -- --build's payload after the mode is a FOREIGN argv — the recipe
-  -- child's own flags (`--build tee out cosmic --report ...`). getopt
-  -- permutes, so it would consume those flags as cosmic options; slice
-  -- the payload off here and parse only up to the mode argument.
-  local build_payload: {string} = nil
-  local build_parse_end: integer = nil
+  -- --build and --test are followed by a FOREIGN argv — the child's own
+  -- flags. getopt permutes, so it would eat those as cosmic options;
+  -- slice the payload off and parse only to the option's own argument.
+  -- --test lacked this (#801): its child ran bare, hit the REPL and
+  -- exited 0, so teal and format reported passes without ever running.
+  local payload: {string} = nil
+  local payload_parse_end: integer = nil
   local i = 1
   while i <= #arg do
     local a = arg[i]
@@ -104,12 +104,14 @@ local function parse_args(): Options
       break
     elseif a:sub(1, 2) == "--" then
       local opt_name = a:sub(3)
-      if opt_name == "build" then
-        build_payload = {}
-        for k = i + 2, #arg do
-          build_payload[#build_payload + 1] = arg[k]
+      if opt_name == "build" or opt_name == "test" then
+        payload = {}
+        -- a `--` here defends against that same bug; step over it
+        local from = arg[i + 2] == "--" and i + 3 or i + 2
+        for k = from, #arg do
+          payload[#payload + 1] = arg[k]
         end
-        build_parse_end = i + 1
+        payload_parse_end = i + 1
         script_idx = nil
         break
       elseif long_greedy[opt_name] then
@@ -142,8 +144,8 @@ local function parse_args(): Options
         cosmic_args[#cosmic_args + 1] = arg[k]
       end
     end
-  elseif build_parse_end then
-    for k = 1, math.min(build_parse_end, #arg) do
+  elseif payload_parse_end then
+    for k = 1, math.min(payload_parse_end, #arg) do
       cosmic_args[#cosmic_args + 1] = arg[k]
     end
   else
@@ -266,7 +268,7 @@ local function parse_args(): Options
       opts.welcome = true
     elseif opt == "test" then
       opts.test_output = optarg
-      opts.test_argv = r.args
+      opts.test_argv = payload or {}
       return opts
     elseif opt == "report" then
       opts.report_paths = r.args
@@ -276,7 +278,7 @@ local function parse_args(): Options
       return opts
     elseif opt == "build" then
       opts.build_mode = optarg
-      opts.build_argv = build_payload or {}
+      opts.build_argv = payload or {}
       return opts
     elseif opt == "make" then
       opts.make = optarg or ""

--- a/lib/cosmic/cli/main_handlers_test.tl
+++ b/lib/cosmic/cli/main_handlers_test.tl
@@ -221,3 +221,30 @@ local function test_test_wrapper_propagates_child_exit_code()
     "a passing check must be recorded as 0, got: " .. got_good)
 end
 test_test_wrapper_propagates_child_exit_code()
+
+--- The same, WITHOUT the `--`. That separator used to be mandatory in
+--- practice and nothing said so: omitting it silently ran no check
+--- (#801). --test now slices its command vector off before the option
+--- parse, the way --build always has, so the child keeps its own flags
+--- either way and the trap is gone rather than merely documented.
+local function test_test_wrapper_needs_no_separator()
+  local bad = fs.join(tmpdir, "nosep_bad.tl")
+  fs.write(bad, 'local function f()\n        return 1\nend\nprint(f())\n')
+  local good = fs.join(tmpdir, "nosep_good.tl")
+  fs.write(good, 'local x = 1\nprint(x)\n')
+
+  local base_bad = fs.join(tmpdir, "nosep_bad.fmt")
+  cli("--test", base_bad, cosmic, "--check-format", bad)
+  local got_bad = check.must(fs.read(base_bad .. ".got"),
+    "--test without `--` should still record an exit code")
+  assert(got_bad:gsub("%s+$", "") ~= "0",
+    "without `--` a failing check must still be non-zero, got: " .. got_bad)
+
+  local base_good = fs.join(tmpdir, "nosep_good.fmt")
+  cli("--test", base_good, cosmic, "--check-format", good)
+  local got_good = check.must(fs.read(base_good .. ".got"),
+    "--test without `--` should still record an exit code")
+  assert(got_good:gsub("%s+$", "") == "0",
+    "without `--` a passing check must be 0, got: " .. got_good)
+end
+test_test_wrapper_needs_no_separator()


### PR DESCRIPTION
Follow-up to #801. That fixed the two broken call sites; this removes the trap that produced them.

## The trap

`--test <out> <cmd...>` handed `<cmd...>` straight to getopt, which permutes — so a child command beginning with a flag lost it. The child ran bare, fell into the REPL, and exited 0.

The two call sites that worked were right **by luck, not design**:

- `lint` carries a `--` for an unrelated reason (separating the child cosmic from the script it runs)
- the test rules pass no inner flags at all

So the next caller to write the obvious thing — `--test out cosmic --check-format f` — would have hit it again, and silently, which is the part that matters.

## The fix

`--build` already had the answer. Its payload is a foreign argv and is sliced off *before* the parse:

```teal
if opt_name == "build" then
  build_payload = { ... arg[i+2 ..] }
  build_parse_end = i + 1
```

`--test` now takes that same path — a one-word widening of the existing condition rather than a second mechanism:

```teal
if opt_name == "build" or opt_name == "test" then
```

A leading `--` in the payload is stepped over, so the recipes from #802 keep working and both spellings mean the same thing. Their `--` becomes belt-and-braces rather than load-bearing; the makefile ratchet pinning it stays valid and costs nothing.

## Verification

Tested in the spelling that used to fail silently — **without** the separator:

| invocation | recorded |
|---|---|
| `--test out cosmic --check-format bad.tl` | `1` |
| `--test out cosmic --check-format good.tl` | `0` |
| `--test out -- cosmic --check-format bad.tl` | `1` |
| `--build list out a b` | unchanged, writes `a b` |

The new test covers the no-separator case directly. Reverting the parser change makes it report:

```
without `--` a failing check must still be non-zero, got: 0
```

## A note on size

`main.tl` was at **497 of its 500-line cap**, so this had to be written for size. My first version generalized the branch into a `long_payload_after_arg` lookup table and came to 514 lines — cleaner in isolation, unaffordable here. Folding `--test` into the existing condition says the same thing in three lines; the file is at 499.

Worth flagging that a file three lines from a hard cap makes every future change to the CLI parser a refactor. Splitting `main.tl` is a candidate before it takes much more.

- `bin/make ci` → `ci: PASS`, with `.teal.got`/`.format.got` deleted first
- `--build` re-verified unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSajNo281T9W53fQN41Ef9)_