### PR TITLE
coverage counts .lua sources; the perf gate re-checks identity on retry

### DIFF
--- a/_perf/gate.tl
+++ b/_perf/gate.tl
@@ -103,6 +103,15 @@ local function gate(opts: GateOptions): integer
   if rc ~= 0 then
     return rc
   end
+  -- The retry just overwrote current.json under whatever binary is
+  -- running now, which may not be the one the baseline was measured
+  -- against. Re-check identity against that freshly measured file, or a
+  -- real regression can be masked by an identity change mid-retry.
+  refusal = identity_refusal(opts.baseline, opts.current, false)
+  if refusal then
+    io.stderr:write(refusal .. "\n")
+    return 1
+  end
   failures, err = compare_once(opts.baseline, opts.current, opts.threshold)
   if failures < 0 then
     io.stderr:write(tostring(err) .. "\n")
@@ -116,6 +125,14 @@ local function gate(opts: GateOptions): integer
   rc = opts.measure(opts.selfcheck_b)
   if rc ~= 0 then
     return rc
+  end
+  -- The A/A control is only a noise floor if it names the SAME binary
+  -- as current; check that before triage(), which otherwise trusts the
+  -- pair silently.
+  refusal = identity_refusal(opts.current, opts.selfcheck_b, true)
+  if refusal then
+    io.stderr:write(refusal .. "\n")
+    return 1
   end
   failures, err = compare_once(opts.baseline, opts.current, opts.threshold,
     opts.current, opts.selfcheck_b)

--- a/_perf/gate_test.tl
+++ b/_perf/gate_test.tl
@@ -232,6 +232,61 @@ test_selfcheck_refuses_two_different_binaries()
 -- A file that does not say what it measured cannot be checked either
 -- way. It says so on stderr and the comparison proceeds, so a results
 -- file written before the field existed stays readable.
+-- The retry's `opts.measure(opts.current)` overwrites current.json under
+-- whatever binary happens to be running at that moment. If that binary
+-- is the SAME as the baseline's, the retry's own re-compare would read
+-- "no regression" for the wrong reason -- current now equals baseline by
+-- construction, not because the change was clean. The post-measure
+-- identity check must catch that before trusting the re-compare.
+local function test_retry_remeasurement_changing_identity_is_refused()
+  local base, cur, selfb = paths("retry-identity-flip")
+  write_results(base, 1000, "aaaa1111")
+  write_results(cur, 1300, "bbbb2222")
+  local calls = 0
+  local code = gate.gate({
+      baseline = base, current = cur, selfcheck_b = selfb, threshold = 10,
+      measure = function(out: string): integer
+        calls = calls + 1
+        -- comes back quiet, but now names the BASELINE's binary
+        write_results(out, 1010, "aaaa1111")
+        return 0
+      end,
+    })
+  assert(code == 1,
+    "an identity flip on the retried file must refuse, got " .. code)
+  assert(calls == 1,
+    "must refuse right after the retry, before any A/A step, got " .. calls)
+end
+test_retry_remeasurement_changing_identity_is_refused()
+
+-- Before triage() trusts the A/A pair as a noise floor, `current` and
+-- `selfcheck_b` must name the SAME binary -- otherwise the "noise floor"
+-- is really two different binaries, which raises the bar every real
+-- regression afterwards has to clear.
+local function test_aa_control_naming_different_binary_is_refused()
+  local base, cur, selfb = paths("aa-identity-mismatch")
+  write_results(base, 1000, "aaaa1111")
+  write_results(cur, 1300, "bbbb2222")
+  local calls = 0
+  local code = gate.gate({
+      baseline = base, current = cur, selfcheck_b = selfb, threshold = 10,
+      measure = function(out: string): integer
+        calls = calls + 1
+        if calls == 1 then
+          write_results(out, 1300, "bbbb2222") -- persists, same binary as cur
+        else
+          write_results(out, 1310, "cccc3333") -- A/A control: a THIRD binary
+        end
+        return 0
+      end,
+    })
+  assert(code == 1,
+    "an A/A control naming a different binary than current must refuse, got " .. code)
+  assert(calls == 2,
+    "must measure the retry and the A/A control before refusing, got " .. calls)
+end
+test_aa_control_naming_different_binary_is_refused()
+
 local function test_a_file_without_a_sha_is_not_refused()
   local base, cur, selfb = paths("no-sha")
   write_results(base, 1000)

