### PR TITLE
sqlite: fix rows() close, transaction/savepoint commit-failure rollback

### DIFF
--- a/cosmic/sqlite/advanced_test.tl
+++ b/cosmic/sqlite/advanced_test.tl
@@ -322,6 +322,39 @@ local function test_nested_transaction_fails_inner_only()
 end
 test_nested_transaction_fails_inner_only()
 
+-- A failing COMMIT (e.g. a deferred foreign-key violation, only checked at
+-- COMMIT/RELEASE time) must roll back instead of leaving the connection
+-- inside an open transaction.
+local function test_transaction_commit_failure_rolls_back()
+  local db = check.must(sqlite.open(":memory:"))
+  db:exec("CREATE TABLE parent (id INTEGER PRIMARY KEY)")
+  db:exec([[CREATE TABLE child (
+    id INTEGER PRIMARY KEY,
+    parent_id INTEGER REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED
+  )]])
+  db:exec("INSERT INTO parent (id) VALUES (1)")
+
+  local ok, err = db:transaction(function(d: sqlite.Database)
+      -- Orphan reference: passes at INSERT time (deferred), fails at COMMIT.
+      assert(d:exec("INSERT INTO child (id, parent_id) VALUES (1, 99)"))
+    end)
+  assert(not ok, "transaction must fail when COMMIT violates a deferred FK")
+  assert(err and err:find("FOREIGN KEY", 1, true),
+    "error should mention the FK violation, got: " .. tostring(err))
+
+  local row = check.must(db:query_one("SELECT COUNT(*) AS c FROM child"))
+  assert(row.c == 0, "orphan row must be rolled back, got: " .. tostring(row.c))
+
+  -- The connection must not be left inside an open transaction: a fresh
+  -- BEGIN must succeed.
+  local begin_ok, begin_err = db:exec("BEGIN IMMEDIATE")
+  assert(begin_ok, "connection must not be stuck inside an open transaction: "
+    .. tostring(begin_err))
+  db:exec("ROLLBACK")
+  db:close()
+end
+test_transaction_commit_failure_rolls_back()
+
 -- Named parameters
 
 local function test_bind_named()

--- a/cosmic/sqlite/close_test.tl
+++ b/cosmic/sqlite/close_test.tl
@@ -108,3 +108,103 @@ local function test_query_list_close_early()
   db:close()
 end
 test_query_list_close_early()
