### PR TITLE
error shapes, part two: records for the multi-value returns

### DIFF
--- a/_make/docs.tl
+++ b/_make/docs.tl
@@ -62,9 +62,9 @@ local function render(proj: Project, paths?: {string}): integer, string
   end
   local written = 0
   for _, f in ipairs(picked as {File}) do -- cast: nil ruled out above
-    local ok, output = doc.render_file(f.path)
-    if not ok then
-      return written, "make: " .. f.path .. ": " .. output
+    local output, rerr = doc.render_file(f.path)
+    if output == nil then
+      return written, "make: " .. f.path .. ": " .. tostring(rerr)
     end
     local out = page_of(f.path)
     if not fs.makedirs(fs.dirname(out)) then

--- a/cosmic/check.tl
+++ b/cosmic/check.tl
@@ -240,15 +240,16 @@ end
 --- @param pid integer The child to reap
 --- @param what string What the child was, for the message
 local function reap(pid: integer, what: string)
-  local wpid, status, _rusage, werr = proc.wait(pid)
+  local wr, werr = proc.wait(pid)
   -- `proc.wait` is a raw passthrough, so a signal delivered to this
   -- process surfaces here as EINTR instead of being retried underneath.
-  while wpid == nil and werr and werr:find("EINTR", 1, true) do
-    wpid, status, _rusage, werr = proc.wait(pid)
+  while wr == nil and werr and werr:find("EINTR", 1, true) do
+    wr, werr = proc.wait(pid)
   end
-  if wpid == nil then
+  if wr == nil then
     error("waiting for " .. what .. ": " .. (werr or "wait failed"), 2)
   end
+  local status = (wr as proc.WaitResult).status -- cast: record union after guard
   local code = 128
   if proc.WIFEXITED(status) then
     code = proc.WEXITSTATUS(status)

--- a/cosmic/check_test.tl
+++ b/cosmic/check_test.tl
@@ -419,12 +419,11 @@ local function test_reap_grades_the_childs_exit_code()
     check.reap(inner, "a grandchild that cannot run here")
     os.exit(0)
   end
-  local wpid, status = proc.wait(outer)
-  assert(wpid, "the outer child must be reapable")
-  assert(proc.WIFEXITED(status), "it exited rather than died")
-  assert(proc.WEXITSTATUS(status) == check.EXIT_SKIP,
+  local wr = check.must(proc.wait(outer), "the outer child must be reapable")
+  assert(proc.WIFEXITED(wr.status), "it exited rather than died")
+  assert(proc.WEXITSTATUS(wr.status) == check.EXIT_SKIP,
     "a child's skip becomes its parent's skip, got " ..
-    proc.WEXITSTATUS(status))
+    proc.WEXITSTATUS(wr.status))
 end
 test_reap_grades_the_childs_exit_code()
 

--- a/cosmic/child/signal_test.tl
+++ b/cosmic/child/signal_test.tl
@@ -10,7 +10,7 @@ local signal = require("cosmic.signal")
 -- instead of surfacing EINTR mid-wait.
 local function test_read_retries_eintr()
   local h = check.must(child.spawn({"sleep", "0.3"}))
-  local old_handler = signal.sigaction(signal.SIGALRM, function(_: number) end)
+  local prev = check.must(signal.sigaction(signal.SIGALRM, function(_: number) end))
   -- Interval timer: fires several times while read blocks on the silent
   -- child, each one interrupting the read.
   signal.setitimer({
@@ -30,7 +30,7 @@ local function test_read_retries_eintr()
       intervalsec = 0,
       intervalns = 0,
     })
-  signal.sigaction(signal.SIGALRM, old_handler)
+  signal.sigaction(signal.SIGALRM, prev.handler, prev.flags, prev.mask)
   assert(data == nil and err == nil,
     "interrupted read should retry to the child's EOF, got "
     .. tostring(data) .. " (err: " .. tostring(err) .. ")")

--- a/cosmic/doc/gendoc.tl
+++ b/cosmic/doc/gendoc.tl
@@ -10,11 +10,10 @@ if not file_path then
   os.exit(1)
 end
 
-local ok, output = doc.render_file(file_path)
-if ok then
+local output, rerr = doc.render_file(file_path)
+if output then
   io.write(output)
   os.exit(0)
-else
-  io.stderr:write(output .. "\n")
-  os.exit(1)
 end
+io.stderr:write(tostring(rerr) .. "\n")
+os.exit(1)

--- a/cosmic/doc/init.tl
+++ b/cosmic/doc/init.tl
@@ -279,10 +279,13 @@ local function parse_file(file_path: string): ModuleDoc | nil, string
   end
 end
 
---- Main entry point: parse file and render markdown.
-local function render_file(file_path: string): boolean, string
+--- Main entry point: parse file and render markdown. A fallible VALUE
+--- (the markdown), not a fallible effect: the old boolean, string shape
+--- made slot 2 the payload on success and the error on failure, so
+--- every caller branched on which meaning it held.
+local function render_file(file_path: string): string | nil, string
   local f, err = io.open(file_path, "r")
-  if not f then return false, "cannot open file: " .. (err or "unknown") end
+  if not f then return nil, "cannot open file: " .. (err or "unknown") end
   local source = f:read("*a")
   f:close()
   local doc: ModuleDoc
@@ -291,7 +294,7 @@ local function render_file(file_path: string): boolean, string
   else
     doc = parse(source, file_path)
   end
-  return true, doc_render.render(doc)
+  return doc_render.render(doc)
 end
 
 local cosmo = require("cosmo")
@@ -330,7 +333,7 @@ local record DocModule
   parse_dtl: function(source: string, file_path: string): ModuleDoc
   parse_file: function(file_path: string): ModuleDoc | nil, string
   render: function(doc: ModuleDoc): string
-  render_file: function(file_path: string): boolean, string
+  render_file: function(file_path: string): string | nil, string
   serialize: function(doc: ModuleDoc): string
   serialize_index: function(index: DocIndex): string
   load_index: function(source: string): DocIndex | nil, string

--- a/cosmic/doc/init_test.tl
+++ b/cosmic/doc/init_test.tl
@@ -3,6 +3,7 @@
 
 local fs = require("cosmic.fs")
 local doc = require("cosmic.doc")
+local check = require("cosmic.check")
 
 local tmpdir = os.getenv("TEST_TMPDIR")
 
@@ -269,8 +270,7 @@ local function helper()
   return 1
 end
 ]])
-  local ok, md = doc.render_file(input)
-  assert(ok, "render_file should succeed")
+  local md = check.must(doc.render_file(input), "render_file should succeed")
   assert(md:find("# doc_test"), "should have filename as header")
   assert(md:find("A test file"), "should have module doc")
 end
@@ -278,8 +278,8 @@ test_render_file()
 
 -- Test render_file with missing file
 local function test_render_file_missing()
-  local ok, err = doc.render_file("/nonexistent/file.tl")
-  assert(not ok, "render_file should fail on missing file")
+  local md, err = doc.render_file("/nonexistent/file.tl")
+  assert(md == nil, "render_file should fail on missing file")
   assert(err:find("cannot open"), "should have error message")
 end
 test_render_file_missing()
@@ -338,8 +338,7 @@ test_example_title()
 -- Test that actual library files have proper documentation
 -- These tests verify that our source files have doc comments
 local function test_embed_has_module_doc()
-  local ok, md = doc.render_file("cosmic/embed/init.tl")
-  assert(ok, "should read embed/init.tl")
+  local md = check.must(doc.render_file("cosmic/embed/init.tl"), "should read embed/init.tl")
   -- Module should have a description after the header
   assert(md:find("# embed\n\n[^#]"), "embed/init.tl should have module description")
 end
@@ -347,24 +346,21 @@ test_embed_has_module_doc()
 
 local function test_embed_has_type_descriptions()
   -- EmbedResult is declared in the extraction half; init.tl aliases it.
-  local ok, md = doc.render_file("cosmic/embed/extract.tl")
-  assert(ok, "should read embed/extract.tl")
+  local md = check.must(doc.render_file("cosmic/embed/extract.tl"), "should read embed/extract.tl")
   -- EmbedResult should have a description, not just a bare header
   assert(md:find("### EmbedResult\n\n[^#]"), "EmbedResult should have description")
 end
 test_embed_has_type_descriptions()
 
 local function test_child_has_type_descriptions()
-  local ok, md = doc.render_file("cosmic/child/init.tl")
-  assert(ok, "should read child/init.tl")
+  local md = check.must(doc.render_file("cosmic/child/init.tl"), "should read child/init.tl")
   -- Handle should have a description
   assert(md:find("### Handle\n\n[^#]"), "Handle should have description")
 end
 test_child_has_type_descriptions()
 
 local function test_fetch_has_module_description()
