### PR TITLE
testrun: the coverage lane reads a source path, not a row label (#819)

### DIFF
--- a/cosmic/records.tl
+++ b/cosmic/records.tl
@@ -43,6 +43,11 @@ local STAGES < const >: {string} = {
   "benchmark", "example", "coverage", "test", "fmt", "lint",
 }
 
+--- The coverage lane's second output tree, which its bases are under.
+--- Dot-prefixed so `o/.coverage/` cannot collide with a project's own
+--- `coverage/` directory.
+local COVERAGE_PREFIX < const > = ".coverage/"
+
 --- Classify the exit code recorded in a `.got` file.
 --- @param exit_code integer Exit code from the .got file
 --- @return string "pass" (0), "skip" (2), or "fail" (anything else)
@@ -76,6 +81,30 @@ local function display(base: string): string
     if cut ~= name then
       return cut
     end
+  end
+  return name
+end
+
+--- The path on disk the row is ABOUT, which is not always the name it
+--- carries.
+---
+--- `display` keeps the coverage lane's `.coverage/` segment on purpose,
+--- because the row names which run produced it. That makes it a LABEL,
+--- not a path: nothing is at `.coverage/cosmic/sys_test.tl`. A caller
+--- that reads the source -- to count what a file defines, say -- needs
+--- the segment gone.
+---
+--- Two functions rather than one, because a single answer is silently
+--- wrong for one caller or the other, and silently is how it went
+--- wrong: `fs.read` of a label returns nil like any absent file, so the
+--- reader took its "nothing here" branch for all 170 coverage rows and
+--- reported a count of zero instead of failing.
+--- @param base string A `.got` base path
+--- @return string The source path, e.g. `cosmic/sys_test.tl`
+local function source_of(base: string): string
+  local name = display(base)
+  if name:sub(1, #COVERAGE_PREFIX) == COVERAGE_PREFIX then
+    return name:sub(#COVERAGE_PREFIX + 1)
   end
   return name
 end
@@ -217,6 +246,7 @@ local record RecordsModule
   ICONS: {string: string}
   status_of: function(exit_code: integer): string
   display: function(base: string): string
+  source_of: function(base: string): string
   stage_of: function(base: string): string
   row: function(status: string, name: string, count: integer, unit: string, wall_ms: integer): string
   counts: function(passed: integer, failed: integer, skipped: integer): string
@@ -232,6 +262,7 @@ local M: RecordsModule = {
   ICONS = ICONS,
   status_of = status_of,
   display = display,
+  source_of = source_of,
   stage_of = stage_of,
   row = row,
   counts = counts,

--- a/cosmic/records_test.tl
+++ b/cosmic/records_test.tl
@@ -28,6 +28,25 @@ local function test_display_names_the_source()
 end
 test_display_names_the_source()
 
+-- The label is not a path. `display` keeps `.coverage/` so the row says
+-- which run produced it, and nothing is on disk at that name -- so a
+-- caller that READS the source needs the segment gone. Reading the
+-- label instead is indistinguishable from an absent file, which is how
+-- every coverage row came to report zero test functions.
+local function test_source_of_names_a_readable_path()
+  assert(records.source_of("o/.coverage/cosmic/sys_test.tl.test") ==
+    "cosmic/sys_test.tl", "the coverage tree is not part of the path")
+  assert(records.source_of("o/cosmic/sys_test.tl.test") ==
+    "cosmic/sys_test.tl", "and the two lanes name the same source")
+  -- Only a LEADING segment, and only the whole one: a project may have
+  -- its own directory whose name starts the same way.
+  assert(records.source_of("o/.coveragex/a_test.tl.test") ==
+    ".coveragex/a_test.tl", "a different directory keeps its name")
+  assert(records.source_of("o/a/.coverage/b_test.tl.test") ==
+    "a/.coverage/b_test.tl", "and the segment is stripped only at the root")
+end
+test_source_of_names_a_readable_path()
+
 -- `.test` must not strip out of `.benchmark`, which contains no `.test`
 -- but shares its shape closely enough to be worth pinning.
 local function test_stage_of_reads_the_suffix()

--- a/cosmic/testrun.tl
+++ b/cosmic/testrun.tl
@@ -156,7 +156,7 @@ local function run(argv: {string}, output_base: string): integer
   local test_names: {string} = {}
   local stage = records.stage_of(output_base)
   if stage == "test" or stage == "coverage" then
-    local src = fs.read(records.display(output_base))
+    local src = fs.read(records.source_of(output_base))
     if src then
       for line in string.gmatch(src, "[^\n]+") do
         local tname = line:match("^local function (test_[%w_]+)")


### PR DESCRIPTION
Fixes #819.

## The mismatch, confirmed

The issue suspected the `.coverage/` prefix and asked for it to be confirmed before fixing. It is exactly that, and the two halves are both deliberate:

- `records.display()` **keeps** the coverage lane's `.coverage/` segment — `records_test.tl` asserts it, and the doc comment says why: the row names which run produced it.
- `testrun.run` read the source **through `display`** to count `test_*` definitions (`testrun.tl:159`).

So the read was `fs.read(".coverage/cosmic/sys_test.tl")`. Nothing is at that path — it is a label, not a location. `.tests` was never written for any coverage target, and all 170 rows reported a count of zero.

**Silently**, which is the part worth naming: `fs.read` of a label returns nil exactly like an absent file, so the reader took its "nothing here" branch and the lane looked like a file that defines no tests rather than a lookup at the wrong path. The read branch at `:245` was dead code there too, so a regression in the count logic would have been caught by only one of the two lanes.

## The change

`records.source_of` answers the other question — the path on disk the row is *about* — and `testrun` reads through that. `display` is untouched.

Two functions rather than one, because a single answer is silently wrong for one caller or the other. The strip is a leading **whole** segment; tested against a directory that merely starts the same way (`.coveragex/`) and one nested below the root (`a/.coverage/`).

## Verification

Same file, both lanes, after the fix:

```
✓ cosmic/sys_test.tl (17 test functions)  7ms            <- test lane
✓ .coverage/cosmic/sys_test.tl (17 test functions)  9ms  <- coverage lane
```

Before, the coverage row was `✓ .coverage/cosmic/sys_test.tl  9ms` and no `.tests` file existed in `o/.coverage/` at all.

`bin/cosmic --make ci` → **`ci: PASS (6 stages)`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQ56YZVuXWho9UUMVJfKPf

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQ56YZVuXWho9UUMVJfKPf)_