### PR TITLE
perf-gate: magnitude-aware A/A triage, fail broken baselines, close two run.tl gaps

### DIFF
--- a/_perf/compare.tl
+++ b/_perf/compare.tl
@@ -161,7 +161,7 @@ local function triage(base: pt.Results, cur: pt.Results, noise_a: pt.Results, no
   for _, d in ipairs(deltas) do
     local sd = self_by_name[d.name]
     if d.verdict == "regression" and sd ~= nil and sd.delta_pct ~= nil
-        and math.abs(d.delta_pct) <= math.max(d.noise_pct, TRIAGE_K * math.abs(sd.delta_pct)) then
+    and math.abs(d.delta_pct) <= math.max(d.noise_pct, TRIAGE_K * math.abs(sd.delta_pct)) then
       d.verdict = "noise"
       failures = failures - 1
     end

--- a/_perf/compare.tl
+++ b/_perf/compare.tl
@@ -4,9 +4,11 @@
 --- regression (or improvement) when it clears the noise bar:
 --- max(threshold, baseline spread, current spread).
 ---
---- Guardrails: scenarios that error, and scenarios present in the baseline
+--- Guardrails: scenarios that error, scenarios present in the baseline
 --- but missing from the current run (deleting a benchmark cannot hide a
---- regression), both count as failures.
+--- regression), scenarios whose baseline row itself errored ("new" would
+--- hide a permanently-broken scenario), and malformed rows (no error but
+--- no timing either) all count as failures.
 
 local json = require("cosmic.json")
 local harness = require("_perf.harness")
@@ -14,6 +16,14 @@ local pt = require("_perf.perf_types")
 local fs = require("cosmic.fs")
 
 local DEFAULT_THRESHOLD_PCT = 10.0
+
+--- Multiplier applied to the A/A self-check delta in triage(): a
+--- regression reclassifies to "noise" only when its own magnitude is
+--- within TRIAGE_K times the self-check's swing (see triage() below).
+--- K=2 lets the reclassification absorb ordinary variance (a self-check
+--- that swings 15% clears a 30% regression) without waving through a
+--- regression many times larger than anything the self-check showed.
+local TRIAGE_K = 2.0
 
 --- Load a results JSON file written by perf.run.
 --- @param path string Path to the results file
@@ -58,9 +68,29 @@ local function diff(base: pt.Results, cur: pt.Results, threshold_pct?: number): 
     if c.error then
       d.verdict = "error"
       failures = failures + 1
-    elseif b == nil or b.error ~= nil or b.wall_ns == nil then
+    elseif c.wall_ns == nil then
+      -- No error, but also no timing: malformed input. Computing a
+      -- delta against this would arithmetic on nil below; say so
+      -- instead of throwing.
+      d.verdict = "malformed"
+      failures = failures + 1
+    elseif b == nil then
       d.cur_ns = c.wall_ns
       d.verdict = "new"
+    elseif b.error ~= nil then
+      -- The baseline scenario errored last time. Unlike a genuinely new
+      -- scenario, this one WAS measured and failed -- treating it as
+      -- "new" (never gated) lets a broken scenario stay broken
+      -- indefinitely, silently, until someone happens to refresh the
+      -- baseline. Count it like "missing": a failing state that a
+      -- fresh, passing baseline clears.
+      d.cur_ns = c.wall_ns
+      d.verdict = "baseline-error"
+      failures = failures + 1
+    elseif b.wall_ns == nil then
+      d.cur_ns = c.wall_ns
+      d.verdict = "malformed"
+      failures = failures + 1
     else
       d.base_ns = b.wall_ns
       d.cur_ns = c.wall_ns
@@ -95,13 +125,21 @@ end
 
 --- Reclassify baseline-vs-current regressions using an A/A self-check.
 --- A regression whose scenario ALSO moves past its noise bar when the
