### PR TITLE
ci: read-only release token, honest coverage diagnostic, per-file ratchet keys

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,9 @@ env:
 
 # Two pushes to main in quick succession would otherwise race on the
 # `docs` branch and one publish would be rejected. Queue instead of
-# cancel: every commit's docs get published, in order.
+# cancel — though GitHub keeps at most one PENDING run per group, so a
+# burst of pushes publishes the latest commit's docs (which is what
+# matters) and may skip intermediate ones.
 concurrency:
   group: docs-publish
   cancel-in-progress: false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,8 +69,9 @@ jobs:
 
       # The gate runs as a non-root user: see the identity note above.
       # The system-wide safe.directory keeps git usable for that user,
-      # since lint discovers files with `git ls-files` and the version
-      # stamp reads `git describe`.
+      # since lint discovers files with `git ls-files`. (The version
+      # stamp does NOT read git — it comes from a root `.version` file
+      # or COSMIC_VERSION; see cmd/cosmic/embed_gen.tl.)
       - name: prepare non-root builder
         shell: bash
         run: |
@@ -155,9 +156,15 @@ jobs:
           # stopped running, which is the difference between reading the
           # diff and guessing at it across CI cycles.
           echo "===== coverage detail for the declining rows ====="
+          # Source dirs too, not just the data dir: the report only lists
+          # a ZERO-hit file when it can scan the directory holding it, so
+          # without them the diagnostic goes silent for exactly the file
+          # that lost all its coverage. The gate already wrote the list it
+          # used to o/project.mk (coverage_dirs); reuse it verbatim.
+          dirs=$(sed -n 's/^coverage_dirs := //p' o/project.mk)
           for f in $(grep -oP '(?<=coverage ratchet: declined: ).*' o/gate.log | tail -1); do
             runuser -u builder -- env HOME="$HOME" PATH="$PATH" \
-              o/bin/cosmic --coverage-report o/.coverage 2>/dev/null \
+              o/bin/cosmic --coverage-report o/.coverage $dirs 2>/dev/null \
               | grep -F "$f "
           done
           exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,20 @@ on:
         type: boolean
         default: true
 
+# The build job runs the whole gate — arbitrary tree code and tests —
+# with the checkout token persisted in .git/config, so the default token
+# must be read-only. The `release` job below elevates itself to
+# `contents: write`, the one permission publishing needs.
+permissions:
+  contents: read
+
+# One release at a time: a schedule fire and a manual dispatch on the
+# same commit race to create the same dated tag, and the loser errors
+# out of `gh release create`. Queue, and never cancel a release mid-run.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 env:
   PRERELEASE: true
 

--- a/_build/workflows_test.tl
+++ b/_build/workflows_test.tl
@@ -95,10 +95,15 @@ test_the_image_is_pinned_by_digest()
 -- rather than derived because "runs build machinery" is a judgement:
 -- the cross-OS smoke matrix deliberately does NOT (real macOS and
 -- Windows runners are its entire point), and a job added without a
--- decision here is a job whose environment nobody chose.
+-- decision here is a job whose environment nobody chose. Keyed by
+-- `<workflow file>:<job>`, not bare job name — a future job that merely
+-- reuses the name `smoke` in another workflow is a fresh decision, not
+-- an inherited exemption.
 local UNCONTAINERISED < const >: {string: string} = {
-  ["smoke"] = "the cross-OS matrix: native macOS/Windows runners are the point",
-  ["release"] = "no build machinery: artifact download + `gh release create`",
+  ["pr.yml:smoke"] =
+  "the cross-OS matrix: native macOS/Windows runners are the point",
+  ["release.yml:release"] =
+  "no build machinery: artifact download + `gh release create`",
 }
 
 -- What a lane pins about its environment, per job.
@@ -192,9 +197,10 @@ local function test_every_build_job_is_containerised()
   for _, path in ipairs(workflows()) do
     for name, job in pairs(jobs_in(path)) do
       jobs = jobs + 1
-      if UNCONTAINERISED[name] then
+      local key = fs.basename(path) .. ":" .. name
+      if UNCONTAINERISED[key] then
         assert(not job.containerised, path .. ": job '" .. name ..
-          "' is recorded as uncontainerised (" .. UNCONTAINERISED[name] ..
+          "' is recorded as uncontainerised (" .. UNCONTAINERISED[key] ..
           ") but declares a container")
       else
         assert(job.containerised, path .. ": job '" .. name .. "' runs " ..


### PR DESCRIPTION
First of a series of PRs fixing findings from a deep review of the repo (code, API, docs, build/CI). This one is the CI/workflow batch — small, low-risk, and worth landing first.

## Fixes

- **release.yml: scope the default token to `contents: read`.** The `build` job runs the entire gate — arbitrary tree code and tests — with the checkout token persisted in `.git/config`, and it inherited the repository default permissions. pr.yml already pins `contents: read`; release.yml now does too, with the `release` job keeping its explicit `contents: write` elevation.
- **release.yml: add a `concurrency` group.** A schedule fire plus a manual dispatch on the same commit race to create the same dated tag (`YYYY-MM-DD-<sha7>`), and the loser errors out of `gh release create`. Queue, never cancel a release mid-run.
- **pr.yml: the coverage-decline diagnostic could not show the worst declines.** The `if: failure()` tail step passed only `o/.coverage` to `--coverage-report`, but the report lists a *zero-hit* file only when it can also scan the source directory holding it — so the diagnostic printed nothing exactly when a file lost all its coverage. It now reuses the `coverage_dirs` list the gate itself wrote to `o/project.mk`.
- **pr.yml: stale comment.** The `safe.directory` justification claimed "the version stamp reads `git describe`"; the version comes from a root `.version` file or `COSMIC_VERSION` (`cmd/cosmic/embed_gen.tl` refuses to shell out to git). The `git ls-files` half is still true, so the config stays.
- **docs.yml: honest concurrency comment.** "Every commit's docs get published, in order" overclaims — GitHub keeps at most one *pending* run per group; the latest commit's docs always publish, intermediate ones may be skipped.
- **workflows_test.tl: key the container-ratchet exemptions by `workflow:job`.** `UNCONTAINERISED` was keyed by bare job name across all workflows, so any future job named `smoke` or `release` in *any* workflow would silently escape the pinned-container ratchet.

## Gate

```
ci: PASS (6 stages)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE)_