-  local ok, md = doc.render_file("cosmic/fetch/init.tl")
-  assert(ok, "should read fetch/init.tl")
+  local md = check.must(doc.render_file("cosmic/fetch/init.tl"), "should read fetch/init.tl")
   -- Module should have a description after the header
   assert(md:find("# fetch\n\n[^#]"), "fetch.tl should have module description")
   -- Should describe what it does

--- a/cosmic/fd_read_test.tl
+++ b/cosmic/fd_read_test.tl
@@ -72,12 +72,12 @@ local function test_blocking_read_retries_eintr()
   local signal = require("cosmic.signal")
   local p = check.must(cfd.pipe())
   local fired = false
-  local old_handler = signal.sigaction(signal.SIGALRM, function(_: number)
+  local prev = check.must(signal.sigaction(signal.SIGALRM, function(_: number)
       if not fired then
         fired = true
         p.writer:write("x")
       end
-    end)
+    end))
   -- Interval timer: keeps firing until the blocked read observes a signal,
   -- so the test cannot hang however the timing lands.
   signal.setitimer({
@@ -97,7 +97,7 @@ local function test_blocking_read_retries_eintr()
       intervalsec = 0,
       intervalns = 0,
     })
-  signal.sigaction(signal.SIGALRM, old_handler)
+  signal.sigaction(signal.SIGALRM, prev.handler, prev.flags, prev.mask)
   assert(data == "x", "interrupted read should retry and return the handler's"
     .. " payload, got " .. tostring(data) .. " (err: " .. tostring(err) .. ")")
   p:close()