+
+-- Statement:rows() shares row_iter.tl's iteration body with db:query (see
+-- cosmic.sqlite.row_iter); this exercises it directly (previously only
+-- reached indirectly through query_list/query_named's own wrapper -- see
+-- cosmic.sqlite.params), plus close semantics: close()/__close end
+-- iteration but must NOT finalize the underlying Statement -- unlike
+-- db:query's Rows (which owns a cache slot or a throwaway statement), a
+-- Statement:rows() is a view over a caller-owned Statement that outlives
+-- its iterators and can be reset()+bound again after the Rows is done.
+
+local function test_statement_rows_basic_iteration()
+  local db = check.must(sqlite.open(":memory:"))
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+  db:exec("INSERT INTO t (name) VALUES ('Alice'), ('Bob'), ('Carol')")
+
+  local stmt = check.must(db:prepare("SELECT * FROM t ORDER BY id"))
+  local rows = stmt:rows()
+  local names: {string} = {}
+  for row in rows do
+    table.insert(names, row.name as string) -- cast: from any
+  end
+  assert(#names == 3, "should get 3 rows")
+  assert(names[1] == "Alice" and names[2] == "Bob" and names[3] == "Carol",
+    "rows should be in insertion order, got: " .. table.concat(names, ","))
+  assert(rows:err() == nil, "clean iteration should report no step error")
+  stmt:close()
+  db:close()
+end
+test_statement_rows_basic_iteration()
+
+local function test_statement_rows_close_does_not_finalize_statement()
+  local db = check.must(sqlite.open(":memory:"))
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+  db:exec("INSERT INTO t (name) VALUES ('a'), ('b'), ('c')")
+
+  local stmt = check.must(db:prepare("SELECT * FROM t ORDER BY id"))
+  local rows = stmt:rows()
+  local first = rows()
+  assert(first and first.name == "a", "should get first row")
+  rows:close()
+  assert(rows() == nil, "closed iterator must yield nil")
+  assert(rows:err() == nil, "close is not a step error")
+
+  -- The Statement must still be usable: rows():close() must not have
+  -- finalized raw_stmt out from under it.
+  stmt:reset()
+  local n = 0
+  local rows2 = stmt:rows()
+  while rows2() ~= nil do
+    n = n + 1
+  end
+  assert(n == 3, "statement must be reusable after rows():close(), got: " .. tostring(n))
+  stmt:close()
+  db:close()
+end
+test_statement_rows_close_does_not_finalize_statement()
+
+local function test_statement_rows_to_be_closed_scope()
+  local db = check.must(sqlite.open(":memory:"))
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+  db:exec("INSERT INTO t (name) VALUES ('a'), ('b')")
+
+  local stmt = check.must(db:prepare("SELECT * FROM t ORDER BY id"))
+  local rows = stmt:rows()
+  local first = rows()
+  assert(first and first.name == "a", "should get first row")
+  -- Exercise the __close metamethod directly (see the db:query tests
+  -- above for why this repo's tests don't use `local x <close> = ...`).
+  local mt = getmetatable(rows) as {string: any} -- cast: raw metatable access
+  local close_mm = mt["__close"] as function(any, any) -- cast: from any
+  assert(close_mm, "Statement:rows() must have a __close metamethod")
+  close_mm(rows, nil)
+  assert(rows() == nil, "__close must release the iterator")
+
+  -- Again: the Statement must survive the Rows' __close.
+  stmt:reset()
+  local n = 0
+  local rows2 = stmt:rows()
+  while rows2() ~= nil do
+    n = n + 1
+  end
+  assert(n == 2, "statement must be reusable after rows() <close>, got: " .. tostring(n))
+  stmt:close()
+  db:close()
+end
+test_statement_rows_to_be_closed_scope()
+
+local function test_statement_rows_close_idempotent()
+  local db = check.must(sqlite.open(":memory:"))
+  db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+  db:exec("INSERT INTO t DEFAULT VALUES")
+
+  local stmt = check.must(db:prepare("SELECT * FROM t"))
+  local rows = stmt:rows()
+  rows:close()
+  rows:close()
+  stmt:close()
+  db:close()
+end
+test_statement_rows_close_idempotent()

--- a/cosmic/sqlite/extras.tl
+++ b/cosmic/sqlite/extras.tl
@@ -44,6 +44,11 @@ local function attach(db_any: any)
       st:close()
       return nil, "bind failed: " .. (bind_err or "unknown error")
     end
+    -- Dodges Values' NULL-first-column/generic-for hazard: this calls the
+    -- iterator directly for exactly one row instead of a `for ... in`
+    -- loop, so a NULL column 1 (the common case here -- query_value IS the
+    -- first column) returns cleanly as v == nil rather than being read as
+    -- end-of-iteration.
     local vals = st:values()
     local v = vals()
     st:close()
@@ -63,7 +68,9 @@ local function attach(db_any: any)
   --- if fn raises or signals failure the library way — a returned `false`,
   --- or `nil` plus an error (nothing returned still releases). Inside a
   --- transaction only the savepoint's own changes are rolled back; at the
-  --- top level a savepoint behaves like its own transaction.
+  --- top level a savepoint behaves like its own transaction. A failing
+  --- RELEASE (e.g. a deferred foreign-key violation) also rolls back to
+  --- the savepoint, so it is never left open.
   function db:savepoint(fn: function(any)): boolean, string
     sp_counter = sp_counter + 1
     local name = "cosmic_sp_" .. sp_counter
@@ -83,7 +90,17 @@ local function attach(db_any: any)
       self:exec("RELEASE " .. name)
       return false, (result_err as string) or "savepoint rolled back" -- cast: from any
     end
-    return self:exec("RELEASE " .. name)
+    local release_ok, release_err = self:exec("RELEASE " .. name)
+    if not release_ok then
+      local rollback_ok, rollback_err = self:exec("ROLLBACK TO " .. name)
+      if not rollback_ok then
+        return false, (release_err or "release failed") ..
+        "; rollback also failed: " .. (rollback_err or "unknown error")
+      end
+      self:exec("RELEASE " .. name)
+      return false, release_err or "release failed"
+    end
+    return true
   end
 end
 

--- a/cosmic/sqlite/extras_test.tl
+++ b/cosmic/sqlite/extras_test.tl
@@ -159,3 +159,35 @@ local function test_savepoint_inside_transaction()
   db:close()
 end
 test_savepoint_inside_transaction()
+
+-- A failing RELEASE (e.g. a deferred foreign-key violation, checked when
+-- the outermost savepoint releases like an implicit COMMIT) must roll back
+-- to the savepoint instead of leaving it open.
+local function test_savepoint_release_failure_rolls_back()
+  local db = check.must(sqlite.open(":memory:"))
+  db:exec("CREATE TABLE parent (id INTEGER PRIMARY KEY)")
+  db:exec([[CREATE TABLE child (
+    id INTEGER PRIMARY KEY,
+    parent_id INTEGER REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED
+  )]])
+  db:exec("INSERT INTO parent (id) VALUES (1)")
+
+  local ok, err = db:savepoint(function(d: sqlite.Database)
+      -- Orphan reference: passes at INSERT time (deferred), fails at RELEASE.
+      assert(d:exec("INSERT INTO child (id, parent_id) VALUES (1, 99)"))
+    end)
+  assert(not ok, "savepoint must fail when RELEASE violates a deferred FK")
+  assert(err and err:find("FOREIGN KEY", 1, true),
+    "error should mention the FK violation, got: " .. tostring(err))
+
+  local n = db:query_value("SELECT COUNT(*) FROM child")
+  assert(n == 0, "orphan row must be rolled back, got: " .. tostring(n))
+
+  -- The connection must not be left inside an open transaction/savepoint.
+  local begin_ok, begin_err = db:exec("BEGIN IMMEDIATE")
+  assert(begin_ok, "connection must not be stuck inside an open transaction: "
+    .. tostring(begin_err))
+  db:exec("ROLLBACK")
+  db:close()
+end
+test_savepoint_release_failure_rolls_back()

--- a/cosmic/sqlite/init.tl
+++ b/cosmic/sqlite/init.tl
@@ -51,6 +51,15 @@ end
 
 --- Callable positional-value iterator, the `Statement:values()` counterpart
 --- to `Rows`. Same `:err()` contract.
+---
+--- CAVEAT: a row whose FIRST column is SQL NULL returns `nil` as its first
+--- (and, to Lua, only visible) value, which a `for ... in` generic-for loop
+--- reads as end-of-iteration — the row is silently dropped, `:err()` stays
+--- nil, and remaining rows are never stepped. This is inherent to Lua's
+--- generic-for protocol (it stops at a nil first return) and the contract
+--- cannot change without breaking `local a, b, c = iter()` positional
+--- callers. Use `rows()` (or call the iterator directly, `local a, b, c =
+--- iter()`, one row at a time) when column 1 may be NULL.
 local record Values
   metamethod __call: function(self: Values): any ...
   --- Step error from iteration, or nil after a clean SQLITE_DONE.
@@ -73,7 +82,9 @@ local record Statement
   --- check `:err()` after the loop for step errors.
   rows: function(self: Statement): Rows
   --- Callable iterator yielding each row's column values positionally;
-  --- same `:err()` contract as rows().
+  --- same `:err()` contract as rows(). CAVEAT: a NULL first column ends a
+  --- `for` loop over this early (see Values above) -- prefer rows() when
+  --- column 1 may be NULL.
   values: function(self: Statement): Values
   --- Step the statement to completion (for INSERT/UPDATE/DDL).
   exec: function(self: Statement): boolean, string
@@ -128,9 +139,18 @@ local record Database
   --- Rows modified by the most recent INSERT/UPDATE/DELETE (0 if closed).
   changes: function(self: Database): integer
   --- Close the database and its cached statements (idempotent); also
-  --- runs on scope exit via to-be-closed.
-  close: function(self: Database)
+  --- runs on scope exit via to-be-closed. Returns false plus sqlite's
+  --- error message if the raw close fails (e.g. SQLITE_BUSY from a
+  --- still-open user-prepared Statement) -- the database is left open
+  --- in that case, so a caller that must know can retry or clean up.
+  close: function(self: Database): boolean, string
 end
+
+-- Statement:rows() release callback: a Statement outlives its iterators
+-- (it may be reused via reset()+bind() after the Rows is done), so
+-- releasing must only end iteration, never finalize the raw statement.
+-- Statement:close() (or its own <close>/__close/gc) owns finalization.
+local function keep_statement_open(_: lsqlite3.Statement) end
 
 local function make_statement(raw_stmt: lsqlite3.Statement, raw_db: lsqlite3.Database): Statement
   local stmt: Statement = {}
@@ -188,41 +208,17 @@ local function make_statement(raw_stmt: lsqlite3.Statement, raw_db: lsqlite3.Dat
   end
 
   function stmt:rows(): Rows
-    local step_err: string
-    local col_count = raw_stmt:columns()
-    local col_names: {integer: string}
-    local first_call = true
-
-    local iter = setmetatable({} as Rows, { -- cast: empty table into callable record
-        __call = function(_: Rows): {string: any}
-          local rc = raw_stmt:step()
-          if rc == sqlite3.ROW then
-            -- Get column names on first row (requires step to be called first)
-            if first_call then
-              first_call = false
-              col_names = {}
-              for idx = 0, col_count - 1 do
-                col_names[idx + 1] = raw_stmt:get_name(idx)
-              end
-            end
-            local row: {string: any} = {}
-            for idx = 0, col_count - 1 do
-              local name = col_names[idx + 1]
-              row[name] = raw_stmt:get_value(idx)
-            end
-            return row
-          end
-          -- Only SQLITE_DONE is a clean end; surface anything else.
-          if rc ~= sqlite3.DONE then
-            step_err = raw_db:errmsg()
-          end
-          return nil
-        end,
-      })
-    iter.err = function(_: Rows): string return step_err end
-    return iter
+    -- Shares row_iter's iteration body (column-name resolution, step,
+    -- error surfacing) instead of a second copy; on_close ends iteration
+    -- without finalizing, since this Statement may still be reused.
+    local iter = row_iter.make(raw_stmt, raw_db, keep_statement_open, sqlite3.ROW, sqlite3.DONE)
+    return iter as Rows -- cast: row_iter record to public Rows
   end
 
+  -- CAVEAT (see Values above): a `for ... in` loop over this iterator ends
+  -- the moment column 1 comes back NULL, because that's Lua's own signal
+  -- for end-of-iteration. rows() doesn't have this hazard; calling the
+  -- iterator directly one row at a time (`local a, b, c = iter()`) does.
   function stmt:values(): Values
     local step_err: string
     local col_count = raw_stmt:columns()
@@ -375,6 +371,8 @@ local function make_database(raw_db: lsqlite3.Database): Database
   --- Execute fn within a transaction. BEGIN before fn; COMMIT if fn returns
   --- cleanly; ROLLBACK if fn raises OR signals failure the library way -- a
   --- returned `false`, or `nil` plus an error (nothing returned still commits).
+  --- A failing COMMIT (e.g. a deferred foreign-key violation) also rolls
+  --- back, so the connection is never left inside an open transaction.
   function db:transaction(fn: function(Database)): boolean, string
     local ok, err = self:exec("BEGIN IMMEDIATE")
     if not ok then
@@ -390,7 +388,16 @@ local function make_database(raw_db: lsqlite3.Database): Database
       self:exec("ROLLBACK")
       return false, (result_err as string) or "transaction rolled back" -- cast: from any
     end
-    return self:exec("COMMIT")
+    local commit_ok, commit_err = self:exec("COMMIT")
+    if not commit_ok then
+      local rollback_ok, rollback_err = self:exec("ROLLBACK")
+      if not rollback_ok then
+        return false, (commit_err or "commit failed") ..
+        "; rollback also failed: " .. (rollback_err or "unknown error")
+      end
+      return false, commit_err or "commit failed"
+    end
+    return true
   end
 
   function db:last_insert_rowid(): integer
@@ -407,12 +414,17 @@ local function make_database(raw_db: lsqlite3.Database): Database
     return raw_db:changes()
   end
 
-  db.close = function(_: Database)
-    if not closed then
-      closed = true
-      stmt_cache:close_all()
-      local _ = raw_db:close()
+  db.close = function(_: Database): boolean, string
+    if closed then
+      return true
     end
+    closed = true
+    stmt_cache:close_all()
+    local rc = raw_db:close()
+    if rc ~= sqlite3.OK then
+      return false, raw_db:errmsg()
+    end
+    return true
   end
 
   return setmetatable(db, {


### PR DESCRIPTION
Implements PR-05 of the review-fix series (section "PR-05 sqlite" in FINDINGS.md).

## What was fixed

- **`cosmic/sqlite/init.tl:190-224` (`Statement:rows()`)**: the returned `Rows` declared `close`/`__close` but the implementation provided neither a `close` method nor the metamethod, so `local rows <close> = stmt:rows()` errored and `rows:close()` was a nil call. Fixed by reusing `row_iter.tl`'s iteration body (the same one `db:query` already shares) with an `on_close` that ends iteration WITHOUT finalizing the raw statement — a user-prepared `Statement` outlives its iterators and can be `reset()`+`rows()`'d again afterward.
- **`cosmic/sqlite/init.tl:226-250` (`Statement:values()`)**: contract can't change (Lua's generic-for stops at a nil first return, so a NULL first column silently ends iteration). Added a prominent doc caveat on the `Values` record and the `:values()` field/method, and made `query_value`'s dodge (call the iterator directly once, instead of a `for` loop) explicit in `extras.tl`.
- **`cosmic/sqlite/init.tl:378-394` (`transaction()`)**: a failing COMMIT (e.g. a deferred foreign-key violation, only checked at commit time) left the connection inside an open transaction. Now attempts ROLLBACK on COMMIT failure and reports both errors if the rollback also fails. `extras.tl:86` (`savepoint()`): same shape for a failing RELEASE (ROLLBACK TO + RELEASE).
- **`cosmic/sqlite/init.tl:410-416` (`db:close()`)**: discarded the raw close's result, silently swallowing e.g. SQLITE_BUSY from a still-open user-prepared statement. Now returns an honest `boolean, string`; every existing caller in the repo already used it as a bare statement (ignoring the return), so this is a non-breaking type widening.

## Tests added

- `close_test.tl`: `Statement:rows()` basic iteration, `close()` and the `__close` metamethod both end iteration without finalizing the statement (verified by `reset()`+`rows()` reuse afterward), and idempotent close.
- `advanced_test.tl`: `db:transaction()` rolls back on COMMIT failure, triggered via the deferrable-FK trick (`DEFERRABLE INITIALLY DEFERRED`, orphan insert, fails only at COMMIT); asserts the connection isn't left inside an open transaction.
- `extras_test.tl`: same shape for `db:savepoint()`'s failing RELEASE.

No findings were skipped — all four were reproduced against current code before fixing.

## CI

```
ci: PASS (6 stages)
```

(fmt, check, test, example, lint, coverage all passed; coverage ratchet held.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE)_