### PR TITLE
format: a parenthesized type is a type, and `as` is not a callee (#808)

### DIFF
--- a/cosmic/fetch/init.tl
+++ b/cosmic/fetch/init.tl
@@ -453,47 +453,47 @@ end
 -- Verb helpers/download come from fetch_extras.make; it receives the
 -- result metatable so download's synthesized results answer is_success().
 local made = fetch_extras.make(
-  Fetch as(function(string, any): any), -- cast: function shape
-    stream as(function(string, any): any), -- cast: function shape
-      function(t: any): any
-        return setmetatable(t as {string: any}, result_mt) -- cast: from any
-      end)
+  Fetch as (function(string, any): any), -- cast: function shape
+  stream as (function(string, any): any), -- cast: function shape
+  function(t: any): any
+    return setmetatable(t as {string: any}, result_mt) -- cast: from any
+  end)
 
-    local record FetchModule
-      fetch: function(url: string, opts?: Options): Result
-      --- GET/POST/PUT/DELETE conveniences: fetch with the method forced.
-      get: function(url: string, opts?: Options): Result
-      post: function(url: string, opts?: Options): Result
-      put: function(url: string, opts?: Options): Result
-      delete: function(url: string, opts?: Options): Result
-      --- Stream a URL to a file. The file is written only for a 2xx
-      --- response (created/truncated, then removed again on a mid-stream
-      --- failure); a non-2xx response returns its status with a bounded
-      --- diagnostic body and writes nothing. The result carries body = ""
-      --- on success.
-      download: function(url: string, path: string, opts?: Options): Result
-      stream: function(url: string, opts?: Options): StreamResult
-      unix_proxy: function(path: string): string | nil, string
-      type ErrorKind = ErrorKind
-      --- Type aliases, not runtime values: a `Result: Result` field
-      --- spelling would declare phantom fields that are nil at runtime.
-      type Options = Options
-      type Part = Part
-      type Result = Result
-      type Reader = Reader
-      type StreamResult = StreamResult
-    end
+local record FetchModule
+  fetch: function(url: string, opts?: Options): Result
+  --- GET/POST/PUT/DELETE conveniences: fetch with the method forced.
+  get: function(url: string, opts?: Options): Result
+  post: function(url: string, opts?: Options): Result
+  put: function(url: string, opts?: Options): Result
+  delete: function(url: string, opts?: Options): Result
+  --- Stream a URL to a file. The file is written only for a 2xx
+  --- response (created/truncated, then removed again on a mid-stream
+  --- failure); a non-2xx response returns its status with a bounded
+  --- diagnostic body and writes nothing. The result carries body = ""
+  --- on success.
+  download: function(url: string, path: string, opts?: Options): Result
+  stream: function(url: string, opts?: Options): StreamResult
+  unix_proxy: function(path: string): string | nil, string
+  type ErrorKind = ErrorKind
+  --- Type aliases, not runtime values: a `Result: Result` field
+  --- spelling would declare phantom fields that are nil at runtime.
+  type Options = Options
+  type Part = Part
+  type Result = Result
+  type Reader = Reader
+  type StreamResult = StreamResult
+end
 
-    local M: FetchModule = {
-      fetch = Fetch,
-      get = made.get as(function(string, Options): Result), -- cast: function shape
-        post = made.post as(function(string, Options): Result), -- cast: function shape
-          put = made.put as(function(string, Options): Result), -- cast: function shape
-            delete = made.delete as(function(string, Options): Result), -- cast: function shape
-              -- cast: function shape
-              download = made.download as(function(string, string, Options): Result),
-                stream = stream,
-                unix_proxy = fetch_extras.unix_proxy,
-              }
+local M: FetchModule = {
+  fetch = Fetch,
+  get = made.get as (function(string, Options): Result), -- cast: function shape
+  post = made.post as (function(string, Options): Result), -- cast: function shape
+  put = made.put as (function(string, Options): Result), -- cast: function shape
+  delete = made.delete as (function(string, Options): Result), -- cast: function shape
+  -- cast: function shape
+  download = made.download as (function(string, string, Options): Result),
+  stream = stream,
+  unix_proxy = fetch_extras.unix_proxy,
+}
 
-              return M
+return M

