### PR TITLE
sqlite: honest lifecycle — close ordering, gc backstop, reject silent multi-statement prefixes

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -73,7 +73,7 @@ cmd/cosmic/main.tl 0 276
 cosmic/_script_cache.tl 72 79
 cosmic/_seal_coverage.tl 9 10
 cosmic/ansi.tl 86 86
-cosmic/benchmark.tl 180 212
+cosmic/benchmark.tl 146 173
 cosmic/check.tl 110 113
 cosmic/child/fast.tl 40 52
 cosmic/child/init.tl 0 212
@@ -123,7 +123,7 @@ cosmic/hash.tl 71 74
 cosmic/html.tl 6 6
 cosmic/init.tl 16 17
 cosmic/instrument.tl 69 74
-cosmic/ip.tl 116 116
+cosmic/ip.tl 109 109
 cosmic/json.tl 23 24
 cosmic/landlock.tl 58 102
 cosmic/literal.tl 222 238
@@ -136,8 +136,8 @@ cosmic/proc.tl 39 77
 cosmic/quicksand/box/env.tl 27 27
 cosmic/quicksand/box/init.tl 0 70
 cosmic/quicksand/box/merge.tl 66 67
-cosmic/quicksand/box/run.tl 0 166
-cosmic/quicksand/caps.tl 59 77
+cosmic/quicksand/box/run.tl 0 165
+cosmic/quicksand/caps.tl 59 79
 cosmic/quicksand/init.tl 0 49
 cosmic/quicksand/netns.tl 37 55
 cosmic/quicksand/proc.tl 91 131
@@ -160,6 +160,7 @@ cosmic/sqlite/extras.tl 40 45
 cosmic/sqlite/init.tl 184 201
 cosmic/sqlite/params.tl 65 77
 cosmic/sqlite/row_iter.tl 49 56
+cosmic/sqlite/sqltext.tl 29 41
 cosmic/sqlite/stmt_cache.tl 57 67
 cosmic/sse.tl 98 103
 cosmic/stream.tl 0 2
@@ -179,4 +180,4 @@ cosmic/user.tl 48 61
 cosmic/uuid.tl 9 9
 cosmic/zip.tl 80 93
 tlconfig.lua 7 7
-total 13751 18129
+total 13739 18125

--- a/cosmic/sqlite/extras.tl
+++ b/cosmic/sqlite/extras.tl
@@ -1,12 +1,12 @@
---- Internal helper for cosmic.sqlite: the query_value and savepoint
---- conveniences attached onto a Database. Lives in its own file so
---- cosmic/sqlite/init.tl stays under the 500-line cap.
+--- Internal helper for cosmic.sqlite: the query_value, transaction and
+--- savepoint conveniences attached onto a Database. Lives in its own
+--- file so cosmic/sqlite/init.tl stays under the 500-line cap.
 
 -- Mirrors of cosmic.sqlite's records (Teal records are nominal, so the
 -- boundary crosses through `any`; same convention as cosmic.sqlite.params).
 local record Values
   metamethod __call: function(self: Values): any ...
-  err: function(self: Values): string
+  err: function(self: Values): string | nil
 end
 
 local record Stmt
@@ -15,11 +15,19 @@ local record Stmt
   close: function(self: Stmt)
 end
 
+-- The transaction/savepoint callback: `false` or `nil, err` rolls
+-- back; `true` or nothing commits/releases. Variadic because Teal
+-- cannot express optional returns — a fixed (boolean, string) type
+-- would reject the no-return commit form outright — so typed callers
+-- can return their verdict (or nothing) without a cast.
+local type TxFn = function(any): any ...
+
 local record Db
   prepare: function(self: Db, sql: string): Stmt | nil, string
   exec: function(self: Db, sql: string, ...: any): boolean, string
   query_value: function(self: Db, sql: string, ...: any): any, string
-  savepoint: function(self: Db, fn: function(any)): boolean, string
+  transaction: function(self: Db, fn: TxFn): boolean, string
+  savepoint: function(self: Db, fn: TxFn): boolean, string
 end
 
 --- Attach query_value and savepoint to a Database under construction.
@@ -59,6 +67,38 @@ local function attach(db_any: any)
     return v
   end
 
