### PR TITLE
fs.Stat has one representation: the raw stat userdata, and `is` works

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,11 +196,10 @@ or map unions through truthiness (`if not x`). Three sanctioned tools:
   (compiles to one `type(x) == "table"` check). Also works for dispatch over `any` (`if
   v is {string: any} then`). A record whose runtime values are userdata needs Teal's
   `userdata` member in its OWN source (see re.tl's Regex) — then `is` compiles to the
-  correct `type(x) == "userdata"` test everywhere. Caveats: narrowing does NOT survive
-  an early-exit guard (`if not (x is Rec) then return end` does not narrow below); and
-  `is` is WRONG for mixed-representation records — `fs.Stat` is usually the raw stat
-  userdata but falls back to a plain wrapper table, so neither marker fits; it stays on
-  casts. `is` works with required `cosmo.*` classes too — the cosmic searcher is the
+  correct `type(x) == "userdata"` test everywhere (`fs.Stat` is one: always the raw
+  stat userdata since the representation unification, so `st is fs.Stat` narrows).
+  Caveat: narrowing does NOT survive an early-exit guard (`if not (x is Rec) then
+  return end` does not narrow below). `is` works with required `cosmo.*` classes too — the cosmic searcher is the
   only loader cosmic installs, and it resolves `.d.tl` markers. The one unsupported path
   is user code calling `require("tl").loader()`, which shadows it with tl's silent one.
 - **Cast in linear code and at userdata boundaries**: after an assert or
@@ -212,7 +211,7 @@ Every `as` cast must carry a justification (enforced by `--make lint`):
 a line containing a cast needs `-- cast: <reason>` trailing on the line,
 or as a comment on the line directly above when the 90-column width
 won't fit it. Write the actual reason (`from any`, `userdata boundary`,
-`tuple element`, `mixed-representation Stat`, ...) — a cast you cannot
+`tuple element`, `record union after guard`, ...) — a cast you cannot
 justify is one to remove, via `is`, `check.must`, or a precise type.
 
 **`find` says whether it means a pattern.** `s:find(x)` treats x as a Lua

--- a/_cli/build/init_test.tl
+++ b/_cli/build/init_test.tl
@@ -36,7 +36,7 @@ local function test_copy_preserves_mode()
   assert(fs.read(dst) == "#!/bin/sh\n", "copy content")
   local st = fs.stat(dst)
   assert(st, "dst should stat")
-  local mode = (st as fs.Stat):mode() % 512 -- cast: mixed-representation Stat
+  local mode = (st as fs.Stat):mode() % 512 -- cast: record union after guard
   assert(mode % 2 == 1, "exec bit preserved, mode: " .. string.format("%o", mode))
 end
 test_copy_preserves_mode()
@@ -85,14 +85,14 @@ local function test_compile_unchanged_restamps_without_rewriting()
   assert(code == 0, "first compile failed")
   local st1 = fs.stat(out)
   assert(st1, "output should exist")
-  local s1, n1 = (st1 as fs.Stat):mtim() -- cast: mixed-representation Stat
+  local s1, n1 = (st1 as fs.Stat):mtim() -- cast: record union after guard
   local body = fs.read(out)
   -- read-only: the second run must not write, only restamp
   fs.chmod(out, tonumber("444", 8) as integer) -- cast: octal is integral
   code = run_driver("compile", test_bin, src, out)
   assert(code == 0, "second compile failed")
   local st2 = fs.stat(out)
-  local s2, n2 = (st2 as fs.Stat):mtim() -- cast: mixed-representation Stat
+  local s2, n2 = (st2 as fs.Stat):mtim() -- cast: record union after guard
   assert(s2 > s1 or (s2 == s1 and n2 >= n1),
     "unchanged compile must bring the output up to date")
   assert(fs.read(out) == body, "and must not rewrite its contents")
@@ -178,10 +178,10 @@ local function test_list_write_if_changed()
   assert(fs.read(out) == "a.tl\nb.tl\n", "write-list content")
   local st1 = fs.stat(out)
   assert(st1, "stamp should exist")
-  local s1, n1 = (st1 as fs.Stat):mtim() -- cast: mixed-representation Stat
+  local s1, n1 = (st1 as fs.Stat):mtim() -- cast: record union after guard
   code = run_driver("write-list", out, "a.tl", "b.tl")
   assert(code == 0, "unchanged list must succeed")
