### PR TITLE
docs: retitle D14 — no self-hosting: make stays the graph executor

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -142,5 +142,5 @@ pinned cosmic builds one from the tree, and *that* one builds what ships
 — so a release is produced by the code it contains rather than by
 whatever the pin happens to be.
 
-The trust root's shape, and the settled decision that a pinned make is
-permanent, are recorded in [decisions/](decisions/) (D13, D14).
+The trust root's shape, and the settled decision that make stays the
+graph executor, are recorded in [decisions/](decisions/) (D13, D14).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -25,6 +25,6 @@ than editing the record it replaces.
 | D11 | sequencing: harness first | [→](d11-harness-first.md) |
 | D12 | goals and decisions are separate documents | [→](d12-goals-and-decisions-separate.md) |
 | D13 | the build's trust root is one pinned artifact behind one committed fetcher | [→](d13-trust-root.md) |
-| D14 | no self-hosting: pinned make is permanent | [→](d14-no-self-hosting.md) |
+| D14 | no self-hosting: make stays the graph executor | [→](d14-no-self-hosting.md) |
 | D15 | an artifact carries its modules and `embed/**`; shipping is opt-in | [→](d15-shipping-is-opt-in.md) |
 | D16 | every build input is enumerable from committed files, the version stamp included | [→](d16-enumerable-build-inputs.md) |

--- a/docs/decisions/d14-no-self-hosting.md
+++ b/docs/decisions/d14-no-self-hosting.md
@@ -1,4 +1,4 @@
-# D14 — no self-hosting: pinned make is permanent
+# D14 — no self-hosting: make stays the graph executor
 
 - **date:** 2026-07
 - **context:** with all build logic in `.tl` under the bootstrap,
@@ -48,3 +48,10 @@
   What make means here is now exactly the first half of the endgame
   sentence: a job-execution system and a dependency graph. Nothing
   else.
+
+  **The title carried the same stale phrase.** "Pinned make is
+  permanent" advertised the separately-pinned binary this amendment
+  retired, and sat in the index directly under D13's "one pinned
+  artifact" saying the opposite — so the record is retitled to the
+  half that is still true: make stays the graph executor. The
+  decision itself is unchanged.


### PR DESCRIPTION
Fixes #820.

The deliberate retitle the issue asked for, using its suggested wording. "Pinned make is permanent" is exactly what D14's own 2026-07 amendment retired — D13's amendment put the engine inside the cosmic release, so there is one pin and make arrives with it — and the old title sat in the index directly under D13's "one pinned artifact" saying the opposite.

Three files:

- `docs/decisions/README.md` — the D14 index row becomes **no self-hosting: make stays the graph executor**
- `docs/decisions/d14-no-self-hosting.md` — the H1 matches, and a short note at the end of the existing amendment records the retitle (the README's own rule: amending is allowed, doing it silently is not). The decision body is untouched.
- `docs/build.md` — its pointer to D13/D14 quoted the retired phrase as D14's content ("the settled decision that a pinned make is permanent") and now states the surviving half instead.

`docs/design/make/README.md`'s "the pinned make, embedded" is left alone: it describes the mechanism (make ships inside the one pinned artifact), not the retired second pin, and the phase logs are historical records.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4M1fcmewrketTSF2MLQas

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4M1fcmewrketTSF2MLQas)_