### PR TITLE
error shapes: the error lives in slot 2, and library code never throws

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -73,6 +73,8 @@ jobs:
   # below for the trust boundary.
   ci:
     runs-on: ubuntu-latest
+    # A green run takes ~2 minutes; anything near this ceiling is a hang.
+    timeout-minutes: 12
     container:
       image: buildpack-deps@sha256:cfb30ff3856780c63b00ec3ad2e4aed77ae6afce5975ebb8ad9525ec45354e2e # noble (Ubuntu 24.04)
       options: --privileged
@@ -145,14 +147,16 @@ jobs:
       #
       # timeout: a recipe child dying mid-test can leave forked test
       # parents blocked on accept/wait, wedging make. Convert a hang into
-      # a failure so the dump step below fires.
+      # a failure so the dump step below fires. 8 minutes is ~4x the
+      # slowest green run on a warm cache and still generous for a cold
+      # one; a hang used to idle out the full 20 before reporting.
       # One command, because the gate converges on its own: `--make ci`
       # in a project that builds its own toolchain builds first and
       # re-execs into what it built, until the artifact stops changing
       # (_make/converge.tl). Building here rather than in the build lane
       # keeps it fenced.
       - name: the gate, with network denied
-        timeout-minutes: 20
+        timeout-minutes: 8
         shell: bash
         env:
           NETNS: |
@@ -230,6 +234,8 @@ jobs:
   # earlier: it needs only this job's artifact, not the repro rebuild.
   build:
     runs-on: ubuntu-latest
+    # A green run takes ~2 minutes; anything near this ceiling is a hang.
+    timeout-minutes: 12
     # Pinned container, identical to the gate lane's; see there.
     container:
       image: buildpack-deps@sha256:cfb30ff3856780c63b00ec3ad2e4aed77ae6afce5975ebb8ad9525ec45354e2e # noble (Ubuntu 24.04)
@@ -318,6 +324,8 @@ jobs:
   repro:
     needs: build
     runs-on: ubuntu-latest
+    # A green run takes ~2 minutes; anything near this ceiling is a hang.
+    timeout-minutes: 12
     # Pinned container, identical to the gate lane's; see there.
     container:
       image: buildpack-deps@sha256:cfb30ff3856780c63b00ec3ad2e4aed77ae6afce5975ebb8ad9525ec45354e2e # noble (Ubuntu 24.04)
@@ -391,6 +399,8 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    # A green run takes ~2 minutes; anything near this ceiling is a hang.
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/_make/pin_test.tl
+++ b/_make/pin_test.tl
@@ -121,8 +121,9 @@ test_version_substitution()
 --- Fork a loopback server answering one request with `body`, under
 --- `status` (default 200).
 local function serve(body: string, status?: integer): integer, integer
-  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  local srv = net.listen_tcp("127.0.0.1", 0)
   local s = check.must(srv, "listen_tcp failed")
