### PR TITLE
test: a forked child's exit code is the only thing it can say (#812)

### DIFF
--- a/cosmic/check.tl
+++ b/cosmic/check.tl
@@ -2,6 +2,7 @@
 --- Functions in this module throw on failure (level 2) so the error points
 --- at the caller's line, not inside this module.
 local codec = require("cosmic.codec")
+local proc = require("cosmic.proc")
 local records = require("cosmic.records")
 
 --- Render any Lua value as a readable string using the Lua serializer.
@@ -220,6 +221,50 @@ local function needs(what: string, present: boolean): boolean
   return false
 end
 
+--- Reap a forked child and grade what its exit code said.
+---
+--- An exit code is the ONLY thing a forked child can tell its parent,
+--- and a parent that discards it makes the fork a hole in the runner's
+--- grading -- the runner grades the PARENT, and the parent exited 0.
+--- Both faces of that are silent:
+---
+--- - a child exiting `EXIT_SKIP` has announced that its environment
+---   cannot run the test, and the run reports a pass instead;
+--- - a child exiting nonzero has failed, and what surfaces upstream is
+---   whatever the parent trips over next -- an EOF from `recv` names
+---   the wrong end of the connection.
+---
+--- A skip ends the FILE rather than the test, by the same argument
+--- `needs` makes: the parent is asserting on half a conversation, and
+--- `records.status_of` reads only the exit code.
+--- @param pid integer The child to reap
+--- @param what string What the child was, for the message
+local function reap(pid: integer, what: string)
+  local wpid, status, _rusage, werr = proc.wait(pid)
+  -- `proc.wait` is a raw passthrough, so a signal delivered to this
+  -- process surfaces here as EINTR instead of being retried underneath.
+  while wpid == nil and werr and werr:find("EINTR", 1, true) do
+    wpid, status, _rusage, werr = proc.wait(pid)
+  end
+  if wpid == nil then
+    error("waiting for " .. what .. ": " .. (werr or "wait failed"), 2)
+  end
+  local code = 128
+  if proc.WIFEXITED(status) then
+    code = proc.WEXITSTATUS(status)
+  elseif proc.WIFSIGNALED(status) then
+    code = 128 + proc.WTERMSIG(status)
+  end
+  if code == records.EXIT_SKIP then
+    io.stderr:write("→ skip: " .. what .. " cannot run here\n")
+    print("skip: " .. what .. " cannot run here")
+    os.exit(records.EXIT_SKIP)
+  end
+  if code ~= 0 then
+    error(what .. " exited " .. code, 2)
+  end
+end
+
 --- Record that a sandbox test actually exercised real enforcement.
 --- Writes a marker the enforce-lane tripwire counts to confirm the lane is
 --- not a silent no-op (every test skipping would otherwise look green).
@@ -238,6 +283,7 @@ local record CheckModule
   enforcing: function(): boolean
   skip: function(reason: string, strict?: boolean)
   needs: function(what: string, present: boolean): boolean
+  reap: function(pid: integer, what: string)
   enforced: function(label: string)
 end
 
@@ -254,6 +300,7 @@ local M: CheckModule = {
   enforcing = enforcing,
   skip = skip,
   needs = needs,
+  reap = reap,
   enforced = enforced,
 }
 

--- a/cosmic/check_test.tl
+++ b/cosmic/check_test.tl
@@ -4,6 +4,8 @@
 local check = require("cosmic.check")
 local fs = require("cosmic.fs")
 local env = require("cosmic.env")
+local proc = require("cosmic.proc")
+local signal = require("cosmic.signal")
 local spawn = require("cosmic.child")
 
 local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
@@ -355,5 +357,75 @@ local function test_needs_skips_locally_and_fails_in_ci()
   end
 end
 test_needs_skips_locally_and_fails_in_ci()
+
+-- A forked child can say exactly one thing to its parent, and `reap` is
+-- what listens. Discarding the status makes the fork a hole in the
+-- runner's grading: the runner grades the PARENT, and the parent exits
+-- 0 whatever the child said.
+local function test_reap_grades_the_childs_exit_code()
+  local good = proc.fork()
+  if good == 0 then
+    os.exit(0)
+  end
+  check.reap(good, "a child that succeeded")
+
+  local bad = proc.fork()
+  if bad == 0 then
+    os.exit(3)
+  end
+  -- Through a wrapper that returns, because `reap` returns nothing and
+  -- a bare `pcall` of it declares no slot for the message.
+  local ok, msg = pcall(function(): string
+      check.reap(bad, "a child that failed")
+      return ""
+    end)
+  assert(not ok, "a nonzero child must not pass silently")
+  assert(msg:find("exited 3", 1, true),
+    "and the failure names the child's own code, got: " .. msg)
+
+  -- A child that DIED said nothing about why, so the conventional
+  -- 128+signal stands in for the code it never got to return.
+  local killed = proc.fork()
+  if killed == 0 then
+    signal.raise(signal.SIGKILL)
+    os.exit(0)
+  end
+  local kok, kmsg = pcall(function(): string
+      check.reap(killed, "a child that died")
+      return ""
+    end)
+  assert(not kok, "a signalled child must not pass either")
+  assert(kmsg:find("exited " .. (128 + signal.SIGKILL), 1, true),
+    "and the signal reads as 128+signal, got: " .. kmsg)
+
+  -- A pid that is not ours cannot be reaped, which is a failure of the
+  -- wait rather than a verdict about a child, and says so.
+  local wok, wmsg = pcall(function(): string
+      check.reap(0x7ffffff, "a pid that is not our child")
+      return ""
+    end)
+  assert(not wok, "an unreapable pid is not a pass")
+  assert(wmsg:find("waiting for", 1, true),
+    "and names the wait, not an exit code, got: " .. wmsg)
+
+  -- A skip ends the FILE, so it is observed one level down: a child
+  -- that reaps a SKIPPING grandchild must itself exit EXIT_SKIP.
+  local outer = proc.fork()
+  if outer == 0 then
+    local inner = proc.fork()
+    if inner == 0 then
+      os.exit(check.EXIT_SKIP)
+    end
+    check.reap(inner, "a grandchild that cannot run here")
+    os.exit(0)
+  end
+  local wpid, status = proc.wait(outer)
+  assert(wpid, "the outer child must be reapable")
+  assert(proc.WIFEXITED(status), "it exited rather than died")
+  assert(proc.WEXITSTATUS(status) == check.EXIT_SKIP,
+    "a child's skip becomes its parent's skip, got " ..
+    proc.WEXITSTATUS(status))
+end
+test_reap_grades_the_childs_exit_code()
 
 print("All check tests passed!")

