### PR TITLE
quicksand: retry EINTR through Box run/Barrier/proxy pump; fix poll events-after-failure crash

### DIFF
--- a/cosmic/poll.tl
+++ b/cosmic/poll.tl
@@ -49,13 +49,18 @@ local record Poller
   clear: function(Poller)
   --- Poll for events with optional timeout.
   --- Returns an iterator over (fd, events) pairs for ready descriptors.
-  --- EINTR is retried internally. On a hard poll error the iterator is
-  --- empty and the error string is returned as the second value.
+  --- EINTR is retried internally by reissuing the same timeoutms, so the
+  --- deadline is not preserved across retries: repeated signals can make
+  --- the effective wait exceed timeoutms. On a hard poll error the
+  --- iterator is empty and the error string is returned as the second
+  --- value.
   --- @param timeoutms integer Timeout in ms (-1 for infinite, 0 for non-blocking)
   --- @return function Iterator yielding (fd: integer, events: Events)
   --- @return string? Error message when the underlying poll failed
   wait: function(Poller, integer): function(): (integer, Events), string
-  --- Poll and return count of ready descriptors.
+  --- Poll and return count of ready descriptors. EINTR is retried
+  --- internally by reissuing the same timeoutms (the deadline is not
+  --- preserved across retries).
   --- @param timeoutms integer Timeout in ms (-1 for infinite, 0 for non-blocking)
   --- @return integer | nil Count of ready descriptors
   --- @return string Error message on failure
@@ -137,6 +142,9 @@ local function new(): Poller
     -- Retry when a signal interrupts the wait: an unretried EINTR otherwise
     -- surfaces as a poll failure, and a caller that loops on it (e.g. a drain
     -- loop waiting on a child that raised SIGCHLD) spins at 100% CPU.
+    -- Retrying reissues the same timeoutms rather than tracking elapsed
+    -- time, so the effective wait can exceed timeoutms under repeated
+    -- signals (see the doc comment on wait/poll above).
     local res: {integer: integer}
     local err: string
     local eno: integer
@@ -146,10 +154,14 @@ local function new(): Poller
         break
       end
     end
-    results = res
-    if not results then
+    if not res then
+      -- Leave results empty rather than nil: events() indexes results
+      -- unconditionally, so a stale or nil table there would crash the
+      -- next events() call instead of just reporting no events.
+      results = {}
       return nil, errno.str(err, "poll")
     end
+    results = res
     local ready = 0
     for _ in pairs(results) do
       ready = ready + 1

--- a/cosmic/poll_test.tl
+++ b/cosmic/poll_test.tl
@@ -265,6 +265,11 @@ local function test_wait_surfaces_hard_error()
     return
   end
   assert(perr:match("E%u+"), "poll error should name the errno, got: " .. perr)
+  -- Regression: results must never be left nil after a failed poll --
+  -- events() indexes it unconditionally, so a nil there crashes instead
+  -- of reporting "no events for this fd".
+  local ev = p:events(1)
+  assert(ev == nil, "events() should return nil (not crash) after a failed poll")
   local iter, werr = p:wait(0)
   assert(type(iter) == "function", "wait must still return an iterator on error")
   for _ in iter do

--- a/cosmic/quicksand/box/run.tl
+++ b/cosmic/quicksand/box/run.tl
@@ -30,6 +30,7 @@
 --- instead of masquerading the failure as a workload exit code.
 local unix = require("cosmo.unix")
 local cosmo = require("cosmo")
+local errno = require("cosmic.errno")
 local netns = require("cosmic.quicksand.netns")
 local qproc = require("cosmic.quicksand.proc")
 local qcaps = require("cosmic.quicksand.caps")
@@ -287,7 +288,20 @@ local function run(opts: BoxOptions, argv: {string}): integer | nil, string
     unix.close(parent_fd)
   end
 
