### PR TITLE
benchmark: let the runner take a tiny duration, so its tests stop paying for calibration

### DIFF
--- a/_cli/build/work.tl
+++ b/_cli/build/work.tl
@@ -57,6 +57,7 @@ end
 --- the skip is never less honest than the scheduler above it.
 local ENV_SWITCHES < const >: {string} = {
   "CI", "COSMIC_COVERAGE", "COSMIC_FENCE", "COSMIC_FIXPOINT",
+  "COSMIC_BENCHMARK_MIN_SECONDS",
 }
 
 --- The key over a step's meaning: its stable argv (relative paths and

--- a/cosmic/benchmark.tl
+++ b/cosmic/benchmark.tl
@@ -4,6 +4,7 @@
 
 local time = require("cosmic.time")
 local scan = require("cosmic.doc.scan")
+local env = require("cosmic.env")
 
 --- Read the monotonic wall clock in nanoseconds.
 --- Uses CLOCK_MONOTONIC so IO-bound benchmarks (which block rather than
@@ -77,15 +78,50 @@ local function parse_benchmarks(source: string): {Benchmark}
   return benchmarks
 end
 
---- Minimum benchmark duration in seconds (like Go's default 1s)
-local MIN_DURATION = 1.0
+--- Default minimum benchmark duration in seconds (like Go's default 1s).
+local DEFAULT_MIN_SECONDS = 1.0
+
+--- Options for `run`.
+local record Options
+  --- Minimum calibrated duration per benchmark, in seconds. Defaults to
+  --- DEFAULT_MIN_SECONDS (Go's 1s convention) when unset. A real
+  --- timing measurement should leave this at the default; a test of
+  --- the RUNNER itself (discovery, naming, iteration counting,
+  --- formatting, error handling) is the intended user of a small
+  --- value here, since 1s of looping proves nothing a 10ms run
+  --- doesn't.
+  min_seconds: number
+end
+
+--- Resolve the minimum calibration duration for a run: an explicit
+--- `Options.min_seconds` wins; otherwise the COSMIC_BENCHMARK_MIN_SECONDS
+--- environment variable, when it parses as a number, lets a caller with
+--- no Options to pass (the `--benchmark` CLI flag spawns no sub-options,
+--- so this is how its own tests shrink calibration through a spawned
+--- `cosmic --benchmark` child); otherwise DEFAULT_MIN_SECONDS.
+--- @param opts Options? Run options
+--- @return number Minimum duration in seconds
+local function resolve_min_seconds(opts: Options): number
+  if opts and opts.min_seconds then
+    return opts.min_seconds
+  end
+  local from_env = env.get("COSMIC_BENCHMARK_MIN_SECONDS")
+  if from_env then
+    local n = tonumber(from_env)
+    if n then
+      return n
+    end
+  end
+  return DEFAULT_MIN_SECONDS
+end
 
 --- Run a single benchmark and measure timing.
 --- Executes the benchmark code repeatedly, auto-calibrating iterations.
 --- @param benchmark Benchmark The benchmark to run
 --- @param _file_path string Path to the source file (unused, for API consistency)
+--- @param min_seconds number Minimum calibrated duration, in seconds
 --- @return BenchmarkResult Result with timing statistics
-local function run_benchmark(benchmark: Benchmark, _file_path: string): BenchmarkResult
+local function run_benchmark(benchmark: Benchmark, _file_path: string, min_seconds: number): BenchmarkResult
   local result: BenchmarkResult = {
     name = benchmark.name,
     iterations = 0,
@@ -134,11 +170,11 @@ end
     _G.print = function() end
   end
 
-  -- Auto-calibrate: start with N=1 and increase until we reach MIN_DURATION
+  -- Auto-calibrate: start with N=1 and increase until we reach min_seconds
   local n = 1
   local elapsed = 0.0
 
-  while elapsed < MIN_DURATION do
+  while elapsed < min_seconds do
     -- Warm up / calibrate
     local start = monotonic_ns()
     for _ = 1, n do
@@ -159,10 +195,10 @@ end
     end
     elapsed = (monotonic_ns() - start) / 1e9
 
-    if elapsed < MIN_DURATION then
-      -- Estimate iterations needed to reach MIN_DURATION
+    if elapsed < min_seconds then
+      -- Estimate iterations needed to reach min_seconds
       if elapsed > 0 then
-        local estimate = math.ceil(n * MIN_DURATION / elapsed)
+        local estimate = math.ceil(n * min_seconds / elapsed)
         -- Don't grow too fast - cap at 10x
         n = math.min(estimate, n * 10)
       else
@@ -192,8 +228,9 @@ end
 --- Parses and executes Benchmark_* functions, returning aggregated results.
 --- @param file_path string Path to the Teal file containing benchmarks
 --- @param filter string Optional SUBSTRING of the benchmark name, matched plainly (e.g. "concat" matches Benchmark_string_concat)
+--- @param opts Options? Run options; see Options.min_seconds
 --- @return RunResult Result with exit code (0=pass, 1=fail, 2=skip), results, and errors
-local function run(file_path: string, filter?: string): RunResult
+local function run(file_path: string, filter?: string, opts?: Options): RunResult
   local f, err = io.open(file_path, "r")
   if not f then
     return {
@@ -240,9 +277,10 @@ local function run(file_path: string, filter?: string): RunResult
 
   local results: {BenchmarkResult} = {}
   local has_error = false
+  local min_seconds = resolve_min_seconds(opts)
 
   for _, benchmark in ipairs(benchmarks) do
-    local result = run_benchmark(benchmark, file_path)
+    local result = run_benchmark(benchmark, file_path, min_seconds)
     table.insert(results, result)
     if result.error then
       has_error = true
@@ -312,7 +350,9 @@ local function format_results(file_path: string, run_result: RunResult): string
 end
 
 local record BenchmarkModule
-  run: function(file_path: string, filter?: string): RunResult
+  type Options = Options
+
+  run: function(file_path: string, filter?: string, opts?: Options): RunResult
   parse_benchmarks: function(source: string): {Benchmark}
   format_results: function(file_path: string, run_result: RunResult): string
 end

--- a/cosmic/benchmark_test.tl
+++ b/cosmic/benchmark_test.tl
@@ -5,9 +5,23 @@ local check = require("cosmic.check")
 local fs = require("cosmic.fs")
 local spawn = require("cosmic.child")
 local benchmark = require("cosmic.benchmark")
+local env = require("cosmic.env")
 
 local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
+
+-- This file exercises the RUNNER (discovery, naming, iteration counting,
+-- formatting, error handling, selection) through real Benchmark_* runs,
+-- not the quality of any one timing. Go-style calibration toward
+-- DEFAULT_MIN_SECONDS (~1s) would cost ~1s per real benchmark run below
+-- for no assertion this shrinks: a tiny floor proves the runner works
+-- exactly as well at 10ms as at 1s. Direct benchmark.run() calls get
+-- an explicit Options.min_seconds; the two tests that spawn `cosmic
+-- --benchmark` as a child (which has no Options to pass) instead set
+-- COSMIC_BENCHMARK_MIN_SECONDS here so the child inherits it.
+local TINY_SECONDS = 0.01
+local TINY: benchmark.Options = {min_seconds = TINY_SECONDS}
+check.must(env.set("COSMIC_BENCHMARK_MIN_SECONDS", tostring(TINY_SECONDS)))
 
 local function write_temp(name: string, content: string): string
   local filepath = fs.join(tmpdir, name)
@@ -55,7 +69,7 @@ local function Benchmark_add()
   local x = 1 + 1
 end
 ]])
-  local result = benchmark.run(input)
+  local result = benchmark.run(input, nil, TINY)
   assert(result.exit_code == 0, "should pass")
   assert(#result.results == 1, "should have one result")
   assert(result.results[1].iterations > 0, "should have iterations")
@@ -122,7 +136,7 @@ local function Benchmark_nested()
   end
 end
 ]])
-  local result = benchmark.run(input)
+  local result = benchmark.run(input, nil, TINY)
   assert(result.exit_code == 0, "should handle nested blocks")
   assert(result.results[1].iterations > 0, "should run iterations")
 end
@@ -135,7 +149,7 @@ local function Benchmark_fmt()
   local x = 1
 end
 ]])
