### PR TITLE
rename wave, the semantic half: re match family, is_tty, url escapes

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -120,7 +120,7 @@ cosmic/fs/walk.tl 145 178
 cosmic/fuzzy.tl 48 50
 cosmic/getopt.tl 36 56
 cosmic/hash.tl 71 74
-cosmic/html.tl 6 6
+cosmic/html.tl 19 19
 cosmic/init.tl 16 17
 cosmic/instrument.tl 69 74
 cosmic/ip.tl 109 109
@@ -128,6 +128,7 @@ cosmic/json.tl 23 24
 cosmic/landlock.tl 58 102
 cosmic/literal.tl 222 238
 cosmic/log.tl 72 74
+cosmic/net/connect.tl 31 37
 cosmic/net/init.tl 0 120
 cosmic/net/socket.tl 228 256
 cosmic/pledge.tl 24 35
@@ -174,11 +175,11 @@ cosmic/tar.tl 114 122
 cosmic/teal.tl 185 193
 cosmic/testrun.tl 144 188
 cosmic/time.tl 142 155
-cosmic/tty.tl 128 135
+cosmic/tty.tl 123 130
 cosmic/unveil.tl 29 50
-cosmic/url.tl 122 124
+cosmic/url.tl 126 141
 cosmic/user.tl 48 61
 cosmic/uuid.tl 9 9
 cosmic/zip.tl 72 85
 tlconfig.lua 7 7
-total 13733 18140
+total 13776 18202

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,10 +110,10 @@ common mappings:
 | `cosmo.Barf(path, data)` | `require("cosmic.fs").write(path, data)` |
 | `cosmo.Slurp(path)` | `require("cosmic.fs").read(path)` |
 | `cosmo.path.join(...)` | `require("cosmic.fs").join(...)` |
-| `cosmo.path.isfile(p)` | `require("cosmic.fs").isfile(p)` |
-| `cosmo.unix.mkdtemp(t)` | `require("cosmic.fs").mkdtemp(t)` |
-| `cosmo.unix.rmrf(p)` | `require("cosmic.fs").rmrf(p)` |
-| `cosmo.unix.makedirs(p)` | `require("cosmic.fs").makedirs(p)` |
+| `cosmo.path.isfile(p)` | `require("cosmic.fs").is_file(p)` |
+| `cosmo.unix.mkdtemp(t)` | `require("cosmic.fs").temp_dir(t)` |
+| `cosmo.unix.rmrf(p)` | `require("cosmic.fs").remove_all(p)` |
+| `cosmo.unix.makedirs(p)` | `require("cosmic.fs").make_dirs(p)` |
 | `cosmo.unix.chmod(p, m)` | `require("cosmic.fs").chmod(p, m)` |
 | `cosmo.DecodeJson(s)` | `require("cosmic.json").decode(s)` |
 | `cosmo.EncodeJson(v)` | `require("cosmic.json").encode(v)` |
@@ -363,7 +363,7 @@ all modules are under `cosmic/` and imported as `cosmic.*`:
 | embed | create custom executables with embedded files |
 | env | environment variable get (nil when unset), get_or, set/unset |
 | envd | load environment variables from embedded env.d directory |
-| errno | canonical errno formatting (`str`) and lookup helpers (`is`, `code`, `constants`) for `cosmo.unix` failures |
+| errno | canonical errno formatting (`wrap`) and lookup helpers (`is`, `code`, `constants`) for `cosmo.unix` failures |
 | example | example runner with `Example_*` functions |
 | fetch | HTTP client with retry support |
 | flags | declarative command-line flag parsing with generated --help |

--- a/_cli/welcome_test.tl
+++ b/_cli/welcome_test.tl
@@ -67,7 +67,7 @@ end
 local function pty_available(): boolean
   -- Write a tiny probe script that prints tty detection result to stderr
   local probe = fs.join(tmpdir, "pty_probe.lua")
-  local write_ok, _ = fs.write(probe, "local tty = require('cosmic.tty'); io.stderr:write(tostring(tty.stderr_isatty()))\n")
+  local write_ok, _ = fs.write(probe, "local tty = require('cosmic.tty'); io.stderr:write(tostring(tty.is_tty(2)))\n")
   if not write_ok then
     return false
   end

--- a/_perf/bench/micro_bench.tl
+++ b/_perf/bench/micro_bench.tl
@@ -45,7 +45,7 @@ local function build_csv(): string
 end
 
 --- Build a deterministic query-value-like string with a realistic mix of
---- safe characters and ones url.encode must percent-escape, so decode()
+--- safe characters and ones url.escape_param must percent-escape, so
 --- has a real handful of %XX sequences to validate, not zero.
 --- @return string The value
 local function build_query_value(): string
@@ -59,7 +59,7 @@ end
 local BLOB = build_blob()
 local CSV = build_csv()
 local QUERY_VALUE = build_query_value()