--- a/cosmic/fd_read_test.tl
+++ b/cosmic/fd_read_test.tl
@@ -73,11 +73,11 @@ local function test_blocking_read_retries_eintr()
   local p = check.must(cfd.pipe())
   local fired = false
   local prev = check.must(signal.sigaction(signal.SIGALRM, function(_: number)
-      if not fired then
-        fired = true
-        p.writer:write("x")
-      end
-    end))
+        if not fired then
+          fired = true
+          p.writer:write("x")
+        end
+      end))
   -- Interval timer: keeps firing until the blocked read observes a signal,
   -- so the test cannot hang however the timing lands.
   signal.setitimer({

--- a/cosmic/fd_test.tl
+++ b/cosmic/fd_test.tl
@@ -272,12 +272,12 @@ end
 test_wrap_tmpfd()
 
 local function test_tmpfile_handle()
-  local h, path = fs.tmpfile(fs.join(TEST_TMPDIR, "wrap_XXXXXX"))
-  local hh = check.must(h, "tmpfile should succeed")
-  assert(hh:write("via tmpfile"))
-  assert(hh:close())
-  assert(fs.read(path) == "via tmpfile", "data lands in the tmpfile")
-  fs.unlink(path)
+  local tf = check.must(fs.tmpfile(fs.join(TEST_TMPDIR, "wrap_XXXXXX")),
+    "tmpfile should succeed")
+  assert(tf.handle:write("via tmpfile"))
+  assert(tf.handle:close())
+  assert(fs.read(tf.path) == "via tmpfile", "data lands in the tmpfile")
+  fs.unlink(tf.path)
 end
 test_tmpfile_handle()
 

--- a/cosmic/fs/init.tl
+++ b/cosmic/fs/init.tl
@@ -227,8 +227,10 @@ local record FsModule
   type Dir = Dir
   type FileInfo = FileInfo
   type WalkStat = WalkStat
-  --- fd.Handle, as returned by tmpfile()/tmpfd().
+  --- fd.Handle, as wrapped by tmpfd() + fd.wrap(); TmpFile is
+  --- tmpfile()'s handle+path record.
   type Handle = Handle
+  type TmpFile = fs_ops.TmpFile
 
   --- Visitor verdict for walk(): nil continues, "skip" prunes, "stop" ends the walk.
   type WalkAction = WalkAction
@@ -301,7 +303,7 @@ local record FsModule
 
   -- Temporary file operations
   mkdtemp: function(template: string): string | nil, string
-  tmpfile: function(template?: string): Handle | nil, string, string
+  tmpfile: function(template?: string): fs_ops.TmpFile | nil, string
   tmpfd: function(): integer | nil, string
 
   -- Filesystem statistics

--- a/cosmic/fs/init_test.tl
+++ b/cosmic/fs/init_test.tl
@@ -406,16 +406,15 @@ end
 test_mkdtemp()
 
 local function test_tmpfile()
-  local h, result = fs.tmpfile(fs.join(tmp_base, "fs_test_XXXXXX"))
-  local hh = check.must(h, result)
+  local tf = check.must(fs.tmpfile(fs.join(tmp_base, "fs_test_XXXXXX")))
+  local hh = tf.handle
 
-  local filepath = result
-  assert(filepath:match("fs_test_"), "expected fs_test_ in path")
+  assert(tf.path:match("fs_test_"), "expected fs_test_ in path")
   local st = fs.fstat(hh:fd())
   assert(st, "fstat should succeed")
 
   hh:close()
-  fs.unlink(filepath)
+  fs.unlink(tf.path)
 end
 test_tmpfile()
 

--- a/cosmic/fs/ops.tl
+++ b/cosmic/fs/ops.tl
@@ -339,24 +339,29 @@ local function mkdtemp(template: string): string | nil, string
   return path
 end
 
+--- A created temp file: the open Handle plus its path. A record so the
+--- error stays in slot 2 — the old (Handle, path, err) triple put a
+--- SUCCESS value where `local h, err = ...` expected the error.
+local record TmpFile
+  --- Open handle to the created file; the Handle owns the descriptor.
+  handle: Handle
+  --- Path to the created file. NOT unlinked automatically — remove it
+  --- when done. For an anonymous descriptor, use tmpfd() + fd.wrap().
+  path: string
+end
+
 --- Create a temporary file, returning an open fd.Handle plus its path.
---- The Handle owns the descriptor (h:close() releases it); the file is
---- NOT unlinked automatically — remove the path when done. For an
---- anonymous descriptor with no path, use tmpfd() + fd.wrap().
---- The second return is always the path (nil on failure); the error, if
---- any, is always in the third slot.
 --- @param template string Path template ending in XXXXXX (default: $TMPDIR/cosmic_XXXXXX)
---- @return Handle | nil Open handle to the created file, or nil on error
---- @return string Path to the created file, or nil on error
+--- @return TmpFile | nil The handle and path, or nil on error
 --- @return string Error message if failed
-local function tmpfile(template?: string): Handle | nil, string, string
+local function tmpfile(template?: string): TmpFile | nil, string
   template = template or ((os.getenv("TMPDIR") or "/tmp") .. "/cosmic_XXXXXX")
   -- The binding returns (fd, path) on success and (nil, Errno) on failure.
   local fd, path = unix.mkstemp(template)
   if not fd then
-    return nil, nil, errstr(path, "tmpfile: " .. template)
+    return nil, errstr(path, "tmpfile: " .. template)
   end
-  return cfd.wrap(fd), path
+  return {handle = cfd.wrap(fd), path = path}
 end
 
 --- Create a temporary file descriptor.
@@ -436,7 +441,8 @@ local record FsOpsModule
   utimensat: function(path: string, atime_secs?: integer, atime_nsecs?: integer, mtime_secs?: integer, mtime_nsecs?: integer): boolean, string
   futimens: function(fd: integer, atime_secs?: integer, atime_nsecs?: integer, mtime_secs?: integer, mtime_nsecs?: integer): boolean, string
   mkdtemp: function(template: string): string | nil, string
-  tmpfile: function(template?: string): Handle | nil, string, string
+  type TmpFile = TmpFile
+  tmpfile: function(template?: string): TmpFile | nil, string
   tmpfd: function(): integer | nil, string
   statfs: function(path: string): Statfs | nil, string
   fstatfs: function(fd: integer): Statfs | nil, string

--- a/cosmic/fs/ops_test.tl
+++ b/cosmic/fs/ops_test.tl
@@ -82,13 +82,13 @@ local function test_copy_retries_eintr_on_read()
   local dst = fs.join(test_dir, "read_eintr_dst")
 
   local fired = false
-  local old_handler = signal.sigaction(signal.SIGALRM, function(_: number)
+  local prev = check.must(signal.sigaction(signal.SIGALRM, function(_: number)
       if not fired then
         fired = true
         p.writer:write("hello")
         p.writer:close()
       end
-    end)
+    end))
   -- Interval timer: keeps firing until the blocked read observes a
   -- signal, so the test cannot hang however the timing lands.
   signal.setitimer({
@@ -103,7 +103,7 @@ local function test_copy_retries_eintr_on_read()
       which = signal.ITIMER_REAL,
       valuesec = 0, valuens = 0, intervalsec = 0, intervalns = 0,
     })
-  signal.sigaction(signal.SIGALRM, old_handler)
+  signal.sigaction(signal.SIGALRM, prev.handler, prev.flags, prev.mask)
 
   assert(ok, "copy should retry a read interrupted by a signal: " .. tostring(err))
   assert(fs.read(dst) == "hello",
@@ -133,10 +133,10 @@ local function test_copy_retries_eintr_on_write()
   local dst = "/proc/self/fd/" .. tostring(p.writer:fd())
 
   local drained: {string} = {}
-  local old_handler = signal.sigaction(signal.SIGALRM, function(_: number)
+  local prev = check.must(signal.sigaction(signal.SIGALRM, function(_: number)
       local got = p.reader:read(65536)
       if got then table.insert(drained, got) end
-    end)
+    end))
   signal.setitimer({
       which = signal.ITIMER_REAL,
       valuesec = 0, valuens = 20000000,
@@ -147,7 +147,7 @@ local function test_copy_retries_eintr_on_write()
       which = signal.ITIMER_REAL,
       valuesec = 0, valuens = 0, intervalsec = 0, intervalns = 0,
     })
-  signal.sigaction(signal.SIGALRM, old_handler)
+  signal.sigaction(signal.SIGALRM, prev.handler, prev.flags, prev.mask)
   p.writer:close()
 
   -- Drain whatever is left buffered in the pipe once copy() is done.
@@ -303,14 +303,13 @@ test_write_atomic_failure_keeps_original()
 
 local function test_tmpfile_success_contract()
   local test_dir = setup()
-  local h, path, err = fs.tmpfile(fs.join(test_dir, "fs_ops_XXXXXX"))
-  assert(h, "tmpfile should succeed: " .. (err or ""))
-  assert(path and path:match("fs_ops_"), "second return should be the path")
+  local tf, err = fs.tmpfile(fs.join(test_dir, "fs_ops_XXXXXX"))
+  local t = check.must(tf, "tmpfile should succeed: " .. tostring(err))
+  assert(t.path:match("fs_ops_"), "the record carries the path")
   assert(err == nil, "error slot should be nil on success")
-  local hh = check.must(h)
-  local st = fs.fstat(hh:fd())
+  local st = fs.fstat(t.handle:fd())
   assert(st, "fstat on tmpfile fd should succeed")
-  hh:close()
+  t.handle:close()
   teardown(test_dir)
 end
 test_tmpfile_success_contract()
@@ -468,11 +467,9 @@ end
 test_rmrf_failure_reports_error()
 
 local function test_tmpfile_failure_contract()
-  -- The second return is always the path (nil on failure); the error is
-  -- always in the third slot.
-  local h, path, err = fs.tmpfile("/no/such/dir/fs_ops_XXXXXX")
-  assert(h == nil, "tmpfile should fail in a missing directory")
-  assert(path == nil, "path slot must be nil on failure, got " .. tostring(path))
+  -- One record on success; the error in slot 2 on failure.
+  local tf, err = fs.tmpfile("/no/such/dir/fs_ops_XXXXXX")
+  assert(tf == nil, "tmpfile should fail in a missing directory")
   assert(err and err:match("ENOENT"), "error should name ENOENT: " .. (err or ""))
 end
 test_tmpfile_failure_contract()

--- a/cosmic/fs/ops_test.tl
+++ b/cosmic/fs/ops_test.tl
@@ -83,12 +83,12 @@ local function test_copy_retries_eintr_on_read()
 
   local fired = false
   local prev = check.must(signal.sigaction(signal.SIGALRM, function(_: number)
-      if not fired then
-        fired = true
-        p.writer:write("hello")
-        p.writer:close()
-      end
-    end))
+        if not fired then
+          fired = true
+          p.writer:write("hello")
+          p.writer:close()
+        end
+      end))
   -- Interval timer: keeps firing until the blocked read observes a
   -- signal, so the test cannot hang however the timing lands.
   signal.setitimer({
@@ -134,9 +134,9 @@ local function test_copy_retries_eintr_on_write()
 
   local drained: {string} = {}
   local prev = check.must(signal.sigaction(signal.SIGALRM, function(_: number)
-      local got = p.reader:read(65536)
-      if got then table.insert(drained, got) end
-    end))
+        local got = p.reader:read(65536)
+        if got then table.insert(drained, got) end
+      end))
   signal.setitimer({
       which = signal.ITIMER_REAL,
       valuesec = 0, valuens = 20000000,

--- a/cosmic/fs/traps_test.tl
+++ b/cosmic/fs/traps_test.tl
@@ -114,11 +114,14 @@ test_copytree_dir_mode_exact()
 
 -- 2. tmpfile: Handle + path on the happy path; fs.mkstemp is gone.
 local function test_tmpfile_handle_and_path()
-  local tmpfile = fsa.tmpfile as function(string): any, string, string -- cast: from any
+  local tmpfile = fsa.tmpfile as function(string): any, string -- cast: from any
   assert(tmpfile, "fs.tmpfile should exist")
-  local h, path, err = tmpfile(fs.join(TEST_TMPDIR, "traps_XXXXXX"))
-  assert(h, "tmpfile failed: " .. tostring(err))
+  local tf, err = tmpfile(fs.join(TEST_TMPDIR, "traps_XXXXXX"))
+  assert(tf, "tmpfile failed: " .. tostring(err))
+  local t = tf as {string: any} -- cast: from any
+  local h = t.handle
   local hh = h as {string: any} -- cast: from any
+  local path = t.path as string -- cast: from any
   -- cast: from any
   assert((hh.write as function(any, string): number, string)(h, "via handle"))
   assert((hh.close as function(any): boolean, string)(h)) -- cast: from any
@@ -128,10 +131,13 @@ end
 test_tmpfile_handle_and_path()
 
 local function test_tmpfile_default_template()
-  local tmpfile = fsa.tmpfile as function(): any, string, string -- cast: from any
-  local h, path = tmpfile()
-  assert(h, "tmpfile() with no template should create somewhere sane")
+  local tmpfile = fsa.tmpfile as function(): any, string -- cast: from any
+  local tf = tmpfile()
+  assert(tf, "tmpfile() with no template should create somewhere sane")
+  local t = tf as {string: any} -- cast: from any
+  local h = t.handle
   local hh = h as {string: any} -- cast: from any
+  local path = t.path as string -- cast: from any
   assert((hh.close as function(any): boolean, string)(h)) -- cast: from any
   assert(fs.isfile(path), "returned path exists")
   fs.unlink(path)

--- a/cosmic/net/io_test.tl
+++ b/cosmic/net/io_test.tl
@@ -235,12 +235,12 @@ local function test_recv_retries_eintr()
   local signal = require("cosmic.signal")
   local a, b = pair()
   local fired = false
-  local old_handler = signal.sigaction(signal.SIGALRM, function(_: number)
+  local prev = check.must(signal.sigaction(signal.SIGALRM, function(_: number)
       if not fired then
         fired = true
         a:sendall("ping")
       end
-    end)
+    end))
   -- Interval timer: keeps firing until the blocked recv observes a signal,
   -- so the test cannot hang however the timing lands.
   signal.setitimer({
@@ -260,7 +260,7 @@ local function test_recv_retries_eintr()
       intervalsec = 0,
       intervalns = 0,
     })
-  signal.sigaction(signal.SIGALRM, old_handler)
+  signal.sigaction(signal.SIGALRM, prev.handler, prev.flags, prev.mask)
   assert(data == "ping", "interrupted recv should retry and return the peer's"
     .. " payload, got " .. tostring(data) .. " (err: " .. tostring(err) .. ")")
   a:close()

--- a/cosmic/net/io_test.tl
+++ b/cosmic/net/io_test.tl
@@ -235,12 +235,13 @@ local function test_recv_retries_eintr()
   local signal = require("cosmic.signal")
   local a, b = pair()
   local fired = false
-  local prev = check.must(signal.sigaction(signal.SIGALRM, function(_: number)
-      if not fired then
-        fired = true
-        a:sendall("ping")
-      end
-    end))
+  local on_alarm = function(_: number)
+    if not fired then
+      fired = true
+      a:sendall("ping")
+    end
+  end
+  local prev = check.must(signal.sigaction(signal.SIGALRM, on_alarm))
   -- Interval timer: keeps firing until the blocked recv observes a signal,
   -- so the test cannot hang however the timing lands.
   signal.setitimer({

--- a/cosmic/proc/init.tl
+++ b/cosmic/proc/init.tl
@@ -213,14 +213,24 @@ end
 --- @return integer Status word (interpret with WIFEXITED/WEXITSTATUS/...)
 --- @return Rusage Resource usage for the reaped child
 --- @return string? Error message on failure
-local function wait(pid?: integer, options?: integer): integer | nil, integer, Rusage, string
+--- What wait(2) reaped. A record rather than (pid, status, rusage,
+--- err) returns: the old shape put the error in slot 4, unreachable
+--- from `local pid, err = ...` and from check.must.
+local record WaitResult
+  pid: integer
+  --- Raw status word; decode with WIFEXITED/WEXITSTATUS/WIFSIGNALED/WTERMSIG.
+  status: integer
+  rusage: Rusage
+end
+
+local function wait(pid?: integer, options?: integer): WaitResult | nil, string
   local wpid, status, rusage = unix.wait(pid, options)
   if wpid == nil then
     -- On failure the binding returns (nil, err, errno): the error string
     -- arrives in the second slot, where the status word would have been.
-    return nil, nil, nil, errstr(status, "wait")
+    return nil, errstr(status, "wait")
   end
-  return wpid, status, rusage
+  return {pid = wpid, status = status, rusage = rusage}
 end
 
 --- Sends a signal to a process.
@@ -296,7 +306,8 @@ local record ProcModule
   fork: function(): integer | nil, string
   posix_spawn: function(prog: string, argv: {string}, envp?: {string}): integer | nil, string
   posix_spawnp: function(prog: string, argv: {string}, envp?: {string}): integer | nil, string
-  wait: function(pid?: integer, options?: integer): integer | nil, integer, Rusage, string
+  type WaitResult = WaitResult
+  wait: function(pid?: integer, options?: integer): WaitResult | nil, string
   kill: function(pid: integer, sig: integer): boolean, string
   WIFEXITED: function(status: integer): boolean
   WEXITSTATUS: function(status: integer): integer
@@ -307,7 +318,8 @@ local record ProcModule
   getrusage: function(who?: integer): Rusage | nil, string
 
   -- Resource limits
-  getrlimit: function(resource: integer): integer | nil, integer, string
+  type Rlimit = rusage_mod.Rlimit
+  getrlimit: function(resource: integer): rusage_mod.Rlimit | nil, string
   setrlimit: function(resource: integer, soft: integer, hard?: integer): boolean, string
 
   -- Priority

--- a/cosmic/proc/rusage.tl
+++ b/cosmic/proc/rusage.tl
@@ -7,6 +7,16 @@ local errstr = require("cosmic.errno").str
 
 local type Rusage = unix.Rusage
 
+--- A resource limit pair. A record rather than (soft, hard, err)
+--- returns: the old shape put the error in slot 3, where
+--- `local soft, hard = ...` silently lost it.
+local record Rlimit
+  --- Soft limit (can be exceeded, may generate a signal).
+  soft: integer
+  --- Hard limit (ceiling for unprivileged processes).
+  hard: integer
+end
+
 -- Resource Usage --
 
 --- Gets resource usage statistics.
@@ -25,19 +35,17 @@ end
 -- Resource Limits --
 
 --- Gets resource limits for the current process.
---- Returns the soft and hard limits for the specified resource.
 --- @param resource integer The RLIMIT_* constant identifying the resource
---- @return integer | nil Soft limit (can be exceeded, may generate signal), or nil on failure
---- @return integer Hard limit (cannot be exceeded by unprivileged processes)
+--- @return Rlimit | nil The soft and hard limits
 --- @return string? Error message on failure
-local function getrlimit(resource: integer): integer | nil, integer, string
+local function getrlimit(resource: integer): Rlimit | nil, string
   local soft, hard = unix.getrlimit(resource)
   if soft == nil then
     -- On failure the binding returns (nil, err, errno): the error string
     -- arrives in the second slot, where the hard limit would have been.
-    return nil, nil, errstr(hard, "getrlimit")
+    return nil, errstr(hard, "getrlimit")
   end
-  return soft, hard
+  return {soft = soft, hard = hard}
 end
 
 --- Sets resource limits for the current process.
@@ -99,7 +107,17 @@ local function setpriority(which: integer, who: integer, prio: integer): boolean
   return true
 end
 
-return {
+local record RusageModule
+  type Rlimit = Rlimit
+  getrusage: function(who?: integer): Rusage | nil, string
+  getrlimit: function(resource: integer): Rlimit | nil, string
+  setrlimit: function(resource: integer, soft: integer, hard?: integer): boolean, string
+  nice: function(inc: integer): integer | nil, string
+  getpriority: function(which: integer, who: integer): integer | nil, string
+  setpriority: function(which: integer, who: integer, prio: integer): boolean, string
+end
+
+local M: RusageModule = {
   getrusage = getrusage,
   getrlimit = getrlimit,
   setrlimit = setrlimit,
@@ -107,3 +125,5 @@ return {
   getpriority = getpriority,
   setpriority = setpriority,
 }
+
+return M

--- a/cosmic/proc_test.tl
+++ b/cosmic/proc_test.tl
@@ -115,7 +115,8 @@ end
 ]])
 
   local pid = proc.posix_spawnp(lua_bin, {lua_bin, script_path})
-  local _, status = proc.wait(pid)
+  local wr = check.must(proc.wait(pid))
+  local status = wr.status
   assert(proc.WIFEXITED(status), "expected normal exit")
   local exit_code = proc.WEXITSTATUS(status)
   assert(exit_code == 0, "expected is_main to return true when script is run directly, got exit code " .. tostring(exit_code))
@@ -134,7 +135,8 @@ end
 ]])
 
   local pid = proc.posix_spawnp(lua_bin, {lua_bin, script_path})
-  local _, status = proc.wait(pid)
+  local wr = check.must(proc.wait(pid))
+  local status = wr.status
   assert(proc.WIFEXITED(status), "expected normal exit")
   local exit_code = proc.WEXITSTATUS(status)
   assert(exit_code == 0, "expected proc.is_main to return true when script is run directly, got exit code " .. tostring(exit_code))
@@ -160,7 +162,8 @@ end
 ]], TEST_TMPDIR))
 
   local pid = proc.posix_spawnp(lua_bin, {lua_bin, script_path})