-  local result = benchmark.run(input)
+  local result = benchmark.run(input, nil, TINY)
   local formatted = benchmark.format_results(input, result)
   assert(formatted:find("Benchmark_fmt"), "should contain benchmark name")
   assert(formatted:find("PASS"), "should show PASS status")
@@ -149,7 +163,7 @@ local function Benchmark_error()
   error("intentional error")
 end
 ]])
-  local result = benchmark.run(input)
+  local result = benchmark.run(input, nil, TINY)
   assert(result.exit_code == 1, "should fail on runtime error")
   assert(result.results[1].error:find("runtime error"), "should capture error")
 end
@@ -172,7 +186,7 @@ local function Benchmark_math_add()
 end
 ]])
   -- Filter to only run "string" benchmarks
-  local result = benchmark.run(input, "string")
+  local result = benchmark.run(input, "string", TINY)
   assert(result.exit_code == 0, "should pass")
   assert(#result.results == 1, "should run only one benchmark")
   assert(result.results[1].name == "Benchmark_string_concat", "should run matching benchmark")

--- a/docs/decisions/d18-step-skip.md
+++ b/docs/decisions/d18-step-skip.md
@@ -15,7 +15,8 @@
   content key. `compile` and `record` (in `_cli/build/work.tl`) hash
   their stable argv, a fixed set of behavior switches from the
   environment (`CI`, `COSMIC_COVERAGE`, `COSMIC_FENCE`,
-  `COSMIC_FIXPOINT`), and the BYTES of every declared input — the
+  `COSMIC_FIXPOINT`, `COSMIC_BENCHMARK_MIN_SECONDS`), and the BYTES
+  of every declared input — the
   source, the closure the rule already passes after `--deps`, and the
   tool stamps, which the compile line now carries after `--deps` too
   so the fence grants them and the key sees them. The key and the


