### PR TITLE
Dedupe the hand-rolled scanner, doc comments, DirHandle, seal_coverage, base64 decode

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -69,6 +69,7 @@ _types/types_gen.tl 0 44
 cmd/cosmic/embed_gen.tl 0 166
 cmd/cosmic/main.tl 0 276
 cosmic/_script_cache.tl 72 79
+cosmic/_seal_coverage.tl 9 10
 cosmic/ansi.tl 86 86
 cosmic/benchmark.tl 180 212
 cosmic/check.tl 110 113
@@ -81,12 +82,14 @@ cosmic/coverage/baseline.tl 136 154
 cosmic/coverage/init.tl 54 117
 cosmic/coverage/lines.tl 65 71
 cosmic/coverage/report.tl 185 210
+cosmic/doc/comments.tl 55 55
 cosmic/doc/gendoc.tl 0 11
 cosmic/doc/index.tl 55 60
-cosmic/doc/init.tl 276 311
+cosmic/doc/init.tl 210 242
 cosmic/doc/lookup.tl 44 69
 cosmic/doc/query.tl 237 303
 cosmic/doc/render.tl 117 234
+cosmic/doc/scan.tl 67 67
 cosmic/doc/show.tl 285 337
 cosmic/doc/types.tl 2 2
 cosmic/doc/visibility.tl 17 17
@@ -96,7 +99,7 @@ cosmic/embed/init.tl 149 187
 cosmic/env.tl 24 34
 cosmic/envd.tl 95 101
 cosmic/errno.tl 17 25
-cosmic/example.tl 170 208
+cosmic/example.tl 129 158
 cosmic/fd.tl 95 118
 cosmic/fetch/extras.tl 198 222
 cosmic/fetch/headers.tl 23 23
@@ -105,13 +108,13 @@ cosmic/flags.tl 140 142
 cosmic/format/init.tl 185 224
 cosmic/format/rules.tl 208 220
 cosmic/format/types.tl 98 113
-cosmic/fs/file.tl 30 46
+cosmic/fs/file.tl 31 48
 cosmic/fs/init.tl 61 81
 cosmic/fs/ops.tl 97 138
 cosmic/fs/path.tl 151 162
-cosmic/fs/tree.tl 32 54
+cosmic/fs/tree.tl 37 64
 cosmic/fs/types.tl 16 51
-cosmic/fs/walk.tl 143 174
+cosmic/fs/walk.tl 145 178
 cosmic/fuzzy.tl 48 50
 cosmic/getopt.tl 36 56
 cosmic/hash.tl 71 74
@@ -125,7 +128,7 @@ cosmic/literal.tl 222 238
 cosmic/log.tl 72 74
 cosmic/net/init.tl 0 120
 cosmic/net/socket.tl 225 252
-cosmic/pledge.tl 28 39
+cosmic/pledge.tl 24 35
 cosmic/poll.tl 82 96
 cosmic/proc.tl 39 77
 cosmic/quicksand/box/env.tl 27 27
@@ -151,8 +154,8 @@ cosmic/shm.tl 117 128
 cosmic/signal.tl 101 109
 cosmic/sqlite/bind.tl 15 15
 cosmic/sqlite/defaults.tl 15 17
-cosmic/sqlite/extras.tl 34 38
-cosmic/sqlite/init.tl 195 211
+cosmic/sqlite/extras.tl 40 45
+cosmic/sqlite/init.tl 184 201
 cosmic/sqlite/params.tl 65 77
 cosmic/sqlite/row_iter.tl 49 56
 cosmic/sqlite/stmt_cache.tl 57 67
@@ -174,4 +177,4 @@ cosmic/user.tl 48 61
 cosmic/uuid.tl 9 9
 cosmic/zip.tl 80 93
 tlconfig.lua 7 7
-total 13439 17751
+total 13462 17773

--- a/cosmic/_seal_coverage.tl
+++ b/cosmic/_seal_coverage.tl
@@ -1,0 +1,27 @@
+--- Flush line-coverage data before rights drop: a dump attempted after
+--- a pledge/unveil policy lands would violate it and kill the process.
+---
+--- Shared by cosmic.pledge and cosmic.unveil, which must not require
+--- each other (cosmic.sandbox composes both over the same policy) —
+--- hence its own internal home here rather than living in either one.
+--- Reaches coverage via `package.loaded` rather than
+--- `require("cosmic.coverage")` so pledge/unveil stay leaf modules
+--- that never force-load coverage instrumentation a caller isn't
+--- using.
+--- @param keep boolean? Skip the seal — the caller granted the
+--- coverage directory itself, so sealing here would throw away
+--- everything recorded under this policy
+local function seal_coverage(keep?: boolean)
+  if keep then
+    return
+  end
+  local cov = package.loaded["cosmic.coverage"]
+  if cov ~= nil then
+    local seal = (cov as {string: any})["seal"] as function() -- cast: from any
+    seal()
+  end
+end
+
+return {
+  seal_coverage = seal_coverage,
+}

--- a/cosmic/benchmark.tl
+++ b/cosmic/benchmark.tl
@@ -3,6 +3,7 @@
 --- Similar to Go's testing.B but simplified: functions are called N times automatically.
 
 local time = require("cosmic.time")
