### PR TITLE
sandbox family: fail closed, report what enforced, split ro from exec

### DIFF
--- a/_cli/driver.tl
+++ b/_cli/driver.tl
@@ -136,15 +136,25 @@ local function fence(verb: string, args: {string}): string | nil
   -- every fenced recipe then reports only the lines it ran before the
   -- fence landed. The dumps are all there and all nearly empty, which
   -- is why it read as a code regression rather than a lost measurement.
-  local ok, err = sandbox.apply({
+  local enforced, err = sandbox.apply({
       fs = fs_policy,
       best_effort = true,
       keep_coverage = true,
     })
-  if not ok then
-    return "fence for '" .. verb .. "' failed: " .. (err or "unknown error")
+  if enforced is sandbox.Availability then
+    -- best_effort can no longer skip silently: apply reports what it
+    -- enforced. A host that cannot enforce runs unfenced by design
+    -- (see above) — say so when the caller explicitly asked for the
+    -- fence (COSMIC_FENCE set), and stay quiet on the implicit
+    -- default, where a per-recipe warning would drown a whole build
+    -- on such hosts.
+    if not enforced.fs and os.getenv("COSMIC_FENCE") ~= nil then
+      io.stderr:write("fence: unenforceable on this host; '"
+        .. verb .. "' runs unfenced\n")
+    end
+    return nil
   end
-  return nil
+  return "fence for '" .. verb .. "' failed: " .. (err or "unknown error")
 end
 
 --- Run one driver entry with line coverage armed.

--- a/_cli/grants.tl
+++ b/_cli/grants.tl
@@ -319,6 +319,8 @@ local function plan(verb: string, args: {string}): sandbox.Fs | nil, string | ni
     -- have yet (docs/design/make/engine.md). Until then the honest
     -- boundary is the one above, stated rather than implied.
     ro[#ro + 1] = "."
+    -- ...and EXEC (ro is read-only now): tests exec project binaries.
+    ex[#ex + 1] = "."
     -- And the RUNTIME, because a test is arbitrary code that uses the
     -- operating system on purpose: this repo's own tests allocate ptys
     -- (`/dev/ptmx`), count their file descriptors (`/proc/self/fd`),
@@ -438,10 +440,8 @@ local function plan(verb: string, args: {string}): sandbox.Fs | nil, string | ni
       rw[#rw + 1] = cov
     end
   end
-  for _, dev in ipairs({"/dev/null"}) do
-    if fs.exists(dev) then
-      rw[#rw + 1] = dev
-    end
+  if fs.exists("/dev/null") then
+    rw[#rw + 1] = "/dev/null"
   end
   for _, dev in ipairs({"/dev/random", "/dev/urandom"}) do
     if fs.exists(dev) then

--- a/cosmic/_seal_coverage.tl
+++ b/cosmic/_seal_coverage.tl
@@ -1,9 +1,10 @@
 --- Flush line-coverage data before rights drop: a dump attempted after
 --- a pledge/unveil policy lands would violate it and kill the process.
 ---
---- Shared by cosmic.pledge and cosmic.unveil, which must not require
---- each other (cosmic.sandbox composes both over the same policy) —
---- hence its own internal home here rather than living in either one.
+--- Shared by cosmic.pledge, cosmic.unveil, and cosmic.landlock, which
+--- must not require each other (cosmic.sandbox composes them over the
+--- same policy) — hence its own internal home here rather than living
+--- in any one of them.
 --- Reaches coverage via `package.loaded` rather than
 --- `require("cosmic.coverage")` so pledge/unveil stay leaf modules
 --- that never force-load coverage instrumentation a caller isn't

--- a/cosmic/ip.tl
+++ b/cosmic/ip.tl
@@ -170,11 +170,13 @@ local record Cidr
   --- Number of addresses in the block (including network/broadcast).
   --- @return integer The block size
   size: function(Cidr): integer
-  --- Check whether the block contains an address.
-  --- @param a Addr | string The address (typed or dotted quad)
-  --- @return boolean True when contained; false (plus an error
-  --- message) when a string address does not parse
-  contains: function(Cidr, Addr | string): boolean, string
+  --- Check whether the block contains an address. Takes the typed
+  --- Addr only: a raw string would make an unparseable input
+  --- indistinguishable from a non-member — the fail-open direction
+  --- for an allowlist check. Parse first and handle the error there.
+  --- @param a Addr The address
+  --- @return boolean True when contained
+  contains: function(Cidr, Addr): boolean
   --- Format as "addr/bits" (same as tostring()).
   --- @return string The CIDR notation
   format: function(Cidr): string
@@ -208,18 +210,8 @@ local function cidr_size(self: Cidr): integer
   return 1 << (32 - self._bits)
 end
 
-local function cidr_contains(self: Cidr, a: Addr | string): boolean, string
-  local n: integer
-  if a is string then
-    local parsed, err = parse(a)
-    if not parsed then
-      return false, err
-    end
-    n = (parsed as Addr):int() -- cast: record union after guard
-  else
-    n = (a as Addr):int() -- cast: record union in is-else branch
-  end
-  return (n & cidr_mask(self._bits)) == self._n
+local function cidr_contains(self: Cidr, a: Addr): boolean
+  return (a:int() & cidr_mask(self._bits)) == self._n
 end
 
 local function cidr_format(self: Cidr): string

--- a/cosmic/ip_test.tl
+++ b/cosmic/ip_test.tl
@@ -265,33 +265,33 @@ local function test_cidr_netmask_broadcast_size()
 end
 test_cidr_netmask_broadcast_size()
 
+-- contains takes the typed Addr only: a raw string would make an
+-- unparseable input indistinguishable from a non-member — fail-open
+-- for an allowlist check. Callers parse first, so the parse error has
+-- somewhere to go.
 local function test_cidr_contains()
   local c = check.must(ip.cidr("192.168.1.0/24"))
-  assert(c:contains("192.168.1.1"), "expected member")
-  assert(c:contains("192.168.1.0"), "expected network address contained")
-  assert(c:contains("192.168.1.255"), "expected broadcast address contained")
-  assert(not c:contains("192.168.2.1"), "expected non-member")
-  assert(not c:contains("10.0.0.1"), "expected non-member")
-
-  local a = assert(ip.parse("192.168.1.42"))
-  assert(c:contains(a), "expected typed Addr accepted")
+  local function member(s: string): boolean
+    local a = check.must(ip.parse(s))
+    return c:contains(a)
+  end
+  assert(member("192.168.1.1"), "expected member")
+  assert(member("192.168.1.0"), "expected network address contained")
+  assert(member("192.168.1.255"), "expected broadcast address contained")
+  assert(not member("192.168.2.1"), "expected non-member")
+  assert(not member("10.0.0.1"), "expected non-member")
 
   local all = check.must(ip.cidr("0.0.0.0/0"))
-  assert(all:contains("8.8.8.8"), "expected /0 to contain everything")
+  local everyone = check.must(ip.parse("8.8.8.8"))
+  assert(all:contains(everyone), "expected /0 to contain everything")
 
   local host = check.must(ip.cidr("1.2.3.4/32"))
-  assert(host:contains("1.2.3.4"), "expected /32 to contain itself")
-  assert(not host:contains("1.2.3.5"), "expected /32 to exclude neighbors")
+  local self_addr = check.must(ip.parse("1.2.3.4"))
+  local neighbor = check.must(ip.parse("1.2.3.5"))
+  assert(host:contains(self_addr), "expected /32 to contain itself")
+  assert(not host:contains(neighbor), "expected /32 to exclude neighbors")
 end
 test_cidr_contains()
-
-local function test_cidr_contains_bad_string()
-  local c = check.must(ip.cidr("10.0.0.0/8"))
-  local ok, err = c:contains("not-an-ip")
-  assert(ok == false, "expected false for unparseable address")
-  assert(err ~= nil, "expected an error message")
-end
-test_cidr_contains_bad_string()
 
 local function test_cidr_equality()
   local a = check.must(ip.cidr("10.0.0.0/8"))

--- a/cosmic/landlock.tl
+++ b/cosmic/landlock.tl
@@ -22,6 +22,7 @@
 --- `cosmic.pledge` on Linux and is complementary to `cosmic.quicksand`
 --- network isolation.
 local unix = require("cosmo.unix")
+local seal_coverage = require("cosmic._seal_coverage").seal_coverage
 
 local EXECUTE < const > = unix.LANDLOCK_ACCESS_FS_EXECUTE
 local WRITE_FILE < const > = unix.LANDLOCK_ACCESS_FS_WRITE_FILE
@@ -91,6 +92,10 @@ local record RestrictOptions
   --- below, so the process reports what it does after restricting
   --- rather than only what it did before.
   keep_coverage: boolean
+  --- Turn an unsupported host into a successful no-op instead of an
+  --- error — the explicit fail-open escape hatch, matching
+  --- cosmic.pledge and cosmic.unveil.
+  best_effort: boolean
 end
 
 local record LandlockModule
@@ -118,7 +123,7 @@ local record LandlockModule
   ALL: integer
   abi: function(): integer | nil, string
   available: function(): boolean
-  restrict: function(opts: RestrictOptions): boolean, string
+  restrict: function(opts?: RestrictOptions): boolean, string
 end
 
 --- Per-ABI "max access" mask. Categories above the kernel's supported
@@ -132,14 +137,30 @@ local function abi_mask(abi_version: integer): integer
   return mask
 end
 
+-- The kernel's ABI answer cannot change within a process; probe once
+-- and cache, matching pledge.available() / unveil.available().
+local abi_cached: integer = nil
+local abi_cached_err: string = nil
+local abi_probed: boolean = false
+
 --- Returns the kernel's supported landlock ABI version (>= 1 when
 --- landlock is enabled). Returns nil + error on ENOSYS or non-Linux.
+--- Probed once and cached.
 local function abi(): integer | nil, string
-  local v, err = unix.landlock_create_ruleset()
-  if not v then
-    return nil, err and tostring(err) or "landlock unavailable"
+  if not abi_probed then
+    abi_probed = true
+    local v, err = unix.landlock_create_ruleset()
+    if v then
+      abi_cached = v
+    else
+      abi_cached_err = err and ("landlock: " .. tostring(err))
+      or "landlock unsupported on this host"
+    end
   end
-  return v
+  if abi_cached == nil then
+    return nil, abi_cached_err
+  end
+  return abi_cached
 end
 
 --- True when abi() >= 1. Gate box setup on this.
@@ -161,15 +182,24 @@ end
 --- outside its allowlist. (Cosmopolitan's C unveil path plugs this with
 --- a seccomp filter; this module does not.) Pair with `cosmic.pledge`
 --- — truncate is governed by its "wpath" group — where that matters.
-local function restrict(opts: RestrictOptions): boolean, string
+local function restrict(opts?: RestrictOptions): boolean, string
   opts = opts or {}
-  local abi_version, aerr = abi()
-  if not abi_version then return false, aerr end
-  if abi_version < 1 then return false, "landlock unavailable" end
+  if not available() then
+    if opts.best_effort then return true end
+    return false, "landlock unsupported on this host"
+  end
+  local abi_version = abi()
+  if abi_version == nil then
+    -- Unreachable past the available() gate; kept so the narrowing is
+    -- honest rather than cast.
+    return false, "landlock unsupported on this host"
+  end
   local mask = abi_mask(abi_version)
   local handled = (opts.handled or ALL) & mask
   local rs, cerr = unix.landlock_create_ruleset(handled, 0)
-  if not rs then return false, tostring(cerr) end
+  if not rs then
+    return false, "landlock: create_ruleset: " .. tostring(cerr)
+  end
   local rsfd = rs
   local function fail(msg: string): boolean, string
     unix.close(rsfd)
@@ -177,13 +207,14 @@ local function restrict(opts: RestrictOptions): boolean, string
   end
   for i, rule in ipairs(opts.rules or {}) do
     if not rule.path then
-      return fail(string.format("rule[%d] missing path", i))
+      return fail(string.format("landlock: rule[%d] missing path", i))
     end
     local access = (rule.access or 0) & mask
     local pfd, perr = unix.open(rule.path,
       (unix.O_PATH) | (unix.O_CLOEXEC))
     if not pfd then
-      return fail(string.format("open(%q): %s", rule.path, tostring(perr)))
+      return fail(string.format("landlock: open(%q): %s",
+          rule.path, tostring(perr)))
     end
     -- Directory-only rights on a non-directory rule are an EINVAL from
     -- the kernel; strip them so file paths accept the composite masks
@@ -198,38 +229,30 @@ local function restrict(opts: RestrictOptions): boolean, string
       local ok, rerr = unix.landlock_add_rule(rsfd, pfd, access, 0)
       if not ok then
         unix.close(pfd)
-        return fail(string.format("add_rule(%q): %s", rule.path, tostring(rerr)))
+        return fail(string.format("landlock: add_rule(%q): %s",
+            rule.path, tostring(rerr)))
       end
     end
     unix.close(pfd)
   end
   if opts.no_new_privs ~= false then
     local ok, err = unix.prctl(unix.PR_SET_NO_NEW_PRIVS, 1)
-    if not ok then return fail("PR_SET_NO_NEW_PRIVS: " .. tostring(err)) end
+    if not ok then
+      return fail("landlock: PR_SET_NO_NEW_PRIVS: " .. tostring(err))
+    end
   end
   -- Flush line-coverage data before rights drop: once the ruleset
   -- lands, the coverage directory MAY no longer be writable, and
-  -- sealing is the only safe answer to "may".
-  --
-  -- `keep_coverage` is a caller that has removed the doubt. The recipe
-  -- fence grants its own coverage directory (see `_cli/grants.tl`), so
-  -- for it the dump at exit works and sealing here is pure loss: it
-  -- reports what the process did BEFORE restricting and discards
-  -- everything it was actually restricted to do. That is not a small
-  -- loss — it read as `_cli/build/steps.tl` at 14%, and as a code
-  -- regression, because the dumps were all present and all nearly
-  -- empty.
-  if not opts.keep_coverage then
-    local cov = package.loaded["cosmic.coverage"]
-    if cov ~= nil then
-      -- cast: from any; function shape
-      local seal = (cov as {string: any})["seal"] as function()
-      seal()
-    end
-  end
+  -- sealing is the only safe answer to "may". `keep_coverage` is a
+  -- caller that has removed the doubt (the recipe fence grants its own
+  -- coverage directory — see `_cli/grants.tl`); the seal-vs-keep rule
+  -- itself lives in cosmic._seal_coverage, shared with pledge/unveil.
+  seal_coverage(opts.keep_coverage)
   local ok, rerr = unix.landlock_restrict_self(rsfd, 0)
   unix.close(rsfd)
-  if not ok then return false, "restrict_self: " .. tostring(rerr) end
+  if not ok then
+    return false, "landlock: restrict_self: " .. tostring(rerr)
+  end
   return true
 end
 

--- a/cosmic/pledge.tl
+++ b/cosmic/pledge.tl
@@ -72,9 +72,12 @@ local PROMISES: {Promise} = {
 --- Options for `apply`. `exec` sets the promises children keep after
 --- execve. `best_effort` turns an unsupported host into a successful
 --- no-op instead of an error — the explicit fail-open escape hatch.
+--- `keep_coverage` skips the pre-pledge coverage seal — set it only
+--- when the promises still permit the coverage dump at exit.
 local record ApplyOptions
   exec: string
   best_effort: boolean
+  keep_coverage: boolean
 end
 
 local avail: boolean = nil
@@ -121,7 +124,7 @@ local function apply(promises: string, opts?: ApplyOptions): boolean, string
     if opts and opts.best_effort then return true end
     return false, "pledge unsupported on this host"
   end
-  seal_coverage()
+  seal_coverage(opts and opts.keep_coverage)
   local ok, err = unix.pledge(promises, opts and opts.exec)
   if not ok then
     return false, errno.str(err, "pledge")

--- a/cosmic/quicksand/box/init.tl
+++ b/cosmic/quicksand/box/init.tl
@@ -8,7 +8,7 @@
 ---
 ---     local quicksand = require("cosmic.quicksand")
 ---     local box = quicksand.Box.new{
----       fs = { ro = { "/usr" }, rw = { "/tmp" } },
+---       fs = { exec = { "/usr" }, rw = { "/tmp" } },
 ---       net = { allow = { ["api.example.com:443"] = {} } },
 ---       proc = { no_new_privs = true },
 ---       cwd = "/tmp",
@@ -23,6 +23,7 @@
 --- fork / exec orchestration lives in cosmic.quicksand.box.run and is
 --- required on demand from `run()` so construction stays cheap.
 local box_merge = require("cosmic.quicksand.box.merge")
+local sandbox = require("cosmic.sandbox")
 local types = require("cosmic.quicksand.types")
 
 --- The policy schema lives in cosmic.quicksand.types (shared with the
@@ -71,29 +72,27 @@ local function validate(opts: BoxOptions): boolean, string
     if proc.gid ~= nil and type(proc.gid) ~= "number" then
       return false, "proc.gid must be a number"
     end
-    if proc.pledge ~= nil and type(proc.pledge) ~= "string" then
-      return false, "proc.pledge must be a string"
-    end
     if proc.keep_caps ~= nil and type(proc.keep_caps) ~= "table" then
       return false, "proc.keep_caps must be a list of capability names"
+    end
+    -- The pledge string moved to opts.sys (cosmic.sandbox's Sys
+    -- schema); catch the retired spelling with a migration message.
+    if (proc as {string: any}).pledge ~= nil then -- cast: probe for removed field
+      return false, "proc.pledge was removed: use sys = { promises = ... }"
+      .. " (cosmic.sandbox's Sys schema)"
     end
   end
   local net = opts.net
   if net and net.allow ~= nil and type(net.allow) ~= "table" then
     return false, "net.allow must be a table"
   end
-  local fs = opts.fs
-  if fs then
-    if (fs as {string: any}).deny ~= nil then -- cast: probe for removed field
-      return false, "fs.deny was removed: the fs policy is an allowlist,"
-      .. " every path not in fs.ro/rw/exec is already denied"
-    end
-    for _, name in ipairs({"ro", "rw", "exec"}) do
-      local v = (fs as {string: any})[name] -- cast: dynamic key into record
-      if v ~= nil and type(v) ~= "table" then
-        return false, "fs." .. name .. " must be a list"
-      end
-    end
+  -- fs and sys are cosmic.sandbox's own schemas; its validator is the
+  -- single source of truth for their shape (including promise-token
+  -- validation), so a typo'd promise fails here at Box.new instead of
+  -- post-fork as an opaque exit 126.
+  if opts.fs ~= nil or opts.sys ~= nil then
+    local sok, serr = sandbox.validate({fs = opts.fs, sys = opts.sys})
+    if not sok then return false, serr end
   end
   return true
 end
@@ -116,13 +115,14 @@ local function preflight(opts: BoxOptions): boolean, string
     if opts.hostname and not c.uts_ns then
       return false, "quicksand: UTS namespace unavailable (hostname requested)"
     end
-    local fs = opts.fs
-    local has_fs = fs and (fs.ro or fs.rw or fs.exec)
-    if has_fs and not c.landlock then
+    -- A present fs section IS a policy (validate() rejects an empty
+    -- one), so its presence alone requires landlock — matching
+    -- sandbox.apply, where fs = { ro = {} } is a real deny-all.
+    if opts.fs and not c.landlock then
       return false, "quicksand: landlock unavailable (fs policy requested)"
     end
-    if opts.proc and opts.proc.pledge and not c.pledge then
-      return false, "quicksand: pledge unavailable"
+    if opts.sys and not c.pledge then
+      return false, "quicksand: pledge unavailable (sys policy requested)"
     end
     local pr = opts.proc
     local wants_caps = pr and (pr.drop_caps or (pr.keep_caps and #pr.keep_caps > 0))

--- a/cosmic/quicksand/box/init_example.tl
+++ b/cosmic/quicksand/box/init_example.tl
@@ -11,8 +11,9 @@ local function Example_new_and_close()
   local Box = require("cosmic.quicksand.box")
   local check = require("cosmic.check")
   local box = check.must(Box.new({
-        fs = {ro = {"/usr"}, rw = {"/tmp"}},
+        fs = {exec = {"/usr"}, rw = {"/tmp"}},
         net = {allow = {["api.example.com:443"] = {}}},
+        sys = {promises = "stdio rpath exec"},
         proc = {no_new_privs = true},
         cwd = "/tmp",
       }))
@@ -26,7 +27,7 @@ end
 -- data, overlay them with Box.merge, and feed the result into new().
 local function Example_merge()
   local Box = require("cosmic.quicksand.box")
-  local base = {fs = {ro = {"/usr", "/etc/ssl/certs"}}}
+  local base = {fs = {exec = {"/usr"}, ro = {"/etc/ssl/certs"}}}
   local network = {net = {allow = {["api.example.com:443"] = {}}}}
   local policy = Box.merge(base, network, {cwd = "/work"})
   io.write(tostring(policy.cwd) .. "\n")

--- a/cosmic/quicksand/box/merge_test.tl
+++ b/cosmic/quicksand/box/merge_test.tl
@@ -64,14 +64,25 @@ test_env_set_and_keep()
 
 local function test_nested_proc_scalars()
   local out = m.merge(
-    {proc = {uid = 1000, gid = 1000, pledge = "stdio"}},
+    {proc = {uid = 1000, gid = 1000, no_new_privs = true}},
     {proc = {uid = 2000}})
   local p = out.proc as {string: any} -- cast: from any
   assert(p.uid == 2000, "later wins")
   assert(p.gid == 1000, "gid preserved")
-  assert(p.pledge == "stdio", "pledge preserved")
+  assert(p.no_new_privs == true, "no_new_privs preserved")
 end
 test_nested_proc_scalars()
+
+-- sys is a section like fs: scalars in it overlay per key.
+local function test_nested_sys_scalars()
+  local out = m.merge(
+    {sys = {promises = "stdio rpath"}},
+    {sys = {exec = "stdio"}})
+  local s = out.sys as {string: any} -- cast: from any
+  assert(s.promises == "stdio rpath", "promises preserved")
+  assert(s.exec == "stdio", "exec overlay applied")
+end
+test_nested_sys_scalars()
 
 local function test_nil_table_skipped()
   local a: {string: any} = {hostname = "x"}

--- a/cosmic/quicksand/box/run.tl
+++ b/cosmic/quicksand/box/run.tl
@@ -36,7 +36,6 @@ local qproc = require("cosmic.quicksand.proc")
 local qcaps = require("cosmic.quicksand.caps")
 local proxy = require("cosmic.quicksand.proxy")
 local sandbox = require("cosmic.sandbox")
-local pledge = require("cosmic.pledge")
 local box_env = require("cosmic.quicksand.box.env")
 local types = require("cosmic.quicksand.types")
 local cenv = require("cosmic.env")
@@ -109,10 +108,11 @@ local function workload_setup(opts: BoxOptions): string
     if not ok then return "chdir: " .. tostring(err) end
   end
   local fs = opts and opts.fs
-  if fs and (fs.ro or fs.rw or fs.exec) then
+  if fs then
     -- The fs policy is cosmic.sandbox's Fs schema; the facade picks the
     -- mechanism (landlock here — Box is Linux-only) and its errors are
-    -- already prefixed "sandbox: fs: ...".
+    -- already prefixed "sandbox: fs: ...". A present section is a real
+    -- policy — fs = { ro = {} } denies everything — matching apply.
     local ok, err = sandbox.apply({fs = fs})
     if not ok then return tostring(err) end
   end
@@ -133,9 +133,13 @@ local function workload_setup(opts: BoxOptions): string
     local ok, err = qproc.drop_privs(pr.uid, gid)
     if not ok then return "drop_privs: " .. tostring(err) end
   end
-  if pr and pr.pledge then
-    local ok, err = pledge.apply(pr.pledge)
-    if not ok then return "pledge: " .. tostring(err) end
+  -- The sys (pledge) policy applies LAST — after the privilege drops
+  -- above, whose setresuid/capset calls a pledge filter could block —
+  -- through the same facade as fs, so validation, ordering and error
+  -- prefixes have one home. Box.new already validated the tokens.
+  if opts and opts.sys then
+    local ok, err = sandbox.apply({sys = opts.sys})
+    if not ok then return tostring(err) end
   end
   return nil
 end

--- a/cosmic/quicksand/box/run_test.tl
+++ b/cosmic/quicksand/box/run_test.tl
@@ -107,33 +107,46 @@ io.write("ok exit=0\n")
 end
 test_run_survives_eintr_during_wait()
 
+-- A typo'd sys policy must be rejected at Box.new — construction time,
+-- before any fork — with an error naming the bad promise. This used to
+-- die post-fork as an opaque exit 126; sys now goes through
+-- cosmic.sandbox's validator at new().
+local function test_bogus_sys_promise_rejected_at_new()
+  local new_any = quicksand.Box.new as function(any): any, any -- cast: deliberate invalid input
+  local j, err = new_any({sys = {promises = "stdio bogus_promise"}})
+  assert(j == nil, "bogus promise must be rejected at new()")
+  assert(err and (err as string):find("bogus_promise", 1, true), -- cast: from any
+    "error should name the bad promise: " .. tostring(err))
+end
+test_bogus_sys_promise_rejected_at_new()
+
 -- Setup failures must come back on the error channel as nil + message,
 -- not masquerade as a workload exit code (a 126 with the reason only on
--- stderr is indistinguishable from the workload itself failing). A
--- bogus pledge promise fails workload_setup after the fork; run() must
--- return nil and an error naming the pledge step.
+-- stderr is indistinguishable from the workload itself failing). A cwd
+-- that does not exist fails workload_setup after the fork; run() must
+-- return nil and an error naming the chdir step.
 local function test_setup_failure_returns_error_not_exit_code()
   local c = quicksand.capabilities()
-  if not (c.linux and c.user_ns and c.net_ns and c.pledge) then
-    check.skip("box namespaces or pledge unavailable on this host")
+  if not (c.linux and c.user_ns and c.net_ns) then
+    check.skip("box namespaces unavailable on this host")
     return
   end
 
-  local r = run_script("box_bogus_pledge.lua", [[
+  local r = run_script("box_bad_cwd.lua", [[
 local qs = require("cosmic.quicksand")
-local j, nerr = qs.Box.new({ proc = { pledge = "bogus_promise" } })
+local j, nerr = qs.Box.new({ cwd = "/nonexistent-quicksand-run-test" })
 if not j then io.stderr:write("new: " .. tostring(nerr) .. "\n"); os.exit(1) end
 local code, rerr = j:run({"/bin/true"})
 if code ~= nil then
   io.stderr:write("expected nil, got exit=" .. tostring(code) .. "\n"); os.exit(1)
 end
-if not (type(rerr) == "string" and rerr:find("pledge")) then
-  io.stderr:write("error should name pledge: " .. tostring(rerr) .. "\n"); os.exit(1)
+if not (type(rerr) == "string" and rerr:find("chdir")) then
+  io.stderr:write("error should name chdir: " .. tostring(rerr) .. "\n"); os.exit(1)
 end
 io.write("ok nil-error: " .. tostring(rerr) .. "\n")
 ]])
   if not r then return end
-  assert(r.ok, "bogus pledge must return nil + pledge error: "
+  assert(r.ok, "bad cwd must return nil + chdir error: "
     .. tostring(r.stdout) .. tostring(r.stderr))
   assert(r.stdout:find("ok nil%-error"),
     "expected nil-error report, got: " .. tostring(r.stdout))

--- a/cosmic/quicksand/caps.tl
+++ b/cosmic/quicksand/caps.tl
@@ -16,8 +16,9 @@
 --- would make subsequent PR_CAPBSET_DROP calls fail with EPERM).
 ---
 --- Linux-only. On non-Linux hosts (or a cosmos build without the CAP_*
---- constants) the constants are nil; drop_bounding() is then a
---- successful no-op and supported() returns false.
+--- constants) the constants are nil; supported() returns false and
+--- drop_bounding() fails closed — `best_effort = true` opts into a
+--- successful no-op instead.
 local unix = require("cosmo.unix")
 local errno = require("cosmic.errno")
 
@@ -42,6 +43,10 @@ local NAMES: {string} = {
 --- Options for drop_bounding().
 local record DropOptions
   keep: {string} -- capability names to retain in the bounding set
+  --- Turn an unsupported host into a successful no-op instead of an
+  --- error — the explicit fail-open escape hatch, matching
+  --- cosmic.pledge / cosmic.unveil / cosmic.landlock.
+  best_effort: boolean
 end
 
 --- Resolve a capability name (e.g. "CAP_NET_RAW") to its integer number
@@ -134,18 +139,21 @@ end
 --- Must run while the caller still holds CAP_SETPCAP (e.g. immediately
 --- after unshare(CLONE_NEWUSER) with a uid map, before proc.drop_privs
 --- clears the capability set). A cap number the kernel does not know
---- (EINVAL) is skipped; ENOSYS ends the sweep successfully. On a host
---- without the CAP_* constants (non-Linux) this is a successful no-op.
+--- (EINVAL) is skipped. Fail-closed: on a host that cannot drop at all
+--- (no CAP_* constants, or ENOSYS from PR_CAPBSET_DROP) this returns
+--- `false, "caps: ... unsupported on this host"` instead of reporting
+--- a drop that did not happen; `best_effort = true` opts into treating
+--- that as a successful no-op.
 ---
---- @param opts DropOptions? optional keep-set
+--- @param opts DropOptions? optional keep-set and best_effort flag
 --- @return boolean true on success
 --- @return string? error message on failure
 local function drop_bounding(opts?: DropOptions): boolean, string
   local last = unix.CAP_LAST_CAP
   if last == nil then
-    -- No capability constants (non-Linux, or a cosmos without them):
-    -- there is nothing to drop.
-    return true
+    -- No capability constants (non-Linux, or a cosmos without them).
+    if opts and opts.best_effort then return true end
+    return false, "caps: capability bounding set unsupported on this host"
   end
   local keep: {integer: boolean} = {}
   if opts and opts.keep then
@@ -162,11 +170,15 @@ local function drop_bounding(opts?: DropOptions): boolean, string
         if errno.is(eno, "EINVAL") then
           -- Capability number unknown to this kernel; skip it.
         elseif errno.is(eno, "ENOSYS") then
-          -- Capabilities unsupported on this host; done.
-          return true
+          -- Capabilities unsupported on this host. Reporting success
+          -- here would claim a drop that did not happen — and worse,
+          -- mid-sweep it would claim a PARTIAL drop as complete.
+          if opts and opts.best_effort then return true end
+          return false,
+          "caps: PR_CAPBSET_DROP unsupported on this host (ENOSYS)"
         else
           return false, errno.str(err,
-            "PR_CAPBSET_DROP " .. tostring(c))
+            "caps: PR_CAPBSET_DROP " .. tostring(c))
         end
       end
     end

--- a/cosmic/quicksand/caps_test.tl
+++ b/cosmic/quicksand/caps_test.tl
@@ -84,13 +84,36 @@ test_bounding_read()
 -- drop_bounding validates the keep-set BEFORE touching the bounding set,
 -- so an unknown keep name returns false + err and drops nothing. This is
 -- safe to run in-process precisely because it never reaches a real drop.
+-- On a host without the capability API the unsupported gate fires first;
+-- that branch is asserted below instead.
 local function test_drop_bounding_bad_keep()
+  if not caps.supported() then
+    check.skip("capabilities unsupported on this host")
+    return
+  end
   local ok, err = caps.drop_bounding({keep = {"CAP_BOGUS"}})
   assert(not ok, "bad keep name should fail")
   assert(type(err) == "string" and err:find("CAP_BOGUS"),
     "error should name the bad capability: " .. tostring(err))
 end
 test_drop_bounding_bad_keep()
+
+-- Fail-closed on an unsupported host: drop_bounding must not report a
+-- drop that did not happen. best_effort is the explicit opt-in to a
+-- successful no-op, matching pledge/unveil/landlock.
+local function test_drop_bounding_fails_closed_when_unsupported()
+  if caps.supported() then
+    check.skip("capabilities supported here; unsupported path not exercisable")
+    return
+  end
+  local ok, err = caps.drop_bounding()
+  assert(not ok, "unsupported host must fail closed")
+  assert(type(err) == "string" and err:find("unsupported", 1, true),
+    "error should say unsupported: " .. tostring(err))
+  assert(caps.drop_bounding({best_effort = true}),
+    "best_effort must turn unsupported into a successful no-op")
+end
+test_drop_bounding_fails_closed_when_unsupported()
 
 -- The real, irreversible drop path is exercised in a subprocess so it
 -- cannot strip this test runner's own bounding set. After a successful

--- a/cosmic/quicksand/proc.tl
+++ b/cosmic/quicksand/proc.tl
@@ -42,6 +42,10 @@ local DEFAULT_SIGNALS: {string} = {"SIGINT", "SIGTERM", "SIGHUP"}
 --- @return boolean true on success
 --- @return string? error message on failure
 local function no_new_privs(): boolean, string
+  if unix.prctl == nil or unix.PR_SET_NO_NEW_PRIVS == nil then
+    -- Calling a nil binding would throw; report the absence instead.
+    return false, "no_new_privs unsupported on this host"
+  end
   local ok, err = unix.prctl(unix.PR_SET_NO_NEW_PRIVS, 1)
   if not ok then return false, errno.str(err, "no_new_privs") end
   return true

--- a/cosmic/quicksand/types.tl
+++ b/cosmic/quicksand/types.tl
@@ -58,10 +58,15 @@ local record ProcOptions
   no_new_privs: boolean
   uid: integer
   gid: integer
-  pledge: string
   drop_caps: boolean -- drop the entire capability bounding set before exec
   keep_caps: {string} -- capability names to retain (implies drop_caps)
 end
+
+--- The system-call policy is cosmic.sandbox's Sys schema (pledge
+--- promises, plus the promises retained after execve) — the same
+--- vocabulary as the in-process facade, validated at Box.new and
+--- applied via sandbox.apply in the workload, after privilege drops.
+local type SysOpts = sandbox.Sys
 
 --- Env policy for the boxed workload: `keep` names inherit from the
 --- parent environment (everything else is dropped), `set` overrides /
@@ -77,6 +82,7 @@ end
 local record BoxOptions
   hostname: string
   fs: FsOpts
+  sys: SysOpts
   net: NetOptions
   proc: ProcOptions
   env: EnvOptions
@@ -110,6 +116,7 @@ local record TypesModule
   type NetRule = NetRule
   type NetOptions = NetOptions
   type FsOpts = FsOpts
+  type SysOpts = SysOpts
   type ProcOptions = ProcOptions
   type EnvOptions = EnvOptions
   type BoxOptions = BoxOptions

--- a/cosmic/sandbox.tl
+++ b/cosmic/sandbox.tl
@@ -12,15 +12,17 @@
 ---
 ---     local sandbox = require("cosmic.sandbox")
 ---     assert(sandbox.apply{
----       fs = { ro = { "/usr" }, rw = { "/tmp" } },
+---       fs = { exec = { "/usr" }, ro = { "/etc" }, rw = { "/tmp" } },
 ---       sys = { promises = "stdio rpath wpath" },
 ---     })
 ---
 --- Like the mechanism modules, the facade is fail-closed: a section
 --- that cannot be enforced on this host makes `apply` return
---- `false, "sandbox: ... unsupported on this host"` before anything is
+--- `nil, "sandbox: ... unsupported on this host"` before anything is
 --- applied, unless `best_effort = true` opts into skipping unenforceable
---- sections. `available()` reports what this host can enforce.
+--- sections — in which case the returned Availability record reports
+--- which sections actually enforced. `available()` reports what this
+--- host can enforce.
 ---
 --- Applying is irreversible and process-wide; policies can only be
 --- narrowed by further calls. `cosmic.quicksand.Box` consumes the same
@@ -31,11 +33,15 @@ local pledge = require("cosmic.pledge")
 local unveil = require("cosmic.unveil")
 
 --- Filesystem policy: path allowlists. Everything not listed is denied
---- once the policy applies. `ro` paths are readable *and executable*
---- (so binaries under read-only roots can run); `rw` paths are
---- readable and writable, including creating and removing entries, but
---- never executable; `exec` is an alias of `ro` that documents intent.
---- A path listed in several groups gets the union of their access.
+--- once the policy applies. The three groups mean three things: `ro`
+--- paths are readable and nothing else — a directory of untrusted
+--- input stays non-executable; `exec` paths are readable *and*
+--- executable, for binaries and libraries that must run; `rw` paths
+--- are readable and writable, including creating and removing entries,
+--- but never executable. A path listed in several groups gets the
+--- union of their access. A present-but-empty group is a real policy
+--- (`fs = { ro = {} }` denies everything); a policy with no group at
+--- all is rejected — omit `fs` entirely to skip filesystem policy.
 local record Fs
   ro: {string}
   rw: {string}
@@ -66,8 +72,11 @@ local record Policy
   keep_coverage: boolean
 end
 
---- What this host can enforce: `fs` (landlock on Linux, unveil on
---- OpenBSD) and `sys` (pledge).
+--- Per-section enforcement report: `fs` (landlock on Linux, unveil on
+--- OpenBSD) and `sys` (pledge). `available()` returns what this host
+--- *can* enforce; a successful `apply` returns what it *did* enforce,
+--- so a `best_effort` caller can see exactly which sections were
+--- skipped instead of flying blind.
 local record Availability
   fs: boolean
   sys: boolean
@@ -81,8 +90,9 @@ local record SandboxModule
   type Sys = Sys
   type Policy = Policy
   type Availability = Availability
-  apply: function(policy: Policy): boolean, string
+  apply: function(policy: Policy): Availability | nil, string
   available: function(): Availability
+  validate: function(policy: Policy): boolean, string
   plan_landlock: function(fs: Fs, keep_coverage?: boolean): RestrictOptions
 end
 
@@ -149,7 +159,7 @@ end
 local function plan_landlock(fs: Fs, keep_coverage?: boolean): RestrictOptions
   local rules: {Rule} = {}
   local seen: {string: integer} = {}
-  add_rules(rules, seen, fs and fs.ro or nil, landlock.READ | landlock.EXEC)
+  add_rules(rules, seen, fs and fs.ro or nil, landlock.READ)
   add_rules(rules, seen, fs and fs.rw or nil, landlock.RW)
   add_rules(rules, seen, fs and fs.exec or nil, landlock.READ | landlock.EXEC)
   return {
@@ -160,11 +170,12 @@ local function plan_landlock(fs: Fs, keep_coverage?: boolean): RestrictOptions
   }
 end
 
--- The unveil equivalents of the landlock group masks: ro/exec expose
--- read + execute, rw exposes read + write + create/remove.
+-- The unveil equivalents of the landlock group masks: ro exposes read
+-- only, exec exposes read + execute, rw exposes read + write +
+-- create/remove.
 local function apply_fs_unveil(fs: Fs, keep_coverage?: boolean): boolean, string
   local groups: {{{string}, unveil.Perm}} = {
-    {fs.ro, "rx"},
+    {fs.ro, "r"},
     {fs.rw, "rwc"},
     {fs.exec, "rx"},
   }
@@ -219,6 +230,10 @@ local function check_policy(policy: Policy): string
         return "sandbox: fs." .. name .. " must be a list of paths"
       end
     end
+    if fs.ro == nil and fs.rw == nil and fs.exec == nil then
+      return "sandbox: fs policy has no groups — pass fs = { ro = {} }"
+      .. " to deny everything, or omit fs to skip filesystem policy"
+    end
   end
   local sys = policy.sys
   if sys then
@@ -233,6 +248,21 @@ local function check_policy(policy: Policy): string
   return nil
 end
 
+--- Validate a policy's structure without enforcing anything: section
+--- shapes, path-list types, and promise tokens. `apply` runs this
+--- itself; it is exported so a policy carried across a process
+--- boundary (e.g. cosmic.quicksand.Box) can be rejected at
+--- construction time instead of dying post-fork.
+---
+--- @param policy Policy the policy to check
+--- @return boolean True when structurally valid
+--- @return string? Error message on failure
+local function validate(policy: Policy): boolean, string
+  local verr = check_policy(policy)
+  if verr then return false, verr end
+  return true
+end
+
 --- Apply a sandbox policy to the current process. Irreversible.
 ---
 --- The policy is validated and this host's enforceability checked for
@@ -243,46 +273,50 @@ end
 --- filesystem-sandbox syscalls.
 ---
 --- Fail-closed: a requested section this host cannot enforce returns
---- `false, "sandbox: ... unsupported on this host"`. With
---- `best_effort = true` unenforceable sections are skipped instead and
---- apply reports success for the sections that did enforce.
+--- `nil, "sandbox: ... unsupported on this host"`. With
+--- `best_effort = true` unenforceable sections are skipped instead —
+--- and the return value says so: on success apply returns an
+--- Availability record of what was actually enforced, so a
+--- best_effort caller can log or refuse when `.fs`/`.sys` came back
+--- false rather than believing in a sandbox that is not there.
 ---
 --- @param policy Policy fs and/or sys sections, best_effort flag
---- @return boolean True on success
+--- @return Availability? What was enforced, on success
 --- @return string? Error message on failure
-local function apply(policy: Policy): boolean, string
+local function apply(policy: Policy): Availability | nil, string
   local verr = check_policy(policy)
-  if verr then return false, verr end
+  if verr then return nil, verr end
   local do_fs = policy.fs ~= nil
   local do_sys = policy.sys ~= nil
   if do_fs and not fs_available() then
     if not policy.best_effort then
-      return false, "sandbox: fs policy unsupported on this host"
+      return nil, "sandbox: fs policy unsupported on this host"
       .. " (needs landlock on Linux, or OpenBSD)"
     end
     do_fs = false
   end
   if do_sys and not pledge.available() then
     if not policy.best_effort then
-      return false, "sandbox: sys policy unsupported on this host"
+      return nil, "sandbox: sys policy unsupported on this host"
     end
     do_sys = false
   end
   if do_fs then
     local ok, err = apply_fs(policy.fs, policy.keep_coverage)
-    if not ok then return false, "sandbox: fs: " .. tostring(err) end
+    if not ok then return nil, "sandbox: fs: " .. tostring(err) end
   end
   if do_sys then
     local ok, err = pledge.apply(policy.sys.promises,
-      {exec = policy.sys.exec})
-    if not ok then return false, "sandbox: sys: " .. tostring(err) end
+      {exec = policy.sys.exec, keep_coverage = policy.keep_coverage})
+    if not ok then return nil, "sandbox: sys: " .. tostring(err) end
   end
-  return true
+  return {fs = do_fs, sys = do_sys}
 end
 
 local M: SandboxModule = {
   apply = apply,
   available = available,
+  validate = validate,
   plan_landlock = plan_landlock,
 }
 

--- a/cosmic/sandbox_test.tl
+++ b/cosmic/sandbox_test.tl
@@ -14,6 +14,7 @@ local tmpdir = os.getenv("TEST_TMPDIR")
 local function test_module_exports()
   assert(type(sandbox.apply) == "function", "apply should be a function")
   assert(type(sandbox.available) == "function", "available should be a function")
+  assert(type(sandbox.validate) == "function", "validate should be a function")
   assert(type(sandbox.plan_landlock) == "function", "plan_landlock should be a function")
 end
 test_module_exports()
@@ -53,6 +54,21 @@ local function test_validation_rejects_before_enforcing()
   ok, err = apply_any({fs = {ro = "x"}})
   assert(not ok and err:find("fs.ro", 1, true),
     "non-list fs group must be rejected: " .. tostring(err))
+
+  -- A groupless fs section is ambiguous (deny-all or forgot-the-key?)
+  -- and must be spelled explicitly: fs = { ro = {} } to deny, or no
+  -- fs at all.
+  ok, err = apply_any({fs = {}})
+  assert(not ok and err:find("no groups", 1, true),
+    "groupless fs must be rejected: " .. tostring(err))
+
+  -- validate() is the same checker without enforcement, for callers
+  -- (Box) that carry a policy across a process boundary.
+  local vok, verr = sandbox.validate({sys = {promises = "stdio bogus_promise"}})
+  assert(not vok and verr:find("bogus_promise", 1, true),
+    "validate must reject what apply rejects: " .. tostring(verr))
+  assert(sandbox.validate({fs = {ro = {"/tmp"}}}),
+    "validate must accept a valid policy")
 
   ok, err = apply_any({sys = {promises = "stdio bogus_promise"}})
   assert(not ok and err:find("bogus_promise", 1, true),
@@ -107,8 +123,11 @@ local function test_fail_closed_when_unavailable()
     local ok2, err2 = apply_any({fs = {ro = {"/tmp"}}, sys = {promises = "stdio"}})
     assert(not ok2 and err2:find("unsupported", 1, true),
       "combined policy must fail closed on the missing section: " .. tostring(err2))
-    assert(sandbox.apply({fs = {ro = {"/tmp"}}, best_effort = true}),
-      "best_effort must skip the unenforceable fs section")
+    -- best_effort skips the unenforceable section — and the returned
+    -- report SAYS so, instead of a bare success.
+    local enforced = check.must(
+      sandbox.apply({fs = {ro = {"/tmp"}}, best_effort = true}))
+    check.eq(enforced.fs, false, "the report must show fs was skipped")
   end
   if not avail.sys then
     local ok, err = apply_any({sys = {promises = "stdio"}})
@@ -131,10 +150,20 @@ end
 local function test_plan_landlock_mapping()
   local plan_any = sandbox.plan_landlock
 
-  local opts = plan_any({ro = {"/usr"}})
-  local r = find_rule(opts.rules, "/usr")
+  -- ro means READ and nothing else: a directory of untrusted input
+  -- must not become executable because its grant said "read-only".
+  local opts = plan_any({ro = {"/srv/uploads"}})
+  local r = find_rule(opts.rules, "/srv/uploads")
+  assert(r, "expected /srv/uploads rule")
+  check.eq(r.access, landlock.READ, "ro -> READ only")
+  assert((r.access as integer & landlock.EXEC) == 0, -- cast: from any
+    "ro must not grant EXEC")
+
+  -- exec is the group that runs things: READ|EXEC.
+  opts = plan_any({exec = {"/usr"}})
+  r = find_rule(opts.rules, "/usr")
   assert(r, "expected /usr rule")
-  check.eq(r.access, landlock.READ | landlock.EXEC, "ro -> READ|EXEC")
+  check.eq(r.access, landlock.READ | landlock.EXEC, "exec -> READ|EXEC")
 
   opts = plan_any({rw = {"/tmp"}})
   r = find_rule(opts.rules, "/tmp")
@@ -143,7 +172,7 @@ local function test_plan_landlock_mapping()
   assert((landlock.RW & landlock.EXEC) == 0, "RW must not include EXEC")
 
   -- A path in several groups gets the union of their masks.
-  opts = plan_any({ro = {"/shared"}, rw = {"/shared"}})
+  opts = plan_any({exec = {"/shared"}, rw = {"/shared"}})
   r = find_rule(opts.rules, "/shared")
   assert(r, "expected /shared rule")
   check.eq(r.access, (landlock.READ | landlock.EXEC) | landlock.RW,

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -253,16 +253,34 @@ sock:close()
 
 ### Sandboxing
 
-`cosmic.quicksand.Box` composes the Linux namespace primitives,
-landlock, pledge, and an allowlist HTTP proxy into a single declarative
-policy + `run(argv)` call. Policy is a plain table, composable with
-`Box.merge(base, over)`:
+`cosmic.sandbox` is the one to reach for in-process: a single
+declarative policy over filesystem (`fs`) and system-call (`sys`)
+restriction, fail-closed, mechanism picked per OS (landlock on Linux,
+unveil on OpenBSD, pledge for `sys`). The `fs` groups mean three
+things: `ro` is read-only (no execute), `exec` is read + execute, `rw`
+is read + write (never execute). A successful `apply` returns a report
+of what was actually enforced:
+
+```teal
+local sandbox = require("cosmic.sandbox")
+assert(sandbox.apply{
+  fs = { exec = {"/usr"}, ro = {"/etc"}, rw = {"/tmp"} },
+  sys = { promises = "stdio rpath wpath" },
+})
+```
+
+`cosmic.quicksand.Box` composes the Linux namespace primitives, the
+same sandbox policy, and an allowlist HTTP proxy into a declarative
+policy + `run(argv)` call for a *child* workload. Policy is a plain
+table, composable with `Box.merge(base, over)`; the `fs` and `sys`
+sections are cosmic.sandbox's own schemas:
 
 ```teal
 local quicksand = require("cosmic.quicksand")
 
 local box = assert(quicksand.Box.new({
-  fs   = { ro = {"/usr", "/etc/ssl/certs"}, rw = {"/tmp"} },
+  fs   = { exec = {"/usr"}, ro = {"/etc/ssl/certs"}, rw = {"/tmp"} },
+  sys  = { promises = "stdio rpath wpath cpath proc exec" },
   net  = { allow = { ["api.example.com:443"] = {} } },
   proc = { no_new_privs = true, uid = 1000 },
   env  = { keep = {"PATH", "HOME"}, set = { CI = "1" } },
@@ -271,20 +289,22 @@ local box = assert(quicksand.Box.new({
 os.exit(assert(box:run({ "/usr/bin/bash", "-c", "make test" })))
 ```
 
-`Box.new` validates shape and runs a capability preflight so
-misconfiguration surfaces before any syscall. `run` forks a supervisor
-that unshares `USER|NET|NS` (+`UTS` if `hostname` is set), writes
-uid/gid maps, brings up loopback, optionally starts the allowlist
-proxy (injecting `HTTP(S)_PROXY` into the workload env unless
-`net.proxy_env == false`), then forks the workload which applies
-landlock, no_new_privs, drop_privs, pledge, chdir and `execvpe(argv,
-env)`. The returned integer is the workload's exit code (or
-`128+signo` on signal).
+`Box.new` validates shape (including `sys` promise tokens, via
+cosmic.sandbox's validator); `run` performs the capability preflight,
+then forks a supervisor that unshares `USER|NET|NS` (+`UTS` if
+`hostname` is set), writes uid/gid maps, brings up loopback,
+optionally starts the allowlist proxy (injecting `HTTP(S)_PROXY` into
+the workload env unless `net.proxy_env == false`), then forks the
+workload which applies chdir, the fs policy, no_new_privs, capability
+drops, drop_privs, the sys policy, and `execvpe(argv, env)`. The
+returned integer is the workload's exit code (or `128+signo` on
+signal).
 
 For finer control the underlying primitives are still available:
 
 - `cosmic.landlock` / `cosmic.pledge` / `cosmic.unveil` for
-  self-restriction in the current process
+  mechanism-specific self-restriction in the current process (custom
+  handled masks, incremental unveil)
 - `cosmic.quicksand.netns` / `.proc` / `.proxy` for manually assembling
   a box
 

--- a/skills/cosmic/platforms.md
+++ b/skills/cosmic/platforms.md
@@ -34,7 +34,7 @@ modules with per-OS differences:
 
 ## Sandbox Behavior Per OS
 
-the sandbox family is where OSes differ most. all four modules are **fail-closed**: on a host that cannot enforce a policy, `apply`/`allow`/`commit` return `false, "... unsupported on this host"` rather than reporting a sandbox that does not exist. every module exposes `available()` so callers can branch, and `best_effort = true` opts into skip-if-unenforceable.
+the sandbox family is where OSes differ most. all four modules are **fail-closed**: on a host that cannot enforce a policy, the mechanism modules' `apply`/`allow`/`commit`/`restrict` return `false, "... unsupported on this host"` (and `sandbox.apply` returns `nil, "sandbox: ... unsupported on this host"`) rather than reporting a sandbox that does not exist. every module exposes `available()` so callers can branch, and `best_effort = true` opts into skip-if-unenforceable — `sandbox.apply` then reports which sections actually enforced via its returned `Availability` record. `sandbox.Fs` groups mean three things: `ro` read-only (no execute), `exec` read+execute, `rw` read+write (no execute).
 
 | mechanism | enforced on | on violation | notes |
 |-----------|------------|--------------|-------|


### PR DESCRIPTION
First of eight planned PRs from the API consistency & ergonomics review — the security-behavior wave, all in the sandbox family. Breaking changes are in scope pre-release (D10).

## What changed

**`sandbox.Fs.ro` no longer silently grants EXEC.** The three groups now mean three things: `ro` = read-only, `exec` = read+execute, `rw` = read+write. Before, `ro` and `exec` computed the identical landlock mask (`READ | EXEC`), so `fs = { ro = { "/srv/uploads" } }` granted execute on every uploaded file and there was no way to express read-but-not-execute at all. The unveil path changes to match (`ro` → `"r"`). The build fence's test grant (`_cli/grants.tl`, `record` verb) gains an explicit exec on the project, which `ro` used to imply.

**`sandbox.apply` returns `Availability | nil, string`.** On success it reports which sections actually enforced. Before, `best_effort = true` returned a bare `true` having enforced nothing — and the only production caller is the build fence, so on a no-landlock host every "fenced" step ran unfenced with no way to know. The fence driver now warns when the fence was requested explicitly (`COSMIC_FENCE` set) but could not be enforced.

**`fs` schema ambiguities closed.** A groupless `fs` section (`fs = {}`) is rejected — `fs = { ro = {} }` is the explicit deny-all spelling. A present `fs` section now means the same thing to `sandbox.apply` (deny-all policy) and `quicksand.Box` (which previously treated it as *no policy at all* — the same literal value produced a total lockdown in one path and no restriction in the other).

**`caps.drop_bounding` fails closed.** On a host without the capability API it returned `true` having dropped nothing, and a mid-sweep ENOSYS reported a *partial* drop as complete — the only primitive in the family whose default was to report a sandbox that does not exist. Both paths now fail with an `unsupported` error; `best_effort` is the explicit opt-in, matching pledge/unveil/landlock.

**`landlock` joins the family conventions.** Availability gate with the sibling wording (`"landlock unsupported on this host"`), a `best_effort` option, memoized ABI probe, `landlock: ` error prefixes throughout, and the shared `cosmic._seal_coverage` helper instead of a private copy of the seal dance.

**`Box` routes its pledge policy through the facade.** `BoxOptions.sys` (cosmic.sandbox's `Sys` schema) replaces `ProcOptions.pledge`, and `Box.new` validates promise tokens via the new `sandbox.validate` — a typo'd promise used to die post-fork as an opaque exit 126; it now fails at construction with the token named. The retired `proc.pledge` spelling gets a migration error. One fs/sys vocabulary for boxed and in-process sandboxes.

**Smaller fixes:** `pledge.apply` gains `keep_coverage` so a combined `{fs, sys}` policy no longer seals coverage in the sys step after the fs step honored the request; quicksand's `no_new_privs` guards a nil `prctl` binding instead of throwing; `ip.Cidr:contains` takes the typed `Addr` only and returns a bare boolean (the string form made an unparseable input indistinguishable from a non-member — fail-open for an allowlist check).

## Verification

`bin/cosmic --make ci` → `ci: PASS (5 stages)` (fmt, check, example, lint, coverage; 185 test files, coverage ratchet ok). The fence runs by default in this gate, so the ro/exec split is exercised against the real recipe grants.

## Follow-ups (separate PRs, in order)

sqlite correctness → type honesty & exports → error shapes → stream & dedup → options & units → surface pruning → naming wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FP31Qs2Ei4uJUsimFMpvkS

---
_Generated by [Claude Code](https://claude.ai/code/session_01FP31Qs2Ei4uJUsimFMpvkS)_