### PR DESCRIPTION
PR 9 in the build/test-performance series — the test-suite tail. `cosmic/benchmark_test.tl` was the suite's slowest file (~15s): it tests the *runner* (discovery, naming, iteration counting, formatting, error handling, selection), but every real execution paid the Go-style ~1s calibration floor.

## What

- `cosmic/benchmark.tl` gains a public `Options` record with `min_seconds` (default 1.0s, unchanged — `--make benchmark` timing quality is someone's measurement). Resolution order: explicit `Options.min_seconds` → `COSMIC_BENCHMARK_MIN_SECONDS` env var → the 1s default. The env var exists so the CLI path (`cosmic --benchmark`, spawned as a child in two tests) can be steered without a flag.
- `benchmark_test.tl` passes `{min_seconds = 0.01}` to every direct run and sets the env var for the spawned-CLI tests. **No assertion touched, loosened, or removed.**
- `COSMIC_BENCHMARK_MIN_SECONDS` added to D18's `ENV_SWITCHES` in `_cli/build/work.tl` (and the ADR's list): benchmark `.got`s go through the same content-keyed record skip, and a cached result must not survive a knob flip.

## Measured

- `cosmic/benchmark_test.tl`: **~15s → 178ms**.
- Default calibration verified unchanged: a scratch `--benchmark` run still takes ~1.8s wall (1s floor + overhead); with the env var at 0.01 it drops to 40ms, confirming the fallback works end-to-end through the CLI.
- Full `bin/cosmic --make ci` → `ci: PASS (5 stages)`, coverage ratchet ok, no floor rebaseline needed.

Suite effect: the slowest test file is now ~7s (`_make/build_test.tl` doing real fixture builds), and the whole plain suite's wall drops accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Ukw9dxadTMm3aVG2A53b

---
_Generated by [Claude Code](https://claude.ai/code/session_0149Ukw9dxadTMm3aVG2A53b)_