### PR TITLE
build: a ratchet requires the value it checks, rather than parsing for it

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -1,5 +1,6 @@
 # coverage ratchet baseline: `cosmic --make coverage --baseline` rewrites this file.
 # columns: path covered-lines total-lines
+_build/ratchet.tl 36 36
 _cli/args.tl 0 31
 _cli/build/init.tl 43 47
 _cli/build/modules.tl 46 49
@@ -13,8 +14,8 @@ _cli/main_handlers.tl 11 220
 _cli/require_hints.tl 104 124
 _cli/run.tl 28 33
 _cli/welcome.tl 0 25
-_docs/publish.tl 116 176
 _docs/derive.tl 54 81
+_docs/publish.tl 116 176
 _make/artifact.tl 163 180
 _make/binaries.tl 24 24
 _make/check.tl 56 57
@@ -37,7 +38,7 @@ _make/root.tl 53 58
 _make/runverb.tl 64 72
 _make/select.tl 33 35
 _make/stage.tl 88 96
-_make/types.tl 26 26
+_make/types.tl 39 39
 _make/validate.tl 208 212
 _perf/bench/child_bench.tl 0 11
 _perf/bench/embed_bench.tl 0 88
@@ -66,7 +67,7 @@ _types/gentype_render.tl 295 311
 _types/gentype_types.tl 2 2
 _types/types_gen.tl 0 44
 cmd/cosmic/embed_gen.tl 0 166
-cmd/cosmic/main.tl 0 275
+cmd/cosmic/main.tl 0 272
 cosmic/_script_cache.tl 72 79
 cosmic/ansi.tl 86 86
 cosmic/benchmark.tl 180 212
@@ -173,4 +174,4 @@ cosmic/user.tl 48 61
 cosmic/uuid.tl 9 9
 cosmic/zip.tl 80 93
 tlconfig.lua 7 7
-total 13286 17558
+total 13389 17685

