### PR TITLE
_types: fix seven silent-mistype bugs in the gentype annotation parser

### DIFF
--- a/_types/gentype.tl
+++ b/_types/gentype.tl
@@ -451,9 +451,12 @@ local function run(module_name: string): Result
     return {success = true, output = output}
   else
     local outputs: {string} = {}
+    local failed: {string} = {}
     for _, m in ipairs(MODULES) do
       local module = parse_module(source, m)
-      if module then
+      if not module then
+        table.insert(failed, m)
+      else
         local output, err = render_module(module)
         if not output then
           return {success = false, error = err}
@@ -461,6 +464,10 @@ local function run(module_name: string): Result
         table.insert(outputs, "-- === " .. m .. " ===")
         table.insert(outputs, output)
       end
+    end
+    if #failed > 0 then
+      return {success = false,
+        error = "Failed to parse module(s): " .. table.concat(failed, ", ")}
     end
     return {success = true, output = table.concat(outputs, "\n")}
   end

--- a/_types/gentype.tl
+++ b/_types/gentype.tl
@@ -378,6 +378,11 @@ local function validate_module(module: ModuleDecl): string
       return bad(module.name .. "." .. c.name, "constant", c.const_type)
     end
   end
+  for _, al in ipairs(module.aliases or {}) do
+    if not parse.valid_type(al.alias_type) then
+      return bad(module.name .. "." .. al.name, "alias", al.alias_type)
+    end
+  end
   return nil
 end
 

--- a/_types/gentype.tl
+++ b/_types/gentype.tl
@@ -272,6 +272,15 @@ local function parse_module(source: string, module_name: string): ModuleDecl
       local method_params_str = line:match("%((.-)%)")
       local desc, params, returns, nodiscard, _, _, fallible, error_type, generics = parse_annotations(anno_lines)
       params = reconcile_params(params, method_params_str)
