### PR TITLE
build: compile and record skip on input bytes, not just mtime

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -5,6 +5,7 @@ _cli/args.tl 0 31
 _cli/build/init.tl 43 47
 _cli/build/modules.tl 46 49
 _cli/build/steps.tl 183 239
+_cli/build/work.tl 145 165
 _cli/check.tl 24 31
 _cli/driver.tl 21 34
 _cli/grants.tl 158 168
@@ -18,7 +19,7 @@ _docs/derive.tl 54 81
 _docs/publish.tl 116 176
 _make/artifact.tl 163 180
 _make/binaries.tl 24 24
-_make/check.tl 51 52
+_make/check.tl 94 96
 _make/clean.tl 28 38
 _make/converge.tl 34 62
 _make/deps.tl 73 73
@@ -178,4 +179,4 @@ cosmic/user.tl 48 61
 cosmic/uuid.tl 9 9
 cosmic/zip.tl 80 93
 tlconfig.lua 7 7
-total 13563 17899
+total 13751 18108

--- a/_cli/build/skip_test.tl
+++ b/_cli/build/skip_test.tl
@@ -1,0 +1,120 @@
+#!/usr/bin/env cosmic
+-- Tests for _cli.build.work's content-keyed skip.
+--
+-- `.in` is written plainly on every REAL run, so its mtime is the
+-- probe these tests read: it moves exactly when the step spawned a
+-- child, and holds exactly when the skip stood in. The output's mtime
+-- moves either way -- that is the restamp make schedules on.
+
+local check = require("cosmic.check")
+local cenv = require("cosmic.env")
+local fs = require("cosmic.fs")
+local work = require("_cli.build.work")
+
+local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
+local cosmic = fs.abspath(fs.join(os.getenv("TEST_BIN") or "o/bin", "cosmic"))
+
+-- The record skip keys the tool stamp the graph writes; without a
+-- built tree there is nothing to key against and nothing to test.
+if not check.needs("a built cosmic at " .. cosmic, fs.isfile(cosmic)) then
+  os.exit(check.EXIT_SKIP)
+end
+if not check.needs("the record stamp at o/.stamp/record",
+  fs.isfile("o/.stamp/record")) then
+  os.exit(check.EXIT_SKIP)
+end
+
+--- The seconds+nanoseconds of a path, as one comparable string.
+local function mtime_of(path: string): string
+  local sec, nsec = check.must(fs.stat(path)):mtim()
+  return tostring(sec) .. "." .. tostring(nsec)
+end
+
+-- compile: a second run with identical bytes skips (no child, `.in`
+-- untouched, output restamped); a corrupted output or changed source
+-- runs for real (`.in` rewritten); a line with no --deps never keys.
+local function test_compile_skips_and_unskips()
+  local src = fs.join(tmpdir, "skip-src.tl")
+  local out = fs.join(tmpdir, "skip-out.lua")
+  assert(fs.write(src, "return { n = 1 }\n"))
+  local args = {cosmic, src, out, "--deps"}
+  assert(work.compile(args) == 0, "first compile")
+  assert(fs.isfile(out .. ".in"), "a keyed compile records itself")
+  local key1 = mtime_of(out .. ".in")
+  local out1 = mtime_of(out)
+
+  assert(work.compile(args) == 0, "second compile")
+  assert(mtime_of(out .. ".in") == key1,
+    "identical inputs must SKIP: the record must not be rewritten")
+  assert(mtime_of(out) ~= out1,
+    "and the output must be restamped for make")
+
+  assert(fs.write(out, "-- corrupted\n"))
+  assert(work.compile(args) == 0, "recompile over a corrupted output")
+  assert(mtime_of(out .. ".in") ~= key1,
+    "an output that does not match its record must be rebuilt")
+  local body = check.must(fs.read(out))
+  assert(not body:find("corrupted", 1, true), "and really rebuilt")
+
+  local key2 = mtime_of(out .. ".in")
+  assert(fs.write(src, "return { n = 2 }\n"))
+  assert(work.compile(args) == 0, "recompile after a source edit")
+  assert(mtime_of(out .. ".in") ~= key2,
+    "changed source bytes must miss the key")
+
+  local bare_out = fs.join(tmpdir, "skip-bare.lua")
+  assert(work.compile({cosmic, src, bare_out}) == 0, "bare compile")
+  assert(not fs.exists(bare_out .. ".in"),
+    "a line that declares no inputs must not key: the mini-graph " ..
+    "expects a dispatched compile to compile")
+end
+test_compile_skips_and_unskips()
+
+-- record: only a recorded PASS stands in. A pass skips the second run;
+-- a failure drops the record and runs every time; a behavior switch in
+-- the environment is part of the key.
+local function test_record_skips_only_a_pass()
+  local target = fs.join(tmpdir, "skip-pass.lua")
+  assert(fs.write(target, "print('ok')\n"))
+  local out = fs.join(tmpdir, "skip-pass-result.test")
+  local args = {out, cosmic, target, "--deps"}
+  assert(work.record(args) == 0, "first record")
+  local got = check.must(fs.read(out .. ".got"))
+  assert(got:match("^0%s*$"), "the run passed; err: "
+    .. tostring((fs.read(out .. ".err"))))
+  assert(fs.isfile(out .. ".in"), "a pass records itself")
+  local key1 = mtime_of(out .. ".in")
+  local ran1 = mtime_of(out .. ".out")
+
+  assert(work.record(args) == 0, "second record")
+  assert(mtime_of(out .. ".in") == key1 and mtime_of(out .. ".out") == ran1,
+    "identical inputs and a recorded pass must SKIP the child")
+
+  local saved = cenv.get("COSMIC_FIXPOINT")
+  cenv.set("COSMIC_FIXPOINT", "1")
+  assert(work.record(args) == 0, "record under a flipped switch")
+  if saved == nil then
+    cenv.unset("COSMIC_FIXPOINT")
+  else
+    cenv.set("COSMIC_FIXPOINT", saved)
+  end
+  assert(mtime_of(out .. ".in") ~= key1,
+    "a behavior switch is part of the key, so the child must re-run")
+
+  local bad = fs.join(tmpdir, "skip-fail.lua")
+  assert(fs.write(bad, "error('boom')\n"))
+  local bout = fs.join(tmpdir, "skip-fail-result.test")
+  local bargs = {bout, cosmic, bad, "--deps"}
+  assert(work.record(bargs) == 0, "record always exits 0; grading is later")
+  local bgot = check.must(fs.read(bout .. ".got"))
+  assert(not bgot:match("^0%s*$"), "the run failed")
+  assert(not fs.exists(bout .. ".in"),
+    "a failure must not record: a red test deserves its re-run")
+  local err1 = mtime_of(bout .. ".err")
+  assert(work.record(bargs) == 0, "second failing record")
+  assert(mtime_of(bout .. ".err") ~= err1,
+    "and it really re-ran rather than standing on the old result")
+end
+test_record_skips_only_a_pass()
+
+print("all skip tests passed")