--- a/_build/ratchet.tl
+++ b/_build/ratchet.tl
@@ -1,0 +1,117 @@
+--- Markdown tables of a committed document, read as rows.
+---
+--- The ratchets in this directory all ask one question of a document --
+--- what does this table teach, and where -- and each used to answer it
+--- with its own inline scan. Three copies of a markdown parser is three
+--- chances to write one that passes a table it never actually read: the
+--- scan in `skills_test.tl` fell back to *no rows* if a heading was
+--- renamed, and only an `assert(#out > 0)` bolted on afterwards caught
+--- it.
+---
+--- So the scan lives here, once, with `ratchet_test.tl` behind it. A
+--- ratchet is only as good as the reader under it, and a reader nobody
+--- tests is the weakest link in a chain built to be trusted.
+---
+--- The rest of a ratchet -- what each row must say, and against which
+--- value -- stays in the test. That part is the judgement; this part is
+--- just bytes.
+
+local fs = require("cosmic.fs")
+
+--- One row of a markdown table.
+local record Row
+  --- The first cell, trimmed. This is the row's subject: the marker,
+  --- the verb, the name the row is about.
+  cell: string
+  --- The whole line, for a check that reads the other cells.
+  line: string
+  --- `path:line`, so a failure names where to go.
+  where: string
+end
+
+--- A markdown table's rows, optionally only those under one heading.
+---
+--- A `|`-led line is a row unless it is the separator (`|---|---|`) or
+--- the header itself, which callers name so it is skipped by content
+--- rather than by counting: a table that grows a column still reads,
+--- and a table whose header moved does not silently shift by one.
+--- @param path string The document to read
+--- @param heading string|nil A `## ` heading to confine the scan to
+--- @param header string|nil The first cell of the header row, skipped
+--- @return {Row}|nil The rows, in file order
+--- @return string An error naming the document
+local function rows(path: string, heading?: string,
+    header?: string): {Row} | nil, string
+  local text, err = fs.read(path)
+  if not text then
+    return nil, path .. ": " .. (err or "cannot be read")
+  end
+  local out: {Row} = {}
+  local scanning = heading == nil
+  local n = 0
+  -- `string.gmatch` rather than `text:gmatch`: method syntax does not
+  -- see through the narrowing the guard above just did.
+  for line in string.gmatch(text, "([^\n]*)\n?") do
+    n = n + 1
+    -- A heading only turns the scan off for a caller that asked for
+    -- one. Without that guard the unfiltered scan -- every table in the
+    -- file -- stops dead at the document's first `## `, and reads like
+    -- a document with nothing in it.
+    if heading ~= nil and line:sub(1, 3) == "## " then
+      scanning = line == "## " .. heading
+    elseif scanning and line:sub(1, 1) == "|" then
+      local cell = line:match("^|%s*(.-)%s*|")
+      -- A separator cell is dashes and colons; an empty first cell is a
+      -- continuation, and neither is a row with a subject.
+      if cell and cell ~= "" and cell ~= header
+      and not cell:match("^[-: ]*$") then
+        out[#out + 1] = {cell = cell, line = line, where = path .. ":" .. n}
+      end
+    end
+  end
+  return out
+end
+
+--- The backticked names in a cell, in order.
+---
+--- A row's subject is not always one name: `` `reproducible` `offline` ``
+--- is one cell naming two verbs, and reading the cell whole would look
+--- for a verb spelled that way and never find either.
+--- @param cell string The cell text
+--- @return {string} The names, without their backticks
+local function names(cell: string): {string}
+  local out: {string} = {}
+  for name in cell:gmatch("`([^`]+)`") do
+    out[#out + 1] = name
+  end
+  return out
+end
+
+--- Does some row's first cell contain this text?
+--- @param list {Row} The rows to search
+--- @param marker string The text looked for, as a substring
+--- @return Row|nil The first row that carries it
+local function bearing(list: {Row}, marker: string): Row | nil
+  for _, row in ipairs(list) do
+    if row.cell:find(marker, 1, true) then
+      return row
+    end
+  end
+  return nil
+end
+
+local record RatchetModule
+  type Row = Row
+  rows: function(path: string, heading?: string,
+  header?: string): {Row} | nil, string
+  names: function(cell: string): {string}
+  bearing: function(list: {Row}, marker: string): Row | nil
+end
+
+local M: RatchetModule = {
+  rows = rows,
+  names = names,
+  bearing = bearing,
+}
+
+return M

--- a/_build/ratchet_test.tl
+++ b/_build/ratchet_test.tl
@@ -1,0 +1,129 @@
+#!/usr/bin/env cosmic
+-- The reader every document ratchet stands on.
+--
+-- A ratchet that reads no rows passes everything, silently, and reads
+-- exactly like a ratchet that read them all. That is the failure worth
+-- testing for here: not "does it parse a table" but "does it come back
+-- empty when it should have found something, and does it stop at the
+-- heading it was given".
+
+local check = require("cosmic.check")
+local fs = require("cosmic.fs")
+local ratchet = require("_build.ratchet")
+
+local DOC < const > = [[
+# a document
+
+## Verbs
+
+| verb | what it does | today |
+|---|---|---|
+| `build` | compile the tree | yes |
+| `reproducible` `offline` | policy lanes | planned |
+
+prose between the tables.
+
+## The project model
+
+| marker | declares |
+|:--|--:|
+| `*_test.tl` | a test |
+| everything else | never embedded |
+]]
+
+--- The fixture document, written into this run's temp directory.
+--- @return string The path
+local function doc(): string
+  local path = fs.join(check.must(os.getenv("TEST_TMPDIR")), "doc.md")
+  assert(fs.write(path, DOC))
+  return path
+end
+
+--- The first cells of some rows.
+--- @param rows {ratchet.Row} The rows
+--- @return {string} Their cells, in order
+local function cells(rows: {ratchet.Row}): {string}
+  local out: {string} = {}
+  for _, row in ipairs(rows) do
+    out[#out + 1] = row.cell
+  end
+  return out
+end
+
+-- A heading confines the scan, and the header row and separator are
+-- not rows. The separator pattern has to admit alignment colons --
+-- `|:--|--:|` is a separator, and a reader that took it for a row
+-- would report a cell of dashes as something the document teaches.
+local function test_a_heading_confines_the_scan()
+  local path = doc()
+  local got = cells((check.must(ratchet.rows(path, "Verbs", "verb"))))
+  assert(#got == 2, "expected the two verb rows, got " .. #got ..
+    ": " .. table.concat(got, " / "))
+  assert(got[1] == "`build`", "got: " .. got[1])
+  assert(got[2] == "`reproducible` `offline`", "got: " .. got[2])
+
+  local model = cells((check.must(ratchet.rows(path, "The project model",
+          "marker"))))
+  assert(#model == 2, "expected the two model rows, got " .. #model)
+  assert(model[1] == "`*_test.tl`", "got: " .. model[1])
+end
+test_a_heading_confines_the_scan()
+
+-- No heading is every table in the file. This is what the checks that
+-- sweep a whole document for a retired word use, and a reader that
+-- quietly scoped itself to the first table would let the rest through.
+local function test_no_heading_reads_every_table()
+  local got = cells((check.must(ratchet.rows(doc()))))
+  assert(#got == 6, "expected every row of both tables plus the two " ..
+    "unfiltered headers, got " .. #got .. ": " .. table.concat(got, " / "))
+end
+test_no_heading_reads_every_table()
+
+-- A heading that is not there returns no rows rather than falling back
+-- to the whole file. Empty is the honest answer; the CALLER is what
+-- must refuse it, which is why every ratchet asserts on the count.
+local function test_a_missing_heading_finds_nothing()
+  local got = check.must(ratchet.rows(doc(), "Nonexistent", "verb"))
+  assert(#got == 0, "a heading that is not in the document must " ..
+    "match nothing, got " .. #got .. " rows")
+end
+test_a_missing_heading_finds_nothing()
+
+-- A row's subject can name more than one thing.
+local function test_a_cell_yields_its_backticked_names()
+  local two = ratchet.names("`reproducible` `offline`")
+  assert(#two == 2 and two[1] == "reproducible" and two[2] == "offline",
+    "got: " .. table.concat(two, ", "))
+  assert(#ratchet.names("everything else") == 0,
+    "a cell with no backticks names nothing")
+  local one = ratchet.names("`cmd/<name>/embed_gen.tl`")
+  assert(#one == 1 and one[1] == "cmd/<name>/embed_gen.tl",
+    "got: " .. table.concat(one, ", "))
+end
+test_a_cell_yields_its_backticked_names()
+
+-- `bearing` searches first cells by substring, never by pattern: a
+-- marker is full of `*`, `.` and `-`, and matching it as a pattern is
+-- how a check passes against a row it did not actually find.
+local function test_bearing_finds_a_row_by_substring()
+  local rows = check.must(ratchet.rows(doc(), "The project model", "marker"))
+  local hit = check.must(ratchet.bearing(rows, "`*_test.tl`"))
+  assert(hit.line:find("a test", 1, true), "the whole line comes back " ..
+    "so a check can read the other cells: " .. hit.line)
+  assert(hit.where:find("doc.md:", 1, true), "got: " .. hit.where)
+  assert(not ratchet.bearing(rows, "`*_bench.tl`"), "a marker no row " ..
+    "carries must not be found")
+end
+test_bearing_finds_a_row_by_substring()
+
+-- A document that is not there is an error, not an empty table. The
+-- distinction is the whole point: nothing found and nothing read look
+-- identical downstream.
+local function test_a_missing_document_is_an_error()
+  local rows, err = ratchet.rows("no/such/doc.md")
+  assert(not rows, "a missing document must not read as an empty table")
+  assert(err:find("no/such/doc.md", 1, true), "got: " .. err)
+end
+test_a_missing_document_is_an_error()
+
+print("all ratchet reader tests passed")

--- a/_build/skills_test.tl
+++ b/_build/skills_test.tl
@@ -11,77 +11,89 @@
 -- review rounds, two commits, for a claim that is one grep. These are
 -- the greps.
 --
--- Parsed from source text rather than required: `_make` is internal to
--- its own tree, so this test reads `_make/types.tl` the way it reads
--- the markdown — as bytes. The enum is the vocabulary's single
--- declaration either way.
+-- Every one of them asks the CODE, by requiring it. The first version
+-- of this file recovered the kind vocabulary by regexing
+-- `_make/types.tl`, because a Teal enum is a type and types are erased
+-- — so there was nothing to require. `_make.types` now carries
+-- `kinds`, and the one assertion that still reads source lives beside
+-- the enum in `_make/types_test.tl`, where a broken parse fails by
+-- name instead of quietly shrinking what this file covers.
 
 local check = require("cosmic.check")
 local fs = require("cosmic.fs")
+local make = require("_make")
+local project = require("_make.project")
+local ratchet = require("_build.ratchet")
+local types = require("_make.types")
 
 local SKILL < const > = "skills/cosmic/make.md"
-local MODEL < const > = "_make/types.tl"
 local SKILLS_DIR < const > = "skills/cosmic"
 
---- The model's kind vocabulary, parsed from the enum's own source.
---- @return {string: boolean} The set of kinds
-local function model_kinds(): {string: boolean}
-  local src = check.must(fs.read(MODEL))
-  local block = src:match("enum Kind(.-)\n%s*end")
-  assert(block, MODEL .. ": no `enum Kind` block found")
-  local out: {string: boolean} = {}
-  for kind in block:gmatch("\"([%w%-]+)\"") do
-    out[kind] = true
-  end
-  return out
+--- How one row of the skill teaches one thing.
+local record Taught
+  --- Text that must appear in the first cell of some row.
+  marker: string
+  --- A path the model must classify as this kind, so the row is held
+  --- against what `--make` DOES and not merely against a vocabulary.
+  --- Without it a row can carry the right marker and teach the wrong
+  --- thing — `` `*_test.tl` `` declaring payload passes a check that
+  --- only looks for the marker.
+  path: string
 end
 
---- One row of a markdown table: its first cell, the rest of the line,
---- and where it is.
-local record Row
-  cell: string
-  line: string
-  where: string
-end
+-- How each model kind is taught. This map IS the pairing the ratchet
+-- enforces — a kind added to the model fails here until the skill
+-- teaches it and this map says how; a kind removed fails until both
+-- drop it. Three copies would drift; two copies plus this test cannot
+-- drift silently.
+local TAUGHT < const >: {string: {Taught}} = {
+  ["module"] = {{marker = "`<dir>/*.tl`", path = "db/query.tl"}},
+  ["entry"] = {
+    {marker = "`main.tl` at the root", path = "main.tl"},
+    -- The entry kind's second position, and a row of its own because
+    -- one binary per subdirectory is the thing most projects need.
+    {marker = "`cmd/<name>/main.tl`", path = "cmd/app/main.tl"},
+  },
+  ["test"] = {{marker = "`*_test.tl`", path = "db/query_test.tl"}},
+  ["example"] = {{marker = "`*_example.tl`", path = "db/query_example.tl"}},
+  ["benchmark"] = {
+    {marker = "`*_benchmark.tl`", path = "db/query_benchmark.tl"},
+  },
+  ["types"] = {{marker = "`*.d.tl`", path = "db/query.d.tl"}},
+  ["pin"] = {{marker = "`*_pin.tl`", path = "3p/lpeg/lpeg_pin.tl"}},
+  ["gen"] = {{marker = "`*_gen.tl`", path = "db/schema_gen.tl"}},
+  ["payload-gen"] = {
+    {marker = "embed_gen.tl", path = "cmd/app/embed_gen.tl"},
+  },
+  ["payload"] = {{marker = "`embed/**`", path = "embed/schema.sql"}},
+  ["testdata"] = {
+    {marker = "`testdata/`", path = "db/testdata/fixture.json"},
+  },
+  ["asset"] = {{marker = "everything else", path = "README.md"}},
+}
 
---- Table rows of one markdown file: every `|`-led line that is neither
---- a header separator nor blank cells of dashes.
---- @param path string The file to scan
---- @return {Row} In file order
-local function table_rows(path: string): {Row}
-  local out: {Row} = {}
-  local n = 0
-  for line in check.must(fs.read(path)):gmatch("([^\n]*)\n?") do
-    n = n + 1
-    if line:sub(1, 1) == "|" then
-      local cell = line:match("^|%s*(.-)%s*|")
-      if cell and not cell:match("^[-: ]*$") then
-        out[#out + 1] = {cell = cell, line = line, where = path .. ":" .. n}
-      end
-    end
-  end
-  return out
-end
+-- Rows of the model table that teach no kind, each with the reason it
+-- belongs there anyway. A row in neither table is a row nobody decided.
+local EXTRA_ROWS < const >: {string: string} = {
+  ["`_<dir>/`"] = "a visibility marker, not a kind",
+}
 
---- The rows of the skill's "The project model" table only.
---- @return {Row} In file order
-local function model_table_rows(): {Row}
-  local out: {Row} = {}
-  local in_section = false
-  local n = 0
-  for line in check.must(fs.read(SKILL)):gmatch("([^\n]*)\n?") do
-    n = n + 1
-    if line:match("^## ") then
-      in_section = line == "## The project model"
-    elseif in_section and line:sub(1, 1) == "|" then
-      local cell = line:match("^|%s*(.-)%s*|")
-      if cell and cell ~= "marker" and not cell:match("^[-: ]*$") then
-        out[#out + 1] = {cell = cell, line = line, where = SKILL .. ":" .. n}
-      end
-    end
-  end
-  assert(#out > 0, SKILL .. ": no table under '## The project model'")
-  return out
+-- Verbs the skill teaches that the registry does not carry, and why.
+local EXTRA_VERBS < const >: {string: string} = {
+  -- `_make/init.tl` answers `help` before it looks the verb up, so it
+  -- is a real verb with no row. Teaching it is right; the registry
+  -- having no row for it is also right.
+  ["help"] = "dispatched ahead of the registry, so it has no row",
+}
+
+--- The rows of one of the skill's tables.
+--- @param heading string The `## ` heading the table sits under
+--- @param header string The header row's first cell
+--- @return {ratchet.Row} In file order
+local function skill_rows(heading: string, header: string): {ratchet.Row}
+  local rows = check.must(ratchet.rows(SKILL, heading, header))
+  assert(#rows > 0, SKILL .. ": no table under '## " .. heading .. "'")
+  return rows
 end
 
 --- Every skill file, in path order.
@@ -93,78 +105,42 @@ local function skill_files(): {string}
   return found
 end
 
--- How each model kind is taught: the marker text that must appear in
--- the first cell of some row of the skill's model table. This map IS
--- the pairing the ratchet enforces — a kind added to the enum fails
--- here until the skill teaches it and this map says how; a kind
--- removed fails until both drop it. Three copies would drift; two
--- copies plus this test cannot drift silently.
-local TAUGHT < const >: {string: string} = {
-  ["module"] = "`<dir>/*.tl`",
-  ["entry"] = "`main.tl` at the root",
-  ["test"] = "`*_test.tl`",
-  ["example"] = "`*_example.tl`",
-  ["benchmark"] = "`*_benchmark.tl`",
-  ["types"] = "`*.d.tl`",
-  ["pin"] = "`*_pin.tl`",
-  ["gen"] = "`*_gen.tl`",
-  ["payload-gen"] = "embed_gen.tl",
-  ["payload"] = "`embed/**`",
-  ["testdata"] = "`testdata/`",
-  ["asset"] = "everything else",
-}
-
--- Rows of the model table that are not a kind's teaching row, each
--- with the reason it belongs there anyway. A row in neither table is
--- a row nobody decided.
-local EXTRA_ROWS < const >: {string: string} = {
-  ["`cmd/<name>/main.tl`"] = "the entry kind's second position",
-  ["`_<dir>/`"] = "a visibility marker, not a kind",
-}
-
 -- The skill's marker table and the model's kind vocabulary are the
--- same list. Both directions: a kind the enum has and the table does
+-- same list. Both directions: a kind the model has and the table does
 -- not teach is advice with a hole in it, and a row teaching a kind the
--- enum no longer has is the D15 failure again — the tool delivering a
+-- model no longer has is the D15 failure again — the tool delivering a
 -- claim the model retired.
 local function test_the_skill_teaches_exactly_the_models_kinds()
-  local kinds = model_kinds()
-  local count = 0
-  for _ in pairs(kinds) do
-    count = count + 1
-  end
-  assert(count >= 8, MODEL .. ": expected the enum's kinds, found " ..
-    count .. " — the parser found the wrong block")
-
-  for kind in pairs(kinds) do
-    assert(TAUGHT[kind], "kind '" .. kind .. "' is in " .. MODEL ..
-      "'s enum but has no teaching row: add the row to " .. SKILL ..
+  for _, kind in ipairs(types.kinds) do
+    assert(TAUGHT[kind], "kind '" .. kind .. "' is in the model's " ..
+      "vocabulary but has no teaching row: add the row to " .. SKILL ..
       "'s model table and its marker to TAUGHT in this test")
   end
+  local known: {string: boolean} = {}
+  for _, kind in ipairs(types.kinds) do
+    known[kind] = true
+  end
   for kind in pairs(TAUGHT) do
-    assert(kinds[kind], "TAUGHT pairs '" .. kind .. "' with a marker " ..
-      "but " .. MODEL .. "'s enum no longer has it: delete the row " ..
-      "from " .. SKILL .. "'s model table and this entry")
+    assert(known[kind], "TAUGHT pairs '" .. kind .. "' with a marker " ..
+      "but `_make.types` no longer lists it: delete the row from " ..
+      SKILL .. "'s model table and this entry")
   end
 
-  local rows = model_table_rows()
-  for kind, marker in pairs(TAUGHT) do
-    local found = false
-    for _, row in ipairs(rows) do
-      if row.cell:find(marker, 1, true) then
-        found = true
-        break
-      end
+  local rows = skill_rows("The project model", "marker")
+  for kind, taught in pairs(TAUGHT) do
+    for _, one in ipairs(taught) do
+      assert(ratchet.bearing(rows, one.marker), SKILL .. ": the model " ..
+        "table has no row whose marker cell contains '" .. one.marker ..
+        "', so the skill no longer teaches the '" .. kind .. "' kind")
     end
-    assert(found, SKILL .. ": the model table has no row whose marker " ..
-      "cell contains '" .. marker .. "', so the skill no longer " ..
-      "teaches the '" .. kind .. "' kind")
   end
 
   for _, row in ipairs(rows) do
     local claimed = EXTRA_ROWS[row.cell] ~= nil
-    for _, marker in pairs(TAUGHT) do
-      claimed = claimed or (row.cell:find(marker, 1, true) ~= nil)
+    for _, taught in pairs(TAUGHT) do
+      for _, one in ipairs(taught) do
+        claimed = claimed or (row.cell:find(one.marker, 1, true) ~= nil)
+      end
     end
     assert(claimed, row.where .. ": the model table row '" .. row.cell ..
       "' teaches no model kind and is not recorded in EXTRA_ROWS — " ..
@@ -173,6 +149,79 @@ local function test_the_skill_teaches_exactly_the_models_kinds()
   end
 end
 test_the_skill_teaches_exactly_the_models_kinds()
+
+-- And each marker means what the walk means by it. The pairing above
+-- only proves a row EXISTS; this runs the model's own classifier over
+-- a path the row describes, so a marker taught as the wrong kind
+-- fails. That is the half of the D15 drift a presence check cannot
+-- see: the deleted row had the right marker in it.
+local function test_each_taught_marker_classifies_as_its_kind()
+  for _, kind in ipairs(types.kinds) do
+    for _, one in ipairs(TAUGHT[kind]) do
+      local got = project.classify(one.path)
+      assert(got == kind, SKILL .. ": the table teaches '" .. one.marker ..
+        "' as " .. kind .. ", but the model classifies " .. one.path ..
+        " as " .. got .. " — the row and the walk disagree")
+    end
+  end
+end
+test_each_taught_marker_classifies_as_its_kind()
+
+-- The verb table is the registry, restated for a reader. The skill
+-- says so itself — "`cosmic --make help` prints this list ... it is
+-- the one that cannot go stale" — which is exactly the sentence a
+-- table drifts behind: `run` shipped and the row still said planned.
+-- `_make` exports both halves already, so this needs no parsing at
+-- all; it is the shape every ratchet here should have.
+local function test_the_verb_table_is_the_registry()
+  local shipped: {string: boolean} = {}
+  for _, name in ipairs(make.IMPLEMENTED) do
+    shipped[name] = true
+  end
+  local planned: {string: boolean} = {}
+  for _, name in ipairs(make.PLANNED) do
+    planned[name] = true
+  end
+
+  local taught: {string: boolean} = {}
+  for _, row in ipairs(skill_rows("Verbs", "verb")) do
+    local named = ratchet.names(row.cell)
+    assert(#named > 0, row.where .. ": a verb row names no verb")
+    for _, name in ipairs(named) do
+      taught[name] = true
+      assert(shipped[name] or planned[name] or EXTRA_VERBS[name] ~= nil,
+        row.where .. ": the table teaches a verb '" .. name ..
+        "' that `--make` has no row for, planned or otherwise")
+      -- The `today` column is the claim that goes stale. A shipped
+      -- verb marked planned tells a reader not to reach for something
+      -- that is right there.
+      local says_planned = row.line:find("planned", 1, true) ~= nil
+      if shipped[name] then
+        assert(not says_planned, row.where .. ": '" .. name ..
+          "' is in the registry and shipped, but its row still says " ..
+          "planned")
+      elseif planned[name] then
+        assert(says_planned, row.where .. ": '" .. name .. "' is a " ..
+          "planned verb, but its row does not say so")
+      end
+    end
+  end
+
+  for _, name in ipairs(make.IMPLEMENTED) do
+    assert(taught[name], "`--make " .. name .. "` ships but " .. SKILL ..
+      "'s verb table does not list it — the skill is the tool's own " ..
+      "answer to what it can do")
+  end
+  for _, name in ipairs(make.PLANNED) do
+    assert(taught[name], "'" .. name .. "' is a planned verb with no " ..
+      "row in " .. SKILL .. "'s verb table")
+  end
+  for name in pairs(EXTRA_VERBS) do
+    assert(taught[name], "EXTRA_VERBS excuses '" .. name .. "' from " ..
+      "the registry, but the table no longer teaches it")
+  end
+end
+test_the_verb_table_is_the_registry()
 
 -- Retired vocabulary stays retired. D15's `ships` table dropped
 -- `asset`: an unlisted repo file is part of the project, never of its
@@ -184,7 +233,7 @@ test_the_skill_teaches_exactly_the_models_kinds()
 -- `o/`") is not a teaching row and stays free.
 local function test_no_table_row_teaches_asset_outside_pins()
   for _, path in ipairs(skill_files()) do
-    for _, row in ipairs(table_rows(path)) do
+    for _, row in ipairs((check.must(ratchet.rows(path)))) do
       local lower = row.line:lower()
       if lower:find("asset", 1, true) then
         assert(lower:find("pin", 1, true), row.where .. ": a table row " ..
@@ -204,7 +253,7 @@ test_no_table_row_teaches_asset_outside_pins()
 local function test_everything_else_teaches_never_embedded()
   local seen = 0
   for _, path in ipairs(skill_files()) do
-    for _, row in ipairs(table_rows(path)) do
+    for _, row in ipairs((check.must(ratchet.rows(path)))) do
       if row.cell == "everything else" then
         seen = seen + 1
         assert(row.line:find("never embedded", 1, true), row.where ..

--- a/_make/types.tl
+++ b/_make/types.tl
@@ -161,7 +161,38 @@ local record make_types
   --- fixture), so linting one gates the build on a file whose job is to
   --- be unacceptable.
   lint_kinds: {Kind: boolean}
+
+  --- The kind vocabulary, as a value.
+  ---
+  --- `Kind` is a type, and Teal erases types: compile this file and the
+  --- enum leaves nothing behind, so a caller that `require`s this
+  --- module can check a kind but cannot ask what the kinds ARE. The
+  --- skill ratchet needs exactly that, and answered it by regexing this
+  --- file -- a second Teal parser, guarded by a magic minimum, which
+  --- silently under-reports a kind its pattern does not cover.
+  ---
+  --- So the vocabulary gets a runtime form. It is typed `{Kind}`, which
+  --- makes the checker refuse an entry that is not a kind; the other
+  --- direction -- that no kind is missing here -- is the one thing
+  --- about this pair no type can state, and it is what
+  --- `_make/types_test.tl` is for.
+  kinds: {Kind}
 end
+
+make_types.kinds = {
+  "module",
+  "entry",
+  "test",
+  "example",
+  "benchmark",
+  "types",
+  "pin",
+  "gen",
+  "payload-gen",
+  "testdata",
+  "payload",
+  "asset",
+}
 
 make_types.lint_kinds = {
   module = true,

--- a/_make/types_test.tl
+++ b/_make/types_test.tl
@@ -1,0 +1,130 @@
+#!/usr/bin/env cosmic
+-- The kind vocabulary is declared twice, and this is what holds the
+-- two copies equal.
+--
+-- `Kind` is an enum, so it is a type, and Teal erases types. Nothing
+-- that `require`s `_make.types` can ask what the kinds are -- which is
+-- why `types.kinds` exists, and why the enum and the list can disagree
+-- with nobody noticing.
+--
+-- The checker gives one direction free: `kinds` is typed `{Kind}`, so
+-- an entry that is not a kind fails `--make check`. This file is the
+-- other direction, and it is the ONLY place in the tree that reads a
+-- source file to recover a declaration. It reads one, at the file that
+-- declares it, to compare two lists it already has -- not to build a
+-- vocabulary every downstream check then depends on. A parse that
+-- breaks fails here, by name, instead of quietly shrinking what some
+-- other test covers.
+
+local check = require("cosmic.check")
+local fs = require("cosmic.fs")
+local types = require("_make.types")
+
+local SOURCE < const > = "_make/types.tl"
+
+--- The set of a list's entries.
+--- @param list {string} The entries
+--- @return {string: boolean} The set
+local function set_of(list: {string}): {string: boolean}
+  local out: {string: boolean} = {}
+  for _, name in ipairs(list) do
+    out[name] = true
+  end
+  return out
+end
+
+--- Names in `want` that `have` does not hold, sorted.
+--- @param want {string: boolean} The names looked for
+--- @param have {string: boolean} The names present
+--- @return {string} The missing names
+local function missing(want: {string: boolean}, have: {string: boolean}): {string}
+  local out: {string} = {}
+  for name in pairs(want) do
+    if not have[name] then
+      out[#out + 1] = name
+    end
+  end
+  table.sort(out)
+  return out
+end
+
+--- The enum's members, read from the enum's own source.
+---
+--- Line-based, and `[^"]+` rather than a character class: a member is a
+--- quoted string alone on its line, whatever it is spelled with. The
+--- pattern this replaced matched `[%w%-]+` between the quotes, so a
+--- kind named with an underscore matched nothing at all and vanished
+--- from the vocabulary without a word.
+--- @return {string: boolean} The set of members
+local function enum_members(): {string: boolean}
+  local out: {string: boolean} = {}
+  local inside = false
+  local closed = false
+  for line in check.must(fs.read(SOURCE)):gmatch("([^\n]*)\n?") do
+    local text = line:match("^%s*(.-)%s*$")
+    if not inside then
+      inside = text == "enum Kind"
+    elseif text == "end" then
+      closed = true
+      break
+    else
+      local member = text:match("^\"([^\"]+)\"$")
+      if member then
+        out[member] = true
+      end
+    end
+  end
+  assert(inside, SOURCE .. ": no line reading `enum Kind`")
+  assert(closed, SOURCE .. ": the `enum Kind` block never closes")
+  return out
+end
+
+-- The enum and the list say the same thing. Both directions by name,
+-- because the two failures read differently: a member with no entry is
+-- a kind no `require` can see, and an entry with no member is a kind
+-- the checker would have caught only if some other code used it.
+local function test_the_kinds_list_is_the_enum()
+  local members = enum_members()
+  local listed = set_of(types.kinds)
+
+  local unlisted = missing(members, listed)
+  assert(#unlisted == 0, SOURCE .. ": `enum Kind` has " ..
+    table.concat(unlisted, ", ") .. " but `make_types.kinds` does not " ..
+    "-- add it there, in the enum's order, or nothing that requires " ..
+    "this module can see the kind")
+
+  local undeclared = missing(listed, members)
+  assert(#undeclared == 0, SOURCE .. ": `make_types.kinds` has " ..
+    table.concat(undeclared, ", ") .. " but `enum Kind` does not " ..
+    "-- one of the two was edited alone")
+
+  local distinct = 0
+  for _ in pairs(listed) do
+    distinct = distinct + 1
+  end
+  assert(#types.kinds == distinct, SOURCE ..
+    ": `make_types.kinds` lists a kind twice")
+end
+test_the_kinds_list_is_the_enum()
+
+-- `lint_kinds`'s doc comment states a law -- "nearly everything ...
+-- `testdata` is the one exception" -- and a law stated only in prose is
+-- how a new kind slips past the linter. Nothing catches that: the
+-- checker enforces that every KEY is a kind, never that every kind is
+-- a key. So a kind added to the enum is silently unlinted until
+-- somebody re-reads this table, which is the same shape of drift the
+-- skill ratchet exists for, one level down.
+local function test_lint_reads_every_kind_but_testdata()
+  for _, kind in ipairs(types.kinds) do
+    local excused = kind == "testdata"
+    local read = types.lint_kinds[kind] or false
+    assert(read ~= excused, "_make/types.tl: `lint_kinds` " ..
+      (read and "reads" or "skips") .. " '" .. kind .. "', and its doc " ..
+      "comment says lint reads every kind but `testdata`. Add the kind " ..
+      "to the table, or amend the comment to say why this one is also " ..
+      "exempt -- an unlinted kind is not a thing to decide by omission")
+  end
+end
+test_lint_reads_every_kind_but_testdata()
+
+print("all model type tests passed")

--- a/skills/cosmic/make.md
+++ b/skills/cosmic/make.md
@@ -37,7 +37,7 @@ replaced it outright.
 | `clean` | remove `o/`, sparing `o/bootstrap` | ✅ |
 | `fetch` | resolve `*_pin.tl` — the only verb with a network | ✅ |
 | `help` | list the verbs, and which are still planned | ✅ |
-| `run` | build, then exec the artifact | planned |
+| `run` | build, then run a source path against the built tree | ✅ |
 | `enforce` | rerun the sandbox tests unsandboxed, where a skip fails | planned |
 | `reproducible` `offline` | policy lanes over the graph | planned |
 


### PR DESCRIPTION
#843 recovered the model's kind vocabulary by regexing `_make/types.tl` for its `enum Kind` block. The comment blamed visibility — `_make` is internal — but `cmd/cosmic/embed_gen.tl` has required `_make.types` all along.

The real reason is that a Teal enum is a **type**, and types are erased:

```
$ bin/cosmic --compile _make/types.tl | head
local make_types = { File = {}, Binary = {}, Project = {}, Issue = {}, Selection = {}, Verb = {} }
```

Records get placeholder tables; `Kind` produces nothing. There was no value to require.

## Why parsing for it cost more than the ask

`[%w%-]+` between the quotes excludes `_`, so a kind spelled with an underscore parsed to nothing — verified, `"payload_gen"` yields no match. The only guard was `count >= 8`, which still passes at 11 of 12. Add a kind to the enum and forget the skill — *the exact drift the ratchet exists to catch* — and it passed green.

## What changed

**The vocabulary gets a runtime form.** `_make.types` carries `kinds`, typed `{Kind}`, so the checker refuses an entry that is not a kind. That is one direction free.

**`_make/types_test.tl`** is the other direction, and the one source read left in the tree. It sits beside the enum, compares two lists it already has rather than building one everything downstream trusts, and reads `"([^"]+)"` off whole lines — so a broken parse fails by name instead of quietly shrinking what some other test covers. It also holds `lint_kinds` to the law its own doc comment states (every kind but `testdata`), which nothing checked: a new kind was silently unlinted.

**Generalized, because it was not the only one.** The skill's *verb* table restates `_make/init.tl`'s registry — which `_make` already exports as `IMPLEMENTED`/`PLANNED` — and nothing checked it. It had already drifted: `run` shipped, and the row two lines under "it is the one that cannot go stale" still said planned. Fixed, and ratcheted both ways including the `today` column.

**The pairing now runs `project.classify`** over a path each row describes. The old check only proved a row *exists* carrying the marker text; the row could teach the wrong thing and pass. The D15 row that started all this had the right marker in it.

**`_build/ratchet.tl`** is the shared markdown reader the three ratchets used to each write inline, with `ratchet_test.tl` behind it — which immediately earned its keep: an unfiltered scan stopped dead at the document's first heading and reported an empty file, and two ratchets read that as a pass.

## Verification

Every direction verified to fail, by name:

| injected drift | fails |
|---|---|
| `payload_gen` in the enum alone | `enum Kind` has payload_gen but `make_types.kinds` does not |
| a kind neither the skill nor `TAUGHT` knows | kind 'payload_gen' … has no teaching row |
| a shipped verb taught as planned | 'run' is in the registry and shipped, but its row still says planned |
| a verb with no row | `test_the_verb_table_is_the_registry` |
| a marker paired with a path the model classifies otherwise | teaches '`*_test.tl`' as test, but the model classifies … as payload |
| the D15 row reinstated | a table row may say 'asset' only about pins |
| a kind dropped from `lint_kinds` | `lint_kinds` skips 'module' … |

`o/bin/cosmic --make ci` → `ci: PASS (6 stages)`. The coverage baseline is rewritten for the new file (`_build/ratchet.tl` 36/36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XkrooRebxBfPyAWrFRCqg

---
_Generated by [Claude Code](https://claude.ai/code/session_013XkrooRebxBfPyAWrFRCqg)_