### PR TITLE
docs: the decisions index is derived from the records it indexes (#820)

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -13,6 +13,7 @@ _cli/require_hints.tl 104 124
 _cli/run.tl 28 33
 _cli/welcome.tl 0 25
 _docs/publish.tl 116 176
+_docs/derive.tl 54 81
 _make/artifact.tl 163 180
 _make/binaries.tl 24 24
 _make/check.tl 56 57

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ cosmic/               standard library modules (*.tl) — the PUBLIC API
 _cli/                 the dispatcher behind every flag (args, help, run, ...)
   build/               the closed verb vocabulary behind `-c`
 _make/                `cosmic --make`: project model, validator, root, verbs
-_build/               workflow ratchet tests
+_build/               ratchets over what the repo ships and derives
 _docs/                doc publishing
 _perf/                performance benchmark harness (see _perf/OPTIMIZE.md)
 _types/               cosmo.* type declarations (generated) + gentype generator

--- a/_build/docs_test.tl
+++ b/_build/docs_test.tl
@@ -1,0 +1,39 @@
+#!/usr/bin/env cosmic
+-- Ratchets over the DERIVED regions of committed documents.
+--
+-- A row that restates something the tree already says is a copy, and a
+-- copy drifts. The decisions index is every record's own H1, written
+-- out a second time -- so the index can disagree with the record it
+-- links to, which is what #820 is about.
+--
+-- The rows stay committed because they are read on GitHub, by people
+-- who are not running a build. So this is the `.cosmic-coverage` shape:
+-- a derived file, a command that rewrites it, and a gate that fails
+-- when the committed copy has gone stale.
+
+local check = require("cosmic.check")
+local derive = require("_docs.derive")
+local fs = require("cosmic.fs")
+
+-- The index says exactly what the records say. Compared as a whole
+-- table rather than row by row, because the failures worth catching are
+-- a row that drifted, a record with no row, and a row whose record is
+-- gone -- and only the whole table sees all three.
+local function test_the_decisions_index_matches_the_records()
+  local rendered, bad = derive.decisions_table()
+  assert(#bad == 0,
+    "decision record(s) with no `# D<n> — <title>` heading, so they " ..
+    "cannot be indexed:\n  " .. table.concat(bad, "\n  "))
+
+  local text = check.must(fs.read(derive.INDEX))
+  local committed = derive.committed_table(text, derive.DECISIONS_HEAD)
+  assert(committed ~= "",
+    derive.INDEX .. " has no `" .. derive.DECISIONS_HEAD .. "` table")
+  assert(committed == rendered,
+    derive.INDEX .. " no longer matches the records it indexes.\n" ..
+    "Run `bin/cosmic _docs/derive.tl` to rewrite it.\n\ncommitted:\n" ..
+    committed .. "\n\nfrom the records:\n" .. rendered)
+end
+test_the_decisions_index_matches_the_records()
+
+print("all derived-document tests passed")

--- a/_docs/derive.tl
+++ b/_docs/derive.tl
@@ -1,0 +1,170 @@
+#!/usr/bin/env cosmic
+--- Derived regions of committed documents, and the command that writes
+--- them.
+---
+--- Some rows in a document are not prose: they are a restatement of
+--- something the tree already says, and a restatement drifts. The
+--- decisions index is the clearest case -- every row repeats a record's
+--- own H1, so the index can disagree with the record it points at, and
+--- has (#820 is a whole issue about one title).
+---
+--- These stay COMMITTED rather than generated into `o/` and embedded:
+--- they are read on GitHub, by people who are not running a build. So
+--- the shape is the one `.cosmic-coverage` already uses in this repo --
+--- a derived file, a command that rewrites it, and a gate that fails
+--- when the committed copy is stale (`_build/docs_test.tl`).
+---
+---     bin/cosmic _docs/derive.tl        # rewrite the derived regions
+---
+--- Rewriting a REGION, not a file, because the surrounding prose is
+--- prose: it says why the records exist and how to add one, which no
+--- generator can know.
+
+local fs = require("cosmic.fs")
+local proc = require("cosmic.proc")
+
+local DECISIONS < const > = "docs/decisions"
+local INDEX < const > = DECISIONS .. "/README.md"
+
+--- The header row the decisions table starts at.
+local DECISIONS_HEAD < const > = "| # | decision | |"
+
+--- One decision record: its number, its title, and its file.
+local record Record
+  n: integer
+  title: string
+  file: string
+end
+
+--- Every record, in numbered order, read from its own H1.
+---
+--- The H1 is the record's title, so the index cannot say something the
+--- record does not: `# D14 — no self-hosting: …` yields both the number
+--- and the words. A record whose H1 does not parse is reported rather
+--- than skipped -- a row silently missing from an index is exactly the
+--- failure the index exists to prevent.
+--- @return {Record} The records, ordered by number
+--- @return {string} Files whose H1 could not be read
+local function records(): {Record}, {string}
+  local found: {Record} = {}
+  local bad: {string} = {}
+  local listed = fs.collect(DECISIONS, "*.md")
+  if listed == nil then
+    return found, {DECISIONS .. ": cannot be listed"}
+  end
+  local names = listed as {string} -- cast: union after the guard
+  table.sort(names)
+  for _, path in ipairs(names) do
+    local base = fs.basename(path)
+    if base ~= "README.md" then
+      local text = fs.read(path) or ""
+      local n, title = string.match(text, "^#%s*D(%d+)%s*—%s*(.-)%s*\n")
+      if n and title then
+        found[#found + 1] = {
+          n = math.tointeger(tonumber(n)) or 0,
+          title = title,
+          file = base,
+        }
+      else
+        bad[#bad + 1] = path
+      end
+    end
+  end
+  table.sort(found, function(a: Record, b: Record): boolean
+      return a.n < b.n
+    end)
+  return found, bad
+end
+
+--- The decisions table, rendered.
+--- @return string The header and rows, newline-joined
+--- @return {string} Files whose H1 could not be read
+local function decisions_table(): string, {string}
+  local found, bad = records()
+  local out: {string} = {DECISIONS_HEAD, "|---|---|---|"}
+  for _, r in ipairs(found) do
+    out[#out + 1] = "| D" .. r.n .. " | " .. r.title ..
+    " | [→](" .. r.file .. ") |"
+  end
+  return table.concat(out, "\n"), bad
+end
+
+--- The table currently committed in a document.
+--- @param text string The document
+--- @param head string The table's header row
+--- @return string The table as committed, or "" when absent
+local function committed_table(text: string, head: string): string
+  local rows: {string} = {}
+  local inside = false
+  for line in (text .. "\n"):gmatch("([^\n]*)\n") do
+    if line == head then
+      inside = true
+      rows[#rows + 1] = line
+    elseif inside then
+      if line:sub(1, 1) ~= "|" then
+        break
+      end
+      rows[#rows + 1] = line
+    end
+  end
+  return table.concat(rows, "\n")
+end
+
+--- Replace a document's derived table with a freshly rendered one.
+--- @param path string The document
+--- @param head string The table's header row
+--- @param rendered string The table to put there
+--- @return boolean Whether the file changed
+--- @return string The reason it could not be written
+local function rewrite(path: string, head: string,
+    rendered: string): boolean, string
+  local text = fs.read(path) or ""
+  if text == "" then
+    return false, path .. ": cannot read"
+  end
+  local current = committed_table(text, head)
+  if current == "" then
+    return false, path .. ": no `" .. head .. "` table to rewrite"
+  end
+  if current == rendered then
+    return false
+  end
+  local pattern = (current:gsub("%p", "%%%1"))
+  local replacement = (rendered:gsub("%%", "%%%%"))
+  local ok, werr = fs.write(path, (string.gsub(text, pattern, replacement, 1)))
+  if not ok then
+    return false, path .. ": " .. (werr or "cannot write")
+  end
+  return true
+end
+
+local record DeriveModule
+  DECISIONS_HEAD: string
+  INDEX: string
+  decisions_table: function(): string, {string}
+  committed_table: function(text: string, head: string): string
+end
+
+local M: DeriveModule = {
+  DECISIONS_HEAD = DECISIONS_HEAD,
+  INDEX = INDEX,
+  decisions_table = decisions_table,
+  committed_table = committed_table,
+}
+
+if proc.is_main() then
+  local rendered, bad = decisions_table()
+  for _, path in ipairs(bad) do
+    io.stderr:write("derive: " .. path ..
+      ": no `# D<n> — <title>` heading; it is not in the index\n")
+  end
+  local changed, err = rewrite(INDEX, DECISIONS_HEAD, rendered)
+  if err then
+    io.stderr:write("derive: " .. err .. "\n")
+    os.exit(1)
+  end
+  print(changed and ("derive: rewrote " .. INDEX)
+    or ("derive: " .. INDEX .. " already matches the records"))
+end
+
+return M


### PR DESCRIPTION
Addresses the **class** behind #820 (see the scope note at the bottom — it deliberately does not retitle D14).

## The copy

Every row of `docs/decisions/README.md` restates a record's own H1, so the index can disagree with the record it links to. #820 is an issue about one such disagreement; round 5 of #793 fixed another by hand. That's the shape of a problem that comes back.

`_docs/derive.tl` renders the table from the records — each `# D<n> — <title>` heading supplies both the number and the words, so a row cannot say something its record does not.

**The derivation reproduces the committed index byte for byte**, which is the check that it's faithful rather than merely plausible:

```
$ o/bin/cosmic _docs/derive.tl
derive: docs/decisions/README.md already matches the records
```

## Shape

The rows stay **committed**, not generated into `o/` — they're read on GitHub by people who aren't running a build. So this is the shape `.cosmic-coverage` already uses here: a derived file, a command that rewrites it, a gate that fails when the committed copy is stale.

```
bin/cosmic _docs/derive.tl
```

A **region** is rewritten, not the file: the surrounding prose says why the records exist and how to add one, which no generator can know.

`_build/docs_test.tl` compares the whole table rather than row by row, because the three failures worth catching are a row that drifted, a record with no row, and a row whose record is gone — only the whole table sees all three. A record whose heading doesn't parse is *reported*, not skipped: a row silently missing from an index is exactly what an index exists to prevent.

## Verification

`bin/cosmic --make ci` → **`ci: PASS (6 stages)`**

| mutation | result |
|---|---|
| a record retitled, index not updated | ✗ `no longer matches the records` |
| an index row edited by hand | ✗ `no longer matches the records` |
| a record with an unparseable heading | ✗ `cannot be indexed` |
| unmutated | ✓ `all derived-document tests passed` |

**One honest limit:** a data-file change doesn't invalidate the test target, so an incremental `--make test` can skip this — the same is true of the workflow ratchet next door. `o/bin/cosmic _build/docs_test.tl` runs it directly, and a fresh tree (CI) runs everything.

## Scope note

This does **not** retitle D14, which is what #820 actually asks for. The wording is a decision, and AGENTS.md says settled decisions are amended deliberately rather than in passing — that call is yours. What this removes is the class: after it, a retitled record and its index cannot disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQ56YZVuXWho9UUMVJfKPf

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQ56YZVuXWho9UUMVJfKPf)_