### PR TITLE
child: resolve stdio sources before dup2; the pty suite skips honestly

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -74,7 +74,7 @@ cosmic/benchmark.tl 180 212
 cosmic/check.tl 110 113
 cosmic/child/fast.tl 40 52
 cosmic/child/init.tl 0 212
-cosmic/child/io.tl 97 112
+cosmic/child/io.tl 102 119
 cosmic/codec.tl 52 57
 cosmic/compress.tl 17 18
 cosmic/coverage/baseline.tl 136 154
@@ -174,4 +174,4 @@ cosmic/user.tl 48 61
 cosmic/uuid.tl 9 9
 cosmic/zip.tl 80 93
 tlconfig.lua 7 7
-total 13389 17685
+total 13394 17692

--- a/cosmic/child/fast.tl
+++ b/cosmic/child/fast.tl
@@ -67,13 +67,33 @@ local function spawn(prog: string, argv: {string}, envp: {string} | nil,
     end
   end
 
+  -- Resolve each target to a source fd immune to the wiring below. A
+  -- target that names another std fd (0/1/2) about to be overwritten by
+  -- a DIFFERENT wiring step -- a full stdout<->stderr swap, say -- would
+  -- otherwise be read AFTER that step already clobbered it: the wiring
+  -- loop dup2's in fixed 0->1->2 order, and an earlier iteration may
+  -- already have overwritten the very std fd a later one names as its
+  -- source. The save loop above already captured every about-to-be-
+  -- overwritten std fd's PRISTINE value before any dup2 ran, so read
+  -- from that saved copy instead of the live (possibly already
+  -- clobbered) std fd.
+  local sources: {integer} = {}
+  for i = 1, 3 do
+    local t = targets[i]
+    if t >= 0 and t <= 2 and saves[t + 1] and saves[t + 1] ~= CLOSED then
+      sources[i] = saves[t + 1]
+    else
+      sources[i] = t
+    end
+  end
+
   -- Wire the child-side fds onto 0/1/2. dup2 copies are not CLOEXEC, so
   -- the child inherits exactly these three.
   local wired = true
   for i = 1, 3 do
     local std = i - 1
     if targets[i] ~= std then
-      if not unix.dup(targets[i], std) then
+      if not unix.dup(sources[i], std) then
         wired = false
         break
       end

--- a/cosmic/child/init.tl
+++ b/cosmic/child/init.tl
@@ -362,48 +362,49 @@ local function spawn(argv: {string}, opts?: Options): Handle | nil, string
   local pid = unix.fork()
   if pid == 0 then
     unix.close(exec_r)
-
+    -- Resolve sources before dup2 below can clobber one (childio.pin_source).
+    local src0 = childio.pin_source(stdin_is_fd, stdin_fd, stdin_r, 0)
+    local src1 = childio.pin_source(stdout_is_fd, stdout_fd, stdout_w, 1)
+    local src2 = childio.pin_source(stderr_is_fd, stderr_fd, stderr_w, 2)
     -- stdin (fd 0)
     if stdin_is_fd then
       if stdin_fd ~= 0 then
-        unix.dup(stdin_fd, 0)
+        unix.dup(src0, 0)
       end
     else
       if stdin_r ~= 0 then
         unix.close(stdin_w)
-        unix.dup(stdin_r, 0)
+        unix.dup(src0, 0)
         unix.close(stdin_r)
       else
         unix.fcntl(0, unix.F_SETFD, 0)
         unix.close(stdin_w)
       end
     end
-
     -- stdout (fd 1)
     if stdout_is_fd then
       if stdout_fd ~= 1 then
-        unix.dup(stdout_fd, 1)
+        unix.dup(src1, 1)
       end
     else
       if stdout_w ~= 1 then
         unix.close(stdout_r)
-        unix.dup(stdout_w, 1)
+        unix.dup(src1, 1)
         unix.close(stdout_w)
       else
         unix.fcntl(1, unix.F_SETFD, 0)
         unix.close(stdout_r)
       end
     end
-
     -- stderr (fd 2)
     if stderr_is_fd then
       if stderr_fd ~= 2 then
-        unix.dup(stderr_fd, 2)
+        unix.dup(src2, 2)
       end
     else
       if stderr_w ~= 2 then
         unix.close(stderr_r)
-        unix.dup(stderr_w, 2)
+        unix.dup(src2, 2)
         unix.close(stderr_w)
       else
         unix.fcntl(2, unix.F_SETFD, 0)

--- a/cosmic/child/io.tl
+++ b/cosmic/child/io.tl
@@ -240,6 +240,28 @@ local function pump(state: PumpState, deadline_ms: number): boolean
   return false
 end
 
+--- Read from `target`/`alt` (whichever `is_fd` selects) unless it names a
+--- DIFFERENT std fd (0/1/2) than `own` -- a fork child wiring 0/1/2 in
+--- fixed order can otherwise dup2 over a std fd BEFORE a later stream
+--- reads it as its own source (a full stdout<->stderr swap, say), which
+--- silently misroutes that stream. In that case dup the untouched
+--- original to a CLOEXEC copy first, so the result stays readable no
+--- matter what order the caller then wires 0/1/2 in.
+--- @param is_fd boolean whether `target` (not `alt`) is the source
+--- @param target integer caller-supplied fd, used when is_fd
+--- @param alt integer this stream's own pipe fd, used when not is_fd
+--- @param own integer the std fd (0, 1, or 2) this stream will wire onto
+--- @return integer a source fd safe to dup2 from regardless of wiring order
+local function pin_source(is_fd: boolean, target: integer, alt: integer,
+    own: integer): integer
+  local src = is_fd and target or alt
+  if src >= 0 and src <= 2 and src ~= own then
+    local copy = unix.dup(src, nil, unix.O_CLOEXEC, 10)
+    if copy then return copy end
+  end
+  return src
+end
+
 local record ChildIoModule
   StdioMode: StdioMode
   PumpState: PumpState
@@ -251,6 +273,8 @@ local record ChildIoModule
   resolve_stdio: function(stdin?: string | cfd.Handle,
   stdout?: cfd.Handle | StdioMode,
   stderr?: cfd.Handle | StdioMode): Stdio | nil, string
+  pin_source: function(is_fd: boolean, target: integer, alt: integer,
+  own: integer): integer
 end
 
 local M: ChildIoModule = {
@@ -259,6 +283,7 @@ local M: ChildIoModule = {
   read_retry = read_retry,
   wait_retry = wait_retry,
   resolve_stdio = resolve_stdio,
+  pin_source = pin_source,
 }
 
 return M

--- a/cosmic/child/stdio_test.tl
+++ b/cosmic/child/stdio_test.tl
@@ -117,3 +117,63 @@ io.stderr:write("got=[" .. (r.stdout or ""):gsub("%s+$", "") .. "]\n")
     "the default must still capture into Result.stdout, got: " .. r.stderr)
 end
 test_default_still_captures()
+
+--- The dup2-ordering hazard: stdout is captured (the default, a pipe)
+--- while stderr is routed to fd.wrap(1) -- what is CURRENTLY the
+--- grandchild's own real fd 1. Fixed 0->1->2 wiring dup2's the capture
+--- pipe onto fd 1 first; reading fd 1 again for stderr's dup2(1, 2) then
+--- reads the PIPE, not the real fd 1, so a fix that regressed would
+--- route the grandchild's stderr into Result.stdout instead of the real
+--- descriptor. Both halves are asserted: fd.wrap(1) must still reach the
+--- real fd 1, and Result.stdout must hold only the grandchild's stdout.
+local function test_stderr_fd_wrap_does_not_clobber_captured_stdout()
+  local r, written = run_capturing("swap_stderr", [[
+local child = require("cosmic.child")
+local cfd = require("cosmic.fd")
+local h = assert(child.spawn({"sh", "-c", "echo OUT; echo ERR >&2"},
+  {stderr = cfd.wrap(1)}))
+local r = assert(h:wait())
+io.stderr:write("stdout=[" .. (r.stdout or "") .. "]\n")
+]])
+  assert(r.ok, "helper failed: " .. (r.stderr or ""))
+  assert(written:find("ERR", 1, true),
+    "stderr routed via fd.wrap(1) must reach the real fd 1, file was: " .. written)
+  assert(not written:find("OUT", 1, true),
+    "the captured stdout must not also reach the real fd 1, file was: " .. written)
+  assert(r.stderr:find("stdout=[OUT\n]", 1, true),
+    "Result.stdout must hold only the grandchild's stdout, got: " .. r.stderr)
+end
+test_stderr_fd_wrap_does_not_clobber_captured_stdout()
+
+--- The full swap: stdout AND stderr each point at what the OTHER
+--- started as. A fix that only handled the single-alias case above
+--- (stderr = fd.wrap(1)) could still misroute a swap, since both
+--- targets alias a std fd the other's wiring is about to overwrite.
+local function test_full_stdio_swap_routes_each_stream_correctly()
+  local r, written = run_capturing("swap_full", [[
+local child = require("cosmic.child")
+local cfd = require("cosmic.fd")
+local h = assert(child.spawn({"sh", "-c", "echo OUT; echo ERR >&2"},
+  {stdout = cfd.wrap(2), stderr = cfd.wrap(1)}))
+local r = assert(h:wait())
+io.stderr:write("stdout=[" .. (r.stdout or "") .. "] stderr=[" ..
+  (r.stderr or "") .. "]\n")
+]])
+  assert(r.ok, "helper failed: " .. (r.stderr or ""))
+  -- `written` is the file behind the helper's own real fd 1, which
+  -- stderr = fd.wrap(1) targets; the helper's own real fd 2, which
+  -- stdout = fd.wrap(2) targets, is what the OUTER spawn (run_capturing)
+  -- itself captures into r.stderr here.
+  assert(written:find("ERR", 1, true),
+    "stderr = fd.wrap(1) should route the grandchild's stderr onto the " ..
+    "real fd 1, but it is missing from the file: " .. written)
+  assert(not written:find("OUT", 1, true),
+    "stdout must not also reach the real fd 1, file was: " .. written)
+  assert(r.stderr:find("OUT", 1, true),
+    "stdout = fd.wrap(2) should route the grandchild's stdout into our " ..
+    "own captured stderr, got: " .. r.stderr)
+  assert(r.stderr:find("stdout=[] stderr=[]", 1, true),
+    "spawn captured neither stream once both were redirected via " ..
+    "fd.wrap, but got: " .. r.stderr)
+end
+test_full_stdio_swap_routes_each_stream_correctly()

--- a/cosmic/tty_pty_test.tl
+++ b/cosmic/tty_pty_test.tl
@@ -24,14 +24,21 @@ local tty = require("cosmic.tty")
 
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
 
---- Open a pty, or skip the whole file where one cannot be had (no
+--- Open a pty, or exit the whole file where one cannot be had (no
 --- Landlock-free /dev/pts, a sandbox without it, a non-POSIX host).
 --- Skipping beats failing: the point is to cover the paths where a
---- terminal EXISTS, not to demand one.
+--- terminal EXISTS, not to demand one -- but skipping means EXITING with
+--- `check.EXIT_SKIP`, not returning nil for each test to shrug off. A
+--- `return` at file scope ends the chunk with status 0, which
+--- `records.status_of` grades as PASS, so a host without /dev/pts would
+--- make this whole suite report green while testing nothing. Same
+--- discipline `check.needs` documents and every other gated precondition
+--- in this repo uses (see e.g. `_make/build_test.tl`).
 local function with_pty(): tty.Pty
   local pty, err = tty.openpty()
   if not pty then
-    check.skip("openpty unavailable: " .. tostring(err))
+    check.needs("a real pty (tty.openpty failed: " .. tostring(err) .. ")", false)
+    os.exit(check.EXIT_SKIP)
     return nil
   end
   return pty
@@ -47,7 +54,6 @@ end
 --- still "pass" while proving nothing.
 local function test_openpty_yields_a_real_terminal()
   local pty = with_pty()
-  if not pty then return end
   assert(tty.isatty(pty.subordinate),
     "the subordinate fd must be a terminal")
   assert(tty.isatty(pty.manager), "the manager fd must be a terminal")
@@ -65,7 +71,6 @@ test_openpty_yields_a_real_terminal()
 --- clear, those tests would pass without doing anything.
 local function test_getattr_on_a_terminal_starts_cooked()
   local pty = with_pty()
-  if not pty then return end
   local t = check.must(tty.getattr(pty.subordinate))
   assert(t.lflag & tty.ECHO ~= 0, "a fresh pty should start with ECHO on")
   assert(t.lflag & tty.ICANON ~= 0, "a fresh pty should start canonical")
@@ -78,7 +83,6 @@ test_getattr_on_a_terminal_starts_cooked()
 --- kernel actually hands back.
 local function test_make_raw_is_pure()
   local pty = with_pty()
-  if not pty then return end
   local before = check.must(tty.getattr(pty.subordinate))
   local lflag, oflag = before.lflag, before.oflag
   local vmin = before.cc[tty.VMIN + 1]
@@ -96,7 +100,6 @@ test_make_raw_is_pure()
 --- restore() must then put every one of those fields back.
 local function test_raw_then_restore_round_trips()
   local pty = with_pty()
-  if not pty then return end
   local sfd = pty.subordinate
   local before = check.must(tty.getattr(sfd))
 
@@ -124,7 +127,6 @@ test_raw_then_restore_round_trips()
 --- there was no way to tell it did anything.
 local function test_raw_keep_signals_leaves_isig()
   local pty = with_pty()
-  if not pty then return end
   check.must(tty.raw(pty.subordinate, {keep_signals = true}))
   local now = check.must(tty.getattr(pty.subordinate))
   assert(now.lflag & tty.ISIG ~= 0,
@@ -138,7 +140,6 @@ test_raw_keep_signals_leaves_isig()
 --- noecho is narrower than raw: echo off, line editing untouched.
 local function test_noecho_clears_only_echo()
   local pty = with_pty()
-  if not pty then return end
   local before = check.must(tty.getattr(pty.subordinate))
   check.must(tty.noecho(pty.subordinate))
   local now = check.must(tty.getattr(pty.subordinate))
@@ -172,7 +173,6 @@ end
 --- passes every check above and fails this one.
 local function test_noecho_actually_stops_echo()
   local pty = with_pty()
-  if not pty then return end
   assert(echo_observed(pty),
     "a cooked terminal should echo what is written to it -- if this "
     .. "fails the test below proves nothing")
@@ -187,7 +187,6 @@ test_noecho_actually_stops_echo()
 --- restore() must bring echoing back.
 local function test_raw_stops_echo_and_restore_revives_it()
   local pty = with_pty()
-  if not pty then return end
   local original = check.must(tty.raw(pty.subordinate))
   assert(not echo_observed(pty), "a raw terminal must not echo")
   assert(tty.restore(pty.subordinate, original))
@@ -227,7 +226,6 @@ end
 
 local function test_getpass_reads_without_echoing()
   local pty = with_pty()
-  if not pty then return end
   local result = fs.join(TEST_TMPDIR, "getpass.out")
 
   local pid = proc.fork()
@@ -249,8 +247,11 @@ local function test_getpass_reads_without_echoing()
     proc.kill(pid, 9)
     proc.wait(pid)
     close_pty(pty)
-    check.skip("getpass never disabled echo; cannot test without racing")
-    return
+    -- Same discipline as `with_pty`: a timed-out race is a SKIP, and a
+    -- skip must exit EXIT_SKIP, not `return` and leave the file to exit
+    -- 0 (a PASS by `records.status_of`'s reading).
+    check.needs("getpass disabling echo before the race timeout", false)
+    os.exit(check.EXIT_SKIP)
   end
   assert(mgr:write("hunter2\n"))
   proc.wait(pid)
@@ -284,7 +285,6 @@ test_getpass_reads_without_echoing()
 --- prompts for a password does not leave the user's terminal mute.
 local function test_getpass_restores_echo_afterwards()
   local pty = with_pty()
-  if not pty then return end
   local result = fs.join(TEST_TMPDIR, "getpass_restore.out")
 
   local pid = proc.fork()
@@ -300,8 +300,11 @@ local function test_getpass_restores_echo_afterwards()
     proc.kill(pid, 9)
     proc.wait(pid)
     close_pty(pty)
-    check.skip("getpass never disabled echo; cannot test without racing")
-    return
+    -- Same discipline as `with_pty`: a timed-out race is a SKIP, and a
+    -- skip must exit EXIT_SKIP, not `return` and leave the file to exit
+    -- 0 (a PASS by `records.status_of`'s reading).
+    check.needs("getpass disabling echo before the race timeout", false)
+    os.exit(check.EXIT_SKIP)
   end
   assert(mgr:write("secret\n"))
   proc.wait(pid)


### PR DESCRIPTION
Third of the review split. Two defects in the process/terminal layer.

## dup2 clobber in `child.spawn`

`spawn` wired the child's fds `0→1→2` in fixed order, reading each target's source fd number **at wiring time** — so an earlier `dup2` could clobber the very fd a later step names as its source. `spawn(argv, {stderr = fd.wrap(1)})` with stdout captured `dup2`'d the pipe onto fd 1 first, then read the now-clobbered fd 1 for stderr, landing **stderr in `Result.stdout`**. Both the fork path and the posix_spawn fast path now resolve every source fd (relocating any that aliases a std fd about to be overwritten to a pristine CLOEXEC copy) before any `dup2` runs. `"inherit"` (identity, no cross) is unchanged.

## the pty suite graded a silent PASS on skip

`tty_pty_test`'s `with_pty()` called `check.skip()` — which only prints — then returned, so on a host without a pty the file ended exit 0, graded PASS while testing nothing: the exact tautology #805/#806 set out to remove. It now exits `EXIT_SKIP`, and the getpass timeout paths with it.

## Tests

An fd-wrap swap keeps each stream on its intended descriptor; a full stdout/stderr swap routes both correctly. The `child/io.tl` coverage floor rises with the new `pin_source` helper.

## Verification

`o/bin/cosmic --make ci` → `ci: PASS (6 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1ga7YYMrjEuy5qbtZNsni)_