+  --- Execute fn within a transaction. BEGIN before fn; COMMIT if fn returns
+  --- cleanly; ROLLBACK if fn raises OR signals failure the library way -- a
+  --- returned `false`, or `nil` plus an error (nothing returned still commits).
+  --- A failing COMMIT (e.g. a deferred foreign-key violation) also rolls
+  --- back, so the connection is never left inside an open transaction.
+  function db:transaction(fn: TxFn): boolean, string
+    local ok, err = self:exec("BEGIN IMMEDIATE")
+    if not ok then
+      return false, err or "begin failed"
+    end
+    -- cast: pcall variadic returns
+    local success, result, result_err = pcall(fn, self) as (boolean, any, any)
+    if not success then
+      self:exec("ROLLBACK")
+      return false, (result as string) or "transaction failed" -- cast: from any
+    end
+    if result == false or (result == nil and result_err ~= nil) then
+      self:exec("ROLLBACK")
+      return false, (result_err as string) or "transaction rolled back" -- cast: from any
+    end
+    local commit_ok, commit_err = self:exec("COMMIT")
+    if not commit_ok then
+      local rollback_ok, rollback_err = self:exec("ROLLBACK")
+      if not rollback_ok then
+        return false, (commit_err or "commit failed") ..
+        "; rollback also failed: " .. (rollback_err or "unknown error")
+      end
+      return false, commit_err or "commit failed"
+    end
+    return true
+  end
+
   -- Savepoint names only have to be unique among currently-active
   -- savepoints; a monotonic counter per database over-satisfies that.
   local sp_counter = 0
@@ -71,7 +111,7 @@ local function attach(db_any: any)
   --- top level a savepoint behaves like its own transaction. A failing
   --- RELEASE (e.g. a deferred foreign-key violation) also rolls back to
   --- the savepoint, so it is never left open.
-  function db:savepoint(fn: function(any)): boolean, string
+  function db:savepoint(fn: TxFn): boolean, string
     sp_counter = sp_counter + 1
     local name = "cosmic_sp_" .. sp_counter
     local ok, err = self:exec("SAVEPOINT " .. name)

--- a/cosmic/sqlite/extras_test.tl
+++ b/cosmic/sqlite/extras_test.tl
@@ -107,7 +107,7 @@ local function test_savepoint_rollback_on_false()
   local ok = db:savepoint(function(d: sqlite.Database): boolean
       assert(d:exec("INSERT INTO t (name) VALUES ('carol')"))
       return false
-    end as function(sqlite.Database)) -- cast: function shape
+    end)
   assert(not ok, "expected savepoint to fail on returned false")
   assert(count(db) == 2, "expected insert rolled back")
   db:close()
@@ -119,7 +119,7 @@ local function test_savepoint_rollback_on_nil_err()
   local ok, err = db:savepoint(function(d: sqlite.Database): any, string
       assert(d:exec("INSERT INTO t (name) VALUES ('carol')"))
       return nil, "signaled failure"
-    end as function(sqlite.Database)) -- cast: function shape
+    end)
   assert(not ok, "expected savepoint to fail on nil+err")
   assert(err == "signaled failure", "expected error message, got " .. tostring(err))
   assert(count(db) == 2, "expected insert rolled back")
@@ -134,7 +134,7 @@ local function test_savepoint_nested_inner_rollback()
       local inner_ok = d:savepoint(function(d2: sqlite.Database): boolean
           assert(d2:exec("INSERT INTO t (name) VALUES ('inner')"))
           return false
-        end as function(sqlite.Database)) -- cast: function shape
+        end)
       assert(not inner_ok, "expected inner savepoint to roll back")
     end)
   assert(ok, "outer savepoint failed: " .. tostring(err))
@@ -152,7 +152,7 @@ local function test_savepoint_inside_transaction()
       d:savepoint(function(d2: sqlite.Database): boolean
           assert(d2:exec("INSERT INTO t (name) VALUES ('sp')"))
           return false
-        end as function(sqlite.Database)) -- cast: function shape
+        end)
     end)
   assert(ok, "transaction failed: " .. tostring(err))
   assert(count(db) == 3, "expected transaction insert kept, savepoint rolled back")

--- a/cosmic/sqlite/init.tl
+++ b/cosmic/sqlite/init.tl
@@ -44,7 +44,7 @@ local record Rows
   metamethod __call: function(self: Rows): {string: any}
   metamethod __close: function(self: Rows)
   --- Step error from iteration, or nil after a clean SQLITE_DONE.
-  err: function(self: Rows): string
+  err: function(self: Rows): string | nil
   --- Release the underlying prepared statement early (idempotent).
   close: function(self: Rows)
 end
