### PR TITLE
Fix nine independent stdlib bugs (ansi, doc, teal, sandbox, sse, shm, re, searcher, instrument)

### DIFF
--- a/cosmic/ansi.tl
+++ b/cosmic/ansi.tl
@@ -195,7 +195,7 @@ end
 --- @param text string The possibly-styled text
 --- @return string The text with SGR sequences removed
 local function strip(text: string): string
-  return (text:gsub(CSI .. "[0-9;]*m", ""))
+  return (text:gsub(ESC .. "%[[0-9;]*m", ""))
 end
 
 --- Decide whether styled output is appropriate for a stream, honoring

--- a/cosmic/ansi_test.tl
+++ b/cosmic/ansi_test.tl
@@ -60,6 +60,14 @@ local function test_strip_leaves_non_sgr_escapes()
 end
 test_strip_leaves_non_sgr_escapes()
 
+local function test_strip_requires_csi_bracket()
+  -- ESC without the "[" is not an SGR sequence and must pass through,
+  -- even though the pattern's "[0-9;]*" would trivially match zero times.
+  assert(ansi.strip(ESC .. "m") == ESC .. "m")
+  assert(ansi.strip(ESC .. "0m") == ESC .. "0m")
+end
+test_strip_requires_csi_bracket()
+
 local function test_reset_constant()
   assert(ansi.reset == ESC .. "[0m")
 end

--- a/cosmic/doc/show.tl
+++ b/cosmic/doc/show.tl
@@ -16,6 +16,7 @@ local COSMIC_EQUIVALENTS: {string: string} = {
 }
 
 local fuzzy = require("cosmic.fuzzy")
+local str = require("cosmic.string")
 
 --- Extract first paragraph from module description.
 --- @param text string Full description text
@@ -253,7 +254,7 @@ local function find_matching_examples(examples: {ExampleDoc}, func_name: string)
   for _, example in ipairs(examples) do
     local example_base = example.name:gsub("^Example_?", "")
     local base_lower = example_base:lower()
-    if base_lower == func_lower or base_lower:match("^" .. func_lower .. "_") then
+    if base_lower == func_lower or str.starts_with(base_lower, func_lower .. "_") then
       table.insert(matches, example)
     end
   end

