### PR TITLE
build: the project model documents itself, out of the model (#822)

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -28,6 +28,7 @@ _make/help.tl 20 20
 _make/imports.tl 60 63
 _make/init.tl 166 222
 _make/law.tl 54 56
+_make/model.tl 182 205
 _make/pin.tl 80 81
 _make/policy.tl 46 104
 _make/project.tl 210 221

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ cosmic/               standard library modules (*.tl) — the PUBLIC API
 _cli/                 the dispatcher behind every flag (args, help, run, ...)
   build/               the closed verb vocabulary behind `-c`
 _make/                `cosmic --make`: project model, validator, root, verbs
-_build/               workflow ratchet tests
+_build/               ratchets over what the repo ships: workflows, the skill
 _docs/                doc publishing
 _perf/                performance benchmark harness (see _perf/OPTIMIZE.md)
 _types/               cosmo.* type declarations (generated) + gentype generator

--- a/_build/skill_test.tl
+++ b/_build/skill_test.tl
@@ -1,0 +1,108 @@
+#!/usr/bin/env cosmic
+-- Ratchets over the skill the binary SHIPS.
+--
+-- `skills/cosmic/**` is staged into the artifact and read by `--docs`,
+-- so a wrong sentence in it is wrong advice delivered by the tool
+-- itself.
+--
+-- Most of what it could get wrong is no longer written down: `_make`
+-- renders the kind vocabulary, what ships and the verbs into
+-- `skills/cosmic/model.md`, and a table nobody writes cannot disagree
+-- with the build. What is left to check is the seam around that —
+-- whether the rendering is WHOLE, and whether a hand-written copy has
+-- crept back in beside it.
+--
+-- The gate is here rather than in the renderer because a renderer that
+-- refuses wedges the build that would fix it: the refusal survives
+-- `--make clean`, and only reaching for the pin by hand gets out of it.
+-- Measured, during this change. A failing test fails the run instead,
+-- which is loud and recoverable.
+
+local check = require("cosmic.check")
+local fs = require("cosmic.fs")
+local model = require("_make.model")
+
+local SKILL_DIR < const > = "skills/cosmic"
+local SKILL < const > = SKILL_DIR .. "/make.md"
+
+-- A claim the model no longer makes, in the words it used to make it.
+-- D15 made shipping opt-in; this is what its return would look like,
+-- and it is what took two commits to remove the first time.
+local RETIRED < const >: {string: string} = {
+  ["embedded at its relative path"] =
+  "shipping is opt-in (D15): nothing ships by falling through to a default",
+}
+
+--- Every markdown file the artifact carries.
+--- @return {string} Paths relative to the repo root, sorted
+local function skill_files(): {string}
+  local found = check.must(fs.collect(SKILL_DIR, "*.md"))
+  table.sort(found)
+  assert(#found > 0, "no skill files under " .. SKILL_DIR)
+  return found
+end
+
+-- The rendered guide covers the model whole: every kind an example
+-- reaches, every kind with a gloss, every verb with a description. Each
+-- gap is a row the guide cannot fill, and a kind added to the model is
+-- exactly the change that opens one -- which is the drift this whole
+-- arrangement is against.
+local function test_the_rendered_model_has_no_gaps()
+  local gaps = model.gaps()
+  assert(#gaps == 0,
+    "the generated model guide cannot describe the model whole:\n  " ..
+    table.concat(gaps, "\n  ") ..
+    "\nThe guide is rendered by _make/model.tl and read with " ..
+    "`cosmic --docs guide.model`")
+end
+test_the_rendered_model_has_no_gaps()
+
+-- And it says so in the guide, not just in the gap list: a row the
+-- renderer could not fill carries a visible marker rather than being
+-- dropped, so a reader sees the hole too.
+local function test_no_row_renders_as_undocumented()
+  local text = model.render()
+  assert(not text:find(model.MISSING, 1, true),
+    "the rendered guide carries a " .. model.MISSING .. " row")
+  -- And it is a real guide, not an empty shell that trivially passes.
+  assert(text:find("| marker | declares | ships |", 1, true),
+    "the rendered guide has no marker table")
+  assert(text:find("| verb | what it does | today |", 1, true),
+    "the rendered guide has no verb table")
+end
+test_no_row_renders_as_undocumented()
+
+-- A retired claim stays retired, across every file the artifact
+-- carries -- not just the one that owns the subject. D15's row survived
+-- in four places precisely because the fix looked at one of them.
+local function test_retired_claims_do_not_come_back()
+  for _, path in ipairs(skill_files()) do
+    local text = check.must(fs.read(path))
+    for claim, why in pairs(RETIRED) do
+      assert(not text:find(claim, 1, true),
+        path .. " teaches a retired claim (\"" .. claim .. "\"): " .. why)
+    end
+  end
+end
+test_retired_claims_do_not_come_back()
+
+-- And the vocabulary is not restated by hand beside the generated one.
+-- A second copy is exactly what generation removed: it reads as
+-- authoritative, nothing compares it to the model, and it drifts on the
+-- next change to `classify`.
+local function test_the_vocabulary_is_not_written_by_hand()
+  local text = check.must(fs.read(SKILL))
+  for line in (text .. "\n"):gmatch("([^\n]*)\n") do
+    local trimmed = line:match("^%s*(.-)%s*$")
+    assert(not trimmed:match("^|%s*marker%s*|"),
+      SKILL .. " restates the marker table by hand: " .. trimmed ..
+      "\nThe vocabulary is rendered by _make/model.tl; read it with " ..
+      "`cosmic --docs guide.model`")
+    assert(not trimmed:match("^|%s*verb%s*|"),
+      SKILL .. " restates the verb table by hand: " .. trimmed ..
+      "\nThe verbs come from the registry the dispatcher is built from")
+  end
+end
+test_the_vocabulary_is_not_written_by_hand()
+
+print("all skill ratchet tests passed")

--- a/_make/init.tl
+++ b/_make/init.tl
@@ -217,14 +217,14 @@ end
 --- A planned row costs one line and turns a typo-shaped failure into a
 --- schedule answer.
 local VERBS < const >: {Verb} = {
-  {name = "build", target = "build", select = stage.SELECTS.build, run = run_build},
+  {name = "build", doc = "compile the tree, then stage + embed → `o/bin/<name>`", target = "build", select = stage.SELECTS.build, run = run_build},
   -- `check` generates first, like every other verb that touches the
   -- graph -- it just does not lower onto make, so it has to say so
   -- itself. The checker resolves `cosmo.*` through what
   -- `_types/types_gen.tl` writes: without this, `--make check` on a
   -- cold tree fails on unresolvable `cosmo.*`, and after a pin bump it
   -- checks against the types the last run left.
-  {name = "check", run = function(proj: Project, paths: {string},
+  {name = "check", doc = "strict type-check (warnings are errors), in process", run = function(proj: Project, paths: {string},
         cosmic: string): integer
       local ok, err = generate.sources(proj, cosmic)
       if not ok then
@@ -233,12 +233,12 @@ local VERBS < const >: {Verb} = {
       end
       return check.run(proj, paths)
     end},
-  {name = "clean", run = clean.run},
-  {name = "fetch", run = function(proj: Project, paths: {string},
+  {name = "clean", doc = "remove `o/`", run = clean.run},
+  {name = "fetch", doc = "resolve `*_pin.tl` — the only verb with a network", run = function(proj: Project, paths: {string},
         _cosmic: string): integer
       return fetch.run(proj, paths)
     end},
-  {name = "fmt", target = "fmt", select = stage.SELECTS.fmt,
+  {name = "fmt", doc = "formatting over every `.tl`; `--fix` rewrites", target = "fmt", select = stage.SELECTS.fmt,
     run = function(proj: Project, paths: {string}, cosmic: string): integer
       if fix_wanted then
         return policy.fix(proj, paths)
@@ -246,16 +246,16 @@ local VERBS < const >: {Verb} = {
       -- cast: the registry defines it
       return stage.run_graph(by_name("fmt") as Verb, proj, paths, cosmic)
     end},
-  {name = "test", target = "test", select = stage.SELECTS.test,
+  {name = "test", doc = "run `*_test.tl` and report", target = "test", select = stage.SELECTS.test,
     run = function(proj: Project, paths: {string}, cosmic: string): integer
       -- cast: the registry defines it
       return run_against_stage(by_name("test") as Verb, proj, paths, cosmic)
     end},
-  {name = "run", planned = true},
+  {name = "run", doc = "build, then exec the artifact", planned = true},
   -- `docs` renders the API to markdown. Its file set comes from the
   -- model, so a directory added to the project is documented without
   -- anyone remembering to say so.
-  {name = "docs", run = function(proj: Project, paths: {string},
+  {name = "docs", doc = "extract the doc index", run = function(proj: Project, paths: {string},
         _cosmic: string): integer
       local n, err = docs.render(proj, paths)
       if err ~= "" then
@@ -273,7 +273,7 @@ local VERBS < const >: {Verb} = {
   -- lets `ci` below be a list of verb names: its pipeline is
   -- fmt -> check -> test -> example -> lint -> coverage, and every one
   -- of those six is a verb in this registry.
-  {name = "example", target = "example", select = stage.SELECTS.example,
+  {name = "example", doc = "run `Example_*` functions and check their output", target = "example", select = stage.SELECTS.example,
     run = function(proj: Project, paths: {string}, cosmic: string): integer
       -- cast: the registry defines it
       return run_against_stage(by_name("example") as Verb, proj, paths, cosmic)
@@ -281,17 +281,17 @@ local VERBS < const >: {Verb} = {
   -- `test`'s third sibling. It runs against the stage for the same
   -- reason `test` and `example` do: a benchmark measures the project's
   -- own code, and often the binary the project builds.
-  {name = "benchmark", target = "benchmark", select = stage.SELECTS.benchmark,
+  {name = "benchmark", doc = "run every `*_benchmark.tl`", target = "benchmark", select = stage.SELECTS.benchmark,
     run = function(proj: Project, paths: {string}, cosmic: string): integer
       -- cast: the registry defines it
       return run_against_stage(by_name("benchmark") as Verb, proj, paths, cosmic)
     end},
-  {name = "lint", target = "lint", select = stage.SELECTS.lint},
-  {name = "ci", run = function(proj: Project, paths: {string},
+  {name = "lint", doc = "style: file length, cast justifications, test order", target = "lint", select = stage.SELECTS.lint},
+  {name = "ci", doc = "fmt, check, test, example, lint, coverage — the gate", run = function(proj: Project, paths: {string},
         cosmic: string): integer
       return policy.run_ci(by_name, proj, paths, cosmic)
     end},
-  {name = "coverage", target = "coverage", select = stage.SELECTS.coverage,
+  {name = "coverage", doc = "tests + line coverage, ratcheted against `.cosmic-coverage`", target = "coverage", select = stage.SELECTS.coverage,
     run = function(proj: Project, paths: {string}, cosmic: string): integer
       local v = by_name("coverage") as Verb -- cast: the registry defines it
       local ready, perr = prepare_stage(proj, cosmic)
@@ -307,9 +307,9 @@ local VERBS < const >: {Verb} = {
       end
       return policy.run_coverage(v, proj, paths, cosmic)
     end},
-  {name = "enforce", planned = true},
-  {name = "reproducible", planned = true},
-  {name = "offline", planned = true},
+  {name = "enforce", doc = "rerun the sandbox tests unsandboxed, where a skip fails", planned = true},
+  {name = "reproducible", doc = "a policy lane over the graph", planned = true},
+  {name = "offline", doc = "a policy lane over the graph", planned = true},
 }
 
 local INDEX < const >: {string: Verb} = {}

--- a/_make/model.tl
+++ b/_make/model.tl
@@ -1,0 +1,371 @@
+--- The project model, rendered for a reader, out of the model itself.
+---
+--- `skills/cosmic/model.md` is what `--docs guide.model` prints, and
+--- every fact in it is derived: the kind vocabulary, what each marker
+--- declares, what an artifact carries, and the verbs. Restating any of
+--- them is a second copy with no gate over it, and the copy is what
+--- goes stale -- D15 made shipping opt-in and deleted one row, and the
+--- guide went on teaching that row in four places, one of them two
+--- lines under a corrected one, through three review rounds and two
+--- commits. A derived table cannot be WRONG; it can only be different.
+---
+--- **Every fact comes from the TREE, never from the running engine.**
+--- That is the whole reason this module looks the way it does.
+--- `package.path` puts `/zip` ahead of the tree, so a `require` here
+--- resolves to the modules embedded in whichever binary drives the
+--- build -- and on a cold clone that is the pinned release, whose model
+--- is a release behind the tree's. Measured: the pin classifies
+--- `pkg/db_benchmark.tl` as `module`, because `benchmark` is newer than
+--- the pin, and compiling the tree's `project.tl` against the pin's
+--- types fails outright with `string "benchmark" is not a member of
+--- Kind`.
+---
+--- A guide rendered from the engine would therefore be wrong on a cold
+--- clone and would CHANGE between build generations, which is the one
+--- thing an artifact's payload may not do: the fixpoint check compares
+--- generations.
+---
+--- So the rule is: **execute the tree's behaviour, read the tree's
+--- data.** `classify` is behaviour, so it is compiled from the tree
+--- with `TL_PATH` pointed there and run. The vocabulary, the `ships`
+--- set and the verb registry are data, so they are read from the
+--- sources that declare them. Nothing here asks the engine anything.
+---
+--- Gaps WARN and never fail. A generator that refuses wedges the build
+--- that would fix it -- the refusal survives `--make clean`, and only
+--- reaching for the pin by hand gets out of it. The gate lives in
+--- `_build/skill_test.tl`, which reads what this renders and fails the
+--- RUN instead.
+
+local fs = require("cosmic.fs")
+local teal = require("cosmic.teal")
+
+--- What a row says when a fact could not be filled in. Rendered rather
+--- than omitted, so a gap is visible to a reader and greppable by the
+--- gate.
+local MISSING < const > = "(undocumented)"
+
+--- Where the guide lands inside an artifact, beside the committed ones.
+local STORED < const > = "skills/cosmic/model.md"
+
+--- Report a gap without failing. See the header.
+--- @param what string The gap, named
+local function warn_gap(what: string)
+  io.stderr:write("model: " .. what .. "\n")
+end
+
+--- Markers, each with a path the model can be asked about.
+---
+--- The example is the input, not decoration: a row's kind is whatever
+--- `classify` answers for it, so a marker that stops meaning what it
+--- meant changes this table rather than contradicting it.
+local MARKERS < const >: {{string, string}} = {
+  {"`<dir>/*.tl`, `<dir>/*.lua`", "pkg/db.tl"},
+  {"`main.tl` at the root", "main.tl"},
+  {"`cmd/<name>/main.tl`", "cmd/tool/main.tl"},
+  {"`*_test.tl`", "pkg/db_test.tl"},
+  {"`*_example.tl`", "pkg/db_example.tl"},
+  {"`*_benchmark.tl`", "pkg/db_benchmark.tl"},
+  {"`*.d.tl`", "pkg/db.d.tl"},
+  {"`*_pin.tl`", "3p/tl/tl_pin.tl"},
+  {"`*_gen.tl`", "pkg/schema_gen.tl"},
+  {"`cmd/<name>/embed_gen.tl`", "cmd/tool/embed_gen.tl"},
+  {"`embed/**`", "embed/schema.sql"},
+  {"`testdata/`", "pkg/testdata/fixture.json"},
+  {"anything that is not a source", "notes.md"},
+}
+
+--- What each kind IS, in a reader's words.
+---
+--- Hand-written, and keyed by KIND rather than by marker, so a kind the
+--- vocabulary gains is named in the warning instead of quietly missing
+--- a row.
+local GLOSS < const >: {string: string} = {
+  ["module"] = "a package — compiled, checked, formatted",
+  ["entry"] = "the project's binary",
+  ["test"] = "a test",
+  ["example"] = "an example",
+  ["benchmark"] = "a benchmark",
+  ["types"] = "type-only; on the include path",
+  ["pin"] = "a pinned external asset — data, never executed",
+  ["gen"] = "a generation unit — runs BEFORE the graph, writes inputs",
+  ["payload-gen"] = "a binary's payload generator — runs AFTER it",
+  ["payload"] = "payload, staged at the artifact root",
+  ["testdata"] = "test fixtures",
+  ["asset"] = "an ordinary part of the project",
+}
+
+--- What each verb DOES. The registry knows every verb's name and
+--- whether it is planned, and nothing about what it is for.
+local VERB_GLOSS < const >: {string: string} = {
+  ["build"] = "compile the tree, then stage + embed → `o/bin/<name>`",
+  ["check"] = "strict type-check (warnings are errors), in process",
+  ["fmt"] = "formatting over every `.tl`; `--fix` rewrites",
+  ["lint"] = "style: file length, cast justifications, test order",
+  ["test"] = "run `*_test.tl` and report",
+  ["example"] = "run `Example_*` functions and check their output",
+  ["benchmark"] = "run every `*_benchmark.tl`",
+  ["coverage"] = "tests + line coverage, ratcheted against `.cosmic-coverage`",
+  ["docs"] = "extract the doc index",
+  ["ci"] = "fmt, check, test, example, lint, coverage — the gate",
+  ["clean"] = "remove `o/`",
+  ["fetch"] = "resolve `*_pin.tl` — the only verb with a network",
+  ["run"] = "build, then exec the artifact",
+  ["enforce"] = "rerun the sandbox tests unsandboxed, where a skip fails",
+  ["reproducible"] = "a policy lane over the graph",
+  ["offline"] = "a policy lane over the graph",
+}
+
+--- One of the tree's sources, read as text.
+--- @param path string Path relative to the project root
+--- @return string The bytes, or "" when unreadable
+local function source(path: string): string
+  return fs.read(path) or ""
+end
+
+--- The tree's `classify`, compiled from the tree and loaded.
+---
+--- `TL_PATH` first, so the compile resolves `_make.types` to the TREE's
+--- enum: without it the pin's enum is consulted and the compile fails
+--- on the kinds the pin does not have. `;;` keeps the engine's own path
+--- after it, for everything the tree does not define.
+--- @return function(string): string The classifier, or nil when unavailable
+local function tree_classify(): function(string): string
+  local before = os.getenv("TL_PATH")
+  require("cosmic.env").set("TL_PATH", "./?.tl;./?/init.tl;;", true)
+  local code, cerr = teal.compile_cached("_make/project.tl")
+  if before then
+    require("cosmic.env").set("TL_PATH", before, true)
+  else
+    require("cosmic.env").unset("TL_PATH")
+  end
+  if not code then
+    warn_gap("cannot compile the tree's _make/project.tl: " ..
+      (cerr or "unknown error"))
+    return nil
+  end
+  local chunk = load(code, "@_make/project.tl")
+  if not chunk then
+    warn_gap("cannot load the compiled _make/project.tl")
+    return nil
+  end
+  local mod = chunk() as {string: function(string): string} -- cast: from any
+  return mod.classify
+end
+
+--- Every kind the model declares, from the enum's source.
+---
+--- A Teal enum is type-level: erased by the time this runs, so there is
+--- no value to ask and the alternative is a list here, which is the
+--- restatement this module exists to delete.
+--- @return {string} Kind names, in declaration order
+local function vocabulary(): {string}
+  local block = string.match(source("_make/types.tl"),
+    "enum Kind\n(.-)\n%s*end\n") or ""
+  local kinds: {string} = {}
+  for name in string.gmatch(block, '"([^"]+)"') do
+    kinds[#kinds + 1] = name
+  end
+  if #kinds == 0 then
+    warn_gap("no `enum Kind` found in _make/types.tl")
+  end
+  return kinds
+end
+
+--- The kinds an artifact carries, from the table the builder reads.
+--- @return {string: boolean} Kind to whether an artifact carries it
+local function ships(): {string: boolean}
+  local block = string.match(source("_make/artifact.tl"),
+    "local ships: {string: boolean} = {(.-)}") or ""
+  local out: {string: boolean} = {}
+  local n = 0
+  for kind in string.gmatch(block, "([%w%-_]+)%s*=%s*true") do
+    out[kind] = true
+    n = n + 1
+  end
+  if n == 0 then
+    warn_gap("no `ships` table found in _make/artifact.tl")
+  end
+  return out
+end
+
+--- The verbs, from the registry the dispatcher is built from.
+--- @return {{string, boolean}} Name and whether it is planned, in order
+local function verb_rows(): {{string, boolean}}
+  local block = string.match(source("_make/init.tl"),
+    "local VERBS < const >: {Verb} = {(.-)\n}") or ""
+  local rows: {{string, boolean}} = {}
+  for line in string.gmatch(block, "[^\n]+") do
+    local name = string.match(line, '{name = "([%w%-_]+)"')
+    if name then
+      rows[#rows + 1] = {name, string.find(line, "planned = true", 1, true) ~= nil}
+    end
+  end
+  if #rows == 0 then
+    warn_gap("no VERBS table found in _make/init.tl")
+  end
+  return rows
+end
+
+--- The marker table.
+--- @param classify function The tree's classifier
+--- @return string The rendered rows
+local function marker_table(classify: function(string): string): string
+  local carried = ships()
+  local out: {string} = {
+    "| marker | declares | ships |",
+    "|---|---|---|",
+  }
+  for _, row in ipairs(MARKERS) do
+    local kind = classify and classify(row[2]) or ""
+    local gloss = GLOSS[kind] or MISSING
+    out[#out + 1] = "| " .. row[1] .. " | " .. gloss .. " | " ..
+    (carried[kind] and "yes" or "no") .. " |"
+  end
+  return table.concat(out, "\n")
+end
+
+--- The verb table.
+--- @return string The rendered rows
+local function verb_table(): string
+  local out: {string} = {"| verb | what it does | today |", "|---|---|---|"}
+  local function emit(planned: boolean, today: string)
+    for _, row in ipairs(verb_rows()) do
+      if row[2] == planned then
+        local what = VERB_GLOSS[row[1]] or MISSING
+        out[#out + 1] = "| `" .. row[1] .. "` | " .. what ..
+        " | " .. today .. " |"
+      end
+    end
+  end
+  emit(false, "✅")
+  emit(true, "planned")
+  return table.concat(out, "\n")
+end
+
+--- Everything this module could not derive, named.
+---
+--- The gate reads this. Rendering only WARNS, because a generator that
+--- refuses wedges the build that would fix it; a test that reads the
+--- same list fails the run instead, which is loud and recoverable.
+--- @return {string} One entry per gap, empty when the guide is whole
+local function gaps(): {string}
+  local out: {string} = {}
+  local classify = tree_classify()
+  if not classify then
+    out[#out + 1] = "the tree's _make/project.tl could not be compiled, " ..
+    "so no row knows what it declares"
+    return out
+  end
+  local seen: {string: boolean} = {}
+  for _, row in ipairs(MARKERS) do
+    local kind = classify(row[2])
+    seen[kind] = true
+    if not GLOSS[kind] then
+      out[#out + 1] = "no gloss for kind '" .. kind .. "' (" .. row[2] ..
+      "): add one to GLOSS in _make/model.tl"
+    end
+  end
+  for _, kind in ipairs(vocabulary()) do
+    if not seen[kind] then
+      out[#out + 1] = "no example produces kind '" .. kind ..
+      "': add a marker and an example path to MARKERS in _make/model.tl"
+    end
+  end
+  for _, row in ipairs(verb_rows()) do
+    if not VERB_GLOSS[row[1]] then
+      out[#out + 1] = "no description for verb '" .. row[1] ..
+      "': add one to VERB_GLOSS in _make/model.tl"
+    end
+  end
+  return out
+end
+
+--- The whole guide.
+--- @return string The rendered markdown
+local function render(): string
+  local classify = tree_classify()
+  local rows = marker_table(classify)
+  for _, gap in ipairs(gaps()) do
+    warn_gap(gap)
+  end
+
+  local carried: {string} = {}
+  local ships_set = ships()
+  for _, kind in ipairs(vocabulary()) do
+    if ships_set[kind] then
+      carried[#carried + 1] = "`" .. kind .. "`"
+    end
+  end
+
+  return table.concat({
+      "# the project model",
+      "",
+      "generated from `_make` itself: what a file declares is" ..
+      " `project.classify` answering about a path of that shape, what" ..
+      " ships is the `ships` table the artifact builder reads, and the" ..
+      " verbs are the registry the dispatcher is built from. nothing" ..
+      " here can disagree with the build, because none of it is written" ..
+      " twice.",
+      "",
+      "## what a file declares",
+      "",
+      "position is the manifest: a file's path and name say what it is.",
+      "",
+      rows,
+      "",
+      "## what an artifact carries",
+      "",
+      "shipping is opt-in. an artifact carries " ..
+      table.concat(carried, ", ") .. " and nothing else, so `docs/`, a" ..
+      " stray `notes.md` and `testdata/` stay behind without anyone" ..
+      " excluding them — a file that is merely IN the repo is not IN the" ..
+      " binary.",
+      "",
+      "## verbs",
+      "",
+      verb_table(),
+      "",
+    }, "\n")
+end
+
+--- Write the guide into a payload directory.
+---
+--- Here rather than at the call site because the artifact path is a
+--- fact about this guide, not about the payload generator that stages
+--- it -- and the generator loads this module by compiling it, so
+--- everything it does not have to know, it does not.
+--- @param dest string The payload directory
+--- @return boolean Whether it was written
+--- @return string The reason it was not
+local function write(dest: string): boolean, string
+  local out = fs.join(dest, STORED)
+  fs.makedirs(fs.dirname(out))
+  local ok, werr = fs.write(out, render())
+  if not ok then
+    return false, out .. ": " .. (werr or "cannot write")
+  end
+  return true
+end
+
+local record ModelModule
+  MISSING: string
+  STORED: string
+  render: function(): string
+  write: function(dest: string): boolean, string
+  gaps: function(): {string}
+  vocabulary: function(): {string}
+  verb_rows: function(): {{string, boolean}}
+end
+
+local M: ModelModule = {
+  MISSING = MISSING,
+  STORED = STORED,
+  render = render,
+  write = write,
+  gaps = gaps,
+  vocabulary = vocabulary,
+  verb_rows = verb_rows,
+}
+
+return M

--- a/_make/model.tl
+++ b/_make/model.tl
@@ -75,47 +75,6 @@ local MARKERS < const >: {{string, string}} = {
   {"anything that is not a source", "notes.md"},
 }
 
---- What each kind IS, in a reader's words.
----
---- Hand-written, and keyed by KIND rather than by marker, so a kind the
---- vocabulary gains is named in the warning instead of quietly missing
---- a row.
-local GLOSS < const >: {string: string} = {
-  ["module"] = "a package — compiled, checked, formatted",
-  ["entry"] = "the project's binary",
-  ["test"] = "a test",
-  ["example"] = "an example",
-  ["benchmark"] = "a benchmark",
-  ["types"] = "type-only; on the include path",
-  ["pin"] = "a pinned external asset — data, never executed",
-  ["gen"] = "a generation unit — runs BEFORE the graph, writes inputs",
-  ["payload-gen"] = "a binary's payload generator — runs AFTER it",
-  ["payload"] = "payload, staged at the artifact root",
-  ["testdata"] = "test fixtures",
-  ["asset"] = "an ordinary part of the project",
-}
-
---- What each verb DOES. The registry knows every verb's name and
---- whether it is planned, and nothing about what it is for.
-local VERB_GLOSS < const >: {string: string} = {
-  ["build"] = "compile the tree, then stage + embed → `o/bin/<name>`",
-  ["check"] = "strict type-check (warnings are errors), in process",
-  ["fmt"] = "formatting over every `.tl`; `--fix` rewrites",
-  ["lint"] = "style: file length, cast justifications, test order",
-  ["test"] = "run `*_test.tl` and report",
-  ["example"] = "run `Example_*` functions and check their output",
-  ["benchmark"] = "run every `*_benchmark.tl`",
-  ["coverage"] = "tests + line coverage, ratcheted against `.cosmic-coverage`",
-  ["docs"] = "extract the doc index",
-  ["ci"] = "fmt, check, test, example, lint, coverage — the gate",
-  ["clean"] = "remove `o/`",
-  ["fetch"] = "resolve `*_pin.tl` — the only verb with a network",
-  ["run"] = "build, then exec the artifact",
-  ["enforce"] = "rerun the sandbox tests unsandboxed, where a skip fails",
-  ["reproducible"] = "a policy lane over the graph",
-  ["offline"] = "a policy lane over the graph",
-}
-
 --- One of the tree's sources, read as text.
 --- @param path string Path relative to the project root
 --- @return string The bytes, or "" when unreadable
@@ -123,34 +82,90 @@ local function source(path: string): string
   return fs.read(path) or ""
 end
 
---- The tree's `classify`, compiled from the tree and loaded.
+--- Load a module from the TREE, whatever the engine carries.
 ---
---- `TL_PATH` first, so the compile resolves `_make.types` to the TREE's
---- enum: without it the pin's enum is consulted and the compile fails
---- on the kinds the pin does not have. `;;` keeps the engine's own path
---- after it, for everything the tree does not define.
+--- The invariant this exists to keep: **a derived document is a pure
+--- function of the tree.** A plain `require` is not -- `package.path`
+--- puts `/zip` first, so it answers with the running binary's embedded
+--- copy, and on a cold clone that binary is the pinned release.
+---
+--- Both halves are needed and both were learned by being wrong:
+---
+--- - **compile, not require**, because the module may be newer than any
+---   release. `_make.model` itself is: the pin has no such module.
+--- - **`TL_PATH` first**, because the module's own imports resolve at
+---   COMPILE time against the engine otherwise. Compiling the tree's
+---   `project.tl` against the pin's `_make.types` fails outright:
+---   `string "benchmark" is not a member of Kind`. `;;` keeps the
+---   engine's path after the tree's, for everything the tree does not
+---   define.
+---
+--- Scoped to one compile rather than set process-wide, deliberately: a
+--- tree-first `TL_PATH` left standing would change resolution for every
+--- later `.tl` require in the process, including the engine's own.
+--- @param path string A source path, relative to the project root
+--- @return table | nil The loaded module, or nil when unavailable
+--- @return string The reason
+local function from_tree(path: string): table, string
+  local env = require("cosmic.env")
+  local before = os.getenv("TL_PATH")
+  env.set("TL_PATH", "./?.tl;./?/init.tl;;", true)
+  local code, cerr = teal.compile_cached(path)
+  if before then
+    env.set("TL_PATH", before, true)
+  else
+    env.unset("TL_PATH")
+  end
+  local chunk = code and load(code, "@" .. path)
+  if not chunk then
+    return nil, path .. ": " .. (cerr or "cannot compile or load")
+  end
+  return chunk() as table -- cast: from any
+end
+
+--- The tree's `classify`.
 --- @return function(string): string The classifier, or nil when unavailable
 local function tree_classify(): function(string): string
-  local before = os.getenv("TL_PATH")
-  require("cosmic.env").set("TL_PATH", "./?.tl;./?/init.tl;;", true)
-  local code, cerr = teal.compile_cached("_make/project.tl")
-  if before then
-    require("cosmic.env").set("TL_PATH", before, true)
-  else
-    require("cosmic.env").unset("TL_PATH")
-  end
-  if not code then
-    warn_gap("cannot compile the tree's _make/project.tl: " ..
-      (cerr or "unknown error"))
+  local mod, err = from_tree("_make/project.tl")
+  if not mod then
+    warn_gap(err)
     return nil
   end
-  local chunk = load(code, "@_make/project.tl")
-  if not chunk then
-    warn_gap("cannot load the compiled _make/project.tl")
-    return nil
+  -- cast: from any, through the tree-loaded module
+  return (mod as {string: function(string): string}).classify
+end
+
+--- What each kind means, from the block that declares the enum.
+---
+--- `_make/types.tl` documents every kind directly above `enum Kind`,
+--- one indented `---   name  text` entry each, continued on deeper
+--- indents. Reading THAT is the point: a description written beside the
+--- declaration cannot be added without the thing it describes being
+--- visible, and cannot be forgotten when the thing is removed. A copy
+--- of it here would be the restatement this module exists to delete --
+--- and it was: `benchmark` was in the enum and absent from the block,
+--- which no reader of either would have noticed.
+--- @return {string: string} Kind to its one-line description
+local function kind_docs(): {string: string}
+  local block = string.match(source("_make/types.tl"),
+    "(.-)\n%s*enum Kind\n") or ""
+  local out: {string: string} = {}
+  local current = ""
+  for line in string.gmatch(block, "[^\n]+") do
+    local name, rest = string.match(line, "^%s*%-%-%-   ([%w%-]+)%s+(.+)$")
+    if name then
+      current = name
+      out[current] = rest
+    elseif current ~= "" then
+      local more = string.match(line, "^%s*%-%-%-%s+(.+)$")
+      if more then
+        out[current] = out[current] .. " " .. more
+      else
+        current = ""
+      end
+    end
   end
-  local mod = chunk() as {string: function(string): string} -- cast: from any
-  return mod.classify
+  return out
 end
 
 --- Every kind the model declares, from the enum's source.
@@ -190,15 +205,22 @@ local function ships(): {string: boolean}
 end
 
 --- The verbs, from the registry the dispatcher is built from.
---- @return {{string, boolean}} Name and whether it is planned, in order
-local function verb_rows(): {{string, boolean}}
+---
+--- Name, description and status all come off the same row, because the
+--- `Verb` record carries `doc` -- so a verb cannot enter the registry
+--- without saying what it is for, and the table below cannot describe a
+--- verb the dispatcher does not have.
+--- @return {{string, string, boolean}} Name, doc and whether planned
+local function verb_rows(): {{string, string, boolean}}
   local block = string.match(source("_make/init.tl"),
     "local VERBS < const >: {Verb} = {(.-)\n}") or ""
-  local rows: {{string, boolean}} = {}
+  local rows: {{string, string, boolean}} = {}
   for line in string.gmatch(block, "[^\n]+") do
     local name = string.match(line, '{name = "([%w%-_]+)"')
     if name then
-      rows[#rows + 1] = {name, string.find(line, "planned = true", 1, true) ~= nil}
+      local doc = string.match(line, 'doc = "(.-)"') or ""
+      rows[#rows + 1] = {name, doc,
+        string.find(line, "planned = true", 1, true) ~= nil}
     end
   end
   if #rows == 0 then
@@ -212,13 +234,14 @@ end
 --- @return string The rendered rows
 local function marker_table(classify: function(string): string): string
   local carried = ships()
+  local docs = kind_docs()
   local out: {string} = {
     "| marker | declares | ships |",
     "|---|---|---|",
   }
   for _, row in ipairs(MARKERS) do
     local kind = classify and classify(row[2]) or ""
-    local gloss = GLOSS[kind] or MISSING
+    local gloss = docs[kind] or MISSING
     out[#out + 1] = "| " .. row[1] .. " | " .. gloss .. " | " ..
     (carried[kind] and "yes" or "no") .. " |"
   end
@@ -231,8 +254,8 @@ local function verb_table(): string
   local out: {string} = {"| verb | what it does | today |", "|---|---|---|"}
   local function emit(planned: boolean, today: string)
     for _, row in ipairs(verb_rows()) do
-      if row[2] == planned then
-        local what = VERB_GLOSS[row[1]] or MISSING
+      if row[3] == planned then
+        local what = row[2] ~= "" and row[2] or MISSING
         out[#out + 1] = "| `" .. row[1] .. "` | " .. what ..
         " | " .. today .. " |"
       end
@@ -258,12 +281,14 @@ local function gaps(): {string}
     return out
   end
   local seen: {string: boolean} = {}
+  local docs = kind_docs()
   for _, row in ipairs(MARKERS) do
     local kind = classify(row[2])
     seen[kind] = true
-    if not GLOSS[kind] then
-      out[#out + 1] = "no gloss for kind '" .. kind .. "' (" .. row[2] ..
-      "): add one to GLOSS in _make/model.tl"
+    if not docs[kind] then
+      out[#out + 1] = "kind '" .. kind .. "' has no description: add a " ..
+      "`---   " .. kind .. "  …` line to the block above `enum Kind` in " ..
+      "_make/types.tl"
     end
   end
   for _, kind in ipairs(vocabulary()) do
@@ -273,9 +298,9 @@ local function gaps(): {string}
     end
   end
   for _, row in ipairs(verb_rows()) do
-    if not VERB_GLOSS[row[1]] then
-      out[#out + 1] = "no description for verb '" .. row[1] ..
-      "': add one to VERB_GLOSS in _make/model.tl"
+    if row[2] == "" then
+      out[#out + 1] = "verb '" .. row[1] .. "' has no description: add " ..
+      "`doc = \"…\"` to its row in the VERBS table in _make/init.tl"
     end
   end
   return out
@@ -351,16 +376,18 @@ end
 local record ModelModule
   MISSING: string
   STORED: string
+  from_tree: function(path: string): table, string
   render: function(): string
   write: function(dest: string): boolean, string
   gaps: function(): {string}
   vocabulary: function(): {string}
-  verb_rows: function(): {{string, boolean}}
+  verb_rows: function(): {{string, string, boolean}}
 end
 
 local M: ModelModule = {
   MISSING = MISSING,
   STORED = STORED,
+  from_tree = from_tree,
   render = render,
   write = write,
   gaps = gaps,

--- a/_make/types.tl
+++ b/_make/types.tl
@@ -10,24 +10,30 @@ local record make_types
   --- What a discovered file declares, derived from its name and
   --- position. One file has exactly one kind.
   ---
-  ---   module    a package source (.tl/.lua) — compiled and embedded
-  ---   entry     main.tl at the root, or cmd/<name>/main.tl — a binary
-  ---   test      *_test.tl
-  ---   example   *_example.tl
-  ---   types     *.d.tl — type-only; on the include path, never embedded
-  ---   pin       *_pin.tl — a pinned external asset, data not code
-  ---   gen       *_gen.tl — a generation unit, scoped to its own
-  ---             directory's subtree, run BEFORE the graph because
-  ---             what it writes is an input to it
-  ---   payload-gen  embed_gen.tl — a BINARY's payload generator: scoped
-  ---             to the binary, run AFTER the graph, writes `o/<unit>/`
-  ---   testdata  anything under a testdata/ directory — never embedded
-  ---   payload   anything under embed/ — embedded at its path INSIDE
-  ---             embed/, which is how a project puts a file somewhere
-  ---             the one layout rule would not
+  ---   module    a package source — compiled, checked, embedded
+  ---   entry     a binary: `main.tl` at the root, or `cmd/<name>/main.tl`
+  ---   test      a test
+  ---   example   a runnable example, checked against its own output
+  ---   benchmark a timed benchmark
+  ---   types     type-only declarations; on the include path
+  ---   pin       a pinned external asset — data, not code
+  ---   gen       a generation unit, scoped to its own directory's
+  ---             subtree, run BEFORE the graph because what it writes
+  ---             is an input to it
+  ---   payload-gen  a BINARY's payload generator: scoped to the binary,
+  ---             run AFTER the graph, writes `o/<unit>/`
+  ---   testdata  test fixtures — never embedded
+  ---   payload   embedded at its path INSIDE `embed/`, which is how a
+  ---             project puts a file somewhere the one layout rule
+  ---             would not
   ---   asset     everything else — part of the project, NOT of its
   ---             artifacts. Shipping is opt-in: `embed/**` is where a
   ---             non-module file says it belongs in the binary
+  ---
+  --- Which NAME declares which kind is `project.classify`, and the
+  --- table of it is generated: `cosmic --docs guide.model`. Repeating
+  --- the markers here would be the same copy, in the same file as the
+  --- thing it copies.
   enum Kind
     "module"
     "entry"
@@ -116,6 +122,11 @@ local record make_types
   record Verb
     --- The name typed on the command line.
     name: string
+    --- What the verb does, one line, for a reader. Declared here with
+    --- the verb so a new one cannot be added without saying what it is
+    --- for: `_make.model` renders the verb table from this field, and
+    --- reports a verb that has none.
+    doc: string
     --- Defined by the design, not shipped yet.
     planned: boolean
     --- The make target this verb lowers onto, when it is a graph verb.

--- a/cmd/cosmic/embed_gen.tl
+++ b/cmd/cosmic/embed_gen.tl
@@ -16,7 +16,8 @@
 ---   make             the graph engine, from the pinned cosmos zip
 ---   cosmic/_version.lua  the stamp `--version` prints
 ---   sys/**           the static `--help` text
----   skills/cosmic/** the guides `--docs` reads
+---   skills/cosmic/** the guides `--docs` reads, plus the generated
+---                    model.md rendered from `_make` itself
 ---
 --- and beside them, `base`: the bare `lua` from the pinned cosmos zip.
 --- Naming it is what makes the fixpoint converge. Without it `build`
@@ -436,6 +437,20 @@ local function generate(out: string): string
       return err
     end
   end
+  -- The model guide, from the TREE's `_make.model`: compiled rather
+  -- than required, for the reason that module's header gives.
+  local mcode = require("cosmic.teal").compile_cached("_make/model.tl")
+  local mchunk = mcode and load(mcode, "@_make/model.tl")
+  if not mchunk then
+    return "_make/model.tl: cannot compile or load"
+  end
+  -- cast: from any
+  local model = mchunk() as {string: function(string): (boolean, string)}
+  local wrote, wrote_err = model.write(dest)
+  if not wrote then
+    return wrote_err
+  end
+
   local vok, verr = write_version(dest)
   if not vok then
     return verr

--- a/cmd/cosmic/embed_gen.tl
+++ b/cmd/cosmic/embed_gen.tl
@@ -437,8 +437,10 @@ local function generate(out: string): string
       return err
     end
   end
-  -- The model guide, from the TREE's `_make.model`: compiled rather
-  -- than required, for the reason that module's header gives.
+  -- The model guide, from the TREE's `_make.model`. Compiled rather
+  -- than required, and written out rather than using that module's own
+  -- `from_tree`: this IS the bootstrap -- the primitive has to be
+  -- loaded by something, and the pin carries no `_make.model`.
   local mcode = require("cosmic.teal").compile_cached("_make/model.tl")
   local mchunk = mcode and load(mcode, "@_make/model.tl")
   if not mchunk then

--- a/skills/cosmic/make.md
+++ b/skills/cosmic/make.md
@@ -22,27 +22,12 @@ replaced it outright.
 
 ## Verbs
 
-| verb | what it does | today |
-|---|---|---|
-| `build` | compile the tree, then stage + embed → `o/bin/<name>` | ✅ |
-| `check` | strict type-check (warnings are errors), in process | ✅ |
-| `fmt` | formatting over every `.tl`; `--fix` rewrites | ✅ |
-| `lint` | style: file length, cast justifications, test order | ✅ |
-| `test` | run `*_test.tl` and report | ✅ |
-| `example` | run `Example_*` functions and check their output | ✅ |
-| `benchmark` | run every `*_benchmark.tl` | ✅ |
-| `coverage` | tests + line coverage, ratcheted against `.cosmic-coverage` | ✅ |
-| `docs` | extract the doc index | ✅ |
-| `ci` | fmt, check, test, example, lint, coverage — the gate | ✅ |
-| `clean` | remove `o/`, sparing `o/bootstrap` | ✅ |
-| `fetch` | resolve `*_pin.tl` — the only verb with a network | ✅ |
-| `help` | list the verbs, and which are still planned | ✅ |
-| `run` | build, then exec the artifact | planned |
-| `enforce` | rerun the sandbox tests unsandboxed, where a skip fails | planned |
-| `reproducible` `offline` | policy lanes over the graph | planned |
+the verbs, what each does, and which are still planned are GENERATED
+from the registry the dispatcher is built from — read them with
+`cosmic --docs guide.model`. `cosmic --make help` prints the names the
+same way. neither can go stale, because neither is written twice.
 
-`cosmic --make help` prints this list, split the same way; it is the
-one that cannot go stale.
+
 
 every verb ends in a machine-readable verdict line and an exit code:
 
@@ -259,22 +244,15 @@ without it cosmic would never see the line at all.
 
 ## The project model
 
-| marker | declares |
-|---|---|
-| `<dir>/*.tl`, `<dir>/*.lua` | a package — compiled, checked, formatted |
-| `main.tl` at the root | the project's binary |
-| `cmd/<name>/main.tl` | one binary per subdirectory |
-| `*_test.tl` | a test |
-| `*_example.tl` | an example |
-| `*.d.tl` | type-only; on the include path, never embedded |
-| `*_pin.tl` | a pinned external asset |
-| `*_benchmark.tl` | a benchmark |
-| `*_gen.tl` | a generation unit — runs BEFORE the graph, writes inputs |
-| `cmd/<name>/embed_gen.tl` | a binary's payload generator — runs AFTER |
-| `embed/**` | payload, staged at the artifact root |
-| `testdata/` | test fixtures; never embedded |
-| `_<dir>/` | internal: importable only from within its container |
-| everything else | an ordinary part of the project; never embedded |
+what each marker declares, and whether an artifact carries it, is
+GENERATED from `_make` itself: the kind is the tree's own
+`project.classify` answering about a path of that shape, and the ships
+column is the `ships` table the artifact builder reads. read it with
+`cosmic --docs guide.model`.
+
+it is not restated here on purpose. this file taught a row D15 had
+deleted, in four places, for three review rounds — a table nobody
+writes cannot disagree with the build.
 
 **import path = path relative to the root**, `/` → `.`, extension
 dropped. `pkg/db.tl` is `require("pkg.db")`; `pkg/init.tl` is


### PR DESCRIPTION
Fixes #822. **Replaces the ratchet this PR originally carried** — instead of checking a hand-written table against the model, the table is rendered from the model and there is nothing left to check. Two commits.

## 1. The model documents itself

`skills/cosmic/model.md` (`cosmic --docs guide.model`) is derived:

| fact | source |
|---|---|
| what a marker declares | the tree's `project.classify`, asked about an example path |
| what an artifact carries | the `ships` table the artifact builder reads |
| the verbs and their status | the registry the dispatcher is built from |

`make.md` keeps the prose and points at it.

### Every fact comes from the TREE, never the running engine

`package.path` puts `/zip` first, so a `require` resolves to whatever binary drives the build — the **pinned release** on a cold clone, whose model is a release behind:

```
$ o/bootstrap/cosmic -e "print(require('_make.project').classify('pkg/db_benchmark.tl'))"
module                                    ← the tree says: benchmark

$ …compile_cached("_make/project.tl") without TL_PATH
error: string "benchmark" is not a member of Kind
```

A guide rendered from the engine would be **wrong** there, and would **change between generations** — the one thing an artifact's payload may not do, since the fixpoint check compares them. Hence the rule: **execute the tree's behaviour, read the tree's data.**

### Why `embed_gen` compiles instead of requiring

Measured in a clean fixture — **the pinned engine does not run source generators at all**:

| engine | new `*_gen.tl` in a fixture project |
|---|---|
| pinned release | **nothing written**, `build: PASS` |
| tree's binary | `generate note_gen.tl`, file written |

So a separate generation unit's output is absent exactly when needed, and requiring it fails the build that would produce the binary that fixes it — a wedge that survives `--make clean` (I hit it). Compiling the tree's copy needs neither. **No phase-2 release dance.**

## 2. A kind and a verb carry their own description

The first commit still held two hand-written maps — a gloss per kind, a description per verb — which is the same restatement, moved one file over. Both now live at the declaration:

- `_make/types.tl` **already** documented every kind above `enum Kind`; `model.tl` reads that block instead of copying it. The copy was already wrong in the way copies are: **`benchmark` was in the enum and absent from the block**, and no reader of either would have noticed.
- the `Verb` record gains `doc`, carried by every row in the registry, so a verb cannot enter the dispatcher without saying what it is for.

The gate changes shape with them: it used to say "add an entry to the map in model.tl"; it now names the declaration — `add a \`---   <kind>  …\` line above \`enum Kind\`` / `add \`doc = "…"\` to its row in VERBS`.

`from_tree` is now named, exported and documented, with the invariant it protects (**a derived document is a pure function of the tree**) and both halves of it — compile-not-require, and `TL_PATH` first. Still scoped to one compile: a tree-first `TL_PATH` left standing would change resolution for every later require in the process. `embed_gen` keeps its inline copy and says why — it is the bootstrap; the primitive has to be loaded by something.

The enum's block is description-first now; it led with the marker, which put the marker in both columns of the rendered table — and repeating which name declares which kind, in the same file as the enum, is the same copy this is against.

## Verification

- **cold build, pin driving** → `build: PASS`, and the artifact says `` `*_benchmark.tl` | a benchmark `` — the tree's answer, not the pin's `module`
- **byte-identical** guide between pin-built and tree-built binaries, so the fixpoint settles
- `bin/cosmic --make ci` → **`ci: PASS (6 stages)`**

| mutation | result |
|---|---|
| kind added to the enum | ✗ `no example produces kind 'sidecar'` |
| a kind's description deleted | ✗ `kind 'benchmark' has no description` |
| a verb's `doc =` removed | ✗ `verb 'lint' has no description` |
| a hand-written table creeps back | ✗ `restates the verb table` |
| unmutated | ✓ `all skill ratchet tests passed` |

`.cosmic-coverage` gains one row for the new file. I did **not** commit the rest of `--make coverage --baseline`'s output: it also lowered 8 unrelated floors, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQ56YZVuXWho9UUMVJfKPf