-  local _, status = proc.wait(pid)
+  local wr = check.must(proc.wait(pid))
+  local status = wr.status
   assert(proc.WIFEXITED(status), "expected normal exit")
   local exit_code = proc.WEXITSTATUS(status)
   assert(exit_code == 0, "expected is_main to return false when script is required, got exit code " .. tostring(exit_code))
@@ -190,29 +193,29 @@ end
 test_rlimit_constants_defined()
 
 local function test_getrlimit_returns_numbers()
-  local soft, hard = proc.getrlimit(proc.RLIMIT_NOFILE)
-  assert(type(soft) == "number", "getrlimit soft should return number, got " .. type(soft))
-  assert(type(hard) == "number", "getrlimit hard should return number, got " .. type(hard))
+  local rl = check.must(proc.getrlimit(proc.RLIMIT_NOFILE))
+  assert(type(rl.soft) == "number", "soft should be a number, got " .. type(rl.soft))
+  assert(type(rl.hard) == "number", "hard should be a number, got " .. type(rl.hard))
 end
 test_getrlimit_returns_numbers()
 
 local function test_getrlimit_soft_le_hard()
-  local soft, hard = proc.getrlimit(proc.RLIMIT_NOFILE)
-  assert(soft > 0, "soft limit should be positive")
-  assert(hard > 0, "hard limit should be positive")
-  assert(soft <= hard, "soft limit should not exceed hard limit")
+  local rl = check.must(proc.getrlimit(proc.RLIMIT_NOFILE))
+  assert(rl.soft > 0, "soft limit should be positive")
+  assert(rl.hard > 0, "hard limit should be positive")
+  assert(rl.soft <= rl.hard, "soft limit should not exceed hard limit")
 end
 test_getrlimit_soft_le_hard()
 
 local function test_setrlimit()
-  local soft, hard = proc.getrlimit(proc.RLIMIT_NOFILE)
-  if soft > 64 then
-    local ok, err = proc.setrlimit(proc.RLIMIT_NOFILE, 64, hard)
+  local rl = check.must(proc.getrlimit(proc.RLIMIT_NOFILE))
+  if rl.soft > 64 then
+    local ok, err = proc.setrlimit(proc.RLIMIT_NOFILE, 64, rl.hard)
     assert(ok == true, "setrlimit should succeed when lowering soft limit: " .. tostring(err))
-    local new_soft, new_hard = proc.getrlimit(proc.RLIMIT_NOFILE)
-    assert(new_soft == 64, "soft limit should be updated to 64")
-    assert(new_hard == hard, "hard limit should remain unchanged")
-    proc.setrlimit(proc.RLIMIT_NOFILE, soft, hard)
+    local nrl = check.must(proc.getrlimit(proc.RLIMIT_NOFILE))
+    assert(nrl.soft == 64, "soft limit should be updated to 64")
+    assert(nrl.hard == rl.hard, "hard limit should remain unchanged")
+    proc.setrlimit(proc.RLIMIT_NOFILE, rl.soft, rl.hard)
   end
 end
 test_setrlimit()
@@ -275,10 +278,11 @@ local function test_fork_and_wait()
     proc.exit(42)
   else
     assert(pid > 0, "expected positive child pid in parent, got " .. tostring(pid))