--- a/cosmic/doc/show_test.tl
+++ b/cosmic/doc/show_test.tl
@@ -1,0 +1,49 @@
+#!/usr/bin/env lua
+--- Tests for cosmic.doc.show: query strings must not be interpreted as
+--- Lua patterns when matched against example names.
+
+local docs_render = require("cosmic.doc.show")
+local doc_types = require("cosmic.doc.types")
+
+local function example(name: string): doc_types.ExampleDoc
+  return {name = name, description = "", body = "", expected_output = "", line = 1}
+end
+
+-- A function name containing Lua pattern magic characters ("(", ")",
+-- "-", ".") must still match its own examples by plain prefix, and
+-- must not throw or mismatch because the name was spliced unescaped
+-- into a pattern.
+local function test_find_matching_examples_escapes_magic_chars()
+  local examples = {
+    example("Example_do(thing)_basic"),
+    example("Example_unrelated"),
+  }
+  local matches = docs_render.find_matching_examples(examples, "do(thing)")
+  assert(#matches == 1, "expected 1 match, got " .. #matches)
+  assert(matches[1].name == "Example_do(thing)_basic", "got: " .. matches[1].name)
+end
+test_find_matching_examples_escapes_magic_chars()
+
+local function test_find_matching_examples_dash_and_dot()
+  local examples = {
+    example("Example_a-b.c_variant"),
+  }
+  local matches = docs_render.find_matching_examples(examples, "a-b.c")
+  assert(#matches == 1, "expected 1 match, got " .. #matches)
+end
+test_find_matching_examples_dash_and_dot()
+
+local function test_find_matching_examples_exact_match_still_works()
+  local examples = {example("Example_greet")}
+  local matches = docs_render.find_matching_examples(examples, "greet")
+  assert(#matches == 1, "expected 1 match, got " .. #matches)
+end
+test_find_matching_examples_exact_match_still_works()
+
+local function test_find_matching_examples_no_false_prefix_match()
+  -- "greet" must not match "greeting_extra" (no separating "_").
+  local examples = {example("Example_greeting_extra")}
+  local matches = docs_render.find_matching_examples(examples, "greet")
+  assert(#matches == 0, "expected 0 matches, got " .. #matches)
+end
+test_find_matching_examples_no_false_prefix_match()

--- a/cosmic/instrument.tl
+++ b/cosmic/instrument.tl
@@ -39,6 +39,24 @@ local record Span
   start_stime_ns: number
 end
 
+--- Escape a field value for the space-delimited `key=value` line
+--- format: literal "%" first (so the decode below is unambiguous),
+--- then the space delimiter itself. A file path with a space would
+--- otherwise silently truncate at parse time, since fields are read
+--- back with a `%S+` (non-space) pattern.
+--- @param s string Raw field value (op or file)
+--- @return string Value safe to place between spaces on the line
+local function escape_field(s: string): string
+  return (s:gsub("%%", "%%25"):gsub(" ", "%%20"))
+end
+
+--- Reverse escape_field, in the opposite order it applied.
+--- @param s string An escaped field value read off a line
+--- @return string The original value
+local function unescape_field(s: string): string
+  return (s:gsub("%%20", " "):gsub("%%25", "%%"))
+end
+
 --- Check whether instrumentation is enabled.
 --- Returns true when COSMIC_INSTRUMENTATION is "1" or "true".
 --- @return boolean
@@ -112,7 +130,7 @@ local function finish_span(span: Span, exit_code: integer): string
 
   local line = string.format(
     "cosmic: op=%s file=%s exit=%d wall_ms=%d cpu_ms=%d maxrss_kb=%d",
-    span.op, span.file, exit_code, wall_ms, cpu_ms, maxrss)
+    escape_field(span.op), escape_field(span.file), exit_code, wall_ms, cpu_ms, maxrss)
 
   io.stderr:write(line .. "\n")
   return line
@@ -136,8 +154,8 @@ local function parse_line(line: string): InstrumentData
     return nil
   end
   return {
-    op = op,
-    file = file,
+    op = unescape_field(op),
+    file = unescape_field(file),
     exit = (tonumber(exit_str) or 0) as integer, -- cast: number to integer
     wall_ms = (tonumber(wall_str) or 0) as integer, -- cast: number to integer
     cpu_ms = (tonumber(cpu_str) or 0) as integer, -- cast: number to integer

--- a/cosmic/instrument_test.tl
+++ b/cosmic/instrument_test.tl
@@ -144,3 +144,40 @@ local function test_parse_lines()
   assert(results[2].exit == 1, "expected exit=1")
 end
 test_parse_lines()
+
+-- A file path with a space must round-trip whole: the line format is
+-- space-delimited key=value pairs and parse_line reads each value back
+-- with a non-space (%S+) pattern, so an unescaped space in a path
+-- would silently truncate it at parse time.
+local function test_file_with_space_round_trips()
+  env.set("COSMIC_INSTRUMENTATION", "1")
+  local span = instrument.begin("test", "cosmic/my file.tl")
+  local line = instrument.finish(span, 0)
+  env.unset("COSMIC_INSTRUMENTATION")
+  assert(line ~= nil, "expected line")
+  local parsed = instrument.parse_line(line)
+  assert(parsed ~= nil, "expected parsed result")
+  assert(parsed.file == "cosmic/my file.tl",
+    "expected the space to survive round-trip, got: " .. tostring(parsed.file))
+  -- The line itself must have no unescaped space inside the file field,
+  -- or the %S+ parse would still see it as two tokens.
+  assert(line:find(" ", 1, true) ~= nil, "sanity: the line has spaces (the delimiters)")
+  assert(not line:find("my file.tl", 1, true),
+    "the raw space must not appear verbatim in the emitted line: " .. line)
+end
+test_file_with_space_round_trips()
+
+-- A literal "%" in a path must also round-trip, and must not be
+-- misinterpreted as an escape sequence introduced by escape_field.
+local function test_file_with_percent_round_trips()
+  env.set("COSMIC_INSTRUMENTATION", "1")
+  local span = instrument.begin("test", "cosmic/100%.tl")
+  local line = instrument.finish(span, 0)
+  env.unset("COSMIC_INSTRUMENTATION")
+  assert(line ~= nil, "expected line")
+  local parsed = instrument.parse_line(line)
+  assert(parsed ~= nil, "expected parsed result")
+  assert(parsed.file == "cosmic/100%.tl",
+    "expected the percent to survive round-trip, got: " .. tostring(parsed.file))
+end
+test_file_with_percent_round_trips()

--- a/cosmic/re.tl
+++ b/cosmic/re.tl
@@ -104,6 +104,21 @@ end
 --- the pattern anchored to exactly that window, with NOTBOL/NOTEOL
 --- supplying the line-boundary context. The engine's leftmost-match
 --- guarantee makes the first verified candidate the true position.
+---
+--- KNOWN LIMITATION: the verification window is exactly #m characters
+--- (found .. found + #m - 1), so it never includes the character before
+--- or after a candidate. Under the NEWLINE compile flag, `^` and `$`
+--- can be satisfied by an EMBEDDED newline rather than true text
+--- start/end ("regardless of NOTBOL/NOTEOL" per POSIX) -- but that
+--- newline byte falls outside this window, so the re-verification
+--- search can never see it and always fails to confirm. The result
+--- is not a silent undercount: all_matches gives up entirely (its
+--- caller sees nil, "failed to locate ..."/a short match count)
+--- as soon as a NEWLINE-anchored match past the first line is hit.
+--- See findall's doc for the concrete case. A fix needs the
+--- verification window widened to include that neighboring byte,
+--- which reintroduces its own edge case (an off-by-one window can
+--- itself contain another literal occurrence of m); not attempted here.
 local function locate(regex: Regex, text: string, pos: integer, m: string): integer | nil
   local q = pos
   while true do
@@ -172,6 +187,13 @@ end
 
 --- Find every non-overlapping match of pattern in text, leftmost
 --- first. Patterns that can match the empty string are rejected.
+---
+--- KNOWN LIMITATION with the NEWLINE flag: `^`/`$` anchors that only
+--- match via an embedded newline (not the true start/end of text) fail
+--- to be re-confirmed past the first line (see locate's doc), so
+--- findall("^foo", "foo\nfoo", re.NEWLINE) returns nil, "failed to
+--- locate match position for: foo" instead of {"foo", "foo"} -- use
+--- split("\n", text) plus a per-line match instead when this matters.
 --- @param pattern string The regex pattern to match
 --- @param text string The text to search in
 --- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE
@@ -197,6 +219,8 @@ end
 --- are kept verbatim, including empty ones from adjacent or
 --- leading/trailing matches; text with no match yields one field.
 --- Patterns that can match the empty string are rejected.
+--- Shares findall's KNOWN LIMITATION with a NEWLINE-anchored `^`/`$`
+--- past the first line (see findall's doc).
 --- @param pattern string The regex pattern to split on
 --- @param text string The text to split
 --- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE
@@ -228,6 +252,8 @@ local type Repl = string | function(string, {string}): string
 
 --- Replace every non-overlapping match of pattern in text.
 --- Patterns that can match the empty string are rejected.
+--- Shares findall's KNOWN LIMITATION with a NEWLINE-anchored `^`/`$`
+--- past the first line (see findall's doc).
 --- @param pattern string The regex pattern to match
 --- @param text string The text to operate on
 --- @param repl Repl A literal replacement string, or function(match, caps)

--- a/cosmic/re_ops_test.tl
+++ b/cosmic/re_ops_test.tl
@@ -66,6 +66,36 @@ local function test_anchor_caret_only_start()
 end
 test_anchor_caret_only_start()
 
+-- DOCUMENTED LIMITATION (see re.tl's locate/findall doc comments): a
+-- `^`/`$` anchor satisfied only via an embedded newline under the
+-- NEWLINE flag (not true text start/end) cannot be re-confirmed by
+-- locate()'s exact-width verification window, so all_matches gives up
+-- as soon as it hits one. This pins today's (regrettable but known)
+-- behavior for both flag states, so a future fix changes this test
+-- deliberately instead of silently regressing an untested path.
+local function test_newline_anchor_past_first_line_is_a_known_limitation()
+  -- Without NEWLINE, `^` only matches true text start: one match.
+  local ms = check.must(re.findall("^foo", "foo\nfoo"))
+  assert(#ms == 1 and ms[1] == "foo", "expected a single match without NEWLINE")
+
+  -- With NEWLINE, `^` should also match right after the embedded \n
+  -- (regardless of NOTBOL, per POSIX) -- but locate() cannot verify
+  -- that second candidate, so the whole call fails instead of
+  -- returning {"foo", "foo"}.
+  local ms2, err2 = re.findall("^foo", "foo\nfoo", re.NEWLINE)
+  assert(ms2 == nil, "expected the known limitation to surface as nil, not a silent undercount")
+  assert(err2 and err2:find("failed to locate", 1, true),
+    "expected a 'failed to locate' error, got: " .. tostring(err2))
+
+  -- The symmetric $ case fails differently (a short list, not nil),
+  -- which is exactly why this is documented rather than papered over
+  -- with one special case.
+  local ms3, err3 = re.findall("foo$", "foo\nfoo\nfoo", re.NEWLINE)
+  assert(ms3 ~= nil and #ms3 == 1, "expected the documented undercount, got: "
+    .. tostring(ms3) .. " " .. tostring(err3))
+end
+test_newline_anchor_past_first_line_is_a_known_limitation()
+
 -- split tests
 
 local function test_split_basic()

--- a/cosmic/sandbox.tl
+++ b/cosmic/sandbox.tl
@@ -83,7 +83,7 @@ local record SandboxModule
   type Availability = Availability
   apply: function(policy: Policy): boolean, string
   available: function(): Availability
-  plan_landlock: function(fs: Fs): RestrictOptions
+  plan_landlock: function(fs: Fs, keep_coverage?: boolean): RestrictOptions
 end
 
 -- Promise-name set for pre-enforcement validation, built from the

--- a/cosmic/sandbox_test.tl
+++ b/cosmic/sandbox_test.tl
@@ -165,6 +165,19 @@ local function test_plan_landlock_mapping()
 end
 test_plan_landlock_mapping()
 
+-- plan_landlock's second parameter (keep_coverage) must be part of its
+-- declared type, not just its implementation: the SandboxModule record
+-- previously omitted it, so a typed caller passing it would fail to
+-- type-check even though the runtime function accepted it.
+local function test_plan_landlock_keep_coverage_param()
+  local opts_default = sandbox.plan_landlock({ro = {"/usr"}})
+  check.eq(opts_default.keep_coverage, false, "keep_coverage defaults false")
+
+  local opts_kept = sandbox.plan_landlock({ro = {"/usr"}}, true)
+  check.eq(opts_kept.keep_coverage, true, "keep_coverage=true must reach RestrictOptions")
+end
+test_plan_landlock_keep_coverage_param()
+
 -- Live enforcement of a combined policy, in a subprocess (applying is
 -- irreversible). Success also evidences the fs-before-sys ordering:
 -- were pledge applied first, its filter would block the landlock

--- a/cosmic/searcher.tl
+++ b/cosmic/searcher.tl
@@ -156,6 +156,13 @@ local tree_map: {string: string} = {}
 --- The project's build directory, relative to the root.
 local tree_build: string = "o"
 
+--- Whether the tree searcher has already been inserted into
+--- package.searchers -- guards install_tree the same way `installed`
+--- guards install(): a repeat call still refreshes tree_root/tree_map
+--- from its manifest, but must not insert a second copy of the
+--- searcher into the chain.
+local tree_installed = false
+
 --- Re-entrancy guard for the compile path below.
 ---
 --- Resolving a module the closure does not name means compiling it, and
@@ -199,11 +206,18 @@ local function compile_tree(path: string, name: string): any, any
     compiling = false
     return "no Teal compiler in this artifact for '" .. name .. "'"
   end
-  local code, cerr = teal.compile_cached(path, true)
+  -- pcall'd so a compile_cached throw still clears `compiling`: left up,
+  -- it would fail every later tree resolution with "compiler bootstrap
+  -- in progress" instead of just this one require.
+  local ok, code, cerr = pcall(teal.compile_cached, path, true)
   compiling = false
+  if not ok then
+    error("error loading module '" .. name .. "' from '" .. path
+      .. "': " .. tostring(code), 0)
+  end
   if not code then
     error("error loading module '" .. name .. "' from '" .. path
-      .. "':\n" .. cerr, 0)
+      .. "':\n" .. tostring(cerr), 0)
   end
   local lua_code = code as string -- cast: nil ruled out by the guard above
   if lua_code:sub(1, 2) == "#!" then
@@ -328,7 +342,10 @@ local function install_tree(path: string): boolean
   tree_root = root
   tree_build = build or tree_build
   tree_map = map
-  table.insert(package.searchers, 2, tree_searcher)
+  if not tree_installed then
+    tree_installed = true
+    table.insert(package.searchers, 2, tree_searcher)
+  end
   return true
 end
 

--- a/cosmic/searcher_tree_test.tl
+++ b/cosmic/searcher_tree_test.tl
@@ -87,14 +87,25 @@ test_the_searcher_misses_without_a_manifest()
 -- searcher, because beating `/zip` is the entire point. Appended, it
 -- would resolve nothing the binary already carries — which is the
 -- failure the whole mechanism exists to fix.
+--
+-- This process may itself already be running under a --modules
+-- manifest (this repo's own build resolving its own tree), so the
+-- delta is checked as "at most one", not "exactly one" -- and
+-- idempotence (the same guarantee install() has) is checked directly
+-- via a second call that must not grow the chain further.
 local function test_install_lands_ahead_of_the_file_searcher()
   local root, path = manifest("install", {"root " .. tmp, "build o"})
   assert(fs.isdir(root))
   local before = #package.searchers
   assert(searcher.install_tree(path), "a well-formed manifest installs")
-  assert(#package.searchers == before + 1, "one searcher is added")
+  assert(#package.searchers - before <= 1, "at most one searcher is added")
   assert(package.searchers[2] == searcher.tree,
     "it must sit at index 2, ahead of the default file searcher")
+
+  local after_first = #package.searchers
+  assert(searcher.install_tree(path), "a repeat install still succeeds")
+  assert(#package.searchers == after_first,
+    "a repeat install_tree must not add a second copy of the searcher")
 end
 test_install_lands_ahead_of_the_file_searcher()
 
@@ -202,6 +213,37 @@ local function test_a_broken_closure_entry_is_loud()
   assert(tostring(err):find("gone", 1, true), "got: " .. tostring(err))
 end
 test_a_broken_closure_entry_is_loud()
+
+-- compile_tree's re-entrancy guard (`compiling`) must clear even when
+-- the compiler itself THROWS instead of returning nil, err: left up,
+-- it sticks true and every later tree resolution fails with "compiler
+-- bootstrap in progress" instead of that one file's own error.
+local function test_compiling_guard_clears_after_a_throw()
+  local root = fs.join(tmp, "st-throw")
+  assert(fs.makedirs(root))
+  assert(fs.write(fs.join(root, "boom.tl"), "return 1\n"))
+  local path = fs.join(root, "m")
+  assert(fs.write(path, "root " .. root .. "\nbuild o\n"))
+  assert(searcher.install_tree(path))
+
+  local teal = require("cosmic.teal")
+  local original = teal.compile_cached
+  teal.compile_cached = function(_input_path: string, _strict?: boolean): string | nil, string
+    error("boom: injected compiler failure", 0)
+  end
+  local ok, err = pcall(searcher.tree, "boom")
+  teal.compile_cached = original
+  assert(not ok, "a throwing compile_cached must still fail the require")
+  assert(tostring(err):find("boom", 1, true), "got: " .. tostring(err))
+
+  -- If the guard stuck, this resolves to "compiler bootstrap in
+  -- progress" instead of the file's own content.
+  assert(fs.write(fs.join(root, "after.tl"), 'return "OK"\n'))
+  local got = searcher.tree("after")
+  local loader = check.must(loader_of(got))
+  assert(loader() == "OK", "resolution after a throw must still work")
+end
+test_compiling_guard_clears_after_a_throw()
 
 -- The argv scan is the channel's other half, and its rule is where the
 -- scan stops: at the first non-flag, which is where getopt stops too.

--- a/cosmic/shm.tl
+++ b/cosmic/shm.tl
@@ -79,12 +79,6 @@ local function check_word(word_index: integer, size: integer, op: string): strin
   return nil
 end
 
---- Translate a pcall failure (a residual binding throw) into the
---- error-return convention.
-local function thrown(op: string, err: any): string
-  return errstr(err, op)
-end
-
 --- Wrap the raw unix.Memory userdata in a Memory record whose methods
 --- validate bounds in Lua and return nil, err instead of throwing.
 local function wrap(raw: unix.Memory, size: integer): Memory
@@ -105,7 +99,7 @@ local function wrap(raw: unix.Memory, size: integer): Memory
     end
     local ok, res = pcall(raw.read, raw, offset, bytes)
     if not ok then
-      return nil, thrown("read", res)
+      return nil, errstr(res, "read")
     end
     return res
   end
@@ -120,10 +114,27 @@ local function wrap(raw: unix.Memory, size: integer): Memory
       return false, "write: byte range out of range (offset " .. tostring(off)
       .. " + " .. tostring(n) .. " > " .. tostring(size) .. ")"
     end
+    -- Pass the CLAMPED count, not the caller's raw `bytes` -- otherwise
+    -- an over-large `bytes` sails past the check above straight into
+    -- the binding. nil still means "no count" (append NUL), per raw.write.
+    local write_count: integer = nil
+    if bytes ~= nil then
+      write_count = n
+    end
+    -- raw.write's real argument order is (self, offset, data[, bytes]),
+    -- NOT (self, data, offset[, bytes]) as its declared Teal type implies
+    -- (a mismatch in the upstream binding's own annotation): it decides
+    -- offset-vs-data by whether arg 2 is a number, so calling it with
+    -- `data` first makes it silently treat our `offset` as `bytes`
+    -- instead (an offset of 0 masked this: `mem:write(x, 0)` always
+    -- wrote 0 bytes). Passing the definite numeric `off` first is
+    -- unambiguous.
+    -- cast: real C arg order disagrees with raw.write's declared type
+    local raw_write = raw.write as function(unix.Memory, integer, string, integer | nil): nil
     -- cast: pcall variadic returns to tuple
-    local ok, err = pcall(raw.write, raw, data, offset, bytes) as (boolean, any)
+    local ok, err = pcall(raw_write, raw, off, data, write_count) as (boolean, any)
     if not ok then
-      return false, thrown("write", err)
+      return false, errstr(err, "write")
     end
     return true
   end
@@ -135,7 +146,7 @@ local function wrap(raw: unix.Memory, size: integer): Memory
     end
     local ok, res = pcall(raw.load, raw, word_index)
     if not ok then
-      return nil, thrown("load", res)
+      return nil, errstr(res, "load")
     end
     return res
   end
@@ -148,7 +159,7 @@ local function wrap(raw: unix.Memory, size: integer): Memory
     -- cast: pcall variadic returns to tuple
     local ok, err = pcall(raw.store, raw, word_index, value) as (boolean, any)
     if not ok then
-      return false, thrown("store", err)
+      return false, errstr(err, "store")
     end
     return true
   end
@@ -161,7 +172,7 @@ local function wrap(raw: unix.Memory, size: integer): Memory
     end
     local ok, res = pcall(fn, raw, word_index, value)
     if not ok then
-      return nil, thrown(op, res)
+      return nil, errstr(res, op)
     end
     return res
   end
@@ -193,7 +204,7 @@ local function wrap(raw: unix.Memory, size: integer): Memory
     end
     local ok, success, actual = pcall(raw.cmpxchg, raw, word_index, old, new)
     if not ok then
-      return nil, nil, thrown("cmpxchg", success)
+      return nil, nil, errstr(success, "cmpxchg")
     end
     return success, actual
   end
@@ -214,7 +225,7 @@ local function wrap(raw: unix.Memory, size: integer): Memory
       ok, rc, err, weno = pcall(raw.wait, raw, word_index, expect, abs_deadline, nanos)
     end
     if not ok then
-      return nil, thrown("wait", rc)
+      return nil, errstr(rc, "wait")
     end
     if rc == nil then
       return nil, errstr(err, "wait")
@@ -281,7 +292,7 @@ local function mapshared(size: integer): Memory | nil, string
   -- Residual throws (e.g. out of memory, size cap) become nil, err.
   local ok, raw = pcall(unix.mapshared, size)
   if not ok then
-    return nil, thrown("mapshared", raw)
+    return nil, errstr(raw, "mapshared")
   end
   return wrap(raw, size)
 end

--- a/cosmic/shm_test.tl
+++ b/cosmic/shm_test.tl
@@ -197,6 +197,34 @@ local function test_memory_write_out_of_range()
 end
 test_memory_write_out_of_range()
 
+-- write must honor an explicit offset: raw.write's real C argument
+-- order is (offset, data, bytes), not (data, offset, bytes), so this
+-- once silently discarded the offset (treating it as a bytes count).
+local function test_memory_write_at_explicit_offset()
+  local mem = check.must(shm.mapshared(4096))
+  local ok1, err1 = mem:write("XXXXXXXXXX", 0)
+  assert(ok1, "setup write failed: " .. tostring(err1))
+  local ok2, err2 = mem:write("world", 3)
+  assert(ok2, "write at offset 3 failed: " .. tostring(err2))
+  local data = check.must(mem:read(0, 8))
+  assert(data == "XXXworld",
+    "expected 'XXXworld' at bytes 0-7, got: " .. tostring(data):gsub("%z", "\\0"))
+end
+test_memory_write_at_explicit_offset()
+
+-- write must clamp `bytes` to the actual data length before it reaches
+-- the binding: passing the caller's raw (over-large) count instead of
+-- the validated min(bytes, #data) either wrote nothing (offset 0
+-- collides with "no count") or threw "bytes is more than what's in data".
+local function test_memory_write_clamps_bytes_to_data_length()
+  local mem = check.must(shm.mapshared(4096))
+  local ok, err = mem:write("hi", 0, 100)
+  assert(ok == true, "write with bytes > #data should still succeed: " .. tostring(err))
+  local data = check.must(mem:read(0, 2))
+  assert(data == "hi", "expected 'hi', got: " .. tostring(data))
+end
+test_memory_write_clamps_bytes_to_data_length()
+
 local function test_memory_word_index_out_of_range()
   local mem = check.must(shm.mapshared(64))
   local v, err = mem:load(9999)

--- a/cosmic/sse.tl
+++ b/cosmic/sse.tl
@@ -158,8 +158,11 @@ local function events(reader: stream.Reader): Stream
         local data = table.concat(current_data, "\n")
         current_data = {}
         if data == "" then
-          -- empty data buffer: reset the event type too, dispatch nothing
+          -- empty data buffer: reset the event type and retry too,
+          -- dispatch nothing. Otherwise a retry: from this discarded
+          -- block would leak into the next dispatched event.
           current_event = nil
+          current_retry = nil
         else
           local ev: Event = {
             data = data,

--- a/cosmic/sse_test.tl
+++ b/cosmic/sse_test.tl
@@ -195,6 +195,16 @@ local function test_empty_data_dispatch_resets_event_type()
 end
 test_empty_data_dispatch_resets_event_type()
 
+local function test_empty_data_dispatch_resets_retry()
+  -- a retry buffered before an empty-data dispatch (which discards the
+  -- whole block, undispatched) must not leak into the next event
+  local events_list = collect("retry: 5000\n\ndata: hi\n\n")
+  assert(#events_list == 1, "should have 1 event")
+  assert(events_list[1].retry == nil,
+    "retry must reset on empty-data dispatch, got: " .. tostring(events_list[1].retry))
+end
+test_empty_data_dispatch_resets_retry()
+
 local function test_unknown_fields_ignored()
   local events_list = collect("unknown: value\ndata: test\ncustom: ignored\n\n")
   assert(#events_list == 1, "should have 1 event")

--- a/cosmic/teal.tl
+++ b/cosmic/teal.tl
@@ -128,6 +128,11 @@ local record ProcessResult
   error: Issue
 end
 
+--- Build a ProcessResult carrying a single top-of-file error.
+local function process_error(input_path: string, message: string): ProcessResult
+  return {error = {file = input_path, line = 0, column = 0, message = message, severity = "error"}}
+end
+
 --- Process a Teal file: read, setup paths, run tl.process_string.
 --- Returns ProcessResult with tl_result on success, or error on failure.
 --- @param input_path string Path to the Teal file to process
@@ -140,15 +145,7 @@ local function process_file(input_path: string, include_dirs: {string}, lax: boo
     gen_target?: string, gen_compat?: string): ProcessResult
   local f, open_err = io.open(input_path, "r")
   if not f then
-    return {
-      error = {
-        file = input_path,
-        line = 0,
-        column = 0,
-        message = "cannot open file: " .. (open_err or "unknown error"),
-        severity = "error",
-      },
-    }
+    return process_error(input_path, "cannot open file: " .. (open_err or "unknown error"))
   end
   local input = f:read("*a")
   f:close()
@@ -180,15 +177,7 @@ local function process_file(input_path: string, include_dirs: {string}, lax: boo
     })
   if not env then
     tl.path = saved_tl_path
-    return {
-      error = {
-        file = input_path,
-        line = 0,
-        column = 0,
-        message = "tl.new_env: " .. (env_err or "unknown error"),
-        severity = "error",
-      },
-    }
+    return process_error(input_path, "tl.new_env: " .. (env_err or "unknown error"))
   end
   -- process_string returns exactly one value (a Result); errors land in
   -- its syntax_errors/type_errors fields or arrive here as a throw.
@@ -197,28 +186,12 @@ local function process_file(input_path: string, include_dirs: {string}, lax: boo
   tl.path = saved_tl_path
 
   if not ok then
-    return {
-      error = {
-        file = input_path,
-        line = 0,
-        column = 0,
-        message = tostring(result_or_err),
-        severity = "error",
-      },
-    }
+    return process_error(input_path, tostring(result_or_err))
   end
   local result = result_or_err as TlResult -- cast: from any
 
   if not result then
-    return {
-      error = {
-        file = input_path,
-        line = 0,
-        column = 0,
-        message = "processing failed",
-        severity = "error",
-      },
-    }
+    return process_error(input_path, "processing failed")
   end
 
   return {tl_result = result, shebang = shebang}

--- a/cosmic/teal.tl
+++ b/cosmic/teal.tl
@@ -133,8 +133,11 @@ end
 --- @param input_path string Path to the Teal file to process
 --- @param include_dirs {string} Directories to search for type definitions
 --- @param lax boolean If true, use lax mode; if false, use strict mode
+--- @param gen_target? string Codegen target ("5.1"|"5.3"|"5.4"), default DEFAULT_GEN_TARGET
+--- @param gen_compat? string Compat shims ("off"|"optional"|"required"), default DEFAULT_GEN_COMPAT
 --- @return ProcessResult Processing result with tl_result or error
-local function process_file(input_path: string, include_dirs: {string}, lax: boolean): ProcessResult
+local function process_file(input_path: string, include_dirs: {string}, lax: boolean,
+    gen_target?: string, gen_compat?: string): ProcessResult
   local f, open_err = io.open(input_path, "r")
   if not f then
     return {
@@ -167,14 +170,26 @@ local function process_file(input_path: string, include_dirs: {string}, lax: boo
   -- Options-form env construction: feature flags are explicit rather than
   -- inherited from tl's version-dependent defaults. feat_arity stays "on"
   -- (0.24 default) so function-arity mismatches are checked in strict mode.
-  local env = tl.new_env({
+  local env, env_err = tl.new_env({
       defaults = {
         feat_lax = lax and "on" or "off",
         feat_arity = "on",
-        gen_target = DEFAULT_GEN_TARGET,
-        gen_compat = DEFAULT_GEN_COMPAT,
+        gen_target = gen_target or DEFAULT_GEN_TARGET,
+        gen_compat = gen_compat or DEFAULT_GEN_COMPAT,
       },
     })
+  if not env then
+    tl.path = saved_tl_path
+    return {
+      error = {
+        file = input_path,
+        line = 0,
+        column = 0,
+        message = "tl.new_env: " .. (env_err or "unknown error"),
+        severity = "error",
+      },
+    }
+  end
   -- process_string returns exactly one value (a Result); errors land in
   -- its syntax_errors/type_errors fields or arrive here as a throw.
   local ok, result_or_err = pcall(tl.process_string, input, false, env, input_path)
@@ -322,7 +337,7 @@ local function compile(input_path: string, opts: CompileOptions): CompileResult
   opts = opts or {}
 
   local dirs = merge_include_dirs(opts.include_dirs)
-  local proc = process_file(input_path, dirs, not opts.strict)
+  local proc = process_file(input_path, dirs, not opts.strict, opts.gen_target, opts.gen_compat)
   if proc.error then
     return {ok = false, code = nil, errors = {proc.error}}
   end
@@ -340,7 +355,8 @@ local function compile(input_path: string, opts: CompileOptions): CompileResult
   -- tl.generate's second argument is the target STRING; passing an
   -- options table silently fell back to tl's default (non-5.4) target,
   -- which rejects 5.4-only syntax like <close> attributes. gen_compat
-  -- is an env-level default (set in make_env), not a generate option.
+  -- was threaded into the env above (tl.new_env rejects gen_target 5.4
+  -- with a non-"off" gen_compat), so both stay consistent here.
   local lua_code = tl.generate(proc.tl_result.ast, opts.gen_target or DEFAULT_GEN_TARGET)
 
   if proc.shebang then

--- a/cosmic/teal_test.tl
+++ b/cosmic/teal_test.tl
@@ -177,6 +177,27 @@ local function test_strict_compile_codegen()
 end
 test_strict_compile_codegen()
 
+-- gen_compat must actually reach tl's codegen: targeting a pre-5.4
+-- runtime with gen_compat="required" inserts a table.pack polyfill;
+-- "off" (the default) must not.
+local function test_compile_gen_compat_wired()
+  local pack_file = fs.join(tmpdir, "c_gen_compat.tl")
+  assert(fs.write(pack_file, "local t = table.pack(1, 2, 3)\nprint(t.n)\n"))
+
+  local off = teal.compile(pack_file, {gen_target = "5.3", gen_compat = "off"})
+  assert(off.ok, "gen_compat=off compile should succeed: "
+    .. (off.ok and "" or teal.format_issues(off.errors)))
+  assert(not off.code:find("_tl_table_pack", 1, true),
+    "gen_compat=off must not add compat shims")
+
+  local required = teal.compile(pack_file, {gen_target = "5.3", gen_compat = "required"})
+  assert(required.ok, "gen_compat=required compile should succeed: "
+    .. (required.ok and "" or teal.format_issues(required.errors)))
+  assert(required.code:find("_tl_table_pack", 1, true),
+    "gen_compat=required must add a table.pack compat shim when targeting 5.3")
+end
+test_compile_gen_compat_wired()
+
 local function test_no_hint_for_plain_errors()
   -- A message outside every known trap must produce no hint at all.
   assert(teal.hint_for_message("unknown variable: x") == nil,

--- a/cosmic/teal_test.tl
+++ b/cosmic/teal_test.tl
@@ -198,6 +198,19 @@ local function test_compile_gen_compat_wired()
 end
 test_compile_gen_compat_wired()
 
+-- tl.new_env itself rejects gen_target="5.4" paired with a non-"off"
+-- gen_compat; compile must surface that as an ordinary ok=false error
+-- (a "tl.new_env:" prefixed message), not a Lua exception.
+local function test_compile_rejects_incompatible_gen_target_and_compat()
+  local clean = fs.join(tmpdir, "c_incompatible.tl")
+  assert(fs.write(clean, "print(1)\n"))
+  local result = teal.compile(clean, {gen_target = "5.4", gen_compat = "required"})
+  assert(not result.ok, "5.4 + gen_compat=required must be rejected")
+  assert(#result.errors > 0 and result.errors[1].message:find("tl.new_env", 1, true),
+    "expected a tl.new_env error, got: " .. teal.format_issues(result.errors))
+end
+test_compile_rejects_incompatible_gen_target_and_compat()
+
 local function test_no_hint_for_plain_errors()
   -- A message outside every known trap must produce no hint at all.
   assert(teal.hint_for_message("unknown variable: x") == nil,


### PR DESCRIPTION
PR-10 of the review-fix series: nine small, independent stdlib fixes.

- `cosmic/ansi.tl:198` — `strip()`'s pattern spliced `CSI`'s literal `[` unescaped into a `gsub` pattern, opening a character class instead of matching `[` literally, so a bare `ESC` (no `[`) was wrongly stripped. Escaped it (`ESC .. "%[[0-9;]*m"`); added `test_strip_requires_csi_bracket`.
- `cosmic/doc/show.tl:256` — `find_matching_examples` spliced a function name into a Lua pattern (`"^" .. func_lower .. "_"`), so a name containing pattern magic characters (`(`, `-`, `.`) threw or mismatched. Replaced with `cosmic.string.starts_with` (plain-text). `doc/query.tl`'s sibling lookup already used `find(..., 1, true)`, so no further fix needed there. Added `cosmic/doc/show_test.tl`.
- `cosmic/teal.tl:26-32` vs `321-351` — `CompileOptions.gen_compat` was declared and documented but ignored; `process_file`'s `tl.new_env` call hardcoded the defaults. Wired `opts.gen_target`/`opts.gen_compat` through, checked `tl.new_env`'s own error return (it rejects `gen_target="5.4"` + non-`"off"` `gen_compat`), and added `test_compile_gen_compat_wired` (a `table.pack` polyfill only appears when `gen_compat="required"`) plus `test_compile_rejects_incompatible_gen_target_and_compat` (coverage ratchet caught the new branch). A follow-up commit factored the four now-similar error records through a `process_error` helper to stay under the 500-line file cap after the new parameters pushed it over.
- `cosmic/sandbox.tl:86` vs `149` — `SandboxModule.plan_landlock`'s declared type omitted the `keep_coverage` second parameter that the implementation and doc comment both have, so a typed caller passing it failed to type-check ("wrong number of arguments"). Fixed the type; added `test_plan_landlock_keep_coverage_param`.
- `cosmic/sse.tl:156-172` — the blank-line handler reset `current_event` but not `current_retry` on an empty-data (discarded) block, leaking a stale `retry:` into the next dispatched event. Reset both; added `test_empty_data_dispatch_resets_retry`.
- `cosmic/shm.tl:113-128` — `write()` validated a clamped `n = min(bytes, #data)` but passed the caller's raw `bytes` to `raw.write`, defeating the clamp (the binding rejects `bytes > #data` outright). While fixing that I found a bigger latent bug in the same call: `raw.write`'s real C argument order is `(self, offset, data[, bytes])`, not `(self, data, offset[, bytes])` as its declared Teal type claims (a mismatch in the binding's own upstream annotation) — so any explicit `offset` was silently reinterpreted as a bytes count, and writes always landed at offset 0. Fixed both (the offset fix needed a justified cast, since pcall's special-form type-checks against the callee's real signature). Also inlined the trivial `thrown(op, err)` alias (`errstr(err, op)`) at its nine call sites. Added `test_memory_write_at_explicit_offset` and `test_memory_write_clamps_bytes_to_data_length`; both fail against the pre-fix code.
- `cosmic/re.tl:150-154` (NOTBOL/NEWLINE) — investigated against cosmopolitan's binding semantics (`tool/net/definitions.lua`) and the pinned binary, testing both flag states. The real bug is worse than described: `findall("^foo", "foo\nfoo", re.NEWLINE)` returns `nil, "failed to locate match position for: foo"` (a hard failure, not an undercount), because `locate()`'s verification window is exactly `#m` characters wide and never includes the newline a NEWLINE-mode `^`/`$` anchor actually matched against. The suggested fix (drop `NOTBOL` when `NEWLINE` is set) is unsafe — it's what rejects false candidate positions, so dropping it would cause over-matching, a worse regression. A window-widening fix has its own edge case (the wider window can contain another literal occurrence of the match text). Documented the limitation on `locate`/`findall`/`split`/`gsub` instead, per the fallback the finding allowed, and added `test_newline_anchor_past_first_line_is_a_known_limitation` pinning today's behavior for both the `^` (nil) and `$` (undercount) cases plus the unaffected without-`NEWLINE` case.
- `cosmic/searcher.tl:195-217` and `:331` — `compile_tree` set `compiling = true` then called `teal.compile_cached` unguarded; a throw (not the normal `nil, err` return) left `compiling` stuck true, failing every later tree resolution with "compiler bootstrap in progress". Wrapped in `pcall`. Separately, `install_tree` lacked the idempotence guard `install()` has, so repeat calls stacked duplicate searchers into `package.searchers`; added a `tree_installed` flag. This required deliberately changing a pinned test (`test_install_lands_ahead_of_the_file_searcher`): it asserted "exactly one searcher is added", which only held because `install_tree` was NOT idempotent — this process's own bootstrap already installs a tree searcher when testing this repo against its own tree. Rewrote it to check "at most one is added" (robust either way) plus an explicit idempotence assertion. Added `test_compiling_guard_clears_after_a_throw` (monkeypatches `compile_cached` to throw), which fails against the pre-fix code.
- `cosmic/instrument.tl:113-115` vs `129-134` — `emit` wrote `file=%s` unquoted; `parse` read `file=(%S+)`, so a path containing a space silently truncated. Added `escape_field`/`unescape_field` (percent-encodes literal `%` then space; decodes in reverse order for an unambiguous round-trip), applied to both `op` and `file`. Typical values are unchanged on the wire. Added `test_file_with_space_round_trips` (fails against pre-fix code) and `test_file_with_percent_round_trips`.

No findings were skipped as already-fixed or wrong; finding 7 (re.tl) was investigated and deliberately resolved as documentation rather than a code fix, per the judgment call the finding itself allowed.

CI verdict:

```
180 checks: 180 passed
coverage: read 722 .cov files
coverage ratchet ok
coverage: PASS (180 files)
ci: PASS (6 stages)
```

Reviewer should double-check:
- The `shm.tl` offset-argument-order fix is outside the original finding's scope — it's a real, independently-verified bug (confirmed against the pinned binary), but it's a bigger behavioral change than the rest of this PR and worth a closer look.
- The `re.tl` NEWLINE limitation is documented, not fixed; a real fix would need to widen `locate()`'s verification window and handle the resulting ambiguity, which felt too risky for this batch.
- The `searcher_tree_test.tl` pinned-test change (idempotence-guard fallout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE)_