--- a/cosmic/net/connect_test.tl
+++ b/cosmic/net/connect_test.tl
@@ -87,7 +87,7 @@ local function test_unix_domain_socket_bind_connect()
 
   client:close()
   server:close()
-  proc.wait(pid)
+  check.reap(pid, "the unix-socket client")
   os.remove(path)
   os.remove(tmpdir)
 end
@@ -124,7 +124,7 @@ local function test_listen_unix_connect_unix()
 
   client:close()
   server:close()
-  proc.wait(pid)
+  check.reap(pid, "the unix-socket client")
   os.remove(path)
   os.remove(tmpdir)
 end
@@ -220,7 +220,7 @@ local function test_connect_tcp()
 
   client:close()
   server:close()
-  proc.wait(pid)
+  check.reap(pid, "the tcp client")
 end
 test_connect_tcp()
 

--- a/cosmic/net/init_test.tl
+++ b/cosmic/net/init_test.tl
@@ -131,7 +131,7 @@ local function test_listen_accept_connect()
   server:close()
 
   -- Wait for child
-  proc.wait(pid)
+  check.reap(pid, "the tcp client")
 end
 test_listen_accept_connect()
 
@@ -397,7 +397,7 @@ local function test_accept_socket_has_close_metamethod()
 
   client:close()
   server:close()
-  proc.wait(pid)
+  check.reap(pid, "the connecting client")
 end
 test_accept_socket_has_close_metamethod()
 
@@ -438,7 +438,7 @@ local function test_listen_tcp_connect_to_returned_port()
   assert(data == "hi", "expected 'hi', got '" .. tostring(data) .. "'")
   conn:close()
   srv:close()
-  proc.wait(pid)
+  check.reap(pid, "the ephemeral-port client")
 end
 test_listen_tcp_connect_to_returned_port()
 


### PR DESCRIPTION
Fixes #812.

## The defect

Six sites called `proc.wait(pid)` and threw the status away. The children were already talking — `os.exit(check.EXIT_SKIP)` when the environment cannot do unix sockets, `os.exit(3)` on a failed send — and nobody was listening. The runner grades the **parent**, and the parent exited 0 whatever the child said.

- `cosmic/net/connect_test.tl:90`, `:127`, `:223`
- `cosmic/net/init_test.tl:134`, `:400`, `:441`

## The helper

`check.reap(pid, what)` waits and grades what came back, by the rules the runner already uses:

| child | verdict |
|---|---|
| exit 0 | passes |
| exit `EXIT_SKIP` | skips — ends the **file**, so the runner sees exit 2 |
| any other exit | throws, naming the child's own code |
| killed by a signal | throws as `128+signal` — a killed child never got to return a code |
| unreapable pid | throws naming the **wait**, not an invented exit code |

EINTR is retried rather than surfaced: `proc.wait` is a raw passthrough, and the discarded call swallowed that too.

A skip ends the file rather than the test, by the argument `needs` already makes — a parent that carries on past a child's skip is asserting on half a conversation, and the assertion it fails names the wrong end of it.

## Verification

`bin/cosmic --make ci` → **`ci: PASS (6 stages)`**.

Measured A/B. Child of `test_unix_domain_socket_bind_connect` made to exit 3 after a successful send, everything else identical:

```
with proc.wait(pid)    ✓ cosmic/net/connect_test.tl (13 test functions)  16ms
                       test: PASS (1 file)

with check.reap(...)   ✗ cosmic/net/connect_test.tl  8ms
                           the unix-socket client exited 3
                       test: FAIL (1 of 1 file)
```

A failing child is a **green test** on main today. `check_test.tl` covers all four verdicts; the skip is observed one level down (a child that reaps a *skipping grandchild* must itself exit `EXIT_SKIP`), since testing it in-process would end the file.

## Scope note

Not addressed here, and not made worse: a child that skips **before** the parent's `accept()` still leaves the parent blocking, because nothing reaches the parent until it waits. Grading the status is what the issue asks for and what makes the skip visible at all; a parent that cannot block on a child that already gave up needs a timeout, which is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQ56YZVuXWho9UUMVJfKPf

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQ56YZVuXWho9UUMVJfKPf)_