### PR TITLE
make: run builds a binary-less target and passes stdin through

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -35,7 +35,7 @@ _make/pin.tl 80 81
 _make/policy.tl 46 104
 _make/project.tl 183 193
 _make/root.tl 53 58
-_make/runverb.tl 64 72
+_make/runverb.tl 73 90
 _make/select.tl 33 35
 _make/stage.tl 88 96
 _make/types.tl 39 39
@@ -174,4 +174,4 @@ cosmic/user.tl 48 61
 cosmic/uuid.tl 9 9
 cosmic/zip.tl 80 93
 tlconfig.lua 7 7
-total 13430 17733
+total 13439 17751

--- a/_make/graph.tl
+++ b/_make/graph.tl
@@ -399,7 +399,7 @@ local function clean_env(): {string}
 end
 
 local function run(proj: Project, target: string, overrides: {string},
-    cosmic: string): integer, string
+    cosmic: string, extra?: {string}): integer, string
   local rules, merr = materialize(proj, cosmic)
   if not rules then
     return 1, merr or "make: could not write the build files"
@@ -427,6 +427,9 @@ local function run(proj: Project, target: string, overrides: {string},
     argv[#argv + 1] = o
   end
   argv[#argv + 1] = target
+  for _, g in ipairs(extra or {}) do -- extra goals build in the same run
+    argv[#argv + 1] = g
+  end
   -- MAKEFLAGS is cleared, and MAKELEVEL with it. A selection is passed
   -- as a command-line variable assignment, and GNU make propagates
   -- those to sub-makes -- so a `--make test <one-test>` whose test runs
@@ -474,7 +477,7 @@ local record GraphModule
   materialize: function(proj: Project, cosmic: string): string | nil, string
   find_make: function(): string | nil, string
   jobs_flag: function(): string
-  run: function(proj: Project, target: string, overrides: {string}, cosmic: string): integer, string
+  run: function(proj: Project, target: string, overrides: {string}, cosmic: string, extra?: {string}): integer, string
   inputs: function(proj: Project, kinds: {Kind}): {File}
   source_dirs: function(proj: Project): {string}
 end

--- a/_make/resolution_test.tl
+++ b/_make/resolution_test.tl
@@ -220,4 +220,67 @@ local function test_run_refusals_in_process()
 end
 test_run_refusals_in_process()
 
+-- A project with NO binary still runs a script: `run` compiles its
+-- target's closure directly, since prepare_stage builds nothing when
+-- there is nothing to stage. Before, run spawned an o/<path>.lua that
+-- was never compiled and died with "cannot open".
+local function test_run_builds_a_target_with_no_binary()
+  local root = fs.join(tmp, "res-nobinary")
+  fs.rmrf(root)
+  assert(fs.makedirs(fs.join(root, "greet")))
+  assert(fs.write(fs.join(root, ".cosmicignore"), ""))
+  assert(fs.write(fs.join(root, "greet", "init.tl"), [[
+local record G
+  hi: function(string): string
+end
+local g: G = {hi = function(who: string): string return "hi " .. who end}
+return g
+]]))
+  assert(fs.write(fs.join(root, "tool.tl"), [[
+local greet = require("greet")
+io.write("TOOL " .. greet.hi("nobin") .. "\n")
+]]))
+  local code, out = make(root, {"run", "tool.tl"})
+  assert(code == 0, "run must build and run a binary-less target: " .. out)
+  assert(out:find("TOOL hi nobin", 1, true),
+    "the target ran against its compiled closure, got: " .. out)
+end
+test_run_builds_a_target_with_no_binary()
+
+-- A binary-less target that does not compile fails `run` loudly, rather
+-- than spawning an o/ file the failed build never wrote.
+local function test_run_reports_a_binaryless_build_failure()
+  local root = fs.join(tmp, "res-buildfail")
+  fs.rmrf(root)
+  assert(fs.makedirs(root))
+  assert(fs.write(fs.join(root, ".cosmicignore"), ""))
+  assert(fs.write(fs.join(root, "bad.tl"),
+      "local x: integer = 'nope'\nreturn x\n"))
+  local code, out = make(root, {"run", "bad.tl"})
+  assert(code ~= 0, "a target that fails to compile must fail run: " .. out)
+end
+test_run_reports_a_binaryless_build_failure()
+
+-- `run` is a stdin passthrough: the target reads the caller's real fd 0,
+-- not the literal string "inherit" (which resolve_stdio reads as pipe
+-- DATA). Fed a line, the target must read that line back.
+local function test_run_passes_stdin_through()
+  local root = fixture("stdin")
+  assert(fs.write(fs.join(root, "cmd/app/main.tl"), [[
+io.write("GOT " .. tostring(io.read("l")) .. "\n")
+]]))
+  local full: {string} = {cosmic, "--make", "run", "cmd/app/main.tl"}
+  local env: {string} = {
+    "PATH=" .. (os.getenv("PATH") or ""),
+    "HOME=" .. root, "TMPDIR=" .. tmp, "NO_COLOR=1", "COSMIC_NO_WELCOME=1",
+  }
+  local h = check.must(spawn.spawn(full,
+      {cwd = root, env = env, stdin = "the-real-stdin"}))
+  local r = check.must(h:wait())
+  local out = (r.stdout or "") .. (r.stderr or "")
+  assert(out:find("GOT the-real-stdin", 1, true),
+    "the target must read the caller's stdin, not \"inherit\": " .. out)
+end
+test_run_passes_stdin_through()
+
 print("all resolution tests passed")

--- a/_make/runverb.tl
+++ b/_make/runverb.tl
@@ -16,9 +16,13 @@
 --- fresh. See docs/design/make/resolution.md.
 
 local child = require("cosmic.child")
+local fd = require("cosmic.fd")
 local fs = require("cosmic.fs")
+local unix = require("cosmo.unix")
 local modules = require("_cli.build.modules")
 local deps = require("_make.deps")
+local generate = require("_make.generate")
+local graph = require("_make.graph")
 local project = require("_make.project")
 local stage = require("_make.stage")
 local types = require("_make.types")
@@ -139,16 +143,44 @@ local function run(proj: Project, path: string, cosmic: string,
   end
   local self = file_of(proj, path) as File -- cast: resolve() proved it
   local built = deps.built_paths(deps.closure(proj, self, deps.index(proj)))
-  local child_argv: {string} = {cosmic,
-    deps.built_path(self.path, project.BUILD_DIR)}
+  local target_lua = deps.built_path(self.path, project.BUILD_DIR)
+  -- prepare_stage builds nothing when the project declares no binary,
+  -- so `run` would spawn a target it never compiled. Generate inputs,
+  -- then build the target and its runtime closure directly, so the
+  -- spawn resolves against fresh o/ output the way the with-a-binary
+  -- path (which compiles the whole tree) already does.
+  if #proj.binaries == 0 then
+    local gok, gerr = generate.sources(proj, cosmic)
+    if not gok then
+      return stage.verdict("run", false, gerr or "generate failed")
+    end
+    local code, cerr = graph.run(proj, target_lua, {}, cosmic, built)
+    if code ~= 0 then
+      if cerr and cerr ~= "" then
+        io.stderr:write(cerr .. "\n")
+      end
+      return stage.verdict("run", false, "build")
+    end
+  end
+  local child_argv: {string} = {cosmic, target_lua}
   modules.attach(child_argv, out_base(self.path), proj.root, built)
   for _, a in ipairs(target_argv) do
     child_argv[#child_argv + 1] = a
   end
   -- stdio inherited: `run` is a passthrough, and a harness that prints
-  -- a line per scenario is unreadable buffered to the end.
+  -- a line per scenario is unreadable buffered to the end. stdin is the
+  -- parent's fd 0 handed through a DUP, not the "inherit" string (which
+  -- resolve_stdio reads as literal pipe DATA): the dup lets the child
+  -- read the real terminal, and closing our copy after cannot touch the
+  -- true stdin.
+  local dup0, derr = unix.dup(0)
+  if dup0 == nil then
+    return stage.verdict("run", false, "dup stdin: " .. tostring(derr))
+  end
+  local stdin0 = fd.wrap(dup0)
   local r, rerr = child.run(child_argv,
-    {cwd = proj.root, stdout = "inherit", stderr = "inherit", stdin = "inherit"})
+    {cwd = proj.root, stdout = "inherit", stderr = "inherit", stdin = stdin0})
+  stdin0:close()
   if not (r is child.Result) then
     return stage.verdict("run", false, rerr or "cannot start")
   end


### PR DESCRIPTION
## Problem

Two defects in `--make run`:

1. **A binary-less project can't run its scripts.** `run` spawns `o/<path>.lua`, but `prepare_stage` compiles only a binary's staged payload — a project that declares no binary builds nothing, so `run` spawned a target that was never written and died with `cannot open`.
2. **stdin isn't a passthrough.** `run` handed the child the literal string `"inherit"` as its stdin. `resolve_stdio` reads a string as pipe *data*, so the target read the six bytes `inherit` instead of the caller's real fd 0 — a script reading stdin got that string, not the terminal or a piped input.

## Change

- `_make/runverb.tl` — on the binary-less path (`#proj.binaries == 0`), generate inputs and build the target plus its runtime closure directly via `graph.run`, so the spawn resolves against fresh `o/` output. And hand the child a `dup(0)` wrapped as an fd (closed after the run) instead of `"inherit"`, so it reads the caller's real stdin.
- `_make/graph.tl` — `run()` gains an optional `extra?: {string}` goals argument so the closure builds in the same make invocation.
- `_make/resolution_test.tl` — three tests: a binary-less target runs against its compiled closure; a binary-less target that fails to compile fails `run` loudly; and `run` passes the caller's stdin through (reads back the line it was fed).

## Testing

`o/bin/cosmic --make ci` passes (6 stages, 178 checks, coverage ratchet ok). Coverage floor bumped for `runverb.tl` (64/72 → 73/90).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1ga7YYMrjEuy5qbtZNsni)_