---- current binary is compared against itself (two same-binary runs) is
---- indistinguishable from run-to-run variance, so it is reclassified to
---- the non-failing verdict "noise". A scenario that stays within the bar
---- under the self-check keeps its "regression" verdict — so a real
---- regression in a stable, low-variance scenario (json, sqlite, ...)
---- still fails the gate. This makes the noise/real call deterministic
---- instead of a manual judgement (see _perf/optimize/measurement.md).
+--- current binary is compared against itself (two same-binary runs) is a
+--- CANDIDATE for run-to-run variance, but instability alone does not
+--- excuse any magnitude: a scenario whose self-check swings 5% does not
+--- get to wave through a +300% regression. The candidate reclassifies to
+--- the non-failing verdict "noise" only when its own delta is comparable
+--- to the self-check's -- |regression delta| <= max(bar, TRIAGE_K *
+--- |self-check delta|), TRIAGE_K = 2 -- so the self-check bounds how much
+--- variance a scenario gets credit for instead of writing it a blank
+--- check. A scenario that stays within the bar under the self-check, or
+--- whose regression dwarfs what the self-check showed, keeps its
+--- "regression" verdict — so a real regression in a stable, low-variance
+--- scenario (json, sqlite, ...) still fails the gate, and so does a huge
+--- regression in an unstable one. This makes the noise/real call
+--- deterministic instead of a manual judgement (see
+--- _perf/optimize/measurement.md).
 --- @param base Results Baseline results
 --- @param cur Results Current results
 --- @param noise_a Results First self-check pass (current binary)
@@ -112,16 +150,18 @@ end
 local function triage(base: pt.Results, cur: pt.Results, noise_a: pt.Results, noise_b: pt.Results, threshold_pct?: number): {pt.Delta}, integer
   local deltas, failures = diff(base, cur, threshold_pct)
   local self_deltas = diff(noise_a, noise_b, threshold_pct)
-  local unstable: {string: boolean} = {}
+  local self_by_name: {string: pt.Delta} = {}
   for _, sd in ipairs(self_deltas) do
     -- The same binary vs itself should read "ok"; a scenario that instead
     -- clears the bar in either direction is too noisy to judge here.
     if sd.verdict == "regression" or sd.verdict == "faster" then
-      unstable[sd.name] = true
+      self_by_name[sd.name] = sd
     end
   end
   for _, d in ipairs(deltas) do
-    if d.verdict == "regression" and unstable[d.name] then
+    local sd = self_by_name[d.name]
+    if d.verdict == "regression" and sd ~= nil and sd.delta_pct ~= nil
+        and math.abs(d.delta_pct) <= math.max(d.noise_pct, TRIAGE_K * math.abs(sd.delta_pct)) then
       d.verdict = "noise"
       failures = failures - 1
     end
@@ -158,7 +198,8 @@ local function format(deltas: {pt.Delta}): string
     counts[d.verdict] = (counts[d.verdict] or 0) + 1
   end
   table.insert(lines, string.format(
-      "%d scenarios: %d regression, %d faster, %d ok, %d noise, %d new, %d missing, %d error",
+      "%d scenarios: %d regression, %d faster, %d ok, %d noise, %d new, %d missing," ..
+      " %d error, %d baseline-error, %d malformed",
       #deltas,
       counts["regression"] or 0,
       counts["faster"] or 0,
@@ -166,7 +207,9 @@ local function format(deltas: {pt.Delta}): string
       counts["noise"] or 0,
       counts["new"] or 0,
       counts["missing"] or 0,
-      counts["error"] or 0))
+      counts["error"] or 0,
+      counts["baseline-error"] or 0,
+      counts["malformed"] or 0))
   return table.concat(lines, "\n")
 end
 
@@ -227,6 +270,7 @@ end
 
 local record compare
   DEFAULT_THRESHOLD_PCT: number
+  TRIAGE_K: number
   load_results: function(path: string): pt.Results, string
   identity_refusal: function(a_path: string, a_res: pt.Results, b_path: string, b_res: pt.Results, same: boolean): string | nil
   diff: function(base: pt.Results, cur: pt.Results, threshold_pct?: number): {pt.Delta}, integer