--- a/_cli/build/steps.tl
+++ b/_cli/build/steps.tl
@@ -2,7 +2,10 @@
 ---
 --- Split out of _cli.build when the vocabulary outgrew the 500-line
 --- cap. The dispatcher next door owns the vocabulary (which names
---- exist, how a line is parsed); this file owns what each name does.
+--- exist, how a line is parsed); this file owns what each name does —
+--- except the three that do real work per source (`compile`,
+--- `capture`, `record`), which live in `_cli.build.work` with the
+--- content-keyed skip that lets them not do it.
 ---
 --- Requires the EMBEDDED stdlib only — deliberately no tree modules:
 --- the compile step is what BUILDS the tree's .lua files, so a tree
@@ -14,7 +17,7 @@ local env = require("cosmic.env")
 local fs = require("cosmic.fs")
 local fs_types = require("cosmic.fs.types")
 local records = require("cosmic.records")
-local modules = require("_cli.build.modules")
+local work = require("_cli.build.work")
 
 --- The one prefix a recipe step's failure wears, matching its siblings
 --- in `_cli/build/init.tl` and `_cli/driver.tl`, so a failed step is
@@ -22,106 +25,6 @@ local modules = require("_cli.build.modules")
 local function fail(msg: string): integer
   io.stderr:write("cosmic -c: " .. msg .. "\n")
   return 1