@@ -62,8 +62,13 @@ end
 --- iter()`, one row at a time) when column 1 may be NULL.
 local record Values
   metamethod __call: function(self: Values): any ...
+  metamethod __close: function(self: Values)
   --- Step error from iteration, or nil after a clean SQLITE_DONE.
-  err: function(self: Values): string
+  err: function(self: Values): string | nil
+  --- End iteration early (idempotent); also runs on scope exit via
+  --- to-be-closed. Does not finalize the owning Statement — that is
+  --- Statement:close()'s job, since the Statement may be reused.
+  close: function(self: Values)
 end
 
 --- Statement handle with automatic cleanup.
@@ -121,7 +126,8 @@ local record Database
   query_value: function(self: Database, sql: string, ...: any): any, string
   --- Execute sql with positional `?` parameters; use for statements
   --- that return no rows (INSERT/UPDATE/DELETE/DDL). Multi-statement
-  --- sql is only supported in the no-parameter form.
+  --- sql runs only in the no-parameter form; with parameters it is
+  --- REJECTED (sqlite would silently run just the first statement).
   exec: function(self: Database, sql: string, ...: any): boolean, string
   --- exec() with parameters in a list, so nil holes bind as NULL.
   exec_list: function(self: Database, sql: string, values: {any}): boolean, string
@@ -129,20 +135,25 @@ local record Database
   exec_named: function(self: Database, sql: string, params: {string: any}): boolean, string
   --- Run fn inside BEGIN IMMEDIATE .. COMMIT. Rolls back when fn
   --- raises, returns false, or returns nil plus an error; returning
-  --- nothing commits.
-  transaction: function(self: Database, fn: function(Database)): boolean, string
+  --- nothing (or true) commits. The callback is typed variadic
+  --- (Teal cannot express optional returns), so a typed
+  --- `function(db): boolean` rollback needs no cast; see
+  --- cosmic.sqlite.extras.
+  transaction: function(self: Database, fn: function(Database): any ...): boolean, string
   --- Run fn in a nestable savepoint with transaction's rollback rules;
   --- see cosmic.sqlite.extras.
-  savepoint: function(self: Database, fn: function(Database)): boolean, string
+  savepoint: function(self: Database, fn: function(Database): any ...): boolean, string
   --- rowid of the most recent successful INSERT (0 if closed).
   last_insert_rowid: function(self: Database): integer
   --- Rows modified by the most recent INSERT/UPDATE/DELETE (0 if closed).
   changes: function(self: Database): integer
   --- Close the database and its cached statements (idempotent); also
-  --- runs on scope exit via to-be-closed. Returns false plus sqlite's
-  --- error message if the raw close fails (e.g. SQLITE_BUSY from a
-  --- still-open user-prepared Statement) -- the database is left open
-  --- in that case, so a caller that must know can retry or clean up.
+  --- runs on scope exit via to-be-closed. Live user-prepared
+  --- Statements do not block it: the binding finalizes them during
+  --- close. Returns false plus sqlite's message if the raw close ever
+  --- fails — the handle is NOT marked closed then, so the database
+  --- stays usable and a retry is a real retry, not a stale-flag
+  --- success.
   close: function(self: Database): boolean, string
 end
 
@@ -221,10 +232,14 @@ local function make_statement(raw_stmt: lsqlite3.Statement, raw_db: lsqlite3.Dat
   -- iterator directly one row at a time (`local a, b, c = iter()`) does.
   function stmt:values(): Values
     local step_err: string
+    local done = false
     local col_count = raw_stmt:columns()
 
     local iter = setmetatable({} as Values, { -- cast: empty table into callable record
         __call = function(_: Values): any ...
+          if done then
+            return nil
+          end
           local rc = raw_stmt:step()
           if rc == sqlite3.ROW then
             local vals: {integer: any} = {}
@@ -238,10 +253,13 @@ local function make_statement(raw_stmt: lsqlite3.Statement, raw_db: lsqlite3.Dat
           if rc ~= sqlite3.DONE then
             step_err = raw_db:errmsg()
           end
+          done = true
           return nil
         end,
+        __close = function(self: Values) self:close() end,
       })
-    iter.err = function(_: Values): string return step_err end
+    iter.err = function(_: Values): string | nil return step_err end
+    iter.close = function(_: Values) done = true end
     return iter
   end
 
@@ -268,11 +286,20 @@ local function make_statement(raw_stmt: lsqlite3.Statement, raw_db: lsqlite3.Dat
   stmt.close = function(_: Statement)
     if closed then return end
     closed = true
-    local _ = raw_stmt:finalize()
+    -- The binding finalizes outstanding statements when the DATABASE
+    -- closes; finalize on such a dead vm throws. Guard so close (and
+    -- the __gc/__close paths that reach it) never raises.
+    if raw_stmt:isopen() then
+      local _ = raw_stmt:finalize()
+    end
   end
 
+  -- __gc is the backstop for an abandoned user Statement, matching the
+  -- Rows iterator: without it a dropped db:prepare() handle leaks its
+  -- raw statement — the very SQLITE_BUSY that makes db:close() fail.
   return setmetatable(stmt, {
-      __close = function(self: Statement) self:close() end
+      __close = function(self: Statement) self:close() end,
+      __gc = function(self: Statement) self:close() end,
     })
 end
 
@@ -337,8 +364,8 @@ local function make_database(raw_db: lsqlite3.Database): Database
 
   -- exec_list, exec_named, query_list, query_named live in
   -- cosmic.sqlite.params (same prepare/bind/consume shape, split out to
-  -- keep this file under the 500-line cap); query_value and savepoint
-  -- live in cosmic.sqlite.extras for the same reason.
+  -- keep this file under the 500-line cap); query_value, transaction
+  -- and savepoint live in cosmic.sqlite.extras for the same reason.
   params_mod.attach(db)
   extras_mod.attach(db)
 
@@ -368,38 +395,6 @@ local function make_database(raw_db: lsqlite3.Database): Database
     return first
   end
 
-  --- Execute fn within a transaction. BEGIN before fn; COMMIT if fn returns
-  --- cleanly; ROLLBACK if fn raises OR signals failure the library way -- a
-  --- returned `false`, or `nil` plus an error (nothing returned still commits).
-  --- A failing COMMIT (e.g. a deferred foreign-key violation) also rolls
-  --- back, so the connection is never left inside an open transaction.
-  function db:transaction(fn: function(Database)): boolean, string
-    local ok, err = self:exec("BEGIN IMMEDIATE")
-    if not ok then
-      return false, err or "begin failed"
-    end
-    -- cast: pcall variadic returns
-    local success, result, result_err = pcall(fn, self) as (boolean, any, any)
-    if not success then
-      self:exec("ROLLBACK")
-      return false, (result as string) or "transaction failed" -- cast: from any
-    end
-    if result == false or (result == nil and result_err ~= nil) then
-      self:exec("ROLLBACK")
-      return false, (result_err as string) or "transaction rolled back" -- cast: from any
-    end
-    local commit_ok, commit_err = self:exec("COMMIT")
-    if not commit_ok then
-      local rollback_ok, rollback_err = self:exec("ROLLBACK")
-      if not rollback_ok then
-        return false, (commit_err or "commit failed") ..
-        "; rollback also failed: " .. (rollback_err or "unknown error")
-      end
-      return false, commit_err or "commit failed"
-    end
-    return true
-  end
-
   function db:last_insert_rowid(): integer
     if closed then
       return 0
@@ -418,12 +413,19 @@ local function make_database(raw_db: lsqlite3.Database): Database
     if closed then
       return true
     end
-    closed = true
+    -- Mark closed only AFTER the raw close succeeds: marking first
+    -- made a failed close unrecoverable — the retry hit the guard
+    -- above and reported success while sqlite's handle stayed open.
+    -- (lsqlite3 finalizes outstanding statements itself, so a failure
+    -- here is defensive rather than reachable today.) close_all is
+    -- idempotent (it clears as it finalizes), so a retry re-runs it
+    -- harmlessly.
     stmt_cache:close_all()
     local rc = raw_db:close()
     if rc ~= sqlite3.OK then
       return false, raw_db:errmsg()
     end
+    closed = true
     return true
   end
 

--- a/cosmic/sqlite/init_test.tl
+++ b/cosmic/sqlite/init_test.tl
@@ -255,7 +255,8 @@ local function test_query_step_error_surfaced()
   for _ in iter do end
   local err = iter:err()
   assert(err ~= nil, "step error must be surfaced, not swallowed as end-of-rows")
-  assert(err:find("overflow"), "error should mention overflow: " .. tostring(err))
+  assert(string.find(err, "overflow"),
+    "error should mention overflow: " .. tostring(err))
   db:close()
 end
 test_query_step_error_surfaced()

--- a/cosmic/sqlite/lifecycle_test.tl
+++ b/cosmic/sqlite/lifecycle_test.tl
@@ -1,0 +1,162 @@
+#!/usr/bin/env cosmic
+--- Lifecycle tests for cosmic.sqlite: close ordering, the Statement
+--- garbage-collection backstop, Values early close, and the
+--- multi-statement rejection on parameterized paths.
+local sqlite = require("cosmic.sqlite")
+local check = require("cosmic.check")
+
+local function open_db(): sqlite.Database
+  local db = check.must(sqlite.open(":memory:"))
+  assert(db:exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)"))
+  assert(db:exec("INSERT INTO t (name) VALUES ('alice'), ('bob')"))
+  return db
+end
+
+-- Close with a live user-prepared Statement: the binding finalizes
+-- outstanding statements during close, so close succeeds — and the
+-- wrapper Statement's own close stays a safe no-op afterwards. (The
+-- close-ordering fix — mark closed only after the raw close succeeds —
+-- is defensive: no reachable failure path exists through lsqlite3
+-- today, which this test also documents by construction.)
+local function test_close_with_live_statement()
+  local db = open_db()
+  local stmt = check.must(db:prepare("SELECT name FROM t"))
+  assert(db:close(), "close finalizes live statements and succeeds")
+  stmt:close()
+  assert(db:close(), "close stays idempotent after success")
+end
+test_close_with_live_statement()
+
+-- An abandoned db:prepare() handle is finalized by garbage collection,
+-- so its raw statement is released as soon as the collector runs, not
+-- held until the database closes.
+local function test_statement_gc_backstop()
+  local db = open_db()
+  do
+    local stmt = check.must(db:prepare("SELECT name FROM t"))
+    local _ = stmt
+  end
+  collectgarbage("collect")
+  collectgarbage("collect")
+  assert(db:close(),
+    "gc must have finalized the abandoned Statement so close succeeds")
+end
+test_statement_gc_backstop()
+
+-- Values:close ends iteration early (and <close> drives it); it must
+-- not finalize the owning Statement, which stays reusable.
+local function test_values_close_ends_iteration()
+  local db = open_db()
+  local stmt = check.must(db:prepare("SELECT id, name FROM t ORDER BY id"))
+  assert(stmt:bind())
+  do
+    local vals < close > = stmt:values()
+    local id, name = vals()
+    check.eq(id, 1)
+    check.eq(name, "alice")
+    vals:close()
+    local after = vals()
+    check.eq(after, nil, "a closed Values yields nothing")
+    check.eq(vals:err(), nil, "close is not an error")
+  end
+  -- The Statement survives its Values: rebind and drain it fully.
+  assert(stmt:bind())
+  local vals2 = stmt:values()
+  local n = 0
+  while true do
+    local id = vals2()
+    if id == nil then break end
+    n = n + 1
+  end
+  check.eq(n, 2, "statement must be reusable after Values:close")
+  check.eq(vals2:err(), nil)
+  stmt:close()
+  assert(db:close())
+end
+test_values_close_ends_iteration()
+
+-- Parameterized exec/query of multi-statement SQL is rejected loudly:
+-- sqlite compiles only the first statement, so the old behavior ran a
+-- silent prefix and reported success.
+local function test_multi_statement_rejected_with_params()
+  local db = open_db()
+
+  local ok, err = db:exec(
+    "INSERT INTO t (name) VALUES (?); INSERT INTO t (name) VALUES ('x')",
+    "carol")
+  assert(not ok, "parameterized multi-statement exec must be rejected")
+  assert(err and err:find("multi-statement", 1, true),
+    "error must name the problem: " .. tostring(err))
+  check.eq(db:query_value("SELECT COUNT(*) FROM t"), 2,
+    "nothing may have run")
+
+  local ok2, err2 = db:exec_list(
+    "INSERT INTO t (name) VALUES (?); DELETE FROM t", {"carol"})
+  assert(not ok2 and err2:find("multi-statement", 1, true),
+    "exec_list must reject: " .. tostring(err2))
+
+  local ok3, err3 = db:exec_named(
+    "INSERT INTO t (name) VALUES (:n); DELETE FROM t", {n = "carol"})
+  assert(not ok3 and err3:find("multi-statement", 1, true),
+    "exec_named must reject: " .. tostring(err3))
+
+  local rows, qerr = db:query("SELECT name FROM t; DELETE FROM t")
+  assert(rows == nil and qerr and qerr:find("multi-statement", 1, true),
+    "query must reject a silent second statement: " .. tostring(qerr))
+
+  local rows2, qerr2 = db:query_list("SELECT ?; DELETE FROM t", {1})
+  assert(rows2 == nil and qerr2 and qerr2:find("multi-statement", 1, true),
+    "query_list must reject: " .. tostring(qerr2))
+
+  db:close()
+end
+test_multi_statement_rejected_with_params()
+
+-- The rejection is lexical and must not misfire: semicolons inside
+-- string literals, comments, or a trailing semicolon are ONE statement.
+local function test_multi_statement_scan_false_positives()
+  local db = open_db()
+
+  assert(db:exec("INSERT INTO t (name) VALUES (?);", "semi"),
+    "trailing semicolon is one statement")
+  assert(db:exec("INSERT INTO t (name) VALUES (?); -- note; really\n", "c1"),
+    "trailing comment after ; is one statement")
+  assert(db:exec("INSERT INTO t (name) VALUES (?); /* a; b */", "c2"),
+    "trailing block comment after ; is one statement")
+  assert(db:exec("INSERT INTO t (name) VALUES ('a; b')"),
+    "semicolon inside a string literal is one statement")
+  local v = db:query_value("SELECT name FROM t WHERE name = ?", "a; b")
+  check.eq(v, "a; b", "the literal value round-trips")
+  assert(db:exec("INSERT INTO t (name) VALUES ('it''s; fine')"),
+    "doubled-quote escape does not end the literal")
+
+  -- The no-parameter exec form still runs multi-statement SQL.
+  assert(db:exec(
+      "INSERT INTO t (name) VALUES ('m1'); INSERT INTO t (name) VALUES ('m2')"),
+    "no-parameter exec keeps multi-statement support")
+  check.eq(db:query_value("SELECT COUNT(*) FROM t WHERE name LIKE 'm_'"), 2)
+
+  db:close()
+end
+test_multi_statement_scan_false_positives()
+
+-- The transaction/savepoint callback type now declares the rollback
+-- protocol, so a typed boolean return needs no cast.
+local function test_transaction_callback_typed_rollback()
+  local db = open_db()
+  local ok = db:transaction(function(d: sqlite.Database): boolean
+      assert(d:exec("INSERT INTO t (name) VALUES ('doomed')"))
+      return false
+    end)
+  assert(not ok, "returned false must roll back")
+  check.eq(db:query_value("SELECT COUNT(*) FROM t"), 2, "insert rolled back")
+
+  local ok2, err2 = db:transaction(function(d: sqlite.Database): boolean, string
+      assert(d:exec("INSERT INTO t (name) VALUES ('kept')"))
+      return true
+    end)
+  assert(ok2, "returned true must commit: " .. tostring(err2))
+  check.eq(db:query_value("SELECT COUNT(*) FROM t"), 3, "insert committed")
+  db:close()
+end
+test_transaction_callback_typed_rollback()

--- a/cosmic/sqlite/params.tl
+++ b/cosmic/sqlite/params.tl
@@ -4,14 +4,24 @@
 --- live together here. Lives in its own file so cosmic/sqlite.tl stays
 --- under the 500-line cap.
 
+local sqltext = require("cosmic.sqlite.sqltext")
+
 -- Mirrors of cosmic.sqlite's records (Teal records are nominal, so the
 -- boundary crosses through `any`; same convention as sqlite_stmt_cache).
 local record Rows
   metamethod __call: function(self: Rows): {string: any}
   metamethod __close: function(self: Rows)
-  err: function(self: Rows): string
+  err: function(self: Rows): string | nil
   close: function(self: Rows)
 end
+
+-- Same rejection as cosmic.sqlite.stmt_cache: prepare compiles only the
+-- first statement, so a parameterized multi-statement call would
+-- silently run a prefix. These paths prepare fresh every call, so the
+-- scan runs per call — they are the documented slow path.
+local MULTI_ERR < const > =
+"multi-statement sql is not supported here; run each statement"
+.. " separately (only exec without parameters runs multi-statement sql)"
 
 local record Stmt
   bind_list: function(self: Stmt, values: {any}): boolean, string
@@ -62,7 +72,7 @@ local function make_query_iter(stmt: Stmt): Rows
         release()
       end,
     })
-  iter.err = function(_: Rows): string return raw_iter:err() end
+  iter.err = function(_: Rows): string | nil return raw_iter:err() end
   iter.close = function(_: Rows)
     release()
   end
@@ -79,6 +89,9 @@ local function attach(db_any: any)
   --- Execute SQL with parameters from a list (table). The count is derived
   --- from the SQL itself, so nil values in the table are handled correctly.
   function db:exec_list(sql: string, values: {any}): boolean, string
+    if sqltext.has_multiple_statements(sql) then
+      return false, MULTI_ERR
+    end
     local stmt, err = self:prepare(sql)
     if not stmt then
       return false, err or "prepare failed"
@@ -99,6 +112,9 @@ local function attach(db_any: any)
   --- Execute SQL with named parameters.
   --- SQL should use :name placeholders. Table keys are names without the colon.
   function db:exec_named(sql: string, params: {string: any}): boolean, string
+    if sqltext.has_multiple_statements(sql) then
+      return false, MULTI_ERR
+    end
     local stmt, err = self:prepare(sql)
     if not stmt then
       return false, err or "prepare failed"
@@ -120,6 +136,9 @@ local function attach(db_any: any)
   --- The parameter count is derived from the SQL itself, so nil values
   --- in the table are handled correctly.
   function db:query_list(sql: string, values: {any}): Rows | nil, string
+    if sqltext.has_multiple_statements(sql) then
+      return nil, MULTI_ERR
+    end
     local stmt, err = self:prepare(sql)
     if not stmt then
       return nil, "query failed: " .. (err or "unknown error")
@@ -138,6 +157,9 @@ local function attach(db_any: any)
   --- Query with named parameters.
   --- SQL should use :name placeholders. Table keys are names without the colon.
   function db:query_named(sql: string, params: {string: any}): Rows | nil, string
+    if sqltext.has_multiple_statements(sql) then
+      return nil, MULTI_ERR
+    end
     local stmt, err = self:prepare(sql)
     if not stmt then
       return nil, "query failed: " .. (err or "unknown error")

--- a/cosmic/sqlite/row_iter.tl
+++ b/cosmic/sqlite/row_iter.tl
@@ -16,7 +16,7 @@ local lsqlite3 = require("cosmo.lsqlite3")
 local record Rows
   metamethod __call: function(self: Rows): {string: any}
   metamethod __close: function(self: Rows)
-  err: function(self: Rows): string
+  err: function(self: Rows): string | nil
   close: function(self: Rows)
 end
 
@@ -47,7 +47,10 @@ local function make(raw_stmt: lsqlite3.Statement, raw_db: lsqlite3.Database, on_
     done = true
     if on_close then
       on_close(raw_stmt)
-    else
+    elseif raw_stmt:isopen() then
+      -- isopen guard: the binding finalizes statements when the
+      -- database closes, and finalize on that dead vm throws — from
+      -- __gc, no less. Never raise from a release path.
       local _ = raw_stmt:finalize()
     end
   end
@@ -87,7 +90,7 @@ local function make(raw_stmt: lsqlite3.Statement, raw_db: lsqlite3.Database, on_
         release()
       end,
     })
-  iter.err = function(_: Rows): string return step_err end
+  iter.err = function(_: Rows): string | nil return step_err end
   iter.close = function(_: Rows)
     release()
   end

--- a/cosmic/sqlite/sqltext.tl
+++ b/cosmic/sqlite/sqltext.tl
@@ -1,0 +1,78 @@
+--- Internal helper for cosmic.sqlite: lexical facts about SQL text.
+---
+--- has_multiple_statements answers one question: does this SQL contain
+--- a second statement after a `;`? sqlite3_prepare compiles only the
+--- FIRST statement and the binding does not expose the tail, so a
+--- parameterized exec/query of multi-statement SQL would silently run
+--- a prefix and report success — the exact silent bug the wrappers
+--- exist to prevent. They reject it instead, using this scan.
+---
+--- The scan is a small lexer, not a parser: it skips string literals
+--- ('...', "...", `...`, with doubled-quote escapes), bracketed
+--- identifiers ([...]), line comments (-- ...\n) and block comments
+--- (/* ... */), so a `;` inside any of those never counts, and
+--- content after a real `;` that is only whitespace or comments never
+--- counts either (a trailing semicolon is one statement, not two).
+
+local function is_space(c: string): boolean
+  return c == " " or c == "\t" or c == "\n" or c == "\r"
+  or c == "\v" or c == "\f"
+end
+
+--- Skip a quoted region starting at i (sql[i] is the quote char).
+--- Doubled quote chars are escapes. Returns the index after the
+--- closing quote (or past the end when unterminated).
+local function skip_quoted(sql: string, i: integer, n: integer): integer
+  local q = sql:sub(i, i)
+  i = i + 1
+  while i <= n do
+    if sql:sub(i, i) == q then
+      if sql:sub(i + 1, i + 1) == q then
+        i = i + 2
+      else
+        return i + 1
+      end
+    else
+      i = i + 1
+    end
+  end
+  return n + 1
+end
+
+--- True when sql contains a second statement after a top-level `;`.
+--- @param sql string The SQL text to scan
+--- @return boolean True when more than one statement is present
+local function has_multiple_statements(sql: string): boolean
+  local i = 1
+  local n = #sql
+  local seen_semi = false
+  while i <= n do
+    local c = sql:sub(i, i)
+    if c == "-" and sql:sub(i + 1, i + 1) == "-" then
+      local nl = sql:find("\n", i + 2, true)
+      i = nl and (nl + 1) or (n + 1)
+    elseif c == "/" and sql:sub(i + 1, i + 1) == "*" then
+      local close = sql:find("*/", i + 2, true)
+      i = close and (close + 2) or (n + 1)
+    elseif is_space(c) then
+      i = i + 1
+    elseif seen_semi then
+      -- Any non-space, non-comment content after a `;` is a second
+      -- statement — including the opening quote of a string.
+      return true
+    elseif c == ";" then
+      seen_semi = true
+      i = i + 1
+    elseif c == "'" or c == "\"" or c == "`" then
+      i = skip_quoted(sql, i, n)
+    elseif c == "[" then
+      local close = sql:find("]", i + 1, true)
+      i = close and (close + 1) or (n + 1)
+    else
+      i = i + 1
+    end
+  end
+  return false
+end
+
+return {has_multiple_statements = has_multiple_statements}