-  local s2, n2 = (fs.stat(out) as fs.Stat):mtim() -- cast: mixed-representation Stat
+  local s2, n2 = (fs.stat(out) as fs.Stat):mtim() -- cast: record union after guard
   assert(s1 == s2 and n1 == n2, "unchanged list must not rewrite the stamp")
   code = run_driver("write-list", out, "a.tl")
   assert(code == 0, "changed list must rewrite")

--- a/_cli/build/steps.tl
+++ b/_cli/build/steps.tl
@@ -99,7 +99,7 @@ local function do_assert_marker(args: {string}): integer
       if name ~= "." and name ~= ".." then
         local p = fs.join(d, name)
         local st = fs.stat(p)
-        if st and (st as fs.Stat):is_dir() then -- cast: mixed-representation Stat
+        if st and (st as fs.Stat):is_dir() then -- cast: record union after guard
           if scan(p) then return true end
         else
           local content = fs.read(p)
@@ -211,7 +211,7 @@ local function do_copy(args: {string}): integer
   if not st then
     return fail("stat " .. src .. " failed")
   end
-  -- cast: mixed-representation Stat
+  -- cast: record union after guard
   local mode = (st as fs.Stat):mode() % 512 -- permission bits (0777)
   fs.makedirs(fs.dirname(dst))
   local ok, werr = fs.write(dst, content, mode)

--- a/_docs/publish.tl
+++ b/_docs/publish.tl
@@ -25,7 +25,7 @@ local function scan_docs(docs_dir: string): {DocInfo}
         local full_path = fs.join(dir, name)
         local st0 = fs.stat(full_path)
         if st0 then
-          local st = st0 as fs.Stat -- cast: mixed-representation Stat
+          local st = st0 as fs.Stat -- cast: record union after guard
           if st:is_dir() then
             scan(full_path)
           elseif string.match(name, "%.md$") and name ~= "README.md" then

