### PR TITLE
comments: say what the code does and why, not what it used to do

### DIFF
--- a/_cli/build/recipe_test.tl
+++ b/_cli/build/recipe_test.tl
@@ -233,12 +233,11 @@ test_exec_refuses_a_symlink_out_of_the_root()
 -- The other direction, because refusing everything would also pass the
 -- test above: a link INSIDE the root still runs.
 --
--- The root is BUILT here, not borrowed from the repo. It used to point
--- at the real `o/bin/` and drop a symlink beside the binary under test,
--- which is a test writing into the tree's build output -- fine while
--- nothing stopped it, and denied the moment the fence became the
--- default. A test may write its own scratch and nothing else, so the
--- program is a copy and the link is beside the copy.
+-- The root is BUILT here, not borrowed from the repo. Pointing at the
+-- real `o/bin/` and dropping a symlink beside the binary under test
+-- is a test writing into the tree's build output -- and the fence
+-- denies exactly that. A test may write its own scratch and nothing
+-- else, so the program is a copy and the link is beside the copy.
 local function test_exec_allows_a_symlink_inside_the_root()
   local root = fs.join(tmpdir, "exec-linked-root")
   fs.rmrf(root)

--- a/_cli/check.tl
+++ b/_cli/check.tl
@@ -6,12 +6,12 @@
 --- take a project and the flag takes a file, so a rule can check one
 --- file without re-scanning the tree for every one of them.
 ---
---- It used to be four arbitrary pairs — `format`/`fmt`, `style`/`lint`,
---- `examples`/`example` — which cost a translation table in this file
---- and a second copy of it in the argument parser, purely so an error
---- message could tell you the other name for the thing you just typed.
---- Two names for one concept is a tax on every reader; the table below
---- is what is left of it.
+--- The flag names ARE the verb names, not synonyms for them. Arbitrary
+--- pairs — `format`/`fmt`, `style`/`lint`, `examples`/`example` — cost
+--- a translation table in this file and a second copy of it in the
+--- argument parser, purely so an error message can tell you the other
+--- name for the thing you just typed. Two names for one concept is a
+--- tax on every reader.
 ---
 --- `types` is the deliberate exception, because the identity would be
 --- `--check check`, which is not a sentence. One exception you can see

