### PR TITLE
ci: give each main push its own concurrency group

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,10 +11,13 @@ permissions:
   contents: read
 
 # A superseded PR run answers a question nobody is asking any more.
-# Pushes to main are never cancelled: each commit on main gets its own
-# verdict, and that verdict is the record.
+# Pushes to main are never cancelled AND never queued behind each other:
+# the group is keyed by the commit SHA on a push, so every commit on main
+# gets its own group and runs concurrently with the others, each getting
+# its own verdict as the record. PR runs still share a group per ref and
+# supersede each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
PR 5 in the build/test-performance series (follows #873–#876; this one is independent of the engine changes).

## Why

Pushes to `main` all share one concurrency group (`pr-refs/heads/main`) with `cancel-in-progress: false`, so each run queues behind the previous one. Measured on a real push train (run 30874030122): a run waited ~6.5 minutes in queue — longer than its own work — because three pushes landed within 16 minutes.

## What

Key the group by commit SHA for push events, by ref otherwise:

```yaml
group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
```

Every commit on `main` still gets its own verdict — now concurrently instead of serially. PR behavior is unchanged (ref-keyed group, superseded runs cancelled). `release.yml`'s serialized group is deliberately untouched (one release at a time is the point there).

## Validation

- `_build/workflows_test.tl` → all ratchets pass.
- `--check lint` on pr.yml, YAML parse check, and a full `bin/cosmic --make ci` → `ci: PASS (5 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Ukw9dxadTMm3aVG2A53b

---
_Generated by [Claude Code](https://claude.ai/code/session_0149Ukw9dxadTMm3aVG2A53b)_