### PR TITLE
perf docs: the runtime stand-in's three traps, with the wrong one corrected

### DIFF
--- a/_perf/optimize/cosmopolitan.md
+++ b/_perf/optimize/cosmopolitan.md
@@ -66,7 +66,33 @@ BENCH=$(ls _perf/bench/*_bench.tl | sed 's|/|.|g;s|\.tl$||')
    build` puts it back; so does `--make clean && --make fetch`. Check
    which one you are holding before you trust a number — that is the
    measurement-identity trap in `measurement.md`, and this procedure
-   walks straight into it.
+   walks straight into it. Three sharp edges, each found the hard way:
+
+   - **a failed `--make build` leaves the previous `o/bin/cosmic` in
+     place.** the swap itself is reliable — the payload generator
+     re-stages `base` from `o/3p/cosmos/lua` on every build — but a
+     build that fails before assembly (a generate error, a compile
+     error) changes nothing, and the stale binary measures happily.
+     read the `build: PASS` verdict or the exit status directly; a
+     pipe (`--make build | tail`) returns the pipe's status, the same
+     laundering AGENTS.md warns about for `ci`.
+   - **`--version` cannot identify the runtime.** the stamp's cosmos
+     half is read from `3p/cosmos/cosmos_pin.tl` at embed time, so a
+     binary embedded onto your local build still reports the pin's
+     version. hash the binary instead (`sha256sum o/bin/cosmic`) and
+     expect it to differ between baseline and current. every results
+     file records the hash as `meta.bin_sha`, and the compare gate
+     refuses a compare whose two sides hashed the same binary — that
+     refusal is the backstop for this whole class, so treat it as a
+     stale-binary diagnosis, not an obstacle.
+   - **tree and runtime must agree on the `cosmo.*` surface.** the
+     type generator's MODULES list (`_types/gentype.tl`) is ratcheted
+     against the runtime's embedded `definitions.lua` in both
+     directions, so standing in a runtime whose defs lack a module the
+     tree lists (or the reverse) fails the build by design. when your
+     checkout changes the surface itself, validate with
+     `GENTYPE_DEFS=$COSMO/tool/net/definitions.lua` (AGENTS.md "Type
+     Generation") rather than time-traveling the tree.
 
 3. **hypothesis, then the smallest C diff that tests it** — one
    hypothesis per commit, exactly like the cosmic layer. pick from the

--- a/_perf/optimize/measurement.md
+++ b/_perf/optimize/measurement.md
@@ -77,9 +77,16 @@ chapter of `_perf/OPTIMIZE.md` — read that first.
 
   So: baseline and compare against paths you built deliberately, in one
   sitting, and re-run `--make build` before each measurement rather
-  than assuming the binary is what it was. If a result is surprising,
-  check `$BIN --version` on both sides before you believe it. This is
-  the same class as the coverage floors' sensitivity to which compiler
+  than assuming the binary is what it was — and read that build's
+  verdict, because a build that fails before assembly leaves the
+  previous binary in place. If a result is surprising, hash the binary
+  on both sides (`sha256sum o/bin/cosmic`) before you believe it. Not
+  `--version`: its cosmos half is stamped from the pin file at embed
+  time, so it reports the pin even when a local runtime was stood in
+  by hand (`cosmopolitan.md` step 2). Every results file records
+  `meta.bin_sha`, and the compare gate refuses a compare whose two
+  sides hashed the same binary. This is the
+  same class as the coverage floors' sensitivity to which compiler
   built the artifact (`cosmic/coverage/SENSITIVITY.md`): a metric
   measured through an artifact inherits that artifact's identity as a
   hidden input.


### PR DESCRIPTION
Follow-up to #883, which carried this field note:

> after a bare `cp` over `o/3p/cosmos/lua`, `--make build` did not re-assemble `o/bin/cosmic` (the staged `cmd/cosmic/base` copy skipped) … Worth a look separately — the documented C-layer loop in `_perf/optimize/cosmopolitan.md` leans on that `cp`.

**That diagnosis was wrong.** I re-investigated with the engine source and a clean experiment, and the swap is reliable: `_make/generate.tl` clears and re-runs the payload generator on every build (so `base` is re-staged from `o/3p/cosmos/lua` each time), `_make/artifact.tl` re-stages and re-embeds unconditionally, and a clean swap between two runtimes re-embedded immediately (binary hash moved on the very next `--make build`). The `o/cmd/cosmic/base` file the note blamed is a leftover from the pinned engine's generation-1 layout, not part of the current staging path.

What actually produced #883's same-binary perf runs was three things stacking, none of them an engine bug:

1. **The build failed before assembly, by design.** The tree's gentype MODULES (ratcheted against the runtime's embedded `definitions.lua` in both directions) demanded the `cov` section that the stood-in *older* runtime lacks — so `--make build` failed at generate, leaving the previous `o/bin/cosmic` in place.
2. **The failure was laundered through a pipe.** `--make build 2>&1 | tail -1` returns tail's status — the exact trap AGENTS.md documents for `ci` — so the loop marched on and measured the stale binary.
3. **`--version` could not have caught it.** The stamp's cosmos half is read from `3p/cosmos/cosmos_pin.tl` at embed time (`cmd/cosmic/embed_gen.tl` `write_version`), so a binary embedded onto a hand-stood-in runtime still reports the pin's version — verified: a binary running my local cosmopolitan build printed `cosmos 2026.08.04-7276edf51`.

The compare gate's `bin_sha` identity check then refused the same-binary compare — the backstop working exactly as designed.

## What changes

Docs only, in the two files that walk this workflow:

- **`_perf/optimize/cosmopolitan.md`** (step 2, the stand-in): the "check which one you are holding" warning gains the three concrete sharp edges — read the `build: PASS` verdict/exit status directly (a failed build measures the previous binary happily); identify binaries by `sha256sum`, never `--version`, with the gate's `bin_sha` refusal named as the backstop to treat as a stale-binary diagnosis; and the tree↔runtime `cosmo.*` surface agreement, with `GENTYPE_DEFS=$COSMO/tool/net/definitions.lua` as the sanctioned escape hatch when the checkout changes the surface itself.
- **`_perf/optimize/measurement.md`** (the know-which-binary-you-measured entry): "check `$BIN --version` on both sides" — advice this episode proved insufficient — becomes "hash both sides", plus the read-the-verdict rule and a pointer to the gate's same-binary refusal.

## Gates

`bin/cosmic --make ci`: `ci: PASS (5 stages)`, `coverage ratchet ok`, 185 test files (docs-only change; the gate lints and length-checks `.md` files, so it still has to run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaYhDUJNS2mE3dSBqj7m9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaYhDUJNS2mE3dSBqj7m9u)_