### PR TITLE
test: gate fixpoint_test behind COSMIC_FIXPOINT=1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -452,6 +452,9 @@ test_something()
 
 each test gets its own temp directory via `TEST_TMPDIR`.
 
+`_make/fixpoint_test.tl` (two full builds) is gated: run it with
+`COSMIC_FIXPOINT=1 bin/cosmic --make test _make/fixpoint_test.tl`.
+
 ## Performance
 
 `_perf` holds the scenario harness: end-to-end scenarios (JSON, SQLite,

--- a/_make/fixpoint_test.tl
+++ b/_make/fixpoint_test.tl
@@ -15,6 +15,19 @@
 -- bytes behind as dead space, so each generation grows ~3.5 MB (12.2 ->
 -- 15.8 -> 19.3, measured) while every generation boots fine. Only
 -- comparing two of them says so.
+--
+-- Gated behind COSMIC_FIXPOINT=1: two full `--make build`s cost ~83s,
+-- more than every other test combined, and paying that on each `--make
+-- test` (and twice per `--make ci`, since coverage runs the tests
+-- again) taxed every developer loop for claims CI already asserts per
+-- push on the REAL artifact: pr.yml's build lane cmp's a second build
+-- (convergence, which catches the growth bug above) and a clean-tree
+-- rebuild at another path (cold buildability, reproducibility), and
+-- the converged gate plus the smoke lane exercise the product. What
+-- stays unique here is the one-command version of the whole story --
+-- run it when touching the artifact pipeline (_make/artifact,
+-- embed_gen, base selection):
+-- `COSMIC_FIXPOINT=1 bin/cosmic --make test _make/fixpoint_test.tl`.
 
 local check = require("cosmic.check")
 local fs = require("cosmic.fs")
@@ -164,6 +177,17 @@ local function generation(label: string, with: string): string
   local built = fs.join(dir, "o/bin/cosmic")
   assert(fs.isfile(built), label .. ": no artifact at o/bin/cosmic:\n" .. out)
   return built
+end
+
+-- Opt-in: this test builds the repo twice (~83s), so it stays out of
+-- the default `--make test` / `--make ci` run; the header names the CI
+-- steps that assert the same claims per push. `check.needs` is wrong
+-- here -- it hard-fails when `CI` is set, and the gate lane runs in CI
+-- and must be able to skip this test rather than fail on its absence.
+if os.getenv("COSMIC_FIXPOINT") ~= "1" then
+  print("skip: COSMIC_FIXPOINT=1 not set (this test runs two full " ..
+    "builds; opt in when touching the artifact pipeline)")
+  os.exit(check.EXIT_SKIP)
 end
 
 -- Both halves need the pinned inputs. Skipping when they are absent


### PR DESCRIPTION
PR 1 of 4 in a build/test-performance series (each lands in sequence; the next stacks on this one).

## Why

`_make/fixpoint_test.tl` runs two full `--make build`s from fresh tree copies. Measured on a 4-core machine:

- 83s of a 157s (summed) `--make test` run — more than every other test combined, and ~100% of the stage's wall-clock critical path (next-slowest test: 13.6s);
- ~207s of the 413s CI gate, because `ci` runs the suite twice (test, then coverage — instrumented, it takes 119s).

Its claims are already asserted per push on the real artifact, which is why this gates the test rather than adding a lane for it:

- pr.yml's `build` lane `cmp`s a second build (convergence — the growth failure this test's header documents) and rebuilds a clean tree at another path (cold buildability, reproducibility);
- the converged gate plus the `smoke` lane exercise the product (compiler, checker + types payload, engine, `--docs`);
- release.yml runs the entire gate under the binary being released, plus a `--version` check.

## What

- The test skips unless `COSMIC_FIXPOINT=1` (plain env check + `EXIT_SKIP`; `check.needs` is deliberately not used — it hard-fails under `CI`, and the gate lane must be able to skip this test in CI).
- It stays in the tree as the one-command local proof for artifact-pipeline work (`_make/artifact`, `embed_gen`, base selection): `COSMIC_FIXPOINT=1 bin/cosmic --make test _make/fixpoint_test.tl`.
- Documented in AGENTS.md.

## Validation

- Default run → `0 passed, 1 skipped`, stage PASS; `COSMIC_FIXPOINT=1` run → `1 passed`.
- Full `bin/cosmic --make ci` → `ci: PASS`, coverage ratchet clean (no floor rows moved).
- `_build/workflows_test.tl` green.

Expected effect: local `--make test` wall time 84s → ~20s; the CI gate loses its two 83–119s fixpoint runs (~3.5min of a 6m53s gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Ukw9dxadTMm3aVG2A53b