+      -- A method's own iterator returns "the receiver again" as a bare
+      -- `self` token (`fun(...) iterator, self` — the module-function
+      -- variants spell this out as `lsqlite3.VM vm` instead). Resolve it to
+      -- this method's class now, while the class name is in scope.
+      for _, r in ipairs(returns) do
+        if r.return_type == "self" then
+          r.return_type = class_name
+        end
+      end
       local method: FuncDecl = {
         name = method_name, module = module_name, description = desc,
         params = params, returns = returns, is_method = true,

--- a/_types/gentype_alias_test.tl
+++ b/_types/gentype_alias_test.tl
@@ -64,4 +64,27 @@ function zip.open() end
 end
 test_userdata_class_marker()
 
+-- A malformed ---@alias right-hand side must fail validate_module loudly,
+-- the same as a malformed param/return/field/constant type — aliases were
+-- not validated against the type grammar at all before, so a bad RHS
+-- rendered invalid Teal silently.
+local function test_malformed_alias_fails_validation()
+  local source = [==[
+zip = {}
+
+---@alias zip.Bad nil,|nil
+
+--- Opens an archive.
+---@return boolean ok
+function zip.open() end
+]==]
+  local module = gentype.parse_module(source, "zip")
+  local output, err = gentype.render_module(module)
+  assert(not output, "a malformed alias RHS must not render, got:\n" .. tostring(output))
+  assert(err, "expected an error message")
+  assert(err:find("zip.Bad", 1, true), "error must name the offending alias: " .. err)
+  print("test_malformed_alias_fails_validation: PASS")
+end
+test_malformed_alias_fails_validation()
+
 print("\nAll tests passed!")

--- a/_types/gentype_defs.tl
+++ b/_types/gentype_defs.tl
@@ -31,9 +31,9 @@ end
 local function read(): string | nil, string
   local override = os.getenv("GENTYPE_DEFS")
   if override then
-    local source = fs.read(override)
+    local source, ferr = fs.read(override)
     if not source then
-      return nil, "Failed to read " .. override
+      return nil, "Failed to read " .. override .. ": " .. (ferr or "unknown error")
     end
     return source
   end

--- a/_types/gentype_gen_test.tl
+++ b/_types/gentype_gen_test.tl
@@ -1,0 +1,46 @@
+#!/usr/bin/env cosmic
+--- Tests for gentype's generation-level robustness: description harvesting
+--- around ---@type, run()'s all-modules failure handling, and
+--- gentype_defs.read()'s GENTYPE_DEFS override error reporting.
+--- Split from gentype_test.tl to respect the 500-line file cap.
+
+local gentype = require("_types.gentype")
+
+-- `---@type` is the one tag upstream also spells with a space after the
+-- dashes ("--- @type integer"). The description harvester must exclude it
+-- like every other tag, or the raw annotation line leaks into the rendered
+-- doc comment above the constant (found above every unix.* errno constant
+-- in the generated cosmo/unix.d.tl).
+local function test_spaced_type_tag_does_not_leak_into_description()
+  local source = [==[
+unix = {
+    --- @type integer
+    EFOO = 1,
+}
+]==]
+  local dtl = gentype.generate_dtl(gentype.parse_module(source, "unix"))
+  assert(not dtl:match("@type"),
+    "a spaced '--- @type' annotation must not leak into the doc comment:\n" .. dtl)
+  assert(dtl:match("EFOO: integer"), "the constant should still render:\n" .. dtl)
+  print("test_spaced_type_tag_does_not_leak_into_description: PASS")
+end
+test_spaced_type_tag_does_not_leak_into_description()
+
+-- A plain two-dash Lua comment mentioning "@type" is not a doc tag and must
+-- not be able to inject a constant type (the recognized tag requires
+-- exactly three dashes, optionally followed by whitespace).
+local function test_two_dash_type_is_not_a_tag()
+  local source = [==[
+unix = {
+    -- @type string
+    EBAR = 2,
+}
+]==]
+  local dtl = gentype.generate_dtl(gentype.parse_module(source, "unix"))
+  assert(dtl:match("EBAR: integer"),
+    "a two-dash '-- @type' comment must not override the default integer type:\n" .. dtl)
+  print("test_two_dash_type_is_not_a_tag: PASS")
+end
+test_two_dash_type_is_not_a_tag()
+
+print("\nAll gentype_gen tests passed!")

--- a/_types/gentype_gen_test.tl
+++ b/_types/gentype_gen_test.tl
@@ -4,6 +4,9 @@
 --- gentype_defs.read()'s GENTYPE_DEFS override error reporting.
 --- Split from gentype_test.tl to respect the 500-line file cap.
 
+local defs = require("_types.gentype_defs")
+local env = require("cosmic.env")
+local fs = require("cosmic.fs")
 local gentype = require("_types.gentype")
 
 -- `---@type` is the one tag upstream also spells with a space after the
@@ -42,5 +45,41 @@ unix = {
   print("test_two_dash_type_is_not_a_tag: PASS")
 end
 test_two_dash_type_is_not_a_tag()
+
+-- run() in all-modules mode must fail loudly, naming every module whose
+-- parse returned nil, instead of silently omitting it from the output.
+local function test_run_all_modules_fails_loudly_on_unparseable_module()
+  local tmpdir = os.getenv("TEST_TMPDIR")
+  local src_path = fs.join(tmpdir, "empty-definitions.lua")
+  assert(fs.write(src_path, "-- no modules defined here\n"))
+  assert(env.set("GENTYPE_DEFS", src_path, true))
+  local result = gentype.run()
+  assert(env.unset("GENTYPE_DEFS"))
+  assert(not result.success,
+    "run() must fail when every module fails to parse, got:\n" .. tostring(result.output))
+  assert(result.error:find("Failed to parse module", 1, true),
+    "error should say modules failed to parse: " .. tostring(result.error))
+  for _, m in ipairs(gentype.get_modules()) do
+    assert(result.error:find(m, 1, true),
+      "error should name missing module '" .. m .. "': " .. tostring(result.error))
+  end
+  print("test_run_all_modules_fails_loudly_on_unparseable_module: PASS")
+end
+test_run_all_modules_fails_loudly_on_unparseable_module()
+
+-- defs.read()'s GENTYPE_DEFS override must include the underlying fs.read
+-- error, not just the path, or a permissions/typo problem is undiagnosable.
+local function test_defs_read_override_error_includes_reason()
+  assert(env.set("GENTYPE_DEFS", "/nonexistent/gentype-defs-test-path", true))
+  local source, err = defs.read()
+  assert(env.unset("GENTYPE_DEFS"))
+  assert(not source, "a missing override path must fail")
+  assert(err:find("/nonexistent/gentype-defs-test-path", 1, true),
+    "error should name the override path: " .. tostring(err))
+  assert(err:find("ENOENT", 1, true) or err:find("No such file", 1, true),
+    "error should include the underlying read failure, not just the path: " .. tostring(err))
+  print("test_defs_read_override_error_includes_reason: PASS")
+end
+test_defs_read_override_error_includes_reason()
 
 print("\nAll gentype_gen tests passed!")

--- a/_types/gentype_parse.tl
+++ b/_types/gentype_parse.tl
@@ -254,8 +254,16 @@ local function parse_annotations(raw_lines: {string}): {string}, {Param}, {Retur
   local fallible = false
   local error_type: string = nil
 
+  -- `@type` is the one tag upstream also spells with a space after the
+  -- dashes ("--- @type integer"), so the plain "^%-%-%-@" description guard
+  -- below misses it and the raw line leaks into the generated doc comment
+  -- (visible above every unix.* errno constant). Anchored to exactly three
+  -- dashes: a plain two-dash Lua comment ("-- @type ...") is not a doc tag
+  -- and must not be able to inject a constant type.
+  local TYPE_TAG = "^%-%-%-%s*@type%s+([%w_%.]+)"
+
   for _, line in ipairs(lines) do
-    if not line:match("^%-%-%-@") then
+    if not line:match("^%-%-%-@") and not line:match(TYPE_TAG) then
       local desc_text = line:match("^%-%-%-(.*)$")
       if desc_text then
         if desc_text:sub(1, 1) == " " then
@@ -314,16 +322,19 @@ local function parse_annotations(raw_lines: {string}): {string}, {Param}, {Retur
         end
         if c == "," and in_angle == 0 and in_brace == 0 and in_paren == 0 then
           -- Split into another return only when the comma is followed by a
-          -- genuine type token: a builtin type name or a module-dotted type
-          -- (`unix.Errno`). Prose in a trailing description ("ARIN, APNIC,
-          -- DOD, etc.") must stay in the description. The literal types
-          -- true/false/nil are deliberately NOT continuation tokens: no
-          -- annotation continues a return list with a bare literal, but
-          -- boolean descriptions routinely read "true when ..., false when
-          -- ..." and failure prose "..., nil on failure" — treating those
-          -- words as types grew phantom returns (unix.Memory:unmap,
-          -- whilp/cosmopolitan#198). Literals on their own @return lines
-          -- are unaffected; only this comma decision is narrowed.
+          -- genuine type token: a builtin type name, a module-dotted type
+          -- (`unix.Errno`), or `self` (the VM iterator methods return
+          -- `fun(...) iterator, self` to mean "the receiver again", the same
+          -- role the Database variants spell out as `lsqlite3.VM vm`). Prose
+          -- in a trailing description ("ARIN, APNIC, DOD, etc.") must stay in
+          -- the description. The literal types true/false/nil are
+          -- deliberately NOT continuation tokens: no annotation continues a
+          -- return list with a bare literal, but boolean descriptions
+          -- routinely read "true when ..., false when ..." and failure prose
+          -- "..., nil on failure" — treating those words as types grew
+          -- phantom returns (unix.Memory:unmap, whilp/cosmopolitan#198).
+          -- Literals on their own @return lines are unaffected; only this
+          -- comma decision is narrowed.
           local rest_after_comma = full_return:sub(i + 1)
           local next_word = rest_after_comma:match("^%s*([%w_%.]+)")
           local builtin_types: {string: boolean} = {
@@ -331,7 +342,7 @@ local function parse_annotations(raw_lines: {string}): {string}, {Param}, {Retur
             ["boolean"] = true, ["any"] = true,
             ["table"] = true, ["function"] = true, ["userdata"] = true,
             ["uint32"] = true, ["uint16"] = true, ["int64"] = true,
-            ["fun"] = true,
+            ["fun"] = true, ["self"] = true,
           }
           local is_type_token = false
           if next_word then
@@ -359,22 +370,32 @@ local function parse_annotations(raw_lines: {string}): {string}, {Param}, {Retur
         local part_type: string = nil
         local part_desc: string = nil
         -- A variadic return (`@return string ... desc`) is rendered as a Teal
-        -- vararg return type. Nothing can follow a vararg, so stop here.
-        local va_type = return_part:match("^([%w_%.]+)%s+%.%.%.") or
-        (return_part == "..." and "any" or nil)
+        -- vararg return type. Nothing can follow a vararg, so stop here. The
+        -- type before `...` need not be a bare identifier — a union
+        -- (`@return string|number? ... desc`, `@return any|nil ... desc`)
+        -- carries no internal whitespace either, so scan a whole type token
+        -- (the same balanced-bracket scanner split_type_desc uses) instead of
+        -- matching a single dotted identifier, which silently dropped the
+        -- variadic marker for a union-typed vararg. A `fun(...)` return is
+        -- excluded here: its own trailing `...: <type>` return is already
+        -- handled inside split_type_desc's fun-parsing branch below, and
+        -- scanning it here would stop at the first top-level space inside
+        -- the fun's OWN return clause and misread that as a top-level vararg.
+        local va_type: string = nil
+        if return_part == "..." then
+          va_type = "any"
+        elseif not return_part:match("^fun%(") then
+          local va_candidate, va_rest = scan_token(return_part)
+          if va_rest:match("^%.%.%.") then
+            va_type = va_candidate
+          end
+        end
         if va_type then
           table.insert(returns, {return_type = va_type .. "...", description = ""})
           break
         end
         part_type, part_desc = split_type_desc(return_part)
         if part_type and part_type ~= "" then
-          if part_type == "table" and part_desc then
-            local specific_type = part_desc:match("^([%w_]+)")
-            if specific_type and specific_type:match("^[%l_]") then
-              part_type = specific_type
-              part_desc = part_desc:match("^[%w_]+%s*(.*)") or part_desc
-            end
-          end
           table.insert(returns, {return_type = part_type, description = part_desc or ""})
         end
       end
@@ -410,7 +431,7 @@ local function parse_annotations(raw_lines: {string}): {string}, {Param}, {Retur
       class_annotation = cname
     end
 
-    local ttype = line:match("^%-%-%-?%s*@type%s+([%w_%.]+)")
+    local ttype = line:match(TYPE_TAG)
     if ttype then
       table.insert(returns, {return_type = ttype, description = "type"})
     end
@@ -434,6 +455,20 @@ local function parse_annotations(raw_lines: {string}): {string}, {Param}, {Retur
       generic_list[#generic_list + 1] = g
     end
     table.sort(generic_list)
+  end
+
+  -- A vararg return is only meaningful as the true LAST return — Teal
+  -- forbids anything after one. Upstream occasionally documents a
+  -- variadic return followed by an error/errno pair on separate @return
+  -- lines (unix.fcntl: `@return any|nil ...` then `@return string? error`,
+  -- `@return unix.Errno? errno`), so the vararg there is not actually
+  -- final; demote it back to a plain (non-variadic) type rather than
+  -- render syntax Teal rejects.
+  for idx = 1, #returns - 1 do
+    local r = returns[idx]
+    if r.return_type and r.return_type:match("%.%.%.$") then
+      r.return_type = r.return_type:sub(1, -4)
+    end
   end
 
   return desc, params, returns, nodiscard, class_annotation, fields, fallible, error_type, generic_list

--- a/_types/gentype_return_test.tl
+++ b/_types/gentype_return_test.tl
@@ -72,3 +72,93 @@ function shm.fail() end
     "leading literal types on their own @return lines keep working:\n" .. dtl)
 end
 test_single_segment_literal_return_unaffected()
+
+-- A union-typed vararg (`@return string|number? ... desc`) must render as a
+-- Teal variadic return, not a single scalar entry that silently drops the
+-- "..." (the old bare-identifier vararg pattern only matched a single word
+-- before "..."). Found via lsqlite3.Statement/VM:get_uvalues,
+-- whilp/cosmopolitan definitions.lua:1088,1252.
+local function test_union_vararg_return()
+  local source = [==[
+lsqlite3 = {}
+
+--- Gets all column values.
+---@return string|number? ... the values of all columns
+---@nodiscard
+function lsqlite3.Statement:get_uvalues() end
+]==]
+  local dtl = gentype.generate_dtl(gentype.parse_module(source, "lsqlite3"))
+  assert(dtl:match("get_uvalues: function%(self: Statement%): string | number | nil %.%.%."),
+    "a union-typed vararg should render as a variadic return:\n" .. dtl)
+  assert(not dtl:match("get_uvalues[^\n]*values of all columns"),
+    "the vararg description must not leak into the type list:\n" .. dtl)
+end
+test_union_vararg_return()
+
+-- A vararg return is only meaningful as the true LAST return: Teal forbids
+-- anything after one. Upstream documents unix.fcntl this way (`@return
+-- any|nil ...` followed by `@return string? error` and `@return
+-- unix.Errno? errno` on separate lines) — the leading vararg there is not
+-- actually final, so it must demote to a plain type instead of rendering
+-- syntax Teal rejects.
+local function test_non_last_vararg_demotes_to_plain_type()
+  local source = [==[
+unix = {}
+
+--- Manipulates file descriptor.
+---@param fd integer
+---@return any|nil ...
+---@return string? error
+---@return unix.Errno? errno
+function unix.fcntl(fd) end
+]==]
+  local module = gentype.parse_module(source, "unix")
+  local output, err = gentype.render_module(module)
+  assert(output, "a non-last vararg must demote instead of failing to render: "
+    .. tostring(err))
+  assert(output:match("fcntl: function%(fd: integer%): any | nil, string, Errno"),
+    "a non-last vararg should demote to a plain type:\n" .. output)
+end
+test_non_last_vararg_demotes_to_plain_type()
+
+-- A class method's iterator return spells "the receiver again" as a bare
+-- `self` token (`fun(...) iterator, self`) — the same role the module's
+-- constructor-style variants spell out with the full class name (`iterator,
+-- lsqlite3.VM vm`). The comma-continuation heuristic must recognize `self`
+-- as a genuine return-type token, not swallow it into the description.
+-- Found via lsqlite3.VM:nrows/rows/urows,
+-- whilp/cosmopolitan definitions.lua:1279,1293,1301.
+local function test_self_return_token()
+  local source = [==[
+lsqlite3 = {}
+
+--- Iterates named rows.
+---@param sql string
+---@return fun(self: lsqlite3.VM): table<string, string|number> iterator, self
+---@nodiscard
+function lsqlite3.VM:nrows(sql) end
+]==]
+  local dtl = gentype.generate_dtl(gentype.parse_module(source, "lsqlite3"))
+  assert(dtl:match("nrows: function%(self: VM, sql: string%): function, VM"),
+    "self should resolve to the enclosing class and gain a second return:\n" .. dtl)
+end
+test_self_return_token()
+
+-- `@return table <word>` must not reinterpret the lowercase word as the
+-- actual type: a heuristic that fires on zero cases in the corpus today
+-- (confirmed by grep) and is a silent hazard for a future annotation like
+-- `@return table result the returned value`, where "result" would wrongly
+-- become the rendered type.
+local function test_table_return_word_not_reinterpreted()
+  local source = [==[
+unix = {}
+
+--- Something.
+---@return table result the returned value
+function unix.something() end
+]==]
+  local dtl = gentype.generate_dtl(gentype.parse_module(source, "unix"))
+  assert(dtl:match("something: function%(%): table\n"),
+    "a table return must stay 'table', not the first description word:\n" .. dtl)
+end
+test_table_return_word_not_reinterpreted()


### PR DESCRIPTION
PR-11 of the cosmic-code-review-pvkr6c series. Fixes seven bugs in the `_types/` gentype annotation parser (`gentype_parse.tl`, `gentype.tl`, `gentype_defs.tl`) that currently emit wrong Teal types or swallow generation failures silently, verified against the real corpus at `whilp/cosmopolitan`'s `tool/net/definitions.lua`.

## What was fixed

1. **`gentype_parse.tl`: union-typed varargs lost their `...`** — the vararg pattern `^([%w_%.]+)%s+%.%.%.` only matched a single bare identifier before `...`, so `@return string|number? ...` (`lsqlite3.Statement`/`VM:get_uvalues`, definitions.lua:1088/1252) rendered as a single non-variadic return, silently dropping the vararg. Now scans a full type token (reusing `scan_token`, the same balanced-bracket scanner `split_type_desc` uses), excluding `fun(...)` returns whose own internal vararg is already handled elsewhere.
2. **`gentype_parse.tl`: a non-last vararg produced invalid Teal** — `unix.fcntl` (definitions.lua:5183) documents `@return any|nil ...` followed by `@return string? error` / `@return unix.Errno? errno` on separate lines. Making the leading vararg variadic (per fix 1) then rendered a return type Teal rejects (nothing may follow a vararg). Fixed by demoting a vararg entry back to a plain type whenever it isn't the true last return.
3. **`gentype_parse.tl`:315-350 comma-continuation heuristic didn't recognize `self`** — `@return fun(...) iterator, self` (`lsqlite3.VM:nrows`/`rows`/`urows`, definitions.lua:1279/1293/1301) folded the second return into the description and lost it, unlike the `Database` variants which spell it out as `iterator, lsqlite3.VM vm`. `self` is now a recognized continuation token, resolved to the enclosing class name in `gentype.tl` once it's in scope.
4. **`gentype_parse.tl`:257-268 + :413 — spaced `--- @type` leaked into doc comments** — the description-harvesting guard only excluded `^---@` (no space), while the `@type` matcher itself accepted `--- @type` (spaced), so `--- @type integer` lines leaked verbatim above every generated `unix.*` errno constant. Fixed by excluding the same spaced form, and tightened the `@type` matcher to require exactly three dashes (a plain two-dash comment can no longer inject a constant type).
5. **`gentype.tl` `validate_module` never validated `module.aliases`** — params/returns/errors/fields/constants were validated against the type grammar, aliases were not. A malformed `---@alias` RHS could render invalid Teal silently. Now validated the same way.
6. **`gentype.tl` `run()` all-modules mode silently skipped unparseable modules** — a module whose `parse_module` returned `nil` was dropped from the output with no error. Now collects every such module and fails loudly, naming all of them.
7. **`gentype_defs.tl`:34-37 — `GENTYPE_DEFS` override read error discarded** — a failed `fs.read` on the override path reported only `"Failed to read <path>"`, dropping the underlying reason (permissions, typo, etc). The underlying error is now included.
8. **`gentype_parse.tl`:371-377 — dead `@return table <word>` reinterpretation heuristic removed** — reinterpreted the first description word as the actual type when the declared type was `table`; confirmed via grep to fire on zero cases in the current corpus and a silent hazard for a future annotation. Deleted.

(Findings list had 7 items; #2 above split into two commits — the union-vararg parse fix and the non-last-vararg render fix it exposed — hence 8 fix bullets from 7 findings.)

No findings were skipped as already-fixed or wrong; all were re-verified against current line numbers before fixing.

## Evidence: generated types before/after

Per the workflow note, `o/_types/types_gen/` was captured after a full build both before and after this change (nothing else touched — a byte-diff of every other generated file is empty). The interesting parts:

**`get_uvalues` gains its variadic marker** (`cosmo/lsqlite3.d.tl`):
```diff
-  get_uvalues: function(self: Statement): string | number | nil
+  get_uvalues: function(self: Statement): string | number | nil ...
...
-  get_uvalues: function(self: VM): string | number | nil
+  get_uvalues: function(self: VM): string | number | nil ...
```

**`VM:nrows`/`rows`/`urows` gain their second return** (`cosmo/lsqlite3.d.tl`), now matching the `Database` variants' `function(...), VM` shape:
```diff
-  nrows: function(self: VM, sql: string): function(self: VM): {string: string | number}
+  nrows: function(self: VM, sql: string): function, VM
-  rows: function(self: VM, sql: string): function(self: VM): {string | number | nil}
+  rows: function(self: VM, sql: string): function, VM
-  urows: function(self: VM, sql: string): function(self: VM): any ...
+  urows: function(self: VM, sql: string): function, VM
```

**`unix.fcntl` is unchanged** (`cosmo/unix.d.tl`) — confirms the non-last-vararg demotion (fix 2) keeps it exactly as before, just at a different line number (the `--- @type` doc-leak removal above it shifted lines):
```
before (line 2036): fcntl: function(fd: integer, cmd: FcntlCmd, ...: any): any | nil, string, Errno
after  (line 1707): fcntl: function(fd: integer, cmd: FcntlCmd, ...: any): any | nil, string, Errno
```

**`--- @type` doc-leak lines removed above every unix.\* errno constant** (`cosmo/unix.d.tl`), sample:
```diff
   type Errno = Errno
   type FcntlCmd = FcntlCmd

-  --- @type integer
   AF_INET: integer
-  --- @type integer
   AF_UNIX: integer
-  --- @type integer
   AF_UNSPEC: integer
```
(330+ such lines removed across the file — every `--- @type integer` annotation that previously leaked above its constant.)

## Tests

Extended `_types/gentype_return_test.tl` (union vararg, non-last-vararg demotion, `self` return token, dead table-heuristic regression), `_types/gentype_alias_test.tl` (malformed alias validation), and added `_types/gentype_gen_test.tl` (spaced/two-dash `@type` handling, `run()` fail-loud, `GENTYPE_DEFS` error reporting).

## Gate

Full `bin/cosmic --make ci` after rebasing onto latest `main` (6b75cb8):

```
392 checks: 392 passed  →  fmt: PASS (392 files)
check: PASS (390 files)
6 checks: 6 passed  →  test: PASS (6 files)  [_types suite: 31 test functions across 6 files]
455 checks: 455 passed  →  lint: PASS (455 files)
181 checks: 181 passed  →  coverage: PASS (181 files)
ci: PASS (6 stages)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE)_