-local QUERY_ENCODED = url.encode(QUERY_VALUE)
+local QUERY_ENCODED = url.escape_param(QUERY_VALUE)
 
 local function scenarios(): {pt.Scenario}, string
   return {
@@ -183,7 +183,7 @@ local function scenarios(): {pt.Scenario}, string
       -- rather than short-circuiting on a string with no '%' at all.
       name = "url_decode_query_value",
       fn = function(_: any): any
-        return (url.decode(QUERY_ENCODED))
+        return (url.unescape_param(QUERY_ENCODED))
       end,
       check = function(_: any, res: any): boolean, string
         if res as string ~= QUERY_VALUE then -- cast: from any

--- a/cmd/cosmic/main.tl
+++ b/cmd/cosmic/main.tl
@@ -366,7 +366,7 @@ local function main(): integer, string
     local welcome = require("_cli.welcome")
     if not welcome.was_shown() then
       local tty = require("cosmic.tty")
-      if tty.stderr_isatty() then
+      if tty.is_tty(2) then
         io.stderr:write(handlers.generate_welcome())
         welcome.mark_shown()
       end

--- a/cosmic/ansi.tl
+++ b/cosmic/ansi.tl
@@ -211,7 +211,7 @@ local function enabled(fd?: integer): boolean
   if env.get("TERM") == "dumb" then
     return false
   end
-  return tty.isatty(fd or 1)
+  return tty.is_tty(fd)
 end
 
 local record AnsiModule

--- a/cosmic/fetch/extras.tl
+++ b/cosmic/fetch/extras.tl
@@ -116,7 +116,7 @@ local function encode_pairs(params: {string: string}): string
   table.sort(keys)
   local out: {string} = {}
   for _, k in ipairs(keys) do
-    table.insert(out, url_mod.encode(k) .. "=" .. url_mod.encode(params[k]))
+    table.insert(out, url_mod.escape_param(k) .. "=" .. url_mod.escape_param(params[k]))
   end
   return table.concat(out, "&")
 end

--- a/cosmic/html.tl
+++ b/cosmic/html.tl
@@ -9,12 +9,41 @@ local function escape(str: string): string
   return cosmo.EscapeHtml(str)
 end
 
+--- The named entities unescape() decodes: exactly escape()'s output
+--- set plus the aliases browsers emit for the same characters.
+local ENTITIES < const >: {string: string} = {
+  ["&lt;"] = "<",
+  ["&gt;"] = ">",
+  ["&quot;"] = '"',
+  ["&#34;"] = '"',
+  ["&#39;"] = "'",
+  ["&apos;"] = "'",
+}
+
+--- Unescape HTML entities: the inverse of escape() (D20 — a pair
+--- ships both halves). Decodes the five entities escape() produces
+--- (&amp; &lt; &gt; &quot; &#39;) plus their common aliases (&apos;,
+--- &#34;). Unknown entities pass through unchanged; this is not a
+--- general HTML parser.
+--- @param str string The string holding HTML entities
+--- @return string The decoded string
+local function unescape(str: string): string
+  -- &amp; last, so "&amp;lt;" decodes to the literal text "&lt;"
+  -- instead of "<" — decoding must not cascade.
+  local out = str:gsub("&%#?%w+;", function(ent: string): string
+      return ENTITIES[ent]
+    end)
+  return (out:gsub("&amp;", "&"))
+end
+
 local record HtmlModule
   escape: function(str: string): string
+  unescape: function(str: string): string
 end
 
 local M: HtmlModule = {
   escape = escape,
+  unescape = unescape,
 }
 
 return M

--- a/cosmic/html_test.tl
+++ b/cosmic/html_test.tl
@@ -44,3 +44,18 @@ local function test_escape_single_quote()
     "single quote should become &#39; or &apos;, got: " .. result)
 end
 test_escape_single_quote()
+
+local function test_unescape_inverts_escape()
+  local original = [[<a href="x">Tom & Jerry's</a>]]
+  assert(html.unescape(html.escape(original)) == original,
+    "unescape(escape(s)) must round-trip")
+end
+test_unescape_inverts_escape()
+
+local function test_unescape_aliases_and_unknowns()
+  assert(html.unescape("&apos;&#34;") == "'\"", "aliases decode")
+  assert(html.unescape("&unknown;") == "&unknown;", "unknown entities pass through")
+  assert(html.unescape("&amp;lt;") == "&lt;",
+    "decoding must not cascade: &amp;lt; is the TEXT &lt;")
+end
+test_unescape_aliases_and_unknowns()

--- a/cosmic/net/connect.tl
+++ b/cosmic/net/connect.tl
@@ -1,0 +1,68 @@
+--- The bounded-connect path behind net.ConnectOptions.timeout_ms
+--- (an internal shard of cosmic.net; require cosmic.net, not this).
+local unix = require("cosmo.unix")
+local net_socket = require("cosmic.net.socket")
+local errstr = require("cosmic.errno").wrap
+local errno_is = require("cosmic.errno").is
+
+local type Socket = net_socket.Socket
+local type Address = net_socket.Address
+
+-- The ConnectOptions.timeout_ms path: switch the socket non-blocking,
+-- start the connect, poll for the outcome up to timeout_ms (default
+-- 10000). Leaves the socket non-blocking; connect_tcp restores
+-- blocking mode on success.
+local function with_timeout(s: Socket, addr: Address, port: integer, timeout_ms?: integer): boolean, string
+  timeout_ms = timeout_ms or 10000
+  if not s.fd then return false, "socket closed" end
+  local nb_ok, nb_err = s:set_nonblocking()
+  if not nb_ok then
+    return false, nb_err
+  end
+  local raw, aerr = net_socket.resolve_addr(addr)
+  if not raw then
+    return false, aerr
+  end
+  -- Bypass Socket:connect to keep the numeric errno: a nonblocking connect
+  -- that returns EINPROGRESS (or is interrupted, EINTR) is still pending —
+  -- poll for the outcome. Any other errno is a synchronous failure
+  -- (ECONNREFUSED, ENETUNREACH, ...) and must return immediately, not be
+  -- misread as "still connecting".
+  local ok, err, eno = unix.connect(s.fd, raw, port)
+  if ok then return true end
+  if not (errno_is(eno, "EINPROGRESS") or errno_is(eno, "EINTR")) then
+    return false, errstr(err, "connect: failed")
+  end
+  local fds: {integer: integer} = {[s.fd] = unix.POLLOUT}
+  local revents, perr, peno = unix.poll(fds, timeout_ms)
+  while revents == nil and errno_is(peno, "EINTR") do
+    revents, perr, peno = unix.poll(fds, timeout_ms)
+  end
+  if not revents then
+    return false, errstr(perr, "connect: poll failed")
+  end
+  local ev = (revents as {integer: integer})[s.fd] or 0 -- cast: record union after guard
+  if ev == 0 then return false, "connect: timed out" end
+  if ev & unix.POLLERR ~= 0 then
+    local so_err = s:getsockopt(unix.SOL_SOCKET, unix.SO_ERROR)
+    return false, "connect: error: " .. tostring(so_err or err)
+  end
+  if ev & unix.POLLOUT ~= 0 then
+    local so_err = s:getsockopt(unix.SOL_SOCKET, unix.SO_ERROR)
+    if so_err and so_err ~= 0 then
+      return false, "connect: failed: SO_ERROR=" .. tostring(so_err)
+    end
+    return true
+  end
+  return false, "connect: unexpected poll events=" .. tostring(ev)
+end
+
+local record NetConnectModule
+  with_timeout: function(s: Socket, addr: Address, port: integer, timeout_ms?: integer): boolean, string
+end
+
+local M: NetConnectModule = {
+  with_timeout = with_timeout,
+}
+
+return M

--- a/cosmic/net/connect_test.tl
+++ b/cosmic/net/connect_test.tl
@@ -137,35 +137,20 @@ local function test_listen_unix_connect_unix()
 end
 test_listen_unix_connect_unix()
 
-local function test_nb_connect_loopback()
-  -- Create a listening socket
-  local server = check.must(net.socket())
-
-  local ok, err = server:setsockopt(net.SOL_SOCKET, net.SO_REUSEADDR, true)
-  assert(ok, "setsockopt failed: " .. tostring(err))
-
-  ok, err = server:bind("127.0.0.1", 0) -- 127.0.0.1
-  assert(ok, "bind failed: " .. tostring(err))
-
+local function test_connect_with_timeout_loopback()
+  -- The old nb_connect surface, now ConnectOptions.timeout_ms
+  -- (api-review-8): connect with a bound, get back a BLOCKING socket.
+  local server = check.must(net.listen_tcp("127.0.0.1", 0))
   local server_port = check.must(server:getsockname()).port
-  assert(server_port > 0, "expected non-zero port")
 
-  ok, err = server:listen()
-  assert(ok, "listen failed: " .. tostring(err))
+  local client = check.must(net.connect_tcp("127.0.0.1", server_port,
+      {timeout_ms = 5000}))
 
-  -- A plain blocking socket: nb_connect must switch it to non-blocking
-  -- itself via Socket:set_nonblocking, rather than silently blocking.
-  local client = check.must(net.socket())
-
-  -- nb_connect to the listening server, by dotted-quad string
-  ok, err = net.nb_connect(client, "127.0.0.1", server_port, 5000)
-  assert(ok, "nb_connect failed: " .. tostring(err))
-
-  -- Accept the connection on the server side
   local raw_accepted, accept_err = server:accept()
   local accepted = check.must(raw_accepted, "accept failed: " .. tostring(accept_err))
 
-  -- Verify the connection works by sending data
+  -- The connection works, and the socket is blocking again: a plain
+  -- send/recv round-trip needs no readiness dance.
   local sent, send_err = client:send("nb_hello")
   assert(sent == 8, "expected 8 bytes sent, got " .. tostring(sent) .. ": " .. tostring(send_err))
 
@@ -176,44 +161,35 @@ local function test_nb_connect_loopback()
   accepted:close()
   server:close()
 end
-test_nb_connect_loopback()
+test_connect_with_timeout_loopback()
 
-local function test_nb_connect_refused()
-  -- Create a non-blocking socket and try to connect to a port with no listener
-  local client = check.must(net.socket({family = net.AF_INET, socktype = net.SOCK_STREAM | net.SOCK_NONBLOCK}))
-
-  -- Connect to localhost port 1 — should be refused
-  local ok, conn_err = net.nb_connect(client, "127.0.0.1", 1, 2000)
-  assert(not ok, "expected nb_connect to fail on refused port")
-  assert(conn_err ~= nil, "expected error message from nb_connect")
-
-  client:close()
+local function test_connect_with_timeout_refused()
+  -- Connect to localhost port 1 — should be refused, inside the bound
+  local sock, conn_err = net.connect_tcp("127.0.0.1", 1, {timeout_ms = 2000})
+  assert(sock == nil, "expected connect to fail on refused port")
+  assert(conn_err ~= nil, "expected error message from refused connect")
 end
-test_nb_connect_refused()
+test_connect_with_timeout_refused()
 
 -- connect() to the broadcast address fails SYNCHRONOUSLY with ENETUNREACH
 -- (no EINPROGRESS at all — unlike a refused port, which the kernel usually
--- reports async). nb_connect must return that error immediately rather
--- than treating the failure as "still connecting" and polling for up to
--- timeout_ms: assert on elapsed time, not just the outcome, so a regression
--- back to "poll no matter what" is caught even though it would eventually
--- return the same error, just slowly.
-local function test_nb_connect_synchronous_failure_returns_immediately()
-  local client = check.must(net.socket())
-
+-- reports async). The timeout path must return that error immediately
+-- rather than treating the failure as "still connecting" and polling for
+-- up to timeout_ms: assert on elapsed time, not just the outcome, so a
+-- regression back to "poll no matter what" is caught even though it would
+-- eventually return the same error, just slowly.
+local function test_connect_timeout_synchronous_failure_is_immediate()
   local t0 = time.monotonic()
-  local ok, err = net.nb_connect(client, "255.255.255.255", 80, 5000)
+  local sock, err = net.connect_tcp("255.255.255.255", 80, {timeout_ms = 5000})
   local t1 = time.monotonic()
 
-  assert(not ok, "connect to the broadcast address should fail")
+  assert(sock == nil, "connect to the broadcast address should fail")
   assert(err ~= nil and err:match("ENETUNREACH"),
     "expected ENETUNREACH, got: " .. tostring(err))
   assert(t1 - t0 < 1, "a synchronous connect failure must not wait out"
     .. " the poll timeout, took " .. tostring(t1 - t0) .. "s")
-
-  client:close()
 end
-test_nb_connect_synchronous_failure_returns_immediately()
+test_connect_timeout_synchronous_failure_is_immediate()
 
 -- Error fidelity: socket()/socketpair()/gethostname() must surface the
 -- binding's real errno, not a generic "X creation failed" string.

--- a/cosmic/net/init.tl
+++ b/cosmic/net/init.tl
@@ -9,7 +9,6 @@ local unix = require("cosmo.unix")
 local ip = require("cosmic.ip")
 local net_socket = require("cosmic.net.socket")
 local errstr = require("cosmic.errno").wrap
-local errno_is = require("cosmic.errno").is
 
 --- Socket handle for network I/O (see cosmic.net.socket for the methods).
 --- Supports Lua 5.4's to-be-closed via __close metamethod.
@@ -116,19 +115,47 @@ local function connect_unix(path: string): Socket | nil, string
   return s
 end
 
+-- The timeout connect path lives in the connect shard.
+local connect_with_timeout = require("cosmic.net.connect").with_timeout
+
+--- Options for connect_tcp and dial.
+local record ConnectOptions
+  --- Bound the connect attempt: fail with an error after this many
+  --- milliseconds instead of waiting on the kernel's own (much longer)
+  --- timeout. The returned socket is BLOCKING either way (api-review-8:
+  --- this option absorbs the old nb_connect, whose manually-managed
+  --- socket + non-blocking aftermath was the module's sharpest edge).
+  timeout_ms: integer
+end
+
 --- Create a TCP socket and connect to an address and port.
 --- The address may be a dotted-quad string ("127.0.0.1") or an ip.Addr.
 --- IPv6 is not supported. For hostname resolution use dial().
 --- @param addr Address Remote IPv4 address
 --- @param port integer Remote port
+--- @param opts ConnectOptions? timeout_ms bounds the attempt
 --- @return Socket | nil Connected socket
 --- @return string Error message on failure
-local function connect_tcp(addr: Address, port: integer): Socket | nil, string
+local function connect_tcp(addr: Address, port: integer, opts?: ConnectOptions): Socket | nil, string
   local sock, err = socket()
   if not sock then
     return nil, err
   end
   local s = sock as Socket -- cast: record union after guard
+  if opts and opts.timeout_ms then
+    local ok, conn_err = connect_with_timeout(s, addr, port, opts.timeout_ms)
+    if not ok then
+      s:close()
+      return nil, conn_err
+    end
+    -- The timeout path connects non-blocking; hand back a normal socket.
+    local bok, berr = s:set_nonblocking(false)
+    if not bok then
+      s:close()
+      return nil, berr
+    end
+    return s
+  end
   local ok, conn_err = s:connect(addr, port)
   if not ok then
     s:close()
@@ -145,9 +172,10 @@ end
 --- signature.
 --- @param host string Host to connect to: dotted-quad literal or DNS name
 --- @param port integer Remote TCP port
+--- @param opts ConnectOptions? timeout_ms bounds the connect attempt
 --- @return Socket | nil Connected socket
 --- @return string Error message on failure
-local function dial(host: string, port: integer): Socket | nil, string
+local function dial(host: string, port: integer, opts?: ConnectOptions): Socket | nil, string
   local a: ip.Addr
   local parsed = ip.parse(host)
   if parsed then
@@ -159,7 +187,7 @@ local function dial(host: string, port: integer): Socket | nil, string
     end
     a = looked as ip.Addr -- cast: record union after guard
   end
-  return connect_tcp(a, port)
+  return connect_tcp(a, port, opts)
 end
 
 --- Options for listen_tcp.
@@ -235,60 +263,6 @@ local function listen_tcp(addr: Address, port: integer, opts?: ListenOptions): S
 end
 
 --- Connect with a bounded wait instead of blocking indefinitely.
---- Switches the socket to non-blocking mode (via Socket:set_nonblocking),
---- starts the connect, and polls for completion up to timeout_ms. The
---- socket remains in non-blocking mode afterwards; call
---- s:set_nonblocking(false) to restore blocking I/O.
---- @param s Socket The socket to connect
---- @param addr Address Remote IPv4 address
---- @param port integer Remote port
---- @param timeout_ms integer Timeout in milliseconds (default 10000)
---- @return boolean True on success
---- @return string Error message on failure
-local function nb_connect(s: Socket, addr: Address, port: integer, timeout_ms?: integer): boolean, string
-  timeout_ms = timeout_ms or 10000
-  if not s.fd then return false, "socket closed" end
-  local nb_ok, nb_err = s:set_nonblocking()
-  if not nb_ok then
-    return false, nb_err
-  end
-  local raw, aerr = net_socket.resolve_addr(addr)
-  if not raw then
-    return false, aerr
-  end
-  -- Bypass Socket:connect to keep the numeric errno: a nonblocking connect
-  -- that returns EINPROGRESS (or is interrupted, EINTR) is still pending —
-  -- poll for the outcome. Any other errno is a synchronous failure
-  -- (ECONNREFUSED, ENETUNREACH, ...) and must return immediately, not be
-  -- misread as "still connecting".
-  local ok, err, eno = unix.connect(s.fd, raw, port)
-  if ok then return true end
-  if not (errno_is(eno, "EINPROGRESS") or errno_is(eno, "EINTR")) then
-    return false, errstr(err, "nb_connect: connect failed")
-  end
-  local fds: {integer: integer} = {[s.fd] = unix.POLLOUT}
-  local revents, perr, peno = unix.poll(fds, timeout_ms)
-  while revents == nil and errno_is(peno, "EINTR") do
-    revents, perr, peno = unix.poll(fds, timeout_ms)
-  end
-  if not revents then
-    return false, errstr(perr, "nb_connect: poll failed")
-  end
-  local ev = (revents as {integer: integer})[s.fd] or 0 -- cast: record union after guard
-  if ev == 0 then return false, "nb_connect: connect timed out" end
-  if ev & unix.POLLERR ~= 0 then
-    local so_err = s:getsockopt(unix.SOL_SOCKET, unix.SO_ERROR)
-    return false, "nb_connect: connect error: " .. tostring(so_err or err)
-  end
-  if ev & unix.POLLOUT ~= 0 then
-    local so_err = s:getsockopt(unix.SOL_SOCKET, unix.SO_ERROR)
-    if so_err and so_err ~= 0 then
-      return false, "nb_connect: connect failed: SO_ERROR=" .. tostring(so_err)
-    end
-    return true
-  end
-  return false, "nb_connect: unexpected poll events=" .. tostring(ev)
-end
 
 --- Get the local hostname.
 --- @return string | nil The hostname
@@ -339,9 +313,9 @@ local record NetModule
   listen_unix: function(path: string, backlog?: integer): Socket | nil, string
   listen_tcp: function(addr: Address, port: integer, opts?: ListenOptions): Socket | nil, string
   connect_unix: function(path: string): Socket | nil, string
-  connect_tcp: function(addr: Address, port: integer): Socket | nil, string
-  dial: function(host: string, port: integer): Socket | nil, string
-  nb_connect: function(s: Socket, addr: Address, port: integer, timeout_ms?: integer): boolean, string
+  type ConnectOptions = ConnectOptions
+  connect_tcp: function(addr: Address, port: integer, opts?: ConnectOptions): Socket | nil, string
+  dial: function(host: string, port: integer, opts?: ConnectOptions): Socket | nil, string
   gethostname: function(): string | nil, string
   interfaces: function(): {Interface} | nil, string
   AF_INET: integer
@@ -423,7 +397,6 @@ local M: NetModule = {
   connect_unix = connect_unix,
   connect_tcp = connect_tcp,
   dial = dial,
-  nb_connect = nb_connect,
   gethostname = gethostname,
   interfaces = interfaces,
   AF_INET = unix.AF_INET,

--- a/cosmic/re.tl
+++ b/cosmic/re.tl
@@ -1,8 +1,11 @@
 --- Regular expression matching using POSIX extended regex syntax.
---- Wraps cosmo.re for pattern compilation and searching.
+--- Wraps cosmo.re for pattern compilation and matching. Module-level
+--- functions are SUBJECT-FIRST (D20): match(text, pattern), like
+--- string.match. The compiled Regex keeps the binding's own :search
+--- method name — a userdata metatable is the C layer's to name.
 ---
 --- For best performance, compile patterns once and reuse them.
---- The search() convenience function compiles on each call (O(2^n) complexity).
+--- The match() convenience function compiles on each call.
 local re = require("cosmo.re")
 
 --- A compiled regular expression pattern.
@@ -41,21 +44,21 @@ local function compile(pattern: string, flags?: integer): Regex | nil, string
   return result as Regex -- cast: userdata boundary
 end
 
---- Search for pattern match in text (convenience function).
---- Compiles pattern on each call - use compile() for repeated searches.
+--- Match pattern against text (convenience function; subject first).
+--- Compiles pattern on each call - use compile() for repeated matching.
 --- Uses POSIX extended syntax by default.
 --- On a match, returns the matched substring plus a table of the
 --- parenthesized capture groups (an empty table when the pattern has no
 --- groups, "" for groups that did not participate). A no-match returns
 --- nil with no error; a bad pattern or an engine failure returns
 --- nil, nil, err.
---- @param pattern string The regex pattern to search for
 --- @param text string The text to search in
+--- @param pattern string The regex pattern to match
 --- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE, NOSUB
 --- @return string | nil The matched substring, or nil on no match or error
 --- @return {string} | nil Capture groups on match
 --- @return string | nil Error message if compilation or the engine failed
-local function search(pattern: string, text: string, flags?: integer): string | nil, {string} | nil, string | nil
+local function match(text: string, pattern: string, flags?: integer): string | nil, {string} | nil, string | nil
   local regex, cerr = compile(pattern, flags)
   if regex is Regex then
     -- Search flags (NOTBOL/NOTEOL) are not passed here; use compile() + :search() for those
@@ -73,22 +76,24 @@ local function search(pattern: string, text: string, flags?: integer): string | 
   return nil, nil, cerr
 end
 
---- Check if pattern matches anywhere in text.
---- Convenience function that returns boolean instead of matched text.
---- Named test (not match) to avoid confusion with Lua's string.match,
---- which returns the matched text.
---- @param pattern string The regex pattern to match
+--- Check if pattern matches anywhere in text (subject first).
+--- Convenience predicate returning boolean instead of matched text.
 --- @param text string The text to search in
+--- @param pattern string The regex pattern to match
 --- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE, NOSUB
 --- @return boolean True if pattern matches, false otherwise
 --- @return string? Error message if compilation or the engine failed
-local function test(pattern: string, text: string, flags?: integer): boolean, string
-  local m, _, err = search(pattern, text, flags)
+local function test(text: string, pattern: string, flags?: integer): boolean, string
+  local m, _, err = match(text, pattern, flags)
   if err then
     return false, err
   end
   return m ~= nil
 end
+
+--- Iterator yielded by gmatch: each call returns the next match and
+--- its capture table, then nil when exhausted.
+local type MatchIterator = function(): string, {string}
 
 --- A located match: absolute 1-based start/stop, the matched text,
 --- and its capture groups.
@@ -116,7 +121,7 @@ end
 --- is not a silent undercount: all_matches gives up entirely (its
 --- caller sees nil, "failed to locate ..."/a short match count)
 --- as soon as a NEWLINE-anchored match past the first line is hit.
---- See findall's doc for the concrete case. A fix needs the
+--- See find_all's doc for the concrete case. A fix needs the
 --- verification window widened to include that neighboring byte,
 --- which reintroduces its own edge case (an off-by-one window can
 --- itself contain another literal occurrence of m); not attempted here.
@@ -186,48 +191,95 @@ local function all_matches(regex: Regex, text: string): {Span} | nil, string
   return spans
 end
 
---- Find every non-overlapping match of pattern in text, leftmost
---- first. Patterns that can match the empty string are rejected.
----
---- KNOWN LIMITATION with the NEWLINE flag: `^`/`$` anchors that only
---- match via an embedded newline (not the true start/end of text) fail
---- to be re-confirmed past the first line (see locate's doc), so
---- findall("^foo", "foo\nfoo", re.NEWLINE) returns nil, "failed to
---- locate match position for: foo" instead of {"foo", "foo"} -- use
---- split("\n", text) plus a per-line match instead when this matters.
---- @param pattern string The regex pattern to match
+--- Find the first match of pattern in text, with its position: a Span
+--- {s, e, m, caps} (absolute 1-based, inclusive). A no-match returns
+--- bare nil; a bad pattern or engine failure returns nil, err.
+--- Patterns that can match the empty string are rejected.
 --- @param text string The text to search in
+--- @param pattern string The regex pattern to match
 --- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE
---- @return {string} | nil The matched substrings (empty when none), or nil on error
+--- @return Span | nil The first match, or nil when none
 --- @return string? Error message on a bad pattern or engine failure
-local function findall(pattern: string, text: string, flags?: integer): {string} | nil, string
+local function find(text: string, pattern: string, flags?: integer): Span | nil, string
   local regex, cerr = compile_for_iter(pattern, flags)
   if not regex then
     return nil, cerr
   end
-  local spans, err = all_matches(regex, text)
+  local m, caps = (regex as Regex):search(text) -- cast: record union after guard
+  if not m then
+    if caps then
+      return nil, tostring(caps)
+    end
+    return nil
+  end
+  local start = locate(regex as Regex, text, 1, m) -- cast: record union after guard
+  if not start then
+    return nil, "failed to locate match position for: " .. m
+  end
+  return {s = start, e = start + #m - 1, m = m, caps = caps}
+end
+
+--- Every non-overlapping match of pattern in text, leftmost first, as
+--- Spans. Patterns that can match the empty string are rejected.
+---
+--- KNOWN LIMITATION with the NEWLINE flag: `^`/`$` anchors that only
+--- match via an embedded newline (not the true start/end of text) fail
+--- to be re-confirmed past the first line (see locate's doc), so
+--- find_all("foo\nfoo", "^foo", re.NEWLINE) returns nil, "failed to
+--- locate match position for: foo" instead of two spans -- use
+--- split plus a per-line match instead when this matters.
+--- @param text string The text to search in
+--- @param pattern string The regex pattern to match
+--- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE
+--- @return {Span} | nil The matches (empty when none), or nil on error
+--- @return string? Error message on a bad pattern or engine failure
+local function find_all(text: string, pattern: string, flags?: integer): {Span} | nil, string
+  local regex, cerr = compile_for_iter(pattern, flags)
+  if not regex then
+    return nil, cerr
+  end
+  return all_matches(regex as Regex, text) -- cast: record union after guard
+end
+
+--- Iterate every non-overlapping match, like string.gmatch: each step
+--- yields the matched text and its capture table. Matching is done up
+--- front (the engine reports no offsets, so lazy stepping buys
+--- nothing); a bad pattern or engine failure returns nil, err instead
+--- of an iterator. Shares find_all's NEWLINE limitation.
+--- @param text string The text to search in
+--- @param pattern string The regex pattern to match
+--- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE
+--- @return function | nil Iterator yielding (match, caps), or nil on error
+--- @return string? Error message on a bad pattern or engine failure
+local function gmatch(text: string, pattern: string, flags?: integer): MatchIterator, string
+  local spans, err = find_all(text, pattern, flags)
   if not spans then
     return nil, err
   end
-  local out: {string} = {}
-  for i, sp in ipairs(spans as {Span}) do -- cast: record union after guard
-    out[i] = sp.m
+  local i = 0
+  local iter: MatchIterator = function(): string, {string}
+    i = i + 1
+    local sp = (spans as {Span})[i] -- cast: record union after guard
+    if not sp then
+      return nil
+    end
+    return sp.m, sp.caps
   end
-  return out
+  return iter
 end
 
 --- Split text around every match of pattern. Fields between matches
 --- are kept verbatim, including empty ones from adjacent or
 --- leading/trailing matches; text with no match yields one field.
 --- Patterns that can match the empty string are rejected.
---- Shares findall's KNOWN LIMITATION with a NEWLINE-anchored `^`/`$`
---- past the first line (see findall's doc).
---- @param pattern string The regex pattern to split on
+--- Shares find_all's KNOWN LIMITATION with a NEWLINE-anchored `^`/`$`
+--- past the first line (see find_all's doc).
 --- @param text string The text to split
+--- @param pattern string The regex pattern to split on
 --- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE
 --- @return {string} | nil The fields, or nil on error
 --- @return string? Error message on a bad pattern or engine failure
-local function split(pattern: string, text: string, flags?: integer): {string} | nil, string
+local function split(text: string, pattern: string, flags?: integer): {string} | nil, string
   local regex, cerr = compile_for_iter(pattern, flags)
   if not regex then
     return nil, cerr
@@ -253,15 +305,15 @@ local type Repl = string | function(string, {string}): string
 
 --- Replace every non-overlapping match of pattern in text.
 --- Patterns that can match the empty string are rejected.
---- Shares findall's KNOWN LIMITATION with a NEWLINE-anchored `^`/`$`
---- past the first line (see findall's doc).
---- @param pattern string The regex pattern to match
+--- Shares find_all's KNOWN LIMITATION with a NEWLINE-anchored `^`/`$`
+--- past the first line (see find_all's doc).
 --- @param text string The text to operate on
+--- @param pattern string The regex pattern to match
 --- @param repl Repl A literal replacement string, or function(match, caps)
 --- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE
 --- @return string | nil The result, or nil on error
 --- @return string? Error message on a bad pattern or engine failure
-local function gsub(pattern: string, text: string, repl: Repl, flags?: integer): string | nil, string
+local function gsub(text: string, pattern: string, repl: Repl, flags?: integer): string | nil, string
   local regex, cerr = compile_for_iter(pattern, flags)
   if not regex then
     return nil, cerr
@@ -291,17 +343,21 @@ local function gsub(pattern: string, text: string, repl: Repl, flags?: integer):
 end
 
 local record ReModule
-  -- Exported so callers can name/cast the fallible compile result.
+  -- Exported so callers can name/cast the fallible results.
   type Regex = Regex
   type Repl = Repl
+  type Span = Span
 
-  -- Functions
+  -- Functions (subject first, D20)
   compile: function(pattern: string, flags?: integer): Regex | nil, string
-  search: function(pattern: string, text: string, flags?: integer): string | nil, {string} | nil, string | nil
-  test: function(pattern: string, text: string, flags?: integer): boolean, string
-  findall: function(pattern: string, text: string, flags?: integer): {string} | nil, string
-  split: function(pattern: string, text: string, flags?: integer): {string} | nil, string
-  gsub: function(pattern: string, text: string, repl: Repl, flags?: integer): string | nil, string
+  match: function(text: string, pattern: string, flags?: integer): string | nil, {string} | nil, string | nil
+  test: function(text: string, pattern: string, flags?: integer): boolean, string
+  find: function(text: string, pattern: string, flags?: integer): Span | nil, string
+  find_all: function(text: string, pattern: string, flags?: integer): {Span} | nil, string
+  type MatchIterator = MatchIterator
+  gmatch: function(text: string, pattern: string, flags?: integer): MatchIterator, string
+  split: function(text: string, pattern: string, flags?: integer): {string} | nil, string
+  gsub: function(text: string, pattern: string, repl: Repl, flags?: integer): string | nil, string
 
   -- Compile flags
   BASIC: integer -- Use basic (obsolete) regex syntax instead of extended
@@ -316,9 +372,11 @@ end
 
 local M: ReModule = {
   compile = compile,
-  search = search,
+  match = match,
   test = test,
-  findall = findall,
+  find = find,
+  find_all = find_all,
+  gmatch = gmatch,
   split = split,
   gsub = gsub,
 

--- a/cosmic/re_ops_test.tl
+++ b/cosmic/re_ops_test.tl
@@ -2,71 +2,85 @@
 local re = require("cosmic.re")
 local check = require("cosmic.check")
 
--- findall tests
+--- The old findall shape, over find_all: every match's text, in order.
+--- Also exercises Span fields via the m projection.
+local function matches_of(text: string, pat: string, flags?: integer): {string} | nil, string
+  local spans, err = re.find_all(text, pat, flags)
+  if not spans then
+    return nil, err
+  end
+  local out: {string} = {}
+  for i, sp in ipairs(spans as {re.Span}) do -- cast: record union after guard
+    out[i] = sp.m
+  end
+  return out
+end
 
-local function test_findall_basic()
-  local ms = check.must(re.findall("[0-9]+", "a1b22c333"))
+-- find_all / gmatch tests
+
+local function test_find_all_basic()
+  local ms = check.must(matches_of("a1b22c333", "[0-9]+"))
   assert(#ms == 3, "expected 3 matches, got " .. #ms)
   assert(ms[1] == "1" and ms[2] == "22" and ms[3] == "333", "expected 1,22,333")
 end
-test_findall_basic()
+test_find_all_basic()
 
-local function test_findall_no_match()
-  local ms = check.must(re.findall("[0-9]+", "abc"))
+local function test_find_all_no_match()
+  local ms = check.must(matches_of("abc", "[0-9]+"))
   assert(#ms == 0, "expected empty list for no matches")
 end
-test_findall_no_match()
+test_find_all_no_match()
 
-local function test_findall_non_overlapping()
-  local ms = check.must(re.findall("aa", "aaaa"))
+local function test_find_all_non_overlapping()
+  local ms = check.must(matches_of("aaaa", "aa"))
   assert(#ms == 2, "expected 2 non-overlapping matches, got " .. #ms)
 end
-test_findall_non_overlapping()
+test_find_all_non_overlapping()
 
-local function test_findall_leftmost_longest()
-  local ms = check.must(re.findall("ab*", "abbb ab a"))
+local function test_find_all_leftmost_longest()
+  local ms = check.must(matches_of("abbb ab a", "ab*"))
   assert(#ms == 3, "expected 3 matches, got " .. #ms)
   assert(ms[1] == "abbb" and ms[2] == "ab" and ms[3] == "a", "expected longest matches")
 end
-test_findall_leftmost_longest()
+test_find_all_leftmost_longest()
 
-local function test_findall_icase_flag()
-  local ms = check.must(re.findall("foo", "Foo foo FOO", re.ICASE))
+local function test_find_all_icase_flag()
+  local ms = check.must(matches_of("Foo foo FOO", "foo", re.ICASE))
   assert(#ms == 3, "expected 3 case-insensitive matches, got " .. #ms)
   assert(ms[1] == "Foo" and ms[3] == "FOO", "expected original casing in results")
 end
-test_findall_icase_flag()
+test_find_all_icase_flag()
 
-local function test_findall_bad_pattern()
-  local ms, err = re.findall("[", "abc")
+local function test_find_all_bad_pattern()
+  local ms, err = matches_of("abc", "[")
   assert(ms == nil and err ~= nil, "expected error for bad pattern")
 end
-test_findall_bad_pattern()
+test_find_all_bad_pattern()
 
-local function test_findall_empty_capable_rejected()
-  local ms, err = re.findall("x*", "abc")
+local function test_find_all_empty_capable_rejected()
+  local ms, err = matches_of("abc", "x*")
   assert(ms == nil, "expected empty-capable pattern to be rejected")
   assert(err and err:find("empty", 1, true), "expected empty-string error, got: " .. tostring(err))
 end
-test_findall_empty_capable_rejected()
+test_find_all_empty_capable_rejected()
 
 -- anchor positioning: the matched text also occurs before the true
 -- match position, so naive plain-find placement would corrupt results.
 
 local function test_anchor_dollar_positions_correctly()
-  assert(re.gsub("o$", "foo", "0") == "fo0", "expected only the final o replaced")
-  assert(re.gsub("a$", "banana", "X") == "bananX", "expected only the final a replaced")
+  assert(re.gsub("foo", "o$", "0") == "fo0", "expected only the final o replaced")
+  assert(re.gsub("banana", "a$", "X") == "bananX", "expected only the final a replaced")
 end
 test_anchor_dollar_positions_correctly()
 
 local function test_anchor_caret_only_start()
-  assert(re.gsub("^a", "aaa", "X") == "Xaa", "expected only the leading a replaced")
-  local ms = check.must(re.findall("^a+", "aa a"))
+  assert(re.gsub("aaa", "^a", "X") == "Xaa", "expected only the leading a replaced")
+  local ms = check.must(matches_of("aa a", "^a+"))
   assert(#ms == 1 and ms[1] == "aa", "expected a single anchored match")
 end
 test_anchor_caret_only_start()
 
--- DOCUMENTED LIMITATION (see re.tl's locate/findall doc comments): a
+-- DOCUMENTED LIMITATION (see re.tl locate/find_all doc comments): a
 -- `^`/`$` anchor satisfied only via an embedded newline under the
 -- NEWLINE flag (not true text start/end) cannot be re-confirmed by
 -- locate()'s exact-width verification window, so all_matches gives up
@@ -75,14 +89,14 @@ test_anchor_caret_only_start()
 -- deliberately instead of silently regressing an untested path.
 local function test_newline_anchor_past_first_line_is_a_known_limitation()
   -- Without NEWLINE, `^` only matches true text start: one match.
-  local ms = check.must(re.findall("^foo", "foo\nfoo"))
+  local ms = check.must(matches_of("foo\nfoo", "^foo"))
   assert(#ms == 1 and ms[1] == "foo", "expected a single match without NEWLINE")
 
   -- With NEWLINE, `^` should also match right after the embedded \n
   -- (regardless of NOTBOL, per POSIX) -- but locate() cannot verify
   -- that second candidate, so the whole call fails instead of
   -- returning {"foo", "foo"}.
-  local ms2, err2 = re.findall("^foo", "foo\nfoo", re.NEWLINE)
+  local ms2, err2 = matches_of("foo\nfoo", "^foo", re.NEWLINE)
   assert(ms2 == nil, "expected the known limitation to surface as nil, not a silent undercount")
   assert(err2 and err2:find("failed to locate", 1, true),
     "expected a 'failed to locate' error, got: " .. tostring(err2))
@@ -90,7 +104,7 @@ local function test_newline_anchor_past_first_line_is_a_known_limitation()
   -- The symmetric $ case fails differently (a short list, not nil),
   -- which is exactly why this is documented rather than papered over
   -- with one special case.
-  local ms3, err3 = re.findall("foo$", "foo\nfoo\nfoo", re.NEWLINE)
+  local ms3, err3 = matches_of("foo\nfoo\nfoo", "foo$", re.NEWLINE)
   assert(ms3 ~= nil and #ms3 == 1, "expected the documented undercount, got: "
     .. tostring(ms3) .. " " .. tostring(err3))
 end
@@ -99,14 +113,14 @@ test_newline_anchor_past_first_line_is_a_known_limitation()
 -- split tests
 
 local function test_split_basic()
-  local fields = check.must(re.split("[0-9]+", "a1b22c"))
+  local fields = check.must(re.split("a1b22c", "[0-9]+"))
   assert(#fields == 3, "expected 3 fields, got " .. #fields)
   assert(fields[1] == "a" and fields[2] == "b" and fields[3] == "c", "expected a,b,c")
 end
 test_split_basic()
 
 local function test_split_edges_and_adjacent()
-  local fields = check.must(re.split("-", "-a--b-"))
+  local fields = check.must(re.split("-a--b-", "-"))
   assert(#fields == 5, "expected 5 fields, got " .. #fields)
   assert(fields[1] == "" and fields[2] == "a" and fields[3] == "", "expected empty edge fields")
   assert(fields[4] == "b" and fields[5] == "", "expected trailing empty field")
@@ -114,13 +128,13 @@ end
 test_split_edges_and_adjacent()
 
 local function test_split_no_match()
-  local fields = check.must(re.split(",", "abc"))
+  local fields = check.must(re.split("abc", ","))
   assert(#fields == 1 and fields[1] == "abc", "expected whole string field")
 end
 test_split_no_match()
 
 local function test_split_whitespace_runs()
-  local fields = check.must(re.split("[ \t]+", "a  b\tc"))
+  local fields = check.must(re.split("a  b\tc", "[ \t]+"))
   assert(#fields == 3, "expected 3 fields, got " .. #fields)
   assert(fields[3] == "c", "expected c")
 end
@@ -129,20 +143,20 @@ test_split_whitespace_runs()
 -- gsub tests
 
 local function test_gsub_literal()
-  assert(re.gsub("[0-9]+", "a1b22c", "#") == "a#b#c", "expected digits replaced")
-  assert(re.gsub("x", "abc", "y") == "abc", "expected no-match text unchanged")
+  assert(re.gsub("a1b22c", "[0-9]+", "#") == "a#b#c", "expected digits replaced")
+  assert(re.gsub("abc", "x", "y") == "abc", "expected no-match text unchanged")
 end
 test_gsub_literal()
 
 local function test_gsub_replacement_is_plain()
   -- No capture references: %1 and & are literal text in the replacement.
-  assert(re.gsub("b", "abc", "%1") == "a%1c", "expected %1 kept literal")
-  assert(re.gsub("b", "abc", "&") == "a&c", "expected & kept literal")
+  assert(re.gsub("abc", "b", "%1") == "a%1c", "expected %1 kept literal")
+  assert(re.gsub("abc", "b", "&") == "a&c", "expected & kept literal")
 end
 test_gsub_replacement_is_plain()
 
 local function test_gsub_function_repl()
-  local out = assert(re.gsub("[0-9]+", "a1b22c", function(m: string, _caps: {string}): string
+  local out = assert(re.gsub("a1b22c", "[0-9]+", function(m: string, _caps: {string}): string
         return "<" .. m .. ">"
       end))
   assert(out == "a<1>b<22>c", "expected wrapped digits, got " .. tostring(out))
@@ -150,7 +164,7 @@ end
 test_gsub_function_repl()
 
 local function test_gsub_function_uses_captures()
-  local out = assert(re.gsub("([a-z]+)=([0-9]+)", "x=1, y=22", function(_m: string, caps: {string}): string
+  local out = assert(re.gsub("x=1, y=22", "([a-z]+)=([0-9]+)", function(_m: string, caps: {string}): string
         return caps[2] .. "=" .. caps[1]
       end))
   assert(out == "1=x, 22=y", "expected swapped pairs, got " .. tostring(out))
@@ -158,7 +172,7 @@ end
 test_gsub_function_uses_captures()
 
 local function test_gsub_function_nil_keeps_match()
-  local out = assert(re.gsub("[0-9]+", "a1b22c", function(m: string, _caps: {string}): string
+  local out = assert(re.gsub("a1b22c", "[0-9]+", function(m: string, _caps: {string}): string
         if m == "22" then
           return "<22>"
         end
@@ -169,14 +183,40 @@ end
 test_gsub_function_nil_keeps_match()
 
 local function test_gsub_whole_string_match()
-  assert(re.gsub("^abc$", "abc", "X") == "X", "expected whole-string match replaced")
+  assert(re.gsub("abc", "^abc$", "X") == "X", "expected whole-string match replaced")
 end
 test_gsub_whole_string_match()
 
 local function test_gsub_bad_pattern_and_empty_capable()
-  local out, err = re.gsub("[", "abc", "x")
+  local out, err = re.gsub("abc", "[", "x")
   assert(out == nil and err ~= nil, "expected error for bad pattern")
-  out, err = re.gsub("a?", "abc", "x")
+  out, err = re.gsub("abc", "a?", "x")
   assert(out == nil and err ~= nil, "expected empty-capable pattern rejected")
 end
 test_gsub_bad_pattern_and_empty_capable()
+
+local function test_find_reports_position()
+  local sp = check.must(re.find("a1b22c", "[0-9]+"))
+  assert(sp.s == 2 and sp.e == 2 and sp.m == "1",
+    "expected first match '1' at 2..2, got " .. sp.m .. " at " .. sp.s .. ".." .. sp.e)
+  local none = re.find("abc", "[0-9]+")
+  assert(none == nil, "no match is bare nil")
+  local bad, err = re.find("abc", "[")
+  assert(bad == nil and err ~= nil, "a bad pattern reports an error")
+end
+test_find_reports_position()
+
+local function test_gmatch_iterates_matches_and_caps()
+  local iter = check.must(re.gmatch("a1b22c333", "([0-9])([0-9]*)"))
+  local got: {string} = {}
+  local first_caps: {string} = nil
+  for m, caps in iter do
+    got[#got + 1] = m
+    if not first_caps then first_caps = caps end
+  end
+  assert(#got == 3 and got[3] == "333", "expected 3 matches ending 333")
+  assert(first_caps[1] == "1" and first_caps[2] == "", "caps carried through")
+  local bad, err = re.gmatch("abc", "[")
+  assert(bad == nil and err ~= nil, "a bad pattern reports an error, not an iterator")
+end
+test_gmatch_iterates_matches_and_caps()

--- a/cosmic/re_test.tl
+++ b/cosmic/re_test.tl
@@ -100,7 +100,7 @@ test_regex_search_no_match_no_error()
 -- search convenience function tests
 
 local function test_search_simple()
-  local result, caps, err = re.search("world", "hello world")
+  local result, caps, err = re.match("hello world", "world")
   assert(err == nil, "expected no error, got: " .. tostring(err))
   assert(result == "world", "expected 'world', got '" .. tostring(result) .. "'")
   local c = check.must(caps)
@@ -110,7 +110,7 @@ test_search_simple()
 
 local function test_search_no_match()
   -- No match is not an error: a bare nil, no captures, no error message.
-  local result, caps, err = re.search("xyz", "hello world")
+  local result, caps, err = re.match("hello world", "xyz")
   assert(result == nil, "expected nil for no match")
   assert(caps == nil, "expected nil captures for no match")
   assert(err == nil, "expected no error for no match")
@@ -118,7 +118,7 @@ end
 test_search_no_match()
 
 local function test_search_invalid_pattern()
-  local result, caps, err = re.search("[invalid", "hello world")
+  local result, caps, err = re.match("hello world", "[invalid")
   assert(result == nil, "expected nil for invalid pattern")
   assert(caps == nil, "expected nil captures for invalid pattern")
   assert(err ~= nil, "expected error message")
@@ -127,7 +127,7 @@ end
 test_search_invalid_pattern()
 
 local function test_search_captures()
-  local result, caps, err = re.search("([0-9]+)-([a-z]+)", "id 42-abc!")
+  local result, caps, err = re.match("id 42-abc!", "([0-9]+)-([a-z]+)")
   assert(err == nil, "expected no error, got: " .. tostring(err))
   assert(result == "42-abc", "expected '42-abc', got '" .. tostring(result) .. "'")
   local c = check.must(caps, "expected captures table")
@@ -138,7 +138,7 @@ end
 test_search_captures()
 
 local function test_search_nonparticipating_group()
-  local result, caps = re.search("(aa)|(bb)", "xxaaxx")
+  local result, caps = re.match("xxaaxx", "(aa)|(bb)")
   assert(result == "aa", "expected 'aa', got '" .. tostring(result) .. "'")
   local c = check.must(caps)
   assert(#c == 2, "expected 2 capture slots, got " .. tostring(#c))
@@ -148,22 +148,22 @@ end
 test_search_nonparticipating_group()
 
 local function test_search_regex_metacharacters()
-  local result = re.search("h.llo", "hello")
+  local result = re.match("hello", "h.llo")
   assert(result == "hello", "expected 'hello', got '" .. tostring(result) .. "'")
 end
 test_search_regex_metacharacters()
 
 local function test_search_quantifiers()
-  local result = re.search("he+llo", "heeeello world")
+  local result = re.match("heeeello world", "he+llo")
   assert(result == "heeeello", "expected 'heeeello', got '" .. tostring(result) .. "'")
 end
 test_search_quantifiers()
 
 local function test_search_optional()
-  local result = re.search("colou?r", "color")
+  local result = re.match("color", "colou?r")
   assert(result == "color", "expected 'color', got '" .. tostring(result) .. "'")
 
-  result = re.search("colou?r", "colour")
+  result = re.match("colour", "colou?r")
   assert(result == "colour", "expected 'colour', got '" .. tostring(result) .. "'")
 end
 test_search_optional()
@@ -171,21 +171,21 @@ test_search_optional()
 -- match convenience function tests
 
 local function test_match_true()
-  local result, err = re.test("world", "hello world")
+  local result, err = re.test("hello world", "world")
   assert(err == nil, "expected no error")
   assert(result == true, "expected true for matching pattern")
 end
 test_match_true()
 
 local function test_match_false()
-  local result, err = re.test("xyz", "hello world")
+  local result, err = re.test("hello world", "xyz")
   assert(err == nil, "expected no error")
   assert(result == false, "expected false for non-matching pattern")
 end
 test_match_false()
 
 local function test_match_invalid_pattern()
-  local result, err = re.test("[invalid", "hello world")
+  local result, err = re.test("hello world", "[invalid")
   assert(result == false, "expected false for invalid pattern")
   assert(err ~= nil, "expected error message")
 end
@@ -195,11 +195,11 @@ test_match_invalid_pattern()
 
 local function test_icase_flag()
   -- Without ICASE, should not match
-  local result = re.search("HELLO", "hello world")
+  local result = re.match("hello world", "HELLO")
   assert(result == nil, "expected nil without ICASE flag")
 
   -- With ICASE, should match
-  result = re.search("HELLO", "hello world", re.ICASE)
+  result = re.match("hello world", "HELLO", re.ICASE)
   assert(result == "hello", "expected 'hello' with ICASE flag, got '" .. tostring(result) .. "'")
 end
 test_icase_flag()
@@ -226,34 +226,34 @@ test_flags_exist()
 -- edge case tests
 
 local function test_empty_pattern()
-  local result = re.search("", "hello")
+  local result = re.match("hello", "")
   -- Empty pattern matches empty string at start
   assert(result == "", "expected empty string match, got '" .. tostring(result) .. "'")
 end
 test_empty_pattern()
 
 local function test_empty_text()
-  local result = re.search("hello", "")
+  local result = re.match("", "hello")
   assert(result == nil, "expected nil for empty text")
 end
 test_empty_text()
 
 local function test_full_match()
-  local result = re.search("^hello world$", "hello world")
+  local result = re.match("hello world", "^hello world$")
   assert(result == "hello world", "expected full match")
 end
 test_full_match()
 
 local function test_special_characters()
   -- Dot matches any character
-  local result = re.search("a.c", "abc")
+  local result = re.match("abc", "a.c")
   assert(result == "abc", "expected 'abc', got '" .. tostring(result) .. "'")
 end
 test_special_characters()
 
 local function test_escaped_special_characters()
   -- Escaped dot matches literal dot
-  local result = re.search("a\\.c", "a.c")
+  local result = re.match("a.c", "a\\.c")
   assert(result == "a.c", "expected 'a.c', got '" .. tostring(result) .. "'")
 end
 test_escaped_special_characters()

--- a/cosmic/tty.tl
+++ b/cosmic/tty.tl
@@ -51,11 +51,13 @@ local record TtyModule
   VMIN: integer
   VTIME: integer
 
+  is_tty: function(fd?: integer): boolean
+  -- DEPRECATED aliases (api-review-8 pin-advance transition)
   isatty: function(fd: integer): boolean
-  winsize: function(fd: integer): WinSize | nil, string
   stdin_isatty: function(): boolean
   stdout_isatty: function(): boolean
   stderr_isatty: function(): boolean
+  winsize: function(fd: integer): WinSize | nil, string
   getattr: function(fd: integer): Termios | nil, string
   setattr: function(fd: integer, action: integer, termios: Termios): boolean, string
   make_raw: function(termios: Termios, opts?: RawOptions): Termios
@@ -100,11 +102,14 @@ local function login_tty(fd: integer): boolean, string
   return true
 end
 
---- Checks if a file descriptor refers to a terminal.
---- @param fd integer File descriptor to check (0=stdin, 1=stdout, 2=stderr)
+--- Checks if a file descriptor refers to a terminal (api-review-8:
+--- one is_tty(fd?) replaces isatty plus the three per-stream wrappers).
+--- @param fd integer? File descriptor to check: 0=stdin, 1=stdout
+--- (the default — "is my output a terminal" is the common question),
+--- 2=stderr
 --- @return boolean True if fd is a terminal
-local function isatty(fd: integer): boolean
-  return (unix.isatty(fd))
+local function is_tty(fd?: integer): boolean
+  return (unix.isatty(fd or 1))
 end
 
 --- Gets the terminal window size for a file descriptor.
@@ -119,24 +124,6 @@ local function winsize(fd: integer): TtyModule.WinSize | nil, string
     return nil, errstr(cols, "tiocgwinsz")
   end
   return {rows = rows, cols = cols}
-end
-
---- Checks if stdin is a terminal.
---- @return boolean True if stdin is a terminal
-local function stdin_isatty(): boolean
-  return (unix.isatty(0))
-end
-
---- Checks if stdout is a terminal.
---- @return boolean True if stdout is a terminal
-local function stdout_isatty(): boolean
-  return (unix.isatty(1))
-end
-
---- Checks if stderr is a terminal.
---- @return boolean True if stderr is a terminal
-local function stderr_isatty(): boolean
-  return (unix.isatty(2))
 end
 
 --- Gets terminal attributes for a file descriptor.
@@ -308,11 +295,12 @@ local function getpass(prompt: string): string | nil, string
 end
 
 local M: TtyModule = {
-  isatty = isatty,
+  is_tty = is_tty,
+  isatty = is_tty,
+  stdin_isatty = function(): boolean return is_tty(0) end,
+  stdout_isatty = function(): boolean return is_tty(1) end,
+  stderr_isatty = function(): boolean return is_tty(2) end,
   winsize = winsize,
-  stdin_isatty = stdin_isatty,
-  stdout_isatty = stdout_isatty,
-  stderr_isatty = stderr_isatty,
   getattr = getattr,
   setattr = setattr,
   make_raw = make_raw,

--- a/cosmic/tty_pty_test.tl
+++ b/cosmic/tty_pty_test.tl
@@ -55,9 +55,9 @@ end
 --- still "pass" while proving nothing.
 local function test_openpty_yields_a_real_terminal()
   local pty = with_pty()
-  assert(tty.isatty(pty.subordinate),
+  assert(tty.is_tty(pty.subordinate),
     "the subordinate fd must be a terminal")
-  assert(tty.isatty(pty.manager), "the manager fd must be a terminal")
+  assert(tty.is_tty(pty.manager), "the manager fd must be a terminal")
   assert(pty.name:match("^/dev/"),
     "expected a device path, got: " .. tostring(pty.name))
   local ws = check.must(tty.winsize(pty.subordinate))

--- a/cosmic/tty_test.tl
+++ b/cosmic/tty_test.tl
@@ -8,49 +8,44 @@ local tty = require("cosmic.tty")
 -- Test module exports
 
 local function test_module_exports()
-  assert(tty.isatty ~= nil, "isatty function should be exported")
+  assert(tty.is_tty ~= nil, "is_tty function should be exported")
   assert(tty.winsize ~= nil, "winsize function should be exported")
-  assert(tty.stdin_isatty ~= nil, "stdin_isatty function should be exported")
-  assert(tty.stdout_isatty ~= nil, "stdout_isatty function should be exported")
-  assert(tty.stderr_isatty ~= nil, "stderr_isatty function should be exported")
 end
 test_module_exports()
 
--- isatty: assert real verdicts on fds whose tty-ness is
+-- is_tty: assert real verdicts on fds whose tty-ness is
 -- known, instead of only checking the return type.
 
-local function test_isatty_regular_file_is_false()
+local function test_is_tty_regular_file_is_false()
   local test_file = fs.join(check.must(os.getenv("TEST_TMPDIR")), "not_a_tty")
   fs.write(test_file, "x")
   local h = check.must(cfd.open(test_file, cfd.O_RDONLY), "should open the scratch file")
-  assert(tty.isatty(h:fd()) == false, "a regular file fd is not a tty")
+  assert(tty.is_tty(h:fd()) == false, "a regular file fd is not a tty")
   h:close()
 end
-test_isatty_regular_file_is_false()
+test_is_tty_regular_file_is_false()
 
-local function test_isatty_bad_fd_is_false()
-  assert(tty.isatty(999) == false, "an unopened fd is not a tty")
+local function test_is_tty_bad_fd_is_false()
+  assert(tty.is_tty(999) == false, "an unopened fd is not a tty")
 end
-test_isatty_bad_fd_is_false()
+test_is_tty_bad_fd_is_false()
 
-local function test_isatty_pty_master_is_true()
+local function test_is_tty_pty_master_is_true()
   -- A pty master is the one fd guaranteed to BE a tty. /dev/ptmx exists
   -- on Linux; elsewhere this case is exercised wherever the device exists.
   if not fs.exists("/dev/ptmx") then
     return
   end
   local h = check.must(cfd.open("/dev/ptmx", cfd.O_RDWR))
-  assert(tty.isatty(h:fd()) == true, "a pty master must report as a tty")
+  assert(tty.is_tty(h:fd()) == true, "a pty master must report as a tty")
   h:close()
 end
-test_isatty_pty_master_is_true()
+test_is_tty_pty_master_is_true()
 
-local function test_convenience_functions_agree_with_isatty()
-  assert(tty.stdin_isatty() == tty.isatty(0), "stdin_isatty must equal isatty(0)")
-  assert(tty.stdout_isatty() == tty.isatty(1), "stdout_isatty must equal isatty(1)")
-  assert(tty.stderr_isatty() == tty.isatty(2), "stderr_isatty must equal isatty(2)")
+local function test_is_tty_defaults_to_stdout()
+  assert(tty.is_tty() == tty.is_tty(1), "no-arg is_tty asks about stdout")
 end
-test_convenience_functions_agree_with_isatty()
+test_is_tty_defaults_to_stdout()
 
 -- Test winsize function
 
@@ -64,7 +59,7 @@ local function test_winsize_non_tty()
     f:close()
   end
   -- In test environment, fd 0 is likely not a tty
-  if not tty.isatty(0) then
+  if not tty.is_tty(0) then
     local ws, err = tty.winsize(0)
     -- Should return nil or a valid winsize
     if ws == nil then
@@ -76,7 +71,7 @@ test_winsize_non_tty()
 
 local function test_winsize_structure()
   -- If stdout is a tty, verify winsize returns proper structure
-  if not tty.isatty(1) then
+  if not tty.is_tty(1) then
     io.stderr:write("SKIP: test_winsize_structure (stdout is not a tty)\n")
     return
   end
@@ -117,7 +112,7 @@ test_termios_constants()
 
 local function test_getattr_non_tty()
   -- When not a tty, getattr should fail with error
-  if not tty.isatty(0) then
+  if not tty.is_tty(0) then
     local termios, err = tty.getattr(0)
     assert(termios == nil, "getattr should return nil for non-tty")
     assert(err ~= nil, "getattr should return error message for non-tty")
@@ -127,7 +122,7 @@ test_getattr_non_tty()
 
 local function test_getattr_structure()
   -- If stdin is a tty, verify getattr returns proper structure
-  if not tty.isatty(0) then
+  if not tty.is_tty(0) then
     io.stderr:write("SKIP: test_getattr_structure (stdin is not a tty)\n")
     return
   end
@@ -147,7 +142,7 @@ test_getattr_structure()
 
 local function test_raw_non_tty()
   -- When not a tty, raw should fail with error
-  if not tty.isatty(0) then
+  if not tty.is_tty(0) then
     local original, err = tty.raw(0)
     assert(original == nil, "raw should return nil for non-tty")
     assert(err ~= nil, "raw should return error message for non-tty")
@@ -157,7 +152,7 @@ test_raw_non_tty()
 
 local function test_noecho_non_tty()
   -- When not a tty, noecho should fail with error
-  if not tty.isatty(0) then
+  if not tty.is_tty(0) then
     local original, err = tty.noecho(0)
     assert(original == nil, "noecho should return nil for non-tty")
     assert(err ~= nil, "noecho should return error message for non-tty")

--- a/cosmic/url.tl
+++ b/cosmic/url.tl
@@ -1,28 +1,33 @@
 --- URL encoding, decoding, parsing, formatting, and escaping utilities.
 local cosmo = require("cosmo")
 
---- Percent-encode a string for use as a URL query parameter value.
---- Use this when building query strings manually: `"q=" .. url.encode(search_term)`.
---- Spaces become %20, special characters become %XX hex sequences.
+--- Percent-encode a string for use as a URL query parameter value
+--- (api-review-8: was `encode` — escape/unescape is the syntax-safety
+--- verb pair, D20). Spaces become %20, specials become %XX.
+--- Use this when building query strings manually:
+--- `"q=" .. url.escape_param(term)` — or format_query() for whole maps.
 ---
 --- For other URL components, use the specific escape functions:
 --- - `escape_path()`: encode a URL path (preserves slashes)
 --- - `escape_segment()`: encode a single path segment (escapes slashes)
 --- - `escape_host()`: encode a hostname
 --- - `escape_fragment()`: encode a URL fragment
+--- and `unescape()` as their shared inverse.
 ---
 --- @param str string The string to encode
 --- @return string The percent-encoded string
-local function encode(str: string): string
+local function escape_param(str: string): string
   return cosmo.EscapeParam(str)
 end
 
---- Decode a percent-encoded string.
---- Handles %XX sequences and + as space.
+--- Decode a percent-encoded query parameter (api-review-8: was
+--- `decode`). Handles %XX sequences and + as space — the param rules.
+--- For other components (paths, hosts, fragments), where + is a
+--- literal plus, use unescape().
 --- @param str string The percent-encoded string
 --- @return string | nil The decoded string, or nil on error
 --- @return string? Error message if decoding failed
-local function decode(str: string): string | nil, string
+local function unescape_param(str: string): string | nil, string
   -- Check for invalid percent-encoding sequences before decoding.
   -- UnescapeParam is lenient (a % not followed by two hex digits passes
   -- through unchanged), so reject malformed input up front; the C
@@ -33,6 +38,21 @@ local function decode(str: string): string | nil, string
 
   -- Use native C implementation for the actual decoding
   return cosmo.UnescapeParam(str)
+end
+
+--- Decode %XX sequences with NO plus-as-space conversion: the shared
+--- inverse of escape_path/escape_segment/escape_host/escape_fragment,
+--- where `+` is an ordinary character.
+--- @param str string The percent-encoded string
+--- @return string | nil The decoded string, or nil on error
+--- @return string? Error message if decoding failed
+local function unescape(str: string): string | nil, string
+  if not cosmo.IsValidPercentEncoding(str) then
+    return nil, "invalid percent-encoding"
+  end
+  return (str:gsub("%%(%x%x)", function(hex: string): string
+        return string.char(tonumber(hex, 16) as integer) -- cast: %x%x is a hex pair
+      end))
 end
 
 --- Parse a query string into its key-value pairs, keeping every value.
@@ -53,6 +73,27 @@ local function parse_query(query: string): {string: {string}}
     table.insert(list, pair[2] or "")
   end
   return result
+end
+
+--- Format a query map back into a query string: the inverse of
+--- parse_query. Keys are sorted (deterministic output) and each of a
+--- key's values becomes its own k=v pair, in order; both halves are
+--- percent-encoded with the param rules (spaces become %20).
+--- @param params {string:{string}} Keys, each with all its values in order
+--- @return string The query string (no leading ?)
+local function format_query(params: {string: {string}}): string
+  local keys: {string} = {}
+  for k in pairs(params) do
+    keys[#keys + 1] = k
+  end
+  table.sort(keys)
+  local out: {string} = {}
+  for _, k in ipairs(keys) do
+    for _, v in ipairs(params[k]) do
+      out[#out + 1] = escape_param(k) .. "=" .. escape_param(v)
+    end
+  end
+  return table.concat(out, "&")
 end
 
 --- Parsed URL components.
@@ -267,11 +308,13 @@ local record UrlModule
   type Url = Url
   type HostPort = HostPort
 
-  encode: function(str: string): string
-  decode: function(str: string): string | nil, string
+  escape_param: function(str: string): string
+  unescape_param: function(str: string): string | nil, string
+  unescape: function(str: string): string | nil, string
   parse: function(url: string): Url | nil, string
   format: function(u: Url): string
   parse_query: function(query: string): {string: {string}}
+  format_query: function(params: {string: {string}}): string
   parse_host: function(hostport: string): HostPort | nil, string
   escape_host: function(str: string): string
   escape_path: function(str: string): string
@@ -284,8 +327,10 @@ local record UrlModule
 end
 
 local M: UrlModule = {
-  encode = encode,
-  decode = decode,
+  escape_param = escape_param,
+  unescape_param = unescape_param,
+  unescape = unescape,
+  format_query = format_query,
   parse = parse,
   format = format,
   parse_query = parse_query,

--- a/cosmic/url_test.tl
+++ b/cosmic/url_test.tl
@@ -2,115 +2,115 @@
 local check = require("cosmic.check")
 local url = require("cosmic.url")
 
-local function test_encode_spaces()
-  local result = url.encode("hello world")
+local function test_escape_param_spaces()
+  local result = url.escape_param("hello world")
   assert(result == "hello%20world", "expected 'hello%20world', got '" .. result .. "'")
 end
-test_encode_spaces()
+test_escape_param_spaces()
 
-local function test_encode_special_chars()
-  local result = url.encode("a,b&c=d")
+local function test_escape_param_special_chars()
+  local result = url.escape_param("a,b&c=d")
   assert(result:match("%%2C"), "expected comma to be encoded")
   assert(result:match("%%26"), "expected ampersand to be encoded")
   assert(result:match("%%3D"), "expected equals to be encoded")
 end
-test_encode_special_chars()
+test_escape_param_special_chars()
 
-local function test_encode_unreserved_chars()
+local function test_escape_param_unreserved_chars()
   -- Most unreserved characters should not be encoded: A-Z a-z 0-9 - _ .
   -- Note: cosmo.EscapeParam encodes ~ as %7E (conservative but valid)
-  local result = url.encode("ABC-xyz_123.test")
+  local result = url.escape_param("ABC-xyz_123.test")
   assert(result == "ABC-xyz_123.test", "unreserved chars should pass through, got '" .. result .. "'")
 end
-test_encode_unreserved_chars()
+test_escape_param_unreserved_chars()
 
-local function test_decode_percent_sequences()
-  local result = url.decode("hello%20world")
+local function test_unescape_param_percent_sequences()
+  local result = url.unescape_param("hello%20world")
   assert(result == "hello world", "expected 'hello world', got '" .. tostring(result) .. "'")
 end
-test_decode_percent_sequences()
+test_unescape_param_percent_sequences()
 
-local function test_decode_plus_as_space()
-  local result = url.decode("hello+world")
+local function test_unescape_param_plus_as_space()
+  local result = url.unescape_param("hello+world")
   assert(result == "hello world", "expected 'hello world', got '" .. tostring(result) .. "'")
 end
-test_decode_plus_as_space()
+test_unescape_param_plus_as_space()
 
-local function test_decode_mixed()
-  local result = url.decode("a%2Cb%26c%3Dd")
+local function test_unescape_param_mixed()
+  local result = url.unescape_param("a%2Cb%26c%3Dd")
   assert(result == "a,b&c=d", "expected 'a,b&c=d', got '" .. tostring(result) .. "'")
 end
-test_decode_mixed()
+test_unescape_param_mixed()
 
 local function test_roundtrip_basic()
   local original = "hello world"
-  local encoded = url.encode(original)
-  local decoded = url.decode(encoded)
+  local encoded = url.escape_param(original)
+  local decoded = url.unescape_param(encoded)
   assert(decoded == original, "roundtrip failed: expected '" .. original .. "', got '" .. tostring(decoded) .. "'")
 end
 test_roundtrip_basic()
 
 local function test_roundtrip_special()
   local original = "name=value&foo=bar"
-  local encoded = url.encode(original)
-  local decoded = url.decode(encoded)
+  local encoded = url.escape_param(original)
+  local decoded = url.unescape_param(encoded)
   assert(decoded == original, "roundtrip failed: expected '" .. original .. "', got '" .. tostring(decoded) .. "'")
 end
 test_roundtrip_special()
 
 local function test_roundtrip_unicode()
   local original = "日本語テスト"
-  local encoded = url.encode(original)
-  local decoded = url.decode(encoded)
+  local encoded = url.escape_param(original)
+  local decoded = url.unescape_param(encoded)
   assert(decoded == original, "unicode roundtrip failed")
 end
 test_roundtrip_unicode()
 
-local function test_decode_invalid_trailing_percent()
-  local result, err = url.decode("test%")
+local function test_unescape_param_invalid_trailing_percent()
+  local result, err = url.unescape_param("test%")
   assert(result == nil, "expected nil for trailing %")
   assert(err ~= nil, "expected error message")
   assert(err == "invalid percent-encoding", "expected 'invalid percent-encoding', got '" .. err .. "'")
 end
-test_decode_invalid_trailing_percent()
+test_unescape_param_invalid_trailing_percent()
 
-local function test_decode_invalid_single_hex()
-  local result, err = url.decode("test%A")
+local function test_unescape_param_invalid_single_hex()
+  local result, err = url.unescape_param("test%A")
   assert(result == nil, "expected nil for single hex digit")
   assert(err ~= nil, "expected error message")
 end
-test_decode_invalid_single_hex()
+test_unescape_param_invalid_single_hex()
 
-local function test_decode_invalid_non_hex()
-  local result, err = url.decode("test%ZZ")
+local function test_unescape_param_invalid_non_hex()
+  local result, err = url.unescape_param("test%ZZ")
   assert(result == nil, "expected nil for non-hex digits")
   assert(err ~= nil, "expected error message")
 end
-test_decode_invalid_non_hex()
+test_unescape_param_invalid_non_hex()
 
-local function test_decode_empty_string()
-  local result = url.decode("")
+local function test_unescape_param_empty_string()
+  local result = url.unescape_param("")
   assert(result == "", "expected empty string")
 end
-test_decode_empty_string()
+test_unescape_param_empty_string()
 
-local function test_encode_empty_string()
-  local result = url.encode("")
+local function test_escape_param_empty_string()
+  local result = url.escape_param("")
   assert(result == "", "expected empty string")
 end
-test_encode_empty_string()
+test_escape_param_empty_string()
 
-local function test_decode_lowercase_hex()
-  local result = url.decode("%2f%3a")
+local function test_unescape_param_lowercase_hex()
+  local result = url.unescape_param("%2f%3a")
   assert(result == "/:", "expected '/:' for lowercase hex, got '" .. tostring(result) .. "'")
 end
-test_decode_lowercase_hex()
+test_unescape_param_lowercase_hex()
 
-local function test_decode_uppercase_hex()
-  local result = url.decode("%2F%3A")
+local function test_unescape_param_uppercase_hex()
+  local result = url.unescape_param("%2F%3A")
   assert(result == "/:", "expected '/:' for uppercase hex, got '" .. tostring(result) .. "'")
 end
-test_decode_uppercase_hex()
+test_unescape_param_uppercase_hex()
 
 -- parse_query tests
 


### PR DESCRIPTION
PR 8b of the API consistency review (after #885–#893): the D20 rename-table rows that change *shape*, not just spelling.

## re — subject-first, and the match/find family

Module functions flip to **subject-first**, matching the string library they sit beside: `re.match(text, pattern)` replaces `re.search(pattern, text)`; `test`/`split`/`gsub` flip the same way. New surface:

- `find(text, pattern)` → exported `Span {s, e, m, caps}` (absolute 1-based)
- `find_all(text, pattern)` → `{Span}`
- `gmatch(text, pattern)` → a `(match, caps)` iterator (matching is eager — the engine reports no offsets, so lazy stepping buys nothing; a bad pattern returns `nil, err` instead of an iterator)

`findall` is gone (its string-list projection is one loop over `find_all`). The compiled `Regex` keeps the binding's own `:search` method name — a userdata metatable is the C layer's to name.

## tty — one `is_tty(fd?)`

Replaces `isatty` + `stdin_isatty`/`stdout_isatty`/`stderr_isatty`. Default fd is 1 — "is my output a terminal" is the question ansi gating asks. The old four remain as deprecated runtime aliases until the pin advances (the pinned binary's embedded dispatcher calls `stderr_isatty` against the tree's tty during a cold build).

## url — the escape family completed

- `escape_param`/`unescape_param` replace `encode`/`decode` (D20: escape/unescape is the syntax-safety pair; encode/decode is for representation changes like json).
- New `unescape()`: %XX decoding with **no** plus-as-space — the shared inverse for `escape_path`/`escape_host`/`escape_segment`/`escape_fragment` (the binding only ships `UnescapeParam`; plus-conversion is a param-only rule).
- New `format_query()`: the inverse of `parse_query` (sorted keys, each of a key's values its own pair) — fetch had been privately reimplementing it.

## html — `unescape()` lands

`escape()`'s inverse per D20's both-halves rule: the five entities escape produces plus common aliases (`&apos;`, `&#34;`), non-cascading (`&amp;lt;` decodes to the *text* `&lt;`), unknown entities pass through.

## net — `ConnectOptions{timeout_ms}` absorbs `nb_connect`

`connect_tcp(addr, port, {timeout_ms = 5000})` and `dial(host, port, opts)` bound the connect attempt and hand back a **blocking** socket — the old `nb_connect` made the caller create the socket, left it non-blocking, and was the module's sharpest edge. Synchronous failures (ENETUNREACH) still return immediately rather than waiting out the poll (test asserts on elapsed time). Implementation lives in a new `cosmic.net.connect` shard (`net/init.tl` was at the 500-line cap).

Also: AGENTS.md's cosmo-mapping table right sides catch up with the 8a renames (dot-prefixed, so the mechanical sweep had skipped them).

**Remaining for the final slice (8c):** zip `Archive`/`Builder` + `open`/`open_bytes`, fs `find`/`find_iter`, syslog `Level` enum, and the check.fails/needs behavior changes.

Local gate: `ci: PASS (5 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FP31Qs2Ei4uJUsimFMpvkS

---
_Generated by [Claude Code](https://claude.ai/code/session_01FP31Qs2Ei4uJUsimFMpvkS)_