### PR TITLE
embed uses zip's records and zip's extract — the twins are deleted

### DIFF
--- a/_make/fetch.tl
+++ b/_make/fetch.tl
@@ -62,7 +62,7 @@ end
 ---
 --- The line delimiter is safe because the extractors refuse control
 --- characters in member names (`cosmic.tar.unsafe_path`,
---- `cosmic.embed.extract.unsafe_entry`) — archive members are
+--- `fs.unsafe_entry_name`) — archive members are
 --- attacker-shaped input, and a member called `a\nb.txt` would be
 --- recorded as two names, neither of which exists, so every later fetch
 --- would decide the pin needs repair. Forever, silently. That guard is

--- a/cosmic/embed/extract.tl
+++ b/cosmic/embed/extract.tl
@@ -1,8 +1,9 @@
---- Extracting an executable's zip contents, and the zip-slip guard
---- that makes it safe.
+--- Extracting an executable's zip contents.
 ---
---- Split out of cosmic.embed for the 500-line cap: extraction is the
---- inverse of embedding and shares only the result record with it.
+--- Split out of cosmic.embed for the 500-line cap. The extraction
+--- itself is czip.extract (api-review: embed no longer reimplements
+--- the loop or re-declares zip's records) — the zip-slip guard, the
+--- upfront validation, and the mode masking all live there, once.
 
 local czip = require("cosmic.zip")
 local fs = require("cosmic.fs")
@@ -13,26 +14,6 @@ local record EmbedResult
   message: string
   file_count: integer
 end
-
---- Directory entry returned by ZipReader:list().
-local record ZipEntry
-  name: string
-  size: integer
-  mode: integer
-end
-
---- Reader interface for reading files from a ZIP archive.
-local record ZipReader
-  list: function(self: ZipReader): {ZipEntry}
-  read: function(self: ZipReader, name: string): string | nil, string | nil
-  close: function(self: ZipReader)
-end
-
---- Whether an archive entry name is unsafe to extract; the predicate
---- is fs.unsafe_entry_name, one guard for zip, tar and embed.
---- @param name string Archive entry name
---- @return boolean true if the entry is unsafe to extract
-local unsafe_entry = fs.unsafe_entry_name
 
 --- Extract the zip contents of a cosmic executable to a directory.
 --- Creates the output directory if needed. Existing files are overwritten.
@@ -51,66 +32,26 @@ local function extract(output_dir: string, exe_path?: string): EmbedResult
     return {ok = false, message = "error: cannot read executable '" .. exe_path .. "'", file_count = 0}
   end
 
-  local reader_maybe = czip.open_bytes(exe_data)
-  if not reader_maybe then
+  local archive_maybe = czip.open_bytes(exe_data)
+  if not archive_maybe then
     return {ok = false, message = "error: no zip archive found in '" .. exe_path .. "'", file_count = 0}
   end
-  local reader = reader_maybe as ZipReader -- cast: record union after guard
+  local archive = archive_maybe as czip.Archive -- cast: record union after guard
 
-  local entries = reader:list()
+  -- The count czip.extract does not return: every non-directory entry
+  -- is written, or the whole extraction fails before partial output.
   local count = 0
-  -- Archive entries are frequently many files under the same directory
-  -- (e.g. a whole embedded tree); memoize which output directories have
-  -- already been created so each one gets exactly one make_dirs(2) walk
-  -- instead of one per file.
-  local made_dirs: {string: boolean} = {}
-
-  for _, entry in ipairs(entries) do
-    local name = entry.name
-    -- Guard against zip-slip: an entry with an absolute path or a ".."
-    -- component could otherwise be written outside output_dir.
-    if unsafe_entry(name) then
-      reader:close()
-      return {ok = false, message = "error: unsafe path in archive: " .. name, file_count = count}
-    end
-    -- Skip directory entries (trailing /)
-    if name:sub(-1) == "/" then
-      local dir_path = fs.join(output_dir, name)
-      if not made_dirs[dir_path] then
-        fs.make_dirs(dir_path)
-        made_dirs[dir_path] = true
-      end
-    else
-      local content, read_err = reader:read(name)
-      if not content then
-        reader:close()
-        return {ok = false, message = "error: cannot read '" .. name .. "' from archive: " .. (read_err or "unknown error"), file_count = count}
-      end
-
-      local filepath = fs.join(output_dir, name)
-      local dir = fs.dirname(filepath)
-      if not made_dirs[dir] then
-        fs.make_dirs(dir)
-        made_dirs[dir] = true
-      end
-
-      -- Sane-masked mode from the archive entry: permission bits only.
-      local file_mode = tonumber("644", 8)
-      local mode = entry.mode & tonumber("777", 8)
-      if mode > 0 then
-        file_mode = mode
-      end
-
-      local write_ok = fs.write(filepath, content, file_mode)
-      if not write_ok then
-        reader:close()
-        return {ok = false, message = "error: cannot write '" .. filepath .. "'", file_count = count}
-      end
+  for _, entry in ipairs(archive:list()) do
+    if entry.name:sub(-1) ~= "/" then
       count = count + 1
     end
   end
 
-  reader:close()
+  local ok, err = czip.extract(archive, output_dir)
+  archive:close()
+  if not ok then
+    return {ok = false, message = "error: " .. (err or "extract failed"), file_count = 0}
+  end
 
   return {
     ok = true,
@@ -122,12 +63,10 @@ end
 local record ExtractModule
   type EmbedResult = EmbedResult
   extract: function(output_dir: string, exe_path?: string): EmbedResult
-  unsafe_entry: function(name: string): boolean
 end
 
 local M: ExtractModule = {
   extract = extract,
-  unsafe_entry = unsafe_entry,
 }
 
 return M

--- a/cosmic/embed/init.tl
+++ b/cosmic/embed/init.tl
@@ -75,34 +75,6 @@ end
 --- publishes.
 local type EmbedResult = extract_mod.EmbedResult
 
---- Options for adding files to a ZIP archive.
-local record AddOptions
-  mode: integer
-  method: string
-  mtime: integer
-end
-
---- Appender interface for modifying a ZIP archive in-place.
-local record ZipAppender
-  add: function(self: ZipAppender, name: string, content: string, options?: AddOptions): boolean, string
-  remove: function(self: ZipAppender, name: string): boolean, string
-  close: function(self: ZipAppender)
-end
-
---- Directory entry returned by ZipReader:list().
-local record ZipEntry
-  name: string
-  size: integer
-  mode: integer
-end
-
---- Reader interface for reading files from a ZIP archive.
-local record ZipReader
-  list: function(self: ZipReader): {ZipEntry}
-  read: function(self: ZipReader, name: string): string | nil, string | nil
-  close: function(self: ZipReader)
-end
-
 local type EmbedDirHandle = fs_types.DirHandle
 
 -- One directory entry plus its d_type, sorted together for deterministic
@@ -368,14 +340,14 @@ local function embed(paths: {string}, opts?: Options): EmbedResult
   unix.chmod(tmp_path, tonumber("755", 8))
 
   -- Open the copy as an appender to modify its zip in-place
-  local appender_result: any
-  local appender_err: any
-  appender_result, appender_err = czip.append(tmp_path)
-  if not appender_result then
+  -- (api-review: cosmic.zip's own Appender — embed no longer keeps a
+  -- structural twin of it)
+  local appender_maybe, appender_err = czip.append(tmp_path)
+  if not appender_maybe then
     fs.unlink(tmp_path)
     return {ok = false, message = "error: failed to open zip for appending: " .. tostring(appender_err or "unknown error"), file_count = 0}
   end
-  local appender = appender_result as ZipAppender -- cast: from any
+  local appender = appender_maybe as czip.Appender -- cast: record union after guard
 
   -- Strip first, so an entry the caller supplies is never removed after
   -- being added. The floor is positive: everything the base carried
@@ -411,7 +383,7 @@ local function embed(paths: {string}, opts?: Options): EmbedResult
     -- removal would surface as the duplicate entry it creates.
     appender:remove(file_info.stored_name)
     local is_lua = file_info.stored_name:sub(-4) == ".lua"
-    local add: AddOptions = {
+    local add: czip.AddOptions = {
       mode = file_info.mode,
       method = is_lua and "store" or "deflate",
       -- Default the epoch rather than letting the binding fall back to
@@ -459,7 +431,6 @@ local record EmbedModule
   --- DEPRECATED alias for embed() (api-review-8 transition)
   run: function(paths: {string}, opts?: Options): EmbedResult
   extract: function(output_dir: string, exe_path?: string): EmbedResult
-  unsafe_entry: function(name: string): boolean
 end
 
 local M: EmbedModule = {
@@ -467,7 +438,6 @@ local M: EmbedModule = {
   embed = embed,
   run = embed,
   extract = extract_mod.extract,
-  unsafe_entry = extract_mod.unsafe_entry,
 }
 
 return M

--- a/cosmic/embed_test.tl
+++ b/cosmic/embed_test.tl
@@ -336,7 +336,6 @@ test_embed_stores_lua()
 -- output directory. cosmic executables also extract on Windows, so the
 -- guard treats "\" as a separator and rejects drive-letter roots too.
 local function test_extract_rejects_zip_slip()
-  local embed = require("cosmic.embed")
   local unsafe = {
     "/etc/passwd", -- POSIX absolute
     "../evil", -- POSIX traversal
@@ -359,13 +358,13 @@ local function test_extract_rejects_zip_slip()
     "tab\there", -- any other control character
   }
   for _, name in ipairs(unsafe) do
-    assert(embed.unsafe_entry(name), "should reject unsafe entry: " .. name)
+    assert(fs.unsafe_entry_name(name), "should reject unsafe entry: " .. name)
   end
   local safe = {
     "main.lua", "sub/dir/file.txt", "a..b/c", "...", "a/b..c/d",
   }
   for _, name in ipairs(safe) do
-    assert(not embed.unsafe_entry(name), "should accept safe entry: " .. name)
+    assert(not fs.unsafe_entry_name(name), "should accept safe entry: " .. name)
   end
 end
 test_extract_rejects_zip_slip()


### PR DESCRIPTION
The last ledger item from the API review that doesn't need a pin advance.

`cosmic.embed` kept structural twins of `cosmic.zip`'s surface — its own `AddOptions`/`ZipAppender`/`ZipEntry`/`ZipReader` records, casting the same underlying handles zip's typed constructors already return — plus a full reimplementation of the extraction loop (same slip guard, same dir-memo, same mode masking, maintained twice; the review flagged them as "comments in each insist they must agree").

Now:

- `embed` uses `czip.Appender`/`czip.Archive`/`czip.AddOptions` directly; the four twin records are deleted.
- `embed.extract` delegates to `czip.extract` — which also **buys embed the upfront whole-archive validation** it didn't have (a malicious archive now fails before any bytes hit the filesystem, instead of mid-extraction with partial output). The one thing `czip.extract` doesn't return — the written-file count `EmbedResult` reports — embed derives from one `list()` pass.
- The `embed.unsafe_entry` re-export goes with the twins: the one guard is `fs.unsafe_entry_name` (PR #890's unification), and the zip-slip test points at it directly.

Net **−92 lines**, one less pair of records to drift.

With this, the review ledger has one item left: the **pin-advance cleanup** (flip tooling to the D20 names, delete all deprecated aliases), which unblocks as soon as a release carrying the renames becomes `bin/cosmic.pin` — tonight's 07:00Z release cron, or a manual `release.yml` dispatch.

Local gate: `ci: PASS (5 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FP31Qs2Ei4uJUsimFMpvkS

---
_Generated by [Claude Code](https://claude.ai/code/session_01FP31Qs2Ei4uJUsimFMpvkS)_