### PR TITLE
Fix silent policy-widening and unsafe HMAC fallback in security paths

### DIFF
--- a/cosmic/hash.tl
+++ b/cosmic/hash.tl
@@ -128,12 +128,15 @@ end
 
 --- Compute HMAC-SHA256 of data with a secret key (RFC 2104).
 --- Returns raw bytes (32 bytes); hex-encode with cosmic.codec.encode_hex
---- if needed. Compare MACs with constant_time_equal, not ==.
---- @param key string The secret key
+--- if needed. Compare MACs with constant_time_equal, not ==. The key
+--- must be non-empty: the C binding treats an empty key as "no key"
+--- and would silently compute a plain digest instead of an HMAC.
+--- @param key string The secret key (must be non-empty)
 --- @param data string The message to authenticate
---- @return string The HMAC-SHA256 tag as raw bytes
-local function hmac_sha256(key: string, data: string): string
-  return (cosmo.GetCryptoHash("SHA256", data, key))
+--- @return string | nil The HMAC-SHA256 tag as raw bytes, or nil on error
+--- @return string? Error message if the key is empty
+local function hmac_sha256(key: string, data: string): string | nil, string
+  return hmac("sha256", key, data)
 end
 
 --- Compare two strings in constant time (for digests and MACs).
@@ -217,7 +220,7 @@ local record HashModule
   hmac: function(algo: Algo, key: string, data: string): string | nil, string
   sha256: function(data: string): string
   sha256_hex: function(data: string): string
-  hmac_sha256: function(key: string, data: string): string
+  hmac_sha256: function(key: string, data: string): string | nil, string
   constant_time_equal: function(a: string, b: string): boolean
   password: function(pwd: string, options?: HashOptions): string | nil, string
   verify_password: function(encoded: string, pwd: string): boolean, string

--- a/cosmic/hash_test.tl
+++ b/cosmic/hash_test.tl
@@ -201,7 +201,7 @@ test_password_default_mcost_is_19456()
 
 local function test_hmac_sha256_rfc4231_case1()
   local key = string.rep("\x0b", 20)
-  local tag = hash.hmac_sha256(key, "Hi There")
+  local tag = check.must(hash.hmac_sha256(key, "Hi There"))
   local hex = codec.encode_hex(tag)
   assert(hex == "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7",
     "RFC 4231 case 1 mismatch: " .. hex)
@@ -209,7 +209,7 @@ end
 test_hmac_sha256_rfc4231_case1()
 
 local function test_hmac_sha256_rfc4231_case2()
-  local tag = hash.hmac_sha256("Jefe", "what do ya want for nothing?")
+  local tag = check.must(hash.hmac_sha256("Jefe", "what do ya want for nothing?"))
   local hex = codec.encode_hex(tag)
   assert(hex == "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843",
     "RFC 4231 case 2 mismatch: " .. hex)
@@ -298,10 +298,19 @@ test_hmac_rfc2202_case1_sha1()
 
 local function test_hmac_matches_hmac_sha256_convenience()
   local tag = hash.hmac("sha256", "key", "message")
