### PR TITLE
check: skip what the graph already proved

### DIFF
--- a/_make/check.tl
+++ b/_make/check.tl
@@ -7,13 +7,26 @@
 --- loop, and one process start per source, to do work this binary
 --- already contains.
 ---
+--- Incremental against the GRAPH, not against itself: a strict compile
+--- type-checks (warnings fail too), so a file whose compiled output is
+--- up to date against the compile rule's own inputs is a check that
+--- already ran. `check` skips those and checks the rest — everything
+--- on a tree that never built, only pins and payload generators right
+--- after a converged gate. See `proved_by_graph` for the exact
+--- freshness question and why it is sound.
+---
 --- Validation comes first and is fatal: a project whose import paths
 --- collide or whose filenames cannot survive a recipe line has problems
 --- the type checker would report as a confusing cascade, or not at all.
 
+local fs = require("cosmic.fs")
+local fs_types = require("cosmic.fs.types")
 local records = require("cosmic.records")
 local teal = require("cosmic.teal")
+local deps = require("_make.deps")
+local project = require("_make.project")
 local selection = require("_make.select")
+local stamp = require("_make.stamp")
 local validate = require("_make.validate")
 local types = require("_make.types")
 
@@ -43,6 +56,66 @@ local checkable: {string: boolean} = {
   ["payload-gen"] = true,
   pin = true,
 }