-    local waited_pid, status = proc.wait(pid)
-    assert(waited_pid == pid, "expected to wait for child " .. tostring(pid) .. ", got " .. tostring(waited_pid))
-    assert(proc.WIFEXITED(status), "expected child to exit normally")
-    assert(proc.WEXITSTATUS(status) == 42, "expected exit code 42, got " .. tostring(proc.WEXITSTATUS(status)))
+    local wr = check.must(proc.wait(pid))
+    assert(wr.pid == pid, "expected to wait for child " .. tostring(pid) .. ", got " .. tostring(wr.pid))
+    assert(proc.WIFEXITED(wr.status), "expected child to exit normally")
+    assert(proc.WEXITSTATUS(wr.status) == 42,
+      "expected exit code 42, got " .. tostring(proc.WEXITSTATUS(wr.status)))
   end
 end
 test_fork_and_wait()
@@ -324,7 +328,7 @@ local function test_wexitstatus_values()
     if pid == 0 then
       proc.exit(expected_code)
     else
-      local _, status = proc.wait(pid)
+      local status = check.must(proc.wait(pid)).status
       assert(proc.WIFEXITED(status), "expected WIFEXITED for code " .. tostring(expected_code))
       assert(proc.WEXITSTATUS(status) == expected_code,
         "expected exit code " .. tostring(expected_code) .. ", got " .. tostring(proc.WEXITSTATUS(status)))
@@ -340,7 +344,7 @@ local function test_wifsignaled_on_kill()
     proc.exit(0)
   else
     assert(proc.kill(pid, signal.SIGKILL), "expected kill to succeed")
-    local _, status = proc.wait(pid)
+    local status = check.must(proc.wait(pid)).status
     assert(proc.WIFSIGNALED(status), "expected WIFSIGNALED to be true")
     assert(proc.WTERMSIG(status) == signal.SIGKILL,
       "expected SIGKILL (" .. tostring(signal.SIGKILL) .. "), got " .. tostring(proc.WTERMSIG(status)))
@@ -354,9 +358,9 @@ local function test_wnohang_returns_zero_for_running_process()
     time.sleep(0, 100000000) -- 100ms
     proc.exit(0)
   else
-    local waited_pid = proc.wait(pid, proc.WNOHANG)
-    assert(waited_pid == 0 or waited_pid == pid, "expected 0 or pid, got " .. tostring(waited_pid))
-    if waited_pid == 0 then
+    local wr = check.must(proc.wait(pid, proc.WNOHANG))
+    assert(wr.pid == 0 or wr.pid == pid, "expected 0 or pid, got " .. tostring(wr.pid))
+    if wr.pid == 0 then
       proc.wait(pid)
     end
   end
@@ -426,8 +430,8 @@ end
 test_getpriority_error_names_errno()
 
 local function test_getrlimit_error_names_errno()
-  local soft, hard, err = proc.getrlimit(999999)
-  assert(soft == nil and hard == nil, "getrlimit with bad resource should return nils")
+  local rl, err = proc.getrlimit(999999)
+  assert(rl == nil, "getrlimit with bad resource should return nil")
   assert(type(err) == "string" and err:match("EINVAL"),
     "getrlimit error should name EINVAL, got: " .. tostring(err))
 end

--- a/cosmic/shm.tl
+++ b/cosmic/shm.tl
@@ -17,6 +17,15 @@ local WORD = 8
 --- Module type for shared memory operations.
 local record ShmModule
   --- Shared memory region with atomic word operations and futexes.
+  --- One compare-exchange outcome: whether the swap happened, and the
+  --- word's actual value at the time (the old value on success). A
+  --- record rather than (swapped, actual, err) returns — the error is
+  --- in slot 2 where `local r, err = ...` can see it.
+  record Cmpxchg
+    swapped: boolean
+    value: integer
+  end
+
   --- Words are 64-bit; word_index is 0-based. Futex words (wait/wake)
   --- only inspect the low 32 bits — store only int32 values in words
   --- you wait on.
@@ -36,7 +45,7 @@ local record ShmModule
     --- Atomic exchange; returns the old value.
     xchg: function(self: Memory, word_index: integer, value: integer): integer | nil, string
     --- Compare-and-exchange; returns success plus the actual old value.
-    cmpxchg: function(self: Memory, word_index: integer, old: integer, new: integer): boolean | nil, integer, string
+    cmpxchg: function(self: Memory, word_index: integer, old: integer, new: integer): Cmpxchg | nil, string
     --- Atomic add; returns the old value.
     fetch_add: function(self: Memory, word_index: integer, value: integer): integer | nil, string
     --- Atomic AND; returns the old value.
@@ -56,7 +65,7 @@ local record ShmModule
     wait: function(self: Memory, word_index: integer, expect: integer, abs_deadline?: integer, nanos?: integer): integer | nil, string
     --- Wake processes waiting on a word; returns how many woke.
     --- Wakes nothing once the region has been unmapped.
-    wake: function(self: Memory, word_index: integer, count?: integer): integer
+    wake: function(self: Memory, word_index: integer, count?: integer): integer | nil, string
     --- Release the mapping now instead of waiting for the garbage
     --- collector. Idempotent: true when this call released the mapping,
     --- false when it was already unmapped. Afterwards every fallible
@@ -69,6 +78,7 @@ local record ShmModule
 end
 
 local type Memory = ShmModule.Memory
+local type Cmpxchg = ShmModule.Cmpxchg
 
 --- Validate a 0-based word index against the region size.
 local function check_word(word_index: integer, size: integer, op: string): string
@@ -197,16 +207,17 @@ local function wrap(raw: unix.Memory, size: integer): Memory
     return atomic("fetch_xor", raw.fetch_xor, word_index, value)
   end
 
-  function mem:cmpxchg(word_index: integer, old: integer, new: integer): boolean | nil, integer, string
+  function mem:cmpxchg(word_index: integer, old: integer, new: integer): Cmpxchg | nil, string
     local range_err = check_word(word_index, size, "cmpxchg")
     if range_err then
-      return nil, nil, range_err
+      return nil, range_err
     end
     local ok, success, actual = pcall(raw.cmpxchg, raw, word_index, old, new)
     if not ok then
-      return nil, nil, errstr(success, "cmpxchg")
+      return nil, errstr(success, "cmpxchg")
     end