+local scan = require("cosmic.doc.scan")
 
 --- Read the monotonic wall clock in nanoseconds.
 --- Uses CLOCK_MONOTONIC so IO-bound benchmarks (which block rather than
@@ -49,17 +50,6 @@ local function parse_benchmarks(source: string): {Benchmark}
   local pos = 1
   local line_num = 1
 
-  -- Track line numbers
-  local function count_lines(s: string, start_pos: integer, end_pos: integer): integer
-    local count = 0
-    for i = start_pos, end_pos do
-      if s:sub(i, i) == "\n" then
-        count = count + 1
-      end
-    end
-    return count
-  end
-
   while true do
     -- Find next Benchmark_* function definition
     local func_start, func_end, func_name = source:find("local%s+function%s+(Benchmark[%w_]*)%s*%(%s*%)", pos)
@@ -67,80 +57,12 @@ local function parse_benchmarks(source: string): {Benchmark}
       break
     end
 
-    line_num = line_num + count_lines(source, pos, func_start)
+    line_num = line_num + scan.count_lines(source, pos, func_start)
     local benchmark_line = line_num
 
     -- Find the function body - need to track nested end keywords
     local body_start = func_end + 1
-    local depth = 1
-    local i = body_start
-
-    -- Keywords that increase depth
-    local block_starts: {string: boolean} = {
-      ["function"] = true,
-      ["if"] = true,
-      ["for"] = true,
-      ["while"] = true,
-      ["repeat"] = true,
-    }
-
-    while i <= #source and depth > 0 do
-      -- Skip strings
-      if source:sub(i, i) == '"' or source:sub(i, i) == "'" then
-        local quote = source:sub(i, i)
-        i = i + 1
-        while i <= #source do
-          if source:sub(i, i) == "\\" then
-            i = i + 2
-          elseif source:sub(i, i) == quote then
-            i = i + 1
-            break
-          else
-            i = i + 1
-          end
-        end
-        -- Skip long strings
-      elseif source:sub(i, i + 1) == "[[" then
-        local close = source:find("]]", i + 2, true)
-        i = close and close + 2 or #source + 1
-        -- Skip comments
-      elseif source:sub(i, i + 1) == "--" then
-        if source:sub(i + 2, i + 3) == "[[" then
-          local close = source:find("]]", i + 4, true)
-          i = close and close + 2 or #source + 1
-        else
-          local newline = source:find("\n", i)
-          i = newline and newline + 1 or #source + 1
-        end
-      else
-        -- Check for keywords
-        local word_start, word_end, word = source:find("(%a+)", i)
-        if word_start == i then
-          if block_starts[word] then
-            -- Make sure it's not part of "end" check (e.g., "endif")
-            -- and that "function" is not just a type annotation
-            if word == "function" then
-              -- Check if this is an anonymous function or function type
-              local before = source:sub(math.max(1, i - 1), i - 1)
-              if before ~= ":" and before ~= ">" then
-                depth = depth + 1
-              end
-            else
-              depth = depth + 1
-            end
-          elseif word == "until" then
-            depth = depth - 1
-          elseif word == "end" then
-            depth = depth - 1
-          end
-          i = word_end + 1
-        else
-          i = i + 1
-        end
-      end
-    end
-
-    local body_end = i - 4 -- Before "end"
+    local body_end, i = scan.find_block_end(source, body_start)
     local body = source:sub(body_start, body_end)
 
     table.insert(benchmarks, {

--- a/cosmic/benchmark_test.tl
+++ b/cosmic/benchmark_test.tl
@@ -192,6 +192,91 @@ end
 end
 test_filter_no_match()
 
+-- Test that a variable/local named with a keyword prefix (`end_time`)
+-- is not lexed as the keyword `end`: a bare `%a+` word match stops at
+-- the `_`, so the scanner used to close the body right there.
+local function test_end_time_not_truncated()
+  local source = [[
+local function Benchmark_time_tracking()
+  local start_time = 1
+  local end_time = 2
+  local elapsed = end_time - start_time
+end
+]]
+  local benchmarks = benchmark.parse_benchmarks(source)
+  assert(#benchmarks == 1, "should find one benchmark")
+  assert(benchmarks[1].body:find("elapsed", 1, true),
+    "body should include the statement after end_time, not stop early")
+end
+test_end_time_not_truncated()
+
+-- Test that a variable named with a block-opening keyword prefix
+-- (`for_each`) is not lexed as `for`: that would open a phantom nesting
+-- level, needing an extra `end` to close and swallowing whatever
+-- benchmark comes next.
+local function test_for_each_prefix_not_over_extended()
+  local source = [[
+local function Benchmark_for_each()
+  local for_each = function(t) return #t end
+  local n = for_each({1, 2, 3})
+end
+
+local function Benchmark_after_for_each()
+  local x = 1
+end
+]]
+  local benchmarks = benchmark.parse_benchmarks(source)
+  assert(#benchmarks == 2, "should find two separate benchmarks, not merge them")
+  assert(benchmarks[1].name == "Benchmark_for_each", "first benchmark name")
+  assert(benchmarks[2].name == "Benchmark_after_for_each", "second benchmark name")
+  assert(not benchmarks[1].body:find("Benchmark_after_for_each", 1, true),
+    "for_each's body must not swallow the next benchmark")
+end
+test_for_each_prefix_not_over_extended()
+
+-- Test that a bare `do ... end` block (not attached to a for/while)
+-- opens its own nesting level: `do` was missing from the depth-tracking
+-- keyword set, so its `end` was mistaken for the function's own.
+local function test_bare_do_end_block()
+  local source = [[
+local function Benchmark_bare_do()
+  do
+    local x = 1
+  end
+  local y = 2
+end
+
+local function Benchmark_after_do()
+  local z = 3
+end
+]]
+  local benchmarks = benchmark.parse_benchmarks(source)
+  assert(#benchmarks == 2, "should find two benchmarks")
+  assert(benchmarks[1].body:find("y = 2", 1, true),
+    "body should include the statement after the bare do-block")
+  assert(benchmarks[2].name == "Benchmark_after_do", "next benchmark parsed separately")
+end
+test_bare_do_end_block()
+
+-- Test a nested (anonymous) function definition inside the benchmark
+-- body: unaffected by either bug, but a regression guard for the
+-- shared scanner now that all three extractors share it.
+local function test_nested_function_definition()
+  local source = [[
+local function Benchmark_nested_fn()
+  local adder = function(a, b)
+    return a + b
+  end
+  local result = adder(1, 2)
+end
+]]
+  local benchmarks = benchmark.parse_benchmarks(source)
+  assert(#benchmarks == 1, "should find one benchmark")
+  assert(benchmarks[1].body:find("result", 1, true),
+    "body should include the statement after the nested function")
+end
+test_nested_function_definition()
+
 -- Test cosmic --benchmark with filter syntax
 local function test_cosmic_benchmark_filter()
   local input = write_temp("cmd_filter.tl", [[

--- a/cosmic/codec.tl
+++ b/cosmic/codec.tl
@@ -84,8 +84,8 @@ end
 --- @return string | nil The alphabet characters with any "=" padding stripped, or nil if invalid
 --- @return string? Error message if invalid
 local function validate_base64_family(
-  str: string, content_pattern: string, bad_char_pattern: string, label: string
-): string | nil, string
+    str: string, content_pattern: string, bad_char_pattern: string, label: string
+  ): string | nil, string
   local content, padding = str:match("^(" .. content_pattern .. ")(%=*)$")
   if not content then
     if str:match(bad_char_pattern) then

--- a/cosmic/codec.tl
+++ b/cosmic/codec.tl
@@ -71,25 +71,43 @@ local function encode_base64(data: string): string
   return cosmo.EncodeBase64(data)
 end
 
+--- Validate a base64-family string's structure (alphabet characters,
+--- then "=" padding, then end) in one pass. On the happy path this is
+--- the only scan needed; a mismatch means either an invalid character
+--- anywhere or padding not confined to the end, so a second, cheaper
+--- scan runs only then to tell which. Shared by decode_base64 and
+--- decode_base64url, which differ only in alphabet and error label.
+--- @param str string The string to validate
+--- @param content_pattern string Lua pattern for the alphabet, zero or more (e.g. "[A-Za-z0-9+/]*")
+--- @param bad_char_pattern string Lua pattern matching a character outside the alphabet and not "=" (e.g. "[^A-Za-z0-9+/=]")
+--- @param label string Name used in error messages ("base64" or "base64url")
+--- @return string | nil The alphabet characters with any "=" padding stripped, or nil if invalid
+--- @return string? Error message if invalid
+local function validate_base64_family(
+  str: string, content_pattern: string, bad_char_pattern: string, label: string
+): string | nil, string
+  local content, padding = str:match("^(" .. content_pattern .. ")(%=*)$")
+  if not content then
+    if str:match(bad_char_pattern) then
+      return nil, "invalid " .. label .. " character"
+    end
+    return nil, "invalid " .. label .. ": padding in middle"
+  end
+  if #padding > 2 then
+    return nil, "invalid " .. label .. " padding"
+  end
+  return content
+end
+
 --- Decode a base64 string to binary data.
 --- Accepts standard base64 encoding with or without padding.
 --- @param str string The base64 string to decode
 --- @return string | nil The decoded binary data, or nil on error
 --- @return string? Error message if decoding failed
 local function decode_base64(str: string): string | nil, string
-  -- Validate structure (content chars, then = padding, then end) in one
-  -- pass. On the happy path this is the only scan needed; a mismatch
-  -- means either an invalid character anywhere or padding not confined
-  -- to the end, so a second, cheaper scan runs only then to tell which.
-  local content, padding = str:match("^([A-Za-z0-9+/]*)(%=*)$")
-  if not content then
-    if str:match("[^A-Za-z0-9+/=]") then
-      return nil, "invalid base64 character"
-    end
-    return nil, "invalid base64: padding in middle"
-  end
-  if #padding > 2 then
-    return nil, "invalid base64 padding"
+  local _, err = validate_base64_family(str, "[A-Za-z0-9+/]*", "[^A-Za-z0-9+/=]", "base64")
+  if err then
+    return nil, err
   end
   return cosmo.DecodeBase64(str)
 end
@@ -114,15 +132,9 @@ end
 --- @return string | nil The decoded binary data, or nil on error
 --- @return string? Error message if decoding failed
 local function decode_base64url(str: string): string | nil, string
-  local content, padding = str:match("^([A-Za-z0-9%-_]*)(%=*)$")
-  if not content then
-    if str:match("[^A-Za-z0-9%-_=]") then
-      return nil, "invalid base64url character"
-    end
-    return nil, "invalid base64url: padding in middle"
-  end
-  if #padding > 2 then
-    return nil, "invalid base64url padding"
+  local content, err = validate_base64_family(str, "[A-Za-z0-9%-_]*", "[^A-Za-z0-9%-_=]", "base64url")
+  if err then
+    return nil, err
   end
   local b64 = string.gsub(content, "%-", "+")
   b64 = string.gsub(b64, "_", "/")
@@ -130,7 +142,7 @@ local function decode_base64url(str: string): string | nil, string
 end
 
 --- Encode binary data as base32.
---- Uses lowercase base32 alphabet (0-9a-v excluding i, l, o, u).
+--- Uses lowercase base32 alphabet (0-9a-z excluding i, l, o, u).
 --- @param data string The binary data to encode
 --- @return string The base32 encoded string
 local function encode_base32(data: string): string

--- a/cosmic/doc/comments.tl
+++ b/cosmic/doc/comments.tl
@@ -1,0 +1,94 @@
+--- Doc-comment extraction shared by the doc extractor (`cosmic.doc.init`)
+--- and its `.d.tl` renderer (`cosmic.doc.render`). Internal by position
+--- (`cosmic.doc.comments` is two segments under `cosmic/`; see
+--- `cosmic/doc/visibility.tl`) — plumbing for those two, not published
+--- API. Housed on its own (rather than in either of its callers) so
+--- neither has to require the other: `doc.init` already requires
+--- `doc.render` to render what it parses, so a copy living in either one
+--- would force a cycle.
+
+local types = require("cosmic.doc.types")
+local Param = types.Param
+local Return = types.Return
+
+local BYTE_NEWLINE = string.byte("\n")
+
+--- Extract leading doc comment (--- or -- style) before a position.
+--- @param source string The source code to search
+--- @param pos integer The position to search backwards from
+--- @param allow_regular_comments boolean If true, also extract -- style comments (default: false)
+--- @return string The extracted doc comment, or nil if none found
+local function extract_doc_comment(source: string, pos: integer, allow_regular_comments?: boolean): string
+  local line_start = pos
+  while line_start > 1 and source:byte(line_start - 1) ~= BYTE_NEWLINE do
+    line_start = line_start - 1
+  end
+  local doc_lines: {string} = {}
+  local check_pos = line_start - 1
+  while check_pos > 0 do
+    local prev_line_start = check_pos
+    while prev_line_start > 1 and source:byte(prev_line_start - 1) ~= BYTE_NEWLINE do
+      prev_line_start = prev_line_start - 1
+    end
+    local line = source:sub(prev_line_start, check_pos - 1)
+    local doc_content = line:match("^%s*%-%-%-(.*)$")
+    if doc_content then
+      table.insert(doc_lines, 1, doc_content)
+      check_pos = prev_line_start - 1
+    elseif allow_regular_comments then
+      local regular_comment = line:match("^%s*%-%-([^%-].*)$")
+      if regular_comment then
+        table.insert(doc_lines, 1, regular_comment)
+        check_pos = prev_line_start - 1
+      elseif line:match("^%s*$") then break
+      else break end
+    elseif line:match("^%s*$") then break
+    else break end
+  end
+  if #doc_lines == 0 then return nil end
+  return table.concat(doc_lines, "\n")
+end
+
+--- Parse @param and @return annotations from doc comment.
+--- @param doc string The doc comment to parse
+--- @return {Param} List of parameters
+--- @return {Return} List of return values
+--- @return string The description text
+local function parse_annotations(doc: string): {Param}, {Return}, string
+  if not doc then return {}, {}, nil end
+  local params: {Param} = {}
+  local returns: {Return} = {}
+  local desc_lines: {string} = {}
+  for line in doc:gmatch("[^\n]+") do
+    local param_name, param_type, param_desc = line:match("^%s*@param%s+(%S+)%s+(%S+)%s*(.*)")
+    if param_name then
+      table.insert(params, {
+          name = param_name, param_type = param_type,
+          description = param_desc ~= "" and param_desc or nil,
+        })
+    else
+      local ret_type, ret_desc = line:match("^%s*@return%s+(%S+)%s*(.*)")
+      if ret_type then
+        table.insert(returns, {
+            return_type = ret_type, description = ret_desc ~= "" and ret_desc or nil,
+          })
+      else
+        table.insert(desc_lines, line)
+      end
+    end
+  end
+  local description = #desc_lines > 0 and table.concat(desc_lines, "\n") or nil
+  return params, returns, description
+end
+
+local record CommentsModule
+  extract_doc_comment: function(source: string, pos: integer, allow_regular_comments?: boolean): string
+  parse_annotations: function(doc: string): {Param}, {Return}, string
+end
+
+local M: CommentsModule = {
+  extract_doc_comment = extract_doc_comment,
+  parse_annotations = parse_annotations,
+}
+
+return M

--- a/cosmic/doc/init.tl
+++ b/cosmic/doc/init.tl
@@ -2,54 +2,17 @@
 --- Parses doc comments, records, functions, and examples from .tl files.
 
 local types = require("cosmic.doc.types")
-local Param = types.Param
-local Return = types.Return
 local ModuleDoc = types.ModuleDoc
 
 local doc_render = require("cosmic.doc.render")
+local scan = require("cosmic.doc.scan")
+local doc_comments = require("cosmic.doc.comments")
+local extract_doc_comment = doc_comments.extract_doc_comment
+local parse_annotations = doc_comments.parse_annotations
 
 local BYTE_NEWLINE = string.byte("\n")
 local BYTE_LPAREN = string.byte("(")
 local BYTE_RPAREN = string.byte(")")
-local BYTE_DQUOTE = string.byte('"')
-local BYTE_SQUOTE = string.byte("'")
-local BYTE_BACKSLASH = string.byte("\\")
-
---- Extract leading doc comment (--- or -- style) before a position.
---- @param source string The source code to search
---- @param pos integer The position to search backwards from
---- @param allow_regular_comments boolean If true, also extract -- style comments (default: false)
---- @return string The extracted doc comment, or nil if none found
-local function extract_doc_comment(source: string, pos: integer, allow_regular_comments?: boolean): string
-  local line_start = pos
-  while line_start > 1 and source:byte(line_start - 1) ~= BYTE_NEWLINE do
-    line_start = line_start - 1
-  end
-  local doc_lines: {string} = {}
-  local check_pos = line_start - 1
-  while check_pos > 0 do
-    local prev_line_start = check_pos
-    while prev_line_start > 1 and source:byte(prev_line_start - 1) ~= BYTE_NEWLINE do
-      prev_line_start = prev_line_start - 1
-    end
-    local line = source:sub(prev_line_start, check_pos - 1)
-    local doc_content = line:match("^%s*%-%-%-(.*)$")
-    if doc_content then
-      table.insert(doc_lines, 1, doc_content)
-      check_pos = prev_line_start - 1
-    elseif allow_regular_comments then
-      local regular_comment = line:match("^%s*%-%-([^%-].*)$")
-      if regular_comment then
-        table.insert(doc_lines, 1, regular_comment)
-        check_pos = prev_line_start - 1
-      elseif line:match("^%s*$") then break
-      else break end
-    elseif line:match("^%s*$") then break
-    else break end
-  end
-  if #doc_lines == 0 then return nil end
-  return table.concat(doc_lines, "\n")
-end
 
 --- Extract function signature starting from a given position.
 --- @param source string The source code
@@ -78,38 +41,6 @@ local function extract_signature(source: string, start_pos: integer): string
     end
   end
   return source:sub(sig_start, sig_end)
-end
-
---- Parse @param and @return annotations from doc comment.
---- @param doc string The doc comment to parse
---- @return {Param} List of parameters
---- @return {Return} List of return values
---- @return string The description text
-local function parse_annotations(doc: string): {Param}, {Return}, string
-  if not doc then return {}, {}, nil end
-  local params: {Param} = {}
-  local returns: {Return} = {}
-  local desc_lines: {string} = {}
-  for line in doc:gmatch("[^\n]+") do
-    local param_name, param_type, param_desc = line:match("^%s*@param%s+(%S+)%s+(%S+)%s*(.*)")
-    if param_name then
-      table.insert(params, {
-          name = param_name, param_type = param_type,
-          description = param_desc ~= "" and param_desc or nil,
-        })
-    else
-      local ret_type, ret_desc = line:match("^%s*@return%s+(%S+)%s*(.*)")
-      if ret_type then
-        table.insert(returns, {
-            return_type = ret_type, description = ret_desc ~= "" and ret_desc or nil,
-          })
-      else
-        table.insert(desc_lines, line)
-      end
-    end
-  end
-  local description = #desc_lines > 0 and table.concat(desc_lines, "\n") or nil
-  return params, returns, description
 end
 
 --- Parse `name: type` fields from a record body.
@@ -305,31 +236,7 @@ local function parse(source: string, file_path: string): ModuleDoc
     local example_doc = extract_doc_comment(source, func_start, true)
     local _, _, example_description = parse_annotations(example_doc)
     local body_start = source:find("%)", func_start) + 1
-    local depth = 1
-    local i = body_start
-    while i <= #source and depth > 0 do
-      local b = source:byte(i)
-      if b == BYTE_DQUOTE or b == BYTE_SQUOTE then
-        local quote = b
-        i = i + 1
-        while i <= #source do
-          if source:byte(i) == BYTE_BACKSLASH then i = i + 2
-          elseif source:byte(i) == quote then i = i + 1; break
-          else i = i + 1 end
-        end
-      elseif source:sub(i, i + 1) == "--" then
-        local newline = source:find("\n", i)
-        i = newline and newline + 1 or #source + 1
-      else
-        local word_start, word_end, word = source:find("(%a+)", i)
-        if word_start == i then
-          if word == "function" or word == "if" or word == "for" or word == "while" then depth = depth + 1
-          elseif word == "until" or word == "end" then depth = depth - 1 end
-          i = word_end + 1
-        else i = i + 1 end
-      end
-    end
-    local body_end = i - 4
+    local body_end, _i = scan.find_block_end(source, body_start)
     local body = source:sub(body_start, body_end)
     local expected: string = nil
     local output_start = body:find("%-%-%s*Output:")

--- a/cosmic/doc/init_test.tl
+++ b/cosmic/doc/init_test.tl
@@ -105,6 +105,92 @@ end
 end
 test_example_not_in_functions()
 
+-- Test that a variable/local named with a keyword prefix (`end_time`)
+-- is not lexed as the keyword `end`: a bare `%a+` word match stops at
+-- the `_`, so the scanner used to close the body right there.
+local function test_example_end_time_not_truncated()
+  local source = [[
+local function Example_time_tracking()
+  local start_time = 1
+  local end_time = 2
+  local elapsed = end_time - start_time
+  print(elapsed)
+end
+]]
+  local result = doc.parse(source, "test.tl")
+  assert(#result.examples == 1, "should find one example")
+  assert(result.examples[1].body:find("elapsed", 1, true),
+    "body should include the statement after end_time, not stop early")
+end
+test_example_end_time_not_truncated()
+
+-- Test that a variable named with a block-opening keyword prefix
+-- (`for_each`) is not lexed as `for`: that would open a phantom nesting
+-- level, needing an extra `end` to close and swallowing whatever
+-- example comes next.
+local function test_example_for_each_prefix_not_over_extended()
+  local source = [[
+local function Example_for_each()
+  local for_each = function(t) return #t end
+  print(for_each({1, 2, 3}))
+end
+
+local function Example_after_for_each()
+  print("after")
+end
+]]
+  local result = doc.parse(source, "test.tl")
+  assert(#result.examples == 2, "should find two separate examples, not merge them")
+  assert(result.examples[1].name == "Example_for_each", "first example name")
+  assert(result.examples[2].name == "Example_after_for_each", "second example name")
+  assert(not result.examples[1].body:find("Example_after_for_each", 1, true),
+    "for_each's body must not swallow the next example")
+end
+test_example_for_each_prefix_not_over_extended()
+
+-- Test that a bare `do ... end` block (not attached to a for/while)
+-- opens its own nesting level: `do` was missing from the depth-tracking
+-- keyword set, so its `end` was mistaken for the function's own.
+local function test_example_bare_do_end_block()
+  local source = [[
+local function Example_bare_do()
+  do
+    local x = 1
+  end
+  print(x or "after do")
+end
+
+local function Example_after_do()
+  print("later")
+end
+]]
+  local result = doc.parse(source, "test.tl")
+  assert(#result.examples == 2, "should find two examples")
+  assert(result.examples[1].body:find("after do", 1, true),
+    "body should include the statement after the bare do-block")
+  assert(result.examples[2].name == "Example_after_do", "next example parsed separately")
+end
+test_example_bare_do_end_block()
+
+-- Test a nested (anonymous) function definition inside the example
+-- body: unaffected by either bug, but a regression guard for the
+-- shared scanner now that all three extractors share it.
+local function test_example_nested_function_definition()
+  local source = [[
+local function Example_nested_fn()
+  local adder = function(a, b)
+    return a + b
+  end
+  print(adder(1, 2))
+end
+]]
+  local result = doc.parse(source, "test.tl")
+  assert(#result.examples == 1, "should find one example")
+  assert(result.examples[1].body:find("adder%(1, 2%)"),
+    "body should include the statement after the nested function")
+end
+test_example_nested_function_definition()
+
 -- Test render produces markdown
 local function test_render_markdown()
   local source = [[--- Test module

--- a/cosmic/doc/init_test.tl
+++ b/cosmic/doc/init_test.tl
@@ -86,6 +86,52 @@ end
 end
 test_parse_example()
 
+-- Test that regular `--` comments (not `---`) directly above an
+-- Example_* function are picked up as its description: doc.parse is
+-- the one caller that passes allow_regular_comments=true to
+-- extract_doc_comment.
+local function test_example_regular_comment_description()
+  local source = [[
+local unrelated = 1
+
+-- part of the example doc
+-- second line
+local function Example_annotated()
+  print("hi")
+end
+]]
+  local result = doc.parse(source, "test.tl")
+  assert(#result.examples == 1, "should find one example")
+  assert(result.examples[1].description, "should have a description")
+  assert(result.examples[1].description:find("part of the example doc", 1, true),
+    "should pick up the regular -- comment: " .. (result.examples[1].description or ""))
+  -- A blank line above the comment block stops the walk without error.
+  assert(not result.examples[1].description:find("unrelated", 1, true),
+    "should not reach past the blank line above the comment block")
+end
+test_example_regular_comment_description()
+
+-- Same, but the comment block is directly preceded by a non-blank,
+-- non-comment line (the other way extract_doc_comment's upward walk
+-- stops when allow_regular_comments is true).
+local function test_example_regular_comment_stops_at_code()
+  local source = [[
+local unrelated = 1
+-- part of the example doc
+local function Example_annotated2()
+  print("hi")
+end
+]]
+  local result = doc.parse(source, "test.tl")
+  assert(#result.examples == 1, "should find one example")
+  assert(result.examples[1].description, "should have a description")
+  assert(result.examples[1].description:find("part of the example doc", 1, true),
+    "should pick up the regular -- comment: " .. (result.examples[1].description or ""))
+  assert(not result.examples[1].description:find("unrelated", 1, true),
+    "should stop at the preceding code line")
+end
+test_example_regular_comment_stops_at_code()
+
 -- Test that Example_* functions are not included in regular functions
 local function test_example_not_in_functions()
   local source = [[

--- a/cosmic/doc/render.tl
+++ b/cosmic/doc/render.tl
@@ -2,70 +2,12 @@
 --- Contains the markdown renderer and the type declaration file parser.
 
 local types = require("cosmic.doc.types")
-local Param = types.Param
-local Return = types.Return
 local FunctionDoc = types.FunctionDoc
 local ModuleDoc = types.ModuleDoc
 
---- Extract leading doc comment before a position.
-local function extract_doc_comment(source: string, pos: integer, allow_regular_comments?: boolean): string
-  local line_start = pos
-  while line_start > 1 and source:sub(line_start - 1, line_start - 1) ~= "\n" do
-    line_start = line_start - 1
-  end
-  local doc_lines: {string} = {}
-  local check_pos = line_start - 1
-  while check_pos > 0 do
-    local prev_line_start = check_pos
-    while prev_line_start > 1 and source:sub(prev_line_start - 1, prev_line_start - 1) ~= "\n" do
-      prev_line_start = prev_line_start - 1
-    end
-    local line = source:sub(prev_line_start, check_pos - 1)
-    local doc_content = line:match("^%s*%-%-%-(.*)$")
-    if doc_content then
-      table.insert(doc_lines, 1, doc_content)
-      check_pos = prev_line_start - 1
-    elseif allow_regular_comments then
-      local regular_comment = line:match("^%s*%-%-([^%-].*)$")
-      if regular_comment then
-        table.insert(doc_lines, 1, regular_comment)
-        check_pos = prev_line_start - 1
-      elseif line:match("^%s*$") then break
-      else break end
-    elseif line:match("^%s*$") then break
-    else break end
-  end
-  if #doc_lines == 0 then return nil end
-  return table.concat(doc_lines, "\n")
-end
-
---- Parse @param and @return annotations from doc comment.
-local function parse_annotations(doc: string): {Param}, {Return}, string
-  if not doc then return {}, {}, nil end
-  local params: {Param} = {}
-  local returns: {Return} = {}
-  local desc_lines: {string} = {}
-  for line in doc:gmatch("[^\n]+") do
-    local param_name, param_type, param_desc = line:match("^%s*@param%s+(%S+)%s+(%S+)%s*(.*)")
-    if param_name then
-      table.insert(params, {
-          name = param_name, param_type = param_type,
-          description = param_desc ~= "" and param_desc or nil,
-        })
-    else
-      local ret_type, ret_desc = line:match("^%s*@return%s+(%S+)%s*(.*)")
-      if ret_type then
-        table.insert(returns, {
-            return_type = ret_type, description = ret_desc ~= "" and ret_desc or nil,
-          })
-      else
-        table.insert(desc_lines, line)
-      end
-    end
-  end
-  local description = #desc_lines > 0 and table.concat(desc_lines, "\n") or nil
-  return params, returns, description
-end
+local doc_comments = require("cosmic.doc.comments")
+local extract_doc_comment = doc_comments.extract_doc_comment
+local parse_annotations = doc_comments.parse_annotations
 
 --- Render documentation as markdown.
 local function render(doc: ModuleDoc): string

--- a/cosmic/doc/scan.tl
+++ b/cosmic/doc/scan.tl
@@ -1,0 +1,142 @@
+--- Shared block-body scanner used by the benchmark, example, and doc
+--- extractors. Internal by position (`cosmic.doc.scan` is two segments
+--- under `cosmic/`, so `cosmic/doc/visibility.tl`'s `is_public` rule
+--- says no) — this is plumbing for those three parsers, not published
+--- API.
+---
+--- Finds the end of a Lua/Teal block by tracking nesting depth, the way
+--- a bracket matcher would, while skipping over string and comment
+--- literals so keywords inside them are never mistaken for real
+--- block-openers or -closers. Two defects that every hand-rolled copy
+--- of this scanner used to repeat, fixed once here:
+--- - keyword matching must consume a FULL identifier: a bare `%a+`
+---   pattern stops at the first `_` or digit, so `end_time` lexed as
+---   `end` and closed the block early.
+--- - a bare `do ... end` block must open its own nesting level. Only
+---   `for`/`while`'s OWN trailing `do` is already accounted for (by the
+---   `for`/`while` keyword itself), so a `do` opens a new level exactly
+---   when it is not one of those.
+
+--- Block-opening keywords that need one matching `end` each. `repeat`
+--- is closed by `until` instead, tracked separately below; `do` is
+--- handled separately too since whether it opens a NEW level depends on
+--- whether a `for`/`while` already opened one for it.
+local BLOCK_STARTS: {string: boolean} = {
+  ["function"] = true,
+  ["if"] = true,
+  ["for"] = true,
+  ["while"] = true,
+  ["repeat"] = true,
+}
+
+--- Count newlines in source over an inclusive position range.
+--- @param source string The text to scan
+--- @param start_pos integer First position to examine
+--- @param end_pos integer Last position to examine
+--- @return integer Number of `\n` bytes in [start_pos, end_pos]
+local function count_lines(source: string, start_pos: integer, end_pos: integer): integer
+  local count = 0
+  for i = start_pos, end_pos do
+    if source:sub(i, i) == "\n" then
+      count = count + 1
+    end
+  end
+  return count
+end
+
+--- Find the end of a block that is already open at depth 1 (typically a
+--- function body) by scanning forward and tracking nesting depth.
+--- @param source string The full source text
+--- @param start_pos integer Position to begin scanning from — just after
+--- whatever already put the scanner at depth 1 (e.g. right after a
+--- function's closing `)`)
+--- @return integer Position of the last body character, just before the
+--- closing `end`
+--- @return integer Position just past that closing `end`
+local function find_block_end(source: string, start_pos: integer): integer, integer
+  local depth = 1
+  local i = start_pos
+  -- Number of `do` tokens still owed to an already-counted `for`/`while`.
+  local pending_do = 0
+
+  while i <= #source and depth > 0 do
+    local c = source:sub(i, i)
+    if c == '"' or c == "'" then
+      -- Skip strings
+      local quote = c
+      i = i + 1
+      while i <= #source do
+        if source:sub(i, i) == "\\" then
+          i = i + 2
+        elseif source:sub(i, i) == quote then
+          i = i + 1
+          break
+        else
+          i = i + 1
+        end
+      end
+    elseif source:sub(i, i + 1) == "[[" then
+      -- Skip long strings
+      local close = source:find("]]", i + 2, true)
+      i = close and close + 2 or #source + 1
+    elseif source:sub(i, i + 1) == "--" then
+      -- Skip comments (including long comments)
+      if source:sub(i + 2, i + 3) == "[[" then
+        local close = source:find("]]", i + 4, true)
+        i = close and close + 2 or #source + 1
+      else
+        local newline = source:find("\n", i)
+        i = newline and newline + 1 or #source + 1
+      end
+    else
+      -- Check for keywords. A full identifier, not just a run of
+      -- letters: `%a+` alone stops at the first `_` or digit.
+      local word_start, word_end, word = source:find("([%a_][%w_]*)", i)
+      if word_start == i then
+        if word == "do" then
+          if pending_do > 0 then
+            -- Already accounted for by an earlier for/while.
+            pending_do = pending_do - 1
+          else
+            -- A bare `do ... end` block: its own nesting level.
+            depth = depth + 1
+          end
+        elseif BLOCK_STARTS[word] then
+          if word == "function" then
+            -- Make sure it's not just a type annotation.
+            local before = source:sub(math.max(1, i - 1), i - 1)
+            if before ~= ":" and before ~= ">" then
+              depth = depth + 1
+            end
+          else
+            depth = depth + 1
+            if word == "for" or word == "while" then
+              pending_do = pending_do + 1
+            end
+          end
+        elseif word == "until" then
+          depth = depth - 1
+        elseif word == "end" then
+          depth = depth - 1
+        end
+        i = word_end + 1
+      else
+        i = i + 1
+      end
+    end
+  end
+
+  return i - 4, i -- Before "end"
+end
+
+local record ScanModule
+  count_lines: function(source: string, start_pos: integer, end_pos: integer): integer
+  find_block_end: function(source: string, start_pos: integer): integer, integer
+end
+
+local M: ScanModule = {
+  count_lines = count_lines,
+  find_block_end = find_block_end,
+}
+
+return M

--- a/cosmic/doc/scan_test.tl
+++ b/cosmic/doc/scan_test.tl
@@ -106,6 +106,35 @@ TRAILING]==]
 end
 test_skips_long_strings_and_comments()
 
+local function test_repeat_until_closes_its_own_level()
+  -- repeat/until pairs its own depth change, distinct from the
+  -- function/if/for/while/do keywords that pair with `end`.
+  local source = "\nrepeat\n  local x = 1\nuntil x > 0\nlocal y = 2\nend\nTRAILING"
+  local body_end, next_pos = scan.find_block_end(source, 2)
+  local body = source:sub(2, body_end)
+  assert(body:find("local y = 2", 1, true), "body: " .. body)
+  assert(source:sub(next_pos + 1, next_pos + #"TRAILING") == "TRAILING",
+    "next_pos should point right at what follows the real end")
+end
+test_repeat_until_closes_its_own_level()
+
+local function test_skips_escaped_quote_in_string()
+  -- A backslash-escaped quote inside a string must not end the string
+  -- scan early (which would then read the rest of the string as code).
+  local source = [[
+
+local s = "a \" end for while do"
+local n = 1
+end
+TRAILING]]
+  local body_end, next_pos = scan.find_block_end(source, 2)
+  local body = source:sub(2, body_end)
+  assert(body:find("local n = 1", 1, true), "body: " .. body)
+  assert(source:sub(next_pos + 1, next_pos + #"TRAILING") == "TRAILING",
+    "next_pos should point right at what follows the real end")
+end
+test_skips_escaped_quote_in_string()
+
 local function test_count_lines()
   local source = "a\nb\nc\nd"
   assert(scan.count_lines(source, 1, #source) == 3, "should count 3 newlines")

--- a/cosmic/doc/scan_test.tl
+++ b/cosmic/doc/scan_test.tl
@@ -1,0 +1,107 @@
+#!/usr/bin/env cosmic
+-- test cosmic.doc.scan module
+
+local scan = require("cosmic.doc.scan")
+
+-- Test the two lexing defects this module exists to fix once: a
+-- keyword-prefixed identifier is not mistaken for the keyword, and a
+-- bare `do ... end` block gets its own nesting level.
+
+local function test_end_time_identifier_not_truncated()
+  local source = "\nlocal end_time = 2\nlocal x = end_time\nend\n"
+  local body_end, next_pos = scan.find_block_end(source, 2)
+  local body = source:sub(2, body_end)
+  assert(body:find("local x = end_time", 1, true), "body: " .. body)
+  assert(source:sub(next_pos - 1, next_pos - 1) == "\n" or next_pos > #source,
+    "next_pos should land right after the real end")
+end
+test_end_time_identifier_not_truncated()
+
+local function test_for_prefixed_identifier_does_not_over_nest()
+  local source = "\nlocal for_each = 1\nlocal y = for_each\nend\nTRAILING"
+  local body_end, next_pos = scan.find_block_end(source, 2)
+  local body = source:sub(2, body_end)
+  assert(body:find("local y = for_each", 1, true), "body: " .. body)
+  assert(not body:find("TRAILING", 1, true), "must not consume past the real end")
+  assert(source:sub(next_pos, next_pos + #"TRAILING" - 1) == "TRAILING",
+    "next_pos should point right at what follows the real end")
+end
+test_for_prefixed_identifier_does_not_over_nest()
+
+local function test_bare_do_end_block_own_nesting()
+  local source = "\ndo\n  local x = 1\nend\nlocal y = 2\nend\nTRAILING"
+  local body_end, next_pos = scan.find_block_end(source, 2)
+  local body = source:sub(2, body_end)
+  assert(body:find("local y = 2", 1, true),
+    "bare do-block must not be mistaken for the function's own end: " .. body)
+  assert(source:sub(next_pos, next_pos + #"TRAILING" - 1) == "TRAILING",
+    "next_pos should point right at what follows the real end")
+end
+test_bare_do_end_block_own_nesting()
+
+local function test_for_do_still_counts_once()
+  -- A real for/while's own `do` must NOT also open a new level -
+  -- exactly one `end` closes it.
+  local source = "\nfor i = 1, 10 do\n  local x = i\nend\nlocal y = 2\nend\nTRAILING"
+  local body_end, next_pos = scan.find_block_end(source, 2)
+  local body = source:sub(2, body_end)
+  assert(body:find("local y = 2", 1, true), "body: " .. body)
+  assert(source:sub(next_pos, next_pos + #"TRAILING" - 1) == "TRAILING",
+    "next_pos should point right at what follows the real end")
+end
+test_for_do_still_counts_once()
+
+local function test_nested_function_definition()
+  local source = "\nlocal f = function()\n  return 1\nend\nlocal z = f()\nend\nTRAILING"
+  local body_end, next_pos = scan.find_block_end(source, 2)
+  local body = source:sub(2, body_end)
+  assert(body:find("local z = f()", 1, true), "body: " .. body)
+  assert(source:sub(next_pos, next_pos + #"TRAILING" - 1) == "TRAILING",
+    "next_pos should point right at what follows the real end")
+end
+test_nested_function_definition()
+
+local function test_skips_strings_and_comments()
+  -- Keywords inside a string or a comment must not affect depth.
+  local source = [[
+
+local s = "end for while do"
+-- this comment mentions end and for and while and do too
+local n = 1
+end
+TRAILING]]
+  local body_end, next_pos = scan.find_block_end(source, 2)
+  local body = source:sub(2, body_end)
+  assert(body:find("local n = 1", 1, true), "body: " .. body)
+  assert(source:sub(next_pos, next_pos + #"TRAILING" - 1) == "TRAILING",
+    "next_pos should point right at what follows the real end")
+end
+test_skips_strings_and_comments()
+
+local function test_skips_long_strings_and_comments()
+  local source = [[
+
+local s = [[==this stays inline==]]
+--[[ a long comment with end for while do inside ]]
+local n = 1
+end
+TRAILING]]
+  -- NOTE: written without nested long-bracket levels to keep this test
+  -- file itself valid Teal; scan.find_block_end handles `[[...]]` and
+  -- `--[[...]]` the same way regardless of what they contain.
+  local body_end, next_pos = scan.find_block_end(source, 2)
+  local body = source:sub(2, body_end)
+  assert(body:find("local n = 1", 1, true), "body: " .. body)
+  assert(source:sub(next_pos, next_pos + #"TRAILING" - 1) == "TRAILING",
+    "next_pos should point right at what follows the real end")
+end
+test_skips_long_strings_and_comments()
+
+local function test_count_lines()
+  local source = "a\nb\nc\nd"
+  assert(scan.count_lines(source, 1, #source) == 3, "should count 3 newlines")
+  assert(scan.count_lines(source, 1, 1) == 0, "no newline in a single-char range")
+end
+test_count_lines()
+
+print("All scan tests passed!")

--- a/cosmic/doc/scan_test.tl
+++ b/cosmic/doc/scan_test.tl
@@ -12,8 +12,8 @@ local function test_end_time_identifier_not_truncated()
   local body_end, next_pos = scan.find_block_end(source, 2)
   local body = source:sub(2, body_end)
   assert(body:find("local x = end_time", 1, true), "body: " .. body)
-  assert(source:sub(next_pos - 1, next_pos - 1) == "\n" or next_pos > #source,
-    "next_pos should land right after the real end")
+  assert(next_pos == #source, "next_pos should land right after the real end")
+  assert(source:sub(next_pos, next_pos) == "\n", "next_pos should point at the trailing newline")
 end
 test_end_time_identifier_not_truncated()
 
@@ -23,7 +23,9 @@ local function test_for_prefixed_identifier_does_not_over_nest()
   local body = source:sub(2, body_end)
   assert(body:find("local y = for_each", 1, true), "body: " .. body)
   assert(not body:find("TRAILING", 1, true), "must not consume past the real end")
-  assert(source:sub(next_pos, next_pos + #"TRAILING" - 1) == "TRAILING",
+  -- next_pos lands right after "end"; a newline separates it from
+  -- TRAILING in these fixtures.
+  assert(source:sub(next_pos + 1, next_pos + #"TRAILING") == "TRAILING",
     "next_pos should point right at what follows the real end")
 end
 test_for_prefixed_identifier_does_not_over_nest()
@@ -34,7 +36,9 @@ local function test_bare_do_end_block_own_nesting()
   local body = source:sub(2, body_end)
   assert(body:find("local y = 2", 1, true),
     "bare do-block must not be mistaken for the function's own end: " .. body)
-  assert(source:sub(next_pos, next_pos + #"TRAILING" - 1) == "TRAILING",
+  -- next_pos lands right after "end"; a newline separates it from
+  -- TRAILING in these fixtures.
+  assert(source:sub(next_pos + 1, next_pos + #"TRAILING") == "TRAILING",
     "next_pos should point right at what follows the real end")
 end
 test_bare_do_end_block_own_nesting()
@@ -46,7 +50,9 @@ local function test_for_do_still_counts_once()
   local body_end, next_pos = scan.find_block_end(source, 2)
   local body = source:sub(2, body_end)
   assert(body:find("local y = 2", 1, true), "body: " .. body)
-  assert(source:sub(next_pos, next_pos + #"TRAILING" - 1) == "TRAILING",
+  -- next_pos lands right after "end"; a newline separates it from
+  -- TRAILING in these fixtures.
+  assert(source:sub(next_pos + 1, next_pos + #"TRAILING") == "TRAILING",
     "next_pos should point right at what follows the real end")
 end
 test_for_do_still_counts_once()
@@ -56,7 +62,9 @@ local function test_nested_function_definition()
   local body_end, next_pos = scan.find_block_end(source, 2)
   local body = source:sub(2, body_end)
   assert(body:find("local z = f()", 1, true), "body: " .. body)
-  assert(source:sub(next_pos, next_pos + #"TRAILING" - 1) == "TRAILING",
+  -- next_pos lands right after "end"; a newline separates it from
+  -- TRAILING in these fixtures.
+  assert(source:sub(next_pos + 1, next_pos + #"TRAILING") == "TRAILING",
     "next_pos should point right at what follows the real end")
 end
 test_nested_function_definition()
@@ -73,26 +81,27 @@ TRAILING]]
   local body_end, next_pos = scan.find_block_end(source, 2)
   local body = source:sub(2, body_end)
   assert(body:find("local n = 1", 1, true), "body: " .. body)
-  assert(source:sub(next_pos, next_pos + #"TRAILING" - 1) == "TRAILING",
+  -- next_pos lands right after "end"; a newline separates it from
+  -- TRAILING in these fixtures.
+  assert(source:sub(next_pos + 1, next_pos + #"TRAILING") == "TRAILING",
     "next_pos should point right at what follows the real end")
 end
 test_skips_strings_and_comments()
 
 local function test_skips_long_strings_and_comments()
-  local source = [[
+  local source = [==[
 
-local s = [[==this stays inline==]]
+local s = [[this stays inline]]
 --[[ a long comment with end for while do inside ]]
 local n = 1
 end
-TRAILING]]
-  -- NOTE: written without nested long-bracket levels to keep this test
-  -- file itself valid Teal; scan.find_block_end handles `[[...]]` and
-  -- `--[[...]]` the same way regardless of what they contain.
+TRAILING]==]
   local body_end, next_pos = scan.find_block_end(source, 2)
   local body = source:sub(2, body_end)
   assert(body:find("local n = 1", 1, true), "body: " .. body)
-  assert(source:sub(next_pos, next_pos + #"TRAILING" - 1) == "TRAILING",
+  -- next_pos lands right after "end"; a newline separates it from
+  -- TRAILING in these fixtures.
+  assert(source:sub(next_pos + 1, next_pos + #"TRAILING") == "TRAILING",
     "next_pos should point right at what follows the real end")
 end
 test_skips_long_strings_and_comments()

--- a/cosmic/embed/init.tl
+++ b/cosmic/embed/init.tl
@@ -43,7 +43,8 @@ local czip = require("cosmic.zip")
 local fs = require("cosmic.fs")
 local unix = require("cosmo.unix")
 local errstr = require("cosmic.errno").str
-local Stat = require("cosmic.fs.types").Stat
+local fs_types = require("cosmic.fs.types")
+local Stat = fs_types.Stat
 local floor = require("cosmic.embed.floor")
 local extract_mod = require("cosmic.embed.extract")
 
@@ -97,14 +98,7 @@ local record ZipReader
   close: function(self: ZipReader)
 end
 
---- Directory handle whose `read` exposes the dirent d_type (unix.DT_DIR /
---- DT_REG / DT_LNK / ... / DT_UNKNOWN) where the filesystem supports it,
---- letting collect_dir skip a stat(2) call for entries d_type already
---- identifies as neither a directory nor a regular file.
-local record EmbedDirHandle
-  read: function(self): string, integer
-  close: function(self)
-end
+local type EmbedDirHandle = fs_types.DirHandle
 
 -- One directory entry plus its d_type, sorted together for deterministic
 -- embed order without needing two parallel arrays.

--- a/cosmic/example.tl
+++ b/cosmic/example.tl
@@ -2,6 +2,7 @@
 --- Parses Example_* functions from Teal files, runs them, and verifies output.
 
 local tl = require("tl")
+local scan = require("cosmic.doc.scan")
 
 --- A parsed example function with its expected output.
 local record Example
@@ -39,17 +40,6 @@ local function parse_examples(source: string): {Example}
   local pos = 1
   local line_num = 1
 
-  -- Track line numbers
-  local function count_lines(s: string, start_pos: integer, end_pos: integer): integer
-    local count = 0
-    for i = start_pos, end_pos do
-      if s:sub(i, i) == "\n" then
-        count = count + 1
-      end
-    end
-    return count
-  end
-
   while true do
     -- Find next Example_* function definition
     local func_start, func_end, func_name = source:find("local%s+function%s+(Example[%w_]*)%s*%(%s*%)", pos)
@@ -57,80 +47,12 @@ local function parse_examples(source: string): {Example}
       break
     end
 
-    line_num = line_num + count_lines(source, pos, func_start)
+    line_num = line_num + scan.count_lines(source, pos, func_start)
     local example_line = line_num
 
     -- Find the function body - need to track nested end keywords
     local body_start = func_end + 1
-    local depth = 1
-    local i = body_start
-
-    -- Keywords that increase depth
-    local block_starts: {string: boolean} = {
-      ["function"] = true,
-      ["if"] = true,
-      ["for"] = true,
-      ["while"] = true,
-      ["repeat"] = true,
-    }
-
-    while i <= #source and depth > 0 do
-      -- Skip strings
-      if source:sub(i, i) == '"' or source:sub(i, i) == "'" then
-        local quote = source:sub(i, i)
-        i = i + 1
-        while i <= #source do
-          if source:sub(i, i) == "\\" then
-            i = i + 2
-          elseif source:sub(i, i) == quote then
-            i = i + 1
-            break
-          else
-            i = i + 1
-          end
-        end
-        -- Skip long strings
-      elseif source:sub(i, i + 1) == "[[" then
-        local close = source:find("]]", i + 2, true)
-        i = close and close + 2 or #source + 1
-        -- Skip comments
-      elseif source:sub(i, i + 1) == "--" then
-        if source:sub(i + 2, i + 3) == "[[" then
-          local close = source:find("]]", i + 4, true)
-          i = close and close + 2 or #source + 1
-        else
-          local newline = source:find("\n", i)
-          i = newline and newline + 1 or #source + 1
-        end
-      else
-        -- Check for keywords
-        local word_start, word_end, word = source:find("(%a+)", i)
-        if word_start == i then
-          if block_starts[word] then
-            -- Make sure it's not part of "end" check (e.g., "endif")
-            -- and that "function" is not just a type annotation
-            if word == "function" then
-              -- Check if this is an anonymous function or function type
-              local before = source:sub(math.max(1, i - 1), i - 1)
-              if before ~= ":" and before ~= ">" then
-                depth = depth + 1
-              end
-            else
-              depth = depth + 1
-            end
-          elseif word == "until" then
-            depth = depth - 1
-          elseif word == "end" then
-            depth = depth - 1
-          end
-          i = word_end + 1
-        else
-          i = i + 1
-        end
-      end
-    end
-
-    local body_end = i - 4 -- Before "end"
+    local body_end, i = scan.find_block_end(source, body_start)
     local body = source:sub(body_start, body_end)
 
     -- Extract expected output from -- Output: comment block

--- a/cosmic/example_test.tl
+++ b/cosmic/example_test.tl
@@ -70,6 +70,104 @@ end
 end
 test_example_no_output()
 
+-- Test that a variable/local named with a keyword prefix (`end_time`)
+-- is not lexed as the keyword `end`: a bare `%a+` word match stops at
+-- the `_`, so the scanner used to close the body right there.
+local function test_end_time_not_truncated()
+  local source = [[
+local function Example_time_tracking()
+  local start_time = 1
+  local end_time = 2
+  local elapsed = end_time - start_time
+  print(elapsed)
+  -- Output:
+  -- 1
+end
+]]
+  local examples = example.parse_examples(source)
+  assert(#examples == 1, "should find one example")
+  assert(examples[1].body:find("elapsed", 1, true),
+    "body should include the statement after end_time, not stop early")
+end
+test_end_time_not_truncated()
+
+-- Test that a variable named with a block-opening keyword prefix
+-- (`for_each`) is not lexed as `for`: that would open a phantom nesting
+-- level, needing an extra `end` to close and swallowing whatever
+-- example comes next.
+local function test_for_each_prefix_not_over_extended()
+  local source = [[
+local function Example_for_each()
+  local for_each = function(t) return #t end
+  print(for_each({1, 2, 3}))
+  -- Output:
+  -- 3
+end
+
+local function Example_after_for_each()
+  print("after")
+  -- Output:
+  -- after
+end
+]]
+  local examples = example.parse_examples(source)
+  assert(#examples == 2, "should find two separate examples, not merge them")
+  assert(examples[1].name == "Example_for_each", "first example name")
+  assert(examples[2].name == "Example_after_for_each", "second example name")
+  assert(not examples[1].body:find("Example_after_for_each", 1, true),
+    "for_each's body must not swallow the next example")
+end
+test_for_each_prefix_not_over_extended()
+
+-- Test that a bare `do ... end` block (not attached to a for/while)
+-- opens its own nesting level: `do` was missing from the depth-tracking
+-- keyword set, so its `end` was mistaken for the function's own.
+local function test_bare_do_end_block()
+  local source = [[
+local function Example_bare_do()
+  do
+    local x = 1
+  end
+  print(x or "after do")
+  -- Output:
+  -- after do
+end
+
+local function Example_after_do()
+  print("later")
+  -- Output:
+  -- later
+end
+]]
+  local examples = example.parse_examples(source)
+  assert(#examples == 2, "should find two examples")
+  assert(examples[1].body:find("after do", 1, true),
+    "body should include the statement after the bare do-block")
+  assert(examples[2].name == "Example_after_do", "next example parsed separately")
+end
+test_bare_do_end_block()
+
+-- Test a nested (anonymous) function definition inside the example
+-- body: unaffected by either bug, but a regression guard for the
+-- shared scanner now that all three extractors share it.
+local function test_nested_function_definition()
+  local source = [[
+local function Example_nested_fn()
+  local adder = function(a, b)
+    return a + b
+  end
+  print(adder(1, 2))
+  -- Output:
+  -- 3
+end
+]]
+  local examples = example.parse_examples(source)
+  assert(#examples == 1, "should find one example")
+  assert(examples[1].body:find("adder%(1, 2%)"),
+    "body should include the statement after the nested function")
+end
+test_nested_function_definition()
+
 -- Test running passing example
 local function test_run_passing()
   local input = write_temp("pass.tl", [[

--- a/cosmic/fs/tree.tl
+++ b/cosmic/fs/tree.tl
@@ -5,12 +5,8 @@ local cosmo_path = require("cosmo.path")
 local errno = require("cosmic.errno")
 local errstr = errno.str
 local fs_ops = require("cosmic.fs.ops")
-
---- Handle for reading directory entries (internal).
-local record TreeDirHandle
-  read: function(self): string, number
-  close: function(self)
-end
+local fs_types = require("cosmic.fs.types")
+local type TreeDirHandle = fs_types.DirHandle
 
 local copytree_into: function(string, string): boolean, string
 

--- a/cosmic/fs/types.tl
+++ b/cosmic/fs/types.tl
@@ -77,6 +77,20 @@ local record fs_types
   --- Stat passed to walk visitors: the same wrapped Stat.
   type WalkStat = Stat
 
+  --- Minimal read+close view of a raw `unix.Dir`, for internal
+  --- directory-traversal code (cosmic.fs.walk, cosmic.fs.tree,
+  --- cosmic.embed) that casts opendir()'s result across the userdata
+  --- boundary and only ever calls these two methods. `Dir` below is the
+  --- richer, publicly wrapped handle callers of cosmic.fs get back.
+  record DirHandle
+    --- Reads next directory entry. Returns nil when done. The second
+    --- return is the dirent d_type (unix.DT_DIR / DT_REG / DT_LNK / ... /
+    --- DT_UNKNOWN where the filesystem does not expose it).
+    read: function(self): string, integer
+    --- Closes directory handle.
+    close: function(self)
+  end
+
   --- Handle for reading directory entries.
   --- Supports automatic cleanup with `<close>` attribute.
   record Dir

--- a/cosmic/fs/walk.tl
+++ b/cosmic/fs/walk.tl
@@ -7,15 +7,7 @@ local types = require("cosmic.fs.types")
 local errstr = require("cosmic.errno").str
 local type WalkStat = types.WalkStat
 local FileInfo = types.FileInfo
-
---- Handle for reading directory entries (internal).
---- `read`'s second return is the dirent d_type (unix.DT_DIR / DT_REG /
---- DT_LNK / ... / DT_UNKNOWN) where the filesystem supports it, letting
---- callers that only need "is this a directory" skip a stat(2) call.
-local record WalkDirHandle
-  read: function(self): string, number
-  close: function(self)
-end
+local type WalkDirHandle = types.DirHandle
 
 --- Visitor verdict for walk(): returning nothing continues as before,
 --- "skip" does not descend into the entry (dirs only; no-op for files),

--- a/cosmic/pledge.tl
+++ b/cosmic/pledge.tl
@@ -27,16 +27,7 @@
 ---   unveil    permit subsequent unveil calls
 local unix = require("cosmo.unix")
 local errno = require("cosmic.errno")
-
---- Flush line-coverage data before rights drop: a dump attempted after
---- the pledge lands would violate it and kill the process.
-local function seal_coverage()
-  local cov = package.loaded["cosmic.coverage"]
-  if cov ~= nil then
-    local seal = (cov as {string: any})["seal"] as function() -- cast: from any
-    seal()
-  end
-end
+local seal_coverage = require("cosmic._seal_coverage").seal_coverage
 
 --- The promise groups the libc accepts, as a Teal enum so typed callers
 --- get promise names checked at compile time. `apply` still takes the

--- a/cosmic/time.tl
+++ b/cosmic/time.tl
@@ -131,12 +131,17 @@ local function sleep_ms(ms: number): integer | nil, string
   return math.ceil(rem_s * 1000 + rem_ns / 1000000), err
 end
 
---- Break down a UNIX timestamp into UTC (Zulu) time components.
+--- Shared by gmtime/localtime: they differ only in which cosmo.unix
+--- function does the breakdown (Zulu vs the TZ-aware local one), and
+--- both shape the same 11 values into a DateTime.
+--- @param fn function The cosmo.unix breakdown function to call (gmtime or localtime)
 --- @param unixts integer UNIX timestamp (seconds since epoch)
---- @return DateTime Broken-down time in UTC
-local function gmtime(unixts: integer): DateTime
-  local year, mon, mday, hour, min, sec, gmtoff, wday, yday, isdst, zone =
-  unix.gmtime(unixts)
+--- @return DateTime Broken-down time
+local function breakdown(
+  fn: function(integer): integer | nil, integer, integer, integer, integer, integer, integer, integer, integer, integer, string, string, unix.Errno,
+  unixts: integer
+): DateTime
+  local year, mon, mday, hour, min, sec, gmtoff, wday, yday, isdst, zone = fn(unixts)
   return {
     year = year,
     month = mon,
@@ -152,26 +157,19 @@ local function gmtime(unixts: integer): DateTime
   }
 end
 
+--- Break down a UNIX timestamp into UTC (Zulu) time components.
+--- @param unixts integer UNIX timestamp (seconds since epoch)
+--- @return DateTime Broken-down time in UTC
+local function gmtime(unixts: integer): DateTime
+  return breakdown(unix.gmtime, unixts)
+end
+
 --- Break down a UNIX timestamp into local time components.
 --- Respects the TZ environment variable.
 --- @param unixts integer UNIX timestamp (seconds since epoch)
 --- @return DateTime Broken-down time in local timezone
 local function localtime(unixts: integer): DateTime
-  local year, mon, mday, hour, min, sec, gmtoff, wday, yday, isdst, zone =
-  unix.localtime(unixts)
-  return {
-    year = year,
-    month = mon,
-    day = mday,
-    hour = hour,
-    min = min,
-    sec = sec,
-    gmtoff = gmtoff,
-    wday = wday,
-    yday = yday,
-    isdst = isdst > 0,
-    zone = zone,
-  }
+  return breakdown(unix.localtime, unixts)
 end
 
 --- Format a UNIX timestamp as an HTTP date string (RFC 7231).

--- a/cosmic/time.tl
+++ b/cosmic/time.tl
@@ -138,9 +138,9 @@ end
 --- @param unixts integer UNIX timestamp (seconds since epoch)
 --- @return DateTime Broken-down time
 local function breakdown(
-  fn: function(integer): integer | nil, integer, integer, integer, integer, integer, integer, integer, integer, integer, string, string, unix.Errno,
-  unixts: integer
-): DateTime
+    fn: function(integer): integer | nil, integer, integer, integer, integer, integer, integer, integer, integer, integer, string, string, unix.Errno,
+    unixts: integer
+  ): DateTime
   local year, mon, mday, hour, min, sec, gmtoff, wday, yday, isdst, zone = fn(unixts)
   return {
     year = year,

--- a/cosmic/unveil.tl
+++ b/cosmic/unveil.tl
@@ -25,22 +25,7 @@
 local cosmo = require("cosmo")
 local unix = require("cosmo.unix")
 local errstr = require("cosmic.errno").str
-
---- Flush line-coverage data before rights drop: once visibility
---- narrows, the coverage directory may no longer be writable.
---- @param keep boolean? The caller granted the coverage directory, so
---- the dump still works after this policy lands and sealing would
---- throw away everything done under it.
-local function seal_coverage(keep?: boolean)
-  if keep then
-    return
-  end
-  local cov = package.loaded["cosmic.coverage"]
-  if cov ~= nil then
-    local seal = (cov as {string: any})["seal"] as function() -- cast: from any
-    seal()
-  end
-end
+local seal_coverage = require("cosmic._seal_coverage").seal_coverage
 
 --- The permission strings `allow` accepts: every combination of r/w/x/c
 --- in canonical rwxc order, as a Teal enum so typos ("rc" vs "cr",


### PR DESCRIPTION
PR-09 of the review-fix series (findings section "PR-09 scanner-dedup").

## What was fixed

1. **The scanner bug (three copies)** — `cosmic/benchmark.tl:79-141`, `cosmic/example.tl:69-131`, `cosmic/doc/init.tl:303-331`. Two real lexing bugs shared by all three: (a) `source:find("(%a+)", i)` matches only the letter run, so `end_time` lexed as `end` and closed the body early, `for_each` lexed as `for` and opened a phantom nesting level; (b) a bare `do ... end` block was never counted, so its `end` was mistaken for the enclosing function's. Fixed once in new internal module `cosmic/doc/scan.tl` (two segments under `cosmic/`, so internal per `cosmic/doc/visibility.tl`'s `is_public` rule), and all three callers now go through it.

   **Approach chosen: patch the hand scanner, not switch to `tl.lex`.** `cosmic/coverage/lines.tl` already reuses `tl.lex`/`tl.parse_program`, so it was worth considering here too. Rejected because: (a) the three callers extract raw source *text* to `load()` or feed back through Teal later — a full lex/parse pass would add a second failure mode (a syntactically-incomplete or intentionally-broken fragment under test) that the current byte scanner tolerates; (b) mapping token positions back to byte offsets for slicing, across three call sites with different post-processing (records vs. functions vs. output-comment stripping), doesn't remove the duplication, it just moves it into three "token stream -> byte range" adapters; (c) it's a much larger behavioral change for a fix whose two defects are narrow and well-understood. The smaller, surgical fix stays closer to "no drive-by restructuring."

   Bonus: unifying also gives `doc/init.tl`'s Example scanner `repeat` support and long-string/long-comment skipping, which its variant never had (the other two already did) — a correctness improvement, not a behavior change any test depended on.

   Tests added directly on `cosmic/doc/scan.tl` (`cosmic/doc/scan_test.tl`) plus at each of the three call sites (`benchmark_test.tl`, `example_test.tl`, `doc/init_test.tl`): bodies containing `end_time`, `for_each`, a bare `do...end` block, `repeat...until`, an escaped quote in a string, and a nested function definition.

2. **doc/render.tl duplicated extract_doc_comment + parse_annotations** from doc/init.tl (the slower `:sub` variant). Shared in new `cosmic/doc/comments.tl` (its own file, not living in either caller, since `doc/init.tl` already requires `doc/render.tl` — a copy in either one would force a require cycle).

3. **Dir-handle records triplicated** — `fs/walk.tl`, `fs/tree.tl`, `embed/init.tl` each declared an identical minimal read+close view of a raw `unix.Dir`. Moved into `cosmic/fs/types.tl` as `DirHandle`.

4. **time.tl gmtime/localtime** were byte-identical except which `cosmo.unix` function did the breakdown. Factored into a private `breakdown(fn, unixts)`.

5. **seal_coverage duplicated** in `cosmic/pledge.tl` vs `cosmic/unveil.tl` (including the `package.loaded` cast dance). Shared in new `cosmic/_seal_coverage.tl` — its own file since pledge and unveil must not require each other (`cosmic.sandbox` composes both).

6. **codec.tl decode_base64/decode_base64url** shared an identical validate-then-decode block; parameterized into `validate_base64_family()`. Also fixed `encode_base32`'s doc (said "0-9a-v", actual alphabet is "0-9a-z" minus i/l/o/u, matching `decode_base32`'s own doc).

7. Coverage ratchet rebaselined (`.cosmic-coverage`): three new internal files added at/near 100%; `doc/init.tl` and `example.tl` legitimately shrank (code moved to `scan.tl`/`comments.tl`), so the same still-untested, out-of-scope lines (parse_file/render_file/serialize/load_index, the nested-record-block path) now weigh a bigger fraction of a smaller file. Two coverage-gap tests were also added directly (the `allow_regular_comments=true` path in `comments.tl`, exercised only via `doc.parse`'s Example-doc extraction).

No public API changes anywhere in this PR.

## Skipped findings

None — all 6 items in the PR-09 findings section were re-verified against current code and fixed as described above.

## CI verdict

```
ci: PASS (6 stages)
```

(fmt, check, test, example, lint, coverage — all green against the rebaselined `.cosmic-coverage`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE)_