+
+--- Kinds the GRAPH strict-compiles. For these, an up-to-date compiled
+--- output IS a passed strict check: `--compile-strict` type-checks
+--- (warnings fail, matching `--check types`) and the compile rule's
+--- prerequisites — the source, its import closure, the compile stamp,
+--- the generated-types stamp — are exactly what a check of the same
+--- file reads. `pin` and `payload-gen` are absent because the graph
+--- never compiles them; they are always checked directly.
+local graph_checked: {string: boolean} = {
+  module = true,
+  entry = true,
+  test = true,
+  example = true,
+  benchmark = true,
+  gen = true,
+}
+
+--- Has the graph already proved this file? True when its compiled
+--- output is at least as new as everything its strict compile read:
+--- the source, every source in its import closure (`.d.tl` included —
+--- the SOURCE closure keeps declarations), the compile tool's stamp,
+--- and the generated-types stamp. Any input missing — a tree that has
+--- never built, a check running before any graph verb — answers
+--- false, and the file is checked directly, which is exactly the old
+--- behavior.
+---
+--- Sound for the same reason the incremental build is: mtime
+--- schedules, and the compile rule restamps its output even when the
+--- bytes did not change, so "output not older than every input" means
+--- "a strict compile of these exact inputs succeeded".
+--- @param proj Project The scanned project
+--- @param f File The candidate file
+--- @param by_import {string: {File}} Index from deps.index()
+--- @return boolean True when the check may be skipped
+local function proved_by_graph(proj: Project, f: File,
+    by_import: {string: {File}}): boolean
+  if not graph_checked[f.kind] then
+    return false
+  end
+  local out = fs.stat(deps.built_path(f.path, project.BUILD_DIR))
+  if not out then
+    return false
+  end
+  local bsec, bnsec = (out as fs_types.Stat):mtim() -- cast: mixed-representation Stat
+  local inputs = deps.source_paths(deps.closure(proj, f, by_import))
+  inputs[#inputs + 1] = f.path
+  inputs[#inputs + 1] = stamp.path_of("compile")
+  inputs[#inputs + 1] = fs.join(project.BUILD_DIR, "_types", "types_gen.stamp")
+  for _, p in ipairs(inputs) do
+    local st = fs.stat(p)
+    if not st then
+      return false
+    end
+    local isec, insec = (st as fs_types.Stat):mtim() -- cast: mixed-representation Stat
+    if isec > bsec or (isec == bsec and insec > bnsec) then
+      return false
+    end
+  end
+  return true
+end
 
 --- Does this path select that file? A selection entry is either the
 --- file itself or a directory containing it. Selection itself lives in
@@ -110,7 +183,28 @@ local function run(proj: Project, paths: {string}): integer
   end
 
   local selected = files as {File} -- cast: record union after the guard
-  local failed = check_files(selected)
+  -- The graph's half first: a file whose strict compile is up to date
+  -- against the same inputs is already checked, so re-deriving the
+  -- answer in process is pure duplication — measured at 2m40s of a
+  -- 2m16s no-op `--make ci` before this skip existed. Gate verbs
+  -- converge before they run, so on a just-built tree this leaves the
+  -- kinds the graph never compiles (pins, payload generators) plus
+  -- whatever actually changed.
+  local by_import = deps.index(proj)
+  local to_check: {File} = {}
+  local proved = 0
+  for _, f in ipairs(selected) do
+    if proved_by_graph(proj, f, by_import) then
+      proved = proved + 1
+    else
+      to_check[#to_check + 1] = f
+    end
+  end
+  if proved > 0 then
+    io.write("check: " .. proved .. " of " .. #selected ..
+      " already proved by their strict compile\n")
+  end
+  local failed = check_files(to_check)
   return records.verdict("check", failed == 0,
     records.detail(failed, #selected, "file"))
 end
@@ -118,11 +212,14 @@ end
 local record CheckModule
   run: function(proj: Project, paths: {string}): integer
   select_files: function(proj: Project, paths: {string}): {File} | nil, string
+  proved_by_graph: function(proj: Project, f: File,
+  by_import: {string: {File}}): boolean
 end
 
 local M: CheckModule = {
   run = run,
   select_files = select_files,
+  proved_by_graph = proved_by_graph,
 }
 
 return M

--- a/_make/check_test.tl
+++ b/_make/check_test.tl
@@ -16,8 +16,12 @@ local check = require("cosmic.check")
 local cenv = require("cosmic.env")
 local fs = require("cosmic.fs")
 local mcheck = require("_make.check")
+local mdeps = require("_make.deps")
 local mfetch = require("_make.fetch")
 local mk = require("_make")
+local mtypes = require("_make.types")
+
+local type File = mtypes.File
 local spawn = require("cosmic.child")
 
 local cosmic = fs.abspath(fs.join(os.getenv("TEST_BIN"), "cosmic"))
@@ -411,5 +415,74 @@ local function test_make_equals_form_keeps_its_selection()
     "the path reached the selection, not dropped: " .. out)
 end
 test_make_equals_form_keeps_its_selection()
+
+-- The graph's proof is honored exactly. A compiled output as new as
+-- the source, its closure, and both tool stamps skips the check; any
+-- input moving past it un-proves it; and a kind the graph never
+-- compiles is never proved. Mtimes are set explicitly -- this is the
+-- freshness QUESTION under test, not the graph that normally answers it.
+local function test_the_graph_proof_and_what_unmakes_it()
+  local root = fixture("proved", {
+      ["db/init.tl"] = "return {}\n",
+      ["3p/dep/dep_pin.tl"] = "return { version = \"1\" }\n",
+    })
+  local proj = check.must(mk.scan(root))
+  local cwd = check.must(fs.getcwd())
+  assert(fs.chdir(root))
+  for _, rel in ipairs({"o/db/init.lua", "o/3p/dep/dep_pin.lua",
+      "o/.stamp/compile", "o/_types/types_gen.stamp"}) do
+    assert(fs.makedirs(fs.dirname(rel)))
+    assert(fs.write(rel, "x\n"))
+    assert(fs.utimensat(rel, 1000, 0, 1000, 0))
+  end
+  assert(fs.utimensat("db/init.tl", 500, 0, 500, 0))
+  local by_import = mdeps.index(proj)
+  local db: File = nil
+  local pin: File = nil
+  for _, f in ipairs(proj.files) do
+    if f.path == "db/init.tl" then db = f end
+    if f.path == "3p/dep/dep_pin.tl" then pin = f end
+  end
+  assert(mcheck.proved_by_graph(proj, db, by_import),
+    "a fresh compile proves the check")
+  assert(not mcheck.proved_by_graph(proj, pin, by_import),
+    "a pin is never graph-proved: the graph never compiles it")
+  assert(fs.utimensat("db/init.tl", 2000, 0, 2000, 0))
+  assert(not mcheck.proved_by_graph(proj, db, by_import),
+    "a source newer than its output un-proves it")
+  assert(fs.utimensat("db/init.tl", 500, 0, 500, 0))
+  assert(fs.utimensat("o/.stamp/compile", 2000, 0, 2000, 0))
+  assert(not mcheck.proved_by_graph(proj, db, by_import),
+    "a moved compile stamp un-proves every file")
+  assert(fs.chdir(cwd))
+end
+test_the_graph_proof_and_what_unmakes_it()
+
+-- End to end: the skip is real. A type-broken source under a CONCOCTED
+-- fresh output passes -- a state the graph cannot produce (its compile
+-- would have failed), constructed to observe the skip -- and the same
+-- tree fails the moment the source's mtime moves past the proof.
+local function test_check_skips_what_the_graph_proved()
+  local root = fixture("skips", {
+      ["bad.tl"] = "local x: integer = 'nope'\nreturn x\n",
+    })
+  local proj = check.must(mk.scan(root))
+  local cwd = check.must(fs.getcwd())
+  assert(fs.chdir(root))
+  for _, rel in ipairs({"o/bad.lua", "o/.stamp/compile",
+      "o/_types/types_gen.stamp"}) do
+    assert(fs.makedirs(fs.dirname(rel)))
+    assert(fs.write(rel, "x\n"))
+    assert(fs.utimensat(rel, 1000, 0, 1000, 0))
+  end
+  assert(fs.utimensat("bad.tl", 500, 0, 500, 0))
+  assert(mcheck.run(proj, {}) == 0,
+    "a graph-proved file must be skipped, not re-checked")
+  assert(fs.utimensat("bad.tl", 2000, 0, 2000, 0))
+  assert(mcheck.run(proj, {}) == 1,
+    "a source newer than its proof must be checked, and fail")
+  assert(fs.chdir(cwd))
+end
+test_check_skips_what_the_graph_proved()
 
 print("all make check tests passed")


### PR DESCRIPTION
PR 4 of 4 in the build/test-performance series. Stacked on #875 (per-tool stamps) — the compile stamp is one of the freshness inputs here, so this targets that branch and should land after it.

## Why

`--make check` re-derived, in process and single-threaded, an answer the graph already held: `--compile-strict` type-checks with warnings-as-errors ("matching `--check types`", per `cosmic/teal.tl`), so every up-to-date compiled output *is* a passed strict check of exactly the same inputs. Measured: **2m40s** to re-check 396 files on a settled tree — nearly the entire 2m16s no-op `--make ci` floor.

## What

`check` now asks the compile rule's own freshness question per file — output at least as new as the source, its import closure (SOURCE paths, `.d.tl` included), the compile tool stamp (#875), and the generated-types stamp (#872) — and checks directly only what fails it, plus the kinds the graph never compiles (pins, payload generators). Any missing input answers "not proved," so a tree that has never built is checked in full, exactly as before; `check` still needs no make binary.

## Measured

- `--make check`, settled tree: **2m40s → 3.7s** (396 of 399 proved by their strict compile).
- No-op `--make ci`: **2m16s → 7.7s**.
- Full gate: `ci: PASS (5 stages)`, coverage ratchet ok.

## Tests

`proved_by_graph` honors the proof and each way of unmaking it (source newer, compile stamp newer, never-compiled kinds), plus an end-to-end run over a concocted fresh-output/broken-source tree that passes — observing the skip; a state the real graph cannot produce, since its compile would have failed — and fails the moment the source's mtime moves past the proof.

## Series result (all four PRs, measured on a 4-core machine)

| scenario | before | after |
|---|---|---|
| `--make test` (full suite) | 84s | ~20s |
| one-line edit → `--make test` | 2m01s | 8.3s |
| post-build "echo" rebuild | 32s | gone (2.2s no-op) |
| `--make check` (settled) | 2m40s | 3.7s |
| no-op `--make ci` | 2m16s | 7.7s |
| CI gate (cold, projected) | 6m53s | ~2.5–3min |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Ukw9dxadTMm3aVG2A53b

---
_Generated by [Claude Code](https://claude.ai/code/session_0149Ukw9dxadTMm3aVG2A53b)_