-  assert(tag == hash.hmac_sha256("key", "message"),
+  assert(tag == check.must(hash.hmac_sha256("key", "message")),
     "hmac('sha256') should match hmac_sha256()")
 end
 test_hmac_matches_hmac_sha256_convenience()
+
+local function test_hmac_sha256_empty_key_rejected()
+  -- hmac_sha256 delegates to hmac("sha256", ...), which refuses an
+  -- empty key rather than silently returning a plain digest.
+  local tag, err = hash.hmac_sha256("", "data")
+  assert(tag == nil, "hmac_sha256 should return nil for empty key")
+  assert(err and err:match("key"), "error should mention the key, got: " .. tostring(err))
+end
+test_hmac_sha256_empty_key_rejected()
 
 local function test_hmac_unknown_algo()
   -- cast: deliberate invalid input

--- a/cosmic/quicksand/box/merge.tl
+++ b/cosmic/quicksand/box/merge.tl
@@ -77,8 +77,13 @@ merge_section = function(prefix: string, a: {string: any}, b: {string: any}): {s
   if b then for k in pairs(b) do keys[k] = true end end
   for k in pairs(keys) do
     local path = prefix == "" and k or (prefix .. "." .. k)
-    local av = a and a[k] or nil
-    local bv = b and b[k] or nil
+    -- Explicit nil-checked indexing: `a and a[k] or nil` collapses a
+    -- stored `false` to nil, silently re-enabling a security opt-out
+    -- (e.g. net.proxy_env = false, pid_ns = false).
+    local av: any
+    if a then av = a[k] end
+    local bv: any
+    if b then bv = b[k] end
     if schema.lists[path] then
       out[k] = concat_unique(av as {any}, bv as {any}) -- cast: from any
     elseif schema.maps[path] then

--- a/cosmic/quicksand/box/merge_test.tl
+++ b/cosmic/quicksand/box/merge_test.tl
@@ -97,3 +97,31 @@ local function test_empty_merge()
   assert(next(out) == nil, "empty merge should return empty table")
 end
 test_empty_merge()
+
+-- Security-policy opt-outs are boolean `false`, and `a and a[k] or nil`
+-- silently collapses that to nil. These three cases pin the fix.
+
+local function test_scalar_false_survives_merge()
+  local out = m.merge({pid_ns = false})
+  assert(out.pid_ns == false, "got: " .. tostring(out.pid_ns))
+end
+test_scalar_false_survives_merge()
+
+local function test_scalar_false_in_b_overrides_true_in_a()
+  local out = m.merge(
+    {net = {proxy_env = true}},
+    {net = {proxy_env = false}})
+  local net = out.net as {string: any} -- cast: from any
+  assert(net.proxy_env == false, "got: " .. tostring(net.proxy_env))
+end
+test_scalar_false_in_b_overrides_true_in_a()
+
+local function test_scalar_false_in_a_survives_absent_b_key()
+  local out = m.merge(
+    {proc = {no_new_privs = false}},
+    {proc = {uid = 1000}})
+  local proc = out.proc as {string: any} -- cast: from any
+  assert(proc.no_new_privs == false, "got: " .. tostring(proc.no_new_privs))
+  assert(proc.uid == 1000, "uid preserved")
+end
+test_scalar_false_in_a_survives_absent_b_key()


### PR DESCRIPTION
Two security-relevant fixes from the review series (PR-04).

- `cosmic/quicksand/box/merge.tl:80-81` (`merge_section`): `local av = a and a[k] or nil` collapsed a stored `false` to `nil`, so a documented sandbox opt-out (`pid_ns=false`, `net.proxy_env=false`, `proc.no_new_privs=false`) was silently dropped by `merge`, letting an earlier `true` win — a security-policy widening. Fixed with explicit nil-checked indexing for `av`/`bv`. Audited the rest of the file for the same idiom: `concat_unique` and `merge_map` already gate on `if a then ... end` over the whole table rather than per-element `and`/`or`, so they were not affected. Added three tests in `cosmic/quicksand/box/merge_test.tl`: `false` survives a single-table merge, `false` in b overrides `true` in a, and `false` in a survives when b's key is absent.
- `cosmic/hash.tl:135-137`: `hmac_sha256` called `cosmo.GetCryptoHash` directly with no empty-key guard, even though the general `hmac()` a few lines above it in the same file guards exactly this (the C binding treats an empty key as "no key" and silently returns a plain digest instead of an HMAC). Fixed by implementing `hmac_sha256` via `hmac("sha256", key, data)`, widening its return type to `string | nil, string` to match. Updated both callers in `cosmic/hash_test.tl` (the RFC 4231 vectors now use `check.must`, and the `hmac()`-equivalence test unwraps the new tuple) and added a test asserting an empty key returns `nil` plus an error mentioning the key.

No findings were skipped — both reproduced against current `main` before the fix.

CI verdict (full `bin/cosmic --make ci` in the worktree): `ci: PASS (6 stages)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE)_