-  local _, status = unix.wait(pid)
+  -- EINTR can arrive mid-wait (e.g. a forwarded signal); retry rather
+  -- than treating the errno string as a wait status.
+  local status: integer
+  while true do
+    local wpid, wstatus, weno = unix.wait(pid)
+    if wpid then
+      status = wstatus
+      break
+    end
+    if not errno.is(weno, "EINTR") then
+      unix.close(erfd)
+      return nil, "quicksand: wait: " .. tostring(wstatus)
+    end
+  end
 
   -- Drain the error pipe. Every write end is closed by now — the
   -- supervisor exited, and become_init reaped the workload and sidecars

--- a/cosmic/quicksand/box/run_test.tl
+++ b/cosmic/quicksand/box/run_test.tl
@@ -63,6 +63,50 @@ io.write("ok exit=0\n")
 end
 test_run_true_in_subprocess()
 
+-- Regression: run() used to call unix.wait(pid) without retrying
+-- EINTR, feeding the errno STRING to WIFEXITED on interrupt (a
+-- type-error throw instead of a clean result). A one-shot SIGALRM
+-- fires ~50ms into a workload that sleeps 300ms, guaranteeing wait(pid)
+-- is interrupted mid-block; run() must still return the workload's
+-- real exit code.
+local function test_run_survives_eintr_during_wait()
+  local c = quicksand.capabilities()
+  if not (c.linux and c.user_ns and c.net_ns) then
+    check.skip("box namespaces unavailable on this host")
+    return
+  end
+
+  local r = run_script("box_run_eintr.lua", [[
+local signal = require("cosmic.signal")
+local qs = require("cosmic.quicksand")
+signal.sigaction(signal.SIGALRM, function() end)
+local sok, serr = signal.setitimer({
+  which = signal.ITIMER_REAL,
+  valuesec = 0,
+  valuens = 50000000,
+  intervalsec = 0,
+  intervalns = 0,
+})
+if not sok then io.stderr:write("setitimer: " .. tostring(serr) .. "\n"); os.exit(1) end
+local j, nerr = qs.Box.new({})
+if not j then io.stderr:write("new: " .. tostring(nerr) .. "\n"); os.exit(1) end
+local code, rerr = j:run({"/bin/sleep", "0.3"})
+if code == nil then
+  io.stderr:write("run nil: " .. tostring(rerr) .. "\n"); os.exit(1)
+end
+if code ~= 0 then
+  io.stderr:write("run exit=" .. tostring(code) .. "\n"); os.exit(1)
+end
+io.write("ok exit=0\n")
+]])
+  if not r then return end
+  assert(r.ok, "box run interrupted by EINTR mid-wait must still succeed: "
+    .. tostring(r.stdout) .. tostring(r.stderr))
+  assert(r.stdout:find("ok exit=0"),
+    "expected ok, got: " .. tostring(r.stdout))
+end
+test_run_survives_eintr_during_wait()
+
 -- Setup failures must come back on the error channel as nil + message,
 -- not masquerade as a workload exit code (a 126 with the reason only on
 -- stderr is indistinguishable from the workload itself failing). A

--- a/cosmic/quicksand/proc.tl
+++ b/cosmic/quicksand/proc.tl
@@ -19,7 +19,7 @@ local errno = require("cosmic.errno")
 --- synchronization.
 local record Barrier
   signal: function(self: Barrier)
-  wait: function(self: Barrier)
+  wait: function(self: Barrier): boolean, string
   drop_read: function(self: Barrier)
   drop_write: function(self: Barrier)
 end
@@ -143,8 +143,10 @@ end
 ---     b:wait()
 ---
 --- signal() writes one byte and closes the write end. wait() reads
---- one byte (EOF counts as signaled, which propagates child crashes)
---- and closes the read end. drop_read() / drop_write() are
+--- one byte (EOF counts as signaled, which propagates child crashes),
+--- retrying internally on EINTR so a forwarded signal can never
+--- release the caller before the other side actually signals or
+--- exits, and closes the read end. drop_read() / drop_write() are
 --- idempotent.
 ---
 --- @return Barrier? barrier object on success
@@ -164,11 +166,25 @@ local function barrier(): Barrier | nil, string
       wfd = nil
     end
   end