@@ -237,6 +281,7 @@ end
 
 local M: compare = {
   DEFAULT_THRESHOLD_PCT = DEFAULT_THRESHOLD_PCT,
+  TRIAGE_K = TRIAGE_K,
   load_results = load_results,
   identity_refusal = identity_refusal,
   diff = diff,

--- a/_perf/compare_test.tl
+++ b/_perf/compare_test.tl
@@ -94,15 +94,59 @@ local function test_errored_scenario_fails()
 end
 test_errored_scenario_fails()
 
-local function test_errored_baseline_treated_as_new()
+-- Deliberate pin: a scenario whose BASELINE row errored used to read as
+-- "new" (never gated) until someone happened to refresh the baseline --
+-- a broken scenario could stay broken indefinitely and silently. It is
+-- now a failing verdict, the same way a "missing" scenario is: a fresh,
+-- passing baseline is what clears it, not merely running the gate again.
+local function test_errored_baseline_is_a_failure()
   local bad: pt.Measurement = {name = "flaky", samples_ns = {}, error = "boom"}
   local deltas, failures = compare.diff(
     results({bad}),
     results({m("flaky", 500, 1)}), 10)
-  assert(failures == 0, "recovered scenario is not a failure")
-  assert(find_delta(deltas, "flaky").verdict == "new", "expected new")
+  assert(failures == 1, "a baseline error must fail until the baseline is refreshed")
+  assert(find_delta(deltas, "flaky").verdict == "baseline-error",
+    "expected baseline-error, got " .. find_delta(deltas, "flaky").verdict)
 end
-test_errored_baseline_treated_as_new()
+test_errored_baseline_is_a_failure()
+
+-- A scenario truly absent from the baseline (never measured, not
+-- errored) stays "new" and non-failing -- this is what makes the case
+-- above about the baseline having ERRORED, not merely being incomplete.
+local function test_truly_new_scenario_is_not_a_failure()
+  local deltas, failures = compare.diff(
+    results({}),
+    results({m("brand_new", 500, 1)}), 10)
+  assert(failures == 0, "a scenario absent from the baseline is not a failure")
+  assert(find_delta(deltas, "brand_new").verdict == "new", "expected new")
+end
+test_truly_new_scenario_is_not_a_failure()
+
+-- c.wall_ns nil without c.error used to arithmetic on nil below and
+-- throw; malformed input gets a clean verdict instead.
+local function test_malformed_current_row_does_not_throw()
+  local malformed: pt.Measurement = {name = "odd", samples_ns = {}}
+  local deltas, failures = compare.diff(
+    results({m("odd", 500, 1)}),
+    results({malformed}), 10)
+  assert(failures == 1, "a malformed current row must fail")
+  assert(find_delta(deltas, "odd").verdict == "malformed",
+    "expected malformed, got " .. find_delta(deltas, "odd").verdict)
+end
+test_malformed_current_row_does_not_throw()
+
+-- Symmetric case: a malformed BASELINE row (no error, no wall_ns) is
+-- just as undiffable as a malformed current row.
+local function test_malformed_baseline_row_does_not_throw()
+  local malformed: pt.Measurement = {name = "odd", samples_ns = {}}
+  local deltas, failures = compare.diff(
+    results({malformed}),
+    results({m("odd", 500, 1)}), 10)
+  assert(failures == 1, "a malformed baseline row must fail")
+  assert(find_delta(deltas, "odd").verdict == "malformed",
+    "expected malformed, got " .. find_delta(deltas, "odd").verdict)
+end
+test_malformed_baseline_row_does_not_throw()
 
 local function test_format_summarizes()
   local deltas = compare.diff(
@@ -144,7 +188,8 @@ test_triage_keeps_stable_regression()
 
 local function test_triage_reclassifies_noisy_regression()
   -- Same +30% "regression", but the current binary swings ~-31% against
-  -- itself for "a": indistinguishable from noise, so reclassify.
+  -- itself for "a": COMPARABLE magnitude (30% is well within
+  -- TRIAGE_K=2 * 31%), so it reclassifies to noise.
   local deltas, failures = compare.triage(
     results({m("a", 1000, 2)}), results({m("a", 1300, 2)}),
     results({m("a", 1300, 2)}), results({m("a", 900, 2)}), 10)
@@ -152,6 +197,44 @@ local function test_triage_reclassifies_noisy_regression()
   assert(find_delta(deltas, "a").verdict == "noise", "should reclassify to noise")
 end
 test_triage_reclassifies_noisy_regression()
+
+-- Magnitude-blindness was the bug: previously ANY regression on a
+-- scenario whose A/A self-check cleared the bar was waved through as
+-- noise, even one many times larger than the self-check swing. A 30%
+-- self-check swing does not excuse a +300% regression.
+local function test_triage_large_regression_in_unstable_scenario_still_fails()
+  local deltas, failures = compare.triage(
+    results({m("a", 1000, 2)}), results({m("a", 4000, 2)}), -- +300%
+    results({m("a", 1000, 2)}), results({m("a", 1300, 2)}), -- self: +30%
+    10)
+  assert(failures == 1,
+    "a regression far larger than the self-check swing must still fail, got " .. failures)
+  assert(find_delta(deltas, "a").verdict == "regression",
+    "should stay regression, got " .. find_delta(deltas, "a").verdict)
+end
+test_triage_large_regression_in_unstable_scenario_still_fails()
+
+-- The K=2 boundary itself: |regression| <= max(bar, K * |self delta|).
+-- Here bar=10, self delta=20%, so the cutoff is exactly 40%. 40% must
+-- reclassify; 41% (a hair over) must not.
+local function test_triage_k_factor_boundary()
+  local at_boundary = compare.triage(
+    results({m("a", 1000, 2)}), results({m("a", 1400, 2)}), -- +40%
+    results({m("a", 1000, 2)}), results({m("a", 1200, 2)}), -- self: +20%
+    10)
+  assert(find_delta(at_boundary, "a").verdict == "noise",
+    "40% regression at exactly K*20% must reclassify, got " ..
+    find_delta(at_boundary, "a").verdict)
+
+  local over_boundary = compare.triage(
+    results({m("a", 1000, 2)}), results({m("a", 1410, 2)}), -- +41%
+    results({m("a", 1000, 2)}), results({m("a", 1200, 2)}), -- self: +20%
+    10)
+  assert(find_delta(over_boundary, "a").verdict == "regression",
+    "41% regression just past K*20% must stay regression, got " ..
+    find_delta(over_boundary, "a").verdict)
+end
+test_triage_k_factor_boundary()
 
 local function test_triage_only_touches_regressions()
   -- "a" is a noisy regression -> noise; "b" is ok in the main diff even

--- a/_perf/gate_test.tl
+++ b/_perf/gate_test.tl
@@ -70,6 +70,12 @@ end
 test_flagged_regression_retries_then_passes()
 
 local function test_persistent_regression_triaged_as_noise_passes()
+  -- The +30% regression and the A/A control's ~+38% swing are
+  -- COMPARABLE magnitudes (30% is well within TRIAGE_K=2 * 38%), which
+  -- is what makes this reclassification legitimate rather than a
+  -- magnitude-blind wave-through -- see
+  -- test_large_regression_survives_unstable_selfcheck_and_fails below
+  -- for the case where the sizes do NOT match and it must still fail.
   local base, cur, selfb = paths("noise")
   write_results(base, 1000)
   write_results(cur, 1300)
@@ -90,6 +96,36 @@ local function test_persistent_regression_triaged_as_noise_passes()
   assert(calls == 2, "expected re-measure + selfcheck-b, got " .. calls)
 end
 test_persistent_regression_triaged_as_noise_passes()
+
+-- Magnitude-blindness was the bug: a scenario's A/A self-check clearing
+-- the bar used to wave through ANY regression there, even one far
+-- larger than the self-check swing itself. A +300% regression must
+-- still fail even though this scenario's A/A control is measurably
+-- unstable (+30%) -- the instability just isn't big enough to explain
+-- the regression.
+local function test_large_regression_survives_unstable_selfcheck_and_fails()
+  local base, cur, selfb = paths("large-unstable")
+  write_results(base, 1000)
+  write_results(cur, 4000) -- +300%
+  local calls = 0
+  local code = gate.gate({
+      baseline = base, current = cur, selfcheck_b = selfb, threshold = 10,
+      measure = function(out: string): integer
+        calls = calls + 1
+        if calls == 1 then
+          write_results(out, 4000) -- regression persists on re-measurement
+        else
+          write_results(out, 5200) -- A/A control swings +30%: unstable, but
+          -- nowhere near +300%
+        end
+        return 0
+      end,
+    })
+  assert(code == 1,
+    "a regression far larger than the self-check swing must still fail, got " .. code)
+  assert(calls == 2, "expected re-measure + selfcheck-b, got " .. calls)
+end
+test_large_regression_survives_unstable_selfcheck_and_fails()
 
 local function test_real_regression_survives_triage_and_fails()
   local base, cur, selfb = paths("real")

--- a/_perf/optimize/measurement.md
+++ b/_perf/optimize/measurement.md
@@ -31,10 +31,14 @@ chapter of `_perf/OPTIMIZE.md` — read that first.
   `json_decode_*` reproduced at ~-30% while `hash`/`startup_*` tripped
   the bar only on variance an A/A control also shows.
 - the reclassification is deliberately conservative: it only ever
-  downgrades a `regression`, and only when the current binary cannot
-  reproduce that scenario's timing against itself. a real regression in
-  a stable scenario (json, sqlite, codec) has a quiet A/A and stays
-  `regression` — the gate still catches it.
+  downgrades a `regression`, only when the current binary cannot
+  reproduce that scenario's timing against itself, AND only when the
+  regression's own size is comparable to that self-check swing (within
+  2x — `TRIAGE_K` in `_perf/compare.tl`). instability alone is not a
+  blank check: a scenario whose A/A wobbles 5% does not excuse a +300%
+  regression, so a real regression in a stable scenario (json, sqlite,
+  codec) — or a huge one in an unstable scenario — has nowhere to hide
+  and stays `regression`.
 - `gate.lua selfcheck` runs the same A/A control on demand, for
   interactive use or to profile the machine's noise floor before you
   start. `--only <name>` narrows it to one

--- a/_perf/perf_test.tl
+++ b/_perf/perf_test.tl
@@ -2,22 +2,39 @@
 -- scenario must define a functional check, carry a unique name, and pass
 -- end to end with tiny settings. This keeps the scenarios from bit-rotting
 -- and enforces the no-check-no-benchmark guardrail in CI.
+--
+-- The module list is DERIVED from _perf/bench/*_bench.tl rather than
+-- hardcoded: a hardcoded list silently stops covering a new bench module
+-- (add one, forget to list it, no check-presence ratchet ever runs it).
 
+local fs = require("cosmic.fs")
 local harness = require("_perf.harness")
 local pt = require("_perf.perf_types")
 
-local MODULES = {
-  "_perf.bench.json_bench",
-  "_perf.bench.sqlite_bench",
-  "_perf.bench.http_bench",
-  "_perf.bench.fs_bench",
-  "_perf.bench.micro_bench",
-  "_perf.bench.startup_bench",
-}
+local BENCH_DIR = "_perf/bench"
+
+--- List every bench module under BENCH_DIR as a require()-able name.
+--- @return {string} Sorted module names, e.g. "_perf.bench.json_bench"
+local function discover_modules(): {string}
+  local paths, err = fs.glob(BENCH_DIR, "*_bench.tl")
+  if paths == nil then
+    error("cannot list " .. BENCH_DIR .. ": " .. tostring(err))
+  end
+  local names: {string} = {}
+  for _, p in ipairs(paths as {string}) do -- cast: narrowed by the nil guard above
+    local stem = fs.splitext(fs.basename(p))
+    table.insert(names, "_perf.bench." .. stem)
+  end
+  table.sort(names)
+  return names
+end
+
+local MODULES = discover_modules()
 
 local SMOKE: pt.Options = {samples = 2, min_sample_secs = 0.001}
 
 local function test_all_scenarios_pass()
+  assert(#MODULES > 0, "no bench modules discovered under " .. BENCH_DIR)
   local seen: {string: boolean} = {}
   for _, name in ipairs(MODULES) do
     local ok, mod = pcall(require, name)

--- a/_perf/perf_types.tl
+++ b/_perf/perf_types.tl
@@ -70,9 +70,14 @@ local record perf_types
 
   --- One row of a baseline-vs-current comparison.
   --- verdict is one of: "ok", "faster", "regression", "noise", "new",
-  --- "missing", "error". "noise" is a regression that an A/A self-check
-  --- reclassified as run-to-run variance (see compare.triage); it does
-  --- not fail the gate. noise_pct is the bar a delta must clear to count
+  --- "missing", "error", "baseline-error", "malformed". "noise" is a
+  --- regression that an A/A self-check reclassified as run-to-run
+  --- variance (see compare.triage); it does not fail the gate.
+  --- "baseline-error" is a scenario whose BASELINE row itself recorded
+  --- an error (unlike "new", which is a scenario absent from the
+  --- baseline entirely) — it fails the gate the same as "missing".
+  --- "malformed" is a row with neither an error nor a wall_ns, which
+  --- cannot be diffed. noise_pct is the bar a delta must clear to count
   --- as real: max(threshold, baseline spread, current spread).
   record Delta
     name: string

--- a/_perf/run.tl
+++ b/_perf/run.tl
@@ -182,6 +182,7 @@ local function run_benches(a: Args): integer
   local opts: pt.Options = {samples = a.samples, min_sample_secs = a.min_secs}
   local all: {pt.Measurement} = {}
   local failed = false
+  local matched = 0
   for _, name in ipairs(a.positional) do
     local mod, merr = load_module(name)
     if mod == nil then
@@ -190,29 +191,43 @@ local function run_benches(a: Args): integer
     end
     local scenarios, serr = mod.scenarios()
     if scenarios == nil then
+      -- A module that fails to build its scenario list is exactly as
+      -- unusable as one that fails to require() -- both abort the run
+      -- rather than silently skipping the module and reporting on
+      -- whatever else happened to load.
       io.stderr:write(name .. ": scenarios: " .. tostring(serr) .. "\n")
-      failed = true
-    else
-      for _, s in ipairs(scenarios) do
-        -- SUBSTRING, plainly. A scenario name is `hash_sha256_small`,
-        -- `startup_run_*`, `net_ip_*` -- full of characters a Lua
-        -- pattern reads as syntax, so `--only startup_run_*` as a
-        -- pattern silently means "startup_ru" followed by any number of
-        -- `n`, and matches things the user did not ask for while
-        -- looking like it worked.
-        if a.only == nil or s.name:find(a.only, 1, true) then
-          local m = harness.run_scenario(s, opts)
-          print(harness.format_line(m))
-          table.insert(all, m)
-          if m.error then
-            failed = true
-          end
+      if mod.cleanup then
+        pcall(mod.cleanup)
+      end
+      return 1
+    end
+    for _, s in ipairs(scenarios) do
+      -- SUBSTRING, plainly. A scenario name is `hash_sha256_small`,
+      -- `startup_run_*`, `net_ip_*` -- full of characters a Lua
+      -- pattern reads as syntax, so `--only startup_run_*` as a
+      -- pattern silently means "startup_ru" followed by any number of
+      -- `n`, and matches things the user did not ask for while
+      -- looking like it worked.
+      if a.only == nil or s.name:find(a.only, 1, true) then
+        matched = matched + 1
+        local m = harness.run_scenario(s, opts)
+        print(harness.format_line(m))
+        table.insert(all, m)
+        if m.error then
+          failed = true
         end
       end
     end
     if mod.cleanup then
       pcall(mod.cleanup)
     end
+  end
+  if a.only and matched == 0 then
+    -- A typo'd --only that matches nothing used to exit 0 with an empty
+    -- results file -- a silently-empty comparison later, not an error
+    -- now.
+    io.stderr:write("--only " .. a.only .. " matched nothing\n")
+    return 1
   end
   if a.out then
     local payload: pt.Results = {

--- a/_perf/run_test.tl
+++ b/_perf/run_test.tl
@@ -65,4 +65,51 @@ local function test_load_module_validates()
 end
 test_load_module_validates()
 
+-- An --only that matches zero scenarios used to exit 0 and write an
+-- empty results file -- a comparison later would silently see nothing
+-- rather than a mistyped filter. It must be an error now.
+local function test_only_matching_nothing_errors()
+  local code = run.main("--samples", "2", "--min-secs", "0.001",
+    "--only", "zzz_no_such_scenario_xyz", "_perf.bench.json_bench")
+  assert(code == 1, "--only matching nothing must error, got " .. code)
+end
+test_only_matching_nothing_errors()
+
+-- The matching case must keep working: this is what confirms the fix
+-- above checks the FILTERED count, not the total scenario count.
+local function test_only_matching_something_still_succeeds()
+  local code = run.main("--samples", "2", "--min-secs", "0.001",
+    "--only", "json", "_perf.bench.json_bench")
+  assert(code == 0, "a matching --only must still succeed, got " .. code)
+end
+test_only_matching_something_still_succeeds()
+
+-- A module whose scenarios() call fails must abort the run exactly like
+-- a module that fails to require() -- not skip past it and report on
+-- whatever other modules happened to load. package.loaded is seeded
+-- directly so this needs no on-disk fixture module.
+local function test_scenarios_failure_aborts_before_later_modules()
+  local later_called = false
+  package.loaded["_perf.testdata.bad_scenarios_fixture"] = {
+    scenarios = function(): {any}, string
+      return nil, "boom"
+    end,
+    cleanup = function() end,
+  }
+  package.loaded["_perf.testdata.later_fixture"] = {
+    scenarios = function(): {any}, string
+      later_called = true
+      return {}
+    end,
+    cleanup = function() end,
+  }
+  local code = run.main("--samples", "2", "--min-secs", "0.001",
+    "_perf.testdata.bad_scenarios_fixture", "_perf.testdata.later_fixture")
+  assert(code == 1, "a scenarios() failure must abort the run, got " .. code)
+  assert(not later_called, "abort must happen before later modules run")
+  package.loaded["_perf.testdata.bad_scenarios_fixture"] = nil
+  package.loaded["_perf.testdata.later_fixture"] = nil
+end
+test_scenarios_failure_aborts_before_later_modules()
+
 print("OK run_test")


### PR DESCRIPTION
Five fixes to `_perf/compare.tl`, `_perf/gate.tl`'s companions, and `_perf/run.tl`. Two are **deliberate pin changes** to test-pinned behavior, called out below.

- `_perf/compare.tl:112-129` (`triage`) — the A/A self-check reclassification was magnitude-blind: once a scenario's self-check swing cleared the noise bar, *any* regression on that scenario reclassified to `"noise"`, even one many times larger than the self-check swing (a 5% self-check wobble could wave through a +300% regression). Now bounded by a K-factor: a regression only reclassifies when `|regression delta| <= max(bar, TRIAGE_K * |self-check delta|)`, `TRIAGE_K = 2`, documented at its definition in `compare.tl` and in `_perf/optimize/measurement.md`. **Deliberate pin change**: `compare_test.tl` and `gate_test.tl` are updated; new tests (`test_triage_large_regression_in_unstable_scenario_still_fails`, `test_triage_k_factor_boundary`, `test_large_regression_survives_unstable_selfcheck_and_fails`) prove a large regression in an unstable scenario still fails the gate. The two previously-passing "reclassifies to noise" tests keep their assertions unchanged — their regression and self-check magnitudes were already comparable, so K=2 still reclassifies them; I added comments explaining why.
- `_perf/compare.tl:61-63,86` — a scenario whose **baseline row itself errored** was treated as `"new"` (never gated) rather than a failure, so a broken scenario could stay broken indefinitely until someone happened to refresh the baseline. Changed to a failing verdict, `"baseline-error"`, counted like `"missing"` — implementing the failing-verdict option named in the finding rather than the "keep non-failing but warn loudly" alternative (a warning above an otherwise-clean report reads as informational and gets read past). **Deliberate pin change**: `test_errored_baseline_treated_as_new` became `test_errored_baseline_is_a_failure`; a new `test_truly_new_scenario_is_not_a_failure` isolates the case that must stay `"new"` (baseline row absent entirely, not baseline row errored).
- `_perf/compare.tl:66-69` — `c.wall_ns` nil without `c.error` fell through to `c.wall_ns - b.wall_ns` and threw on malformed input. Both a malformed current row and a malformed baseline row now get a clean, failing `"malformed"` verdict instead of throwing.
- `_perf/perf_test.tl:9-16` — the smoke test's `MODULES` list was hardcoded to 6 of the 11 modules under `_perf/bench/`; `child_bench`, `embed_bench`, `embed_startup_bench`, `fuzzy_bench`, `stream_bench`, and `time_bench` were never smoke-tested. Now derived via `fs.glob("_perf/bench", "*_bench.tl")`, so a new bench module is automatically covered.
- `_perf/run.tl:199-206` — an `--only` filter matching zero scenarios across every given module used to exit 0 and write an empty (but well-formed) results file, so a typo'd filter looked like a clean, empty comparison later instead of the mistake it was. Now an error (`"--only SUB matched nothing"`). Also fixed the noted asymmetry: a module whose `scenarios()` call failed used to be skipped (set `failed=true`, continue to the next module) while a module that failed to `require()` aborted the whole run immediately — `scenarios()` failure now aborts the same way, before any later module runs. Covered by a `package.loaded`-stubbed test (no on-disk fixture module needed).

`compare.diff`'s summary line (`format()`) now also counts `baseline-error` and `malformed` verdicts; `perf_types.tl`'s `Delta.verdict` doc comment lists all 9 verdicts.

The identity-refusal and retry logic in `compare.tl`/`gate.tl` (same-binary refusal, cross-binary A/A refusal, retry-then-A/A-triage flow) was read in full and is untouched.

**ci verdict**: `ci: PASS (6 stages)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbwKidxrrbN2PffXxSFvCE)_