--- a/cosmic/coverage/report.tl
+++ b/cosmic/coverage/report.tl
@@ -111,9 +111,18 @@ local function normalize(src: string, cwd: string): string | nil, string
     return nil
   end
   if p:match("^o/") and p:match("%.lua$") then
-    local tl_path = p:sub(3):gsub("%.lua$", ".tl")
-    if fs.isfile(tl_path) then
-      return tl_path, p
+    -- Two spellings, because `.lua` sources are first-class in this
+    -- project (see the `luaonly` fixture): `o/greet.lua` is the staged
+    -- copy of `greet.tl` when that exists, or, when it does not, of
+    -- `greet.lua` itself. Trying only the `.tl` spelling dropped every
+    -- Lua-only source, so a Lua-only project's coverage read as empty
+    -- and its floor went in at zero.
+    local rel = p:sub(3)
+    local tl_path = rel:gsub("%.lua$", ".tl")
+    for _, source in ipairs({tl_path, rel}) do
+      if not is_excluded(source) and fs.isfile(source) then
+        return source, p
+      end
     end
     return nil
   end

--- a/cosmic/coverage/report_test.tl
+++ b/cosmic/coverage/report_test.tl
@@ -68,6 +68,20 @@ local function test_normalize_maps_embedded_directory_modules()
 end
 test_normalize_maps_embedded_directory_modules()
 
+-- `.lua` sources are first-class in this project (see the `luaonly`
+-- fixture and `_make/testdata/luaonly/`): when a staged `o/x.lua` has
+-- no matching `x.tl`, the source IS `x.lua` and must not be dropped.
+local function test_normalize_maps_lua_only_source_with_no_tl()
+  local saved = check.must(fs.getcwd(), "getcwd failed")
+  assert(fs.write(fs.join(tmpdir, "greet.lua"), "print('hi')\n"))
+  assert(fs.chdir(tmpdir))
+  local display, parse = report.normalize("@o/greet.lua", "")
+  fs.chdir(saved)
+  assert(display == "greet.lua", "got: " .. tostring(display))
+  assert(parse == "o/greet.lua", "got: " .. tostring(parse))
+end
+test_normalize_maps_lua_only_source_with_no_tl()
+
 local function test_normalize_accepts_existing_tl_script()
   -- a directly-run script records a cwd-relative source; absolute
   -- sources normalize only when they sit under the given cwd


### PR DESCRIPTION
Second of the review split. Two gates that reported clean without measuring what they claim.

## coverage dropped first-class `.lua` sources

`normalize()` mapped a staged `o/x.lua` back only to `x.tl`. When the source **is** `x.lua` (first-class in this project — the `luaonly` fixture), no `x.tl` exists, the chunk was dropped, and a Lua-only project's coverage read as empty: `--make coverage --baseline` wrote a `total 0 0` floor, a vacuous ratchet. It now tries the `.lua` spelling too, mirroring the `/zip` two-spelling probe just above it, gated by `is_excluded`.

## the perf gate did not re-check binary identity across its retry

`gate()` checked binary identity once at entry, then on a flagged regression re-measured `current.json` under whatever binary is running now — with no identity re-check — so restoring the pinned runtime before the gate could mask a real regression. And the A/A triage pair was never identity-checked. The gate now re-checks after each re-measure and on the A/A control.

## Tests

The `.lua`-only mapping, and both post-measure identity paths (a retry that flips the binary, and an A/A control naming a different binary).

## Verification

`o/bin/cosmic --make ci` → `ci: PASS (6 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1ga7YYMrjEuy5qbtZNsni)_