### PR TITLE
docs: the fixpoint, measured — and a generator test that can actually fail

### DIFF
--- a/_make/generate_test.tl
+++ b/_make/generate_test.tl
@@ -361,46 +361,47 @@ local function test_the_real_payload_generator()
 end
 test_the_real_payload_generator()
 
--- A generator's helpers come from the TREE, in ONE build.
+-- A generator's helpers come from the TREE, even when the BINARY ships
+-- a module by that name.
 --
--- The failure this closes: a generator resolved its own imports out of
--- the running binary, so a helper that the binary also embedded was a
--- generation behind. Editing it took two full builds to take effect and
--- the first one reported PASS. The mini-graph -- compile the
--- generator's closure, hand it a manifest -- is what makes one build
--- enough. See docs/design/make/resolution.md.
+-- The collision is the whole test. A generator used to resolve its own
+-- imports out of the running binary, so a helper the artifact also
+-- embedded was a generation behind -- and a fixture module with a name
+-- cosmic does not ship can only ever come from the tree, before the fix
+-- as much as after. An earlier version of this test used `helper`,
+-- which is exactly that shape: it passed against a pre-change binary,
+-- so it proved nothing about the thing it was named for.
+--
+-- `_make/imports` collides with a module the artifact carries. Verified
+-- both ways by hand: a pre-change binary answers ZIP here, this one
+-- answers TREE.
+--
+-- `.lua` on both sides, and that is not incidental. The artifact ships
+-- `.tl/**` beside its compiled modules, so a `.tl` generator importing
+-- a colliding name resolves the TYPE from the binary too and fails to
+-- compile before it can run. That is the same shadowing one layer up,
+-- and it is why the runtime question needs a file with no types.
 local function test_a_generator_reads_its_helpers_from_the_tree()
