### PR TITLE
cli: fix three argv-dispatch defects in the parser

### DIFF
--- a/_cli/args_test.tl
+++ b/_cli/args_test.tl
@@ -413,3 +413,23 @@ local function test_help_includes_all_options()
   end
 end
 test_help_includes_all_options()
+
+-- A `--` among a script's arguments is the SCRIPT's, kept verbatim the
+-- way real `lua s.lua a -- b` keeps it -- a tool that parses its own
+-- flags, or forwards a `--`-separated argv to a child, needs it. The
+-- dispatcher used to strip every `--` after the script name.
+local function test_double_dash_reaches_the_script()
+  local script = fs.join(tmpdir, "dashes.lua")
+  fs.write(script, [[
+print("n=" .. #arg)
+for i = 1, #arg do print("a[" .. i .. "]=" .. arg[i]) end
+]])
+  local h = check.must(spawn.spawn({cosmic, script, "one", "--", "two", "--", "three"}))
+  local r = check.must(h:wait())
+  assert(r.ok, "cosmic should succeed: " .. (r.stderr or ""))
+  local out = r.stdout or ""
+  assert(out:find("n=5", 1, true), "all five args reach the script, got: " .. out)
+  assert(out:find("a[2]=--", 1, true) and out:find("a[4]=--", 1, true),
+    "the `--` separators are kept verbatim, got: " .. out)
+end
+test_double_dash_reaches_the_script()

--- a/_make/check_test.tl
+++ b/_make/check_test.tl
@@ -396,4 +396,20 @@ local function test_the_verbs_refuse_a_bad_selection_on_their_own()
 end
 test_the_verbs_refuse_a_bad_selection_on_their_own()
 
+-- `--make=verb path` (the GNU `=` spelling) keeps its path selection.
+-- It used to drop it silently -- the pre-scan matched only `--make`,
+-- not `--make=check` -- and run the whole verb. A path that names
+-- nothing must reach the selection and be refused, not ignored.
+local function test_make_equals_form_keeps_its_selection()
+  local root = app("equals")
+  local h = check.must(spawn.spawn({cosmic, "--make=check", "nope.tl"},
+      {cwd = root}))
+  local r = check.must(h:wait())
+  local out = (r.stdout or "") .. (r.stderr or "")
+  assert(r.code ~= 0, "a bad selection via --make= must fail: " .. out)
+  assert(out:find("nothing to do under: nope.tl", 1, true),
+    "the path reached the selection, not dropped: " .. out)
+end
+test_make_equals_form_keeps_its_selection()
+
 print("all make check tests passed")

--- a/cmd/cosmic/main.tl
+++ b/cmd/cosmic/main.tl
@@ -132,14 +132,17 @@ local function parse_args(): Options
       -- --make joins them (a): `--make <verb> [paths…]` is a verb plus
       -- a path list, and a path is a positional getopt would permute
       -- into its own option parse.
-      if opt_name == "test" or opt_name == "make" then
+      if opt_name == "test" or opt_name == "make"
+      or opt_name:find("^test=") or opt_name:find("^make=") then
+        -- `--make=verb` embeds the verb; the space form has it at i+1.
+        local eq = opt_name:find("=", 1, true) ~= nil
+        local vstart = eq and i + 1 or i + 2
         payload = {}
-        -- a `--` here defends against that same bug; step over it
-        local from = arg[i + 2] == "--" and i + 3 or i + 2
+        local from = arg[vstart] == "--" and vstart + 1 or vstart
         for k = from, #arg do
           payload[#payload + 1] = arg[k]
         end
-        payload_parse_end = i + 1
+        payload_parse_end = eq and i or i + 1
         script_idx = nil
         break
       elseif long_greedy[opt_name] then
@@ -220,11 +223,16 @@ local function parse_args(): Options
     return opts
   end
 
-  -- Global modifiers are collected before the dispatch loop so they are
-  -- honored regardless of position (`--extract dir --exe app`).
+  -- Modifiers up front, so a command flag cannot swallow a later --output.
   for _, o in ipairs(r.opts) do
     if o.opt == "exe" then
       opts.exe = o.arg
+    elseif o.opt == "output" then
+      opts.output = o.arg
+    elseif o.opt == "write-if-changed" then
+      opts.write_if_changed = true
+    elseif o.opt == "include-dir" then
+      opts.include_dirs[#opts.include_dirs + 1] = o.arg
     end
   end
 
@@ -270,8 +278,6 @@ local function parse_args(): Options
       return opts
     elseif opt == "embed" then
       opts.embed[#opts.embed + 1] = optarg
-    elseif opt == "output" then
-      opts.output = optarg
     elseif opt == "extract" then
       opts.extract = optarg
       return opts
@@ -303,10 +309,6 @@ local function parse_args(): Options
     elseif opt == "skill" then
       opts.skill = optarg
       return opts
-    elseif opt == "write-if-changed" then
-      opts.write_if_changed = true
-    elseif opt == "include-dir" then
-      opts.include_dirs[#opts.include_dirs + 1] = optarg
     elseif opt == "modules" then -- acted on at the top of this file
     end
   end
@@ -315,12 +317,15 @@ local function parse_args(): Options
   if script_idx then
     opts.script = arg[script_idx]
     opts.script_args[0] = arg[script_idx]
+    -- Drop one leading `--` separator; keep later ones (a script's own).
+    local start = script_idx + 1
+    if arg[start] == "--" then
+      start = start + 1
+    end
     local arg_num = 1
-    for k = script_idx + 1, #arg do
-      if arg[k] ~= "--" then
-        opts.script_args[arg_num] = arg[k]
-        arg_num = arg_num + 1
-      end
+    for k = start, #arg do
+      opts.script_args[arg_num] = arg[k]
+      arg_num = arg_num + 1
     end
     opts.script_args[-1] = arg[-1]
   end

--- a/cosmic/compile_test.tl
+++ b/cosmic/compile_test.tl
@@ -272,4 +272,23 @@ local function test_format_write_if_changed()
 end
 test_format_write_if_changed()
 
+-- --output/--write-if-changed are honored even AFTER --compile. The
+-- dispatch used to return at --compile before reaching them, so a
+-- trailing --output silently wrote to stdout instead of the file.
+local function test_output_after_compile_reaches_the_file()
+  local input = write_temp("after.tl", "local x: number = 7\nprint(x)\n")
+  local out_path = fs.join(tmpdir, "after_out.lua")
+  fs.unlink(out_path)
+  local h = check.must(spawn.spawn({cosmic, "--compile", input,
+        "--output", out_path, "--write-if-changed"}))
+  local r = check.must(h:wait())
+  assert(r.ok, "compile with a trailing --output should succeed: " ..
+    (r.stderr or ""))
+  assert(fs.isfile(out_path),
+    "an --output after --compile must reach the file, not stdout")
+  local written = check.must(fs.read(out_path))
+  assert(written:find("local x = 7", 1, true), "got: " .. written)
+end
+test_output_after_compile_reaches_the_file()
+
 print("All compile tests passed!")


### PR DESCRIPTION
Fourth of the review split. Three ways the CLI dispatcher mishandled its own argv.

## `--make=verb` dropped its selection silently

The pre-scan matched only `--make`/`--test` (space form), so `--make=test foo.tl` ran the **whole** suite instead of the one file — the path was discarded. It now recognizes the `=` form and keeps the payload.

## `--output` / `--write-if-changed` after a command flag were lost

The dispatch loop returns the instant it reaches `--compile` (etc.), so a trailing `--output` never registered and the compiled result went to stdout. These modifiers now join `--exe` in the position-independent pre-collection, so order no longer matters.

## every `--` was stripped from a script's argv

A single leading `--` right after the script is the separator and is still dropped; every later one is the script's own — its getopt, a child it forwards to — and is now kept, the way real `lua s.lua a -- b` keeps it. (The existing `test_arguments_with_special_chars` still passes: its leading `--` is the one that's dropped.)

## Tests

The `=` form refuses a bad selection (proving the path reached it), an `--output` after `--compile` reaches the file, and a `--`-carrying argv arrives at the script intact.

## Verification

`o/bin/cosmic --make ci` → `ci: PASS (6 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1ga7YYMrjEuy5qbtZNsni)_