### PR TITLE
Fix --check= pre-scan, verdict-line drift, and dead code in build-cli

### DIFF
--- a/_cli/main_handlers_test.tl
+++ b/_cli/main_handlers_test.tl
@@ -58,6 +58,17 @@ local function test_check_format_accepts_formatted_source()
 end
 test_check_format_accepts_formatted_source()
 
+--- The `--check=kind file` equals-form embeds the kind in the option
+--- itself; without matching pre-scan handling the file is misread as
+--- the script to run and --check refuses it for lack of a file.
+local function test_check_format_accepts_eq_form()
+  local r = cli("--check=fmt", formatted)
+  assert(r.code == 0,
+    "well-formatted file should pass via --check=fmt, got " .. r.code ..
+    ": " .. r.err)
+end
+test_check_format_accepts_eq_form()
+
 local function test_check_format_rejects_misformatted_source()
   local r = cli("--check", "fmt", misformatted)
   assert(r.code ~= 0, "misformatted file must be rejected, got exit 0")

--- a/_make/artifact.tl
+++ b/_make/artifact.tl
@@ -261,8 +261,11 @@ local function collision(out: {Staged}): string | nil
     if out[i].stored == out[i - 1].stored then
       local a = out[i - 1].source
       local b = out[i].source
+      -- `a` and `b` are staged SOURCE PATHS, not unit directories --
+      -- `project.unit_label` is for the latter ("" -> "the build") and
+      -- passes a path through unrecognized, so name the path itself.
       return "make: " .. out[i].stored .. ": staged by both " ..
-      project.unit_label(a) .. " and " .. project.unit_label(b)
+      a .. " and " .. b
     end
   end
   return nil

--- a/_make/artifact.tl
+++ b/_make/artifact.tl
@@ -354,39 +354,29 @@ local function stage(proj: Project, binary: Binary): string | nil, string
   return dir
 end
 
---- The runtime this artifact is built on.
----
---- A unit that produced `o/<unit>/embed_gen/base` names its own — cosmic's own
---- generator copies the `lua` out of the pinned cosmos zip, so a
---- cosmic built by any cosmic is built on the runtime the project
---- pinned rather than on whichever binary happened to run the build.
---- Everything else falls back to the running cosmic, which is the
---- right answer for a project that pins nothing: their artifact is a
---- cosmic with their code in it.
---- @param proj Project The scanned project
---- @param binary Binary The artifact being built
---- @param cosmic string Absolute path to the running cosmic
---- @return string The base to embed onto
-local function base_of(proj: Project, binary: Binary, cosmic: string): string
-  local declared = fs.join(gen_dir(binary.dir), BASE_NAME)
-  if fs.isfile(fs.join(proj.root, declared)) then
-    return declared
-  end
-  return cosmic
-end
-
 --- Every runtime this unit ships its payload on.
 ---
---- A unit that writes `base-<variant>` beside `base` gets a second
---- artifact, `o/bin/<name>-<variant>`, carrying the SAME payload on a
---- different runtime. That is what a debug build is — cosmic ships
---- `cosmic` and `cosmic-debug` off one payload and two cosmos runtimes —
---- and expressing it as another file in the directory the convention
---- already reads keeps it out of the model: no variant field, no second
---- `cmd/` unit whose generator has to be kept in step with the first.
+--- A unit that produced `o/<unit>/embed_gen/base` names its own —
+--- cosmic's own generator copies the `lua` out of the pinned cosmos
+--- zip, so a cosmic built by any cosmic is built on the runtime the
+--- project pinned rather than on whichever binary happened to run the
+--- build. Everything else falls back to the running cosmic, which is
+--- the right answer for a project that pins nothing: their artifact is
+--- a cosmic with their code in it.
+---
+--- A unit that also writes `base-<variant>` beside `base` gets a
+--- second artifact, `o/bin/<name>-<variant>`, carrying the SAME
+--- payload on a different runtime. That is what a debug build is —
+--- cosmic ships `cosmic` and `cosmic-debug` off one payload and two
+--- cosmos runtimes — and expressing it as another file in the
+--- directory the convention already reads keeps it out of the model:
+--- no variant field, no second `cmd/` unit whose generator has to be
+--- kept in step with the first.
 ---
 --- The plain `base` comes first, so the unnamed artifact is the one a
