### PR TITLE
test: a check.needs guard exits, so a skip is not graded a pass (#814)

### DIFF
--- a/_cli/lint.tl
+++ b/_cli/lint.tl
@@ -342,6 +342,54 @@ local function check_find_needle(file: string, content: string): {Diagnostic}
   return diagnostics
 end
 
+--- Report each `check.needs` guard that returns instead of exiting.
+---
+--- `check.needs` says an environment cannot run a test; the exit code is
+--- the only part of that the runner reads. A `return` ends the function
+--- and lets the file run on to a clean exit, and a clean exit is graded
+--- `pass` -- so the guard reports the test as run and green when it did
+--- neither. `os.exit(check.EXIT_SKIP)` is what `records.status_of`
+--- grades as a skip, and it is the form `check.needs` documents.
+---
+--- Line-based rather than token-based: the shape is two adjacent lines,
+--- and the lexer's own guards (comments, strings) do not apply to a
+--- `return` that has to be at statement position to parse at all.
+--- @param file string Path, for the diagnostic
+--- @param lines {string} The file's lines
+--- @return {Diagnostic} One per guard that returns rather than exits
+local function check_needs_exit(file: string, lines: {string}): {Diagnostic}
+  if not file:match("_test%.tl$") then
+    return {}
+  end
+  local diagnostics: {Diagnostic} = {}
+  for i, line in ipairs(lines) do
+    if line:find("check.needs(", 1, true) then
+      -- The call wraps when its arguments are long, so the `then` that
+      -- opens the guard may be a line or two below the call. Beyond
+      -- that it is some other use of `needs` and not this shape.
+      for j = i, math.min(i + 2, #lines) do
+        if lines[j]:match("then%s*$") then
+          if (lines[j + 1] or ""):match("^%s*return%s*$") then
+            diagnostics[#diagnostics + 1] = {
+              file = file,
+              line = j + 1,
+              col = 1,
+              rule = "needs-exit",
+              message = string.format(
+                "%s:%d: a `check.needs` guard that returns exits 0, which"
+                .. " the runner grades as a PASS for a test that never"
+                .. " ran: `os.exit(check.EXIT_SKIP)` reports the skip",
+                file, j + 1),
+            }
+          end
+          break
+        end
+      end
+    end
+  end
+  return diagnostics
+end
+
 --- Every style check, for one file.
 ---
 --- `.d.tl` declarations are exempt: they describe C binding interfaces
@@ -397,6 +445,9 @@ local function lint_file(path: string): {Diagnostic} | nil, string
     for _, d in ipairs(check_find_needle(path, content)) do
       diagnostics[#diagnostics + 1] = d
     end
+    for _, d in ipairs(check_needs_exit(path, lines)) do
+      diagnostics[#diagnostics + 1] = d
+    end
   end
   return diagnostics
 end
@@ -406,6 +457,7 @@ local record LintModule
   check_cosmo_require: function(file: string, lines: {string}): {Diagnostic}
   check_call_after_define: function(file: string, content: string, lines: {string}): {Diagnostic}
   check_find_needle: function(file: string, content: string): {Diagnostic}
+  check_needs_exit: function(file: string, lines: {string}): {Diagnostic}
   lint_file: function(path: string): {Diagnostic} | nil, string
 end
 
@@ -414,6 +466,7 @@ local M: LintModule = {
   check_cosmo_require = check_cosmo_require,
   check_call_after_define = check_call_after_define,
   check_find_needle = check_find_needle,
+  check_needs_exit = check_needs_exit,
   lint_file = lint_file,
 }
 

--- a/_cli/lint_test.tl
+++ b/_cli/lint_test.tl
@@ -258,6 +258,53 @@ local function test_find_needle_wants_the_intent_stated()
 end
 test_find_needle_wants_the_intent_stated()
 
+-- A `check.needs` guard that returns is the failure the rule is named
+-- for: the file runs on, exits 0, and the runner grades 0 as a pass, so
+-- a test that opted out of running contributes a green tick. Only the
+-- exit reaches the runner, which is why the shape is checkable at all.
+local function test_needs_exit_flags_a_guard_that_returns()
+  local returns = lines_of(
+    'if not check.needs("a built cosmic", ok) then\n' ..
+    '  return\n' ..
+    'end\n')
+  local diags = lint.check_needs_exit("m_test.tl", returns)
+  assert(#diags == 1, "a returning guard is flagged, got " .. #diags)
+  assert(diags[1].rule == "needs-exit", "got: " .. diags[1].rule)
+  assert(diags[1].line == 2, "names the return, got line " .. diags[1].line)
+
+  -- The call wraps when its arguments are long, which puts the `then`
+  -- below the line naming `check.needs`.
+  local wrapped = lines_of(
+    'if not check.needs("the cosmic tree",\n' ..
+    '  fs.isfile(gen)) then\n' ..
+    '  return\n' ..
+    'end\n')
+  assert(#lint.check_needs_exit("m_test.tl", wrapped) == 1,
+    "a wrapped call is the same guard")
+
+  for _, clean in ipairs({
+      'if not check.needs("a built cosmic", ok) then\n' ..
+      '  os.exit(check.EXIT_SKIP)\n' ..
+      'end\n',
+      -- A guard that returns a value is a function answering its
+      -- caller, not a test opting out of the runner.
+      'if not check.needs("a built cosmic", ok) then\n' ..
+      '  return false\n' ..
+      'end\n',
+      -- `needs` used as a value, with no guard to grade.
+      'local ok, err = pcall(check.needs, "an absent fixture", false)\n',
+    }) do
+    assert(#lint.check_needs_exit("m_test.tl", lines_of(clean)) == 0,
+      "should pass: " .. clean)
+  end
+
+  -- Scoped to tests, because `check.needs` grades a test run: the same
+  -- lines in a library file are some other function's control flow.
+  assert(#lint.check_needs_exit("m.tl", returns) == 0,
+    "only test files are graded by the runner")
+end
+test_needs_exit_flags_a_guard_that_returns()
+
 -- `--check <kind>` refuses an unknown kind by naming the ones it has,
 -- refuses a retired one by naming what replaced it, and refuses a
 -- missing file by naming the project-wide verb — the three ways a

--- a/_make/generate_test.tl
+++ b/_make/generate_test.tl
@@ -298,13 +298,13 @@ local function test_the_real_payload_generator()
   local gen = fs.join(repo, "cmd/cosmic/embed_gen.tl")
   if not check.needs("the cosmic tree (cmd/cosmic/embed_gen.tl)",
     fs.isfile(gen)) then
-    return
+    os.exit(check.EXIT_SKIP)
   end
   -- The generator reads its pinned inputs from `o/3p/**`, which only
   -- `--make fetch` writes. CI fetches before it gates, so this runs
   -- there; a cold checkout skips rather than failing.
   if not check.needs("fetched pins", seed_pins(repo)) then
-    return
+    os.exit(check.EXIT_SKIP)
   end
   local out = fs.join(tmpdir, "real-payload")
   fs.rmrf(out)

--- a/cosmic/coverage/baseline_test.tl
+++ b/cosmic/coverage/baseline_test.tl
@@ -253,7 +253,7 @@ local function test_a_failing_ratchet_names_the_rows_that_moved()
   -- A child, because the report goes to this process's stderr.
   local cosmic = fs.join(os.getenv("TEST_BIN") or "", "cosmic")
   if not check.needs("a built cosmic at " .. cosmic, fs.isfile(cosmic)) then
-    return
+    os.exit(check.EXIT_SKIP)
   end
   -- A SCRIPT file, not `-e`: only the script path arms line coverage,
   -- so a `-e` child runs the code under test and reports none of it.


### PR DESCRIPTION
Fixes #814.

## The defect

`check.needs` says an environment cannot run a test, and **the exit code is the only part of that the runner reads**. Three guards said it with a bare `return`:

```teal
if not check.needs("a built cosmic at " .. cosmic, fs.isfile(cosmic)) then
  return
end
```

The `return` ends the *function*. The file runs on, reaches its end normally, exits 0 — and `records.status_of` grades 0 as `pass`. So a test that opted out of running contributed a green tick to the gate, which is worse than an absent test.

Sites, all three in the **last** test of their file, so the exit costs no other test a run:

- `cosmic/coverage/baseline_test.tl:255` — no `TEST_BIN`
- `_make/generate_test.tl:299`, `:306` — no cosmic tree, no fetched pins

The nine other `check.needs` guards in the tree already `os.exit(check.EXIT_SKIP)`, which is the form `check.tl` documents.

## Why a rule and not just a sweep

The issue asks for a sweep of the same shape. A sweep is true once. The shape reads correct and is not, so it comes back — hence `needs-exit` in `_cli.lint`: a `check.needs` guard whose body is a bare `return` is a diagnostic. Scoped to `_test.tl`, because it is the runner's grade that is at stake; a `return false` (a function answering its caller) and `pcall(check.needs, …)` (no guard to grade) both pass.

Line-based rather than token-based, deliberately: the shape is two adjacent lines, and a `return` has to be at statement position to parse at all — so the comment-and-string false positives the lexer exists to prevent cannot arise here. The wrapped form (`then` a line or two below the call, as in `generate_test.tl`) is handled.

## Verification

- `bin/cosmic --make ci` → **`ci: PASS (6 stages)`**
- `--make lint` → 440/440 clean on the fixed tree
- The rule catches the defect it was written for — run against the **pre-fix** sources it reports all three sites:

```
cosmic/coverage/baseline_test.tl:256:1: needs-exit: ...
_make/generate_test.tl:301:1: needs-exit: ...
_make/generate_test.tl:307:1: needs-exit: ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQ56YZVuXWho9UUMVJfKPf

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQ56YZVuXWho9UUMVJfKPf)_