### PR TITLE
ci: run tests once, instrumented — the coverage lane is the test run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,7 +240,7 @@ the project, and a file's position and name say what it is.
 
 ```bash
 bin/cosmic --make fetch     # resolve *_pin.tl — the only verb with a network
-bin/cosmic --make ci        # fmt, check, test, example, lint, coverage
+bin/cosmic --make ci        # fmt, check, example, lint, coverage
 bin/cosmic --make test      # …or one stage; add paths to narrow it
 bin/cosmic --make build     # just the binaries
 bin/cosmic --make clean     # remove o/
@@ -482,16 +482,16 @@ discipline). the backlog is GitHub issues labeled `perf`.
 ## CI
 
 - **pr.yml**: three lanes on push/PR to main. `ci` fetches with a network, then builds
-  and runs the whole gate (fmt, check, test, example, lint, coverage) inside a loopback-
-  only network namespace, so a stray download fails loudly. It builds first and gates
-  with the RESULT, or the six stages would report on the pinned release instead of the
-  change. `build` does what needs a real network: double-build reproducibility (two tree
-  paths) and `--make fetch` against the real pins. Both Linux lanes are privileged and
-  non-root: `_cli/fence_test.tl` asserts a real Landlock denial, the quicksand tests
-  unshare and mount. `smoke` runs the built binary on real macOS/Windows runners. The
-  fence is ON by default (`COSMIC_FENCE=0` opts out); the build lane asserts the host
-  can enforce and that a real build passes fenced — the direction a denial test cannot
-  prove
+  and runs the whole gate (fmt, check, example, lint, coverage) inside a loopback-only
+  network namespace, so a stray download fails loudly — tests run once, instrumented, via
+  the coverage stage's ratchet. It builds first and gates with the RESULT, or the five
+  stages would report on the pinned release instead of the change. `build` does what
+  needs a real network: double-build reproducibility (two tree paths) and `--make fetch`
+  against the real pins. Both Linux lanes are privileged and non-root: `_cli/fence_test.tl`
+  asserts a real Landlock denial, the quicksand tests unshare and mount. `smoke` runs the
+  built binary on real macOS/Windows runners. The fence is ON by default
+  (`COSMIC_FENCE=0` opts out); the build lane asserts the host can enforce and that a
+  real build passes fenced — the direction a denial test cannot prove
 - **docs.yml**: `--make docs` then `_docs/publish.tl`, to the `docs`
   branch on push to main
 - **release.yml**: daily release, built twice — the pinned cosmic builds

--- a/_make/fixpoint_test.tl
+++ b/_make/fixpoint_test.tl
@@ -18,15 +18,15 @@
 --
 -- Gated behind COSMIC_FIXPOINT=1: two full `--make build`s cost ~83s,
 -- more than every other test combined, and paying that on each `--make
--- test` (and twice per `--make ci`, since coverage runs the tests
--- again) taxed every developer loop for claims CI already asserts per
--- push on the REAL artifact: pr.yml's build lane cmp's a second build
--- (convergence, which catches the growth bug above) and a clean-tree
--- rebuild at another path (cold buildability, reproducibility), and
--- the converged gate plus the smoke lane exercise the product. What
--- stays unique here is the one-command version of the whole story --
--- run it when touching the artifact pipeline (_make/artifact,
--- embed_gen, base selection):
+-- test` (and again in `--make ci`'s coverage stage, the one
+-- instrumented test run) taxed every developer loop for claims CI
+-- already asserts per push on the REAL artifact: pr.yml's build lane
+-- cmp's a second build (convergence, which catches the growth bug
+-- above) and a clean-tree rebuild at another path (cold buildability,
+-- reproducibility), and the converged gate plus the smoke lane
+-- exercise the product. What stays unique here is the one-command
+-- version of the whole story -- run it when touching the artifact
+-- pipeline (_make/artifact, embed_gen, base selection):
 -- `COSMIC_FIXPOINT=1 bin/cosmic --make test _make/fixpoint_test.tl`.
 
 local check = require("cosmic.check")

