### PR TITLE
perf: results name which binary they measured, and the gate checks (#810)

### DIFF
--- a/_perf/compare.tl
+++ b/_perf/compare.tl
@@ -170,9 +170,65 @@ local function format(deltas: {pt.Delta}): string
   return table.concat(lines, "\n")
 end
 
+--- Refuse a pair of results files that cannot answer the question asked
+--- of them.
+---
+--- `meta.bin` is a NAME: two runs forty commits apart both say
+--- `o/bin/cosmic`. `meta.bin_sha` is the identity, and these are the
+--- two ways a comparison can be about something other than what the
+--- operator thinks. Both produce a confident, wrong answer rather than
+--- an error, which is why they refuse rather than warn -- a warning
+--- above a plausible-looking table gets read past:
+---
+--- - **compared against the same binary**, "no regression" is a
+---   statement about a binary and itself. It is the failure that looks
+---   most like success, and a plausible slip: build, forget to
+---   rebuild, re-run, compare.
+--- - **a noise floor measured across two binaries** reports the change
+---   as noise, and raises the bar every real regression afterwards has
+---   to clear. A noise floor is only a noise floor if the subject is
+---   constant.
+---
+--- A file with no `bin_sha` cannot be checked either way, which is said
+--- out loud rather than passed over: an unchecked identity is exactly
+--- the invisible thing this exists to make visible.
+--- @param a_path string First results path, for the message
+--- @param a_res Results The first file
+--- @param b_path string Second results path, for the message
+--- @param b_res Results The second file
+--- @param same boolean Whether the two must name the SAME binary
+--- @return string|nil The refusal, or nil when the pair is sound
+local function identity_refusal(a_path: string, a_res: pt.Results,
+    b_path: string, b_res: pt.Results, same: boolean): string | nil
+  local sa = a_res.meta and a_res.meta.bin_sha
+  local sb = b_res.meta and b_res.meta.bin_sha
+  if not sa or not sb then
+    io.stderr:write("perf: " .. (not sa and a_path or b_path) ..
+      " does not record which binary it measured, so these two runs" ..
+      " cannot be told apart\n")
+    return nil
+  end
+  if same and sa ~= sb then
+    return "perf: " .. a_path .. " and " .. b_path ..
+    " measured DIFFERENT binaries (" .. string.sub(sa, 1, 12) .. " vs " ..
+    string.sub(sb, 1, 12) .. "). A noise floor is only a noise floor if" ..
+    " the subject is constant; across two binaries it reports the" ..
+    " change as noise and raises the bar every real regression has to" ..
+    " clear."
+  end
+  if not same and sa == sb then
+    return "perf: " .. a_path .. " and " .. b_path ..
+    " measured the SAME binary (" .. string.sub(sa, 1, 12) ..
+    "). A binary compared against itself has no regression to find," ..
+    " so a clean result says nothing about your change."
+  end
+  return nil
+end
+
 local record compare
   DEFAULT_THRESHOLD_PCT: number
   load_results: function(path: string): pt.Results, string
+  identity_refusal: function(a_path: string, a_res: pt.Results, b_path: string, b_res: pt.Results, same: boolean): string | nil
   diff: function(base: pt.Results, cur: pt.Results, threshold_pct?: number): {pt.Delta}, integer
   triage: function(base: pt.Results, cur: pt.Results, noise_a: pt.Results, noise_b: pt.Results, threshold_pct?: number): {pt.Delta}, integer
   format_delta: function(d: pt.Delta): string
@@ -182,6 +238,7 @@ end
 local M: compare = {
   DEFAULT_THRESHOLD_PCT = DEFAULT_THRESHOLD_PCT,
   load_results = load_results,
+  identity_refusal = identity_refusal,
   diff = diff,
   triage = triage,
   format_delta = format_delta,

--- a/_perf/gate.tl
+++ b/_perf/gate.tl
@@ -65,10 +65,31 @@ local function compare_once(base_path: string, cur_path: string,
   return failures
 end
 
+--- The identity rule of `compare.identity_refusal`, over two paths.
+--- @param a string First results path
+--- @param b string Second results path
+--- @param same boolean Whether the two must name the SAME binary
+--- @return string|nil The refusal, or nil when the pair is sound
+local function identity_refusal(a: string, b: string, same: boolean): string | nil
+  local ra = compare.load_results(a)
+  local rb = compare.load_results(b)
+  if ra == nil or rb == nil then
+    -- A file that will not load is the next call's error to report, in
+    -- its own words.
+    return nil
+  end
+  return compare.identity_refusal(a, ra, b, rb, same)
+end
+
 --- Run the compare gate over an already-measured current file.
 --- @param opts GateOptions Paths, threshold, and the measure function
 --- @return integer Exit code: 0 clean or noise, 1 on a real regression
 local function gate(opts: GateOptions): integer
+  local refusal = identity_refusal(opts.baseline, opts.current, false)
+  if refusal then
+    io.stderr:write(refusal .. "\n")
+    return 1
+  end
   local failures, err = compare_once(opts.baseline, opts.current, opts.threshold)
   if failures < 0 then
     io.stderr:write(tostring(err) .. "\n")
@@ -122,6 +143,11 @@ local function selfcheck(opts: SelfcheckOptions): integer
   rc = opts.measure(opts.b)
   if rc ~= 0 then
     return rc
+  end
+  local refusal = identity_refusal(opts.a, opts.b, true)
+  if refusal then
+    io.stderr:write(refusal .. "\n")
+    return 1
   end
   local failures, err = compare_once(opts.a, opts.b, opts.threshold)
   if failures < 0 then

--- a/_perf/gate_test.tl
+++ b/_perf/gate_test.tl
@@ -11,9 +11,9 @@ local json = require("cosmic.json")
 
 local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
 
-local function write_results(path: string, wall_ns: number)
+local function write_results(path: string, wall_ns: number, bin_sha?: string)
   local payload = {
-    meta = {},
+    meta = {bin_sha = bin_sha},
     results = {
       {
         name = "scenario",
@@ -172,3 +172,76 @@ local function test_main_parses_positionals_without_separator()
   assert(code == 2, "unknown mode must print usage, got " .. code)
 end
 test_main_parses_positionals_without_separator()
+
+-- The identity rules. `meta.bin` is a NAME -- two runs forty commits
+-- apart both say `o/bin/cosmic` -- so the gate reads `bin_sha`, and
+-- refuses the two pairings that answer confidently about the wrong
+-- thing.
+local function test_compare_refuses_a_binary_against_itself()
+  local base, cur, selfb = paths("same-bin")
+  write_results(base, 1000, "aaaa1111")
+  write_results(cur, 1010, "aaaa1111")
+  local calls = 0
+  local code = gate.gate({
+      baseline = base, current = cur, selfcheck_b = selfb, threshold = 10,
+      measure = function(_out: string): integer
+        calls = calls + 1
+        return 0
+      end,
+    })
+  assert(code == 1, "comparing a binary with itself must refuse, got " .. code)
+  assert(calls == 0, "and refuse before measuring anything, got " .. calls)
+end
+test_compare_refuses_a_binary_against_itself()
+
+-- The same pair naming DIFFERENT binaries is the comparison the gate
+-- exists for, so it runs -- which is what makes the refusal above about
+-- identity rather than about the field being present.
+local function test_compare_runs_when_the_binaries_differ()
+  local base, cur, selfb = paths("diff-bin")
+  write_results(base, 1000, "aaaa1111")
+  write_results(cur, 1010, "bbbb2222")
+  local code = gate.gate({
+      baseline = base, current = cur, selfcheck_b = selfb, threshold = 10,
+      measure = function(_out: string): integer
+        return 0
+      end,
+    })
+  assert(code == 0, "a real comparison must proceed, got " .. code)
+end
+test_compare_runs_when_the_binaries_differ()
+
+-- A noise floor is only a noise floor if the subject is constant.
+-- Measured across two binaries it reports the change as noise and
+-- raises the bar every real regression afterwards has to clear.
+local function test_selfcheck_refuses_two_different_binaries()
+  local a, b = paths("selfcheck-bins")
+  write_results(a, 1000, "aaaa1111")
+  write_results(b, 1010, "bbbb2222")
+  local code = gate.selfcheck({
+      a = a, b = b, threshold = 10,
+      measure = function(_out: string): integer
+        return 0
+      end,
+    })
+  assert(code == 1,
+    "an A/A control across two binaries must refuse, got " .. code)
+end
+test_selfcheck_refuses_two_different_binaries()
+
+-- A file that does not say what it measured cannot be checked either
+-- way. It says so on stderr and the comparison proceeds, so a results
+-- file written before the field existed stays readable.
+local function test_a_file_without_a_sha_is_not_refused()
+  local base, cur, selfb = paths("no-sha")
+  write_results(base, 1000)
+  write_results(cur, 1010)
+  local code = gate.gate({
+      baseline = base, current = cur, selfcheck_b = selfb, threshold = 10,
+      measure = function(_out: string): integer
+        return 0
+      end,
+    })
+  assert(code == 0, "an unidentified pair still compares, got " .. code)
+end
+test_a_file_without_a_sha_is_not_refused()

--- a/_perf/perf_types.tl
+++ b/_perf/perf_types.tl
@@ -48,6 +48,11 @@ local record perf_types
   record Meta
     timestamp: number
     bin: string
+    --- The measured binary's sha256, hex. The identity, where `bin` is
+    --- only a name: two runs forty commits apart both say
+    --- `o/bin/cosmic`. Absent when the binary could not be read, which
+    --- is a results file that cannot name its subject.
+    bin_sha: string
     cosmic_version: string
     cosmos_version: string
     os: string

--- a/_perf/run.tl
+++ b/_perf/run.tl
@@ -22,6 +22,7 @@ local harness = require("_perf.harness")
 local compare = require("_perf.compare")
 local pt = require("_perf.perf_types")
 local fs = require("cosmic.fs")
+local hash = require("cosmic.hash")
 
 local record Args
   out: string
@@ -128,6 +129,21 @@ local function collect_meta(samples: integer, min_secs: number): pt.Meta
   }
   -- cast: from any
   meta.bin = os.getenv("PERF_BIN") or rawget(arg, -1) as string or "unknown"
+  -- The name is not the identity: two runs forty commits apart both say
+  -- `o/bin/cosmic`, so a comparison across them cannot tell it read two
+  -- different binaries. The hash is what a gate can check.
+  --
+  -- A file that cannot name its subject is left visibly incomplete --
+  -- no `bin_sha` at all -- rather than filled in with a word like
+  -- `unknown`, which reads as an answer and compares equal to the next
+  -- run that could not name its subject either.
+  local bytes = fs.read(meta.bin)
+  if bytes then
+    meta.bin_sha = hash.sha256_hex(bytes)
+  else
+    io.stderr:write("perf: cannot read " .. meta.bin ..
+      " to hash it; this results file cannot name the binary it measured\n")
+  end
   -- Resolved dynamically: cosmic._version only exists inside a built binary.
   local version_module = "cosmic._version"
   local vok, version = pcall(require, version_module)
@@ -238,6 +254,14 @@ local function run_compare(a: Args): integer
   local cur, cerr = compare.load_results(a.positional[2])
   if cur == nil then
     io.stderr:write(cerr .. "\n")
+    return 1
+  end
+  -- Given files, so this is where the by-hand slip lands: two runs of
+  -- the same binary compared against each other.
+  local refusal = compare.identity_refusal(a.positional[1], base,
+    a.positional[2], cur, false)
+  if refusal then
+    io.stderr:write(refusal .. "\n")
     return 1
   end
   local deltas: {pt.Delta}


### PR DESCRIPTION
Fixes #810.

## 1. Record the subject

`meta.bin` is a **name** — two runs forty commits apart both say `o/bin/cosmic` — and nothing read it, so the gate had no opinion about whether its two inputs came from the same binary.

`meta.bin_sha` is the identity: the measured binary's sha256, hashed with `cosmic.hash`. `meta.bin` stays, because a path is what you read a results file by hand with.

A run that cannot read its binary writes **no field** and says so on stderr, per the issue: `unknown` reads as an answer, and compares equal to the next run that could not name its subject either.

## 2. Make the gate assert on identity

`compare.identity_refusal` — **refusing, not warning**, because a warning above a plausible-looking table gets read past:

| pairing | verdict |
|---|---|
| two files naming the **same** binary | not a comparison — refuse |
| two files naming **different** binaries as an A/A control | not a noise floor — refuse |
| either file missing `bin_sha` | cannot be checked; said on stderr, comparison proceeds |

One definition, three callers: the compare gate, the A/A selfcheck, and **`run.tl --compare`**. That last one matters — it is the by-hand path where both files are *given* rather than measured in-process, so it is where "build, forget to rebuild, re-run, compare" actually lands. (`gate.lua selfcheck` measures both files itself, so its rule guards the module API and any future given-files path rather than a live CLI slip; it is asserted by test either way.)

The missing-`bin_sha` case is deliberately not a refusal: a results file written before this change stays readable. It is not silent, though — an unchecked identity is exactly the invisible thing this exists to make visible.

## Verification

`bin/cosmic --make ci` → **`ci: PASS (6 stages)`**.

Against real measurements of the built binary:

```
$ o/bin/cosmic o/_perf/run.lua --out o/perf/a.json ... ; ... --out o/perf/b.json ...
o/perf/a.json  o/bin/cosmic  e8d6e0af9503
o/perf/b.json  o/bin/cosmic  e8d6e0af9503

$ o/bin/cosmic o/_perf/run.lua --compare o/perf/a.json o/perf/b.json
perf: o/perf/a.json and o/perf/b.json measured the SAME binary (e8d6e0af9503).
A binary compared against itself has no regression to find, so a clean result
says nothing about your change.
   exit=1

$ o/bin/cosmic o/_perf/gate.lua compare o/perf/a.json o/perf/b.json o/perf/selfb.json ...
perf: ... measured the SAME binary (e8d6e0af9503). ...
   exit=1

$ o/bin/cosmic o/_perf/run.lua --compare o/perf/other.json o/perf/a.json
json_roundtrip_small   2.74 µs ->  2.67 µs   -2.4%  (noise ±10.0%)  ok
4 scenarios: 0 regression, 0 faster, 4 ok, 0 noise, 0 new, 0 missing, 0 error
```

`_perf/gate_test.tl` covers all four verdicts (refuse-same, run-when-different, refuse-differing-selfcheck, proceed-without-sha) with fabricated files and an injected measure. The refuse-same test also asserts it refuses **before** measuring anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQ56YZVuXWho9UUMVJfKPf

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQ56YZVuXWho9UUMVJfKPf)_