-end
-
---- Run argv, pass stderr through, and write stdout to out only when
---- the content changed, so an unchanged result does not touch the
---- output's mtime.
-local function run_into(argv: {string}, out: string): integer
-  local result, serr = child.run(argv)
-  if not result then
-    return fail("spawn " .. argv[1] .. " failed: " .. tostring(serr))
-  end
-  local r = result as child.Result -- cast: record union after guard
-  if r.stderr and r.stderr ~= "" then
-    io.stderr:write(r.stderr)
-  end
-  if not r.ok then
-    return r.code or 1
-  end
-  local existing = fs.read(out)
-  if existing == r.stdout then
-    -- Same bytes, new schedule. Make ran this recipe because the target
-    -- was out of date against something -- a source, or the driver
-    -- itself -- and a target whose mtime never advances stays out of
-    -- date FOREVER: every later run re-runs the step, and with the
-    -- driver as a prerequisite that is the whole tree, every build.
-    -- Content still decides what the file IS; the timestamp only
-    -- records that it has been brought up to date against the inputs
-    -- make just compared. The cost, paid knowingly: an edit that
-    -- compiles to identical bytes now re-runs the tests that import it.
-    local ok, terr = fs.touch(out)
-    if not ok then
-      -- Never silent: a target that cannot be restamped stays out of
-      -- date forever, and make re-runs this step on every future
-      -- invocation. That is the non-convergence this line exists to
-      -- close, arriving instead as a failure nobody sees.
-      io.stderr:write("restamp " .. out .. " failed: " ..
-        (terr or "unknown error") .. "\n")
-    end
-    return 0
-  end
-  fs.makedirs(fs.dirname(out))
-  local ok, werr = fs.write(out, r.stdout)
-  if not ok then
-    return fail("write " .. out .. " failed: " .. (werr or "unknown error"))
-  end
-  return 0
-end
-
---- compile <bootstrap> <src> <out> [compiler flags...]
---- Always a STRICT compile: --compile-strict type checks and then
---- generates from that same checked AST, so nothing ships that did not
---- typecheck, under LUA_PATH=";;" so output cannot depend on parallel
---- build order. TL_PATH passes through from the rule's export.
----
---- Compiles are unconditionally strict, with no flag-stamp argument to
---- probe: a driver that falls back to a non-strict, order-dependent
---- compile when the stamp says the flag is unavailable is a place where
---- a stale input degrades silently.
-local function do_compile(args: {string}): integer
-  local bootstrap, src, out = args[1], args[2], args[3]
-  if not out then
-    return fail("usage: compile <bootstrap> <src> <out> [flags...]"
-      .. " [--deps <path>...]")
-  end
-  env.set("LUA_PATH", ";;")
-  local argv: {string} = {bootstrap}
-  for i = 4, #args do
-    -- Everything after --deps is an INPUT, named so the derived fence
-    -- can grant it, and never forwarded to the child. Forwarding was a
-    -- silent disaster the first time it was written: a bare path lands
-    -- as the child's first positional, getopt stops parsing there, and
-    -- `cosmic --include-dir . util.tl --compile-strict main.tl` RUNS
-    -- util.tl as a script and writes its empty stdout as main.lua. The
-    -- compile "passes" having checked nothing -- the shape,
-    -- where an argv ambiguity makes a gate report a pass it never ran.
-    if args[i] == "--deps" then
-      break
-    end
-    table.insert(argv, args[i])
-  end
-  table.insert(argv, "--compile-strict")
-  table.insert(argv, src)
-  return run_into(argv, out)
-end
-
---- capture <bootstrap> <out> <script+args...> — run a script under the
---- bootstrap and write its stdout to out if changed (the doc-index
---- rule's shape). The child gets NO manifest, deliberately: the one
---- caller (the doc-index rule) imports nothing from the project it
---- indexes. Attaching one is the right move the day a captured script
---- does -- `record` shows the shape.
-local function do_capture(args: {string}): integer
-  local bootstrap, out = args[1], args[2]
-  if not out or not args[3] then
-    return fail("usage: capture <bootstrap> <out> <script> [args...]")
-  end
-  local argv: {string} = {bootstrap}
-  for i = 3, #args do
-    table.insert(argv, args[i])
-  end
-  return run_into(argv, out)
 end
 
 --- tee <out> <cmd...> — run a command, print its stdout AND write it to
@@ -176,72 +79,6 @@ local function do_write_list(args: {string}): integer
   local ok, werr = fs.write(out, content)
   if not ok then
     return fail("write " .. out .. " failed: " .. (werr or "unknown error"))
-  end
-  return 0
-end
-
---- record <out> <cmd> [args...] — run one test file, writing the
---- `<out>.got`/`.out`/`.err` contract testrun already owns, and then
---- **always succeed**.
----
---- That last part is the whole point, and it is a decision rather than
---- an oversight. `--test` propagates its child's exit code, so a rule
---- shaped `cosmic --test …` fails when the test fails: under `make`
---- that stops the build at the first failing test, and — worse — a
---- test that means to SKIP exits 2, which is indistinguishable from a
---- failure to make. The graph's job is to record what happened; the
---- report step grades it, where 0/2/other already mean pass/skip/fail.
---- So the verb writes the result and returns 0, every test in a run
---- gets to run, and skip semantics survive the trip through make.
----
---- A step that could not record a result at all (unwritable output) is
---- still a failure: that is the graph breaking, not a test failing.
-local function do_record(args: {string}): integer
-  local out = args[1]
-  if not out or not args[2] then
-    return fail("usage: record <out> <cmd> [args...]")
-  end
-  local argv: {string} = {}
-  local deps: {string} = {}
-  local in_deps = false
-  for i = 2, #args do
-    -- Same contract as compile: --deps names inputs for the fence and
-    -- never reaches the child as ARGUMENTS -- a test that read arg[1]
-    -- would find its own dependency list there. It is the child's
-    -- RESOLUTION set too, via the manifest below: see _cli.build.modules.
-    if args[i] == "--deps" then
-      in_deps = true
-    elseif in_deps then
-      deps[#deps + 1] = args[i]
-    else
-      argv[#argv + 1] = args[i]
-    end
-  end
-  modules.attach(argv, out, fs.abspath("."), deps)
-  -- The test fence, behavioural half: point TMP at a scratch directory
-  -- beside this step's own output, so testrun's mkdtemp lands there and
-  -- the test's TEST_TMPDIR is inside its own unit rather than in a
-  -- shared /tmp. Two things follow, and the first matters more than the
-  -- second: tests stop being able to collide with each other through
-  -- the temp directory at all, on every platform, whether or not a
-  -- kernel is enforcing anything; and the derived fence's write grant
-  -- (this step's output directory) already covers it, so the kernel
-  -- half needs no extra rule.
-  --
-  -- ABSOLUTE, because `out` is a path relative to the project root and
-  -- TEST_TMPDIR outlives the cwd it was written against: a test that
-  -- chdirs — or that spawns a child with `cwd = TEST_TMPDIR` and
-  -- compares the result to it — resolves a relative one against
-  -- somewhere else and gets a different directory, or a mismatch it
-  -- reports as its own bug.
-  local scratch = fs.abspath(out .. ".tmp.d")
-  env.set("TMP", scratch)
-  fs.makedirs(scratch)
-  fs.unlink(out .. ".got") -- freshness: an early testrun exit writes none
-  local testrun = require("cosmic.testrun")
-  testrun.run(argv, out)
-  if not fs.isfile(out .. ".got") then
-    return fail("record " .. out .. ": no result recorded")
   end
   return 0
 end
@@ -484,12 +321,12 @@ end
 local modes: {string: function({string}): integer} = {
   ["assert-elf"] = do_assert_elf,
   ["assert-marker"] = do_assert_marker,
-  capture = do_capture,
-  compile = do_compile,
+  capture = work.capture,
+  compile = work.compile,
   copy = do_copy,
   exec = do_exec,
   link = do_link,
-  record = do_record,
+  record = work.record,
   remove = do_remove,
   tee = do_tee,
   verdict = do_verdict,

--- a/_cli/build/work.tl
+++ b/_cli/build/work.tl
@@ -1,0 +1,321 @@
+--- The recipe steps that do real work — `compile`, `capture`,
+--- `record` — and the content-keyed skip that lets them not do it.
+---
+--- Split from `_cli.build.steps` when the skip outgrew the 500-line
+--- cap, on the seam the verbs already had: steps.tl owns the cheap
+--- bookkeeping verbs (copy, tee, write-list, asserts), this file owns
+--- the two that spawn a child per source and the shared `run_into`
+--- contract they write through.
+---
+--- **The skip.** Make schedules on mtime, and mtimes lie in exactly
+--- the situations that hurt: a branch switch restamps every source, a
+--- CI cache restore sits under a fresh checkout, a `touch` storm — and
+--- the graph re-runs the world to reproduce bytes it already has. So
+--- a step that is about to do expensive work first asks a question
+--- mtime cannot answer: are the BYTES of my inputs exactly the ones
+--- that produced the recorded result? `<out>.in` records the answer —
+--- a hash over the step's stable argv, a fixed set of behavior
+--- switches from the environment, and the bytes of every input file
+--- (the source, the declared closure, and the tool stamps riding in
+--- the line). A hit re-stamps the output for make and does nothing; a
+--- miss runs the child and re-records.
+---
+--- Three rules keep it honest:
+--- - **Only lines that declare inputs get the skip.** The graph's
+---   compile and record lines carry `--deps` (and the compile line its
+---   tool stamps); a bare `compile` — the generator mini-graph's
+---   spelling, which does its own scheduling and expects a dispatched
+---   compile to COMPILE — has no input list to key on, and never skips.
+--- - **Only a recorded PASS short-circuits a record.** A failing test
+---   deserves to run again, and a SKIP is an answer about the
+---   environment, which the key cannot see in full — so both drop the
+---   record instead of writing one.
+--- - **The output must still be the recorded output.** The key names
+---   the output's own hash, so a corrupted or hand-edited artifact is
+---   recompiled rather than trusted.
+---
+--- `.in` is written PLAINLY, not write-if-changed: nothing schedules
+--- on its mtime, and an always-fresh write makes it a probe — its
+--- mtime moves exactly when the step really ran, which is what the
+--- tests observe. Decision record: docs/decisions/d18-step-skip.md.
+
+local child = require("cosmic.child")
+local env = require("cosmic.env")
+local fs = require("cosmic.fs")
+local hash = require("cosmic.hash")
+local modules = require("_cli.build.modules")
+
+--- The one prefix a recipe step's failure wears; see steps.tl.
+local function fail(msg: string): integer
+  io.stderr:write("cosmic -c: " .. msg .. "\n")
+  return 1
+end
+
+--- Environment switches that change what a step's child DOES, folded
+--- into the key by name=value. Everything else in the environment is
+--- assumed inert — the same assumption make itself already makes, so
+--- the skip is never less honest than the scheduler above it.
+local ENV_SWITCHES < const >: {string} = {
+  "CI", "COSMIC_COVERAGE", "COSMIC_FENCE", "COSMIC_FIXPOINT",
+}
+
+--- The key over a step's meaning: its stable argv (relative paths and
+--- flags — never the absolute driver path, whose identity is the tool
+--- stamp's job), the behavior switches, and the bytes of every input.
+--- @param label {string} Stable argv fragments
+--- @param inputs {string} Files whose BYTES are the meaning
+--- @return string|nil The key, or nil when an input cannot be read
+local function inkey(label: {string}, inputs: {string}): string | nil
+  local parts: {string} = {}
+  for _, l in ipairs(label) do
+    parts[#parts + 1] = l
+    parts[#parts + 1] = "\0"
+  end
+  for _, name in ipairs(ENV_SWITCHES) do
+    parts[#parts + 1] = name .. "=" .. env.get_or(name, "")
+    parts[#parts + 1] = "\0"
+  end
+  for _, p in ipairs(inputs) do
+    local body = fs.read(p)
+    if not (body is string) then
+      return nil
+    end
+    parts[#parts + 1] = p
+    parts[#parts + 1] = "\0"
+    parts[#parts + 1] = body
+    parts[#parts + 1] = "\0"
+  end
+  return hash.sha256_hex(table.concat(parts))
+end
+
+--- Whether a `.got` records a PASS. The file holds the exit code plus
+--- a trailing newline, so this matches the digit, not the bytes.
+--- @param path string The `.got` path
+--- @return boolean True when the recorded run passed
+local function got_pass(path: string): boolean
+  local body = fs.read(path)
+  return body is string and body:match("^0%s*$") ~= nil
+end
+
+--- Read a recorded `<out>.in` into its two fields.
+--- @param path string The record's path
+--- @return string|nil The input key
+--- @return string The output hash ("" when the record has none)
+local function recorded(path: string): string | nil, string
+  local body = fs.read(path)
+  if not (body is string) then
+    return nil, ""
+  end
+  local rin = body:match("^in (%x+)")
+  local rout = body:match("\nout (%x+)") or ""
+  return rin, rout
+end
+
+--- Run argv, pass stderr through, and write stdout to out only when
+--- the content changed, so an unchanged result does not touch the
+--- output's mtime. (Moved verbatim from steps.tl; see the restamp
+--- comment there for why an unchanged result still touches the mtime.)
+local function run_into(argv: {string}, out: string): integer
+  local result, serr = child.run(argv)
+  if not result then
+    return fail("spawn " .. argv[1] .. " failed: " .. tostring(serr))
+  end
+  local r = result as child.Result -- cast: record union after guard
+  if r.stderr and r.stderr ~= "" then
+    io.stderr:write(r.stderr)
+  end
+  if not r.ok then
+    return r.code or 1
+  end
+  local existing = fs.read(out)
+  if existing == r.stdout then
+    -- Same bytes, new schedule: a target whose mtime never advances
+    -- stays out of date forever. Content decides what the file IS; the
+    -- timestamp records that it was brought up to date.
+    local ok, terr = fs.touch(out)
+    if not ok then
+      io.stderr:write("restamp " .. out .. " failed: " ..
+        (terr or "unknown error") .. "\n")
+    end
+    return 0
+  end
+  fs.makedirs(fs.dirname(out))
+  local ok, werr = fs.write(out, r.stdout)
+  if not ok then
+    return fail("write " .. out .. " failed: " .. (werr or "unknown error"))
+  end
+  return 0
+end
+
+--- compile <bootstrap> <src> <out> [flags...] [--deps <inputs>...]
+--- Always a STRICT compile under LUA_PATH=";;" (see steps.tl history).
+--- Everything after --deps is an INPUT — the source closure and the
+--- tool stamps the rule names — granted to the fence, keyed by the
+--- skip, and never forwarded to the child.
+local function do_compile(args: {string}): integer
+  local src, out = args[2], args[3]
+  if not out then
+    return fail("usage: compile <bootstrap> <src> <out> [flags...]"
+      .. " [--deps <path>...]")
+  end
+  local label: {string} = {"compile"}
+  local inputs: {string} = {src}
+  local in_deps = false
+  for i = 2, #args do
+    if args[i] == "--deps" then
+      in_deps = true
+    elseif in_deps then
+      inputs[#inputs + 1] = args[i]
+    else
+      label[#label + 1] = args[i]
+    end
+  end
+  local key: string | nil = nil
+  if in_deps then
+    key = inkey(label, inputs)
+  end
+  local record_path = out .. ".in"
+  if key is string then
+    local rin, rout = recorded(record_path)
+    if rin == key then
+      local body = fs.read(out)
+      if body is string and hash.sha256_hex(body) == rout then
+        local ok, terr = fs.touch(out)
+        if ok then
+          return 0
+        end
+        io.stderr:write("restamp " .. out .. " failed: " ..
+          (terr or "unknown error") .. "\n")
+      end
+    end
+  end
+  env.set("LUA_PATH", ";;")
+  local argv: {string} = {args[1]}
+  for i = 4, #args do
+    -- Forwarding an input as an argument was a silent disaster once
+    -- already (see the history in steps.tl): stop at --deps.
+    if args[i] == "--deps" then
+      break
+    end
+    table.insert(argv, args[i])
+  end
+  table.insert(argv, "--compile-strict")
+  table.insert(argv, src)
+  local code = run_into(argv, out)
+  if code == 0 and key is string then
+    local body = fs.read(out)
+    if body is string then
+      fs.write(record_path, "in " .. key .. "\nout " ..
+        hash.sha256_hex(body) .. "\n")
+    end
+  end
+  return code
+end
+
+--- capture <bootstrap> <out> <script+args...> — run a script under the
+--- bootstrap and write its stdout to out if changed. No skip: its one
+--- caller declares no inputs, and a captured script may read anything.
+local function do_capture(args: {string}): integer
+  local bootstrap, out = args[1], args[2]
+  if not out or not args[3] then
+    return fail("usage: capture <bootstrap> <out> <script> [args...]")
+  end
+  local argv: {string} = {bootstrap}
+  for i = 3, #args do
+    table.insert(argv, args[i])
+  end
+  return run_into(argv, out)
+end
+
+--- record <out> <cmd> [args...] [--deps <inputs>...] — run one test
+--- file, writing the `<out>.got`/`.out`/`.err` contract testrun owns,
+--- and then **always succeed** (grading is `--report`'s job; see the
+--- history in steps.tl). The skip may stand in for a run whose inputs
+--- are byte-identical AND whose recorded verdict was a PASS: a `.got`
+--- of 0 restamps and the child never spawns. A recorded failure or
+--- skip always re-runs — a failure deserves the retry, and a skip is a
+--- statement about the environment the key cannot see in full.
+local function do_record(args: {string}): integer
+  local out = args[1]
+  if not out or not args[2] then
+    return fail("usage: record <out> <cmd> [args...]")
+  end
+  local argv: {string} = {}
+  local deps: {string} = {}
+  local in_deps = false
+  for i = 2, #args do
+    if args[i] == "--deps" then
+      in_deps = true
+    elseif in_deps then
+      deps[#deps + 1] = args[i]
+    else
+      argv[#argv + 1] = args[i]
+    end
+  end
+  local key: string | nil = nil
+  local record_path = out .. ".in"
+  if in_deps then
+    -- The label is the argv MINUS the driver's absolute path (its
+    -- identity is the record stamp, an input below) and minus input
+    -- files, which are keyed by bytes: the target and the closure.
+    local label: {string} = {"record"}
+    local inputs: {string} = {}
+    for i = 2, #argv do
+      if fs.isfile(argv[i]) then
+        inputs[#inputs + 1] = argv[i]
+      else
+        label[#label + 1] = argv[i]
+      end
+    end
+    for _, d in ipairs(deps) do
+      inputs[#inputs + 1] = d
+    end
+    inputs[#inputs + 1] = "o/.stamp/record"
+    key = inkey(label, inputs)
+  end
+  if key is string then
+    local rin = recorded(record_path)
+    if rin == key and got_pass(out .. ".got") then
+      local ok, terr = fs.touch(out .. ".got")
+      if ok then
+        return 0
+      end
+      io.stderr:write("restamp " .. out .. ".got failed: " ..
+        (terr or "unknown error") .. "\n")
+    end
+  end
+  modules.attach(argv, out, fs.abspath("."), deps)
+  local scratch = fs.abspath(out .. ".tmp.d")
+  env.set("TMP", scratch)
+  fs.makedirs(scratch)
+  fs.unlink(out .. ".got") -- freshness: an early testrun exit writes none
+  local testrun = require("cosmic.testrun")
+  testrun.run(argv, out)
+  if not fs.isfile(out .. ".got") then
+    return fail("record " .. out .. ": no result recorded")
+  end
+  if key is string and got_pass(out .. ".got") then
+    fs.write(record_path, "in " .. key .. "\n")
+  else
+    fs.unlink(record_path)
+  end
+  return 0
+end
+
+local record WorkModule
+  inkey: function(label: {string}, inputs: {string}): string | nil
+  compile: function(args: {string}): integer
+  capture: function(args: {string}): integer
+  record: function(args: {string}): integer
+  run_into: function(argv: {string}, out: string): integer
+end
+
+local M: WorkModule = {
+  inkey = inkey,
+  compile = do_compile,
+  capture = do_capture,
+  record = do_record,
+  run_into = run_into,
+}
+
+return M

--- a/cosmic/format/init_test.tl
+++ b/cosmic/format/init_test.tl
@@ -128,6 +128,28 @@ assert_format(
   "function value does indent"
 )
 
+-- `record` in ACCESS and CALL positions is not a declaration: a field
+-- access (`work.record(...)`), a call's own name (`record(x)`), and a
+-- bare reference in an argument list must not open a block. The `=`/`:`
+-- disambiguation already covers keys; these cover the sites found the
+-- day the `-c` verbs moved behind a module with a `record` field, when
+-- every line after `work.record(args)` acquired one indent forever.
+assert_format(
+  "local a = work.record(x)\nlocal b = 1\n",
+  "local a = work.record(x)\nlocal b = 1\n",
+  "field access named record does not indent"
+)
+assert_format(
+  "record(x)\nlocal b = 1\n",
+  "record(x)\nlocal b = 1\n",
+  "a call named record does not indent"
+)
+assert_format(
+  "f(record, enum)\nlocal b = 1\n",
+  "f(record, enum)\nlocal b = 1\n",
+  "record as an argument does not indent"
+)
+
 -- Bug 1 variant: function definition should still indent
 assert_format(
   "local function foo(x)\nreturn x\nend\n",

--- a/cosmic/format/rules.tl
+++ b/cosmic/format/rules.tl
@@ -115,18 +115,31 @@ local type_decl_kw: {string: boolean} = {
 --- from that line down with `--make fmt` reporting PASS.
 ---
 --- The same shape reaches `enum` and `interface`, which are equally
---- legal keys.
+--- legal keys — and it reaches ACCESS and CALL positions too:
+--- `work.record(args)` is a field access followed by a call, found
+--- the day the `-c` verbs moved behind a module named for them, and
+--- read as an opener it cascaded an extra indent per call, forever,
+--- with the gate passing on its own idempotent damage again.
 --- @param item Item The token to test
 --- @param next_item Item The token after it, nil at end of line
+--- @param prev_item Item The token before it, nil at start of line
 --- @return boolean Whether it opens a block
-local function is_block_opener(item: Item, next_item: Item): boolean
+local function is_block_opener(item: Item, next_item: Item,
+    prev_item: Item): boolean
   if item.kind == "keyword" and block_openers[item.tk] then
     return true
   end
   if item.kind == "identifier" and type_decl_kw[item.tk] then
-    -- `record =` and `record:` are a table key and a field name.
-    -- A declaration is `record Name` or `record` alone on the line.
-    if next_item ~= nil and (next_item.tk == "=" or next_item.tk == ":") then
+    -- `record =` and `record:` are a table key and a field name;
+    -- `record(`, `record,`, `record)` are a call and its arguments;
+    -- `x.record` and `x:record` are member access. A declaration is
+    -- `record Name` or `record` alone on the line.
+    if next_item ~= nil and (next_item.tk == "=" or next_item.tk == ":"
+      or next_item.tk == "(" or next_item.tk == ","
+      or next_item.tk == ")") then
+      return false
+    end
+    if prev_item ~= nil and (prev_item.tk == "." or prev_item.tk == ":") then
       return false
     end
     return true
@@ -251,7 +264,7 @@ local function compute_indent_change(line_items: {Item},
     elseif type_ctx[idx] then
       is_first_code = false
     else
-      if is_block_opener(item, line_items[idx + 1]) then
+      if is_block_opener(item, line_items[idx + 1], line_items[idx - 1]) then
         post_change = post_change + 1
       elseif item.tk == "{" or item.tk == "(" then
         post_change = post_change + 1

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -29,3 +29,4 @@ than editing the record it replaces.
 | D15 | an artifact carries its modules and `embed/**`; shipping is opt-in | [→](d15-shipping-is-opt-in.md) |
 | D16 | every build input is enumerable from committed files, the version stamp included | [→](d16-enumerable-build-inputs.md) |
 | D17 | a graph rule's tool prerequisite is a per-tool stamp, not the binary | [→](d17-tool-stamps.md) |
+| D18 | expensive recipe steps skip on input bytes, not just on mtime | [→](d18-step-skip.md) |

--- a/docs/decisions/d18-step-skip.md
+++ b/docs/decisions/d18-step-skip.md
@@ -1,0 +1,51 @@
+# D18 — expensive recipe steps skip on input bytes, not just on mtime
+
+- **date:** 2026-08
+- **context:** make schedules on mtime, and mtimes lie in exactly the
+  situations that hurt: a branch switch restamps every source, a CI
+  cache restore sits under a fresh checkout, a `touch` sweep — and the
+  graph re-runs the world to reproduce bytes it already has. D17 made
+  invalidation precise about the TOOL; this is the same honesty about
+  the WORK. `engine.md` had already named the general form — "an
+  action cache keyed on (argv + input hashes), deferred until
+  profiling justifies it" — and the profiling that motivated this
+  series justifies it: a full recompile costs ~33s and a full test
+  sweep minutes, where verifying that nothing changed costs seconds.
+- **decision:** the two steps that do real work per source gain a
+  content key. `compile` and `record` (in `_cli/build/work.tl`) hash
+  their stable argv, a fixed set of behavior switches from the
+  environment (`CI`, `COSMIC_COVERAGE`, `COSMIC_FENCE`,
+  `COSMIC_FIXPOINT`), and the BYTES of every declared input — the
+  source, the closure the rule already passes after `--deps`, and the
+  tool stamps, which the compile line now carries after `--deps` too
+  so the fence grants them and the key sees them. The key and the
+  output's own hash land in `<out>.in`; a later invocation whose key
+  and output both match restamps the output for make and spawns no
+  child. Three rules bound it: only a line that declares inputs
+  (`--deps` present) gets the skip, so the generator mini-graph's bare
+  `compile` — which does its own scheduling and expects a dispatched
+  compile to compile — never skips; only a recorded PASS
+  short-circuits a `record`, so failures re-run and environment-gated
+  skips never stick; and the output must hash to what the record
+  names, so a corrupted artifact is rebuilt rather than trusted.
+- **rejected:** hashing the whole environment (unbounded, and make
+  itself already assumes env is inert — the fixed switch list makes
+  the skip strictly more honest than the scheduler above it, not
+  less); caching failing results (a red test deserves the re-run, and
+  a skip's cause lives partly outside the key); skipping `capture`
+  (its one caller declares no inputs, and a captured script may read
+  anything); replacing make's scheduling outright with content
+  addressing (D14 keeps make the graph executor; this composes with
+  it instead).
+- **consequences:** re-verifying an unchanged tree costs hashing, not
+  compiling: a `touch` of every source, or a branch switch that
+  changes few bytes, settles in seconds. A restored `o/` cache under a
+  fresh checkout becomes usable, which is what CI caching needs
+  (D18's `.in` records are self-verifying against the cached outputs:
+  a record that does not match its output's bytes is ignored and the
+  step runs). `.in` files are written plainly — nothing schedules on
+  their mtime, and an always-fresh write makes them a probe for "the
+  step really ran", which the tests use. The declared trust boundary:
+  a `.in` beside its output stands for a prior run of this same
+  project state; in CI that means trusting the cache's writer, which
+  GitHub scopes to the branch that wrote it.

--- a/embed/cosmic.mk
+++ b/embed/cosmic.mk
@@ -111,8 +111,13 @@ compile: $(compiled) $(staged)
 # content-addressed (`_make.generate`'s stamp_types), so a run that
 # regenerates byte-identical declarations does not move its mtime and
 # a no-op build stays a no-op.
+# The two stamps ride in the line as well as the prerequisite list:
+# everything after --deps is an INPUT -- granted by the fence, keyed by
+# the step's content skip (_cli/build/work.tl), never forwarded to the
+# child. A line that declares its inputs is one the step can prove it
+# already ran.
 $(O)/%.lua: %.tl $(O)/.stamp/compile $(O)/_types/types_gen.stamp $$(srcdeps_$$*)
-	compile $(COSMIC) $< $@ --include-dir . --deps $(srcdeps_$*) ;
+	compile $(COSMIC) $< $@ --include-dir . --deps $(srcdeps_$*) $(O)/.stamp/compile $(O)/_types/types_gen.stamp ;
 
 # .lua sources are first-class. They are copied, not compiled; the
 # validator has already refused foo.tl beside foo.lua, so these two


### PR DESCRIPTION
PR 6 in the build/test-performance series (decision record D18; this is `engine.md`'s deferred "action cache keyed on (argv + input hashes)", now justified by profiling). PR 7 will build CI caching on top of it.

## Why

Make schedules on mtime, and mtimes lie in exactly the situations that hurt: a branch switch restamps every source, a CI cache restore sits under a fresh checkout, a `touch` sweep. Measured: touching every source cost a ~33s full recompile plus a ~2min test sweep to conclude nothing changed.

## What

`compile` and `record` — moved to a new `_cli/build/work.tl` together with `run_into`/`capture`, since `steps.tl` sat at the 500-line cap — key their work on content: a hash over the stable argv, a fixed set of behavior switches (`CI`, `COSMIC_COVERAGE`, `COSMIC_FENCE`, `COSMIC_FIXPOINT`), and the **bytes** of every declared input (the source, the `--deps` closure, and the tool stamps, which the compile line now carries after `--deps` so the fence grants them and the key sees them). `<out>.in` records the key plus the output's own hash; a match restamps for make and spawns no child.

Three bounds keep it honest:
- only a line that **declares inputs** keys — the generator mini-graph's bare `compile` does its own scheduling and always compiles;
- only a recorded **PASS** stands in for a `record` — failures re-run, and environment-gated skips never stick;
- the output must hash to what the record names — a corrupted artifact is rebuilt, not trusted.

## Also: a formatter bug this change surfaced

`work.record(args)` was the tree's first *field access* named `record`, and the formatter's `record`-as-identifier disambiguation (which already handled `record =` and `record:`) read access and call positions as a type declaration opening a block — every later line gained one indent, forever, idempotently, so the fmt gate passed on its own damage. Fixed in `cosmic/format/rules.tl` with regression cases in `init_test.tl`.

## Measured

- touch every source → `--make build`: **33s → 6.9s**
- same storm → `--make test`: **~2min → 10.1s** (once `.in` records exist)
- Full gate: `ci: PASS (5 stages)`, coverage ratchet ok (one row rebaselined for #876's added lines; rows added for the new files).
- New `_cli/build/skip_test.tl`: skip on identical bytes, rebuild on corrupted output, rebuild on changed source, no keying without `--deps`, pass-only record caching, env-switch sensitivity, failures always re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Ukw9dxadTMm3aVG2A53b

---
_Generated by [Claude Code](https://claude.ai/code/session_0149Ukw9dxadTMm3aVG2A53b)_