--- a/_make/init.tl
+++ b/_make/init.tl
@@ -276,8 +276,9 @@ local VERBS < const >: {Verb} = {
   -- gets a verb rather than folding into `check` because its file set
   -- is the whole tree, not the compiled closure. Naming them is what
   -- lets `ci` below be a list of verb names: its pipeline is
-  -- fmt -> check -> test -> example -> lint -> coverage, and every one
-  -- of those six is a verb in this registry.
+  -- fmt -> check -> example -> lint -> coverage (tests run once,
+  -- instrumented, inside coverage), and every one of those five is a
+  -- verb in this registry.
   {name = "example", target = "example", select = stage.SELECTS.example,
     run = function(proj: Project, paths: {string}, cosmic: string): integer
       -- cast: the registry defines it

--- a/_make/policy.tl
+++ b/_make/policy.tl
@@ -1,13 +1,13 @@
 --- The policy verbs: `coverage` and `ci`.
 ---
 --- Orchestration over the graph, never graph rules. `coverage` runs the
---- test lane a second time with collection on and then gates the result
---- against a committed floor; `ci` is a fixed order of other verbs.
+--- test lane with collection on and then gates the result against a
+--- committed floor; `ci` is a fixed order of other verbs.
 ---
 --- Both are gated by MATERIAL rather than by configuration: a project
---- with no tests has no test stage, one with no committed baseline gets
---- no ratchet, and neither is an error. Zero configuration, and a fresh
---- project does not fail on a stage that had nothing to do.
+--- with no tests has no coverage stage, one with no committed baseline
+--- gets no ratchet, and neither is an error. Zero configuration, and a
+--- fresh project does not fail on a stage that had nothing to do.
 
 local baseline = require("cosmic.coverage.baseline")
 local fs = require("cosmic.fs")
@@ -176,10 +176,19 @@ end
 --- claims to run. There is no separate model stage: validating the
 --- project is what `check` opens with, so `ci` gets it by listing
 --- `check`.
+---
+--- No separate `test` stage: `coverage` runs the identical test recipe
+--- with collection on, and its ratchet summary passes or fails exactly
+--- the way a plain test run would, so a failing test still fails `ci`
+--- through `coverage`. Running the suite twice — once plain, once
+--- instrumented — bought `ci` nothing but wall-clock: measured, 157s
+--- summed for the plain lane against 351s for the instrumented one,
+--- pure duplication inside the gate. `--make test` standalone is
+--- untouched — it is still the fast, uninstrumented developer loop —
+--- this only drops the plain lane's second run inside `ci`.
 local STAGES < const >: {Stage} = {
   {verb = "fmt", needs = {}},
   {verb = "check", needs = {}},
-  {verb = "test", needs = {"test"}},
   {verb = "example", needs = {"example"}},
   {verb = "lint", needs = {}},
   {verb = "coverage", needs = {"test"}},

--- a/_make/policy_test.tl
+++ b/_make/policy_test.tl
@@ -60,7 +60,7 @@ local function test_stage_order_is_the_documented_pipeline()
   for _, s in ipairs(policy.STAGES) do
     names[#names + 1] = s.verb
   end
-  assert(table.concat(names, " ") == "fmt check test example lint coverage",
+  assert(table.concat(names, " ") == "fmt check example lint coverage",
     "got: " .. table.concat(names, " "))
 end
 test_stage_order_is_the_documented_pipeline()
@@ -83,7 +83,7 @@ local function test_material_earns_the_stage()
   local code = policy.run_ci(stub.lookup, project_of({"module", "test", "example"}),
     {}, "cosmic")
   assert(code == 0, "got " .. code)
-  assert(table.concat(stub.ran, " ") == "fmt check test example lint coverage",
+  assert(table.concat(stub.ran, " ") == "fmt check example lint coverage",
     "got: " .. table.concat(stub.ran, " "))
 end
 test_material_earns_the_stage()

--- a/docs/build.md
+++ b/docs/build.md
@@ -5,7 +5,7 @@
 ```bash
 bin/cosmic --make fetch     # resolve *_pin.tl — the only verb with a network
 bin/cosmic --make build     # o/bin/cosmic and o/bin/cosmic-debug
-bin/cosmic --make ci        # fmt, check, test, example, lint, coverage
+bin/cosmic --make ci        # fmt, check, example, lint, coverage
 bin/cosmic --make clean     # remove o/
 bin/cosmic --make help      # every verb, and which are still planned
 ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -26,7 +26,8 @@ Everything after runs under that pin. All build artifacts go to `o/`.
    Or one stage at a time: `--make fmt`, `--make check`, `--make test`.
 4. open a PR against `main`
 
-CI runs the same `--make ci`: fmt, check, test, example, lint, coverage.
+CI runs the same `--make ci`: fmt, check, example, lint, coverage — tests
+run once, instrumented, in the coverage stage.
 
 ## Writing a Module
 

--- a/docs/design/make/README.md
+++ b/docs/design/make/README.md
@@ -53,7 +53,7 @@ what ships. Dropped whole in 2a; the fuller account is in
 $ cosmic --make build          # strict check, compile, stage, embed → o/bin/myapp
 $ cosmic --make test           # tests, fenced, against the staged tree
 $ cosmic --make fetch          # the only verb that touches the network
-$ cosmic --make ci             # fmt → check → test → example → lint → coverage
+$ cosmic --make ci             # fmt → check → example → lint → coverage
 ```
 
 Two sentences carry most of the design:

--- a/docs/design/make/payload.md
+++ b/docs/design/make/payload.md
@@ -71,6 +71,7 @@ version, and runs `--make check` — on a tree it did not build, with
 nothing on the host but itself. `_make/fixpoint_test.tl` gates both
 halves in CI.
 
-`--make ci` owns the gate now: fmt, check, test, example, lint,
-coverage. What is still a workflow step rather than a verb — enforce,
-reproducible, offline — the design puts in phase 4.
+`--make ci` owns the gate now: fmt, check, example, lint, coverage —
+tests run once, instrumented, inside coverage. What is still a workflow
+step rather than a verb — enforce, reproducible, offline — the design
+puts in phase 4.

--- a/docs/design/make/verbs.md
+++ b/docs/design/make/verbs.md
@@ -44,7 +44,7 @@ costs a walk instead of a rebuild.
 **Policy verbs** — orchestration over the graph, never graph rules.
 
 ```
-ci              fmt → check → test → example → lint → coverage        [now]
+ci              fmt → check → example → lint → coverage               [now]
 coverage        tests with line coverage + ratchet                    [now]
 docs  [paths…]  render the model's file set to o/docs                 [now]
 enforce         sandbox-enforced lane                             [planned]
@@ -54,13 +54,19 @@ offline         no-network lane, asserted against the pins        [planned]
 
 `example` and `lint` are verbs in their own right (above), so
 `ci` is a list of verb names rather than a lane reimplementing two of
-its six stages. `example` is `test`'s sibling — same staging, same
+its five stages. `example` is `test`'s sibling — same staging, same
 fence, `Example_*` instead of the test contract — which is what the
 model already says everywhere else. `lint` stays out of `check`: its
-file set is the whole tree, not the compiled closure.
+file set is the whole tree, not the compiled closure. There is no
+separate `test` stage in `ci`: `coverage` runs the same test recipe
+with collection on, and its ratchet summary passes or fails a failing
+test the same way a plain run would, so a second, uninstrumented pass
+bought the gate nothing but wall-clock (measured: 157s summed for the
+plain lane against 351s for the instrumented one). `--make test` alone
+is unchanged — it stays the fast, uninstrumented developer loop.
 
 `ci` is a fixed order with **each stage gated by whether the project has
-material for it** — no tests, no test stage; no committed coverage
+material for it** — no tests, no coverage stage; no committed coverage
 baseline, no ratchet. Zero configuration, and a fresh project doesn't
 fail on a stage that had nothing to do. (A baseline is *input* data, so
 it stays committed; only generated things are banned from the tree.)

--- a/skills/cosmic/make.md
+++ b/skills/cosmic/make.md
@@ -33,7 +33,7 @@ replaced it outright.
 | `benchmark` | run every `*_benchmark.tl` | ✅ |
 | `coverage` | tests + line coverage, ratcheted against `.cosmic-coverage` | ✅ |
 | `docs` | extract the doc index | ✅ |
-| `ci` | fmt, check, test, example, lint, coverage — the gate | ✅ |
+| `ci` | fmt, check, example, lint, coverage — the gate; tests run once, instrumented, in `coverage` | ✅ |
 | `clean` | remove `o/`, sparing `o/bootstrap` | ✅ |
 | `fetch` | resolve `*_pin.tl` — the only verb with a network | ✅ |
 | `help` | list the verbs, and which are still planned | ✅ |
@@ -76,7 +76,7 @@ build: PASS (377 files, 1 binary)
 make: root=/home/you/cosmic        # ← the re-exec, now under the new binary
 fmt: PASS (377 files)
 ...
-ci: PASS (6 stages)
+ci: PASS (5 stages)
 ```
 
 it terminates because the build is content-addressed — `o/bin/<name>`


### PR DESCRIPTION
PR 2 of 4 in the build/test-performance series (follows #873).

## Why

`--make ci` ran every test twice: once plain (the `test` stage, 157s summed), once instrumented (the `coverage` stage, `COSMIC_COVERAGE=1`, 351s summed, second output tree). The recipes are byte-identical apart from the env var — the plain run was pure duplication inside the gate, ~91s of CI wall-clock.

## What

- Remove the `{verb = "test", needs = {"test"}}` row from `_make/policy.tl`'s `STAGES`. The gate is now fmt → check → example → lint → coverage; the coverage stage's instrumented run is the one test run, and its summary already gates pass/fail.
- `--make test` standalone is untouched — still the fast, uninstrumented developer loop.
- Doc/comment sweep for the old six-stage listing (AGENTS.md, docs/build.md, docs/contributing.md, docs/design/make/*, skills/cosmic/make.md, pr.yml comments); `_make/policy_test.tl` expectations updated.

## Validation

- `bin/cosmic --make ci` → `ci: PASS (5 stages)`, no `test:` stage line, coverage ratchet ok.
- Failure path proven: a tripwire test appended to `cosmic/uuid_test.tl` made the gate end `coverage: FAIL (1 of 182 files)` → `ci: FAIL (coverage)`; reverted, gate green again.
- `--make test` standalone → `test: PASS (182 files)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Ukw9dxadTMm3aVG2A53b

---
_Generated by [Claude Code](https://claude.ai/code/session_0149Ukw9dxadTMm3aVG2A53b)_