### PR TITLE
build: assert the fixpoint in the lane that already builds twice

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -197,7 +197,24 @@ jobs:
             # it is missing, it refuses.
             bin/cosmic --make fetch
             bin/cosmic --make build
+            # THE FIXPOINT. `--make build` in a project that builds its
+            # own toolchain converges by itself -- it re-execs into the
+            # binary it just built when the bytes moved -- so the
+            # explicit second build on the next line must change
+            # nothing. Asserting it costs a copy and a compare over
+            # bytes this lane already produces.
+            #
+            # What it pins: one build is enough. It does NOT prove
+            # generation 1 was right before converging (a cold pin
+            # reaches the same bytes either way, which is why the
+            # obvious hash-gen1-hash-gen2 experiment reports IDENTICAL
+            # even on a tree where generators ran stale -- see
+            # docs/design/make/resolution.md). It fires if convergence
+            # regresses, or if any step stops being idempotent.
+            cp o/bin/cosmic cosmic-converged
             o/bin/cosmic --make build
+            cmp cosmic-converged o/bin/cosmic
+            echo "fixpoint: PASS — a second build changes nothing"
             cp o/bin/cosmic cosmic-first
             # A different tree PATH, not just a different output dir: an
             # absolute path leaking into the artifact only shows up when


### PR DESCRIPTION
Follow-up to #835, which *measured* that generation 2 no longer changes the answer. Nothing guarded it, so it could silently stop being true.

## Two lines, no new lane, no extra build

`--make build` in a project that builds its own toolchain converges by itself — it re-execs into the binary it just built when the bytes moved. So the explicit second build the reproducibility step **already runs** must change nothing:

```diff
 bin/cosmic --make build
+cp o/bin/cosmic cosmic-converged
 o/bin/cosmic --make build
+cmp cosmic-converged o/bin/cosmic
+echo "fixpoint: PASS — a second build changes nothing"
 cp o/bin/cosmic cosmic-first
```

A copy and a compare over bytes the lane has already produced.

## Why not a unit test

Narrower reason than "it's slow": the property is that **this artifact's** packer, dispatcher and compiler agree with the tree's. A fixture toolchain whose `main.tl` is `print('x')` has no packer to disagree with, so it cannot exhibit the property at any level of cleverness. It needs a real artifact, which means a build.

The half that fixtures *can* reach is already covered — `_make/converge_test.tl` drives `converge.to_the_tree` in-process against toolchain fixtures and asserts each refusal by name (no artifact, not-a-fixpoint at the cap via `COSMIC_MAKE_GEN`, look-alike toolchain).

## What the check does not prove, and why the comment says so

The obvious reading is wrong, and I made that mistake first: a cold pin reaches the same bytes **whether or not** generation 1 ran stale generators, because converge repairs within the invocation. So hashing gen1 against gen2 reports IDENTICAL even on a tree with the bug — it's a confounded experiment, recorded in the chapter by #835 for the same reason.

This check pins *one build is enough*. It fires if convergence regresses, or if any step stops being idempotent. It does not pin *generation 1 was already correct* — that's what `_make/generate_test.tl`'s collision fixture does, at unit speed.

## Verified

Locally, exactly as the lane runs it, from a cold pin:

```
fixpoint: PASS — a second build changes nothing
```

`--make ci`: **PASS (6 stages), 174 checks.** `_build/workflows_test.tl` — the ratchet that reads this file — passes; `.github/**` is pruned from the model as a dotfile, so that ratchet is the gate here rather than `lint`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoYddHr9Lgqr9t3JpwkkUT)_