### PR TITLE
docs: fix docs/comments that drifted from the code (PR-03)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ not yet carry is in [docs/design/make/](docs/design/make/).
 - **naming**: `snake_case` for functions and variables. `PascalCase` for record types and record constructors (e.g. `signal.Sigset()`); options records are named `Options` (or `<Thing>Options` when a module has several).
 - **formatting**: 2-space indent, LF line endings, enforced by `cosmic --check fmt`
 - **column width**: 90 columns is house style, and the one style rule
-  that is NOT a gate — the tree has 858 lines over it and the gate never
+  that is NOT a gate — the tree has roughly 800+ lines over it and the gate never
   checked (`cosmic.style.check_column_length` is exported and unused by
   `--check lint`). Write to 90; do not expect a failure if you do not.
 - **warnings are errors**: `--check types` fails on any Teal warning (unused, shadowing, unreachable branch). mark deliberately-unused values with a leading underscore (`local _out`, `_self: Poller`).
@@ -182,33 +182,27 @@ formatted string plus the numeric errno), wrappers add context with
 **Narrowing record/map unions.** Teal (0.24.8) does not flow-narrow record
 or map unions through truthiness (`if not x`). Three sanctioned tools:
 
-- **In tests and examples, use `check.must`** for fallible returns:
-  `local db = check.must(sqlite.open(path))` yields a plain `Database` —
-  no cast, no assert. Lua passes multiple returns through, so a failing
-  call reports the callee's own error string. `must` narrows nil only
-  (`false` passes through), and it throws, so it is for tests/examples,
-  never library code. Like `assert`, must forwards extra returns past
-  the second, so `for p in check.must(fs.files(d)) do` keeps the 4th
-  return (the to-be-closed guard that releases directory handles on
-  early break); a plain `value, err` pair still collapses to the value
-  alone. Never write `assert(x) as T` in a test; that pattern is
-  retired.
-- **Prefer `is` where the code branches, for table-backed records**:
-  `if sock is net.Socket then sock:send(...) end` narrows `Socket | nil`
-  inside the positive branch (compiles to one `type(x) == "table"` check).
-  Also works for dispatch over `any` (`if v is {string: any} then`).
-  A record whose runtime values are userdata needs Teal's `userdata`
-  member in its OWN source (see re.tl's Regex) — then `is` compiles to
-  the correct `type(x) == "userdata"` test everywhere. Caveats:
-  narrowing does NOT survive an early-exit guard (`if not (x is Rec)
-  then return end` does not narrow below); and `is` is WRONG for
-  mixed-representation records — `fs.Stat` is usually the raw stat
-  userdata but falls back to a plain wrapper table, so neither marker
-  fits; it stays on casts. `is` works with required `cosmo.*` classes
-  too — the cosmic searcher is the only loader cosmic installs, and it
-  resolves `.d.tl` markers. The one unsupported path is user code
-  calling `require("tl").loader()`, which shadows it with tl's silent
-  one.
+- **In tests and examples, use `check.must`** for fallible returns: `local db =
+  check.must(sqlite.open(path))` yields a plain `Database` — no cast, no assert. Lua
+  passes multiple returns through, so a failing call reports the callee's own error
+  string. `must` narrows nil only (`false` passes through), and it throws, so it is for
+  tests/examples, never library code. Like `assert`, must forwards extra returns past
+  the second, so `for p in check.must(fs.files(d)) do` keeps the 4th return (the to-be-
+  closed guard that releases directory handles on early break); a plain `value, err`
+  pair still collapses to the value alone. Never write `assert(x) as T` in a test; that
+  pattern is retired.
+- **Prefer `is` where the code branches, for table-backed records**: `if sock is
+  net.Socket then sock:send(...) end` narrows `Socket | nil` inside the positive branch
+  (compiles to one `type(x) == "table"` check). Also works for dispatch over `any` (`if
+  v is {string: any} then`). A record whose runtime values are userdata needs Teal's
+  `userdata` member in its OWN source (see re.tl's Regex) — then `is` compiles to the
+  correct `type(x) == "userdata"` test everywhere. Caveats: narrowing does NOT survive
+  an early-exit guard (`if not (x is Rec) then return end` does not narrow below); and
+  `is` is WRONG for mixed-representation records — `fs.Stat` is usually the raw stat
+  userdata but falls back to a plain wrapper table, so neither marker fits; it stays on
+  casts. `is` works with required `cosmo.*` classes too — the cosmic searcher is the
+  only loader cosmic installs, and it resolves `.d.tl` markers. The one unsupported path
+  is user code calling `require("tl").loader()`, which shadows it with tl's silent one.
 - **Cast in linear code and at userdata boundaries**: after an assert or
   early-exit guard, `(x as Rec).field`, `(x as {K:V})[k]`. Scalars
   (`string | nil`) narrow normally, except method-call syntax: use
@@ -360,13 +354,16 @@ all modules are under `cosmic/` and imported as `cosmic.*`:
 |--------|-------------|
 | ansi | ANSI terminal styling: colors, attributes, strip, NO_COLOR-aware gating |
 | benchmark | benchmark runner with `Benchmark_*` functions (`--make benchmark`) |
+| check | assertion helpers for tests/examples (`eq`, `ok`, `must`) plus environment-gating helpers (`skip`, `needs`, `enforcing`) |
 | child | child process spawning with I/O control |
 | codec | hex encoding/decoding, Lua serialization |
 | compress | zlib compression/decompression |
+| coverage | line coverage collection for cosmic programs (`--make coverage`) |
 | doc | extract docs from source and query the embedded documentation index |
 | embed | create custom executables with embedded files |
 | env | environment variable get (nil when unset), get_or, set/unset |
 | envd | load environment variables from embedded env.d directory |
+| errno | canonical errno formatting (`str`) and lookup helpers (`is`, `code`, `constants`) for `cosmo.unix` failures |
 | example | example runner with `Example_*` functions |
 | fetch | HTTP client with retry support |
 | flags | declarative command-line flag parsing with generated --help |
@@ -398,8 +395,9 @@ all modules are under `cosmic/` and imported as `cosmic.*`:
 | signal | signal handling, timers, sigsets |
 | sqlite | SQLite with ergonomic query/exec/transaction API |
 | sse | Server-Sent Events parser |
+| stream | the byte-stream Reader/Writer contract every producer and consumer composes over |
 | string | trim, split, capitalize, starts_with, etc. |
-| style | the style checks behind `--check lint`: file length, column width, ordering |
+| style | pure style checks — only file length is actually behind `--check lint`; column width is exported but unenforced, and test-call ordering (`call-after-define`) lives in `_cli/lint.tl`, not here |
 | sys | OS/architecture detection, sysconf (nproc, page size), uname |
 | syslog | system logging |
 | table | deep copy/merge/equality and map/filter/reduce for tables |
@@ -480,21 +478,20 @@ discipline). the backlog is GitHub issues labeled `perf`.
 
 ## CI
 
-- **pr.yml**: three lanes on push/PR to main. `ci` fetches with a network,
-  then builds and runs the whole gate (fmt, check, test, example, lint,
-  coverage) inside a loopback-only network namespace, so a stray download
-  fails loudly. It builds first and gates with the RESULT, or the six
-  stages would report on the pinned release instead of the change.
-  `build` does what needs a real network: double-build reproducibility
-  (two tree paths) and `--make fetch` against the real pins. Both Linux
-  lanes are privileged and non-root: `_cli/fence_test.tl` asserts a real
-  Landlock denial, the quicksand tests unshare and mount. `smoke` runs
-  the built binary on real macOS/Windows runners. The fence is ON by
-  default (`COSMIC_FENCE=0` opts out); the build lane asserts the host
-  can enforce and that a real build passes fenced — the direction a
-  denial test cannot prove
+- **pr.yml**: three lanes on push/PR to main. `ci` fetches with a network, then builds
+  and runs the whole gate (fmt, check, test, example, lint, coverage) inside a loopback-
+  only network namespace, so a stray download fails loudly. It builds first and gates
+  with the RESULT, or the six stages would report on the pinned release instead of the
+  change. `build` does what needs a real network: double-build reproducibility (two tree
+  paths) and `--make fetch` against the real pins. Both Linux lanes are privileged and
+  non-root: `_cli/fence_test.tl` asserts a real Landlock denial, the quicksand tests
+  unshare and mount. `smoke` runs the built binary on real macOS/Windows runners. The
+  fence is ON by default (`COSMIC_FENCE=0` opts out); the build lane asserts the host
+  can enforce and that a real build passes fenced — the direction a denial test cannot
+  prove
 - **docs.yml**: `--make docs` then `_docs/publish.tl`, to the `docs`
   branch on push to main
-- **release.yml**: daily release. Builds twice — the pinned cosmic builds
+- **release.yml**: daily release, built twice — the pinned cosmic builds
   one from the tree, and THAT one builds what ships, so a release is
-  produced by the code it contains rather than by whatever the pin is
+  produced by its own code, not the pin. cron runs default to a
+  prerelease; a real one needs `workflow_dispatch` with `prerelease: false`

--- a/_make/check.tl
+++ b/_make/check.tl
@@ -24,11 +24,14 @@ local type Project = types.Project
 --- include path by the sources that require it. `.lua` sources are
 --- absent too — Lua is not type-checked, by definition.
 ---
---- Everything else that compiles is here, including the two kinds that
---- are easy to forget: `build` strict-compiles a `benchmark`, so a
---- table without it lets `check` pass a tree `build` rejects; and a
+--- Everything else that compiles is here, including the three kinds
+--- that are easy to forget: `build` strict-compiles a `benchmark`, so a
+--- table without it lets `check` pass a tree `build` rejects; a
 --- binary's `payload-gen` is the file that decides what SHIPS, which
---- makes it the last one that should be gated by fmt and lint alone.
+--- makes it the last one that should be gated by fmt and lint alone;
+--- and `pin` -- a `*_pin.tl` is read as data (never executed) but is
+--- still Teal source, so it gets the same strict type-check as
+--- everything else here.
 local checkable: {string: boolean} = {
   module = true,
   entry = true,

--- a/_make/select.tl
+++ b/_make/select.tl
@@ -67,9 +67,6 @@ local function select_files(files: {File}, paths: {string}, root: string): {File
   return picked
 end
 
---- The paths of a file list, for handing to make or a message.
---- @param files {File} The files
---- @return {string} Their paths, in order
 local record SelectModule
   covers: function(sel: string, path: string): boolean
   files: function(files: {File}, paths: {string}, root: string): {File} | nil, string

--- a/_perf/OPTIMIZE.md
+++ b/_perf/OPTIMIZE.md
@@ -19,11 +19,11 @@ file so no chapter ever fights the repo's 500-line-per-file cap:
 
 ## the harness in one minute
 
-`_perf` benchmarks ~25 end-to-end scenarios (JSON, SQLite, HTTP client,
-filesystem, hashing/codecs/compression, binary startup, Teal compilation,
-subprocess spawn). every scenario validates its own output with a
-`check()` function, so a change that makes a workload faster but wrong
-FAILS the benchmark.
+`_perf` benchmarks ~36 end-to-end scenarios across 12 bench modules
+(JSON, SQLite, HTTP client, filesystem, hashing/codecs/compression,
+binary startup, Teal compilation, subprocess spawn). every scenario
+validates its own output with a `check()` function, so a change that
+makes a workload faster but wrong FAILS the benchmark.
 
 The harness is scripts, driven through `--make run` by whichever binary
 you are measuring. `$BIN` is the cosmic under test (`o/bin/cosmic`, or a
@@ -54,8 +54,9 @@ $BIN --make run _perf/run.tl --out o/perf/current.json $BENCH
 # …the same, filtered to one scenario group
 $BIN --make run _perf/run.tl --only json --out o/perf/current.json $BENCH
 
-# compare two runs with the noise-aware bar
-$BIN --make run _perf/run.tl --compare o/perf/baseline.json o/perf/current.json
+# compare two runs with the noise-aware bar (retries + A/A auto-triage)
+$BIN --make run _perf/gate.tl compare o/perf/baseline.json o/perf/current.json \
+  o/perf/selfb.json $BENCH
 
 # A/A control: the same binary against itself is the noise floor
 $BIN --make run _perf/gate.tl selfcheck o/perf/a.json o/perf/b.json $BENCH
@@ -64,22 +65,26 @@ $BIN --make run _perf/gate.tl selfcheck o/perf/a.json o/perf/b.json $BENCH
 A baseline is just a results file you keep: run the unmodified build
 into `o/perf/baseline.json` before changing anything.
 
-`--compare` already handles the false alarm for you: when a
+`gate.tl compare` already handles the false alarm for you: when a
 regression survives its retry, it runs one more pass of the same binary
 and auto-triages against that A/A self-check — a fixed-overhead
 microbench (`hash_sha256_small`, `startup_run_*`, `net_ip_*`) that swung
 on frequency scaling, a noisy neighbor, or code-layout shift is reported
 as `noise` and does not fail the gate, while a regression the binary
-reproduces against itself still fails. `gate.tl selfcheck` runs that same
-A/A control standalone, for interactive use or to profile the machine's
-noise floor before you start. `_perf/optimize/measurement.md` has the
-full playbook.
+reproduces against itself still fails. (`_perf/run.tl --compare` is the
+plain, non-retrying diff the gate builds on — it just diffs two files.)
+`gate.tl selfcheck` runs that same A/A control standalone, for
+interactive use or to profile the machine's noise floor before you
+start. `_perf/optimize/measurement.md` has the full playbook.
 
-knobs: `PERF_SAMPLES` (default 5), `PERF_MIN_SECS` (default 0.15),
-`PERF_THRESHOLD` (regression bar in percent, default 10), `PERF_BIN`
-(which cosmic binary to measure). Measuring a local Cosmopolitan build
-takes no knob — you stand it in at `o/3p/cosmos/lua` and rebuild; see
-the cosmopolitan chapter.
+knobs: `--samples` (default 5), `--min-secs` (default 0.15),
+`--threshold` (regression bar in percent, default 10). `PERF_BIN` is not
+a knob on the runner — it is an env var the process-spawning scenarios
+(`startup_*`, `embed_*`) read to pick which binary they exec; `run.tl`
+itself only records it (or falls back to `arg[-1]`) as a metadata label
+in the report. Measuring a local Cosmopolitan build takes no knob — you
+stand it in at `o/3p/cosmos/lua` and rebuild; see the cosmopolitan
+chapter.
 
 report columns, per scenario:
 
@@ -133,9 +138,9 @@ work ONE scenario (or one closely related group) at a time.
    the binary your change builds. the perf smoke test
    (`_perf/perf_test.tl`) runs every scenario end to end in CI, so a
    broken scenario check fails here too.
-5. **gate 2 — performance:** re-measure and `--compare` against your
-   baseline. it uses a noise-aware bar
-   (max of `PERF_THRESHOLD`, baseline spread, current spread), retries
+5. **gate 2 — performance:** re-measure and run `gate.tl compare` against
+   your baseline. it uses a noise-aware bar
+   (max of `--threshold`, baseline spread, current spread), retries
    once on failure to filter machine noise, and exits nonzero if any
    scenario regressed, errored, or disappeared. if a regression survives
    the retry it runs one more pass of the same binary and auto-triages:

--- a/_perf/optimize/cosmopolitan.md
+++ b/_perf/optimize/cosmopolitan.md
@@ -95,7 +95,8 @@ BENCH=$(ls _perf/bench/*_bench.tl | sed 's|/|.|g;s|\.tl$||')
    cp $COSMO/o/tool/lua/lua o/3p/cosmos/lua
    bin/cosmic --make build
    $BIN --make run _perf/run.tl --out o/perf/current.json $BENCH
-   $BIN --make run _perf/run.tl --compare o/perf/baseline.json o/perf/current.json
+   $BIN --make run _perf/gate.tl compare o/perf/baseline.json o/perf/current.json \
+     o/perf/selfb.json $BENCH
    ```
 
 6. **decide** with the same rules as the main loop: target scenario
@@ -124,11 +125,15 @@ two-repo dance — but only AFTER the local loop already proved the win:
    own conventions). quote the local `perf-compare` numbers in the PR.
 2. once merged, the release workflow publishes a new cosmos release
    tagged `YYYY.MM.DD-<sha>` with a `cosmos.zip` + SHA256SUMS.
-3. in cosmic: bump `3p/cosmos/cosmos_pin.tl` (version + sha256), then
-   `cosmic --make run _types/gentype.tl`, fix any wrapper breakage, `--make ci`, and
-   a `--compare` against a baseline taken on the OLD pin —
-   this final compare is the end-to-end confirmation, quoted in the
-   bump commit.
+3. in cosmic: bump `3p/cosmos/cosmos_pin.tl` (version + sha256). there is
+   no separate regen step — `_types/gentype.tl` is a pure library with
+   no `is_main` entry, so `--make run` on it is a no-op; every graph
+   verb (`--make build`, `--make ci`, ...) runs `_types/types_gen.tl`
+   first and it regenerates `o/_types/types_gen` from the new pin (see
+   AGENTS.md "Type Generation"). so: `bin/cosmic --make build`, fix any
+   wrapper breakage, `--make ci`, and a `gate.tl compare` against a
+   baseline taken on the OLD pin — this final compare is the end-to-end
+   confirmation, quoted in the bump commit.
 
 ## finding C-layer opportunities
 

--- a/_perf/optimize/finding.md
+++ b/_perf/optimize/finding.md
@@ -34,10 +34,10 @@ below. the closed-as-completed issues are worked examples of each.
   `http_tcp_roundtrip` isolates the fetch-wrapper overhead from raw
   socket cost; `startup_run_teal` vs `startup_run_lua` isolates the Teal
   loader from runtime boot.
-- **profile a single scenario** by bisection: `run.lua
-  PERF_ONLY=<name>` is cheap; temporarily splitting a scenario's fn into
-  narrower scenarios in a scratch bench file localizes the cost. delete
-  scratch scenarios before committing.
+- **profile a single scenario** by bisection: `run.lua --only <name>`
+  is cheap; temporarily splitting a scenario's fn into narrower
+  scenarios in a scratch bench file localizes the cost. delete scratch
+  scenarios before committing.
 - **alloc-per-op sanity math.** for each scenario ask "what does one op
   *have* to allocate?" and compare to the `alloc` column — the gap is
   machinery. a single-row sqlite point query has to allocate roughly

--- a/_perf/optimize/measurement.md
+++ b/_perf/optimize/measurement.md
@@ -42,7 +42,7 @@ chapter of `_perf/OPTIMIZE.md` — read that first.
   on both builds back to back (`run.lua --only <name>` on A,
   then on B) also removes the thermal/cache wake left by the ~20
   scenarios that precede it in a full suite.
-- prefer default `PERF_SAMPLES`/`PERF_MIN_SECS` for accept/reject
+- prefer the default `--samples`/`--min-secs` for accept/reject
   decisions; use lower values only for quick scouting.
 - scenarios must be stationary: an op must not get slower the more often
   it runs (growing tables, leaking fds, write-churn on overlay

--- a/cosmic/check.tl
+++ b/cosmic/check.tl
@@ -206,7 +206,7 @@ end
 ---     end
 ---
 --- @param what string What is missing, named for the message
---- @param ok boolean Whether the precondition holds
+--- @param present boolean Whether the precondition holds
 --- @return boolean True when the test may proceed
 local function needs(what: string, present: boolean): boolean
   if present then

--- a/cosmic/coverage/baseline.tl
+++ b/cosmic/coverage/baseline.tl
@@ -1,4 +1,3 @@
-#!/usr/bin/env cosmic
 --- Coverage ratchet: compare a coverage run against a committed baseline.
 ---
 --- The baseline (`.cosmic-coverage` at the project root) records covered/total
@@ -9,9 +8,9 @@
 --- entry) — the ratchet only moves up. `cosmic --make coverage` runs the
 --- check; `cosmic --make coverage --baseline` rewrites the baseline.
 ---
---- Dual use: `require`d for the API, or run as a script:
----   cosmic .../baseline.lua write <report paths...>   > baseline.txt
----   cosmic .../baseline.lua check <baseline.txt> <report paths...>
+--- A library module: `require`d for its API (`gate`, `text_for`,
+--- `lowered`, ...) by the `coverage` verb. There is no standalone CLI
+--- here.
 local fs = require("cosmic.fs")
 local rep = require("cosmic.coverage.report")
 

--- a/cosmic/style.tl
+++ b/cosmic/style.tl
@@ -8,8 +8,8 @@
 --- composes these with those and is what `--check lint` runs.
 ---
 --- Column length is exported and not run by that composition: this tree
---- does not satisfy it (~840 lines over 90 columns, most of them prose
---- in doc comments) and never did, because the gate ran a linter that
+--- does not satisfy it (roughly 800+ lines over 90 columns, most of
+--- them prose in doc comments) and never did, because the gate ran a linter that
 --- never called it. A rule a gate does not enforce reads as enforced,
 --- which is worse than no rule; enforcing this one is its own change.
 ---

--- a/cosmic/style_test.tl
+++ b/cosmic/style_test.tl
@@ -32,12 +32,12 @@ end
 test_style_valid()
 
 -- A long line is REPORTED by the check and is not a gate failure. The
--- 90-column limit is house style: this tree has 858 lines over it in
--- 184 files, and the gate never ran the check (it ran a second linter
--- that did not call it), so making `--check lint` fail on one would
--- fail the gate on the tree that documents the rule. The check stays
--- exported for a project that wants it, and enforcing it here is its
--- own change with its own 858-line diff.
+-- 90-column limit is house style: this tree has roughly 800+ lines
+-- over it across ~180 files, and the gate never ran the check (it ran
+-- a second linter that did not call it), so making `--check lint` fail
+-- on one would fail the gate on the tree that documents the rule. The
+-- check stays exported for a project that wants it, and enforcing it
+-- here is its own change with its own multi-hundred-line diff.
 local function test_style_long_line_is_reported_not_enforced()
   local long_line = string.rep("x", 91)
   local input = write_temp("style_long.tl", long_line .. "\n")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,6 +114,13 @@ and built once, and an editor needs that directory on its include path.
 
 ### `_build/` — Build Infrastructure
 
+- `ratchet.tl`: reads a committed document's markdown tables as rows —
+  the shared reader every ratchet below stands on
+- `ratchet_test.tl`: tests that reader
+- `docs_test.tl`: ratchets over the derived regions of committed
+  documents (e.g. the decisions index against the decision records)
+- `skills_test.tl`: ratchets `skills/cosmic/make.md` (the shipped make
+  skill) against `_make/`
 - `workflows_test.tl`: ratchets over the GitHub workflow definitions
 
 ### `3p/` — Third-Party Dependencies

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -116,8 +116,9 @@ per-site `-- cast: <reason>` justification enforced by `--make lint`
 — are scaffolding, not goals: each retires when the gap it polices
 closes.
 
-- **measured by:** total `as` casts in `lib/`, per release; the size of
-  the narrowing doctrine in AGENTS.md.
+- **measured by:** total `as` casts in the tree (`cosmic/` and the
+  root-level internals), per release; the size of the narrowing
+  doctrine in AGENTS.md.
 - **win condition:** zero casts; the scaffolding deleted; the doctrine
   reduced to a footnote.
 

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -26,6 +26,8 @@ local sqlite = require("cosmic.sqlite")
 | `cosmic.sys` | OS and architecture detection |
 | `cosmic.time` | timestamps, sleep, clock, datetime breakdown |
 | `cosmic.uuid` | UUIDv4 (random) and UUIDv7 (time-ordered) |
+| `cosmic.table` | deep copy/merge/equality and map/filter/reduce for tables |
+| `cosmic.searcher` | the runtime `.tl` package searcher every artifact installs at boot |
 
 ### Networking
 
@@ -47,6 +49,7 @@ local sqlite = require("cosmic.sqlite")
 | `cosmic.compress` | zlib/gzip/raw compress/decompress |
 | `cosmic.html` | HTML entity escaping |
 | `cosmic.zip` | ZIP archive reading and writing |
+| `cosmic.tar` | extract a gzipped tarball, in process |
 
 ### Security
 
@@ -77,6 +80,9 @@ local sqlite = require("cosmic.sqlite")
 | `cosmic.tty` | terminal detection, window size, termios |
 | `cosmic.syslog` | system logging with priority levels |
 | `cosmic.getopt` | command-line option parsing |
+| `cosmic.flags` | declarative command-line flag parsing built on getopt, with generated `--help` |
+| `cosmic.ansi` | ANSI terminal styling: colors, attributes, strip, NO_COLOR-aware gating |
+| `cosmic.log` | leveled logging to stderr with key=value fields |
 
 ### Text
 
@@ -96,6 +102,11 @@ local sqlite = require("cosmic.sqlite")
 | `cosmic.example` | example runner |
 | `cosmic.benchmark` | benchmark runner |
 | `cosmic.testrun` | test execution and reporting |
+| `cosmic.coverage` | line coverage collection for cosmic programs (`--make coverage`) |
+| `cosmic.instrument` | timing/resource spans: emit key=value lines to stderr, and parse them back |
+| `cosmic.records` | a build's machine-readable records: row, summary, verdict, exit codes |
+| `cosmic.style` | pure style checks (file length, column width) that `_cli.lint` composes into `--check lint` |
+| `cosmic.literal` | read a Teal/Lua file as data: one `return { … }` of literals, never executed |
 
 ## Error Handling Patterns
 

--- a/embed/cosmic.mk
+++ b/embed/cosmic.mk
@@ -27,11 +27,17 @@ SHELL := $(COSMIC)
 # per-target variable the facts file computed.
 .SECONDEXPANSION:
 
-# Content decides, mtime only schedules: every verb writes its output
-# only when the bytes change, so a no-op step leaves its target's
-# mtime alone and non-changes stop propagating. `--make build` holds
-# to it for the ARTIFACT too, which is what makes the next line
-# affordable.
+# Not every verb leaves a no-op target's mtime alone -- only three
+# things actually do: `write-list` and the makefiles (`o/project.mk`,
+# via `write_if_changed`) skip the write entirely when the bytes match,
+# and the ARTIFACT itself is swapped in only when it differs
+# (`replace_if_changed`), so an unchanged binary never invalidates the
+# tree that depends on the tool that built it. Most recipe steps
+# (`compile`, `capture`, via `run_into`) instead restamp the target's
+# mtime even when the bytes are unchanged -- deliberately, so a target
+# make judged out of date does not stay out of date forever -- and
+# `tee`/`copy` write unconditionally. Convergence rests on the
+# artifact, not on every intermediate staying untouched.
 #
 # $(COSMIC_DEP) — the driver itself — is a prerequisite of every graph
 # rule, because a result is only as fresh as the tool that produced it.
@@ -59,8 +65,10 @@ SHELL := $(COSMIC)
 # early for a phony file too, and a phony target's recipe always runs.
 # A summary is a REPORT over targets that already exist -- reading a
 # handful of `.got` files -- so always-fresh is what it should have
-# been. Content still decides what lands: `tee` writes only on change,
-# so an unchanged summary keeps its mtime and stops propagating.
+# been. `tee` writes the summary unconditionally every run (it does not
+# compare against the existing file), which is fine precisely because
+# the target is phony: nothing depends on the summary's mtime for
+# freshness, only on the `.got` files it reads.
 .PHONY: $(O)/fmt-summary.txt $(O)/test-summary.txt \
         $(O)/example-summary.txt $(O)/benchmark-summary.txt \
         $(O)/lint-summary.txt $(O)/coverage-summary.txt
@@ -121,9 +129,14 @@ test: $(O)/test-summary.txt
 
 # A test's prerequisites are exactly what it imports, transitively --
 # as BUILT paths, since a test runs against compiled Lua. The same list
-# goes into the recipe line, so the derived fence grants the test read
-# access to what it imports and nothing else. One answer, two
-# consumers: the argument positions are the declaration.
+# goes into the recipe line, feeding the derived fence -- but the fence
+# grants a test read access to the whole project ("."), plus the
+# runtime paths tests legitimately touch (ptys, /proc/self/fd, resolver
+# files), not just what it imports: an import-only read grant did not
+# survive contact with real tests (see `_cli/grants.tl`'s "record"
+# case). What IS narrow is the write grant: only the test's own `.got`
+# base and TMPDIR. One answer, two consumers: the argument positions
+# are the declaration.
 $(O)/%.tl.test.got: $(O)/%.lua $(COSMIC_DEP) $$(deps_$$*)
 	record $(basename $@) $(COSMIC) $< --deps $(deps_$*) ;
 

--- a/skills/cosmic/make.md
+++ b/skills/cosmic/make.md
@@ -446,7 +446,9 @@ than by anyone configuring a build: `COSMIC_ENFORCE=1` turns a sandbox
 test that cannot enforce from a skip into a failure (CI's enforce lane
 sets it), `GENTYPE_DEFS` points type generation at a cosmopolitan
 checkout's `definitions.lua` to validate before a release is cut, and
-`PERF_BIN` names which binary `_perf` measures.
+`PERF_BIN` names which binary the process-spawning `_perf` scenarios
+(`startup_*`, `embed_*`) exec — it does not select the binary the
+harness itself runs under.
 
 **internal** — the build sets these for its own children. Setting one
 by hand is a way to confuse a build, not to configure it:

--- a/sys/help.md
+++ b/sys/help.md
@@ -29,7 +29,7 @@ Cosmic options:
   --report <paths>...           report on .got files written by --test
                                 e.g. cosmic --report o/foo.got
   --coverage-report <paths>...  merge .cov data, print per-file line coverage
-                                e.g. cosmic --coverage-report o/coverage cosmic
+                                e.g. cosmic --coverage-report o/.coverage cosmic
   -c <line>                     run one recipe line as argv, not shell
                                 (for make: SHELL := cosmic. the closed
                                  vocabulary: assert-elf, assert-marker,
@@ -37,7 +37,7 @@ Cosmic options:
                                  record, remove, tee, verdict, write-list)
   --make <verb> [paths]...      build this project
                                 (build, check, test, fmt, lint, example,
-                                 benchmark, docs, coverage, ci, fetch,
+                                 benchmark, docs, coverage, run, ci, fetch,
                                  clean; `--make help` lists them)
   --skill <dir>                 write agent skill file (SKILL.md) to directory
   --welcome                     show welcome message


### PR DESCRIPTION
Documentation/comment-only. Each claim was re-verified against the current code before editing; no behavior changed.

- `_perf/OPTIMIZE.md:78-79`: `PERF_SAMPLES`/`PERF_MIN_SECS`/`PERF_THRESHOLD` don't exist; replaced with the real `--samples`/`--min-secs`/`--threshold` CLI flags. `PERF_BIN` clarified as a label the process-spawning scenarios read to pick a binary, not a runner knob (`_perf/run.tl:131`). Same fix in `_perf/optimize/measurement.md:45` and `skills/cosmic/make.md:449`.
- `_perf/optimize/finding.md:37-38`: `run.lua PERF_ONLY=<name>` doesn't exist; fixed to `run.lua --only <name>`.
- `_perf/OPTIMIZE.md:58,67-76,141` and `_perf/optimize/cosmopolitan.md:98`: the retry + A/A auto-triage loop lives in `gate.tl compare` (`_perf/gate.tl:84-150`), not `run.tl --compare` (a plain two-file diff, `_perf/run.tl:244-289`). Renamed the examples and prose to `gate.tl compare`.
- `_perf/optimize/cosmopolitan.md:128`: `cosmic --make run _types/gentype.tl` is a no-op (`_types/gentype.tl` has no `is_main` entry); pointed the pin-bump procedure at the real regen path (`_types/types_gen.tl`, run by every graph verb).
- `AGENTS.md`/`CLAUDE.md` module table: added missing rows for `check`, `coverage`, `errno`, `stream`, described from each module's header doc comment.
- `docs/stdlib.md`: added the missing `ansi`, `coverage`, `flags`, `instrument`, `literal`, `log`, `records`, `searcher`, `style`, `table`, `tar` rows.
- `sys/help.md:32,38`: the `--make` verb list omitted `run` (real verb in `_make/init.tl:256`); the `--coverage-report` example said `o/coverage`, actual path is `o/.coverage` (`_make/policy.tl:41,80`).
- `docs/goals.md:119`: G3 measured `as` casts "in `lib/`", which no longer exists; reworded to `cosmic/` + root-level internals.
- `docs/architecture.md:115-117`: `_build/` section listed only `workflows_test.tl`; added `ratchet.tl`, `ratchet_test.tl`, `docs_test.tl`, `skills_test.tl` with what each actually ratchets.
- `AGENTS.md` `style` row: claimed file length, column width AND ordering are behind `--check lint`; only file length actually is (`_cli/lint.tl:434`) — column width is exported-but-unenforced and ordering (`call-after-define`) lives in `_cli/lint.tl`, not `cosmic.style`.
- `AGENTS.md:82` / `cosmic/style.tl:11` / `cosmic/style_test.tl:35`: "858"/"~840" lines over 90 columns had drifted (recounted: 826 today); reworded to "roughly 800+" so the number stops rotting.
- `_perf/OPTIMIZE.md:22`: "~25 end-to-end scenarios" — actual is 12 bench modules / 36 scenarios (counted); fixed.
- `AGENTS.md` release section: noted `release.yml`'s scheduled (cron) run defaults to a GitHub prerelease (`PRERELEASE=true`); a real release needs manual `workflow_dispatch` with `prerelease: false`.
- `cosmic/coverage/baseline.tl:1,12-14`: shebang + docstring claimed a `write`/`check` argv-dispatch CLI that doesn't exist (no `is_main` block); dropped the shebang and script claims, module is library-only.
- `embed/cosmic.mk:30-34,60-63`: preamble claimed every verb writes-if-changed so a no-op leaves mtime alone; false for `run_into` (`compile`/`capture` deliberately restamp on a no-op) and for `do_tee`/`do_copy` (write unconditionally, no comparison). Rewrote to state the real contract: only `write-list`, the makefiles (`write_if_changed`), and the artifact (`replace_if_changed`) skip the write when unchanged.
- `embed/cosmic.mk:122-126`: claimed the derived fence grants a test read access to "what it imports and nothing else"; actual grant is the whole project (`"."`, `_cli/grants.tl:300-344`) plus runtime paths. Fixed.
- `_make/select.tl:70-72`: orphaned docstring described a function that now lives at `project.paths_of`; deleted.
- `cosmic/check.tl:209`: `@param ok boolean` on `needs(what, present)` — fixed to `@param present boolean`.
- `_make/check.tl`: the `checkable` comment named only `benchmark` and `payload-gen` as the easy-to-forget checkable kinds, omitting `pin` (also in the table); added it.

No findings were skipped — all 19 items in the PR-03 section verified against current code and fixed as described. Two of `AGENTS.md`'s existing paragraphs (the `check.must`/`is` narrowing bullets and the `pr.yml` CI bullet) were rewrapped tighter at 90 columns — wording unchanged — to keep the file under its 500-line cap after the mandatory table additions.

CI verdict:
```
ci: PASS (6 stages)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE)_