-  b.wait = function(_: Barrier)
-    if rfd then
-      unix.read(rfd, 1)
-      unix.close(rfd)
-      rfd = nil
+  b.wait = function(_: Barrier): boolean, string
+    if not rfd then return true end
+    while true do
+      -- A byte or EOF both mean "signaled". EINTR (a forwarded
+      -- signal arriving mid-read) must be retried, never treated as
+      -- EOF -- doing so would release the caller before the other
+      -- side actually finished setup, the exact race this barrier
+      -- exists to prevent.
+      local chunk, rerr, reno = unix.read(rfd, 1)
+      if chunk then
+        unix.close(rfd)
+        rfd = nil
+        return true
+      end
+      if not errno.is(reno, "EINTR") then
+        unix.close(rfd)
+        rfd = nil
+        return false, errno.str(rerr, "barrier wait")
+      end
     end
   end
   b.drop_read = function(_: Barrier)

--- a/cosmic/quicksand/proc_test.tl
+++ b/cosmic/quicksand/proc_test.tl
@@ -155,6 +155,72 @@ io.write("done\n")
 end
 test_barrier_signal_wait()
 
+--- Regression for the race Barrier exists to prevent: EINTR arriving
+--- mid-read must be retried, not treated as "signaled". A child sends
+--- an interrupting signal early, then only calls b:signal() well
+--- after; if wait() ever returned at the EINTR point instead of
+--- retrying, the parent would proceed before the child's real setup
+--- finished.
+local function test_barrier_retries_eintr()
+  local c = quicksand.capabilities()
+  if not c.linux then
+    check.skip("barrier EINTR retry: non-Linux host")
+    return
+  end
+  local script = fs.join(tmpdir, "barrier_eintr.lua")
+  fs.write(script, [[
+local unix = require("cosmo.unix")
+local time = require("cosmic.time")
+local proc = require("cosmic.quicksand.proc")
+local b, err = proc.barrier()
+if not b then
+  io.write("skipped: " .. tostring(err) .. "\n")
+  os.exit(0)
+end
+local pid, ferr = unix.fork()
+if not pid then
+  io.write("skipped: fork: " .. tostring(ferr) .. "\n")
+  os.exit(0)
+end
+if pid == 0 then
+  b:drop_read()
+  time.sleep(0, 50000000) -- 50ms: let the parent block in b:wait() first
+  unix.kill(unix.getppid(), unix.SIGUSR1) -- interrupt the parent's read
+  time.sleep(0, 200000000) -- 200ms "still finishing setup"
+  b:signal()
+  os.exit(0)
+end
+b:drop_write()
+unix.sigaction(unix.SIGUSR1, function() end) -- no-op: interrupts read, doesn't kill
+local start = time.monotonic_ms()
+local ok, werr = b:wait()
+local elapsed = time.monotonic_ms() - start
+unix.wait(pid)
+io.write("ok=" .. tostring(ok) .. " err=" .. tostring(werr)
+  .. " elapsed=" .. tostring(elapsed) .. "\n")
+]])
+  local h = check.must(spawn.spawn({cosmic, script}))
+  local r = check.must(h:wait())
+  if not r.ok then
+    check.skip("barrier EINTR retry: child died before reporting (outer sandbox)")
+    return
+  end
+  local s = r.stdout
+  if s:find("skipped") then
+    check.skip("barrier EINTR retry: " .. s:gsub("%s+$", ""))
+    return
+  end
+  assert(s:find("ok=true"), "expected ok=true, got: " .. s)
+  local elapsed = tonumber(s:match("elapsed=(%d+)"))
+  assert(elapsed ~= nil, "no elapsed in output: " .. s)
+  -- EINTR fires at ~50ms; the real signal() doesn't land until ~250ms.
+  -- A regression that treats EINTR as "signaled" would return near
+  -- 50ms instead.
+  assert(elapsed >= 150,
+    "wait() returned too early -- EINTR treated as signaled? " .. s)
+end
+test_barrier_retries_eintr()
+
 -- become_init: the PID-1 supervisor loop.
 --
 -- These exercise behavior, not just exports. become_init does NOT

