### PR TITLE
coverage: collect through the runtime's C line hook when it has one

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -81,7 +81,7 @@ cosmic/child/io.tl 102 119
 cosmic/codec.tl 52 57
 cosmic/compress.tl 17 18
 cosmic/coverage/baseline.tl 136 154
-cosmic/coverage/init.tl 54 117
+cosmic/coverage/init.tl 54 138
 cosmic/coverage/lines.tl 65 71
 cosmic/coverage/report.tl 185 210
 cosmic/doc/comments.tl 55 55
@@ -179,4 +179,4 @@ cosmic/user.tl 48 61
 cosmic/uuid.tl 9 9
 cosmic/zip.tl 80 93
 tlconfig.lua 7 7
-total 13751 18108
+total 13751 18129

--- a/3p/cosmos/cosmos_pin.tl
+++ b/3p/cosmos/cosmos_pin.tl
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "7fd335d19fad64087c4d79dbfcd557796e0e96947ece4ab6ed92af195356ecdf"}},
+  platforms = {["*"] = {sha = "1e2563b79a0d7317c2eb1196c776283adf7b385a6fea73defdaa774525cff470"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.07.25-acc1e43aa"
+  version = "2026.08.04-7276edf51"
 }

--- a/_types/gentype.tl
+++ b/_types/gentype.tl
@@ -32,7 +32,7 @@ local parse_annotations = parse.parse_annotations
 
 -- Modules to generate (in order). "cosmo" is the top-level cosmo record
 -- (kCosmoFuncs surface); the rest are require("cosmo.<name>") submodules.
-local MODULES = {"cosmo", "unix", "path", "getopt", "lsqlite3", "re", "argon2", "zip", "repl"}
+local MODULES = {"cosmo", "unix", "path", "getopt", "lsqlite3", "re", "argon2", "zip", "cov", "repl"}
 
 --- Helper to process a class annotation block.
 local function process_class_block(anno_lines: {string}, module_name: string, classes: {ClassDecl})

--- a/cosmic/coverage/init.tl
+++ b/cosmic/coverage/init.tl
@@ -1,7 +1,9 @@
 --- Line coverage collection for cosmic programs.
---- Installs a Lua line hook that counts executed (source, line) pairs,
---- and dumps the counts as a Lua-serialized .cov file for
---- `cosmic --coverage-report` to merge and render.
+--- Counts executed (source, line) pairs via a line hook and dumps the
+--- counts as a Lua-serialized .cov file for `cosmic --coverage-report`
+--- to merge and render. When the runtime carries the C collector
+--- (cosmo.cov), the hook runs in C at a small fraction of the per-line
+--- cost; otherwise a Lua debug hook does the same accounting.
 ---
 --- The CLI arms collection automatically when the COSMIC_COVERAGE
 --- environment variable names a directory: the hook starts before the
@@ -18,8 +20,41 @@ local fs = require("cosmic.fs")
 local proc = require("cosmic.proc")
 local time = require("cosmic.time")
 
+--- The runtime's C line-hit collector (require("cosmo.cov")), when
+--- this runtime carries one. Same attribution as the Lua hook below —
+--- chunks keyed by their debug source, values line -> hit count — at a
+--- small fraction of the per-line cost.
+local record CCov
+  start: function()
+  stop: function()
+  running: function(): boolean
+  arm: function(thread: thread)
+  snapshot: function(): {string: {integer: integer}}
+  reset: function()
+end
+
+--- Detected through package.preload, where the interpreter registers
+--- its modules at boot: a runtime without the binding never pays a
+--- searcher walk for it, and the require below then resolves from
+--- preload without touching the filesystem. Dynamic (not
+--- require("cosmo.cov") spelled out) because the generated cosmo.*
+--- types come from the PINNED runtime, which may predate the binding.
+--- @return CCov | nil The C collector, or nil on an older runtime
+local function find_ccov(): CCov
+  local preload = package.preload as {string: any} -- cast: untyped stdlib table
+  if preload["cosmo.cov"] == nil then
+    return nil
+  end
+  local req = require as function(string): any -- cast: bypass static module resolution
+  return req("cosmo.cov") as CCov -- cast: binding newer than the pinned types
+end
+
+local ccov: CCov = find_ccov()
+
 --- Executed line counts, keyed by chunk source (as reported by
---- debug.getinfo, e.g. "@o/cosmic/fs/init.lua").
+--- debug.getinfo, e.g. "@o/cosmic/fs/init.lua"). Used by the Lua
+--- fallback hook; with the C collector the counts live on its side and
+--- this table stays empty.
 local counts: {string: {integer: integer}} = {}
 
 local depth = 0