--- a/cosmic/format/rules.tl
+++ b/cosmic/format/rules.tl
@@ -162,6 +162,13 @@ local function needs_space(prev_prev: Item, prev: Item, cur: Item, next_item: It
     return false
   end
   if cur.tk == "(" then
+    -- `as` is an OPERATOR the lexer hands back as an identifier (Teal
+    -- keeps it usable as a name), so the callee rule below claims it and
+    -- rewrites the parenthesized type `x as (T | nil)` to `x as(T | nil)`
+    -- -- legal, and wrong about what the code is.
+    if prev.tk == "as" then
+      return true
+    end
     if prev.kind == "identifier" or prev.tk == ")" or prev.tk == "]"
     or prev.kind == "string" or (prev.kind == "keyword" and prev.tk == "function") then
       return false

--- a/cosmic/format/types.tl
+++ b/cosmic/format/types.tl
@@ -193,6 +193,45 @@ local function mark_carried_type(line_items: {Item},
   end
 end
 
+--- Mark a PARENTHESIZED type -- `as (T | nil)`, `: (T | nil)` -- from
+--- its `(` through the matching `)`.
+---
+--- The group has to be marked whole, not just the `function` inside it.
+--- Marked items are skipped for indent accounting on both sides, so
+--- marking the keyword alone leaves the `(` counted as an opener while
+--- its `)` is marked away, which banks the same phantom level a false
+--- block opener does. `mark_function_type` cannot reach this shape from
+--- the other end either: it marks from a `function` whose next token is
+--- `(`, and here the `(` comes first.
+---
+--- A `(` in this position is always a type: after `as` there is nothing
+--- else it can be, and a method call puts its `(` after the name
+--- (`obj:m(x)`), never against the `:`.
+--- @param line_items {Item} The line's items
+--- @param type_ctx {integer: boolean} Marks, updated in place
+local function mark_parenthesized_types(line_items: {Item},
+    type_ctx: {integer: boolean})
+  for idx, item in ipairs(line_items) do
+    local next_item = line_items[idx + 1]
+    if (item.tk == "as" or item.tk == ":")
+    and next_item and next_item.tk == "(" and not type_ctx[idx + 1] then
+      local depth = 0
+      for k = idx + 1, #line_items do
+        type_ctx[k] = true
+        local tk = line_items[k].tk
+        if tk == "(" then
+          depth = depth + 1
+        elseif tk == ")" then
+          depth = depth - 1
+          if depth == 0 then
+            break
+          end
+        end
+      end
+    end
+  end
+end
+
 --- Every item on this line that belongs to a type rather than to code.
 --- @param line_items {Item} The line's items
 --- @param continues_type boolean Whether the previous line left a type open
@@ -203,6 +242,7 @@ local function type_marks(line_items: {Item},
   if continues_type then
     mark_carried_type(line_items, type_ctx)
   end
+  mark_parenthesized_types(line_items, type_ctx)
   for idx, item in ipairs(line_items) do
     if item.kind == "keyword" and item.tk == "function" and not type_ctx[idx]
     and not is_function_block_opener(line_items, idx, continues_type) then

--- a/cosmic/format/types_test.tl
+++ b/cosmic/format/types_test.tl
@@ -210,4 +210,52 @@ local function test_a_comment_carries_type_position_through()
 end
 test_a_comment_carries_type_position_through()
 
+-- A parenthesized union. `mark_function_type` cannot reach this shape:
+-- it marks from a `function` whose NEXT token is `(`, and here the `(`
+-- comes first, so the backward scan hits an unmatched `(` and calls the
+-- `function` a definition -- one phantom level from that line to the
+-- end of the file.
+--
+-- The group is marked whole rather than the keyword alone. Marks are
+-- skipped for indent accounting on both sides, so marking `function`
+-- and leaving its brackets bare banks the same level the false opener
+-- did: the `(` counts as an opener and the marked `)` never pays it
+-- back.
+local function test_a_parenthesized_union_opens_no_block()
+  local src = "local record R\n" ..
+  "  f: function(a: integer): integer\n" ..
+  "end\n" ..
+  "local g = (nil as any) as (function | nil)\n" ..
+  "local h = 1\n" ..
+  "return R, g, h\n"
+  assert_format(src, src, "a parenthesized union after `as`", "test.tl")
+
+  -- The same group in the other type position, and one with its own
+  -- brackets inside, so the scan has to match rather than stop at the
+  -- first `)`.
+  local colon = "local x: (function | nil) = nil\n" ..
+  "local y: (function(a: integer): integer | nil) = nil\n" ..
+  "local z = 1\n" ..
+  "return x, y, z\n"
+  assert_format(colon, colon, "a parenthesized union after `:`", "test.tl")
+end
+test_a_parenthesized_union_opens_no_block()
+
+-- `as` lexes as an identifier -- Teal keeps it usable as a name -- so
+-- the "no space before `(` in a call" rule claimed it and wrote
+-- `x as(T | nil)`. Legal, and wrong about what the code is: `as` is an
+-- operator, and the parens are a type, not an argument list.
+local function test_as_keeps_its_space_before_a_parenthesized_type()
+  local src = "local f = (nil as any) as (function | nil)\n" ..
+  "return f\n"
+  assert_format(src, src, "`as (` is not a call", "test.tl")
+
+  -- The rule it must not have broken: a real call still binds tight.
+  local call = "local n = tostring(1)\n" ..
+  "return n\n"
+  assert_format(call, call, "a call keeps no space before its `(`",
+    "test.tl")
+end
+test_as_keeps_its_space_before_a_parenthesized_type()
+
 print("all format type-position tests passed")

--- a/cosmic/shm.tl
+++ b/cosmic/shm.tl
@@ -121,7 +121,7 @@ local function wrap(raw: unix.Memory, size: integer): Memory
       .. " + " .. tostring(n) .. " > " .. tostring(size) .. ")"
     end
     -- cast: pcall variadic returns to tuple
-    local ok, err = pcall(raw.write, raw, data, offset, bytes) as(boolean, any)
+    local ok, err = pcall(raw.write, raw, data, offset, bytes) as (boolean, any)
     if not ok then
       return false, thrown("write", err)
     end
@@ -146,7 +146,7 @@ local function wrap(raw: unix.Memory, size: integer): Memory
       return false, range_err
     end
     -- cast: pcall variadic returns to tuple
-    local ok, err = pcall(raw.store, raw, word_index, value) as(boolean, any)
+    local ok, err = pcall(raw.store, raw, word_index, value) as (boolean, any)
     if not ok then
       return false, thrown("store", err)
     end

--- a/cosmic/sqlite/extras.tl
+++ b/cosmic/sqlite/extras.tl
@@ -72,7 +72,7 @@ local function attach(db_any: any)
       return false, err or "savepoint failed"
     end
     -- cast: pcall multi-return shape
-    local success, result, result_err = pcall(fn, self) as(boolean, any, any)
+    local success, result, result_err = pcall(fn, self) as (boolean, any, any)
     if not success then
       self:exec("ROLLBACK TO " .. name)
       self:exec("RELEASE " .. name)

--- a/cosmic/sqlite/init.tl
+++ b/cosmic/sqlite/init.tl
@@ -381,7 +381,7 @@ local function make_database(raw_db: lsqlite3.Database): Database
       return false, err or "begin failed"
     end
     -- cast: pcall variadic returns
-    local success, result, result_err = pcall(fn, self) as(boolean, any, any)
+    local success, result, result_err = pcall(fn, self) as (boolean, any, any)
     if not success then
       self:exec("ROLLBACK")
       return false, (result as string) or "transaction failed" -- cast: from any

--- a/cosmic/sys.tl
+++ b/cosmic/sys.tl
@@ -123,7 +123,7 @@ end
 --- @return Uname | nil The system identification record
 --- @return string? Error message on failure
 local function uname(): Uname | nil, string
-  local uts, err = unix.uname() as(Uname, any) -- cast: pre-narrow record union tuple
+  local uts, err = unix.uname() as (Uname, any) -- cast: pre-narrow record union tuple
   if not uts then
     return nil, errstr(err, "uname")
   end


### PR DESCRIPTION
Fixes #808. Both holes, in the shape `x as (T | nil)`.

## 1. `function` inside a parenthesized union false-block-opens

The backward scan from the keyword hits the `(` at depth 0 and calls it a definition, so every line after it indents one level deeper to the end of the file. `mark_function_type` cannot reach the shape from the other end, exactly as the issue says: it marks from a `function` whose *next* token is `(`, and here the `(` comes first.

Fixed by marking the parenthesized type as a group, from `(` to the matching `)`.

**Marking the group whole is the part that is easy to get wrong.** Marks are skipped for indent accounting on *both* sides, so marking `function` alone and leaving its brackets bare banks the same phantom level the false opener did — the `(` counts as an opener and the marked `)` never pays it back. Net effect identical, cause different.

`: (T | nil)` is the same group in the other type position and is marked the same way; a `(` there is always a type, since a method call puts its `(` after the name (`obj:m(x)`), never against the `:`.

## 2. `as (` → `as(`

`as` lexes as an **identifier** (Teal keeps it usable as a name), so the "no space before `(` in a call" rule claimed it:

```
tk=as    kind=identifier
```

Legal, and wrong about what the code is — `as` is an operator, and the parens are a type, not an argument list.

## This one had already shipped

Same as the type-position hole in #793: five committed files carry `as(` written by the formatter itself, with the gate green the whole time, because the output is idempotent and re-blesses its own damage.

```
cosmic/fetch/init.tl    Fetch as(function(string, any): any)
cosmic/shm.tl           pcall(raw.write, …) as(boolean, any)
cosmic/sqlite/init.tl   pcall(fn, self) as(boolean, any, any)
cosmic/sqlite/extras.tl pcall(fn, self) as(boolean, any, any)
cosmic/sys.tl           unix.uname() as(Uname, any)
```

Rewritten here by `--make fmt --fix`. Nothing else in the tree moved.

## Verification

The issue's repro, before → after:

```teal
local record R
  f: function(a: integer): integer
end
local g = (nil as any) as (function | nil)
local h = 1
return R, g, h
```

```diff
-local g = (nil as any) as(function | nil)
-  local h = 1
-  return R, g, h
+local g = (nil as any) as (function | nil)
+local h = 1
+return R, g, h
```

The acceptance bar the issue sets is a test, not a clean run. Both cases are in `cosmic/format/types_test.tl`, and they **fail against the unfixed formatter** — verified by reverting `types.tl`/`rules.tl`, rebuilding, and running them:

```
✗ cosmic/format/types_test.tl  19ms
    local g = (nil as any) as(function | nil)
test: FAIL (1 of 1 file)
```

`bin/cosmic --make ci` → **`ci: PASS (6 stages)`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQ56YZVuXWho9UUMVJfKPf

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQ56YZVuXWho9UUMVJfKPf)_