--- a/cosmic/sqlite/stmt_cache.tl
+++ b/cosmic/sqlite/stmt_cache.tl
@@ -4,7 +4,16 @@
 --- and finalizing a fresh one every time.
 
 local bind_mod = require("cosmic.sqlite.bind")
+local sqltext = require("cosmic.sqlite.sqltext")
 local lsqlite3 = require("cosmo.lsqlite3")
+
+-- sqlite compiles only the FIRST statement of a multi-statement string,
+-- so running one through the parameterized paths would silently execute
+-- a prefix and report success. Rejected instead — and only on the
+-- prepare (cache-miss) path, so the hot cached path never re-scans.
+local MULTI_ERR < const > =
+"multi-statement sql is not supported here; run each statement"
+.. " separately (only exec without parameters runs multi-statement sql)"
 
 -- Named alias (shared through cosmic.sqlite.bind) so a function-typed
 -- return value never appears as an inline literal in a multi-return
@@ -37,6 +46,9 @@ local function new(raw_db: lsqlite3.Database, ok_code: number, done_code: number
     local cached = cache[sql]
     if cached then
       return cached
+    end
+    if sqltext.has_multiple_statements(sql) then
+      return nil, MULTI_ERR
     end
     local raw_stmt = raw_db:prepare(sql)
     if not raw_stmt then
@@ -84,6 +96,9 @@ local function new(raw_db: lsqlite3.Database, ok_code: number, done_code: number
     if cached and not checked_out[sql] then
       checked_out[sql] = true
       return cached, function(_: lsqlite3.Statement) checked_out[sql] = nil end
+    end
+    if not cached and sqltext.has_multiple_statements(sql) then
+      return nil, nil, MULTI_ERR
     end
     local raw_stmt = raw_db:prepare(sql)
     if not raw_stmt then


### PR DESCRIPTION
Second of eight PRs from the API review — the sqlite correctness wave.

## What changed

**`close()` ordering.** The handle was marked closed *before* the raw close ran, so a failed close was unrecoverable: the retry hit the closed guard and reported success while sqlite's handle stayed open, contradicting `close`'s own doc. Now `closed` is set only after the raw close succeeds. Probing the binding showed lsqlite3 finalizes outstanding statements during close (a live `Statement` cannot actually produce SQLITE_BUSY), so the doc now states what's true and the ordering fix is defensive.

**`Statement` gets the `__gc` backstop `Rows` already had** — an abandoned `db:prepare()` handle releases its raw statement when the collector runs. Writing the test for this exposed a real crash: the binding kills statements when the *database* closes, and `finalize` on that dead vm throws — including from `__gc`. `Statement:close` and the row iterator's release path now guard with `isopen`.

**`Values` gets a close story.** It had no release path at all next to `Rows`' close/`__close`/`__gc`. Now `close()`/`__close` end iteration early without finalizing the owning `Statement` (which stays reusable — tested).

**Parameterized multi-statement SQL is rejected, not silently truncated.** `db:exec("A; B", param)` used to run only `A` and return `true` — sqlite compiles just the first statement and the binding hides the tail. All parameterized paths (`exec`, `exec_list`, `exec_named`, `query`, `query_list`, `query_named`) now reject with an error naming the problem. Detection is a small lexical scan (`cosmic/sqlite/sqltext.tl`) that skips string literals (with doubled-quote escapes), bracket identifiers, and both comment forms — and it runs only on the statement-cache miss path, so hot cached calls never re-scan. The no-parameter `exec` form keeps multi-statement support, as documented.

**Honest `err()`.** `Rows:err()`/`Values:err()` are now `string | nil`, which is what they return; the bare `string` type let `local m: string = rows:err()` typecheck and hold nil.

**Transaction callback type is expressible.** `transaction`/`savepoint` callbacks are typed `function(Database): any...` — the documented protocol (return nothing/`true` to commit, `false` or `nil, err` to roll back) was previously impossible to write without a cast, and the repo's own tests carried four `-- cast: function shape` casts, now deleted. (Teal can't express optional returns: a fixed `(boolean, string)` type rejects both the no-return and single-`boolean` forms — verified against the checker.) `transaction` moved beside `savepoint` in `cosmic.sqlite.extras` to keep `init.tl` under the 500-line cap.

`.cosmic-coverage` gains a row for the new `sqltext.tl`; `--baseline` also trued up three rows whose files changed in earlier merges.

## Verification

`bin/cosmic --make ci` → `ci: PASS (5 stages)`, 186 test files, coverage ratchet ok. New `cosmic/sqlite/lifecycle_test.tl` covers close-with-live-statement, the gc backstop, `Values:close`, multi-statement rejection (plus false-positive guards: semicolons in literals/comments, trailing semicolons, doubled quotes), and cast-free typed transaction callbacks.

## Follow-ups

Next waves in order: type honesty & exports → error shapes → stream & dedup → options & units → surface pruning → naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FP31Qs2Ei4uJUsimFMpvkS

---
_Generated by [Claude Code](https://claude.ai/code/session_01FP31Qs2Ei4uJUsimFMpvkS)_