--- a/cosmic/quicksand/proxy/http.tl
+++ b/cosmic/quicksand/proxy/http.tl
@@ -6,6 +6,7 @@
 --- Parsing functions are pure; the I/O helpers operate on raw socket
 --- fds via cosmo.unix and return cosmic's value,string error shape.
 local unix = require("cosmo.unix")
+local errno = require("cosmic.errno")
 
 --- One parsed header: {original_name, lower_name, value}.
 local type Header = {string}
@@ -237,22 +238,27 @@ local function pump(a: integer, b: integer)
     open[fd] = false
   end
   while open[a] or open[b] do
-    local ready = unix.poll(fds)
-    if not ready then return end
-    for fd, ev in pairs(ready as {integer: integer}) do -- cast: record union after guard
-      local peer = (fd == a) and b or a
-      local evi = ev
-      local readable = (evi & (unix.POLLIN)) ~= 0
-      local hup = (evi & hup_mask) ~= 0
-      if readable then
-        local chunk = unix.recv(fd, 16384)
-        if not chunk or chunk == "" then
+    local ready, _perr, peno = unix.poll(fds)
+    if not ready then
+      -- A forwarded signal arriving mid-poll is not a real failure;
+      -- only a non-EINTR error tears down the tunnel.
+      if not errno.is(peno, "EINTR") then return end
+    else
+      for fd, ev in pairs(ready as {integer: integer}) do -- cast: record union after guard
+        local peer = (fd == a) and b or a
+        local evi = ev
+        local readable = (evi & (unix.POLLIN)) ~= 0
+        local hup = (evi & hup_mask) ~= 0
+        if readable then
+          local chunk = unix.recv(fd, 16384)
+          if not chunk or chunk == "" then
+            close_side(fd, peer)
+          elseif not send_all(peer, chunk) then
+            return
+          end
+        elseif hup then
           close_side(fd, peer)
-        elseif not send_all(peer, chunk) then
-          return
         end
-      elseif hup then
-        close_side(fd, peer)
       end
     end
   end

--- a/cosmic/quicksand/proxy/http_test.tl
+++ b/cosmic/quicksand/proxy/http_test.tl
@@ -1,5 +1,11 @@
 #!/usr/bin/env cosmic
 local http = require("cosmic.quicksand.proxy.http")
+local net = require("cosmic.net")
+local proc = require("cosmic.proc")
+local signal = require("cosmic.signal")
+local pollmod = require("cosmic.poll")
+local time = require("cosmic.time")
+local check = require("cosmic.check")
 
 local function test_parse_request_line()
   local m, t, v = http.parse_request_line("GET http://a.example.com/ HTTP/1.1\r\n")
@@ -127,3 +133,59 @@ local function test_rebuild_request_replaces_client_auth()
     "bodyless request gets content-length 0")
 end
 test_rebuild_request_replaces_client_auth()