--- a/_make/check.tl
+++ b/_make/check.tl
@@ -98,7 +98,7 @@ local function proved_by_graph(proj: Project, f: File,
   if not out then
     return false
   end
-  local bsec, bnsec = (out as fs.Stat):mtim() -- cast: mixed-representation Stat
+  local bsec, bnsec = (out as fs.Stat):mtim() -- cast: record union after guard
   local inputs = deps.source_paths(deps.closure(proj, f, by_import))
   inputs[#inputs + 1] = f.path
   inputs[#inputs + 1] = stamp.path_of("compile")
@@ -108,7 +108,7 @@ local function proved_by_graph(proj: Project, f: File,
     if not st then
       return false
     end
-    local isec, insec = (st as fs.Stat):mtim() -- cast: mixed-representation Stat
+    local isec, insec = (st as fs.Stat):mtim() -- cast: record union after guard
     if isec > bsec or (isec == bsec and insec > bnsec) then
       return false
     end

--- a/_make/converge.tl
+++ b/_make/converge.tl
@@ -131,7 +131,7 @@ local function stamp_of(path: string): string
   if not info then
     return ""
   end
-  local st = info as fs.Stat -- cast: mixed-representation Stat
+  local st = info as fs.Stat -- cast: record union after guard
   local secs, nsecs = st:mtim()
   return tostring(st:size()) .. "-" .. tostring(secs) .. "." ..
   tostring(nsecs)

--- a/_make/extract.tl
+++ b/_make/extract.tl
@@ -86,7 +86,7 @@ local function strip_into(from: string, to: string, strip: integer,
       -- not carry it, so the source is stat'd for the bits.
       local src = fs.stat(path)
       if src then
-        fs.chmod(dest, (src as fs.Stat):mode() & tonumber("777", 8)) -- cast: mixed-representation Stat
+        fs.chmod(dest, (src as fs.Stat):mode() & tonumber("777", 8)) -- cast: record union after guard
       end
       return nil
     end)

--- a/_make/fixpoint_test.tl
+++ b/_make/fixpoint_test.tl
@@ -45,7 +45,7 @@ local function copy(from: string, to: string)
   assert(fs.write(to, body))
   local st = fs.stat(from)
   if st then
-    fs.chmod(to, (st as fs.Stat):mode() & tonumber("777", 8)) -- cast: mixed-representation Stat
+    fs.chmod(to, (st as fs.Stat):mode() & tonumber("777", 8)) -- cast: record union after guard
   end
 end
 

--- a/_make/generate.tl
+++ b/_make/generate.tl
@@ -99,7 +99,7 @@ local function fresh(proj: Project, src: string, built: string): boolean
   if not into then
     return false
   end
-  -- cast: mixed-representation Stat
+  -- cast: record union after guard
   local osec, onsec = (out as fs.Stat):mtim()
   local isec, insec = (into as fs.Stat):mtim() -- cast: same
   if osec ~= isec then

--- a/_perf/bench/fs_bench.tl
+++ b/_perf/bench/fs_bench.tl
@@ -141,7 +141,7 @@ local function scenarios(): {pt.Scenario}, string
           for f = 1, FILES_PER_DIR do
             local st, serr = fs.stat(fs.join(tmpdir, "dir-" .. d, "file-" .. f .. ".txt"))
             assert(st, serr)
-            local stt = st as fs.Stat -- cast: mixed-representation Stat
+            local stt = st as fs.Stat -- cast: record union after guard
             size_total = size_total + stt:size()
           end
         end

--- a/cosmic/_script_cache.tl
+++ b/cosmic/_script_cache.tl
@@ -69,7 +69,7 @@ local function trusted(dir: string): boolean
   if not st then
     return false
   end
-  local info = st as fs_types.Stat -- cast: mixed-representation Stat
+  local info = st as fs_types.Stat -- cast: record union after guard
   if info:uid() ~= user.getuid() then
     return false
   end
@@ -100,7 +100,7 @@ local function build_id(): string
   local self = arg and arg[-1]
   local info = self and fs.stat(self)
   if info then
-    local st = info as fs_types.Stat -- cast: mixed-representation Stat
+    local st = info as fs_types.Stat -- cast: record union after guard
     -- Bound, not inlined: mtim returns seconds AND nanoseconds, and a
     -- multi-return call spreads into the argument list it sits in.
     local secs = st:mtim()

--- a/cosmic/embed/init.tl
+++ b/cosmic/embed/init.tl
@@ -170,7 +170,7 @@ local function collect_dir(dir: string): {FileToEmbed} | nil, string
         -- prevention as the d_type == DT_DIR branch above).
         local st = fs.lstat(full_path)
         if st then
-          local sst = st as Stat -- cast: mixed-representation Stat
+          local sst = st as Stat -- cast: record union after guard
           if sst:is_dir() then
             local walk_err = do_walk(full_path, rel)
             if walk_err then return walk_err end

--- a/cosmic/fs/dir_test.tl
+++ b/cosmic/fs/dir_test.tl
@@ -201,7 +201,7 @@ local function test_major_minor()
   -- Test with /dev/null which should have rdev set
   local st = fs.stat("/dev/null")
   if st then
-    local rdev = (st as fs_types.Stat):rdev() -- cast: mixed-representation Stat
+    local rdev = (st as fs_types.Stat):rdev() -- cast: record union after guard
     local maj = fs.major(rdev)
     local min = fs.minor(rdev)
     -- /dev/null is typically major 1, minor 3

--- a/cosmic/fs/types.tl
+++ b/cosmic/fs/types.tl
@@ -33,7 +33,12 @@ local record fs_types
 
   --- File or directory metadata.
   --- Use the is_dir()/is_file()/is_link()/... methods to check file type.
+  --- ONE representation (api-review, fs.Stat unification): always the
+  --- raw cosmo.unix stat userdata, with the is_* predicates installed
+  --- once on the binding's shared metatable — so `st is fs.Stat`
+  --- narrows correctly and no wrapper table is ever allocated.
   record Stat
+    userdata
     --- Returns file size in bytes.
     size: function(self: Stat): integer
     --- Returns file mode (permissions and type bits).
@@ -119,7 +124,10 @@ local record fs_types
   end
 
   --- Wrap a raw cosmo.unix Stat so it carries the type predicates.
-  wrap: function(raw: unix.Stat): Stat
+  --- Fallible only in the one way the unification allows: a runtime
+  --- whose stat metatable cannot take the predicates is refused, not
+  --- papered over with a second representation.
+  wrap: function(raw: unix.Stat): Stat | nil, string
 
 end
 
@@ -141,8 +149,7 @@ local raw_predicates: {string: any} = {
 --- Install the predicates on the raw stat's metatable. Lazy — uses the
 --- first stat wrap() sees, so module load never needs a stat(2) call
 --- (which a sandbox could deny). Returns false if the metatable is not
---- an extensible Lua table, in which case wrap() falls back to the
---- per-call wrapper table below.
+--- an extensible Lua table.
 local function install_predicates(raw: unix.Stat): boolean
   local mt = getmetatable(raw as any) -- cast: userdata boundary
   if type(mt) ~= "table" then
@@ -159,50 +166,24 @@ local function install_predicates(raw: unix.Stat): boolean
   return true
 end
 
---- Fallback wrapper table: holds the raw stat userdata; a shared
---- metatable delegates the accessors and implements the predicates, so
---- wrapping costs one small table per stat call.
-local record Wrapped
-  raw: unix.Stat
-end
-
-local stat_methods: {string: any} = {
-  size = function(self: Wrapped): integer return self.raw:size() end,
-  mode = function(self: Wrapped): integer return self.raw:mode() end,
-  uid = function(self: Wrapped): integer return self.raw:uid() end,
-  gid = function(self: Wrapped): integer return self.raw:gid() end,
-  birthtim = function(self: Wrapped): integer, integer return self.raw:birthtim() end,
-  mtim = function(self: Wrapped): integer, integer return self.raw:mtim() end,
-  atim = function(self: Wrapped): integer, integer return self.raw:atim() end,
-  ctim = function(self: Wrapped): integer, integer return self.raw:ctim() end,
-  blocks = function(self: Wrapped): integer return self.raw:blocks() end,
-  nlink = function(self: Wrapped): integer return self.raw:nlink() end,
-  dev = function(self: Wrapped): integer return self.raw:dev() end,
-  rdev = function(self: Wrapped): integer return self.raw:rdev() end,
-  is_dir = function(self: Wrapped): boolean return unix.S_ISDIR(self.raw:mode()) end,
-  is_file = function(self: Wrapped): boolean return unix.S_ISREG(self.raw:mode()) end,
-  is_link = function(self: Wrapped): boolean return unix.S_ISLNK(self.raw:mode()) end,
-  is_block_device = function(self: Wrapped): boolean return unix.S_ISBLK(self.raw:mode()) end,
-  is_char_device = function(self: Wrapped): boolean return unix.S_ISCHR(self.raw:mode()) end,
-  is_fifo = function(self: Wrapped): boolean return unix.S_ISFIFO(self.raw:mode()) end,
-  is_socket = function(self: Wrapped): boolean return unix.S_ISSOCK(self.raw:mode()) end,
-}
-
-local stat_mt: metatable < Wrapped > = {
-  __index = stat_methods,
-}
-
+-- "unknown" until the first wrap probes; then "direct" or
+-- "unsupported". There is no wrapper-table fallback any more
+-- (api-review, fs.Stat unification): two representations made `is`
+-- unusable and put a justified cast at every Stat use site, to cover a
+-- runtime shape the pinned cosmos has never had. A sealed metatable is
+-- now an honest error from stat/lstat/fstat instead of a silent switch
+-- to a second representation.
 local wrap_mode: string = "unknown"
 
-fs_types.wrap = function(raw: unix.Stat): fs_types.Stat
+fs_types.wrap = function(raw: unix.Stat): fs_types.Stat | nil, string
   if wrap_mode == "unknown" then
-    wrap_mode = install_predicates(raw) and "direct" or "fallback"
+    wrap_mode = install_predicates(raw) and "direct" or "unsupported"
   end
   if wrap_mode == "direct" then
-    return raw as fs_types.Stat -- cast: mixed-representation Stat
+    return raw as fs_types.Stat -- cast: userdata boundary
   end
-  local wrapped: Wrapped = setmetatable({raw = raw}, stat_mt)
-  return wrapped as fs_types.Stat -- cast: mixed-representation Stat
+  return nil, "stat: this runtime's Stat metatable is sealed; " ..
+  "cosmic.fs requires the pinned cosmos runtime"
 end
 
 return fs_types

--- a/cosmic/fs/walk.tl
+++ b/cosmic/fs/walk.tl
@@ -44,8 +44,13 @@ local function walk_entries<T>(dir: string, h: WalkDirHandle,
       -- Use AT_SYMLINK_NOFOLLOW so symlinked dirs are seen as S_ISLNK, not S_ISDIR.
       -- This prevents infinite recursion through symlink cycles.
       local st, serr = unix.stat(full_path, unix.AT_SYMLINK_NOFOLLOW)
+      local wst: WalkStat
+      local werr: string
       if st then
-        local action = visitor(full_path, entry, types.wrap(st), ctx)
+        wst, werr = types.wrap(st)
+      end
+      if wst is WalkStat then
+        local action = visitor(full_path, entry, wst, ctx)
         if action == "stop" then
           h:close()
           return true
@@ -59,7 +64,7 @@ local function walk_entries<T>(dir: string, h: WalkDirHandle,
           end
         end
       elseif not errbox[1] then
-        errbox[1] = errstr(serr, "stat: " .. full_path)
+        errbox[1] = werr or errstr(serr, "stat: " .. full_path)
       end
     end
   end

--- a/cosmic/tar_test.tl
+++ b/cosmic/tar_test.tl
@@ -72,7 +72,7 @@ local function test_extract_files_dirs_modes()
   local st = fs.stat(fs.join(dest, "pkg/tool"))
   assert(st, "tool should stat")
   -- exec bit survives extraction (the reason unzip/tar mattered at all)
-  local mode = (st as fs_types.Stat):mode() -- cast: mixed-representation Stat
+  local mode = (st as fs_types.Stat):mode() -- cast: record union after guard
   assert(mode % 2 == 1, "tool should keep the exec bit, mode: " .. string.format("%o", mode))
 end
 test_extract_files_dirs_modes()


### PR DESCRIPTION
The deferred perf-sensitive item from the API review.

## The problem

`fs.Stat` was two things at runtime: usually the raw `cosmo.unix` stat **userdata** (predicates installed once on the binding's shared metatable — zero allocation), but a per-call **wrapper table** when that metatable couldn't take them. Two representations meant Teal's `is` could never narrow a Stat — neither the `userdata` marker nor the table shape fit — so every Stat use site carried a justified cast (`-- cast: mixed-representation Stat`, 22 of them), all to cover a runtime shape the pinned cosmos has never actually had.

## The fix

One representation. The `Stat` record declares `userdata`; `wrap()` installs the predicates or — on a hypothetical runtime whose stat metatable is sealed — returns an **honest error** from `stat`/`lstat`/`fstat` instead of silently switching shape (fail-closed beats a second representation). Deleted: the wrapper record, its 19 delegating methods, and the mode switch. `st is fs.Stat` now narrows correctly; AGENTS.md's mixed-representation caveat is gone; the 22 cast reasons updated.

## Perf (the reason this waited)

The walk hot path gains one `is`-check branch per visited entry. Compare gate per `_perf/OPTIMIZE.md` — baseline from a main worktree, A/A selfcheck for the noise floor:

```
fs_walk_tree     398.12 µs ->  392.30 µs   -1.5%  (noise ±10.0%)  ok
fs_files_tree    193.08 µs ->  199.13 µs   +3.1%  (noise ±10.0%)  ok
fs_barf_slurp    121.94 µs ->  120.73 µs   -1.0%  (noise ±15.7%)  ok
fs_relpath         7.43 µs ->    5.57 µs  -25.0%  (noise ±19.9%)  faster
fs_stat_tree     322.72 µs ->  314.02 µs   -2.7%  (noise ±10.0%)  ok
5 scenarios: 0 regression, 1 faster, 4 ok
```

The direct (userdata) mode was already the only path taken in practice, so this deletes the dead half rather than changing the hot one. Net −15 lines.

Local gate: `ci: PASS (5 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FP31Qs2Ei4uJUsimFMpvkS

---
_Generated by [Claude Code](https://claude.ai/code/session_01FP31Qs2Ei4uJUsimFMpvkS)_