@@ -59,17 +94,24 @@ local function install_wrappers(do_dump: function())
 
   local co = coroutine as {string: any} -- cast: patch stdlib table
   local raw_create = co["create"] as function(any): any -- cast: from any
+  local function arm(thread: any)
+    if ccov then
+      ccov.arm(thread as thread) -- cast: from any
+    else
+      debug.sethook(thread as thread, on_line, "l") -- cast: from any
+    end
+  end
   co["create"] = function(f: any): any
     local thread = raw_create(f)
     if depth > 0 then
-      debug.sethook(thread as thread, on_line, "l") -- cast: from any
+      arm(thread)
     end
     return thread
   end
   co["wrap"] = function(f: any): any
     local thread = raw_create(f)
     if depth > 0 then
-      debug.sethook(thread as thread, on_line, "l") -- cast: from any
+      arm(thread)
     end
     return function(...: any): any ...
       -- cast: from any
@@ -102,7 +144,11 @@ end
 local function start()
   depth = depth + 1
   if depth == 1 then
-    debug.sethook(on_line, "l")
+    if ccov then
+      ccov.start()
+    else
+      debug.sethook(on_line, "l")
+    end
   end
 end
 
@@ -115,8 +161,12 @@ local function stop()
   end
   depth = depth - 1
   if depth == 0 then
-    local clear_hook = debug.sethook as function() -- cast: function shape
-    clear_hook()
+    if ccov then
+      ccov.stop()
+    else
+      local clear_hook = debug.sethook as function() -- cast: function shape
+      clear_hook()
+    end
   end
 end
 
@@ -125,6 +175,9 @@ end
 --- "@o/cosmic/fs/init.lua"), values map line number to hit count.
 --- @return {string: {integer: integer}}
 local function snapshot(): {string: {integer: integer}}
+  if ccov then
+    return ccov.snapshot()
+  end
   local out: {string: {integer: integer}} = {}
   for src, lines in pairs(counts) do
     local t: {integer: integer} = {}
@@ -138,6 +191,9 @@ end
 
 --- Discard all collected counts.
 local function reset()
+  if ccov then
+    ccov.reset()
+  end
   counts = {}
   cur_src = nil
   cur = nil
@@ -167,7 +223,11 @@ local function dump(dir?: string): boolean, string
     dump_name = string.format("%d-%d%09d.cov",
       math.floor(proc.getpid()), math.floor(secs), math.floor(nanos))
   end
-  local body, enc_err = codec.encode_lua({version = 1, hits = counts})
+  local hits = counts
+  if ccov then
+    hits = ccov.snapshot()
+  end
+  local body, enc_err = codec.encode_lua({version = 1, hits = hits})
   if not body then
     return false, "coverage: " .. (enc_err or "encode failed")
   end


### PR DESCRIPTION
Closes #880 — the deliberate pass the issue asked for, landing candidate 3 (C-side accounting), which is where the measurement said the win actually is. Two commits: the collector change, and the cosmos pin bump that turns it on (whilp/cosmopolitan#222 merged and released as `2026.08.04-7276edf51`).

## Why not candidates 1–2 alone

The per-line cost is dominated by crossing the C↔Lua boundary, which scoping and cheaper accounting cannot touch:

- The current hook costs ~1.3µs/line on this container; `debug.getinfo(2, "S")` (a table allocation per executed line) is ~70% of it, the hook invocation itself most of the rest.
- **Scoping the hook (candidate 1)** only saves the final table store: the hook must still call `getinfo` on every line to know *which* chunk it is in. And for this repo the report set covers most execution anyway (tests resolve deps from `o/`, `/zip` chunks map back to tree sources).
- **Cheaper accounting (candidate 2)**: the only pure-Lua way to drop the per-line `getinfo` is a `"clr"`-mask hook that resolves the chunk lazily after control transfers. Measured: 3.4× faster on line-heavy code, **1.3–1.4× slower on call-heavy code** — the added call/return hook invocations are themselves C→Lua crossings.

