### PR TITLE
make: survive a PATH-less env, and never grade a stale .got

### DIFF
--- a/_cli/build/recipe_test.tl
+++ b/_cli/build/recipe_test.tl
@@ -63,6 +63,23 @@ local function test_recipe_dispatches()
 end
 test_recipe_dispatches()
 
+-- record grades a result THIS run wrote, never a stale one. When its
+-- scratch directory cannot be made -- here a plain file sits where the
+-- directory goes -- record must FAIL, not exit 0 on the `.got` a green
+-- previous run left behind. `COSMIC_FENCE=0` so this exercises record's
+-- own guard, not the fence derivation.
+local function test_record_does_not_grade_a_stale_got()
+  local out = fs.join(tmpdir, "rec-stale")
+  assert(fs.write(out .. ".got", "0")) -- a passing result from "before"
+  assert(fs.write(out .. ".tmp.d", "")) -- a file where the scratch dir goes
+  local code, _o, err = run_recipe("record " .. out .. " " .. test_bin,
+    {["COSMIC_FENCE"] = "0"})
+  assert(code ~= 0,
+    "record must fail when it cannot run, not pass on a stale .got: " ..
+    tostring(code) .. " " .. err)
+end
+test_record_does_not_grade_a_stale_got()
+
 -- A fence that cannot be DERIVED fails the step rather than waving it
 -- through: dispatching would run the step with no Landlock at all. The
 -- blocker is a regular file, so the derivation's makedirs hits ENOTDIR.

--- a/_cli/build/steps.tl
+++ b/_cli/build/steps.tl
@@ -237,6 +237,7 @@ local function do_record(args: {string}): integer
   local scratch = fs.abspath(out .. ".tmp.d")
   env.set("TMP", scratch)
   fs.makedirs(scratch)
+  fs.unlink(out .. ".got") -- freshness: an early testrun exit writes none
   local testrun = require("cosmic.testrun")
   testrun.run(argv, out)
   if not fs.isfile(out .. ".got") then

--- a/_make/stage.tl
+++ b/_make/stage.tl
@@ -193,7 +193,7 @@ local function binaries_on_path(proj: Project)
   local abs = fs.join(proj.root, rel)
   local sep = sys.host_os() == "windows" and ";" or ":"
   local path = cenv.get("PATH")
-  if path == "" then
+  if path == nil or path == "" then
     cenv.set("PATH", abs, true)
   elseif not (sep .. path .. sep):find(sep .. abs .. sep, 1, true) then
     cenv.set("PATH", abs .. sep .. path, true)

--- a/_make/stage_test.tl
+++ b/_make/stage_test.tl
@@ -120,4 +120,21 @@ local function test_binaries_go_on_the_path()
 end
 test_binaries_go_on_the_path()
 
+-- A PATH-less environment must not crash. `get` returns nil, not "",
+-- for an unset variable, so the guard has to admit nil -- the concat in
+-- the "already present?" branch threw on the very setup a stripped-env
+-- CI runner or a minimal container hands the build.
+local function test_binaries_on_path_without_a_path()
+  local env = require("cosmic.env")
+  local saved = env.get("PATH")
+  env.unset("PATH")
+  local proj: types.Project = {root = "/p", binaries = {}, files = {}}
+  stage.binaries_on_path(proj)
+  assert(env.get("PATH") == stage.bin_dir(proj),
+    "an unset PATH becomes the build's bin dir, got: " ..
+    tostring(env.get("PATH")))
+  if saved ~= nil then env.set("PATH", saved, true) end
+end
+test_binaries_on_path_without_a_path()
+
 print("all stage tests passed")


### PR DESCRIPTION
First of several small, independent fixes split out of a review of the last two months. Two fail shapes the gate could not catch itself.

## PATH-less crash

`binaries_on_path` guarded `path == ""`, but `env.get("PATH")` returns `nil` for an unset variable, so the concat in the "already present?" branch threw — a plain crash on the stripped-env container or PATH-less runner the build is meant to run on. It now admits `nil`. (`_make/stage_test.tl` already documented this hazard for itself while the production code kept it.)

## `record` graded a stale `.got` (fail-open gate)

`do_record` gated on the **existence** of `<out>.got`, not its freshness, and ignored `testrun.run`'s result. `testrun` has early exits (a failed `mkdtemp` or `makedirs`) that write no `.got` at all; on a target holding one from a green previous run, `record` saw the stale file, exited 0, and the summary graded yesterday's number. `record` now unlinks any prior `.got` first, so the check means "this run wrote a result."

## Tests

`binaries_on_path` with `PATH` unset; and `record` refusing to pass on a stale `.got` when its scratch dir cannot be made.

## Verification

`o/bin/cosmic --make ci` → `ci: PASS (6 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1ga7YYMrjEuy5qbtZNsni)_