-  local root = fixture("closure", {
-      ["helper.tl"] = 'local record H\n  mark: function(): string\nend\n'
-      .. 'local h: H = {mark = function(): string return "FIRST" end}\n'
-      .. 'return h\n',
-      ["thing_gen.tl"] = 'local helper = require("helper")\n'
+  local root = fixture("shadow", {
+      ["_make/imports.lua"] = 'return {mark = function() return "TREE" end}\n',
+      ["thing_gen.lua"] = 'local imports = require("_make.imports")\n'
       .. 'local fs = require("cosmic.fs")\n'
-      .. 'fs.write(fs.join(arg[1], "out.txt"), helper.mark())\n',
+      .. "local ok, mark = pcall(function() return imports.mark() end)\n"
+      .. 'fs.write(fs.join(arg[1], "out.txt"), (ok and mark) or "ZIP")\n',
     })
-  local made = fs.join(root, "o", "thing_gen", "out.txt")
-
-  local function build(): string
-    local h = check.must(spawn.spawn({cosmic, "--make", "build"},
-        {cwd = root, env = {"PATH=" .. (os.getenv("PATH") or ""),
-            "HOME=" .. root, "TMPDIR=" .. tmpdir, "NO_COLOR=1"}}))
-    local r = check.must(h:wait())
-    assert(r.code == 0, "the fixture must build: " ..
-      (r.stdout or "") .. (r.stderr or ""))
-    local text = check.must(fs.read(made))
-    return text
-  end
-
-  assert(build() == "FIRST", "the generator runs its own helper")
-
-  -- One edit, one build. Two would mean the generator ran the previous
-  -- generation's helper, which is exactly the bug.
-  assert(fs.write(fs.join(root, "helper.tl"),
-      "local record H\n  mark: function(): string\nend\n" ..
-      'local h: H = {mark = function(): string return "SECOND" end}\n' ..
-      "return h\n"))
-  assert(build() == "SECOND",
-    "one build must be enough for a generator's helper to take effect")
+  -- A fixture project does not claim the `cosmic` namespace, so it does
+  -- not converge: this is ONE pass, and a second could not hide a stale
+  -- first one.
+  local h = check.must(spawn.spawn({cosmic, "--make", "build"},
+      {cwd = root, env = {"PATH=" .. (os.getenv("PATH") or ""),
+          "HOME=" .. root, "TMPDIR=" .. tmpdir, "NO_COLOR=1"}}))
+  local r = check.must(h:wait())
+  assert(r.code == 0, "the fixture must build: " ..
+    (r.stdout or "") .. (r.stderr or ""))
+  local got = check.must(fs.read(fs.join(root, "o/thing_gen/out.txt")))
+  assert(got == "TREE",
+    "a generator's helper must come from the tree, not the binary; got: "
+    .. got)
 end
 test_a_generator_reads_its_helpers_from_the_tree()
 

--- a/docs/design/make/resolution.md
+++ b/docs/design/make/resolution.md
@@ -47,11 +47,14 @@ $ o/bin/cosmic --make build && head -2 o/_types/types_gen/cosmo.d.tl
 -- GENERATED-MARKER-XYZ from cosmopolitan's definitions.lua by …         # second build
 ```
 
-Two full builds for a one-line change to a generator's helper, and the
-first one reports `build: PASS`. This is the fixpoint
-([converge](../../../_make/converge.tl)) and the release loop's second
-`--make build` earning their keep — but they are covering for
-resolution, not for anything intrinsic.
+The first pass produces stale output and reports `build: PASS`. Nobody
+had to type the command twice, and saying so was the imprecise part of
+this analysis before the measurement below: `--make build` in a project
+that builds its own toolchain SELF-converges, so the second pass came
+from [converge](../../../_make/converge.tl) re-execing into the binary
+it had just built. The cost was a wasted pass and a wrong pass-1
+output, not a second command — and converge was silently supplying the
+repair, which is the worst place for a repair to live.
 
 **A test never runs what the graph compiled.** The `deps_*` machinery
 computes each test's transitive closure as *built* paths, makes them
@@ -343,6 +346,42 @@ loop's second `--make build` stays with it. The expectation is that
 generation 2 stops changing bytes in the common case; that is a
 measurement to take after this lands, not a claim to make before.
 
+## The fixpoint, measured
+
+The measurement this chapter deferred, taken after landing. Same
+protocol both sides: warm to a tree-built binary, edit
+`_types/gentype_render.tl` (a generator's helper the artifact embeds),
+then pin **exactly one pass** with `COSMIC_MAKE_GEN=2` so converge
+cannot supply a second.
+
+| tree | output after one pass |
+|---|---|
+| `a6688d7`, before | `-- GENERATED from …` — **stale** |
+| `b39d961`, after | `-- FIXPOINT-PROBE from …` — **current** |
+
+And afterwards, a freely-converging build is one pass that changes
+**zero bytes**. So generation 2 no longer changes the answer.
+
+**Converge stays, and its trigger is unchanged**: re-exec when the built
+artifact differs from the running binary. What changed is its ROLE. It
+was load-bearing for correctness — pass 1 could emit stale payload that
+pass 2 repaired — and it is now confirmation. The release loop's second
+`--make build` is a check rather than a requirement by the same
+argument.
+
+What still needs a second generation is the boundary this chapter
+already drew: code running INSIDE the gating binary before it spawns
+anything. The dispatcher, the artifact packer, and the `compile` step's
+own `cosmic.teal` all load from `/zip`, because a recipe step is a fresh
+cosmic with no manifest. Change one of those and pass 1 builds with the
+old one. That is why the cap is 2 rather than 1, and why it is not 1.
+
+**A note on measuring this.** The obvious experiment — clean build from
+the pin, hash, build again, hash — reports IDENTICAL on both sides and
+proves nothing. From a cold pin both sides converge by re-exec, so the
+end states agree and only the pass COUNT differs. Any future check here
+has to pin the generation.
+
 ## The gates
 
 Each claim above has a test, and each reads a
@@ -354,8 +393,12 @@ bytes ran" without trusting the thing under test to report on itself.
   require inside the project; `run` passes argv and the target's exit
   code through; a build spawned from a test resolves against *its own*
   root, never the outer one.
-- `_make/generate_test.tl` — edit a generator's helper, build **once**,
-  the output reflects it. Two builds would be the bug.
+- `_make/generate_test.tl` — a generator's helper whose import path
+  COLLIDES with one the binary embeds resolves to the tree. The
+  collision is the whole test: a fixture module with a name cosmic does
+  not ship can only ever come from the tree, so a fixture that does not
+  shadow passes before and after and proves nothing. Verified against
+  a pre-change binary, which answers `ZIP` where this answers `TREE`.
 - `cosmic/searcher_tree_test.tl` — the layers one at a time, plus the
   edges an end-to-end test cannot reach: a manifest with no root, a
   missing one, a closure entry naming a file that is not there (loud,
@@ -404,9 +447,7 @@ embedded copies; they are now measured against what the graph built.
   is the one sanctioned place a build reads the running binary's bytes
   instead of the tree's, and a silent sanctioned exception is how the
   rest of this chapter's failures got in.
-- **Whether the fixpoint shrinks.** The measurement this chapter said to
-  take after landing, not before. `converge` and the release loop's
-  second `--make build` are both still here.
+
 - **How deep a fenced build nests.** Found while writing the gates and
   recorded rather than dropped: a `--make` build run from a test that is
   itself run by a nested `--make test` — four levels of `record`, each


### PR DESCRIPTION
#832 left *"whether the fixpoint shrinks"* as a measurement to take after landing, not before. Taken.

## The result

Same protocol both sides: warm to a tree-built binary, edit `_types/gentype_render.tl` (a generator's helper the artifact embeds), then pin **exactly one pass** with `COSMIC_MAKE_GEN=2` so converge cannot supply a second.

| tree | output after one pass |
|---|---|
| `a6688d7`, before | `-- GENERATED from …` — **stale** |
| `b39d961`, after | `-- FIXPOINT-PROBE from …` — **current** |

And afterwards, a freely-converging build is one pass that changes **zero bytes**. Generation 2 no longer changes the answer.

## Converge stays

Its trigger is unchanged and correct — re-exec when the built artifact differs from the running binary. What changed is its **role**: it was load-bearing for correctness (pass 1 could emit stale payload that pass 2 repaired) and is now confirmation. The release loop's second `--make build` is a check rather than a requirement, by the same argument.

What still needs a second generation is the boundary the chapter already drew: **code running inside the gating binary before it spawns anything.** The dispatcher, the artifact packer, and the `compile` step's own `cosmic.teal` all load from `/zip`, because a recipe step is a fresh cosmic with no manifest. Change one of those and pass 1 builds with the old one. That is why the cap is 2 rather than 1 — and why it is not 1.

## Two corrections, both in the failure analysis

**"Two full builds for a one-line change" was wrong about who supplied the second.** `--make build` self-converges in a project that builds its own toolchain, so nobody typed the command twice — converge re-exec'd into the binary it had just built and silently repaired the stale pass. The real cost was a wasted pass and a wrong pass-1 output. Converge quietly repairing things is a worse story than "run it twice", and the chapter should say the true one.

**The obvious way to measure this does not work.** Clean build from the pin, hash, build again, hash → **IDENTICAL on both sides**. From a cold pin both converge by re-exec, so the end states agree and only the pass *count* differs. I ran exactly that first and nearly reported "no change". Recorded in the chapter so the next person doesn't repeat it.

## The test named for this bug could not fail

`test_a_generator_reads_its_helpers_from_the_tree` used a fixture module called `helper` — a name cosmic does not ship. So it resolved from the tree before the fix as much as after. Verified against a pre-change binary: it passes.

Replaced with the collision that *is* the bug — a fixture `_make/imports`, which the artifact carries:

```
pre-change binary  → ZIP
this one           → TREE
```

`.lua` on both sides is not incidental: the artifact ships `.tl/**` beside its compiled modules, so a `.tl` generator importing a colliding name resolves the **type** from the binary too and fails to compile before it can run. Same shadowing, one layer up — which is itself worth knowing.

## Gates

`--make ci`: **PASS (6 stages), 174 checks.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoYddHr9Lgqr9t3JpwkkUT)_