+
+-- Regression: pump() used to return (tearing down the CONNECT tunnel)
+-- on ANY unix.poll failure, including EINTR. A one-shot SIGALRM fires
+-- ~50ms into a forked pump's initial (data-less) poll; the parent only
+-- sends its payload ~150ms in, well after the old code would have
+-- already torn the tunnel down. No unshare needed -- pump() is plain
+-- fd plumbing over a plain fork, like proxy/serve_test.tl's worker.
+local function test_pump_relays_data_across_eintr()
+  local raw_c1, c2, cerr = net.socketpair()
+  assert(raw_c1 ~= nil and c2 ~= nil, "socketpair failed: " .. tostring(cerr))
+  local c1 = check.must(raw_c1)
+  local raw_u1, u2, uerr = net.socketpair()
+  assert(raw_u1 ~= nil and u2 ~= nil, "socketpair failed: " .. tostring(uerr))
+  local u1 = check.must(raw_u1)
+
+  local pid = proc.fork()
+  if pid == nil then
+    c1:close()
+    c2:close()
+    u1:close()
+    u2:close()
+    check.skip("pump EINTR: fork unavailable")
+    return
+  end
+  if pid == 0 then
+    c1:close()
+    u1:close()
+    signal.sigaction(signal.SIGALRM, function() end)
+    signal.setitimer({
+        which = signal.ITIMER_REAL,
+        valuesec = 0, valuens = 50000000,
+        intervalsec = 0, intervalns = 0,
+      })
+    http.pump(c2.fd, u2.fd)
+    os.exit(0)
+  end
+
+  c2:close()
+  u2:close()
+  time.sleep(0, 150000000)
+  local payload = "hello-through-pump"
+  local sent = c1:send(payload)
+  assert(sent == #payload, "send failed: " .. tostring(sent))
+
+  local pp = pollmod.new()
+  pp:add(u1.fd, pollmod.POLLIN)
+  local n = check.must(pp:poll(2000))
+  assert(n == 1, "pump should have relayed the payload across the EINTR")
+  local got = u1:recv(64)
+  assert(got == payload, "expected relayed payload, got: " .. tostring(got))
+
+  c1:close()
+  u1:close()
+  proc.wait(pid)
+end
+test_pump_relays_data_across_eintr()


### PR DESCRIPTION
Sweeps the repo's EINTR-retry discipline (house pattern: `quicksand/proc.tl` `become_init`) through quicksand's `Box:run`, `Barrier`, and the proxy's CONNECT pump, plus an unrelated `cosmic/poll.tl` crash found in the same review pass.

- `cosmic/quicksand/box/run.tl:290` (`run()`): `unix.wait(pid)` was not EINTR-retried, and on any wait failure fed the error STRING into `unix.WIFEXITED` — a type-error throw from library code. Now loops on EINTR and returns `nil, err` for a real wait failure. Verified manually (temporarily reverting) that this reproduces `bad argument #1 to 'WIFEXITED' (number expected, got string)`.
- `cosmic/quicksand/proc.tl:167` (`Barrier:wait`): `unix.read` returning `(nil, err, EINTR)` was treated like EOF ("signaled"), releasing the parent before the child finished unshare/setup — the exact race the barrier exists to prevent. Now retries EINTR and returns `false, msg` on a real read error (`wait`'s contract is now `boolean, string`, matching the repo's "fallible effect" convention). Verified manually that reverting drops the observed `wait()` latency from ≥150ms to ~50ms (i.e. it used to return right at the injected EINTR instead of waiting for the real signal).
- `cosmic/quicksand/proxy/http.tl:239` (`pump()`): returned (tearing down the CONNECT tunnel) on any `unix.poll` failure including EINTR. Now retries EINTR; other poll failures keep the existing teardown behavior. Verified manually that reverting makes a payload sent after the injected EINTR fail to send (pump already exited and shut the peer down).
- `cosmic/poll.tl:149,161`: after a failed `poll()`, `results` was left `nil`, so a later `events()` call indexed `nil` and crashed. Now resets `results` to `{}` on failure so `events()` returns `nil` (no crash); `poll()` still returns `nil, err` as before. Extended the existing `test_wait_surfaces_hard_error` case (which reliably provokes a real poll failure via `RLIMIT_NOFILE`) to also call `events()` afterward and assert it returns `nil` instead of throwing.
- `cosmic/poll.tl:143-148`: doc-only fix — documented that the EINTR retry re-issues the original `timeoutms` rather than tracking elapsed time, so the effective wait can exceed `timeoutms` under repeated signals. No behavior change.

All four EINTR fixes ship with regression tests that inject a real EINTR via a one-shot `SIGALRM`/itimer and assert the fixed timing/behavior; each was verified to fail with the pre-fix code and pass with the fix (checked manually, not committed). The `Box:run` and `Barrier` tests gate on `quicksand.capabilities()` (`user_ns`/`net_ns`/`linux`) like the existing quicksand tests, so they skip gracefully on hosts that can't unshare and exercise fully in CI (privileged, non-root). The `pump()` and `Barrier` tests need no namespaces (plain fork + sockets/pipes), so they exercise fully even in a sandboxed dev container.

No findings skipped.

ci verdict: `ci: PASS (6 stages)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE)_