---- project without variants gets and the one every other verb means.
+--- project without variants gets and the one every other verb means —
+--- `result[1][2]` is "the" base a unit builds on, with no separate
+--- single-base accessor to drift from it.
 --- @param proj Project The scanned project
 --- @param binary Binary The artifact being built
 --- @param cosmic string Absolute path to the running cosmic
@@ -482,7 +472,7 @@ local function build(proj: Project, binary: Binary, cosmic: string): string | ni
 end
 
 local record ArtifactModule
-  base_of: function(proj: Project, binary: Binary, cosmic: string): string
+  bases_of: function(proj: Project, binary: Binary, cosmic: string): {{string, string}}
   scope_of: function(proj: Project, binary: Binary): {File}
   plan: function(proj: Project, binary: Binary): {Staged}
   stage: function(proj: Project, binary: Binary): string | nil, string
@@ -490,7 +480,7 @@ local record ArtifactModule
 end
 
 local M: ArtifactModule = {
-  base_of = base_of,
+  bases_of = bases_of,
   scope_of = scope_of,
   plan = plan,
   stage = stage,

--- a/_make/check.tl
+++ b/_make/check.tl
@@ -11,6 +11,7 @@
 --- collide or whose filenames cannot survive a recipe line has problems
 --- the type checker would report as a confusing cascade, or not at all.
 
+local records = require("cosmic.records")
 local teal = require("cosmic.teal")
 local selection = require("_make.select")
 local validate = require("_make.validate")
@@ -98,27 +99,20 @@ local function run(proj: Project, paths: {string}): integer
   local issues = validate.validate(proj)
   if #issues > 0 then
     io.stderr:write(validate.format_issues(issues) .. "\n")
-    io.write(string.format("check: FAIL (%d validation %s)\n",
-        #issues, #issues == 1 and "error" or "errors"))
-    return 1
+    return records.verdict("check", false,
+      records.detail(0, #issues, "validation error"))
   end
 
   local files, err = select_files(proj, paths)
   if not files then
     io.stderr:write((err or "make: no such selection") .. "\n")
-    io.write("check: FAIL (bad selection)\n")
-    return 1
+    return records.verdict("check", false, "bad selection")
   end
 
   local selected = files as {File} -- cast: record union after the guard
   local failed = check_files(selected)
-  if failed > 0 then
-    io.write(string.format("check: FAIL (%d of %d files)\n", failed, #selected))
-    return 1
-  end
-  io.write(string.format("check: PASS (%d %s)\n",
-      #selected, #selected == 1 and "file" or "files"))
-  return 0
+  return records.verdict("check", failed == 0,
+    records.detail(failed, #selected, "file"))
 end
 
 local record CheckModule

--- a/_make/fetch.tl
+++ b/_make/fetch.tl
@@ -16,6 +16,7 @@ local fs = require("cosmic.fs")
 local hash = require("cosmic.hash")
 local pin = require("_make.pin")
 local project = require("_make.project")
+local records = require("cosmic.records")
 local selection = require("_make.select")
 local types = require("_make.types")
 
@@ -241,16 +242,14 @@ local function run(proj: Project, paths: {string}): integer
   local picked, serr = selection.files(candidates, paths, proj.root)
   if not picked then
     io.stderr:write((serr or "make: no such selection") .. "\n")
-    io.write("fetch: FAIL (bad selection)\n")
-    return 1
+    return records.verdict("fetch", false, "bad selection")
   end
   local files = picked as {File} -- cast: record union after the guard
 
   local pins, rerr = resolve(files)
   if not pins then
     io.stderr:write((rerr or "make: cannot read the pins") .. "\n")
-    io.write("fetch: FAIL (bad pin)\n")
-    return 1
+    return records.verdict("fetch", false, "bad pin")
   end
 
   use_system_certs()
@@ -263,13 +262,7 @@ local function run(proj: Project, paths: {string}): integer
     end
   end
   local n = #(pins as {Pin}) -- cast: record union after the guard
-  if failed > 0 then
-    io.write(string.format("fetch: FAIL (%d of %d pins)\n", failed, n))
-    return 1
-  end
-  io.write(string.format("fetch: PASS (%d %s)\n", n,
-      n == 1 and "pin" or "pins"))
-  return 0
+  return records.verdict("fetch", failed == 0, records.detail(failed, n, "pin"))
 end
 
 local record FetchModule

--- a/_make/generate_test.tl
+++ b/_make/generate_test.tl
@@ -160,10 +160,13 @@ local function test_base_is_the_units_own_when_it_declares_one()
       "not really a runtime\n"))
 
   local proj = scan(root)
-  assert(artifact.base_of(proj, binary_of(proj, "tool"), cosmic) ==
+  -- The plain base is always the first pair `bases_of` returns (see
+  -- its own doc comment), so that is the single source for "the" base
+  -- a unit builds on -- there is no separate `base_of` to drift from it.
+  assert(artifact.bases_of(proj, binary_of(proj, "tool"), cosmic)[1][2] ==
     "o/cmd/tool/embed_gen/base",
     "a declared base wins, so the artifact does not depend on its builder")
-  assert(artifact.base_of(proj, binary_of(proj, "lean"), cosmic) == cosmic,
+  assert(artifact.bases_of(proj, binary_of(proj, "lean"), cosmic)[1][2] == cosmic,
     "and a unit that declares none is built on the running cosmic")
 end
 test_base_is_the_units_own_when_it_declares_one()

--- a/_make/graph.tl
+++ b/_make/graph.tl
@@ -22,7 +22,6 @@ local deps = require("_make.deps")
 local project = require("_make.project")
 local types = require("_make.types")
 
-local type File = types.File
 local type Kind = types.Kind
 local type Project = types.Project
 
@@ -458,15 +457,6 @@ local function run(proj: Project, target: string, overrides: {string},
   return res.code or 1
 end
 
---- Files of the given kinds, for a verb that wants to count what it
---- built without re-deriving the rules' patsubst.
---- @param proj Project The scanned project
---- @param kinds {Kind} Kinds to count
---- @return {File} The matching files
-local function inputs(proj: Project, kinds: {Kind}): {File}
-  return project.of_kind(proj, kinds)
-end
-
 local record GraphModule
   MAKE_ENV: string
   MAKE_ZIP: string
@@ -478,7 +468,6 @@ local record GraphModule
   find_make: function(): string | nil, string
   jobs_flag: function(): string
   run: function(proj: Project, target: string, overrides: {string}, cosmic: string, extra?: {string}): integer, string
-  inputs: function(proj: Project, kinds: {Kind}): {File}
   source_dirs: function(proj: Project): {string}
 end
 
@@ -493,7 +482,6 @@ local M: GraphModule = {
   find_make = find_make,
   jobs_flag = jobs_flag,
   run = run,
-  inputs = inputs,
   source_dirs = source_dirs,
 }
 

--- a/_make/stage.tl
+++ b/_make/stage.tl
@@ -44,11 +44,17 @@ local function kinds_of(set: {Kind: boolean}): {Kind}
 end
 
 local SELECTS < const >: {string: Selection} = {
+  -- No `variable`: a selected build still compiles the whole tree (see
+  -- `run_build`'s own comment), and `run_build` always lowers onto the
+  -- graph with an empty selection, so there is no path list here to
+  -- turn into an override. `--make build <binary>` narrows which
+  -- binaries get STAGED, resolved separately through
+  -- `binaries.select` (`_make/law.tl`'s RESOLVERS), never through this
+  -- table.
   build = {
     kinds = {"module", "entry", "test", "example", "benchmark", "gen",
       "payload-gen"},
     suffix = ".tl",
-    variable = "tl_sources",
   },
   -- Derived from the one definition in types, so a selected `fmt` and
   -- the facts writer's `fmt_sources` cannot disagree about what is
@@ -135,8 +141,9 @@ local function graph_stage(v: Verb, proj: Project, paths: {string},
   local files = picked as {File} -- cast: record union after the guard
 
   local overrides: {string} = {}
-  if #paths > 0 then
-    overrides[1] = sel.variable .. "=" ..
+  local variable = sel.variable
+  if variable and #paths > 0 then
+    overrides[1] = variable .. "=" ..
     table.concat(project.paths_of(files), " ")
   end
 

--- a/_make/types.tl
+++ b/_make/types.tl
@@ -101,7 +101,12 @@ local record make_types
     --- and the guard against it lived in a comment. The type says it
     --- now.
     suffix: string | nil
-    variable: string
+    --- The make variable a path selection overrides, or nil when the
+    --- verb never lowers a selection onto the graph this way (`build`:
+    --- the whole tree compiles either way, and its own paths narrow
+    --- which BINARIES get staged, resolved through `binaries.select`
+    --- rather than this override).
+    variable: string | nil
   end
 
   --- One verb: everything the dispatcher, the usage text and the

--- a/cmd/cosmic/main.tl
+++ b/cmd/cosmic/main.tl
@@ -148,8 +148,8 @@ local function parse_args(): Options
       elseif long_greedy[opt_name] then
         script_idx = nil
         break
-      elseif long_extra_arg[opt_name] then
-        i = i + 3
+      elseif long_extra_arg[opt_name:match("^([^=]+)=") or opt_name] then
+        i = i + (opt_name:find("=", 1, true) and 2 or 3)
       elseif not opt_name:find("=") and long_needs_arg[opt_name] then
         i = i + 2
       else


### PR DESCRIPTION
Four independent fixes from the review-fix series (PR-13).

- **cmd/cosmic/main.tl:151-157** — the argv pre-scan handled `--make=`/`--test=` eq-forms but not `--check=<kind> <file>`: with the kind embedded in the option, the file argument was misclassified as the script to run and `--check` refused it for lack of a file. Fixed to skip 2 tokens (option, file) instead of 3 when the kind is embedded, mirroring `--make=`'s handling. Added a regression test in `_cli/main_handlers_test.tl` spawning the built binary with `--check=fmt`.
- **_make/fetch.tl:244-267, _make/check.tl:98-116** — both hand-assembled `"verb: PASS/FAIL"` lines with `io.write`/`string.format` instead of `cosmic.records.verdict`/`detail` — the exact drift `records.tl`'s own header warns against. Routed both through `records.verdict`/`records.detail`; output is byte-for-byte unchanged (verified against `check_test.tl`'s pinned lines and a live `--make fetch` run).
- **_make/graph.tl:466-468, _make/stage.tl:47-52, _make/artifact.tl:370-376** — three dead-code items collapsed to their single source of truth: `graph.inputs` (zero callers, deleted); `SELECTS.build`'s `variable = "tl_sources"` override (unreachable — `run_build`/`prepare_stage` always pass an empty selection to `graph_stage`, and `law.tl`'s `RESOLVERS["build"]` answers the pre-flight question through `binaries.select` instead — `Selection.variable` is now `string | nil`); `artifact.base_of` (duplicated `bases_of`'s plain-base case and was only called from a test — deleted, `bases_of` exported, test adapted to `bases_of(...)[1][2]`).
- **_make/artifact.tl:263-265** — `collision()` passed staged *source paths* to `project.unit_label`, a unit-directory formatter (`"" -> "the build"`, anything else passed through unchanged) — cosmetic for ordinary paths but mislabels the one path that legitimately is `""` (the derived `.args` entry) as "the build". Now labels with the path itself.

No findings skipped — all four were confirmed against current code (line numbers had drifted slightly but the issues were present as described).

CI verdict (full `bin/cosmic --make ci` after rebasing onto latest `main`):

```
ci: PASS (6 stages)
```

Per-stage: fmt: PASS (391 files), check: PASS (391 files), test: PASS (180 files), example: PASS (36 files), lint: PASS (454 files), coverage: PASS (180 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE