### PR TITLE
env: `get` admits the nil it returns; `get_or` is the half that cannot fail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,7 +365,7 @@ all modules are under `cosmic/` and imported as `cosmic.*`:
 | compress | zlib compression/decompression |
 | doc | extract docs from source and query the embedded documentation index |
 | embed | create custom executables with embedded files |
-| env | environment variable get/set/unset |
+| env | environment variable get (nil when unset), get_or, set/unset |
 | envd | load environment variables from embedded env.d directory |
 | example | example runner with `Example_*` functions |
 | fetch | HTTP client with retry support |

--- a/_cli/build/steps.tl
+++ b/_cli/build/steps.tl
@@ -430,7 +430,7 @@ local function do_exec(args: {string}): integer
   -- matters when the build directory is itself reached through a link.
   -- A relative symlink inside `o/` still resolves inside it, so the
   -- staging links a build makes keep working.
-  local root_named = fs.abspath(env.get("COSMIC_EXEC_ROOT", "o"))
+  local root_named = fs.abspath(env.get_or("COSMIC_EXEC_ROOT", "o"))
   local root = (fs.realpath(root_named) or root_named) as string -- cast: scalar fallback
   local named = fs.abspath(program)
   -- Falling back to the lexical path when realpath fails keeps the

--- a/_make/converge.tl
+++ b/_make/converge.tl
@@ -197,7 +197,7 @@ local function to_the_tree(proj: Project, argv: {string},
   end
   local built = fs.join(project.BUILD_DIR, "bin",
     (tool as Binary).name) -- cast: record union after the guard
-  local gen = math.tointeger(tonumber(env.get(GEN_ENV, "0")) or 0) or 0
+  local gen = math.tointeger(tonumber(env.get_or(GEN_ENV, "0")) or 0) or 0
 
   local was_us = fs.isfile(built) and same_file(built, self)
   local before = stamp_of(built)

--- a/_make/stage_test.tl
+++ b/_make/stage_test.tl
@@ -98,10 +98,14 @@ local function test_binaries_go_on_the_path()
   local proj: types.Project = {root = "/p", binaries = {}, files = {}}
   env.set("PATH", "/usr/bin", true)
   stage.binaries_on_path(proj)
-  assert(env.get(stage.BIN_ENV) == fs.join(project.BUILD_DIR, "bin"),
-    "TEST_BIN names the build's bin directory, got: " ..
-    env.get(stage.BIN_ENV))
-  local first = env.get("PATH"):match("^[^:]+")
+  local bin = env.get(stage.BIN_ENV)
+  assert(bin == fs.join(project.BUILD_DIR, "bin"),
+    "TEST_BIN names the build's bin directory, got: " .. tostring(bin))
+  -- `get_or` rather than `get`: this is a read the test cannot survive
+  -- being nil, so it says so instead of indexing whatever came back.
+  -- The honest return type is what surfaced it; before, this line
+  -- type-checked and would have crashed on a PATH-less environment.
+  local first = env.get_or("PATH", ""):match("^[^:]+")
   assert(first == stage.bin_dir(proj),
     "the project's binaries come first, got: " .. tostring(first))
 

--- a/cmd/cosmic/embed_gen.tl
+++ b/cmd/cosmic/embed_gen.tl
@@ -312,7 +312,13 @@ local function declared_version(): string
       end
     end
   end
-  return env.get("COSMIC_VERSION", "unknown")
+  -- `get() or …` rather than `get_or`, and the reason is bootstrap: a
+  -- generator is RUN by whatever cosmic is driving the build, which on
+  -- a cold tree is the pinned release -- and it resolves `cosmic.env`
+  -- from its own zip, where a newly added function does not exist yet.
+  -- Anything here must compile and run against the PIN. `get_or` moves
+  -- in one release later.
+  return env.get("COSMIC_VERSION") or "unknown"
 end
 
 --- Write the version stamp `--version` prints.

--- a/cosmic/env.tl
+++ b/cosmic/env.tl
@@ -1,17 +1,39 @@
 --- Environment variable utilities.
 --- Provides get, set, unset, clear, and all functions for environment variables.
---- For the common case of reading a single variable, use env.get() — it wraps
---- os.getenv() internally and is the simplest approach. Use env.all() to get
---- all variables as a {string:string} map parsed from unix.environ().
+--- For the common case of reading a single variable, use env.get(), which
+--- returns nil when the variable is not set, or env.get_or() when you have
+--- a fallback. Use env.all() to get all variables as a {string:string} map
+--- parsed from unix.environ().
 local unix = require("cosmo.unix")
 local errstr = require("cosmic.errno").str
 
---- Get the value of an environment variable.
---- Returns the default (nil if not given) when the variable is not set.
+--- Get the value of an environment variable, or nil when it is not set.
+---
+--- **The nil is in the type**, which is the whole point of this
+--- function's shape. It used to take an optional default and return a
+--- bare `string`, and that was a lie the checker could not see: with no
+--- default the body returns the parameter, which is `string` inside the
+--- function and nil at the call site. `local v: string = env.get("X")`
+--- type-checked strictly and crashed on the next line. A reading that
+--- can fail says so, and the caller narrows -- see `get_or` for the
+--- half that cannot fail.
 --- @param name string The name of the environment variable
---- @param default string? Value to return when the variable is not set
---- @return string? The value of the environment variable, or the default
-local function get(name: string, default?: string): string
+--- @return string|nil The value, or nil when the variable is not set
+local function get(name: string): string | nil
+  return os.getenv(name)
+end
+
+--- Get the value of an environment variable, or `default` when unset.
+---
+--- The infallible half, and it is a separate function rather than an
+--- optional argument because the two have genuinely different types: a
+--- read with a fallback CANNOT fail, so making its caller narrow would
+--- be noise, and folding both into one signature is what produced a
+--- return type that was wrong half the time.
+--- @param name string The name of the environment variable
+--- @param default string The value to return when it is not set
+--- @return string The value, or `default`
+local function get_or(name: string, default: string): string
   local value = os.getenv(name)
   if value == nil then
     return default
@@ -86,7 +108,8 @@ local function list(): {string}
 end
 
 local record EnvModule
-  get: function(name: string, default?: string): string
+  get: function(name: string): string | nil
+  get_or: function(name: string, default: string): string
   set: function(name: string, value: string, overwrite?: boolean): boolean, string
   unset: function(name: string): boolean, string
   clear: function(): boolean, string
@@ -96,6 +119,7 @@ end
 
 local M: EnvModule = {
   get = get,
+  get_or = get_or,
   set = set,
   unset = unset,
   clear = clear,

--- a/cosmic/env_example.tl
+++ b/cosmic/env_example.tl
@@ -1,7 +1,9 @@
 --- Examples for the cosmic.env module.
 --- Demonstrates reading, setting, and listing environment variables.
 --- For the common case of reading a single variable, env.get() is
---- the simplest approach (it wraps os.getenv() internally).
+--- the simplest approach (it wraps os.getenv() internally). It returns
+--- nil when the variable is not set, so the caller narrows; env.get_or()
+--- takes a fallback and cannot fail.
 
 -- Example_get demonstrates reading a single environment variable.
 -- This is the most common operation. env.get() returns the value
@@ -14,6 +16,15 @@ local function Example_get()
   end
   -- Output:
   -- PATH is set
+end
+
+-- Example_get_or demonstrates the infallible read: a fallback means the
+-- result cannot be nil, so the caller never narrows.
+local function Example_get_or()
+  local env = require("cosmic.env")
+  print(env.get_or("COSMIC_EXAMPLE_UNSET_VAR", "fallback"))
+  -- Output:
+  -- fallback
 end
 
 -- Example_get_missing demonstrates reading a variable that is not set.
@@ -65,4 +76,5 @@ local function Example_all()
 end
 
 -- Suppress unused warnings for examples
-local _ = {Example_get, Example_get_missing, Example_set_and_get, Example_unset, Example_all}
+local _ = {Example_get, Example_get_or, Example_get_missing, Example_set_and_get,
+  Example_unset, Example_all}

--- a/cosmic/env_test.tl
+++ b/cosmic/env_test.tl
@@ -132,7 +132,7 @@ env.unset("COSMIC_TEST_NO_OVERWRITE")
 
 local function test_get_default_when_unset()
   env.unset("COSMIC_TEST_DEFAULT")
-  local value = env.get("COSMIC_TEST_DEFAULT", "fallback")
+  local value = env.get_or("COSMIC_TEST_DEFAULT", "fallback")
   assert(value == "fallback", "expected default, got '" .. tostring(value) .. "'")
   assert(env.get("COSMIC_TEST_DEFAULT") == nil,
     "without a default, unset should still be nil")
@@ -141,7 +141,7 @@ test_get_default_when_unset()
 
 local function test_get_default_ignored_when_set()
   env.set("COSMIC_TEST_DEFAULT", "real")
-  local value = env.get("COSMIC_TEST_DEFAULT", "fallback")
+  local value = env.get_or("COSMIC_TEST_DEFAULT", "fallback")
   assert(value == "real", "set value should win over default, got '" .. tostring(value) .. "'")
   env.unset("COSMIC_TEST_DEFAULT")
 end
@@ -149,8 +149,54 @@ test_get_default_ignored_when_set()
 
 local function test_get_default_empty_value_wins()
   env.set("COSMIC_TEST_DEFAULT", "")
-  local value = env.get("COSMIC_TEST_DEFAULT", "fallback")
+  local value = env.get_or("COSMIC_TEST_DEFAULT", "fallback")
   assert(value == "", "empty string is set, default must not apply")
   env.unset("COSMIC_TEST_DEFAULT")
 end
 test_get_default_empty_value_wins()
+
+-- The bug this shape closes, asserted where it lives: in the TYPE.
+--
+-- `get` used to take an optional default and declare a bare `string`
+-- return. With no default the body returns the parameter -- `string`
+-- inside the function, nil at the call site -- so the checker never saw
+-- the nil escape and an unguarded use of the result type-checked
+-- strictly, then crashed. That is a silent bug of exactly the class the
+-- honest-nil rule exists to stop.
+--
+-- What the honest type buys, precisely: Teal 0.24.8 checks nilability at
+-- the USE, not at the assignment. `local v: string = get(x)` is still
+-- accepted (the declaration is taken at its word); `get(x):match(...)`
+-- is not. The use site is where the crash was, and it is the one this
+-- pins -- `_make/stage_test.tl` had exactly that line, and the honest
+-- return type is what surfaced it.
+--
+-- A runtime assertion cannot pin a type, so this asks the checker.
+local function test_get_admits_nil_in_its_type()
+  local fs = require("cosmic.fs")
+  local teal = require("cosmic.teal")
+  local dir = env.get_or("TEST_TMPDIR", "/tmp")
+  local bad = fs.join(dir, "env_nil_use.tl")
+  assert(fs.write(bad, 'local e = require("cosmic.env")\n'
+      .. 'print(e.get("DEFINITELY_NOT_SET"):upper())\n'))
+  -- `.` first, so `cosmic.env` resolves to THIS tree's copy rather than
+  -- to whatever the running binary embeds.
+  local result = teal.check(bad, {include_dirs = {"."}})
+  assert(not result.ok, "using env.get()'s result unguarded must not check")
+  local named = false
+  for _, e in ipairs(result.errors) do
+    if e.message:find("string | nil", 1, true) then
+      named = true
+    end
+  end
+  assert(named, "and the error must name the nil the type admits")
+
+  -- The narrowed form is accepted, so the type is honest rather than
+  -- merely obstructive.
+  local good = fs.join(dir, "env_nil_ok.tl")
+  assert(fs.write(good, 'local e = require("cosmic.env")\n'
+      .. 'print(e.get_or("DEFINITELY_NOT_SET", "d"):upper())\n'))
+  assert(teal.check(good, {include_dirs = {"."}}).ok,
+    "get_or cannot fail, so its result needs no narrowing")
+end
+test_get_admits_nil_in_its_type()


### PR DESCRIPTION
Found while reviewing #832 — routing around this was the reason that PR reads `os.getenv` directly in one place. Split out so it can merge first.

## The bug

`cosmic.env.get` declared `string` and returned nil. The doc comment was already honest (`@return string?`); the signature was not:

```teal
--- @return string? The value of the environment variable, or the default
local function get(name: string, default?: string): string
  local value = os.getenv(name)
  if value == nil then
    return default        -- nil when no default was passed
  end
```

It type-checks because `default?: string` is plain `string` inside the body, so Teal never sees the nil escape:

```
$ cosmic --check types envbug.tl     # local v: string = env.get("NOT_SET")
Type check passed
$ cosmic envbug.tl
attempt to get length of a nil value (local 'v')
```

Strict check clean, nil at runtime, in a published `cosmic.*` module. That's the silent-bug class D3 names, and the honest-nil rule in AGENTS.md — *"Fallible value: `T | nil, string` — the checker forces callers to narrow"* — broken by the stdlib itself.

## The fix: split, not widen

- `get(name): string | nil` — the fallible read
- `get_or(name, default): string` — the infallible one

One signature can't be honest about both. A read *with* a fallback genuinely cannot fail, so a blunt `string | nil` would force every such caller to narrow for nothing — and folding the two cases together is exactly what produced a return type that was wrong half the time.

## What it actually catches

Worth stating precisely, because it's narrower than "the checker forces callers to narrow" suggests: **Teal 0.24.8 checks nilability at the use, not the assignment.**

```teal
local v: string = f()   -- accepted; the declaration is taken at its word
f():match("^[^:]+")     -- error: cannot index key 'match' in type string | nil
```

Running the honest type over the whole tree produced **exactly one** error: `_make/stage_test.tl` did `env.get("PATH"):match("^[^:]+")` — a real unguarded index the checker had been blind to. That's the entire ripple. Every other caller compares against string literals or guards with `not val`, and nil passes both, so nothing in the tree was crashing today — it was latent, not live.

## One deliberate non-migration

`cmd/cosmic/embed_gen.tl` stays on `env.get(x) or "unknown"`. A generator is *run by whatever cosmic drives the build*, which on a cold tree is the pinned release — and it resolves `cosmic.env` from its own zip, where a newly added function doesn't exist yet. I hit this: the first build failed with `invalid key 'get_or' in record 'env'`. So anything in a generator has to compile and run against the pin, and `get_or` moves there one release later.

That resolution asymmetry is itself what #832 is about, which is the other reason this lands first and separately.

## Tests

The behavioural pair already existed and now exercises `get_or`. Added one that asks the **checker**, since a runtime assertion cannot pin a type:

- the unguarded use must be refused, and the error must name `string | nil`
- the `get_or` form must still pass — so the type is honest rather than merely obstructive

`--make ci`: **PASS (6 stages), 171 checks.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoYddHr9Lgqr9t3JpwkkUT)_