--- a/_make/artifact.tl
+++ b/_make/artifact.tl
@@ -178,9 +178,9 @@ end
 --- path minus extension>/`**, which is already how `_types/types_gen.tl`
 --- gets `o/_types/types_gen/`. Nothing else writes there, so the engine
 --- clears it before each run and a name the generator stops emitting
---- stops shipping. Why it is not `o/<unit>/`, where it used to be — the
---- build's own bookkeeping lives there — is in
---- docs/design/make/model.md.
+--- stops shipping. Why it is not `o/<unit>/` — the build's own
+--- bookkeeping lives there, and clearing it would take that too — is
+--- in docs/design/make/model.md.
 --- @param unit string The unit's directory, "" for the root
 --- @return string `o/<unit>/embed_gen`, relative to the project root
 local function gen_dir(unit: string): string

--- a/_make/artifact_test.tl
+++ b/_make/artifact_test.tl
@@ -480,8 +480,8 @@ local function test_generated_payload_stages_like_committed()
   assert(fs.write(fs.join(root, unit .. "/.types/cosmo.d.tl"), "return {}\n"))
   assert(fs.makedirs(fs.join(root, "o/embed_gen/embed")))
   assert(fs.write(fs.join(root, "o/embed_gen/embed/shared.lua"), "return {}\n"))
-  -- The build's own notes sit where the payload used to, and must not
-  -- ship: the collision that made the move worth making.
+  -- The build's own notes share `o/<unit>/`, and must not ship: the
+  -- collision that is why generated payload has its own directory.
   assert(fs.makedirs(fs.join(root, "o/cmd/tool/embed")))
   assert(fs.write(fs.join(root, "o/cmd/tool/embed/committed.txt.lint.got"), "0"))
 

--- a/_make/build_test.tl
+++ b/_make/build_test.tl
@@ -283,10 +283,10 @@ local function test_a_changed_contract_recompiles_its_importers()
 
   -- The same property for a DECLARATION. The checker resolves
   -- `require("ffi")` to `ffi.d.tl` when one sits beside `ffi.lua` -- the
-  -- pattern the validator explicitly protects -- but `.d.tl` was excluded
-  -- from the closure, so editing the declaration moved no listed
-  -- prerequisite's mtime and importers were never re-checked. Reproduced
-  -- before the fix: incremental PASS, clean FAIL, on one tree.
+  -- pattern the validator explicitly protects -- so a closure that
+  -- excludes `.d.tl` means editing the declaration moves no listed
+  -- prerequisite's mtime and importers are never re-checked:
+  -- incremental PASS, clean FAIL, on one tree.
   local function test_a_changed_declaration_recompiles_its_importers()
     local root = fixture("declaration", {
         ["ffi.lua"] = 'return { greet = function(n) return "hi " .. n end }\n',
@@ -379,9 +379,9 @@ local function test_a_test_reruns_only_for_what_it_imports()
   -- And the closure travels in the line, which is what the fence
   -- grants. Asserted against the FACTS rather than a recipe echo:
   -- `o/project.mk` is where the closure is computed and the rule reads
-  -- it as `--deps $(deps_$*)`. make runs silently now, so the echo is
-  -- no longer a place this claim can be read -- and the facts file
-  -- always was the better one.
+  -- it as `--deps $(deps_$*)`. make runs silently (`-s`), so a recipe
+  -- echo is not a place this claim can be read -- and the facts file
+  -- is the better one regardless.
   local facts = check.must(fs.read(fs.join(root, "o/project.mk")))
   assert(facts:find("deps_db/a_test := o/db/init.lua", 1, true),
     "a_test's closure is its import, computed into the facts: " .. facts)

--- a/_make/check_test.tl
+++ b/_make/check_test.tl
@@ -275,11 +275,12 @@ local function test_fmt_fix_rewrites()
 end
 test_fmt_fix_rewrites()
 
--- `help` is a verb you asked for, so it succeeds on stdout. It used to
--- reach the reader only as the unknown-verb error's incidental output --
--- the right text, on stderr, under exit 1 -- while docs/build.md told
--- people to run it. It also answers outside a project root, which is
--- where "what are the verbs" gets asked.
+-- `help` is a verb you asked for, so it succeeds on stdout. Without
+-- the verb, the text reaches the reader only as the unknown-verb
+-- error's incidental output -- the right text, on stderr, under exit 1
+-- -- while docs/build.md tells people to run it. It also answers
+-- outside a project root, which is where "what are the verbs" gets
+-- asked.
 local function test_help_is_a_verb()
   local root = app("help")
   local h = make(root, "help")

--- a/_make/deps.tl
+++ b/_make/deps.tl
@@ -25,10 +25,10 @@ local type Project = types.Project
 ---
 --- `types` is here because the type checker resolves `require("ffi")`
 --- to `ffi.d.tl` when one exists -- the sanctioned `.d.tl`-beside-`.lua`
---- pattern the validator protects. Leaving it out meant a declaration's
---- contract could change with no listed prerequisite's mtime moving, so
---- importers were never re-checked: incremental build PASS, clean build
---- FAIL, on the same tree. Reproduced before the fix.
+--- pattern the validator protects. Leaving it out lets a declaration's
+--- contract change with no listed prerequisite's mtime moving, so
+--- importers are never re-checked: incremental build PASS, clean build
+--- FAIL, on the same tree.
 ---
 --- A `.d.tl` is a SOURCE dependency only. It compiles to nothing, so
 --- `built_paths` skips it -- listing `o/ffi.lua` for a declaration that

--- a/_make/fixpoint_test.tl
+++ b/_make/fixpoint_test.tl
@@ -88,11 +88,10 @@ local function seed_pins(dest: string): boolean
     {"cosmos", "lua-debug", "o/3p/cosmos/lua-debug"},
   }
   for _, w in ipairs(want) do
-    -- `o/3p` is where `--make fetch` unpacks a pin, and now the only
-    -- place: this used to fall back to `o/staged/<dep>/<ver>-<sha>/`,
-    -- which the Makefile pipeline wrote and nothing writes any more.
-    -- A fallback to a directory no code produces is not a fallback,
-    -- it is a branch that can only ever return nil.
+    -- `o/3p` is where `--make fetch` unpacks a pin, and the ONLY
+    -- place this looks: a fallback to some second location nothing
+    -- writes (`o/staged/**` is the retired candidate) is not a
+    -- fallback, it is a branch that can only ever return nil.
     local from = fs.join(repo, w[3])
     if not fs.isfile(from) then
       return false

--- a/_make/generate.tl
+++ b/_make/generate.tl
@@ -98,10 +98,10 @@ end
 --- an input that goes away has to take its output with it: a renamed
 --- module leaving the old name behind means the artifact ships a file
 --- no source produces, and the next `--make build` embeds it again.
---- Cosmic's own generator happened to clear its directory itself,
---- which made the whole class look handled; a project whose generator
---- does not would have shipped stale payload with no way to notice
---- short of `--make clean`.
+--- Cosmic's own generator clears its directory itself, which makes
+--- the whole class LOOK handled; a project whose generator does not
+--- would ship stale payload with no way to notice short of
+--- `--make clean`, so the engine clears for everyone.
 ---
 --- Safe only because the directory is the GENERATOR's -- `o/<its path
 --- minus extension>/` -- and holds nothing else. Handing a generator

--- a/_make/generate_test.tl
+++ b/_make/generate_test.tl
@@ -89,12 +89,11 @@ local function make(dir: string, ...: string): integer, string
   return r.code or 128, (r.stdout or "") .. (r.stderr or "")
 end
 
---- Whether `o/3p/**` holds everything the generator reads.
----
---- It used to also COPY, from an `o/staged/**` tree the Makefile
---- pipeline wrote. Nothing writes that tree now, so the copy could
---- only ever be skipped, and what is left is the question it was
---- guarding: has this tree fetched?
+--- Whether `o/3p/**` holds everything the generator reads — the
+--- question is exactly "has this tree fetched?". A copy step from some
+--- other staging tree does not belong here: a source nothing writes
+--- can only ever be skipped, and a helper that copies sometimes is a
+--- helper whose answer depends on which tree it ran in.
 --- @param repo string The project root
 --- @return boolean True when every pinned input is in place
 local function seed_pins(repo: string): boolean
@@ -242,8 +241,9 @@ test_the_root_generator_runs_for_cmd_binaries()
 local function test_in_process_build_runs_the_generator()
   -- The generator imports a project MODULE, so the in-process path
   -- runs the mini-graph too: compile the closure, write the manifest,
-  -- hand it over. A generator that imports only `cosmic.*` has an empty
-  -- closure and skips all of it, which is what this fixture used to be.
+  -- hand it over. A generator that imports only `cosmic.*` has an
+  -- empty closure and skips all of it — a fixture shaped that way
+  -- would leave this test green while the mini-graph never ran.
   local root = fixture("inproc", {
       ["note.tl"] = "local record N\n  text: function(): string\nend\n"
       .. 'local n: N = {text = function(): string return "from the generator" end}\n'
@@ -364,17 +364,17 @@ test_the_real_payload_generator()
 -- A generator's helpers come from the TREE, even when the BINARY ships
 -- a module by that name.
 --
--- The collision is the whole test. A generator used to resolve its own
--- imports out of the running binary, so a helper the artifact also
--- embedded was a generation behind -- and a fixture module with a name
--- cosmic does not ship can only ever come from the tree, before the fix
--- as much as after. An earlier version of this test used `helper`,
--- which is exactly that shape: it passed against a pre-change binary,
--- so it proved nothing about the thing it was named for.
+-- The collision is the whole test. A generator that resolves its own
+-- imports out of the running binary serves a helper the artifact also
+-- embeds from a generation behind -- while a fixture module with a
+-- name cosmic does not ship can only ever come from the tree, under
+-- either resolution. Naming the fixture `helper` is exactly that
+-- second shape: the test passes against a binary with the bug, so it
+-- proves nothing about the thing it is named for.
 --
 -- `_make/imports` collides with a module the artifact carries. Verified
--- both ways by hand: a pre-change binary answers ZIP here, this one
--- answers TREE.
+-- both ways by hand: a binary resolving zip-first answers ZIP here,
+-- this one answers TREE.
 --
 -- `.lua` on both sides, and that is not incidental. The artifact ships
 -- `.tl/**` beside its compiled modules, so a `.tl` generator importing

--- a/_make/resolution_test.tl
+++ b/_make/resolution_test.tl
@@ -67,9 +67,9 @@ local function make(root: string, argv: {string},
 end
 
 -- The failure this exists to kill: a test scheduled and fenced against
--- `o/greet/init.lua` used to load `./greet/init.tl` instead -- the
--- source, lax-compiled -- so the graph's own output was never the thing
--- under test.
+-- `o/greet/init.lua` that loads `./greet/init.tl` instead -- the
+-- source, lax-compiled -- is a test the graph's own output never
+-- reaches.
 local function test_a_test_loads_what_the_graph_built()
   local root = fixture("built")
   assert(fs.write(fs.join(root, "greet", "greet_test.tl"), [[
@@ -126,8 +126,8 @@ os.exit(7)
 end
 test_run_passes_argv_and_exit_code_through()
 
--- A binary NAME is the spelling the design's verb table used to
--- promise, so it gets a sentence rather than "no such selection".
+-- A binary NAME is the rejected `run [binary]` spelling, so it is the
+-- one wrong guess worth a sentence rather than "no such selection".
 local function test_run_refuses_a_binary_name()
   local root = fixture("name")
   assert(fs.write(fs.join(root, "main.tl"), 'io.write("x")\n'))

--- a/_make/runverb.tl
+++ b/_make/runverb.tl
@@ -1,10 +1,10 @@
 --- `run <path> [args…]` — build, then run that source against the tree.
 ---
---- **Paths, never binary names.** `verbs.md` used to promise `run
---- [binary]`: build, then exec `o/bin/<name>`. That form has no caller,
---- here or anywhere — a built binary is already executable, so the verb
---- bought a rebuild and two saved tokens. The source form is what every
---- caller in this repo needs and none of them can spell today:
+--- **Paths, never binary names.** The rejected form is `run [binary]`
+--- — build, then exec `o/bin/<name>` — and it has no caller, here or
+--- anywhere: a built binary is already executable, so that verb buys a
+--- rebuild for two saved tokens. The source form is what every caller
+--- in this repo needs and none of them can spell otherwise:
 --- `_perf/run.tl` and `_perf/gate.tl` (four documented commands),
 --- `_docs/publish.tl` from `docs.yml`, and `_types/gentype.tl` after a
 --- pin bump. `run cosmic` refuses, naming `o/bin/cosmic`.
@@ -64,8 +64,8 @@ end
 --- a source the model knows.
 ---
 --- A binary name gets its own sentence rather than "no such selection":
---- it is the spelling `verbs.md` used to promise, so it is the one
---- wrong guess worth answering precisely.
+--- it is the rejected `run [binary]` spelling, so it is the one wrong
+--- guess worth answering precisely.
 --- @param proj Project The scanned project
 --- @param paths {string} The selection paths, as typed
 --- @return boolean Whether the selection names something

--- a/_make/selection_test.tl
+++ b/_make/selection_test.tl
@@ -179,9 +179,9 @@ end
 test_whole_project_verbs_refuse_paths()
 
 -- The refusal comes BEFORE the build. In a project whose own binary is
--- the toolchain the gate converges into, a typo used to cost a full
--- rebuild before the two-line complaint; the model already knows the
--- answer, so the answer is given from the model.
+-- the toolchain the gate converges into, refusing after would price a
+-- typo at a full rebuild before the two-line complaint; the model
+-- already knows the answer, so the answer is given from the model.
 local function test_a_bad_selection_refuses_before_building()
   local root = app("earlyrefusal")
   local r = make(root, "test", "nope")

--- a/_types/gentype.tl
+++ b/_types/gentype.tl
@@ -80,8 +80,8 @@ local function process_class_block(anno_lines: {string}, module_name: string, cl
   end
 end
 
---- True when an annotation block carries a `---@type` tag (used to surface
---- lowercase module-table fields such as `argon2.variants`).
+--- True when an annotation block carries a `---@type` tag (the tag that
+--- surfaces lowercase module-table fields such as `argon2.variants`).
 local function has_type_annotation(anno_lines: {string}): boolean
   for _, line in ipairs(anno_lines) do
     if line:match("^%s*%-%-%-?%s*@type%s") then

--- a/cmd/cosmic/embed_gen.tl
+++ b/cmd/cosmic/embed_gen.tl
@@ -396,10 +396,9 @@ local function generate(out: string): string
   -- The directory handed over is this generator's own —
   -- `o/cmd/cosmic/embed_gen` — cleared and created by the engine
   -- before the call, so a name this generator stops writing stops
-  -- shipping without anything here to remember it. That used to be
-  -- this file's job, and it could only ever be this file's job while
-  -- the directory was the unit's output, shared with the compiled
-  -- entry the build puts there.
+  -- shipping without anything here to remember it. Remembering would
+  -- be this file's job only if the directory were the unit's output,
+  -- shared with the compiled entry the build puts there; it is not.
   local dest = fs.join(out, PAYLOAD_DIR)
   local mok, merr = fs.makedirs(dest)
   if not mok then

--- a/cosmic/child/io.tl
+++ b/cosmic/child/io.tl
@@ -50,8 +50,8 @@ end
 --- ours goes instead of being captured and withheld until exit.
 ---
 --- It resolves to the same "caller supplied this descriptor" path a
---- Handle takes, which spawn never closes -- so callers no longer have
---- to reach for fd.wrap(1), which cosmic.fd explicitly does not model.
+--- Handle takes, which spawn never closes -- so a caller never has to
+--- reach for fd.wrap(1), which cosmic.fd explicitly does not model.
 local enum StdioMode
   "inherit"
 end

--- a/cosmic/cosmic_test.tl
+++ b/cosmic/cosmic_test.tl
@@ -61,14 +61,14 @@ test_cosmic_main_exists()
 -- `cosmic.main(fn)` RUNS fn and exits with its code. It does not ask
 -- whether its caller is the main chunk, and cannot: `cosmo.is_main()`
 -- answers for the chunk that CALLS it, and that chunk is always
--- `cosmic/init.tl`. The guard it used to carry was therefore false
--- every time, so every caller silently did nothing.
+-- `cosmic/init.tl`. A guard there is therefore false every time, and
+-- every caller silently does nothing.
 --
 -- In a child, because the exit IS the contract: asserting it in this
--- process would end the run. The old test called `cosmic.main` inline,
--- so `os.exit(0)` fired inside the call, its assertion never ran, and
--- exit 0 graded as PASS -- a test that could not fail, and one that
--- would have silently swallowed anything appended after it.
+-- process would end the run. Calling `cosmic.main` inline instead
+-- fires `os.exit(0)` inside the call, so the assertion never runs and
+-- exit 0 grades as PASS -- a test that cannot fail, and one that
+-- silently swallows anything appended after it.
 local function test_cosmic_main_runs_fn_and_exits_with_its_code()
   local script = fs.join(tmpdir, "cosmic_main_exit.tl")
   assert(fs.write(script, table.concat({

--- a/cosmic/coverage/init.tl
+++ b/cosmic/coverage/init.tl
@@ -231,8 +231,8 @@ local function enable_from_env(): function()
   end
   enable(dir)
   return function()
-    -- A dump that FAILS says so. It used to discard `dump`'s status,
-    -- which makes the one failure mode that matters — collection armed,
+    -- A dump that FAILS says so. Discarding `dump`'s status instead
+    -- makes the one failure mode that matters — collection armed,
     -- work done, and the result unwritable — indistinguishable from
     -- code that never ran. The symptom surfaces much later and
     -- somewhere else: a ratchet reporting a file at 14% because the

--- a/cosmic/env.tl
+++ b/cosmic/env.tl
@@ -10,13 +10,12 @@ local errstr = require("cosmic.errno").str
 --- Get the value of an environment variable, or nil when it is not set.
 ---
 --- **The nil is in the type**, which is the whole point of this
---- function's shape. It used to take an optional default and return a
---- bare `string`, and that was a lie the checker could not see: with no
---- default the body returns the parameter, which is `string` inside the
---- function and nil at the call site. `local v: string = env.get("X")`
---- type-checked strictly and crashed on the next line. A reading that
---- can fail says so, and the caller narrows -- see `get_or` for the
---- half that cannot fail.
+--- function's shape. An optional default with a bare `string` return
+--- is a lie the checker cannot see: with no default the body returns
+--- the parameter, which is `string` inside the function and nil at the
+--- call site, so `local v: string = env.get("X")` type-checks strictly
+--- and crashes on the next line. A reading that can fail says so, and
+--- the caller narrows -- see `get_or` for the half that cannot fail.
 --- @param name string The name of the environment variable
 --- @return string|nil The value, or nil when the variable is not set
 local function get(name: string): string | nil

--- a/cosmic/env_test.tl
+++ b/cosmic/env_test.tl
@@ -157,12 +157,12 @@ test_get_default_empty_value_wins()
 
 -- The bug this shape closes, asserted where it lives: in the TYPE.
 --
--- `get` used to take an optional default and declare a bare `string`
--- return. With no default the body returns the parameter -- `string`
--- inside the function, nil at the call site -- so the checker never saw
--- the nil escape and an unguarded use of the result type-checked
--- strictly, then crashed. That is a silent bug of exactly the class the
--- honest-nil rule exists to stop.
+-- A `get` with an optional default and a bare `string` return hides
+-- the failure. With no default the body returns the parameter --
+-- `string` inside the function, nil at the call site -- so the checker
+-- never sees the nil escape, and an unguarded use of the result
+-- type-checks strictly, then crashes. That is a silent bug of exactly
+-- the class the honest-nil rule exists to stop.
 --
 -- What the honest type buys, precisely: Teal 0.24.8 checks nilability at
 -- the USE, not at the assignment. `local v: string = get(x)` is still

--- a/cosmic/format/types_test.tl
+++ b/cosmic/format/types_test.tl
@@ -9,8 +9,8 @@
 --
 -- They are regression tests in the strict sense. A formatter's output
 -- is idempotent, so the gate re-blesses its own damage on every run —
--- which is how two files came to ship mis-indented with `--make fmt`
--- reporting PASS. Nothing here is caught by the gate; only by these.
+-- two files shipped mis-indented with `--make fmt` reporting PASS.
+-- Nothing here is caught by the gate; only by these.
 
 local fmt = require("cosmic.format")
 

--- a/cosmic/init.tl
+++ b/cosmic/init.tl
@@ -21,11 +21,11 @@ end
 ---
 --- It does NOT check `is_main` itself, and cannot: `cosmo.is_main()`
 --- answers for the chunk that CALLS it, and this chunk is always
---- `cosmic/init.tl`, never your script. The guard it used to carry was
---- therefore false every time, so every caller silently did nothing —
---- and the test that covered it asserted the function existed rather
---- than that it ran. A file that is both a module and a script asks in
---- its OWN chunk, where the answer is about that file:
+--- `cosmic/init.tl`, never your script. A guard here is therefore
+--- false every time, and every caller silently does nothing — a
+--- failure a test that asserts the function exists cannot see. A file
+--- that is both a module and a script asks in its OWN chunk, where the
+--- answer is about that file:
 ---
 ---     if proc.is_main() then
 ---       cosmic.main(function(args: {string}): number, string … end)

--- a/cosmic/literal_test.tl
+++ b/cosmic/literal_test.tl
@@ -151,8 +151,8 @@ test_deep_nesting_is_refused_not_thrown()
 -- module; these are the other two, and they are the same bug wearing
 -- different clothes. A token that LEXES is not a value that EXISTS.
 --
--- Both are reachable from a pin, so both used to crash `--make fetch`
--- with a traceback where a named refusal belongs.
+-- Both are reachable from a pin, where a throw is a `--make fetch`
+-- traceback standing where a named refusal belongs.
 local function test_a_crafted_value_is_refused_not_thrown()
   -- `%x+` has no length limit, so the escape parses and the code point
   -- is past what utf8.char takes.

--- a/cosmic/records_test.tl
+++ b/cosmic/records_test.tl
@@ -31,8 +31,8 @@ test_display_names_the_source()
 -- The label is not a path. `display` keeps `.coverage/` so the row says
 -- which run produced it, and nothing is on disk at that name -- so a
 -- caller that READS the source needs the segment gone. Reading the
--- label instead is indistinguishable from an absent file, which is how
--- every coverage row came to report zero test functions.
+-- label instead is indistinguishable from an absent file, which reads
+-- back as every coverage row reporting zero test functions.
 local function test_source_of_names_a_readable_path()
   assert(records.source_of("o/.coverage/cosmic/sys_test.tl.test") ==
     "cosmic/sys_test.tl", "the coverage tree is not part of the path")

--- a/cosmic/searcher.tl
+++ b/cosmic/searcher.tl
@@ -145,7 +145,7 @@ end
 --- of this repo's own tests spawn a cosmic against a different project
 --- root, and an inherited path would answer their imports out of THIS
 --- tree while they build something else. That is the ambient-export
---- bug class the old build fought and it is why there is no env var.
+--- bug class, and it is why there is no env var.
 
 --- Absolute project root, or nil when no manifest was installed.
 local tree_root: string | nil = nil

--- a/cosmic/time_parse_test.tl
+++ b/cosmic/time_parse_test.tl
@@ -136,7 +136,8 @@ end
 test_parse_date_rejects_datetime()
 
 local function test_parse_date_out_of_range()
-  -- structurally well-formed but semantically invalid: no longer swallowed
+  -- Structurally well-formed but semantically invalid: a parse that
+  -- checks only the shape accepts both of these.
   assert(time.parse_date("2025-14-01") == nil, "month 14 should be rejected")
   assert(time.parse_date("2025-01-99") == nil, "day 99 should be rejected")
 end


### PR DESCRIPTION
Fixes #809.

The standalone prose commit the issue asked for: every comment the issue's grep finds that narrates the code's former behavior is rewritten as a counterfactual — same failure mode, no timestamp — across `cosmic/`, `_make/`, `_cli/`, `cmd/`, and `_types/`. 26 files, 114/−116 lines, prose only.

Applied with the issue's two cautions:

**Load-bearing history is kept, as "X does not work because Y".** The rejected `run [binary]` spelling stays named in `runverb.tl` and `resolution_test.tl` (it is why a binary name earns a precise answer); `generate_test.tl` keeps the explanation of why a fixture named `helper` proves nothing; the formatter regression headers keep their incident evidence ("two files shipped mis-indented with `--make fmt` reporting PASS") minus the narrating idiom.

**Nothing was deleted to a bare mechanism.** Each rewrite preserves the failure mode as the reason the code looks the way it does — e.g. `env.tl`'s "an optional default with a bare `string` return is a lie the checker cannot see", `coverage/init.tl`'s "discarding `dump`'s status makes the one failure mode that matters indistinguishable from code that never ran".

Deliberately untouched, for the record: "the old value/contents/inode/PID ns" (runtime state, e.g. `shm.tl`'s atomics), "previously returned/defined" (API semantics), "as if it had been committed" (a simile in `artifact.tl`/`artifact_test.tl`), "no longer" clauses describing runtime conditions, and two lines the grep only appears to hit — "ref**used to**o" in `embed/extract.tl:37` and `_make/fetch.tl:168`. After the sweep, every remaining grep hit is one of these classes.

## Gates

- full `bin/cosmic --make ci` — **`ci: PASS (6 stages)`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4M1fcmewrketTSF2MLQas

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4M1fcmewrketTSF2MLQas)_