So the hook moved to C: whilp/cosmopolitan#222 added `cosmo.cov`, a `LUA_MASKLINE` hook with identical attribution (chunks keyed by their debug source, values line → hit count), ~8–14× cheaper per line.

## What changes here

**Commit 1 — the collector.** `cosmic/coverage/init.tl` prefers `cosmo.cov` when the runtime carries it and keeps the Lua hook as the fallback, unchanged in behavior. Detection goes through `package.preload` — where the interpreter registers its modules at boot — so a runtime without the binding pays no searcher walk, and the generated `cosmo.*` types are never consulted; the dynamic `require` carries the cast justifications. The coroutine wrapper arms new threads through whichever collector is active (with the C hook this is belt-and-braces: `lua_newthread` copies C hooks, so coroutines created while armed inherit it). On the old pin nothing changes at all.

**Commit 2 — the pin bump.** `3p/cosmos/cosmos_pin.tl` → `2026.08.04-7276edf51`, the release built from the merged binding. `_types/gentype.tl` MODULES gains `"cov"` in the same commit because the bump cannot land without it — `gentype_test` fails the build when a module section in the runtime's embedded `definitions.lua` has no generator entry (verified: that guard fired before the entry was added). `cosmo/cov.d.tl` generates from the pin like every other `cosmo.*` surface.

## Measured (the OPTIMIZE.md loop)

A/B on one runtime carrying the binding, differing **only** by the collector (old vs new `init.tl`), 185-file instrumented suite, 4-core container:

```
plain suite:            59.4s summed   (21s wall)
Lua hook (old, A):     284.9s summed   (87s wall)   4.8x over plain
C hook  (new, B):       75.5s summed   (26s wall)   1.27x over plain
```

~92% of the collection overhead gone (the issue measured the multiplier at 2.2×; this container measures the same suite at 4.8× under the Lua hook). With the pin landed, the real gate's coverage stage ran at 81.3s summed.

**Attribution is unchanged.** Per-file coverage reports from A and B differ in 3 of 180 rows; a B-vs-B rerun flaps the same number of rows at the same magnitude (including the identical `_make/generate.tl` one-line swap), so the A/B delta is inside the run-to-run noise floor. No drive-by `--baseline`: the one floor that moves is `cosmic/coverage/init.tl` itself — the collector now has two disjoint code paths and only one can execute per runtime, so its line universe grows 117→138 — and `.cosmic-coverage` lowers exactly that row (and the total by the same 21 lines) by hand, so no other floor absorbs this machine's environment.

**Pin compare gate** (same payload embedded onto each runtime, A/A selfcheck alongside): 35 scenarios, **0 regressions, 12 faster**. A first pass flagged `http_fetch_get_with_headers` (+18.6% vs ±13.8%) and `startup_run_lua` (+13.9% vs ±12.4%) just over their noise bars; the re-measure pass put both well inside (+3.4% on `startup_run_lua` vs ±10%) — machine noise, not the pin.

One field note from the measurement: after a bare `cp` over `o/3p/cosmos/lua`, `--make build` did not re-assemble `o/bin/cosmic` (the staged `cmd/cosmic/base` copy skipped); the perf gate's binary-identity check caught the resulting same-binary compare exactly as designed, and forcing the reassembly (`rm o/bin/cosmic o/cmd/cosmic/base*`) fixed it. Worth a look separately — the documented C-layer loop in `_perf/optimize/cosmopolitan.md` leans on that `cp`.

Not done here, deliberately: the `.cov` workspace-relative-paths rework the issue flags as prior art — a format change with its own rebaseline coordination, orthogonal to the speed goal.

## Gates

- Old pin (fallback path): `bin/cosmic --make ci` → `ci: PASS (5 stages)`, ratchet ok.
- New pin (C hook live, verified `cosmo.cov` active in-process): `bin/cosmic --make fetch && bin/cosmic --make ci` → `ci: PASS (5 stages)`, `coverage ratchet ok`, 185 test files.
- Perf compare vs previous pin: clean (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaYhDUJNS2mE3dSBqj7m9u