### PR TITLE
make: memoize generator runs within one process invocation

### DIFF
--- a/_make/generate.tl
+++ b/_make/generate.tl
@@ -23,6 +23,23 @@ local types = require("_make.types")
 local type File = types.File
 local type Project = types.Project
 
+--- Generators already run this INVOCATION, keyed by the absolute output
+--- directory each one owns.
+---
+--- `graph_stage` runs `sources` before every graph verb, and `test`,
+--- `example`, `coverage` (and `run`) each stage the binaries before
+--- their own graph verb runs -- so one `--make ci` reaches
+--- `run_generator` for the same generator many times over, and every
+--- one of those calls clears and re-runs it. The tree does not move
+--- between them: a graph verb's own stages never edit sources, so
+--- the second call is paying full generator cost to reproduce what
+--- the first already wrote. Memoized for the life of this process
+--- only -- a fresh invocation (and `converge`'s re-exec into a freshly
+--- built binary is exactly that, a new process) starts with this
+--- table empty, which is required: the tree it runs against may not be
+--- the one the last process saw.
+local ran: {string: boolean} = {}
+
 --- A path with its extension removed.
 ---
 --- Both spellings, because a marker is a name: stripping a fixed three
@@ -202,6 +219,9 @@ end
 local function run_generator(proj: Project, gen: string, dest: string,
     cosmic: string): boolean, string
   local at = fs.join(proj.root, dest)
+  if ran[at] then
+    return true
+  end
   if fs.exists(at) then
     local rok, rerr = fs.rmrf(at)
     if not rok then
@@ -234,6 +254,7 @@ local function run_generator(proj: Project, gen: string, dest: string,
   if not (r as child.Result).ok then
     return false, "make: " .. gen .. " failed"
   end
+  ran[at] = true
   return true
 end
 


### PR DESCRIPTION
Fixes finding PR-02 make-memo.

## What was fixed

- `_make/generate.tl:202` (`run_generator`): `_make/stage.tl`'s `graph_stage` calls `generate.sources` before every graph verb, and `test`/`example`/`coverage` (via `prepare_stage`) each stage a binary — `generate.generate` + `artifact.build` — before their own graph verb runs. One `--make ci` therefore reached `run_generator` for the same generator many times over (~7x for `_types/types_gen`, ~3x for payload staging/embedding), and it unconditionally cleared and re-executed the generator every time even though nothing in the tree moves between those calls within one `ci` run (confirmed: ci's stages never edit sources). Fixed by memoizing in `run_generator`, keyed by the absolute output directory each generator owns (`fs.join(proj.root, dest)`), for the life of the current process only, and only on success. A fresh process — including `converge`'s re-exec into a freshly built binary, which genuinely is a new process — starts with an empty memo table and reruns every generator, which is required: that process may be running against a tree the previous process never saw.

Diff is 21 lines, entirely inside `_make/generate.tl`: a module-level `ran: {string: boolean}` table, an early-return at the top of `run_generator` when the key is already memoized, and setting the key right before the final success return (not on failure paths, so a failed run isn't cached as done).

## Findings skipped

None — this PR covers exactly the one finding in its section (PR-02 make-memo), and it was still present as described.

## Verification

- `_make/generate_test.tl`, `_make/build_test.tl`, `_make/check_test.tl`, `_make/artifact_test.tl`, `_make/resolution_test.tl`, `_make/pin_test.tl` all PASS — these specifically exercise multiple in-process `mk.run(...)` calls against the same and different fixture projects, which is the scenario most likely to be broken by over-eager memoization; none were.
- Timing, warm `bin/cosmic --make ci`, full wall clock measured end-to-end (file birth-to-last-write, since the tool's own per-stage `wall:` lines sum concurrent test time rather than elapsed clock and aren't a fair before/after basis):
  - before (this repo's tip, unmodified): **445.58s** (13:16:23.085 → 13:23:48.665)
  - after (same tree + this change): **361s** (17:22:15 → 17:28:16)
  - ≈ 19% faster on this box. Both runs shared the box with other parallel gates going at the time (this machine was running several agents' gates concurrently), so treat the delta as directional, not a clean noise-floor number — the mechanism (cutting redundant generator re-execution from ~7x/~3x down to 1x per process) is what the change buys regardless of the exact percentage. A later full gate run after rebasing onto origin/main (with 2 additional upstream test files) took ~18 minutes under heavier contention, illustrating how much this box's own load dominates wall-clock noise here.

- `ci: PASS (6 stages)` — quoted verbatim from the final full gate, run after rebasing onto `origin/main` (6b75cb8):

```
180 checks: 180 passed
wall: 1449872ms  slowest: .coverage/_make/fixpoint_test.tl (456431ms)
coverage: read 722 .cov files
coverage ratchet ok
coverage: PASS (180 files)
ci: PASS (6 stages)
```

## For a reviewer to double-check

- The memo key is the generator's absolute output directory, not its process-relative gen path, specifically so that two projects with a same-named generator file (e.g. two fixtures both named `thing_gen.lua`) processed in one process don't collide on the memo — I traced every current in-process multi-`mk.run()` test to confirm none currently hits that path, but the key choice defends it anyway.
- `--make clean` and generation don't interact within a single process today (clean is always its own top-level verb invocation), so there's no in-process invalidation path to add; a `clean` then `build` from the CLI is always two separate processes and gets a fresh memo either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE)_