+  local port = check.must(s:getsockname()).port
   local pid = proc.fork()
   if pid == 0 then
     signal.setitimer({

--- a/_perf/bench/http_bench.tl
+++ b/_perf/bench/http_bench.tl
@@ -52,11 +52,17 @@ local function serve_loop(srv: net.Socket)
 end
 
 local function scenarios(): {pt.Scenario}, string
-  local srv, port, lerr = net.listen_tcp(LOCALHOST, 0)
+  local srv, lerr = net.listen_tcp(LOCALHOST, 0)
   if srv == nil then
     return nil, "listen_tcp: " .. tostring(lerr)
   end
-  listener = srv
+  local lsock = srv as net.Socket -- cast: record union after guard
+  local ep, eperr = lsock:getsockname()
+  if ep == nil then
+    return nil, "getsockname: " .. tostring(eperr)
+  end
+  local port = (ep as net.Endpoint).port -- cast: record union after guard
+  listener = lsock
   local pid, ferr = proc.fork()
   if pid == 0 then
     serve_loop(srv)

--- a/_perf/bench/micro_bench.tl
+++ b/_perf/bench/micro_bench.tl
@@ -119,7 +119,7 @@ local function scenarios(): {pt.Scenario}, string
     {
       name = "compress_roundtrip_64k",
       fn = function(_: any): any
-        local packed = compress.compress(BLOB)
+        local packed = assert(compress.compress(BLOB))
         return (compress.decompress(packed))
       end,
       check = function(_: any, res: any): boolean, string
@@ -137,7 +137,7 @@ local function scenarios(): {pt.Scenario}, string
       -- size-prefixed deflate format.
       name = "compress_raw_roundtrip_small",
       fn = function(_: any): any
-        local packed = compress.compress(ABC, {format = "raw"})
+        local packed = assert(compress.compress(ABC, {format = "raw"}))
         return (compress.decompress(packed, {format = "raw"}))
       end,
       check = function(_: any, res: any): boolean, string

--- a/_perf/bench/stream_bench.tl
+++ b/_perf/bench/stream_bench.tl
@@ -92,11 +92,17 @@ local function serve_loop(srv: net.Socket)
 end
 
 local function scenarios(): {pt.Scenario}, string
-  local srv, port, lerr = net.listen_tcp(LOCALHOST, 0)
+  local srv, lerr = net.listen_tcp(LOCALHOST, 0)
   if srv == nil then
     return nil, "listen_tcp: " .. tostring(lerr)
   end
-  listener = srv
+  local lsock = srv as net.Socket -- cast: record union after guard
+  local ep, eperr = lsock:getsockname()
+  if ep == nil then
+    return nil, "getsockname: " .. tostring(eperr)
+  end
+  local port = (ep as net.Endpoint).port -- cast: record union after guard
+  listener = lsock
   local pid, ferr = proc.fork()
   if pid == 0 then
     serve_loop(srv)

--- a/_perf/run.tl
+++ b/_perf/run.tl
@@ -54,7 +54,7 @@ local function parse_args(argv: {string}): Args
     threshold = compare.DEFAULT_THRESHOLD_PCT,
     positional = {},
   }
-  local parser = getopt.new(argv, "h", {
+  local raw_parser, gerr = getopt.new(argv, "h", {
       {name = "out", has_arg = "required"},
       {name = "samples", has_arg = "required"},
       {name = "min-secs", has_arg = "required"},
@@ -65,6 +65,11 @@ local function parse_args(argv: {string}): Args
       {name = "selfcheck-b", has_arg = "required"},
       {name = "help", has_arg = "none", short = "h"},
     })
+  if raw_parser == nil then
+    a.err = "argument parse failed: " .. tostring(gerr)
+    return a
+  end
+  local parser = raw_parser as getopt.Parser -- cast: record union after guard
   while true do
     local opt, optarg = parser:next()
     if opt == nil then

--- a/cosmic/compress.tl
+++ b/cosmic/compress.tl
@@ -6,24 +6,29 @@
 --- and should checksum the output separately.
 local cosmo = require("cosmo")
 
---- Compressed stream framing produced by compress().
-local type Format = cosmo.CompressFormat
-
---- Framing accepted by decompress(). "auto" detects zlib or gzip from
---- the stream header; raw streams carry no header and must be named
---- explicitly.
-local type DecompressFormat = cosmo.UncompressFormat
+--- Stream framing, one enum for both directions: "zlib" (default),
+--- "gzip", "raw" (headerless, as inside ZIP files), and "auto" —
+--- decompress-only header detection. One enum instead of the old
+--- compress/decompress pair, so round-tripping your own format value
+--- no longer needs an enum-widening cast; compress() rejects "auto"
+--- at runtime (it names no producible framing).
+local enum Format
+  "zlib"
+  "gzip"
+  "raw"
+  "auto"
+end
 
 --- Options for compress().
 local record CompressOptions
-  --- output framing; defaults to "zlib"
+  --- output framing; defaults to "zlib" ("auto" is rejected)
   format: Format
 end
 
 --- Options for decompress().
 local record DecompressOptions
   --- input framing; defaults to "zlib"
-  format: DecompressFormat
+  format: Format
   --- cap on the decompressed size in bytes (default 64 MiB)
   max_output: integer
 end
@@ -34,14 +39,19 @@ end
 --- DEFLATE, suitable for embedding into formats like ZIP files.
 --- @param data string The data to compress
 --- @param opts CompressOptions? format: "zlib" (default) | "gzip" | "raw"
---- @return string The compressed data
-local function compress(data: string, opts?: CompressOptions): string
+--- @return string | nil The compressed data
+--- @return string? Error message on failure ("auto" format, or a
+--- binding failure — the old infallible signature hid the error()
+--- this used to throw from library code)
+local function compress(data: string, opts?: CompressOptions): string | nil, string
   local format: Format = opts and opts.format or "zlib"
-  local result, err = cosmo.Deflate(data, {format = format})
+  if format == "auto" then
+    return nil, "compress: format \"auto\" is decompress-only; name the framing"
+  end
+  -- cast: one Format enum, narrowed above; the binding's compress enum lacks "auto"
+  local result, err = cosmo.Deflate(data, {format = format as cosmo.CompressFormat})
   if not result then
-    -- Unreachable with valid options; surface a loud failure rather than
-    -- silently breaking the infallible contract.
-    error("compress: " .. tostring(err))
+    return nil, "compress: " .. tostring(err)
   end
   return result
 end
@@ -55,22 +65,23 @@ end
 --- @return string | nil The decompressed data, or nil on error
 --- @return string? Error message if decompression failed
 local function decompress(data: string, opts?: DecompressOptions): string | nil, string
-  local format: DecompressFormat = opts and opts.format or "zlib"
+  local format: Format = opts and opts.format or "zlib"
   local max_output = opts and opts.max_output
   -- The binding reports truncated or corrupt input as nil, err.
-  local result, err = cosmo.Inflate(data, {format = format, maxsize = max_output})
+  -- cast: one Format enum; the binding's decompress enum is the same word set
+  local result, err = cosmo.Inflate(data,
+    {format = format as cosmo.UncompressFormat, maxsize = max_output})
   if not result then
-    return nil, err
+    return nil, "decompress: " .. tostring(err)
   end
   return result
 end
 
 local record CompressModule
   type Format = Format
-  type DecompressFormat = DecompressFormat
   type CompressOptions = CompressOptions
   type DecompressOptions = DecompressOptions
-  compress: function(data: string, opts?: CompressOptions): string
+  compress: function(data: string, opts?: CompressOptions): string | nil, string
   decompress: function(data: string, opts?: DecompressOptions): string | nil, string
 end
 

--- a/cosmic/compress.tl
+++ b/cosmic/compress.tl
@@ -69,8 +69,8 @@ local function decompress(data: string, opts?: DecompressOptions): string | nil,
   local max_output = opts and opts.max_output
   -- The binding reports truncated or corrupt input as nil, err.
   -- cast: one Format enum; the binding's decompress enum is the same word set
-  local result, err = cosmo.Inflate(data,
-    {format = format as cosmo.UncompressFormat, maxsize = max_output})
+  local bformat = format as cosmo.UncompressFormat
+  local result, err = cosmo.Inflate(data, {format = bformat, maxsize = max_output})
   if not result then
     return nil, "decompress: " .. tostring(err)
   end

--- a/cosmic/compress_test.tl
+++ b/cosmic/compress_test.tl
@@ -6,7 +6,7 @@ local compress = require("cosmic.compress")
 
 local function test_roundtrip_default_zlib()
   local data = "Hello, World! This is a test of zlib compression.\x00\xff"
-  local compressed = compress.compress(data)
+  local compressed = check.must(compress.compress(data))
   assert(#compressed > 0, "expected non-empty output")
   assert(compressed ~= data, "expected different output")
   local result, err = compress.decompress(compressed)
@@ -19,9 +19,9 @@ local function test_roundtrip_explicit_formats()
   local data = "format round-trip \x00\xff\x10\x20 payload"
   local formats: {compress.Format} = {"zlib", "gzip", "raw"}
   for _, format in ipairs(formats) do
-    local compressed = compress.compress(data, {format = format})
+    local compressed = check.must(compress.compress(data, {format = format}))
     -- cast: enum widening
-    local result, err = compress.decompress(compressed, {format = format as compress.DecompressFormat})
+    local result, err = compress.decompress(compressed, {format = format})
     assert(err == nil, format .. " roundtrip failed: " .. (err or ""))
     assert(result == data, format .. " roundtrip mismatch")
   end
@@ -31,9 +31,9 @@ test_roundtrip_explicit_formats()
 local function test_roundtrip_empty_per_format()
   local formats: {compress.Format} = {"zlib", "gzip", "raw"}
   for _, format in ipairs(formats) do
-    local compressed = compress.compress("", {format = format})
+    local compressed = check.must(compress.compress("", {format = format}))
     -- cast: enum widening
-    local result, err = compress.decompress(compressed, {format = format as compress.DecompressFormat})
+    local result, err = compress.decompress(compressed, {format = format})
     assert(err == nil, format .. " empty roundtrip failed: " .. (err or ""))
     assert(result == "", format .. ": expected empty string")
   end
@@ -42,7 +42,7 @@ test_roundtrip_empty_per_format()
 
 local function test_compress_large()
   local data = string.rep("hello world, ", 1000)
-  local compressed = compress.compress(data)
+  local compressed = check.must(compress.compress(data))
   assert(#compressed < #data, "expected compression ratio for repetitive data")
 end
 test_compress_large()
@@ -51,13 +51,13 @@ test_compress_large()
 -- interoperate with other tooling.
 
 local function test_zlib_magic_bytes()
-  local compressed = compress.compress("hello", {format = "zlib"})
+  local compressed = check.must(compress.compress("hello", {format = "zlib"}))
   assert(string.byte(compressed, 1) == 0x78, "expected zlib CMF byte 0x78")
 end
 test_zlib_magic_bytes()
 
 local function test_gzip_magic_bytes()
-  local compressed = compress.compress("hello", {format = "gzip"})
+  local compressed = check.must(compress.compress("hello", {format = "gzip"}))
   local b1, b2, b3 = string.byte(compressed, 1, 3)
   assert(b1 == 0x1f and b2 == 0x8b, "expected gzip magic 1f 8b")
   assert(b3 == 0x08, "expected deflate compression method byte 0x08")
@@ -68,11 +68,11 @@ local function test_raw_has_no_header()
   -- Raw is headerless DEFLATE: no zlib or gzip magic, and strictly
   -- smaller than the framed encodings of the same input.
   local data = "hello, raw deflate"
-  local raw = compress.compress(data, {format = "raw"})
+  local raw = check.must(compress.compress(data, {format = "raw"}))
   local b1, b2 = string.byte(raw, 1, 2)
   assert(not (b1 == 0x1f and b2 == 0x8b), "raw output must not carry gzip magic")
   assert(b1 ~= 0x78, "raw output must not carry zlib header")
-  assert(#raw < #compress.compress(data, {format = "zlib"}), "raw must be smaller than zlib")
+  assert(#raw < #check.must(compress.compress(data, {format = "zlib"})), "raw must be smaller than zlib")
 end
 test_raw_has_no_header()
 
@@ -95,7 +95,7 @@ local function test_auto_detects_zlib_and_gzip()
   local data = "auto-detected payload"
   local formats: {compress.Format} = {"zlib", "gzip"}
   for _, format in ipairs(formats) do
-    local compressed = compress.compress(data, {format = format})
+    local compressed = check.must(compress.compress(data, {format = format}))
     local result, err = compress.decompress(compressed, {format = "auto"})
     assert(err == nil, "auto failed on " .. format .. ": " .. (err or ""))
     assert(result == data, "auto mismatch on " .. format)
@@ -105,7 +105,7 @@ test_auto_detects_zlib_and_gzip()
 
 local function test_auto_rejects_raw()
   -- Raw streams carry no header, so auto detection cannot identify them.
-  local raw = compress.compress("headerless", {format = "raw"})
+  local raw = check.must(compress.compress("headerless", {format = "raw"}))
   local result, err = compress.decompress(raw, {format = "auto"})
   assert(result == nil, "auto must not accept a headerless raw stream")
   assert(err ~= nil, "expected error message")
@@ -122,7 +122,7 @@ end
 test_decompress_invalid()
 
 local function test_decompress_wrong_format()
-  local gz = compress.compress("cross-format", {format = "gzip"})
+  local gz = check.must(compress.compress("cross-format", {format = "gzip"}))
   local result, err = compress.decompress(gz, {format = "zlib"})
   assert(result == nil, "gzip input must not decompress as zlib")
   assert(err ~= nil, "expected error message")
@@ -130,7 +130,7 @@ end
 test_decompress_wrong_format()
 
 local function test_decompress_truncated()
-  local compressed = compress.compress(string.rep("truncate me, ", 100))
+  local compressed = check.must(compress.compress(string.rep("truncate me, ", 100)))
   local result, err = compress.decompress(compressed:sub(1, #compressed // 2))
   assert(result == nil, "truncated input must fail")
   assert(err ~= nil, "expected error message")
@@ -142,13 +142,13 @@ test_decompress_truncated()
 
 local function test_max_output_bound_per_format()
   local data = string.rep("x", 2000)
-  local formats: {compress.DecompressFormat} = {"zlib", "gzip", "raw", "auto"}
+  local formats: {compress.Format} = {"zlib", "gzip", "raw", "auto"}
   for _, format in ipairs(formats) do
     local cformat: compress.Format = "gzip"
     if format ~= "auto" then
       cformat = format as compress.Format -- cast: enum narrowing after guard
     end
-    local compressed = compress.compress(data, {format = cformat})
+    local compressed = check.must(compress.compress(data, {format = cformat}))
     local result, err = compress.decompress(compressed, {format = format, max_output = 100})
     assert(result == nil, format .. ": output beyond max_output must be rejected")
     assert(err ~= nil, format .. ": expected error message")

--- a/cosmic/fetch/init.tl
+++ b/cosmic/fetch/init.tl
@@ -106,9 +106,7 @@ end
 local record Reader is stream_mod.Reader
   metamethod __close: function(self: Reader)
   read: function(self: Reader): string | nil, string
-  --- Close the reader. boolean, string like every close in the
-  --- stdlib: today it cannot fail, but the type admits failure for
-  --- the day the underlying transport's close can.
+  --- Close the reader; boolean, string like every stdlib close.
   close: function(self: Reader): boolean, string
   closed: function(self: Reader): boolean
   lines: function(self: Reader): function(): string | nil, string
@@ -315,9 +313,7 @@ local function make_reader(raw_reader: cosmo.StreamReader): Reader
     return chunk
   end
 
-  --- Close the reader. Idempotent; cannot fail today, but the shape
-  --- admits failure like every other close.
-  --- @return boolean always true
+  --- Close the reader. Idempotent; cannot fail today.
   function reader:close(): boolean, string
     if not is_closed then
       raw_reader:close()

--- a/cosmic/fetch/init.tl
+++ b/cosmic/fetch/init.tl
@@ -106,7 +106,10 @@ end
 local record Reader is stream_mod.Reader
   metamethod __close: function(self: Reader)
   read: function(self: Reader): string | nil, string
-  close: function(self: Reader): boolean
+  --- Close the reader. boolean, string like every close in the
+  --- stdlib: today it cannot fail, but the type admits failure for
+  --- the day the underlying transport's close can.
+  close: function(self: Reader): boolean, string
   closed: function(self: Reader): boolean
   lines: function(self: Reader): function(): string | nil, string
 end
@@ -312,9 +315,10 @@ local function make_reader(raw_reader: cosmo.StreamReader): Reader
     return chunk
   end
 
-  --- Close the reader. Idempotent.
+  --- Close the reader. Idempotent; cannot fail today, but the shape
+  --- admits failure like every other close.
   --- @return boolean always true
-  function reader:close(): boolean
+  function reader:close(): boolean, string
     if not is_closed then
       raw_reader:close()
       is_closed = true

--- a/cosmic/fetch/init_example.tl
+++ b/cosmic/fetch/init_example.tl
@@ -12,11 +12,12 @@ local function Example_get()
   local net = require("cosmic.net")
   local proc = require("cosmic.proc")
 
-  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  local srv = net.listen_tcp("127.0.0.1", 0)
   local s = check.must(srv)
+  local port = check.must(s:getsockname()).port
   local pid = check.must(proc.fork())
   if pid == 0 then
-    local conn = check.must((s:accept()))
+    local conn = check.must(s:accept())
     conn:recv(4096)
     conn:send("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello")
     conn:close()
@@ -42,8 +43,9 @@ local function Example_retry()
   local net = require("cosmic.net")
   local proc = require("cosmic.proc")
 
-  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  local srv = net.listen_tcp("127.0.0.1", 0)
   local s = check.must(srv)
+  local port = check.must(s:getsockname()).port
   local pid = check.must(proc.fork())
   if pid == 0 then
     local responses = {
@@ -51,7 +53,7 @@ local function Example_retry()
       "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
     }
     for _, resp in ipairs(responses) do
-      local conn = check.must((s:accept()))
+      local conn = check.must(s:accept())
       conn:recv(4096)
       conn:send(resp)
       conn:close()
@@ -79,12 +81,13 @@ local function Example_stream_lines()
   local net = require("cosmic.net")
   local proc = require("cosmic.proc")
 
-  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  local srv = net.listen_tcp("127.0.0.1", 0)
   local s = check.must(srv)
+  local port = check.must(s:getsockname()).port
   local pid = check.must(proc.fork())
   if pid == 0 then
     local body = "alpha\nbeta\ngamma\n"
-    local conn = check.must((s:accept()))
+    local conn = check.must(s:accept())
     conn:recv(4096)
     conn:send("HTTP/1.1 200 OK\r\nContent-Length: " .. #body
       .. "\r\nConnection: close\r\n\r\n" .. body)

--- a/cosmic/fetch/init_test.tl
+++ b/cosmic/fetch/init_test.tl
@@ -33,8 +33,9 @@ end
 --- A response of "echo" answers 200 with the raw request as the body.
 --- @return integer port, integer child pid (caller must proc.wait it)
 local function serve(responses: {string}): integer, integer
-  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  local srv = net.listen_tcp("127.0.0.1", 0)
   local s = check.must(srv, "listen_tcp failed")
+  local port = check.must(s:getsockname()).port
   local pid = proc.fork()
   if pid == 0 then
     for _, resp in ipairs(responses) do
@@ -162,8 +163,9 @@ test_follow_redirects_false_returns_redirect()
 local function test_redirect_followed_reports_final_url()
   -- serve() can't express a redirect that targets its own port (the
   -- response text needs the port), so fork by hand here.
-  local srv, port2 = net.listen_tcp("127.0.0.1", 0)
+  local srv = net.listen_tcp("127.0.0.1", 0)
   local s = check.must(srv, "listen_tcp failed")
+  local port2 = check.must(s:getsockname()).port
   local final_url = "http://127.0.0.1:" .. math.tointeger(port2) .. "/final"
   local pid2 = proc.fork()
   if pid2 == 0 then
@@ -196,8 +198,9 @@ end
 test_redirect_followed_reports_final_url()
 
 local function test_opts_table_not_mutated()
-  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  local srv = net.listen_tcp("127.0.0.1", 0)
   local s = check.must(srv, "listen_tcp failed")
+  local port = check.must(s:getsockname()).port
   local redirect_url = "http://127.0.0.1:" .. math.tointeger(port) .. "/after"
   local pid = proc.fork()
   if pid == 0 then

--- a/cosmic/fetch/multiheader_test.tl
+++ b/cosmic/fetch/multiheader_test.tl
@@ -16,8 +16,9 @@ local RESPONSE = "HTTP/1.1 200 OK\r\n"
 
 --- Fork a loopback server answering n requests with RESPONSE.
 local function serve(n: integer): integer, integer
-  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  local srv = net.listen_tcp("127.0.0.1", 0)
   local s = check.must(srv, "listen_tcp failed")
+  local port = check.must(s:getsockname()).port
   local pid = proc.fork()
   if pid == 0 then
     for _ = 1, n do

--- a/cosmic/fetch/retry_test.tl
+++ b/cosmic/fetch/retry_test.tl
@@ -26,8 +26,9 @@ end
 --- any other reason, SIGALRM's default action kills the child so
 --- proc.wait() can never hang the suite.
 local function serve(responses: {string}): integer, integer
-  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  local srv = net.listen_tcp("127.0.0.1", 0)
   local s = check.must(srv, "listen_tcp failed")
+  local port = check.must(s:getsockname()).port
   local pid = proc.fork()
   if pid == 0 then
     signal.setitimer({

--- a/cosmic/fetch/stream_test.tl
+++ b/cosmic/fetch/stream_test.tl
@@ -10,8 +10,9 @@ local check = require("cosmic.check")
 --- Fork a loopback server answering one request per response string,
 --- closing the connection right after each send.
 local function serve(responses: {string}): integer, integer
-  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  local srv = net.listen_tcp("127.0.0.1", 0)
   local s = check.must(srv, "listen_tcp failed")
+  local port = check.must(s:getsockname()).port
   local pid = proc.fork()
   if pid == 0 then
     for _, resp in ipairs(responses) do

--- a/cosmic/fetch/verbs_test.tl
+++ b/cosmic/fetch/verbs_test.tl
@@ -36,8 +36,9 @@ end
 --- the body.
 --- @return integer port, integer child pid (caller must proc.wait it)
 local function serve(responses: {string}): integer, integer
-  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  local srv = net.listen_tcp("127.0.0.1", 0)
   local s = check.must(srv, "listen_tcp failed")
+  local port = check.must(s:getsockname()).port
   local pid = proc.fork()
   if pid == 0 then
     for _, resp in ipairs(responses) do

--- a/cosmic/getopt.tl
+++ b/cosmic/getopt.tl
@@ -142,7 +142,7 @@ end
 --- @param optstring string Short options specification
 --- @param longopts {LongOpt}|nil Long option definitions
 --- @return Parser A parser instance for iterating through options
-local function new(args: {string}, optstring: string, longopts?: {LongOpt}): Parser
+local function new(args: {string}, optstring: string, longopts?: {LongOpt}): Parser | nil, string
   if legacy.new then
     -- Older cosmos: use the native iterator directly.
     -- cast: from any
@@ -150,7 +150,13 @@ local function new(args: {string}, optstring: string, longopts?: {LongOpt}): Par
   end
 
   -- Newer cosmos: replay parse() results through an iterator interface.
-  local r = parse(args, optstring, longopts) as Result -- cast: record union, nil handled
+  local raw_r, perr = parse(args, optstring, longopts)
+  if raw_r == nil then
+    -- The old code swallowed this and returned an empty Parser — a
+    -- parse failure was indistinguishable from an empty argv.
+    return nil, perr
+  end
+  local r = raw_r as Result -- cast: record union after guard
   local stream: {Option} = {}
   if r then
     for _, o in ipairs(r.opts) do
@@ -196,7 +202,7 @@ local record GetoptModule
   --- Parse a command-line argument vector in one shot
   parse: function(args: {string}, optstring: string, longopts?: {LongOpt}): Result | nil, string
   --- Create a stateful parser (compatibility shim over parse)
-  new: function(args: {string}, optstring: string, longopts?: {LongOpt}): Parser
+  new: function(args: {string}, optstring: string, longopts?: {LongOpt}): Parser | nil, string
 end
 
 local M: GetoptModule = {

--- a/cosmic/net/connect_test.tl
+++ b/cosmic/net/connect_test.tl
@@ -85,7 +85,7 @@ local function test_unix_domain_socket_bind_connect()
   end
 
   -- Parent: accept connection
-  local raw_client, _, _, accept_err = server:accept()
+  local raw_client, accept_err = server:accept()
   local client = check.must(raw_client, "accept failed: " .. tostring(accept_err))
 
   -- Read data from client
@@ -118,7 +118,7 @@ local function test_listen_unix_connect_unix()
   end
 
   -- Parent: accept connection
-  local raw_client, _, _, accept_err = server:accept()
+  local raw_client, accept_err = server:accept()
   local client = check.must(raw_client, "accept failed: " .. tostring(accept_err))
 
   -- Read data from client
@@ -147,7 +147,7 @@ local function test_nb_connect_loopback()
   ok, err = server:bind("127.0.0.1", 0) -- 127.0.0.1
   assert(ok, "bind failed: " .. tostring(err))
 
-  local _, server_port = server:getsockname()
+  local server_port = check.must(server:getsockname()).port
   assert(server_port > 0, "expected non-zero port")
 
   ok, err = server:listen()
@@ -162,7 +162,7 @@ local function test_nb_connect_loopback()
   assert(ok, "nb_connect failed: " .. tostring(err))
 
   -- Accept the connection on the server side
-  local raw_accepted, _, _, accept_err = server:accept()
+  local raw_accepted, accept_err = server:accept()
   local accepted = check.must(raw_accepted, "accept failed: " .. tostring(accept_err))
 
   -- Verify the connection works by sending data
@@ -227,8 +227,8 @@ test_socket_error_names_errno()
 
 local function test_socketpair_error_names_errno()
   -- socketpair() only supports AF_UNIX; AF_INET fails synchronously.
-  local a, _b, err = net.socketpair(net.AF_INET, net.SOCK_STREAM, 0)
-  assert(a == nil, "socketpair with AF_INET should fail")
+  local pair, err = net.socketpair(net.AF_INET, net.SOCK_STREAM, 0)
+  assert(pair == nil, "socketpair with AF_INET should fail")
   assert(err ~= nil and err:match("E%u+"),
     "socketpair error should name the errno, got: " .. tostring(err))
 end
@@ -244,7 +244,7 @@ local function test_connect_tcp()
   ok, err = server:bind("127.0.0.1", 0)
   assert(ok, "bind failed: " .. tostring(err))
 
-  local _, server_port = server:getsockname()
+  local server_port = check.must(server:getsockname()).port
   assert(server_port > 0, "expected non-zero port")
 
   ok, err = server:listen()
@@ -261,7 +261,7 @@ local function test_connect_tcp()
   end
 
   -- Parent: accept connection
-  local raw_client, _, _, accept_err = server:accept()
+  local raw_client, accept_err = server:accept()
   local client = check.must(raw_client, "accept failed: " .. tostring(accept_err))
 
   -- Read data from client
@@ -275,20 +275,21 @@ end
 test_connect_tcp()
 
 local function test_connect_tcp_accepts_string_and_addr()
-  local raw_server, port, lerr = net.listen_tcp("127.0.0.1", 0)
+  local raw_server, lerr = net.listen_tcp("127.0.0.1", 0)
   local server = check.must(raw_server,
     "listen_tcp with string address failed: " .. tostring(lerr))
+  local port = check.must(server:getsockname()).port
 
   -- connect by dotted-quad string
   local c1 = check.must(net.connect_tcp("127.0.0.1", port))
-  local a1 = check.must((server:accept()))
+  local a1 = check.must(server:accept())
   c1:close()
   a1:close()
 
   -- connect by typed ip.Addr
   local addr = ip.addr(0x7f000001)
   local c2 = check.must(net.connect_tcp(addr, port))
-  local a2 = check.must((server:accept()))
+  local a2 = check.must(server:accept())
   c2:close()
   a2:close()
 
@@ -330,7 +331,7 @@ local function test_bind_error_names_errno()
   local first = check.must(net.socket(net.AF_INET, net.SOCK_STREAM))
   assert(first:bind("127.0.0.1", 0))
   assert(first:listen())
-  local _, port = first:getsockname()
+  local port = check.must(first:getsockname()).port
   local second = check.must(net.socket(net.AF_INET, net.SOCK_STREAM))
   local ok, berr = second:bind("127.0.0.1", port)
   assert(ok == false, "second bind to same port should fail")
@@ -343,16 +344,17 @@ test_bind_error_names_errno()
 local function test_dial()
   -- dial is the stable name-and-shape entry point (from):
   -- resolution happens inside, for literals and DNS names alike.
-  local srv, port, serr = net.listen_tcp("127.0.0.1", 0)
+  local srv, serr = net.listen_tcp("127.0.0.1", 0)
   local s = check.must(srv, "listen_tcp failed: " .. tostring(serr))
+  local port = check.must(s:getsockname()).port
 
   local c1 = check.must(net.dial("127.0.0.1", port))
-  local a1 = check.must((s:accept()))
+  local a1 = check.must(s:accept())
   c1:close()
   a1:close()
 
   local c2 = check.must(net.dial("localhost", port))
-  local a2 = check.must((s:accept()))
+  local a2 = check.must(s:accept())
   c2:close()
   a2:close()
   s:close()
@@ -367,22 +369,23 @@ test_dial()
 -- listen_tcp socket options are configurable — SO_REUSEADDR stays
 -- the default but can be opted out, and SO_REUSEPORT can be opted in.
 local function test_listen_tcp_socket_options()
-  local s1, port, derr = net.listen_tcp("127.0.0.1", 0)
+  local s1, derr = net.listen_tcp("127.0.0.1", 0)
   local d = check.must(s1, "listen_tcp failed: " .. tostring(derr))
+  local port = check.must(d:getsockname()).port
   assert(port > 0, "expected a bound port")
   local ra = d:getsockopt(net.SOL_SOCKET, net.SO_REUSEADDR)
   assert(ra == true or ra == 1,
     "SO_REUSEADDR should default on, got " .. tostring(ra))
   d:close()
 
-  local s2, _, oerr = net.listen_tcp("127.0.0.1", 0, nil, {reuseaddr = false})
+  local s2, oerr = net.listen_tcp("127.0.0.1", 0, nil, {reuseaddr = false})
   local o = check.must(s2, "listen_tcp with reuseaddr=false failed: " .. tostring(oerr))
   local ra2 = o:getsockopt(net.SOL_SOCKET, net.SO_REUSEADDR)
   assert(ra2 == false or ra2 == 0,
     "reuseaddr=false should leave SO_REUSEADDR off, got " .. tostring(ra2))
   o:close()
 
-  local s3, _, perr = net.listen_tcp("127.0.0.1", 0, nil, {reuseport = true})
+  local s3, perr = net.listen_tcp("127.0.0.1", 0, nil, {reuseport = true})
   local p = check.must(s3, "listen_tcp with reuseport failed: " .. tostring(perr))
   local rp = p:getsockopt(net.SOL_SOCKET, net.SO_REUSEPORT)
   assert(rp == true or rp == 1,

--- a/cosmic/net/init.tl
+++ b/cosmic/net/init.tl
@@ -38,14 +38,22 @@ local function socket(family?: integer, socktype?: integer, protocol?: integer):
   return make_socket(fd)
 end
 
+--- A connected socket pair, as returned by socketpair(). A record
+--- rather than (Socket, Socket, err) returns: the old shape typed slot
+--- 2 as a non-nil Socket while returning nil there on failure, and put
+--- the error in slot 3 where `local a, b = ...` silently lost it.
+local record Pair
+  a: Socket
+  b: Socket
+end
+
 --- Create a pair of connected sockets.
 --- @param family integer Address family (AF_UNIX). Default: AF_UNIX
 --- @param socktype integer Socket type (SOCK_STREAM, SOCK_DGRAM). Default: SOCK_STREAM
 --- @param protocol integer Protocol. Default: 0
---- @return Socket | nil First socket of the pair
---- @return Socket Second socket of the pair
+--- @return Pair | nil Both sockets, on success
 --- @return string Error message on failure
-local function socketpair(family?: integer, socktype?: integer, protocol?: integer): Socket | nil, Socket, string
+local function socketpair(family?: integer, socktype?: integer, protocol?: integer): Pair | nil, string
   family = family or unix.AF_UNIX
   socktype = socktype or unix.SOCK_STREAM
   protocol = protocol or 0
@@ -53,9 +61,9 @@ local function socketpair(family?: integer, socktype?: integer, protocol?: integ
   if not fd1 then
     -- On failure the binding returns (nil, err, errno): the error string
     -- arrives in the second slot, where the second fd would have been.
-    return nil, nil, errstr(fd2, "socketpair")
+    return nil, errstr(fd2, "socketpair")
   end
-  return make_socket(fd1), make_socket(fd2)
+  return {a = make_socket(fd1), b = make_socket(fd2)}
 end
 
 --- Create a Unix domain socket, bind it to a path, and start listening.
@@ -178,46 +186,43 @@ end
 --- @param port integer Local port to bind; use 0 for an OS-assigned ephemeral port
 --- @param backlog integer Maximum pending connections (default 128)
 --- @param opts ListenOptions? Socket options (reuseaddr default true, reuseport default false)
---- @return Socket | nil Listening socket ready to accept
---- @return integer Actual bound port (useful when port 0 was requested)
+--- @return Socket | nil Listening socket ready to accept; when port 0
+--- was requested, read the OS-assigned port with
+--- `s:getsockname().port` (the old (Socket, port, err) triple put the
+--- error in slot 3, where `check.must` and `local s, err = ...` lost it)
 --- @return string Error message on failure
-local function listen_tcp(addr: Address, port: integer, backlog?: integer, opts?: ListenOptions): Socket | nil, integer, string
+local function listen_tcp(addr: Address, port: integer, backlog?: integer, opts?: ListenOptions): Socket | nil, string
   opts = opts or {}
   local sock, serr = socket(unix.AF_INET, unix.SOCK_STREAM, 0)
   if not sock then
-    return nil, nil, serr
+    return nil, serr
   end
   local s = sock as Socket -- cast: record union after guard
   if opts.reuseaddr ~= false then
     local ok, setopt_err = s:setsockopt(unix.SOL_SOCKET, unix.SO_REUSEADDR, true)
     if not ok then
       s:close()
-      return nil, nil, setopt_err
+      return nil, setopt_err
     end
   end
   if opts.reuseport then
     local ok, setopt_err = s:setsockopt(unix.SOL_SOCKET, unix.SO_REUSEPORT, true)
     if not ok then
       s:close()
-      return nil, nil, setopt_err
+      return nil, setopt_err
     end
   end
   local bok, bind_err = s:bind(addr, port)
   if not bok then
     s:close()
-    return nil, nil, bind_err
-  end
-  local _, bound_port, name_err = s:getsockname()
-  if not bound_port then
-    s:close()
-    return nil, nil, name_err
+    return nil, bind_err
   end
   local lok, listen_err = s:listen(backlog)
   if not lok then
     s:close()
-    return nil, nil, listen_err
+    return nil, listen_err
   end
-  return s, bound_port
+  return s
 end
 
 --- Connect with a bounded wait instead of blocking indefinitely.
@@ -316,10 +321,13 @@ local record NetModule
   type Address = Address
   type ListenOptions = ListenOptions
   type Interface = Interface
+  type Endpoint = net_socket.Endpoint
+  type Datagram = net_socket.Datagram
+  type Pair = Pair
   socket: function(family?: integer, socktype?: integer, protocol?: integer): Socket | nil, string
-  socketpair: function(family?: integer, socktype?: integer, protocol?: integer): Socket | nil, Socket, string
+  socketpair: function(family?: integer, socktype?: integer, protocol?: integer): Pair | nil, string
   listen_unix: function(path: string, backlog?: integer): Socket | nil, string
-  listen_tcp: function(addr: Address, port: integer, backlog?: integer, opts?: ListenOptions): Socket | nil, integer, string
+  listen_tcp: function(addr: Address, port: integer, backlog?: integer, opts?: ListenOptions): Socket | nil, string
   connect_unix: function(path: string): Socket | nil, string
   connect_tcp: function(addr: Address, port: integer): Socket | nil, string
   dial: function(host: string, port: integer): Socket | nil, string

--- a/cosmic/net/init.tl
+++ b/cosmic/net/init.tl
@@ -166,21 +166,21 @@ local record ListenOptions
 end
 
 --- Create a TCP socket, bind it to addr:port, and start listening.
---- Passing port 0 lets the OS assign an ephemeral port; the actual port is
---- returned as the second value so callers never need a separate getsockname
---- call. The address may be a dotted-quad string, a raw integer, or an
---- ip.Addr (0 binds all interfaces). IPv6 is not supported.
+--- Passing port 0 lets the OS assign an ephemeral port; read it with
+--- getsockname().port. The address may be a dotted-quad string, a raw
+--- integer, or an ip.Addr (0 binds all interfaces). IPv6 is not
+--- supported.
 ---
 --- Example — listen on an OS-assigned port:
 ---   local net = require("cosmic.net")
----   local srv, port, err = net.listen_tcp("127.0.0.1", 0)
----   -- port is now the OS-assigned port, e.g. 54321
+---   local srv = assert(net.listen_tcp("127.0.0.1", 0))
+---   local port = assert(srv:getsockname()).port
 ---   local client = net.connect_tcp("127.0.0.1", port)
 ---
---- Recorded decision (api-review-2): the (Socket, port, err) return
---- order — the bound port between the value and the error slot — is
---- deliberate port-0 ergonomics, kept as-is rather than reshuffled to the
---- usual value-then-error order.
+--- Amends the api-review-2 recorded decision: the (Socket, port, err)
+--- triple's slot-3 error was invisible to `check.must` and to
+--- `local s, err = ...` — every misuse type-checked and crashed at
+--- runtime. Error-in-slot-2 wins over the port convenience.
 ---
 --- @param addr Address Local IPv4 address to bind ("127.0.0.1", "0.0.0.0" for all)
 --- @param port integer Local port to bind; use 0 for an OS-assigned ephemeral port

--- a/cosmic/net/init_example.tl
+++ b/cosmic/net/init_example.tl
@@ -5,14 +5,14 @@
 local function Example_echo()
   local net = require("cosmic.net")
   local check = require("cosmic.check")
-  local raw_srv, port, err = net.listen_tcp("127.0.0.1", 0)
-  local srv = check.must(raw_srv, err)
+  local srv = check.must(net.listen_tcp("127.0.0.1", 0))
+  local port = check.must(srv:getsockname()).port
   assert(port > 0)
 
   local client = check.must(net.connect_tcp("127.0.0.1", port))
 
-  local raw_conn, _, _, aerr = srv:accept()
-  local conn = check.must(raw_conn, aerr)
+  -- accept's error is in slot 2 now, so must() forwards it directly.
+  local conn = check.must(srv:accept())
 
   client:send("hello")
   local msg = check.must(conn:recv())
@@ -32,11 +32,11 @@ end
 local function Example_recv_eof()
   local net = require("cosmic.net")
   local check = require("cosmic.check")
-  local raw_srv, port, err = net.listen_tcp("127.0.0.1", 0)
-  local srv = check.must(raw_srv, err)
+  local srv = check.must(net.listen_tcp("127.0.0.1", 0))
+  local port = check.must(srv:getsockname()).port
 
   local client = check.must(net.connect_tcp("127.0.0.1", port))
-  local conn = check.must((srv:accept()))
+  local conn = check.must(srv:accept())
 
   client:close()
   local data, recv_err = conn:recv()

--- a/cosmic/net/init_test.tl
+++ b/cosmic/net/init_test.tl
@@ -16,9 +16,8 @@ end
 test_socket_creation()
 
 local function test_socketpair()
-  local raw_sock1, sock2, err = net.socketpair()
-  assert(raw_sock1 ~= nil and sock2 ~= nil, "socketpair failed: " .. tostring(err))
-  local sock1 = check.must(raw_sock1)
+  local pair = check.must(net.socketpair())
+  local sock1, sock2 = pair.a, pair.b
 
   -- Test sending data between the pair
   local sent, send_err = sock1:send("hello")
@@ -36,9 +35,8 @@ local function test_send_to_closed_peer_returns_error()
   -- Regression: sending to a peer that has closed must return nil, err --
   -- NOT kill the process with SIGPIPE (which surfaces as exit 141, an
   -- unambiguous red before send() ORed in MSG_NOSIGNAL).
-  local raw_a, b, err = net.socketpair()
-  assert(raw_a ~= nil and b ~= nil, "socketpair failed: " .. tostring(err))
-  local a = check.must(raw_a)
+  local pair = check.must(net.socketpair())
+  local a, b = pair.a, pair.b
   b:close()
 
   -- Loop so a kernel that accepts the first write into the buffer before
@@ -62,10 +60,9 @@ local function test_bind_and_getsockname()
   local ok, bind_err = sock:bind("0.0.0.0", 0)
   assert(ok, "bind failed: " .. tostring(bind_err))
 
-  local addr, port, name_err = sock:getsockname()
-  assert(addr ~= nil, "getsockname failed: " .. tostring(name_err))
-  assert(check.must(addr).family == "inet", "local address must be a typed Addr")
-  assert(port > 0, "expected non-zero port, got " .. tostring(port))
+  local ep = check.must(sock:getsockname())
+  assert(ep.addr.family == "inet", "local address must be a typed Addr")
+  assert(ep.port > 0, "expected non-zero port, got " .. tostring(ep.port))
 
   sock:close()
 end
@@ -81,7 +78,7 @@ local function test_listen_accept_connect()
   ok, err = server:bind("0.0.0.0", 0)
   assert(ok, "bind failed: " .. tostring(err))
 
-  local _, server_port = server:getsockname()
+  local server_port = check.must(server:getsockname()).port
   assert(server_port > 0, "expected non-zero port")
 
   ok, err = server:listen()
@@ -109,23 +106,23 @@ local function test_listen_accept_connect()
     os.exit(0)
   end
 
-  -- Parent: accept connection
-  local raw_client, client_ip, client_port, accept_err = server:accept()
+  -- Parent: accept connection; the peer's endpoint comes from
+  -- getpeername now that accept returns the socket alone.
+  local raw_client, accept_err = server:accept()
   assert(raw_client ~= nil, "accept failed: " .. tostring(accept_err))
-  assert(client_ip ~= nil, "expected raw_client IP")
-  assert(client_ip.family == "inet", "peer address must be a typed Addr")
-  assert(client_ip:is_loopback(), "peer should be loopback, got " .. client_ip:format())
-  assert(client_port ~= nil and client_port > 0, "expected raw_client port")
   local client = check.must(raw_client)
+  local peer = check.must(client:getpeername())
+  assert(peer.addr.family == "inet", "peer address must be a typed Addr")
+  assert(peer.addr:is_loopback(), "peer should be loopback, got " .. peer.addr:format())
+  assert(peer.port > 0, "expected raw_client port")
 
   -- Read data from client
   local data, recv_err = client:recv()
   assert(data == "hello from client", "expected 'hello from client', got '" .. tostring(data) .. "': " .. tostring(recv_err))
 
-  -- Get peer name
-  local peer_ip, peer_port, peer_err = client:getpeername()
-  assert(peer_ip ~= nil, "getpeername failed: " .. tostring(peer_err))
-  assert(peer_port == client_port, "peer port mismatch")
+  -- Get peer name again; it must agree with itself.
+  local peer2 = check.must(client:getpeername())
+  assert(peer2.port == peer.port, "peer port mismatch")
 
   client:close()
   server:close()
@@ -143,9 +140,8 @@ end
 test_gethostname()
 
 local function test_shutdown()
-  local raw_sock1, sock2, err = net.socketpair()
-  assert(raw_sock1 ~= nil and sock2 ~= nil, "socketpair failed: " .. tostring(err))
-  local sock1 = check.must(raw_sock1)
+  local pair = check.must(net.socketpair())
+  local sock1, sock2 = pair.a, pair.b
 
   -- Shutdown write side of sock1
   local ok, shutdown_err = sock1:shutdown(net.SHUT_WR)
@@ -165,9 +161,8 @@ local function test_poll_readiness()
   -- net.poll was a duplicate of cosmic.poll and is gone; sockets compose
   -- with the Poller directly via their fd.
   local poll = require("cosmic.poll")
-  local raw_sock1, sock2, err = net.socketpair()
-  assert(raw_sock1 ~= nil and sock2 ~= nil, "socketpair failed: " .. tostring(err))
-  local sock1 = check.must(raw_sock1)
+  local pair = check.must(net.socketpair())
+  local sock1, sock2 = pair.a, pair.b
 
   -- Send data on sock1
   sock1:send("hello")
@@ -194,20 +189,19 @@ local function test_udp_sendto_recvfrom()
   local ok, bind_err = receiver:bind("127.0.0.1", 0)
   assert(ok, "bind failed: " .. tostring(bind_err))
 
-  local _, recv_port = receiver:getsockname()
+  local recv_port = check.must(receiver:getsockname()).port
   assert(recv_port > 0, "expected non-zero port")
 
   -- Send datagram
   local sent, send_err = sender:sendto("hello udp", "127.0.0.1", recv_port)
   assert(sent == 9, "expected 9 bytes sent, got " .. tostring(sent) .. ": " .. tostring(send_err))
 
-  -- Receive datagram: the sender address arrives as a typed ip.Addr
-  local data, from_ip, from_port, recv_err = receiver:recvfrom(100)
-  assert(data == "hello udp", "expected 'hello udp', got '" .. tostring(data) .. "': " .. tostring(recv_err))
-  assert(from_ip ~= nil, "expected sender IP")
-  assert(from_ip.family == "inet", "sender address must be a typed Addr")
-  assert(from_ip:format() == "127.0.0.1", "expected loopback sender, got " .. from_ip:format())
-  assert(from_port ~= nil and from_port > 0, "expected sender port")
+  -- Receive datagram: one record, the sender endpoint inside it
+  local dg = check.must(receiver:recvfrom(100))
+  assert(dg.data == "hello udp", "expected 'hello udp', got '" .. tostring(dg.data) .. "'")
+  assert(dg.addr.family == "inet", "sender address must be a typed Addr")
+  assert(dg.addr:format() == "127.0.0.1", "expected loopback sender, got " .. dg.addr:format())
+  assert(dg.port > 0, "expected sender port")
 
   sender:close()
   receiver:close()
@@ -304,8 +298,8 @@ local function test_socket_methods_after_close()
   assert(n == nil and serr == "socket closed", "send: " .. tostring(serr))
   local d, rerr = sock:recv()
   assert(d == nil and rerr == "socket closed", "recv: " .. tostring(rerr))
-  local addr, port, gerr = sock:getsockname()
-  assert(addr == nil and port == nil and gerr == "socket closed",
+  local ep, gerr = sock:getsockname()
+  assert(ep == nil and gerr == "socket closed",
     "getsockname: " .. tostring(gerr))
   local bok, berr = sock:bind()
   assert(bok == false and berr == "socket closed", "bind: " .. tostring(berr))
@@ -343,9 +337,8 @@ test_socket_has_close_metamethod()
 
 local function test_socketpair_has_close_metamethod()
   -- Verify socketpair sockets also have __close
-  local raw_sock1, sock2, err = net.socketpair()
-  assert(raw_sock1 ~= nil and sock2 ~= nil, "socketpair failed: " .. tostring(err))
-  local sock1 = check.must(raw_sock1)
+  local pair = check.must(net.socketpair())
+  local sock1, sock2 = pair.a, pair.b
 
   local mt1 = getmetatable(sock1)
   local mt2 = getmetatable(sock2)
@@ -367,7 +360,7 @@ local function test_accept_socket_has_close_metamethod()
   ok, err = server:bind("0.0.0.0", 0)
   assert(ok, "bind failed: " .. tostring(err))
 
-  local _, server_port = server:getsockname()
+  local server_port = check.must(server:getsockname()).port
   ok, err = server:listen()
   assert(ok, "listen failed: " .. tostring(err))
 
@@ -385,7 +378,7 @@ local function test_accept_socket_has_close_metamethod()
   end
 
   -- Accept and verify __close exists on accepted socket
-  local raw_client, _, _, accept_err = server:accept()
+  local raw_client, accept_err = server:accept()
   assert(raw_client ~= nil, "accept failed: " .. tostring(accept_err))
   local client = check.must(raw_client)
 
@@ -402,21 +395,23 @@ end
 test_accept_socket_has_close_metamethod()
 
 local function test_listen_tcp_ephemeral_port()
-  -- listen_tcp with port 0 should return a listening socket and a port > 0
-  local raw_srv, port, err = net.listen_tcp("127.0.0.1", 0)
+  -- listen_tcp with port 0: the OS-assigned port comes from getsockname
+  local raw_srv, err = net.listen_tcp("127.0.0.1", 0)
   assert(raw_srv ~= nil, "listen_tcp failed: " .. tostring(err))
-  assert(port ~= nil and port > 0, "expected non-zero port, got " .. tostring(port))
   local srv = check.must(raw_srv)
+  local port = check.must(srv:getsockname()).port
+  assert(port > 0, "expected non-zero port, got " .. tostring(port))
   srv:close()
 end
 test_listen_tcp_ephemeral_port()
 
 local function test_listen_tcp_connect_to_returned_port()
-  -- bind on 127.0.0.1:0, then connect_tcp to the returned port
-  local raw_srv, port, serr = net.listen_tcp("127.0.0.1", 0)
+  -- bind on 127.0.0.1:0, then connect_tcp to the bound port
+  local raw_srv, serr = net.listen_tcp("127.0.0.1", 0)
   assert(raw_srv ~= nil, "listen_tcp failed: " .. tostring(serr))
-  assert(port > 0, "expected non-zero port")
   local srv = check.must(raw_srv)
+  local port = check.must(srv:getsockname()).port
+  assert(port > 0, "expected non-zero port")
 
   -- Fork: child connects and sends, parent accepts and reads
   local pid = proc.fork()
@@ -431,7 +426,7 @@ local function test_listen_tcp_connect_to_returned_port()
     os.exit(0)
   end
 
-  local raw_conn, _, _, aerr = srv:accept()
+  local raw_conn, aerr = srv:accept()
   assert(raw_conn ~= nil, "accept failed: " .. tostring(aerr))
   local conn = check.must(raw_conn)
   local data = conn:recv()
@@ -445,14 +440,15 @@ test_listen_tcp_connect_to_returned_port()
 local function test_listen_tcp_double_bind_same_port_fails()
   -- Bind a specific port, then try to bind the same port again without
   -- REUSEPORT; the second listen_tcp should fail.
-  local raw_srv, port, serr = net.listen_tcp("127.0.0.1", 0)
+  local raw_srv, serr = net.listen_tcp("127.0.0.1", 0)
   assert(raw_srv ~= nil, "first listen_tcp failed: " .. tostring(serr))
-  assert(port > 0, "expected non-zero port")
   local srv = check.must(raw_srv)
+  local port = check.must(srv:getsockname()).port
+  assert(port > 0, "expected non-zero port")
 
   -- Second bind to the same explicit port should fail (SO_REUSEADDR alone
   -- does not allow two listeners on the same port simultaneously)
-  local srv2, _, serr2 = net.listen_tcp("127.0.0.1", port)
+  local srv2, serr2 = net.listen_tcp("127.0.0.1", port)
   assert(srv2 == nil, "expected second listen_tcp to fail on same port")
   assert(serr2 ~= nil, "expected error message from second listen_tcp")
 
@@ -462,7 +458,7 @@ test_listen_tcp_double_bind_same_port_fails()
 
 local function test_listen_tcp_invalid_ip_bind_fails()
   -- Attempt to bind to a non-local IP should fail
-  local srv, _, serr = net.listen_tcp("1.2.3.4", 0) -- not a local address
+  local srv, serr = net.listen_tcp("1.2.3.4", 0) -- not a local address
   assert(srv == nil, "expected listen_tcp to fail on non-local IP")
   assert(serr ~= nil, "expected error message")
 end

--- a/cosmic/net/io_test.tl
+++ b/cosmic/net/io_test.tl
@@ -3,9 +3,10 @@ local check = require("cosmic.check")
 local net = require("cosmic.net")
 
 local function pair(): net.Socket, net.Socket
-  local a, b, err = net.socketpair()
-  assert(a ~= nil and b ~= nil, "socketpair failed: " .. tostring(err))
-  return (check.must(a)), b
+  -- socketpair's error lives in slot 2 now; the record makes the old
+  -- shape-laundering helper a one-liner.
+  local p = check.must(net.socketpair())
+  return p.a, p.b
 end
 
 -- sendall tests

--- a/cosmic/net/socket.tl
+++ b/cosmic/net/socket.tl
@@ -27,16 +27,13 @@ local function resolve_addr(addr: Address): integer | nil, string
   return (addr):int()
 end
 
---- A local or peer endpoint, as reported by getsockname/getpeername.
---- A record rather than (Addr, integer, err) returns, so the error is
---- always in slot 2 and `check.must` composes.
+--- A local or peer endpoint (getsockname/getpeername), error in slot 2.
 local record Endpoint
   addr: ip.Addr
   port: integer
 end
 
---- One received datagram, as returned by recvfrom: the payload plus
---- the sender's endpoint.
+--- One received datagram (recvfrom): payload plus sender endpoint.
 local record Datagram
   data: string
   addr: ip.Addr
@@ -55,8 +52,7 @@ local record Socket is stream.Reader, stream.Writer
   metamethod __close: function(self: Socket)
   --- The underlying file descriptor.
   fd: integer
-  --- Close the socket. Idempotent; reports the close(2) error —
-  --- an EIO on a dirty flush or an EBADF double-close is load-bearing.
+  --- Close the socket. Idempotent; reports the close(2) error.
   close: function(self: Socket): boolean, string
   --- True when the socket has been closed.
   closed: function(self: Socket): boolean
@@ -96,8 +92,7 @@ local record Socket is stream.Reader, stream.Writer
   --- the stream contract. With max set, returns at most max bytes even
   --- if no newline was seen (the rest stays readable), like fgets.
   readline: function(self: Socket, max?: integer): string | nil, string
-  --- Receive a datagram: the payload plus sender endpoint, with the
-  --- error in slot 2 where every other fallible value keeps it.
+  --- Receive a datagram: payload plus sender endpoint, error in slot 2.
   recvfrom: function(self: Socket, bufsiz?: integer, flags?: integer): Datagram | nil, string
   --- Local endpoint; use after bind for the OS-assigned port.
   getsockname: function(self: Socket): Endpoint | nil, string
@@ -110,10 +105,8 @@ local record Socket is stream.Reader, stream.Writer
   --- Start listening for connections.
   listen: function(self: Socket, backlog?: integer): boolean, string
   --- Accept one connection (blocks until a client connects). Returns
-  --- the connection socket alone — the error in slot 2, so
-  --- `check.must(s:accept())` narrows without dropping the message.
-  --- The peer's address is a getpeername() away when wanted (every
-  --- former in-tree caller discarded the extra returns).
+  --- the socket alone, error in slot 2; the peer's endpoint is a
+  --- getpeername() away when wanted.
   accept: function(self: Socket, flags?: integer): Socket | nil, string
   --- Connect to addr:port. The one blocking call NOT retried on EINTR:
   --- POSIX keeps the connection attempt going in the background after a

--- a/cosmic/net/socket.tl
+++ b/cosmic/net/socket.tl
@@ -27,6 +27,22 @@ local function resolve_addr(addr: Address): integer | nil, string
   return (addr):int()
 end
 
+--- A local or peer endpoint, as reported by getsockname/getpeername.
+--- A record rather than (Addr, integer, err) returns, so the error is
+--- always in slot 2 and `check.must` composes.
+local record Endpoint
+  addr: ip.Addr
+  port: integer
+end
+
+--- One received datagram, as returned by recvfrom: the payload plus
+--- the sender's endpoint.
+local record Datagram
+  data: string
+  addr: ip.Addr
+  port: integer
+end
+
 --- Socket handle for network I/O.
 --- Sockets are BLOCKING by default: recv and accept wait until data or a
 --- connection arrives. Blocking calls interrupted by a signal are retried
@@ -39,8 +55,9 @@ local record Socket is stream.Reader, stream.Writer
   metamethod __close: function(self: Socket)
   --- The underlying file descriptor.
   fd: integer
-  --- Close the socket.
-  close: function(self: Socket): boolean
+  --- Close the socket. Idempotent; reports the close(2) error —
+  --- an EIO on a dirty flush or an EBADF double-close is load-bearing.
+  close: function(self: Socket): boolean, string
   --- True when the socket has been closed.
   closed: function(self: Socket): boolean
   --- Shut down reading and/or writing (unix.SHUT_RD/WR/RDWR).
@@ -79,21 +96,25 @@ local record Socket is stream.Reader, stream.Writer
   --- the stream contract. With max set, returns at most max bytes even
   --- if no newline was seen (the rest stays readable), like fgets.
   readline: function(self: Socket, max?: integer): string | nil, string
-  --- Receive a datagram; returns data, sender Addr, sender port.
-  recvfrom: function(self: Socket, bufsiz?: integer, flags?: integer): string | nil, ip.Addr, integer, string
-  --- Local address as (Addr, port); use after bind for the real port.
-  getsockname: function(self: Socket): ip.Addr | nil, integer, string
-  --- Peer address as (Addr, port).
-  getpeername: function(self: Socket): ip.Addr | nil, integer, string
+  --- Receive a datagram: the payload plus sender endpoint, with the
+  --- error in slot 2 where every other fallible value keeps it.
+  recvfrom: function(self: Socket, bufsiz?: integer, flags?: integer): Datagram | nil, string
+  --- Local endpoint; use after bind for the OS-assigned port.
+  getsockname: function(self: Socket): Endpoint | nil, string
+  --- Peer endpoint.
+  getpeername: function(self: Socket): Endpoint | nil, string
   --- Bind to a local addr:port (default all interfaces, OS-assigned port).
   bind: function(self: Socket, addr?: Address, port?: integer): boolean, string
   --- Bind to a unix-domain socket path.
   bind_unix: function(self: Socket, path: string): boolean, string
   --- Start listening for connections.
   listen: function(self: Socket, backlog?: integer): boolean, string
-  --- Accept one connection (blocks until a client connects).
-  --- Returns the connection socket, peer Addr, peer port.
-  accept: function(self: Socket, flags?: integer): Socket | nil, ip.Addr, integer, string
+  --- Accept one connection (blocks until a client connects). Returns
+  --- the connection socket alone — the error in slot 2, so
+  --- `check.must(s:accept())` narrows without dropping the message.
+  --- The peer's address is a getpeername() away when wanted (every
+  --- former in-tree caller discarded the extra returns).
+  accept: function(self: Socket, flags?: integer): Socket | nil, string
   --- Connect to addr:port. The one blocking call NOT retried on EINTR:
   --- POSIX keeps the connection attempt going in the background after a
   --- signal, so a blind retry would fail with EALREADY. On EINTR, poll
@@ -127,11 +148,13 @@ local function make_socket(fd: integer): Socket
     unix.setsockopt(fd, unix.SOL_SOCKET, unix.SO_NOSIGPIPE, true)
   end
 
-  function sock:close(): boolean
+  function sock:close(): boolean, string
     if self.fd then
-      local ok = unix.close(self.fd)
+      local ok, err = unix.close(self.fd)
       self.fd = nil
-      return ok
+      if not ok then
+        return false, errstr(err, "close")
+      end
     end
     return true
   end
@@ -299,8 +322,8 @@ local function make_socket(fd: integer): Socket
     return line
   end
 
-  function sock:recvfrom(bufsiz?: integer, flags?: integer): string | nil, ip.Addr, integer, string
-    if not self.fd then return nil, nil, nil, "socket closed" end
+  function sock:recvfrom(bufsiz?: integer, flags?: integer): Datagram | nil, string
+    if not self.fd then return nil, "socket closed" end
     local data, sender, port = unix.recvfrom(self.fd, bufsiz or 65536, flags or 0)
     while data == nil and errno_is(port, "EINTR") do
       data, sender, port = unix.recvfrom(self.fd, bufsiz or 65536, flags or 0)
@@ -308,31 +331,31 @@ local function make_socket(fd: integer): Socket
     if not data then
       -- On failure the binding returns (nil, err, errno): the error string
       -- arrives in the second slot, where the sender ip would have been.
-      return nil, nil, nil, errstr(sender, "recvfrom")
+      return nil, errstr(sender, "recvfrom")
     end
-    return data, ip.addr(sender), port
+    return {data = data, addr = ip.addr(sender), port = port}
   end
 
-  function sock:getsockname(): ip.Addr | nil, integer, string
-    if not self.fd then return nil, nil, "socket closed" end
+  function sock:getsockname(): Endpoint | nil, string
+    if not self.fd then return nil, "socket closed" end
     local raw, port = unix.getsockname(self.fd)
     if not raw then
       -- On failure the binding returns (nil, err, errno): the error string
       -- arrives in the second slot, where the port would have been.
-      return nil, nil, errstr(port, "getsockname")
+      return nil, errstr(port, "getsockname")
     end
-    return ip.addr(raw), port
+    return {addr = ip.addr(raw), port = port}
   end
 
-  function sock:getpeername(): ip.Addr | nil, integer, string
-    if not self.fd then return nil, nil, "socket closed" end
+  function sock:getpeername(): Endpoint | nil, string
+    if not self.fd then return nil, "socket closed" end
     local raw, port = unix.getpeername(self.fd)
     if not raw then
       -- On failure the binding returns (nil, err, errno): the error string
       -- arrives in the second slot, where the port would have been.
-      return nil, nil, errstr(port, "getpeername")
+      return nil, errstr(port, "getpeername")
     end
-    return ip.addr(raw), port
+    return {addr = ip.addr(raw), port = port}
   end
 
   function sock:bind(addr?: Address, port?: integer): boolean, string
@@ -371,8 +394,8 @@ local function make_socket(fd: integer): Socket
     return true
   end
 
-  function sock:accept(flags?: integer): Socket | nil, ip.Addr, integer, string
-    if not self.fd then return nil, nil, nil, "socket closed" end
+  function sock:accept(flags?: integer): Socket | nil, string
+    if not self.fd then return nil, "socket closed" end
     local clientfd, peer, port = unix.accept(self.fd, flags or 0)
     while clientfd == nil and errno_is(port, "EINTR") do
       clientfd, peer, port = unix.accept(self.fd, flags or 0)
@@ -380,9 +403,9 @@ local function make_socket(fd: integer): Socket
     if not clientfd then
       -- On failure the binding returns (nil, err, errno): the error string
       -- arrives in the second slot, where the peer ip would have been.
-      return nil, nil, nil, errstr(peer, "accept")
+      return nil, errstr(peer, "accept")
     end
-    return make_socket(clientfd), ip.addr(peer), port
+    return make_socket(clientfd)
   end
 
   function sock:connect(addr: Address, port: integer): boolean, string
@@ -470,6 +493,8 @@ end
 local record NetSocketModule
   type Socket = Socket
   type Address = Address
+  type Endpoint = Endpoint
+  type Datagram = Datagram
   make_socket: function(fd: integer): Socket
   resolve_addr: function(addr: Address): integer | nil, string
 end

--- a/cosmic/poll.tl
+++ b/cosmic/poll.tl
@@ -38,10 +38,15 @@ end
 
 --- Poll set for monitoring multiple file descriptors.
 local record Poller
-  --- Add a file descriptor to the set.
+  --- Add a file descriptor to the set. Fallible instead of throwing:
+  --- a nil or negative fd (e.g. an unchecked open, or a closed
+  --- fd.Handle's -1) is a caller bug that would otherwise silently
+  --- turn every wait into a timeout.
   --- @param fd integer File descriptor number
   --- @param events integer Event mask (POLLIN, POLLOUT, etc.)
-  add: function(Poller, integer, integer)
+  --- @return boolean True when registered
+  --- @return string? Error message for a nil or negative fd
+  add: function(Poller, integer, integer): boolean, string
   --- Remove a file descriptor from the set.
   --- @param fd integer The file descriptor to remove
   remove: function(Poller, integer)
@@ -52,12 +57,15 @@ local record Poller
   --- EINTR is retried internally by reissuing the same timeoutms, so the
   --- deadline is not preserved across retries: repeated signals can make
   --- the effective wait exceed timeoutms. On a hard poll error the
-  --- iterator is empty and the error string is returned as the second
-  --- value.
+  --- iterator is empty; check err() after the loop — the old second
+  --- return was consumed as loop state by the generic `for`, so no
+  --- caller ever saw it (the Rows:err() pattern, for the same reason).
   --- @param timeoutms integer Timeout in ms (-1 for infinite, 0 for non-blocking)
   --- @return function Iterator yielding (fd: integer, events: Events)
-  --- @return string? Error message when the underlying poll failed
-  wait: function(Poller, integer): function(): (integer, Events), string
+  wait: function(Poller, integer): function(): (integer, Events)
+  --- The error from the last wait(), or nil when it polled cleanly.
+  --- Cleared by the next wait().
+  err: function(Poller): string | nil
   --- Poll and return count of ready descriptors. EINTR is retried
   --- internally by reissuing the same timeoutms (the deadline is not
   --- preserved across retries).
@@ -102,16 +110,23 @@ end
 local function new(): Poller
   local fds: {integer: integer} = {}
   local results: {integer: integer} = {}
+  local wait_err: string = nil
 
   local poller: Poller = {}
 
-  poller.add = function(_self: Poller, fd: integer, events: integer)
+  poller.add = function(_self: Poller, fd: integer, events: integer): boolean, string
     if fd == nil then
       -- A nil fd is a caller bug (e.g. an unchecked open); registering
       -- nothing would silently turn every wait into a timeout.
-      error("poll.add: fd must not be nil", 2)
+      return false, "poll.add: fd must not be nil"
+    end
+    if fd < 0 then
+      -- A closed fd.Handle reports -1; registering it would poll fd -1
+      -- forever-quietly, the same silent-timeout failure as nil.
+      return false, "poll.add: fd must be non-negative, got " .. tostring(fd)
     end
     fds[fd] = events
+    return true
   end
 
   poller.remove = function(_self: Poller, fd: integer)
@@ -177,13 +192,15 @@ local function new(): Poller
     return nil
   end
 
-  poller.wait = function(self: Poller, timeoutms: integer): function(): (integer, Events), string
+  poller.wait = function(self: Poller, timeoutms: integer): function(): (integer, Events)
     local n, err = self:poll(timeoutms)
     if n == nil then
+      wait_err = err
       return function(): (integer, Events)
         return nil, nil
-      end, err
+      end
     end
+    wait_err = nil
     local iter_results = results
     local k: integer = nil
     return function(): (integer, Events)
@@ -194,6 +211,10 @@ local function new(): Poller
       end
       return nil, nil
     end
+  end
+
+  poller.err = function(_self: Poller): string | nil
+    return wait_err
   end
 
   return poller

--- a/cosmic/poll_test.tl
+++ b/cosmic/poll_test.tl
@@ -137,8 +137,8 @@ end
 test_poll_timeout()
 
 local function test_poll_with_socket()
-  local raw_sock1, sock2, err = net.socketpair()
-  assert(raw_sock1 ~= nil and sock2 ~= nil, "socketpair failed: " .. tostring(err))
+  local sp = check.must(net.socketpair())
+  local raw_sock1, sock2 = sp.a, sp.b
   local sock1 = check.must(raw_sock1)
 
   -- Send data on sock1
@@ -240,18 +240,22 @@ local function test_poll_hangup()
 end
 test_poll_hangup()
 
--- Error fidelity: add(nil) raises instead of silently
--- doing nothing, and wait() surfaces a hard poll error instead of
--- returning an indistinguishable empty iterator.
+-- Error fidelity: add(nil)/add(-1) return false + err instead of
+-- silently doing nothing (or, before the error-shape wave, throwing
+-- from library code), and wait() surfaces a hard poll error through
+-- err() instead of an indistinguishable empty iterator.
 
-local function test_add_nil_fd_errors()
+local function test_add_bad_fd_errors()
   local p = poll.new()
-  local ok = pcall(function()
-      p:add(nil, poll.POLLIN)
-    end)
-  assert(not ok, "add(nil) should raise, not silently no-op")
+  local ok, err = p:add(nil, poll.POLLIN)
+  assert(not ok, "add(nil) must fail, not silently no-op")
+  assert(err and err:find("nil", 1, true), "error names the problem: " .. tostring(err))
+  local ok2, err2 = p:add(-1, poll.POLLIN)
+  assert(not ok2, "add(-1) must fail: a closed fd.Handle reports -1")
+  assert(err2 and err2:find("-1", 1, true), "error names the fd: " .. tostring(err2))
+  assert(p:empty(), "failed adds register nothing")
 end
-test_add_nil_fd_errors()
+test_add_bad_fd_errors()
 
 local function test_wait_surfaces_hard_error()
   -- Provoke a real poll failure: more fds than RLIMIT_NOFILE is EINVAL.
@@ -270,13 +274,14 @@ local function test_wait_surfaces_hard_error()
   -- of reporting "no events for this fd".
   local ev = p:events(1)
   assert(ev == nil, "events() should return nil (not crash) after a failed poll")
-  local iter, werr = p:wait(0)
+  local iter = p:wait(0)
   assert(type(iter) == "function", "wait must still return an iterator on error")
   for _ in iter do
     assert(false, "the error iterator must be empty")
   end
-  assert(type(werr) == "string" and werr:match("E%u+"),
-    "wait should surface the poll error, got: " .. tostring(werr))
+  local werr = p:err()
+  assert(type(werr) == "string" and string.match(werr, "E%u+"),
+    "err() should surface the poll error, got: " .. tostring(werr))
 end
 test_wait_surfaces_hard_error()
 

--- a/cosmic/quicksand/proxy/http_test.tl
+++ b/cosmic/quicksand/proxy/http_test.tl
@@ -141,12 +141,10 @@ test_rebuild_request_replaces_client_auth()
 -- already torn the tunnel down. No unshare needed -- pump() is plain
 -- fd plumbing over a plain fork, like proxy/serve_test.tl's worker.
 local function test_pump_relays_data_across_eintr()
-  local raw_c1, c2, cerr = net.socketpair()
-  assert(raw_c1 ~= nil and c2 ~= nil, "socketpair failed: " .. tostring(cerr))
-  local c1 = check.must(raw_c1)
-  local raw_u1, u2, uerr = net.socketpair()
-  assert(raw_u1 ~= nil and u2 ~= nil, "socketpair failed: " .. tostring(uerr))
-  local u1 = check.must(raw_u1)
+  local cp = check.must(net.socketpair())
+  local c1, c2 = cp.a, cp.b
+  local up = check.must(net.socketpair())
+  local u1, u2 = up.a, up.b
 
   local pid = proc.fork()
   if pid == nil then

--- a/cosmic/quicksand/proxy/serve_test.tl
+++ b/cosmic/quicksand/proxy/serve_test.tl
@@ -135,9 +135,9 @@ test_deny_precedes_body_checks()
 local UPSTREAM_BODY = "hello-from-upstream"
 
 local function test_allowlist_does_not_bypass_the_ssrf_guard()
-  local listener, lport = net.listen_tcp("127.0.0.1", 0, 8)
+  local listener = net.listen_tcp("127.0.0.1", 0, 8)
   local ls = check.must(listener, "upstream listen failed")
-  local port = lport
+  local port = check.must(ls:getsockname()).port
 
   local pid = proc.fork()
   if not pid then

--- a/cosmic/sse_test.tl
+++ b/cosmic/sse_test.tl
@@ -31,7 +31,7 @@ local function mock_reader(content: string, fail_with?: string): fetch.Reader
     return chunk
   end
 
-  function reader:close(): boolean
+  function reader:close(): boolean, string
     is_closed = true
     return true
   end
@@ -356,10 +356,8 @@ local function test_events_from_socket_backed_reader()
   local net = require("cosmic.net")
   local fd = require("cosmic.fd")
 
-  local s1, s2, serr = net.socketpair()
-  assert(s1 ~= nil and s2 ~= nil, "socketpair failed: " .. tostring(serr))
-  local a = check.must(s1)
-  local b = s2
+  local sp = check.must(net.socketpair())
+  local a, b = sp.a, sp.b
 
   assert(a:send("data: from a socket\n\nevent: ping\ndata: second\n\n"))
   a:close()

--- a/cosmic/stream_test.tl
+++ b/cosmic/stream_test.tl
@@ -104,8 +104,9 @@ test_child_handle_conforms()
 
 --- Fork a loopback server answering one request, closing right after.
 local function serve_once(response: string): integer, integer
-  local srv, port = net.listen_tcp("127.0.0.1", 0)
+  local srv = net.listen_tcp("127.0.0.1", 0)
   local s = check.must(srv, "listen_tcp failed")
+  local port = check.must(s:getsockname()).port
   local pid = proc.fork()
   if pid == 0 then
     local conn = s:accept()

--- a/cosmic/stream_test.tl
+++ b/cosmic/stream_test.tl
@@ -50,10 +50,8 @@ end
 test_fd_handle_conforms()
 
 local function test_socket_recv_eof_is_nil()
-  local s1, s2, err = net.socketpair()
-  assert(s1 ~= nil and s2 ~= nil, "socketpair failed: " .. tostring(err))
-  local a = check.must(s1)
-  local b = check.must(s2)
+  local sp = check.must(net.socketpair())
+  local a, b = sp.a, sp.b
 
   assert(a:send("socket bytes"))
   a:close()
@@ -80,10 +78,8 @@ test_socket_recv_eof_is_nil()
 local function test_socket_zero_byte_datagram_stays_empty()
   -- "" is reserved for the one honest case: a zero-byte datagram on a
   -- message socket. It must NOT be collapsed into nil.
-  local s1, s2, err = net.socketpair(nil, net.SOCK_DGRAM)
-  assert(s1 ~= nil and s2 ~= nil, "dgram socketpair failed: " .. tostring(err))
-  local a = check.must(s1)
-  local b = check.must(s2)
+  local sp = check.must(net.socketpair(nil, net.SOCK_DGRAM))
+  local a, b = sp.a, sp.b
 
   assert(a:send(""))
   local dgram, derr = b:recv(4096)

--- a/cosmic/tar_example.tl
+++ b/cosmic/tar_example.tl
@@ -32,7 +32,7 @@ local function Example_extract()
   local archive = fs.join(dir, "release.tar.gz")
   local tarball = block("notes.txt", "hello from a tarball\n")
   .. string.rep("\0", 1024)
-  assert(fs.write(archive, compress.compress(tarball, {format = "gzip"})))
+  assert(fs.write(archive, (check.must(compress.compress(tarball, {format = "gzip"})))))
 
   assert(tar.extract(archive, fs.join(dir, "out")))
   print(check.must(fs.read(fs.join(dir, "out/notes.txt"))))

--- a/cosmic/tar_test.tl
+++ b/cosmic/tar_test.tl
@@ -5,6 +5,7 @@
 
 local compress = require("cosmic.compress")
 local fs = require("cosmic.fs")
+local check = require("cosmic.check")
 local fs_types = require("cosmic.fs.types")
 local untar = require("cosmic.tar")
 
@@ -52,7 +53,7 @@ end
 
 local function make_targz(path: string, parts: {string})
   local archive = table.concat(parts) .. string.rep("\0", 2 * BLOCK)
-  local gz = compress.compress(archive, {format = "gzip"})
+  local gz = check.must(compress.compress(archive, {format = "gzip"}))
   assert(fs.write(path, gz))
 end
 
@@ -162,7 +163,7 @@ local function test_rejects_truncated_archive()
   local ar = fs.join(tmpdir, "trunc.tar.gz")
   local entry = tar_entry("big.txt", string.rep("a", 600), oct("644"), "0", "")
   -- header claims 600 bytes; hand extract() only the header + 100 bytes
-  local gz = compress.compress(entry:sub(1, BLOCK + 100), {format = "gzip"})
+  local gz = check.must(compress.compress(entry:sub(1, BLOCK + 100), {format = "gzip"}))
   assert(fs.write(ar, gz))
   local ok, err = untar.extract(ar, dest)
   assert(not ok, "truncated archive must be rejected")
@@ -216,7 +217,7 @@ local function test_truncated_archive_is_refused()
   -- without one, which is what a boundary-aligned truncation leaves.
   local body = tar_entry("a.txt", "one\n", oct("644"), "0", "") ..
   tar_entry("b.txt", "two\n", oct("644"), "0", "")
-  assert(fs.write(path, compress.compress(body, {format = "gzip"})))
+  assert(fs.write(path, (check.must(compress.compress(body, {format = "gzip"})))))
 
   fs.rmrf(dest)
   local ok, err = untar.extract(path, dest)


### PR DESCRIPTION
Fourth PR from the API review — first half of the error-shape wave: net, poll, compress, getopt, fetch. Pushed while the local gate is still running so CI gives an independent signal; I'll fix anything either one flags.

## net

- **`Socket:accept` → `Socket | nil, string`.** The old `(Socket, Addr, port, err)` tuple put the error in slot 4, where `local conn, err = s:accept()` never saw it — and the examples' own `check.must((s:accept()))` extra parens silently discarded it. Every in-tree caller already ignored the addr/port extras; peer info is a `getpeername()` away.
- **`Endpoint` / `Datagram` / `Pair` records** for `getsockname`/`getpeername`, `recvfrom`, and `socketpair`, with the error uniformly in slot 2. `socketpair`'s old slot 2 was *typed* non-nil `Socket` while returning nil there on failure.
- **`listen_tcp` → `Socket | nil, string`**; the OS-assigned port comes from `getsockname().port` instead of riding in slot 2 above an unreachable slot-3 error.
- **`Socket:close` reports the close(2) error** (`boolean, string`) instead of discarding errno — `fetch.download` already demonstrated close errors are load-bearing. `fetch.Reader:close` adopts the same shape.

## poll

- **`add` no longer throws from library code.** It rejects a nil fd *and* the `-1` a closed `fd.Handle` reports (both silently turned every wait into a timeout) with `false, err`. Nothing previously rejected `-1` at all.
- **`wait`'s error is reachable now.** The old second return was consumed as generic-`for` loop state, so a hard poll failure was indistinguishable from "nothing ready" at every call site but the one test built to prove otherwise. It's now `Poller:err()` — the same pattern as sqlite's `Rows:err()`.

## compress

- **`compress()` is `string | nil, string`** instead of `error()`-ing on a binding failure (a direct "never throw from library code" violation).
- **One `Format` enum for both directions** — round-tripping your own format value no longer needs the enum-widening cast the module's *own tests* carried; `"auto"` is rejected by `compress` at runtime.

## getopt

- **`new` propagates a parse failure as `nil, err`** instead of returning an empty Parser indistinguishable from an empty argv (a "never silently discard errors" violation).

## Scope note

Second half of the wave follows as its own PR to keep this reviewable: `proc.wait`/`getrlimit`/`sigaction`/`shm` record returns, `fs.tmpfile` → TmpFile, `doc.render_file`, `url.parse_host`, and `child.run`'s Result fold.

## Verification

Full build + all module type checks pass locally; the complete `--make ci` gate is finishing in the background and this PR's CI runs the same gate cold. I'll drive both to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FP31Qs2Ei4uJUsimFMpvkS

---
_Generated by [Claude Code](https://claude.ai/code/session_01FP31Qs2Ei4uJUsimFMpvkS)_