-    return success, actual
+    -- cast: from any (pcall widens the binding's returns)
+    return {swapped = success as boolean, value = actual as integer}
   end
 
   function mem:wait(word_index: integer, expect: integer, abs_deadline?: integer, nanos?: integer): integer | nil, string
@@ -238,12 +249,15 @@ local function wrap(raw: unix.Memory, size: integer): Memory
   -- keep the raw call — which throws once unmapped — behind the flag.
   local unmapped = false
 
-  function mem:wake(word_index: integer, count?: integer): integer
+  function mem:wake(word_index: integer, count?: integer): integer | nil, string
     local range_err = check_word(word_index, size, "wake")
-    if range_err or unmapped then
-      -- wake never fails in the binding; an out-of-range index wakes
-      -- nothing rather than growing an error slot for it.
-      return 0
+    if range_err then
+      -- An out-of-range index is a caller bug; waking nothing and
+      -- reporting 0 hid it as "no waiters".
+      return nil, range_err
+    end
+    if unmapped then
+      return nil, "wake: memory is unmapped"
     end
     return raw:wake(word_index, count)
   end

--- a/cosmic/shm_test.tl
+++ b/cosmic/shm_test.tl
@@ -76,9 +76,9 @@ test_memory_xchg()
 local function test_memory_cmpxchg_success()
   local mem = check.must(shm.mapshared(4096))
   mem:store(0, 100)
-  local ok, actual = mem:cmpxchg(0, 100, 200)
-  assert(ok == true, "cmpxchg should succeed when old matches")
-  assert(actual == 100, "cmpxchg should return old value 100, got " .. tostring(actual))
+  local r = check.must(mem:cmpxchg(0, 100, 200))
+  assert(r.swapped == true, "cmpxchg should succeed when old matches")
+  assert(r.value == 100, "cmpxchg should return old value 100, got " .. tostring(r.value))
   local current = mem:load(0)
   assert(current == 200, "after successful cmpxchg, value should be 200, got " .. tostring(current))
 end
@@ -87,9 +87,9 @@ test_memory_cmpxchg_success()
 local function test_memory_cmpxchg_failure()
   local mem = check.must(shm.mapshared(4096))
   mem:store(0, 100)
-  local ok, actual = mem:cmpxchg(0, 50, 200)
-  assert(ok == false, "cmpxchg should fail when old doesn't match")
-  assert(actual == 100, "cmpxchg should return actual value 100, got " .. tostring(actual))
+  local r = check.must(mem:cmpxchg(0, 50, 200))
+  assert(r.swapped == false, "cmpxchg should fail when old doesn't match")
+  assert(r.value == 100, "cmpxchg should return actual value 100, got " .. tostring(r.value))
   local current = mem:load(0)
   assert(current == 100, "after failed cmpxchg, value should still be 100, got " .. tostring(current))
 end
@@ -256,7 +256,7 @@ local function test_memory_wait_retries_eintr_until_deadline()
   local time = require("cosmic.time")
   local mem = check.must(shm.mapshared(64))
   mem:store(0, 0)
-  local old_handler = signal.sigaction(signal.SIGALRM, function(_: number) end)
+  local prev = check.must(signal.sigaction(signal.SIGALRM, function(_: number) end))
   -- Interval timer: interrupts the wait several times before the deadline.
   signal.setitimer({
       which = signal.ITIMER_REAL,
@@ -281,7 +281,7 @@ local function test_memory_wait_retries_eintr_until_deadline()
       intervalsec = 0,
       intervalns = 0,
     })
-  signal.sigaction(signal.SIGALRM, old_handler)
+  signal.sigaction(signal.SIGALRM, prev.handler, prev.flags, prev.mask)
   assert(rc == nil, "wait on an unchanged word should time out")
   assert(type(err) == "string" and err:match("ETIMEDOUT"),
     "interrupted wait should retry to the deadline (ETIMEDOUT), got: "
@@ -306,6 +306,8 @@ local function test_memory_unmap()
   assert(ok == false and type(werr) == "string", "write after unmap should fail")
   local rc, werr2 = mem:wait(0, 0)
   assert(rc == nil and type(werr2) == "string", "wait after unmap should fail")
-  assert(mem:wake(0) == 0, "wake after unmap should wake nothing")
+  local woken, wake_err = mem:wake(0)
+  assert(woken == nil and wake_err and wake_err:find("unmapped", 1, true),
+    "wake after unmap is a caller bug and must say so, got: " .. tostring(wake_err))
 end
 test_memory_unmap()

--- a/cosmic/signal.tl
+++ b/cosmic/signal.tl
@@ -279,9 +279,11 @@ local function sigaction(sig: integer, handler?: any, flags?: integer, mask?: Si
     -- arrives in the second slot.
     return nil, errstr(prev_flags, "sigaction")
   end
-  -- cast: from any (binding returns untyped triple)
-  return {handler = prev as (function | integer), flags = prev_flags as integer,
-    mask = prev_mask as Sigset}
+  -- The binding returns an untyped triple; type each slot on its way in.
+  local phandler = prev as (function | integer) -- cast: from any
+  local pflags = prev_flags as integer -- cast: from any
+  local pmask = prev_mask as Sigset -- cast: from any
+  return {handler = phandler, flags = pflags, mask = pmask}
 end
 
 --- Modify the process signal mask.

--- a/cosmic/signal.tl
+++ b/cosmic/signal.tl
@@ -43,6 +43,17 @@ end
 
 --- Signal handling module.
 --- Provides signal constants, sigaction, sigprocmask, sigsuspend, and delivery functions.
+--- The disposition sigaction replaced. A record rather than
+--- (handler, flags, mask, err) returns: the old shape put the error in
+--- slot 4, unreachable from `local prev, err = ...`. Restore with
+--- `signal.sigaction(sig, prev.handler, prev.flags, prev.mask)`.
+local record PrevAction
+  --- The previous handler: a Lua function, or SIG_DFL/SIG_IGN.
+  handler: function | integer
+  flags: integer
+  mask: Sigset
+end
+
 local record SignalModule
 
   -- Signal constants
@@ -114,7 +125,8 @@ local record SignalModule
   --- An error raised inside a handler is logged, not propagated.
   --- Returns the previous handler, flags, and mask; on failure returns
   --- nil, nil, nil plus an error message.
-  sigaction: function(sig: integer, handler?: function | integer, flags?: integer, mask?: Sigset): function | integer, integer, Sigset, string
+  type PrevAction = PrevAction
+  sigaction: function(sig: integer, handler?: function | integer, flags?: integer, mask?: Sigset): PrevAction | nil, string
 
   --- Modify the process signal mask.
   --- how: SIG_BLOCK, SIG_UNBLOCK, or SIG_SETMASK
@@ -247,7 +259,7 @@ local raw_sigsuspend = unix.sigsuspend as function(Sigset): (any, any)
 -- handler and the first return are typed any here because the formatter
 -- cannot parse a bare `function | integer` union in a function statement;
 -- the SignalModule record above carries the precise public type.
-local function sigaction(sig: integer, handler?: any, flags?: integer, mask?: Sigset): any, integer, Sigset, string
+local function sigaction(sig: integer, handler?: any, flags?: integer, mask?: Sigset): PrevAction | nil, string
   -- Never pass explicit trailing nils: the binding leaves nil-valued
   -- stack slots 3/4 in place, which shifts the stack index it later uses
   -- to store a Lua handler in its registry table — the handler would be
@@ -265,9 +277,11 @@ local function sigaction(sig: integer, handler?: any, flags?: integer, mask?: Si
   if prev == nil then
     -- On failure the binding returns (nil, err, errno): the error string
     -- arrives in the second slot.
-    return nil, nil, nil, errstr(prev_flags, "sigaction")
+    return nil, errstr(prev_flags, "sigaction")
   end
-  return prev, prev_flags as integer, prev_mask as Sigset -- cast: from any
+  -- cast: from any (binding returns untyped triple)
+  return {handler = prev as (function | integer), flags = prev_flags as integer,
+    mask = prev_mask as Sigset}
 end
 
 --- Modify the process signal mask.

--- a/cosmic/signal_example.tl
+++ b/cosmic/signal_example.tl
@@ -8,22 +8,23 @@
 -- runs before the sleep returns.
 local function Example_handler()
   local signal = require("cosmic.signal")
+  local check = require("cosmic.check")
   local time = require("cosmic.time")
 
   local received: number = 0
   local blockmask = signal.sigset(signal.SIGUSR1)
   local oldmask = signal.sigprocmask(signal.SIG_BLOCK, blockmask)
 
-  local old_handler = signal.sigaction(signal.SIGUSR1, function(sig: number)
+  local prev = check.must(signal.sigaction(signal.SIGUSR1, function(sig: number)
       received = sig
-    end)
+    end))
 
   signal.raise(signal.SIGUSR1) -- pending: SIGUSR1 is blocked
   signal.sigprocmask(signal.SIG_SETMASK, oldmask)
   time.sleep(0, 1000000) -- give delivery a moment
 
   print(received == signal.SIGUSR1)
-  signal.sigaction(signal.SIGUSR1, old_handler)
+  signal.sigaction(signal.SIGUSR1, prev.handler, prev.flags, prev.mask)
   -- Output:
   -- true
 end
@@ -32,10 +33,11 @@ end
 -- ignore, raise() delivers nothing and the process carries on.
 local function Example_ignore()
   local signal = require("cosmic.signal")
-  local old_handler = signal.sigaction(signal.SIGUSR2, signal.SIG_IGN)
+  local check = require("cosmic.check")
+  local prev = check.must(signal.sigaction(signal.SIGUSR2, signal.SIG_IGN))
   local ok = signal.raise(signal.SIGUSR2)
   print(ok)
-  signal.sigaction(signal.SIGUSR2, old_handler)
+  signal.sigaction(signal.SIGUSR2, prev.handler, prev.flags, prev.mask)
   -- Output:
   -- true
 end

--- a/cosmic/signal_example.tl
+++ b/cosmic/signal_example.tl
@@ -15,9 +15,10 @@ local function Example_handler()
   local blockmask = signal.sigset(signal.SIGUSR1)
   local oldmask = signal.sigprocmask(signal.SIG_BLOCK, blockmask)
 
-  local prev = check.must(signal.sigaction(signal.SIGUSR1, function(sig: number)
-      received = sig
-    end))
+  local on_usr1 = function(sig: number)
+    received = sig
+  end
+  local prev = check.must(signal.sigaction(signal.SIGUSR1, on_usr1))
 
   signal.raise(signal.SIGUSR1) -- pending: SIGUSR1 is blocked
   signal.sigprocmask(signal.SIG_SETMASK, oldmask)

--- a/cosmic/signal_test.tl
+++ b/cosmic/signal_test.tl
@@ -95,9 +95,10 @@ local function test_sigaction_handler()
   local oldmask = signal.sigprocmask(signal.SIG_BLOCK, blockmask)
 
   -- Install handler
-  local prev = check.must(signal.sigaction(signal.SIGUSR1, function(sig: number)
-      received_signal = sig
-    end))
+  local on_sig = function(sig: number)
+    received_signal = sig
+  end
+  local prev = check.must(signal.sigaction(signal.SIGUSR1, on_sig))
 
   -- Raise the signal (it will be pending since blocked)
   signal.raise(signal.SIGUSR1)
@@ -127,9 +128,10 @@ test_kill()
 local function test_raise()
   -- Set up handler for SIGUSR2
   local received = false
-  local prev = check.must(signal.sigaction(signal.SIGUSR2, function(_: number)
-      received = true
-    end))
+  local on_sig = function(_: number)
+    received = true
+  end
+  local prev = check.must(signal.sigaction(signal.SIGUSR2, on_sig))
 
   signal.raise(signal.SIGUSR2)
 
@@ -152,9 +154,10 @@ local function test_setitimer()
   local oldmask = signal.sigprocmask(signal.SIG_BLOCK, blockmask)
 
   -- Install handler
-  local prev = check.must(signal.sigaction(signal.SIGALRM, function(_: number)
-      received = true
-    end))
+  local on_sig = function(_: number)
+    received = true
+  end
+  local prev = check.must(signal.sigaction(signal.SIGALRM, on_sig))
 
   -- Set single-shot timer: fire in 100ms, no repeat
   signal.setitimer({

--- a/cosmic/signal_test.tl
+++ b/cosmic/signal_test.tl
@@ -1,5 +1,6 @@
 #!/usr/bin/env cosmic
 local signal = require("cosmic.signal")
+local check = require("cosmic.check")
 local proc = require("cosmic.proc")
 local time = require("cosmic.time")
 
@@ -74,14 +75,14 @@ test_sigprocmask()
 
 local function test_sigaction_ignore()
   -- Set up SIGUSR1 to be ignored
-  local old_handler, old_flags, old_mask = signal.sigaction(signal.SIGUSR1, signal.SIG_IGN)
+  local prev = check.must(signal.sigaction(signal.SIGUSR1, signal.SIG_IGN))
 
   -- Raise SIGUSR1 - should not terminate since it's ignored
   local ok, err = signal.raise(signal.SIGUSR1)
   assert(ok, "raise should succeed: " .. (err or ""))
 
   -- Restore old handler
-  signal.sigaction(signal.SIGUSR1, old_handler, old_flags, old_mask)
+  signal.sigaction(signal.SIGUSR1, prev.handler, prev.flags, prev.mask)
 end
 test_sigaction_ignore()
 
@@ -94,9 +95,9 @@ local function test_sigaction_handler()
   local oldmask = signal.sigprocmask(signal.SIG_BLOCK, blockmask)
 
   -- Install handler
-  local old_handler = signal.sigaction(signal.SIGUSR1, function(sig: number)
+  local prev = check.must(signal.sigaction(signal.SIGUSR1, function(sig: number)
       received_signal = sig
-    end)
+    end))
 
   -- Raise the signal (it will be pending since blocked)
   signal.raise(signal.SIGUSR1)
@@ -111,7 +112,7 @@ local function test_sigaction_handler()
     "handler should have received SIGUSR1, got " .. tostring(received_signal))
 
   -- Restore old handler
-  signal.sigaction(signal.SIGUSR1, old_handler)
+  signal.sigaction(signal.SIGUSR1, prev.handler, prev.flags, prev.mask)
 end
 test_sigaction_handler()
 
@@ -126,9 +127,9 @@ test_kill()
 local function test_raise()
   -- Set up handler for SIGUSR2
   local received = false
-  local old_handler = signal.sigaction(signal.SIGUSR2, function(_: number)
+  local prev = check.must(signal.sigaction(signal.SIGUSR2, function(_: number)
       received = true
-    end)
+    end))
 
   signal.raise(signal.SIGUSR2)
 
@@ -138,7 +139,7 @@ local function test_raise()
   assert(received, "should have received SIGUSR2")
 
   -- Restore old handler
-  signal.sigaction(signal.SIGUSR2, old_handler)
+  signal.sigaction(signal.SIGUSR2, prev.handler, prev.flags, prev.mask)
 end
 test_raise()
 
@@ -151,9 +152,9 @@ local function test_setitimer()
   local oldmask = signal.sigprocmask(signal.SIG_BLOCK, blockmask)
 
   -- Install handler
-  local old_handler = signal.sigaction(signal.SIGALRM, function(_: number)
+  local prev = check.must(signal.sigaction(signal.SIGALRM, function(_: number)
       received = true
-    end)
+    end))
 
   -- Set single-shot timer: fire in 100ms, no repeat
   signal.setitimer({
@@ -180,7 +181,7 @@ local function test_setitimer()
       intervalsec = 0,
       intervalns = 0,
     })
-  signal.sigaction(signal.SIGALRM, old_handler)
+  signal.sigaction(signal.SIGALRM, prev.handler, prev.flags, prev.mask)
 end
 test_setitimer()
 
@@ -221,7 +222,7 @@ test_sigprocmask_error_names_errno()
 local function test_sigsuspend_returns_eintr()
   -- sigsuspend never succeeds: it returns nil plus EINTR once a signal
   -- is delivered. Arm a short one-shot timer to provide that signal.
-  local old_handler = signal.sigaction(signal.SIGALRM, function(_: number) end)
+  local prev = check.must(signal.sigaction(signal.SIGALRM, function(_: number) end))
   signal.setitimer({
       which = signal.ITIMER_REAL,
       valuesec = 0,
@@ -240,6 +241,6 @@ local function test_sigsuspend_returns_eintr()
       intervalsec = 0,
       intervalns = 0,
     })
-  signal.sigaction(signal.SIGALRM, old_handler)
+  signal.sigaction(signal.SIGALRM, prev.handler, prev.flags, prev.mask)
 end
 test_sigsuspend_returns_eintr()

--- a/cosmic/time_test.tl
+++ b/cosmic/time_test.tl
@@ -1,5 +1,6 @@
 #!/usr/bin/env cosmic
 local time = require("cosmic.time")
+local check = require("cosmic.check")
 
 -- clock_gettime tests
 
@@ -113,7 +114,7 @@ local function test_sleep_ms_interrupted_returns_ms_remainder()
   -- cast: signature transition
   local sleep_ms = (time as {string: any}).sleep_ms as function(number): number, string
 
-  local old_handler = signal.sigaction(signal.SIGALRM, function(_: number) end)
+  local prev = check.must(signal.sigaction(signal.SIGALRM, function(_: number) end))
   -- Single-shot timer: interrupt the sleep after ~50ms.
   signal.setitimer({
       which = signal.ITIMER_REAL,
@@ -134,7 +135,7 @@ local function test_sleep_ms_interrupted_returns_ms_remainder()
       intervalsec = 0,
       intervalns = 0,
     })
-  signal.sigaction(signal.SIGALRM, old_handler)
+  signal.sigaction(signal.SIGALRM, prev.handler, prev.flags, prev.mask)
 
   assert(rem ~= nil, "interrupted sleep_ms must return a remainder")
   assert(rem > 0 and rem <= 2000,

--- a/cosmic/url.tl
+++ b/cosmic/url.tl
@@ -141,16 +141,23 @@ local function format(u: Url): string
     })
 end
 
+--- A parsed host:port pair; port is nil when the input carried none.
+--- A record rather than (host, port, err) returns: the error is in
+--- slot 2, where check.must and `local h, err = ...` can see it.
+local record HostPort
+  host: string
+  port: integer
+end
+
 --- Parse a host:port string into its components.
 --- IPv6 hosts must be bracketed ("[::1]" or "[::1]:8080"); a port, when
 --- present, must be an integer in 1..65535.
 --- @param hostport string The host:port string (e.g., "example.com:8080")
---- @return string | nil The host, or nil on error
---- @return integer? The port, or nil if not specified
+--- @return HostPort | nil The parsed host (port nil when absent)
 --- @return string? Error message if parsing failed
-local function parse_host(hostport: string): string | nil, integer, string
+local function parse_host(hostport: string): HostPort | nil, string
   if not hostport or hostport == "" then
-    return nil, nil, "empty host"
+    return nil, "empty host"
   end
 
   local port_str: string = nil
@@ -163,7 +170,7 @@ local function parse_host(hostport: string): string | nil, integer, string
     if r ~= "" then
       port_str = r:match("^:(%d+)$")
       if not port_str then
-        return nil, nil, "invalid host:port: " .. hostport
+        return nil, "invalid host:port: " .. hostport
       end
     end
   else
@@ -174,13 +181,13 @@ local function parse_host(hostport: string): string | nil, integer, string
       host = hostport:sub(1, colon - 1)
       port_str = hostport:sub(colon + 1)
       if port_str:find(":", 1, true) then
-        return nil, nil, "IPv6 host must be bracketed, e.g. [::1]:8080"
+        return nil, "IPv6 host must be bracketed, e.g. [::1]:8080"
       end
       if host == "" then
-        return nil, nil, "empty host in: " .. hostport
+        return nil, "empty host in: " .. hostport
       end
       if not port_str:match("^%d+$") then
-        return nil, nil, "invalid port: " .. port_str
+        return nil, "invalid port: " .. port_str
       end
     end
   end
@@ -188,11 +195,11 @@ local function parse_host(hostport: string): string | nil, integer, string
   if port_str then
     local port = math.tointeger(tonumber(port_str))
     if not port or port < 1 or port > 65535 then
-      return nil, nil, "invalid port: " .. port_str
+      return nil, "invalid port: " .. port_str
     end
-    return host, port
+    return {host = host, port = port}
   end
-  return host, nil
+  return {host = host}
 end
 
 --- Escape a hostname for use in a URL.
@@ -258,13 +265,14 @@ end
 
 local record UrlModule
   type Url = Url
+  type HostPort = HostPort
 
   encode: function(str: string): string
   decode: function(str: string): string | nil, string
   parse: function(url: string): Url | nil, string
   format: function(u: Url): string
   parse_query: function(query: string): {string: {string}}
-  parse_host: function(hostport: string): string | nil, integer, string
+  parse_host: function(hostport: string): HostPort | nil, string
   escape_host: function(str: string): string
   escape_path: function(str: string): string
   escape_segment: function(str: string): string

--- a/cosmic/url_test.tl
+++ b/cosmic/url_test.tl
@@ -285,44 +285,44 @@ test_format_minimal()
 -- parse_host tests
 
 local function test_parse_host_with_port()
-  local host, port = url.parse_host("example.com:8080")
-  assert(host == "example.com", "expected 'example.com', got '" .. tostring(host) .. "'")
-  assert(port == 8080, "expected 8080, got " .. tostring(port))
+  local hp = check.must(url.parse_host("example.com:8080"))
+  assert(hp.host == "example.com", "expected 'example.com', got '" .. tostring(hp.host) .. "'")
+  assert(hp.port == 8080, "expected 8080, got " .. tostring(hp.port))
 end
 test_parse_host_with_port()
 
 local function test_parse_host_without_port()
-  local host, port = url.parse_host("example.com")
-  assert(host == "example.com", "expected 'example.com', got '" .. tostring(host) .. "'")
-  assert(port == nil, "expected nil port, got " .. tostring(port))
+  local hp = check.must(url.parse_host("example.com"))
+  assert(hp.host == "example.com", "expected 'example.com', got '" .. tostring(hp.host) .. "'")
+  assert(hp.port == nil, "expected nil port, got " .. tostring(hp.port))
 end
 test_parse_host_without_port()
 
 local function test_parse_host_ipv4()
-  local host, port = url.parse_host("192.168.1.1:80")
-  assert(host == "192.168.1.1", "expected '192.168.1.1', got '" .. tostring(host) .. "'")
-  assert(port == 80, "expected 80, got " .. tostring(port))
+  local hp = check.must(url.parse_host("192.168.1.1:80"))
+  assert(hp.host == "192.168.1.1", "expected '192.168.1.1', got '" .. tostring(hp.host) .. "'")
+  assert(hp.port == 80, "expected 80, got " .. tostring(hp.port))
 end
 test_parse_host_ipv4()
 
 local function test_parse_host_ipv6_with_port()
-  local host, port = url.parse_host("[::1]:8080")
-  assert(host == "::1", "expected '::1', got '" .. tostring(host) .. "'")
-  assert(port == 8080, "expected 8080, got " .. tostring(port))
+  local hp = check.must(url.parse_host("[::1]:8080"))
+  assert(hp.host == "::1", "expected '::1', got '" .. tostring(hp.host) .. "'")
+  assert(hp.port == 8080, "expected 8080, got " .. tostring(hp.port))
 end
 test_parse_host_ipv6_with_port()
 
 local function test_parse_host_ipv6_without_port()
-  local host, port = url.parse_host("[::1]")
-  assert(host == "::1", "expected '::1', got '" .. tostring(host) .. "'")
-  assert(port == nil, "expected nil port, got " .. tostring(port))
+  local hp = check.must(url.parse_host("[::1]"))
+  assert(hp.host == "::1", "expected '::1', got '" .. tostring(hp.host) .. "'")
+  assert(hp.port == nil, "expected nil port, got " .. tostring(hp.port))
 end
 test_parse_host_ipv6_without_port()
 
 local function test_parse_host_unbracketed_ipv6_rejected()
   -- A bare IPv6 address is all host: no port to split off.
-  local host, _, err = url.parse_host("::1")
-  assert(host == nil, "unbracketed IPv6 must be rejected, got '" .. tostring(host) .. "'")
+  local hp, err = url.parse_host("::1")
+  assert(hp == nil, "unbracketed IPv6 must be rejected")
   assert(err ~= nil and err:find("bracket") ~= nil,
     "error should say brackets are required, got '" .. tostring(err) .. "'")
 end
@@ -330,38 +330,37 @@ test_parse_host_unbracketed_ipv6_rejected()
 
 local function test_parse_host_port_out_of_range()
   -- Ports above 65535 are not ports.
-  local host, _, err = url.parse_host("example.com:99999")
-  assert(host == nil, "port 99999 must be rejected")
+  local hp, err = url.parse_host("example.com:99999")
+  assert(hp == nil, "port 99999 must be rejected")
   assert(err ~= nil and err:find("invalid port") ~= nil,
     "expected invalid-port error, got '" .. tostring(err) .. "'")
 end
 test_parse_host_port_out_of_range()
 
 local function test_parse_host_port_zero_rejected()
-  local host, _, err = url.parse_host("example.com:0")
-  assert(host == nil, "port 0 must be rejected")
+  local hp, err = url.parse_host("example.com:0")
+  assert(hp == nil, "port 0 must be rejected")
   assert(err ~= nil, "expected error for port 0")
 end
 test_parse_host_port_zero_rejected()
 
 local function test_parse_host_trailing_colon_rejected()
-  local host, _, err = url.parse_host("example.com:")
-  assert(host == nil, "trailing colon without digits must be rejected")
+  local hp, err = url.parse_host("example.com:")
+  assert(hp == nil, "trailing colon without digits must be rejected")
   assert(err ~= nil, "expected error message")
 end
 test_parse_host_trailing_colon_rejected()
 
 local function test_parse_host_empty()
-  local host, port, err = url.parse_host("")
-  assert(host == nil, "expected nil host for empty string")
-  assert(port == nil, "expected nil port for empty string")
+  local hp, err = url.parse_host("")
+  assert(hp == nil, "expected nil result for empty string")
   assert(err ~= nil, "expected error for empty string")
 end
 test_parse_host_empty()
 
 local function test_parse_host_empty_host_rejected()
-  local host, _, err = url.parse_host(":8080")
-  assert(host == nil, "empty host must be rejected")
+  local hp, err = url.parse_host(":8080")
+  assert(hp == nil, "empty host must be rejected")
   assert(err ~= nil, "expected error message")
 end
 test_parse_host_empty_host_rejected()


### PR DESCRIPTION
Fifth PR from the API review — the second half of the error-shape wave. Every remaining public function that buried its error past slot 2 now returns a record, so `check.must` and `local v, err = ...` see the error every time:

- **`proc.wait` → `WaitResult {pid, status, rusage}`** (error was in slot 4) and **`proc.getrlimit` → `Rlimit {soft, hard}`** (slot 3).
- **`signal.sigaction` → `PrevAction {handler, flags, mask}`** (slot 4). The save/restore idiom becomes `local prev = check.must(signal.sigaction(...))` … `signal.sigaction(sig, prev.handler, prev.flags, prev.mask)`, updated at every site — which as a side effect makes every restore carry the flags and mask it used to silently drop.
- **`fs.tmpfile` → `TmpFile {handle, path}`** — the old triple put a *success* value (the path) in slot 2, so `local h, err = fs.tmpfile()` bound the path as its error and the error itself was unreachable.
- **`url.parse_host` → `HostPort {host, port}`**.
- **`shm`**: `Memory:cmpxchg` → `Cmpxchg {swapped, value}`; `Memory:wake` on an out-of-range or unmapped word reports the caller bug (`nil, err`) instead of silently waking nothing and returning 0.
- **`doc.render_file` → `string | nil, string`** — it was a fallible *value* wearing the effect shape: slot 2 held the rendered markdown on success and the error on failure, and both in-tree consumers had to branch on which meaning applied.

Deferred to the options wave: `child.run`'s fetch-style Result fold — an ergonomics reshape rather than a slot fix, with a caller fanout of its own.

## Verification

Full build green across all 402 files; the complete `--make ci` gate is finishing locally and this PR's CI runs the same gate cold (now with the 8-minute hang ceiling from #888). I'll drive both to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FP31Qs2Ei4uJUsimFMpvkS

---
_Generated by [Claude Code](https://claude.ai/code/session_01FP31Qs2Ei4uJUsimFMpvkS)_