### PR TITLE
pin advance: tooling flips to the D20 names, the deprecated aliases die

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -108,6 +108,15 @@ jobs:
       # SKIPPED test's coverage read as 0% and fail the ratchet red —
       # loud, but wrong-red. Keying on the path means a moved workspace
       # (a runner image change) starts cold and green instead.
+      #
+      # The PIN is part of the key because `o/` is a product of a
+      # toolchain generation: `bin/cosmic` execs a restored
+      # `o/bin/cosmic` as-is, and its startup (the welcome check, before
+      # make and D18 ever run) resolves `_cli.*` from cached compiled
+      # artifacts while `cosmic.*` resolves against the tree — so a
+      # cache handed across a pin advance mixes generations and crashes
+      # on any name only one side has. A pin bump is exactly when the
+      # old names may die (D20's transition), so it starts cold instead.
       - name: restore o/ from the previous run
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
@@ -115,9 +124,9 @@ jobs:
             o
             !o/gate.log
             !o/perf
-          key: o-${{ runner.os }}-${{ github.workspace }}-${{ github.sha }}
+          key: o-${{ runner.os }}-${{ github.workspace }}-${{ hashFiles('bin/cosmic.pin') }}-${{ github.sha }}
           restore-keys: |
-            o-${{ runner.os }}-${{ github.workspace }}-
+            o-${{ runner.os }}-${{ github.workspace }}-${{ hashFiles('bin/cosmic.pin') }}-
 
       # The gate runs as a non-root user: see the identity note above.
       # The system-wide safe.directory keeps git usable for that user,

--- a/3p/cosmos/cosmos_test.tl
+++ b/3p/cosmos/cosmos_test.tl
@@ -1,7 +1,7 @@
 #!/usr/bin/env cosmic
 
 local check = require("cosmic.check")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 local fs = require("cosmic.fs")
 
 -- Where the pinned cosmos products landed. `cosmic --make fetch` unpacks
@@ -18,7 +18,7 @@ local TEST_DIR = os.getenv("TEST_DIR") or "o/3p/cosmos"
 
 local function test_lua()
   local bin = fs.join(TEST_DIR, "lua")
-  local handle = check.must(spawn.spawn({bin, "-v"}))
+  local handle = check.must(child.start({bin, "-v"}))
   local __r1 = check.must(handle:wait())
   local ok, got = __r1.ok, __r1.stdout
   assert(ok, "lua -v failed")
@@ -29,7 +29,7 @@ test_lua()
 
 local function test_zip()
   local bin = fs.join(TEST_DIR, "zip")
-  local handle = check.must(spawn.spawn({bin, "--version"}))
+  local handle = check.must(child.start({bin, "--version"}))
   local __r2 = check.must(handle:wait())
   local ok, got = __r2.ok, __r2.stdout
   assert(ok, "zip --version failed")

--- a/_build/skills_test.tl
+++ b/_build/skills_test.tl
@@ -100,7 +100,7 @@ end
 --- Every skill file, in path order.
 --- @return {string} Paths relative to the repo root
 local function skill_files(): {string}
-  local found = check.must(fs.collect(SKILLS_DIR, "*.md"))
+  local found = check.must(fs.find(SKILLS_DIR, {glob = "*.md"}))
   table.sort(found)
   assert(#found > 0, "no skill files found under " .. SKILLS_DIR)
   return found

--- a/_build/workflows_test.tl
+++ b/_build/workflows_test.tl
@@ -30,7 +30,7 @@ local WORKFLOWS < const > = ".github/workflows"
 --- Every workflow file, in path order.
 --- @return {string} Paths relative to the repo root
 local function workflows(): {string}
-  local found = check.must(fs.collect(WORKFLOWS, "*.yml"))
+  local found = check.must(fs.find(WORKFLOWS, {glob = "*.yml"}))
   table.sort(found)
   assert(#found > 0, "no workflows found under " .. WORKFLOWS)
   return found

--- a/_cli/args_test.tl
+++ b/_cli/args_test.tl
@@ -3,7 +3,7 @@
 
 local check = require("cosmic.check")
 local fs = require("cosmic.fs")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 
 local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
 local tmpdir = os.getenv("TEST_TMPDIR")
@@ -19,7 +19,7 @@ for i, v in ipairs(args) do
 end
 ]])
 
-  local h1 = check.must(spawn.spawn({cosmic, script, "foo", "bar", "baz"}))
+  local h1 = check.must(child.start({cosmic, script, "foo", "bar", "baz"}))
   local __r1 = check.must(h1:wait())
   local ok, out = __r1.ok, __r1.stdout
   assert(ok, "cosmic should succeed")
@@ -41,7 +41,7 @@ for i = 1, #arg do
 end
 ]])
 
-  local h2 = check.must(spawn.spawn({cosmic, script, "alpha", "beta"}))
+  local h2 = check.must(child.start({cosmic, script, "alpha", "beta"}))
   local __r2 = check.must(h2:wait())
   local ok, out = __r2.ok, __r2.stdout
   assert(ok, "cosmic should succeed")
@@ -65,7 +65,7 @@ for i = 1, #arg do
 end
 ]])
 
-  local h3 = check.must(spawn.spawn({cosmic, script, "x", "y", "z"}))
+  local h3 = check.must(child.start({cosmic, script, "x", "y", "z"}))
   local __r3 = check.must(h3:wait())
   local ok, out = __r3.ok, __r3.stdout
   assert(ok, "cosmic should succeed")
@@ -94,7 +94,7 @@ end
 os.exit(main(...))
 ]])
 
-  local h4 = check.must(spawn.spawn({cosmic, script, "one", "two"}))
+  local h4 = check.must(child.start({cosmic, script, "one", "two"}))
   local __r4 = check.must(h4:wait())
   local ok, out = __r4.ok, __r4.stdout
   assert(ok, "cosmic should succeed")
@@ -118,14 +118,14 @@ os.exit(main(...))
 ]])
 
   -- Test with argument
-  local h5 = check.must(spawn.spawn({cosmic, script, "custom"}))
+  local h5 = check.must(child.start({cosmic, script, "custom"}))
   local __r5 = check.must(h5:wait())
   local ok, out = __r5.ok, __r5.stdout
   assert(ok, "cosmic should succeed")
   assert(out:find("param=custom"), "param should be custom")
 
   -- Test with no argument (should use default)
-  local h6 = check.must(spawn.spawn({cosmic, script}))
+  local h6 = check.must(child.start({cosmic, script}))
   local __r6 = check.must(h6:wait())
   ok, out = __r6.ok, __r6.stdout
   assert(ok, "cosmic should succeed")
@@ -143,7 +143,7 @@ print("arg_count=" .. #arg)
 print("arg[0]=" .. tostring(arg[0]))
 ]])
 
-  local h7 = check.must(spawn.spawn({cosmic, script}))
+  local h7 = check.must(child.start({cosmic, script}))
   local __r7 = check.must(h7:wait())
   local ok, out = __r7.ok, __r7.stdout
   assert(ok, "cosmic should succeed")
@@ -163,7 +163,7 @@ for i, v in ipairs(args) do
 end
 ]])
 
-  local h8 = check.must(spawn.spawn({cosmic, script, "hello world", "foo bar"}))
+  local h8 = check.must(child.start({cosmic, script, "hello world", "foo bar"}))
   local __r8 = check.must(h8:wait())
   local ok, out = __r8.ok, __r8.stdout
   assert(ok, "cosmic should succeed")
@@ -182,7 +182,7 @@ for i, v in ipairs(args) do
 end
 ]])
 
-  local h9 = check.must(spawn.spawn({cosmic, script, "--", "--flag", "-x", "value=123"}))
+  local h9 = check.must(child.start({cosmic, script, "--", "--flag", "-x", "value=123"}))
   local __r9 = check.must(h9:wait())
   local ok, out = __r9.ok, __r9.stdout
   assert(ok, "cosmic should succeed")
@@ -210,7 +210,7 @@ if proc.is_main() then
 end
 ]])
 
-  local h10 = check.must(spawn.spawn({cosmic, script, "test1", "test2"}))
+  local h10 = check.must(child.start({cosmic, script, "test1", "test2"}))
   local __r10 = check.must(h10:wait())
   local ok, out = __r10.ok, __r10.stdout
   assert(ok, "cosmic should succeed")
@@ -230,7 +230,7 @@ for i, v in ipairs(args) do
 end
 ]])
 
-  local h11 = check.must(spawn.spawn({cosmic, script, "--version"}))
+  local h11 = check.must(child.start({cosmic, script, "--version"}))
   local __r11 = check.must(h11:wait())
   local ok, out = __r11.ok, __r11.stdout
   assert(ok, "cosmic should succeed")
@@ -250,7 +250,7 @@ for i, v in ipairs(args) do
 end
 ]])
 
-  local h12 = check.must(spawn.spawn({cosmic, script, "--help"}))
+  local h12 = check.must(child.start({cosmic, script, "--help"}))
   local __r12 = check.must(h12:wait())
   local ok, out = __r12.ok, __r12.stdout
   assert(ok, "cosmic should succeed")
@@ -270,7 +270,7 @@ for i, v in ipairs(args) do
 end
 ]])
 
-  local h13 = check.must(spawn.spawn({cosmic, script, "-v"}))
+  local h13 = check.must(child.start({cosmic, script, "-v"}))
   local __r13 = check.must(h13:wait())
   local ok, out = __r13.ok, __r13.stdout
   assert(ok, "cosmic should succeed")
@@ -291,7 +291,7 @@ end
 ]])
 
   -- cosmic -e before script, then script gets --version
-  local h14 = check.must(spawn.spawn({cosmic, "-e", "print('cosmic executed')", script, "--version", "arg2"}))
+  local h14 = check.must(child.start({cosmic, "-e", "print('cosmic executed')", script, "--version", "arg2"}))
   local __r14 = check.must(h14:wait())
   local ok, out = __r14.ok, __r14.stdout
   assert(ok, "cosmic should succeed")
@@ -313,7 +313,7 @@ for i, v in ipairs(args) do
 end
 ]])
 
-  local h15 = check.must(spawn.spawn({cosmic, script, "--version", "--help", "-v", "-i", "--unknown"}))
+  local h15 = check.must(child.start({cosmic, script, "--version", "--help", "-v", "-i", "--unknown"}))
   local __r15 = check.must(h15:wait())
   local ok, out = __r15.ok, __r15.stdout
   assert(ok, "cosmic should succeed")
@@ -337,7 +337,7 @@ for i, v in ipairs(args) do
 end
 ]])
 
-  local h16 = check.must(spawn.spawn({cosmic, script, "--", "arg1", "arg2"}))
+  local h16 = check.must(child.start({cosmic, script, "--", "arg1", "arg2"}))
   local __r16 = check.must(h16:wait())
   local ok, out = __r16.ok, __r16.stdout
   assert(ok, "cosmic should succeed")
@@ -363,7 +363,7 @@ end
 print("No --version flag found")
 ]])
 
-  local h17 = check.must(spawn.spawn({cosmic, script, "--version"}))
+  local h17 = check.must(child.start({cosmic, script, "--version"}))
   local __r17 = check.must(h17:wait())
   local ok, out = __r17.ok, __r17.stdout
   assert(ok, "cosmic should succeed")
@@ -377,7 +377,7 @@ local function test_help_includes_all_options()
   local cli = require("_cli.args")
 
   -- Run cosmic --help and capture output
-  local h18 = check.must(spawn.spawn({cosmic, "--help"}))
+  local h18 = check.must(child.start({cosmic, "--help"}))
   local __r18 = check.must(h18:wait())
   local ok, out = __r18.ok, __r18.stdout
   assert(ok, "cosmic --help should succeed")
@@ -424,7 +424,7 @@ local function test_double_dash_reaches_the_script()
 print("n=" .. #arg)
 for i = 1, #arg do print("a[" .. i .. "]=" .. arg[i]) end
 ]])
-  local h = check.must(spawn.spawn({cosmic, script, "one", "--", "two", "--", "three"}))
+  local h = check.must(child.start({cosmic, script, "one", "--", "two", "--", "three"}))
   local r = check.must(h:wait())
   assert(r.ok, "cosmic should succeed: " .. (r.stderr or ""))
   local out = r.stdout or ""

--- a/_cli/build/init_test.tl
+++ b/_cli/build/init_test.tl
@@ -57,7 +57,7 @@ test_link_replaces()
 -- fixture is just a source and an output path.
 local function compile_fixture(name: string, content: string): string, string
   local dir = fs.join(tmpdir, name)
-  fs.makedirs(dir)
+  fs.make_dirs(dir)
   local src = fs.join(dir, "mod.tl")
   local out = fs.join(dir, "mod.lua")
   assert(fs.write(src, content))
@@ -191,7 +191,7 @@ test_list_write_if_changed()
 
 local function test_require_marker()
   local dir = fs.join(tmpdir, "markers/nested")
-  fs.makedirs(dir)
+  fs.make_dirs(dir)
   assert(fs.write(fs.join(dir, "probe.err"), "x enforce-ran: pledge\n"))
   local code = run_driver("assert-marker", "enforce-ran:", fs.join(tmpdir, "markers"))
   assert(code == 0, "marker present must pass")
@@ -224,17 +224,17 @@ local function test_remove()
   assert(fs.write(target, "x"))
   assert(fs.symlink(target, link))
   assert(fs.unlink(target), "target goes first, leaving the link dangling")
-  assert(fs.islink(link) and not fs.exists(link), "precondition: dangling")
+  assert(fs.is_link(link) and not fs.exists(link), "precondition: dangling")
   local code = run_driver("remove", a, fs.join(tmpdir, "rm-missing"), link)
   assert(code == 0, "remove must succeed, missing files ignored")
   assert(not fs.stat(a), "existing file removed")
-  assert(not fs.islink(link), "dangling symlink removed")
+  assert(not fs.is_link(link), "dangling symlink removed")
 end
 test_remove()
 
 local function test_verdict()
   local o_dir = fs.join(tmpdir, "verdict")
-  fs.makedirs(o_dir)
+  fs.make_dirs(o_dir)
   -- pass: clean summary + marker; launder: clean summary, NO marker;
   -- bad: failing summary; ghost: no summary at all
   assert(fs.write(fs.join(o_dir, "good-summary.txt"), "good: 2 checks: 2 passed, 0 failed\n"))

--- a/_cli/build/modules.tl
+++ b/_cli/build/modules.tl
@@ -110,8 +110,8 @@ local function write(out: string, root: string,
     built: {string}): string | nil
   local path = out .. SUFFIX
   local dir = fs.dirname(path)
-  if dir ~= "" and dir ~= "." and not fs.isdir(dir) then
-    if not fs.makedirs(dir) then
+  if dir ~= "" and dir ~= "." and not fs.is_dir(dir) then
+    if not fs.make_dirs(dir) then
       return nil
     end
   end

--- a/_cli/build/modules_test.tl
+++ b/_cli/build/modules_test.tl
@@ -68,7 +68,7 @@ test_render_drops_what_is_not_a_module()
 -- together with it.
 local function test_attach_puts_the_flag_after_the_program()
   local dir = fs.join(tmp, "modattach")
-  assert(fs.makedirs(dir))
+  assert(fs.make_dirs(dir))
   local argv: {string} = {"/bin/cosmic", "o/t.lua", "--flag", "value"}
   modules.attach(argv, fs.join(dir, "t"), "/r", {"o/a.lua"})
   assert(argv[1] == "/bin/cosmic", "the program stays first")

--- a/_cli/build/recipe_test.tl
+++ b/_cli/build/recipe_test.tl
@@ -146,7 +146,7 @@ local function test_recipe_refuses_globs()
   assert(code ~= 0, "a glob must fail the line, not match nothing")
   assert(err:match("argv, not shell"),
     "expected the argv/shell message, got: " .. err)
-  assert(fs.isfile(victim), "and nothing may be deleted on the way")
+  assert(fs.is_file(victim), "and nothing may be deleted on the way")
 
   for _, ch in ipairs({"?", "[", "]", "~", "^", "!", "#"}) do
     local c = select(1, run_recipe("copy a" .. ch .. " b"))
@@ -232,8 +232,8 @@ test_exec_refuses_outside_the_root()
 -- stronger claim than the check enforced.
 local function test_exec_refuses_a_symlink_out_of_the_root()
   local root = fs.join(tmpdir, "exec-root")
-  fs.rmrf(root)
-  assert(fs.makedirs(root))
+  fs.remove_all(root)
+  assert(fs.make_dirs(root))
   local link = fs.join(root, "escape")
   assert(fs.symlink("/bin/sh", link))
   local code, _out, err = run_recipe_env("exec " .. link .. " -c true", root)
@@ -255,8 +255,8 @@ test_exec_refuses_a_symlink_out_of_the_root()
 -- else, so the program is a copy and the link is beside the copy.
 local function test_exec_allows_a_symlink_inside_the_root()
   local root = fs.join(tmpdir, "exec-linked-root")
-  fs.rmrf(root)
-  assert(fs.makedirs(root))
+  fs.remove_all(root)
+  assert(fs.make_dirs(root))
   local prog = fs.join(root, "prog")
   assert(fs.copy(test_bin, prog))
   assert(fs.chmod(prog, tonumber("755", 8) as integer)) -- cast: octal is integral

--- a/_cli/build/skip_test.tl
+++ b/_cli/build/skip_test.tl
@@ -16,9 +16,9 @@ local cosmic = fs.abspath(fs.join(os.getenv("TEST_BIN") or "o/bin", "cosmic"))
 
 -- The record skip keys the tool stamp the graph writes; without a
 -- built tree there is nothing to key against and nothing to test.
-check.needs("a built cosmic at " .. cosmic, fs.isfile(cosmic))
+check.needs("a built cosmic at " .. cosmic, fs.is_file(cosmic))
 check.needs("the record stamp at o/.stamp/record",
-  fs.isfile("o/.stamp/record"))
+  fs.is_file("o/.stamp/record"))
 
 --- The seconds+nanoseconds of a path, as one comparable string.
 local function mtime_of(path: string): string
@@ -35,7 +35,7 @@ local function test_compile_skips_and_unskips()
   assert(fs.write(src, "return { n = 1 }\n"))
   local args = {cosmic, src, out, "--deps"}
   assert(work.compile(args) == 0, "first compile")
-  assert(fs.isfile(out .. ".in"), "a keyed compile records itself")
+  assert(fs.is_file(out .. ".in"), "a keyed compile records itself")
   local key1 = mtime_of(out .. ".in")
   local out1 = mtime_of(out)
 
@@ -78,7 +78,7 @@ local function test_record_skips_only_a_pass()
   local got = check.must(fs.read(out .. ".got"))
   assert(got:match("^0%s*$"), "the run passed; err: "
     .. tostring((fs.read(out .. ".err"))))
-  assert(fs.isfile(out .. ".in"), "a pass records itself")
+  assert(fs.is_file(out .. ".in"), "a pass records itself")
   local key1 = mtime_of(out .. ".in")
   local ran1 = mtime_of(out .. ".out")
 

--- a/_cli/build/steps.tl
+++ b/_cli/build/steps.tl
@@ -46,7 +46,7 @@ local function do_tee(args: {string}): integer
     io.stderr:write(r.stderr)
   end
   io.write(r.stdout)
-  fs.makedirs(fs.dirname(out))
+  fs.make_dirs(fs.dirname(out))
   local ok, werr = fs.write(out, r.stdout)
   if not ok then
     return fail("write " .. out .. " failed: " .. (werr or "unknown error"))
@@ -73,7 +73,7 @@ local function do_write_list(args: {string}): integer
   if existing == content then
     return 0
   end
-  fs.makedirs(fs.dirname(out))
+  fs.make_dirs(fs.dirname(out))
   local ok, werr = fs.write(out, content)
   if not ok then
     return fail("write " .. out .. " failed: " .. (werr or "unknown error"))
@@ -148,7 +148,7 @@ local function do_remove(args: {string}): integer
     -- rule clearing a stale one silently kept it. `islink` is the second
     -- question because exists cannot see it either.
     local ok, uerr = fs.unlink(p)
-    if not ok and (fs.exists(p) or fs.islink(p)) then
+    if not ok and (fs.exists(p) or fs.is_link(p)) then
       return fail("remove " .. p .. ": " .. (uerr or "unknown error"))
     end
   end
@@ -213,7 +213,7 @@ local function do_copy(args: {string}): integer
   end
   -- cast: record union after guard
   local mode = (st as fs.Stat):mode() % 512 -- permission bits (0777)
-  fs.makedirs(fs.dirname(dst))
+  fs.make_dirs(fs.dirname(dst))
   local ok, werr = fs.write(dst, content, mode)
   if not ok then
     return fail("write " .. dst .. " failed: " .. (werr or "unknown error"))
@@ -228,7 +228,7 @@ local function do_link(args: {string}): integer
   if not linkpath then
     return fail("usage: link <target> <linkpath>")
   end
-  fs.makedirs(fs.dirname(linkpath))
+  fs.make_dirs(fs.dirname(linkpath))
   fs.unlink(linkpath)
   local ok, lerr = fs.symlink(target, linkpath)
   if not ok then
@@ -281,7 +281,7 @@ local function do_exec(args: {string}): integer
       ", which is not under the build root " .. root
       .. "; a recipe may only exec pinned or built bytes, never PATH")
   end
-  if not fs.isfile(abs) then
+  if not fs.is_file(abs) then
     return fail("exec " .. program .. ": no such file (" .. abs .. ")")
   end
   local argv: {string} = {abs}
@@ -290,7 +290,7 @@ local function do_exec(args: {string}): integer
   end
   -- "inherit" so the program streams as it runs, like every other
   -- recipe step.
-  local h, serr = child.spawn(argv, {stdout = "inherit", stderr = "inherit"})
+  local h, serr = child.start(argv, {stdout = "inherit", stderr = "inherit"})
   if not (h is child.Handle) then
     return fail("exec " .. program .. ": " .. (serr or "unknown error"))
   end

--- a/_cli/build/work.tl
+++ b/_cli/build/work.tl
@@ -139,7 +139,7 @@ local function run_into(argv: {string}, out: string): integer
     end
     return 0
   end
-  fs.makedirs(fs.dirname(out))
+  fs.make_dirs(fs.dirname(out))
   local ok, werr = fs.write(out, r.stdout)
   if not ok then
     return fail("write " .. out .. " failed: " .. (werr or "unknown error"))
@@ -261,7 +261,7 @@ local function do_record(args: {string}): integer
     local label: {string} = {"record"}
     local inputs: {string} = {}
     for i = 2, #argv do
-      if fs.isfile(argv[i]) then
+      if fs.is_file(argv[i]) then
         inputs[#inputs + 1] = argv[i]
       else
         label[#label + 1] = argv[i]
@@ -287,11 +287,11 @@ local function do_record(args: {string}): integer
   modules.attach(argv, out, fs.abspath("."), deps)
   local scratch = fs.abspath(out .. ".tmp.d")
   env.set("TMP", scratch)
-  fs.makedirs(scratch)
+  fs.make_dirs(scratch)
   fs.unlink(out .. ".got") -- freshness: an early testrun exit writes none
   local testrun = require("cosmic.testrun")
   testrun.run(argv, out)
-  if not fs.isfile(out .. ".got") then
+  if not fs.is_file(out .. ".got") then
     return fail("record " .. out .. ": no result recorded")
   end
   if key is string and got_pass(out .. ".got") then

--- a/_cli/driver.tl
+++ b/_cli/driver.tl
@@ -74,7 +74,7 @@ local function seed_ape_loaders(scratch: string)
   end
   for _, src in ipairs(found as {string}) do -- cast: nil-checked above
     local dst = fs.join(scratch, fs.basename(src))
-    if fs.isfile(src) and not fs.exists(dst) then
+    if fs.is_file(src) and not fs.exists(dst) then
       local bytes = fs.read(src)
       if bytes ~= nil then
         local part = dst .. ".part." .. tostring(proc.getpid())
@@ -103,7 +103,7 @@ local function ensure_build_tmpdir()
     return
   end
   local scratch = fs.abspath(fs.join("o", "tmp"))
-  if fs.makedirs(scratch) then
+  if fs.make_dirs(scratch) then
     seed_ape_loaders(scratch)
     env.set("TMPDIR", scratch, true)
   end

--- a/_cli/driver_test.tl
+++ b/_cli/driver_test.tl
@@ -110,7 +110,7 @@ local function test_a_compile_may_read_the_checkers_own_inputs()
     "through; derived from cosmic.teal so the two cannot drift")
 
   -- REAL host paths only. Two include dirs live inside the executable's
-  -- own zip, where `fs.isdir` answers yes and the kernel knows nothing:
+  -- own zip, where `fs.is_dir` answers yes and the kernel knows nothing:
   -- handing one to Landlock fails the whole policy with EBADFD, so the
   -- fenced compile died instead of denying anything. They need no grant
   -- — they are bytes in a file the exec grant already covers.
@@ -184,7 +184,7 @@ test_exec_gets_its_units_not_the_whole_tree()
 local function test_exec_reads_the_units_its_arguments_name()
   local prog = touch("fence-tool2")
   local input = fs.join(tmpdir, "unit-input")
-  assert(fs.makedirs(input))
+  assert(fs.make_dirs(input))
   local src = fs.join(input, "a.txt")
   assert(fs.write(src, "x\n"))
   local p = grants.plan("exec", {prog, src})
@@ -201,7 +201,7 @@ local function test_a_generation_unit_is_the_whole_subtree()
   local prog = touch("fence-tool3")
   local unit = fs.join(tmpdir, "gen-unit")
   local deep = fs.join(unit, "sub")
-  assert(fs.makedirs(deep))
+  assert(fs.make_dirs(deep))
   assert(fs.write(fs.join(unit, "index_gen.tl"), "return {}\n"))
   local src = fs.join(deep, "input.txt")
   assert(fs.write(src, "x\n"))
@@ -261,7 +261,7 @@ local function test_every_step_can_extract_and_run_the_ape_loader()
   -- denied path, and is the exact failure that turned the gate red
   -- once the fence became the default.
   local dir = fs.join(tmpdir, "apedir")
-  assert(fs.makedirs(dir))
+  assert(fs.make_dirs(dir))
   local prev = env.get("TMPDIR")
   env.set("TMPDIR", dir, true)
   local p = grants.plan("exec", {fs.join(dir, "tool")})
@@ -283,13 +283,13 @@ local function test_an_unset_tmpdir_is_pinned_under_o_not_home()
   local driver = require("_cli.driver")
   local home = fs.join(tmpdir, "fakehome")
   local box = fs.join(tmpdir, "tmpbox")
-  assert(fs.makedirs(home))
-  assert(fs.makedirs(box))
+  assert(fs.make_dirs(home))
+  assert(fs.make_dirs(box))
   -- A loader in $HOME must be SEEDED into the pinned scratch: a nested
   -- driver (spawned by a fenced test) cannot read $HOME to find it, so
   -- its $TMPDIR probe is the one that has to hit.
   assert(fs.write(fs.join(home, ".ape-9.9"), "pretend loader"))
-  local cwd = assert(fs.getcwd())
+  local cwd = assert(fs.cwd())
   local prev_t, prev_h = env.get("TMPDIR"), env.get("HOME")
   assert(fs.chdir(box))
   env.unset("TMPDIR")
@@ -298,7 +298,7 @@ local function test_an_unset_tmpdir_is_pinned_under_o_not_home()
   driver.ensure_build_tmpdir()
   local pinned = env.get("TMPDIR")
   local seeded = pinned ~= nil
-  and fs.isfile(fs.join(pinned as string, ".ape-9.9")) -- cast: guarded
+  and fs.is_file(fs.join(pinned as string, ".ape-9.9")) -- cast: guarded
   local p = grants.plan("record", {fs.join(box, "out")})
 
   assert(fs.chdir(cwd))
@@ -325,11 +325,11 @@ test_an_unset_tmpdir_is_pinned_under_o_not_home()
 -- it is the over-grant the pin exists to remove.
 local function test_an_existing_home_loader_is_granted_as_a_file_only()
   local home = fs.join(tmpdir, "loaderhome")
-  assert(fs.makedirs(home))
+  assert(fs.make_dirs(home))
   local loader = fs.join(home, ".ape-1.10")
   assert(fs.write(loader, "pretend loader"))
   local scratch = fs.join(tmpdir, "loader-scratch")
-  assert(fs.makedirs(scratch))
+  assert(fs.make_dirs(scratch))
   local prev_t, prev_h = env.get("TMPDIR"), env.get("HOME")
   env.set("TMPDIR", scratch, true)
   env.set("HOME", home, true)
@@ -364,7 +364,7 @@ local function test_the_coverage_directory_is_granted_before_it_exists()
   -- at exit is denied — so it surfaced as three recipe-path files
   -- losing most of their coverage at once.
   local cov = fs.join(tmpdir, "cov-not-yet", "deeper")
-  fs.rmrf(fs.dirname(cov))
+  fs.remove_all(fs.dirname(cov))
   local prev = env.get("COSMIC_COVERAGE")
   env.set("COSMIC_COVERAGE", cov, true)
   local p = grants.plan("write-list", {fs.join(tmpdir, "out.txt")})

--- a/_cli/fence_test.tl
+++ b/_cli/fence_test.tl
@@ -68,7 +68,7 @@ local function test_the_fence_denies_an_undeclared_write()
   end
 
   local root = fs.join(tmpdir, "root")
-  assert(fs.makedirs(root))
+  assert(fs.make_dirs(root))
   local target = fs.join(tmpdir, "outside.txt")
   local script = fs.join(root, "write-outside.lua")
   assert(fs.write(script,
@@ -85,14 +85,14 @@ local function test_the_fence_denies_an_undeclared_write()
   -- A: unfenced, the write lands.
   local direct = check.must(child.run({cosmic, script}, {env = envlist}))
   assert(direct.ok, "the script must succeed unfenced: " .. direct.stderr)
-  assert(fs.isfile(target), "unfenced, the write must land")
+  assert(fs.is_file(target), "unfenced, the write must land")
   assert(fs.unlink(target))
 
   -- B: the same script under exec's fence, which does not reach it.
   local fenced = check.must(child.run(
       {cosmic, "-c", "exec " .. cosmic .. " " .. script}, {env = envlist}))
   assert(not fenced.ok, "the fenced write must fail")
-  assert(not fs.isfile(target),
+  assert(not fs.is_file(target),
     "fenced, the write must NOT land (fence did not deny)")
   check.enforced("recipe fence")
 end
@@ -114,7 +114,7 @@ local function test_the_fence_confines_a_test_to_its_own_step()
   end
 
   local root = fs.join(tmpdir, "testfence")
-  assert(fs.makedirs(root))
+  assert(fs.make_dirs(root))
   local target = fs.join(tmpdir, "test-escaped.txt")
   local script = fs.join(root, "escape.lua")
   assert(fs.write(script,
@@ -127,7 +127,7 @@ local function test_the_fence_confines_a_test_to_its_own_step()
   -- A: the same script run directly writes the file.
   local direct = check.must(child.run({cosmic, script}, {env = envlist}))
   assert(direct.ok, "the script must succeed unfenced: " .. direct.stderr)
-  assert(fs.isfile(target), "unfenced, the write must land")
+  assert(fs.is_file(target), "unfenced, the write must land")
   assert(fs.unlink(target))
 
   -- B: through the `record` verb, whose fence grants only the step's
@@ -140,7 +140,7 @@ local function test_the_fence_confines_a_test_to_its_own_step()
       {env = envlist}))
   assert(fenced.ok, "the record verb records rather than grades: " ..
     fenced.stderr)
-  assert(not fs.isfile(target),
+  assert(not fs.is_file(target),
     "fenced, a test must NOT write outside its own step")
   check.enforced("record fence")
 end
@@ -164,7 +164,7 @@ test_the_fence_confines_a_test_to_its_own_step()
 --- host that could run it existed until CI did.
 local function test_the_fence_permits_a_real_compile()
   local dir = fs.join(tmpdir, "compilefence")
-  assert(fs.makedirs(fs.join(dir, "pkg")))
+  assert(fs.make_dirs(fs.join(dir, "pkg")))
   -- Two files, so the compile resolves an import through the include
   -- path rather than only reading the file it was handed.
   assert(fs.write(fs.join(dir, "pkg", "greet.tl"),
@@ -190,7 +190,7 @@ local function test_the_fence_permits_a_real_compile()
   -- docs/design/make/engine.md.
   local self = fs.abspath(cosmic)
   local boot = fs.join(fs.dirname(self), "cosmic-check")
-  if not fs.isfile(boot) then
+  if not fs.is_file(boot) then
     check.enforce_skip("no assimilated cosmic at " .. boot)
     return
   end
@@ -206,7 +206,7 @@ local function test_the_fence_permits_a_real_compile()
         " --deps " .. fs.join(dir, "pkg", "greet.tl")}, {env = permitted}))
   assert(r.ok, "a real compile must SUCCEED under the fence; a fence " ..
     "that denies everything is not enforcement: " .. r.stderr)
-  assert(fs.isfile(built), "…and produce its output")
+  assert(fs.is_file(built), "…and produce its output")
   if sandbox.available().fs then
     check.enforced("recipe fence permits a compile")
   else

--- a/_cli/grants.tl
+++ b/_cli/grants.tl
@@ -168,7 +168,7 @@ local function nearest_existing(path: string): string
     if p == "" or p == "." then
       return "."
     end
-    if fs.isdir(p) then
+    if fs.is_dir(p) then
       return p
     end
     p = fs.dirname(p)
@@ -263,7 +263,7 @@ local function plan(verb: string, args: {string}): sandbox.Fs | nil, string | ni
   -- (`verdict <o_dir>`, `assert-marker <marker> <dir>`), which is why
   -- the two are separated rather than filtered together.
   for _, p in ipairs(ro_rest) do
-    if fs.isfile(p) then
+    if fs.is_file(p) then
       ro[#ro + 1] = p
     end
   end
@@ -289,7 +289,7 @@ local function plan(verb: string, args: {string}): sandbox.Fs | nil, string | ni
     -- fence at all.
     local dir = fs.dirname(p)
     if dir ~= "" and dir ~= "." then
-      local ok, merr = fs.makedirs(dir)
+      local ok, merr = fs.make_dirs(dir)
       if not ok then
         return nil, "cannot create " .. dir .. ": "
         .. (merr or "unknown error")
@@ -373,7 +373,7 @@ local function plan(verb: string, args: {string}): sandbox.Fs | nil, string | ni
       ro[#ro + 1] = dir
     end
     local root = os.getenv("COSMIC_EXEC_ROOT") or "o"
-    if fs.isdir(root) then
+    if fs.is_dir(root) then
       rw[#rw + 1] = root
     end
   end
@@ -385,7 +385,7 @@ local function plan(verb: string, args: {string}): sandbox.Fs | nil, string | ni
   -- fence denies every real compile, which is the concrete reason it
   -- could not become the default.
   if compiles[verb] then
-    if fs.isfile(TLCONFIG) then
+    if fs.is_file(TLCONFIG) then
       ro[#ro + 1] = TLCONFIG
     end
     -- Required HERE rather than at the top of the module: acquiring
@@ -396,13 +396,13 @@ local function plan(verb: string, args: {string}): sandbox.Fs | nil, string | ni
     for _, dir in ipairs(teal.get_default_include_dirs()) do
       -- Real host paths only. Two of the include dirs live INSIDE the
       -- executable's own zip (`/zip/.types`, `/zip/.tl`), where
-      -- `fs.isdir` answers yes -- cosmic's own syscall shims see them
+      -- `fs.is_dir` answers yes -- cosmic's own syscall shims see them
       -- -- and the kernel knows nothing at all. Handing one to Landlock
       -- fails the whole policy with EBADFD, which took the fenced
       -- compile down entirely rather than denying anything. They need
       -- no grant either way: they are bytes in a file the exec grant
       -- already covers.
-      if not in_zip(dir) and fs.isdir(dir) then
+      if not in_zip(dir) and fs.is_dir(dir) then
         ro[#ro + 1] = dir
       end
     end
@@ -413,7 +413,7 @@ local function plan(verb: string, args: {string}): sandbox.Fs | nil, string | ni
   -- /dev/urandom or exec an APE dies, which is exactly how the enforce,
   -- build, and offline lanes went red when this shipped without one.
   local tmp = os.getenv("TMPDIR") or "/tmp"
-  if fs.isdir(tmp) then
+  if fs.is_dir(tmp) then
     rw[#rw + 1] = tmp
   end
   -- Coverage output, created before it is granted for the same reason
@@ -435,8 +435,8 @@ local function plan(verb: string, args: {string}): sandbox.Fs | nil, string | ni
   -- project root. One definition of that rule, and it is over there.
   local cov = require("cosmic.coverage").dir_from_env()
   if cov ~= nil then
-    fs.makedirs(cov)
-    if fs.isdir(cov) then
+    fs.make_dirs(cov)
+    if fs.is_dir(cov) then
       rw[#rw + 1] = cov
     end
   end
@@ -465,12 +465,12 @@ local function plan(verb: string, args: {string}): sandbox.Fs | nil, string | ni
   -- above): the driver seeds $HOME's loaders into it before fencing
   -- (see driver.tl), because execve caches TMPDIR/HOME at process
   -- startup and a NESTED driver cannot read $HOME to find one here.
-  if fs.isdir(tmp) then
+  if fs.is_dir(tmp) then
     ex[#ex + 1] = tmp
   end
   local loaders: {string} = {"/usr/bin/ape"}
   for _, base in ipairs({tmp, os.getenv("HOME") or "", "."}) do
-    if base ~= "" and fs.isdir(base) then
+    if base ~= "" and fs.is_dir(base) then
       local found = fs.glob(base, ".ape-*")
       if found ~= nil then
         for _, f in ipairs(found as {string}) do -- cast: nil-checked above
@@ -480,7 +480,7 @@ local function plan(verb: string, args: {string}): sandbox.Fs | nil, string | ni
     end
   end
   for _, f in ipairs(loaders) do
-    if fs.isfile(f) then
+    if fs.is_file(f) then
       ex[#ex + 1] = f
     end
   end

--- a/_cli/lint.tl
+++ b/_cli/lint.tl
@@ -359,7 +359,7 @@ local function lint_file(path: string): {Diagnostic} | nil, string
   -- same as unreadable, which stays a failure below — the linter it
   -- replaced counted a directory as zero lines and reported it clean,
   -- which is the fail-open shape this distinction exists to avoid.
-  if not fs.isfile(path) then
+  if not fs.is_file(path) then
     return {}
   end
   local f, oerr = io.open(path, "r")

--- a/_cli/main_handlers.tl
+++ b/_cli/main_handlers.tl
@@ -33,7 +33,7 @@ local function run_repl()
   -- Inject help() into REPL
   local docs = require("cosmic.doc")
   rawset(_G, "help", function(query: string)
-      local result = docs.run(query or "")
+      local result = docs.query(query or "")
       print(result.output)
     end)
 
@@ -65,7 +65,7 @@ end
 local function run_docs(query: string): DocsRunResult
   local docs = require("cosmic.doc")
 
-  local result = docs.run(query)
+  local result = docs.query(query)
   if result.ok then
     return {ok = true, output = result.output}
   end
@@ -261,7 +261,7 @@ end
 --- Handle --embed flag.
 local function handle_embed(paths: {string}, output: string, exe?: string): integer
   local embed = require("cosmic.embed")
-  local result = embed.run(paths, {output = output, exe_path = exe})
+  local result = embed.embed(paths, {output = output, exe_path = exe})
   io.write(result.message .. "\n")
   return result.ok and 0 or 1
 end
@@ -289,7 +289,7 @@ local function handle_examples(module_name: string): integer
   local docs = require("cosmic.doc")
 
   if module_name == "" then
-    local result = docs.run("examples")
+    local result = docs.query("examples")
     io.write(result.output .. "\n")
     return result.ok and 0 or 1
   else
@@ -322,7 +322,7 @@ end
 local function handle_docs(query: string): integer
   if query == "" then
     local docs = require("cosmic.doc")
-    local result = docs.run("")
+    local result = docs.query("")
     io.write(result.output .. "\n")
     return result.ok and 0 or 1
   else
@@ -433,7 +433,7 @@ end
 local function handle_skill(dir: string): integer
   local fs = require("cosmic.fs")
 
-  local ok, err = fs.makedirs(dir)
+  local ok, err = fs.make_dirs(dir)
   if not ok then
     io.stderr:write("--skill: " .. (err or "failed to create directory") .. "\n")
     return 1

--- a/_cli/main_handlers_test.tl
+++ b/_cli/main_handlers_test.tl
@@ -11,7 +11,7 @@
 
 local check = require("cosmic.check")
 local fs = require("cosmic.fs")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 
 -- Absolute: TEST_BIN is relative to the repo root under `make test`,
 -- and the --make test below runs a child with a different cwd.
@@ -31,7 +31,7 @@ local function cli(...: string): Run
   for _, a in ipairs({...}) do
     argv[#argv + 1] = a
   end
-  local h = check.must(spawn.spawn(argv))
+  local h = check.must(child.start(argv))
   local r = check.must(h:wait())
   -- code is nil when the child was signaled; report that as non-zero
   -- so callers can treat "did not exit cleanly" uniformly.
@@ -149,13 +149,13 @@ test_examples_miss_fails()
 
 local function test_make_dispatches_verb_and_paths()
   local dir = fs.join(tmpdir, "mk-src")
-  fs.makedirs(dir)
+  fs.make_dirs(dir)
   -- A directory declares itself a project; an ordinary directory of
   -- Teal files is a package inside one, and `--make` refuses it.
   fs.write(fs.join(dir, ".cosmicignore"), "")
   fs.write(fs.join(dir, "a.tl"), "local x: integer = 1\nprint(x)\n")
   fs.write(fs.join(dir, "b.tl"), "return {}\n")
-  local h = check.must(spawn.spawn({cosmic, "--make", "check", "a.tl"},
+  local h = check.must(child.start({cosmic, "--make", "check", "a.tl"},
       {cwd = dir}))
   local r = check.must(h:wait())
   assert(r.code == 0, "--make check should pass here, got " ..

--- a/_cli/require_hints_test.tl
+++ b/_cli/require_hints_test.tl
@@ -61,8 +61,8 @@ local function test_require_valid_module_works()
   local unix = require("cosmo.unix")
   assert(unix ~= nil, "require('cosmo.unix') should work")
 
-  local spawn = require("cosmic.child")
-  assert(spawn ~= nil, "require('cosmic.child') should work")
+  local child = require("cosmic.child")
+  assert(child ~= nil, "require('cosmic.child') should work")
 end
 test_require_valid_module_works()
 

--- a/_cli/welcome.tl
+++ b/_cli/welcome.tl
@@ -39,7 +39,7 @@ end
 --- @return boolean True when the config-dir marker or an embedded /zip marker exists
 local function was_shown(): boolean
   local dir = config_dir()
-  if dir and fs.isfile(fs.join(dir, MARKER)) then
+  if dir and fs.is_file(fs.join(dir, MARKER)) then
     return true
   end
   return fs.read("/zip/.cosmic/" .. MARKER) ~= nil
@@ -54,7 +54,7 @@ local function mark_shown()
   if not dir then
     return
   end
-  fs.makedirs(dir)
+  fs.make_dirs(dir)
   fs.write(fs.join(dir, MARKER), "")
 end
 

--- a/_cli/welcome_test.tl
+++ b/_cli/welcome_test.tl
@@ -3,7 +3,7 @@
 
 local check = require("cosmic.check")
 local fs = require("cosmic.fs")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 local sys = require("cosmic.sys")
 
 local cosmic = fs.join(os.getenv("TEST_BIN"), "cosmic")
@@ -11,7 +11,7 @@ local tmpdir = os.getenv("TEST_TMPDIR")
 
 -- Test --welcome shows message
 local function test_welcome_flag()
-  local r = check.must(spawn.run({cosmic, "--welcome"}))
+  local r = check.must(child.run({cosmic, "--welcome"}))
   assert(r.ok, "cosmic --welcome should succeed")
   local s = r.stdout
   assert(s:find("Welcome to cosmic%-lua!"), "should show welcome message")
@@ -24,7 +24,7 @@ test_welcome_flag()
 
 -- Test --help mentions --welcome and COSMIC_NO_WELCOME
 local function test_help_mentions_welcome()
-  local r = check.must(spawn.run({cosmic, "--help"}))
+  local r = check.must(child.run({cosmic, "--help"}))
   assert(r.ok, "cosmic --help should succeed")
   local s = r.stdout
   assert(s:find("%-%-welcome"), "help should mention --welcome flag")
@@ -49,7 +49,7 @@ end
   -- keep PATH: a replacement env with no PATH strands the APE stub —
   -- it can't find the staged `ape` loader (see tl_loader_test)
   local env = {"COSMIC_NO_WELCOME=1", "PATH=" .. os.getenv("PATH")}
-  local r = check.must(spawn.run({cosmic, test_script}, {env = env}))
+  local r = check.must(child.run({cosmic, test_script}, {env = env}))
   local s = r.stdout
   assert(r.ok, "script should succeed: " .. s)
   assert(s:find("COSMIC_NO_WELCOME is set"), "env var should be accessible: " .. s)
@@ -74,7 +74,7 @@ local function pty_available(): boolean
   -- Run cosmic through script to simulate a PTY (suppress welcome so this
   -- probe leaves no first-run state behind)
   local cmd = "COSMIC_NO_WELCOME=1 " .. cosmic .. " " .. probe
-  local r = check.must(spawn.run({"script", "-qc", cmd, "/dev/null"}))
+  local r = check.must(child.run({"script", "-qc", cmd, "/dev/null"}))
   local s = r.stdout
   if not r.ok then
     return false
@@ -98,14 +98,14 @@ end
 -- 10), so each test isolates first-run state with its own config dir.
 local function fresh_confdir(name: string): string
   local dir = fs.join(tmpdir, "conf-" .. name)
-  assert(fs.makedirs(dir))
+  assert(fs.make_dirs(dir))
   return dir
 end
 
 -- Copy the cosmic binary so no test ever touches the shared TEST_BIN one.
 local function copy_binary(name: string): string
   local dest = fs.join(tmpdir, "cosmic-" .. name)
-  local cp = check.must(spawn.run({"cp", cosmic, dest}))
+  local cp = check.must(child.run({"cp", cosmic, dest}))
   assert(cp.ok, "failed to copy cosmic binary")
   return dest
 end
@@ -118,7 +118,7 @@ local function run_with_pty(bin: string, args: {string}, confdir: string): boole
     -- Escape single quotes in arguments
     cmd = cmd .. " '" .. a:gsub("'", "'\\''") .. "'"
   end
-  local r = check.must(spawn.run({"script", "-qc", cmd, "/dev/null"}))
+  local r = check.must(child.run({"script", "-qc", cmd, "/dev/null"}))
   return r.ok, r.stdout
 end
 
@@ -166,7 +166,7 @@ local function test_marker_written_to_config_dir()
   local ok, out = run_with_pty(copy_binary("marker"), {"-e", "print(1)"}, confdir)
   assert(ok, "run should succeed: " .. out)
   assert(out:find("Welcome to cosmic%-lua!"), "welcome should appear: " .. out)
-  assert(fs.isfile(fs.join(confdir, "cosmic", "welcome-shown")),
+  assert(fs.is_file(fs.join(confdir, "cosmic", "welcome-shown")),
     "marker should be written to $XDG_CONFIG_HOME/cosmic/welcome-shown")
   print("test_marker_written_to_config_dir: PASS")
 end
@@ -175,13 +175,13 @@ test_marker_written_to_config_dir()
 -- With XDG_CONFIG_HOME unset, the marker falls back to $HOME/.config.
 local function test_marker_home_fallback()
   local home = fs.join(tmpdir, "home-fallback")
-  assert(fs.makedirs(home))
+  assert(fs.make_dirs(home))
   local bin = copy_binary("home-fallback")
   local cmd = "XDG_CONFIG_HOME= HOME='" .. home .. "' " .. bin .. " -e 'print(1)'"
-  local r = check.must(spawn.run({"script", "-qc", cmd, "/dev/null"}))
+  local r = check.must(child.run({"script", "-qc", cmd, "/dev/null"}))
   assert(r.ok, "run should succeed: " .. r.stdout)
   assert(r.stdout:find("Welcome to cosmic%-lua!"), "welcome should appear: " .. r.stdout)
-  assert(fs.isfile(fs.join(home, ".config", "cosmic", "welcome-shown")),
+  assert(fs.is_file(fs.join(home, ".config", "cosmic", "welcome-shown")),
     "marker should fall back to $HOME/.config/cosmic/welcome-shown")
   print("test_marker_home_fallback: PASS")
 end
@@ -208,7 +208,7 @@ test_welcome_not_shown_twice()
 local function test_embedded_marker_suppresses()
   local czip = require("cosmic.zip")
   local bin = copy_binary("embedded")
-  local a = check.must(czip.appender(bin))
+  local a = check.must(czip.append(bin))
   assert(a:add(".cosmic/welcome-shown", ""))
   a:close()
   local ok, out = run_with_pty(bin, {"-e", "print(1)"}, fresh_confdir("embedded"))
@@ -224,7 +224,7 @@ local function test_no_welcome_env_suppresses()
   local bin = copy_binary("no-welcome")
   local confdir = fresh_confdir("no-welcome")
   local cmd = "COSMIC_NO_WELCOME=1 XDG_CONFIG_HOME='" .. confdir .. "' " .. bin .. " -e 'print(1)'"
-  local r = check.must(spawn.run({"script", "-qc", cmd, "/dev/null"}))
+  local r = check.must(child.run({"script", "-qc", cmd, "/dev/null"}))
   local s = r.stdout
   assert(r.ok, "should succeed: " .. s)
   assert(not s:find("Welcome to cosmic%-lua!"), "welcome should be suppressed: " .. s)

--- a/_docs/derive.tl
+++ b/_docs/derive.tl
@@ -48,7 +48,7 @@ end
 local function records(): {Record}, {string}
   local found: {Record} = {}
   local bad: {string} = {}
-  local listed = fs.collect(DECISIONS, "*.md")
+  local listed = fs.find(DECISIONS, {glob = "*.md"})
   if listed == nil then
     return found, {DECISIONS .. ": cannot be listed"}
   end

--- a/_docs/publish.tl
+++ b/_docs/publish.tl
@@ -1,7 +1,7 @@
 -- docs-publish: publish generated docs to a git branch
 local fs = require("cosmic.fs")
 local proc = require("cosmic.proc")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 
 local record DocInfo
   path: string
@@ -98,7 +98,7 @@ local function prune_internal(docs_dir: string)
       end
     end, internal)
   for _, path in ipairs(internal) do
-    fs.rmrf(path)
+    fs.remove_all(path)
   end
 end
 
@@ -185,7 +185,7 @@ local function make_readme(docs_dir: string): string
 end
 
 local function run(argv: {string}): boolean, string
-  local r = spawn.run(argv)
+  local r = child.run(argv)
   if r.spawn_error then
     return nil, r.spawn_error
   end
@@ -201,10 +201,10 @@ local function main(source_sha: string, docs_dir: string, branch: string): boole
   end
 
   -- copy docs to temp before switching branches (checkout will clear working dir)
-  local temp_dir = fs.mkdtemp("/tmp/docs-publish-XXXXXX")
+  local temp_dir = fs.temp_dir("/tmp/docs-publish-XXXXXX")
   local ok, err = run({"cp", "-r", docs_dir .. "/.", temp_dir})
   if not ok then
-    fs.rmrf(temp_dir)
+    fs.remove_all(temp_dir)
     return nil, err
   end
 
@@ -218,9 +218,9 @@ local function main(source_sha: string, docs_dir: string, branch: string): boole
   if not ok then return nil, err end
 
   -- fetch and checkout docs branch, or create orphan
-  local fetch_res = spawn.run({"git", "fetch", "origin", branch})
+  local fetch_res = child.run({"git", "fetch", "origin", branch})
   -- cast: record union after nil check
-  local fetch_ok = fetch_res ~= nil and (fetch_res as spawn.Result).ok
+  local fetch_ok = fetch_res ~= nil and (fetch_res as child.Result).ok
 
   if fetch_ok then
     ok, err = run({"git", "switch", branch})
@@ -232,7 +232,7 @@ local function main(source_sha: string, docs_dir: string, branch: string): boole
   end
 
   -- remove old content (ignore errors for empty repos)
-  local _ = spawn.run({"git", "rm", "-rf", "."})
+  local _ = child.run({"git", "rm", "-rf", "."})
 
   -- clear working directory
   local dir0 = fs.opendir(".")
@@ -242,14 +242,14 @@ local function main(source_sha: string, docs_dir: string, branch: string): boole
       local name = dir:read()
       if not name then break end
       if name ~= "." and name ~= ".." and name ~= ".git" then
-        fs.rmrf(name)
+        fs.remove_all(name)
       end
     end
   end
 
   -- copy docs from temp
   ok, err = run({"cp", "-r", temp_dir .. "/.", "."})
-  fs.rmrf(temp_dir)
+  fs.remove_all(temp_dir)
   if not ok then return nil, err end
 
   -- write readme with doc table
@@ -261,9 +261,9 @@ local function main(source_sha: string, docs_dir: string, branch: string): boole
   if not ok then return nil, err end
 
   -- check if there are changes
-  local diff_res = spawn.run({"git", "diff", "--staged", "--quiet"})
+  local diff_res = child.run({"git", "diff", "--staged", "--quiet"})
   -- cast: record union after nil check
-  if diff_res ~= nil and (diff_res as spawn.Result).ok then
+  if diff_res ~= nil and (diff_res as child.Result).ok then
     io.stderr:write("no documentation changes detected\n")
     return true
   end

--- a/_docs/publish_test.tl
+++ b/_docs/publish_test.tl
@@ -12,7 +12,7 @@ end
 
 local function write_doc(docs_dir: string, rel: string, title: string, desc: string)
   local path = fs.join(docs_dir, rel)
-  fs.makedirs(fs.dirname(path))
+  fs.make_dirs(fs.dirname(path))
   fs.write(path, "# " .. title .. "\n\n" .. desc .. "\n\n## Types\n")
 end
 
@@ -67,7 +67,7 @@ local function test_prune_internal_keeps_public_surface_only()
     "cosmo/unix.md",
   }
   for _, rel in ipairs(kept) do
-    assert(fs.isfile(fs.join(docs_dir, rel)), "must keep public page: " .. rel)
+    assert(fs.is_file(fs.join(docs_dir, rel)), "must keep public page: " .. rel)
   end
 
   local pruned = {
@@ -77,7 +77,7 @@ local function test_prune_internal_keeps_public_surface_only()
     "_perf/harness.md",
   }
   for _, rel in ipairs(pruned) do
-    assert(not fs.isfile(fs.join(docs_dir, rel)), "must prune internal page: " .. rel)
+    assert(not fs.is_file(fs.join(docs_dir, rel)), "must prune internal page: " .. rel)
   end
 
   local readme = publish.make_readme(docs_dir)

--- a/_make/artifact.tl
+++ b/_make/artifact.tl
@@ -208,7 +208,7 @@ local function generated_payload(root: string, unit: string, out: {Staged})
   -- resolve against the caller's directory instead of the project's.
   local rel = fs.join(gen_dir(unit), PAYLOAD_DIR)
   local dir = fs.join(root, rel)
-  if not fs.isdir(dir) then
+  if not fs.is_dir(dir) then
     return
   end
   fs.walk(dir, function(path: string, _name: string,
@@ -309,7 +309,7 @@ end
 --- Copy the plan into a staging directory under `o/`.
 ---
 --- Staging to disk rather than handing `embed` a list of (content,
---- name) pairs keeps one code path: `embed.run` on a directory stores
+--- name) pairs keeps one code path: `embed.embed` on a directory stores
 --- everything relative to that directory's root, which is exactly the
 --- artifact layout once the plan has named it.
 --- @param proj Project The scanned project
@@ -321,7 +321,7 @@ local function stage(proj: Project, binary: Binary): string | nil, string
   -- Clear rather than merge: a file removed from the project must not
   -- survive in the artifact because it is still sitting in the stage.
   if fs.exists(dir) then
-    local ok, rerr = fs.rmrf(dir)
+    local ok, rerr = fs.remove_all(dir)
     if not ok then
       return nil, "make: cannot clear " .. dir .. ": " .. (rerr or "unknown error")
     end
@@ -342,7 +342,7 @@ local function stage(proj: Project, binary: Binary): string | nil, string
       content = body
     end
     local dst = fs.join(dir, s.stored)
-    local mok, merr = fs.makedirs(fs.dirname(dst))
+    local mok, merr = fs.make_dirs(fs.dirname(dst))
     if not mok then
       return nil, "make: cannot create " .. fs.dirname(dst) .. ": " ..
       (merr or "unknown error")
@@ -387,7 +387,7 @@ local function bases_of(proj: Project, binary: Binary,
     cosmic: string): {{string, string}}
   local dir = gen_dir(binary.dir)
   local base = fs.join(dir, BASE_NAME)
-  if not fs.isfile(fs.join(proj.root, base)) then
+  if not fs.is_file(fs.join(proj.root, base)) then
     return {{"", cosmic}}
   end
   local out: {{string, string}} = {{"", base}}
@@ -442,7 +442,7 @@ local function build(proj: Project, binary: Binary, cosmic: string): string | ni
     return nil, serr or "make: staging failed"
   end
   local bindir = fs.join(project.BUILD_DIR, "bin")
-  local mok, merr = fs.makedirs(bindir)
+  local mok, merr = fs.make_dirs(bindir)
   if not mok then
     return nil, "make: cannot create " .. bindir .. ": " ..
     (merr or "unknown error")
@@ -458,7 +458,7 @@ local function build(proj: Project, binary: Binary, cosmic: string): string | ni
     -- base's copy as well would ship two standard libraries, with the
     -- project's winning on package.path and the base's riding along.
     local staged_out = out .. ".new"
-    local result = embed.run({dir as string}, -- cast: scalar narrowing after the guard
+    local result = embed.embed({dir as string}, -- cast: scalar narrowing after the guard
       {output = staged_out, exe_path = pair[2], strip = true,
         provides = validate.claims(proj), mtime = embed.EPOCH})
     if not result.ok then

--- a/_make/artifact_test.tl
+++ b/_make/artifact_test.tl
@@ -14,7 +14,7 @@ local hash = require("cosmic.hash")
 local artifact = require("_make.artifact")
 local mk = require("_make")
 local project = require("_make.project")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 local types = require("_make.types")
 local zip = require("cosmic.zip")
 
@@ -31,24 +31,24 @@ local make_bin = fs.abspath(os.getenv("COSMIC_MAKE") or "o/make")
 -- a build; CI always provisions the engine, so its absence there means
 -- provisioning broke -- and the whole `--make` graph-test surface
 -- silently becoming green skips is the failure this guards (029).
-check.needs("the make engine at " .. make_bin, fs.isfile(make_bin))
+check.needs("the make engine at " .. make_bin, fs.is_file(make_bin))
 
 --- Build a fixture tree, returning its absolute root.
 local function fixture(name: string, files: {string: string}): string
   local root = fs.join(tmpdir, "artifact-" .. name)
-  fs.rmrf(root)
-  assert(fs.makedirs(root))
+  fs.remove_all(root)
+  assert(fs.make_dirs(root))
   for rel, content in pairs(files) do
     local path = fs.join(root, rel)
-    assert(fs.makedirs(fs.dirname(path)))
+    assert(fs.make_dirs(fs.dirname(path)))
     assert(fs.write(path, content))
   end
   -- A directory is not a project until it says so. Fixtures that
   -- declare a root themselves keep theirs; the rest get the marker
   -- that means "yes, this one" so the fixture tests what it is about.
-  if not fs.isfile(fs.join(root, "main.tl"))
-  and not fs.isfile(fs.join(root, "main.lua"))
-  and not fs.isfile(fs.join(root, ".cosmicignore")) then
+  if not fs.is_file(fs.join(root, "main.tl"))
+  and not fs.is_file(fs.join(root, "main.lua"))
+  and not fs.is_file(fs.join(root, ".cosmicignore")) then
     assert(fs.write(fs.join(root, ".cosmicignore"), ""))
   end
   return root
@@ -73,7 +73,7 @@ local function make(dir: string, ...: string): integer, string
     "NO_COLOR=1",
     "COSMIC_NO_WELCOME=1",
   }
-  local h = check.must(spawn.spawn(argv, {cwd = dir, env = env}))
+  local h = check.must(child.start(argv, {cwd = dir, env = env}))
   local r = check.must(h:wait())
   return r.code or 128, (r.stdout or "") .. (r.stderr or "")
 end
@@ -94,7 +94,7 @@ local function run_artifact(path: string): integer, string
     "NO_COLOR=1",
     "COSMIC_NO_WELCOME=1",
   }
-  local h = check.must(spawn.spawn({fs.abspath(path)}, {env = env}))
+  local h = check.must(child.start({fs.abspath(path)}, {env = env}))
   local r = check.must(h:wait())
   return r.code or 128, (r.stdout or "") .. (r.stderr or "")
 end
@@ -202,7 +202,7 @@ local function test_artifact_runs_on_the_floor()
   local code, out = make(root, "build")
   assert(code == 0, "build should succeed: " .. out)
   local bin = fs.join(root, "o/bin/artifact-runs")
-  assert(fs.isfile(bin), "expected " .. bin)
+  assert(fs.is_file(bin), "expected " .. bin)
   local rc, ran = run_artifact(bin)
   assert(rc == 0, "the artifact should run, got " .. rc .. ": " .. ran)
   assert(ran:find('{"said":"hi"}', 1, true),
@@ -225,7 +225,7 @@ local function test_stripped_to_the_floor()
       -- one module pitched at config-as-data threw at load, and every
       -- require miss reported a missing `tl` instead of itself.
       "local lit = require('cosmic.literal')\n" ..
-      "local cfg = lit.of_source([[return { s = \"\\u{41}BC\" }]], {file = 'c'})\n" ..
+      "local cfg = lit.parse([[return { s = \"\\u{41}BC\" }]], {file = 'c'})\n" ..
       "print('literal:', (cfg as {string:string}).s)\n" ..
       -- Non-literal, so the checker cannot resolve it at build time and
       -- the miss happens at runtime, where the searcher answers it.
@@ -253,7 +253,7 @@ local function test_stripped_to_the_floor()
 
   -- And it is gone from the archive, not merely unreachable: nothing
   -- outside the floor is extractable either.
-  local reader = check.must(zip.reader(bin))
+  local reader = check.must(zip.open(bin))
   local bytes: {string: integer} = {}
   for _, e in ipairs(reader:list()) do
     local top = e.name:match("^(%.lua/[^/]+)") or e.name:match("^([^/]+)")
@@ -300,7 +300,7 @@ local function test_provided_namespace_supersedes_the_floor()
   -- cannot be asked by prefix. It is asked by naming a module only the
   -- BASE has: cosmic/json.lua is present in every unstripped artifact
   -- and must be absent here, while the project's own entry stays.
-  local reader = check.must(zip.reader(bin))
+  local reader = check.must(zip.open(bin))
   local own, base_leftover = false, false
   for _, e in ipairs(reader:list()) do
     if e.name == "cosmic/mine.lua" then
@@ -366,7 +366,7 @@ local function test_build_takes_binaries_not_sources()
   -- Selecting the binary builds it, whole.
   local bcode, bout = make(root, "build", "artifact-selected")
   assert(bcode == 0, "selecting the binary should build it: " .. bout)
-  assert(fs.isfile(fs.join(root, "o/bin/artifact-selected")),
+  assert(fs.is_file(fs.join(root, "o/bin/artifact-selected")),
     "a selected build produces its artifact: " .. bout)
 end
 test_build_takes_binaries_not_sources()
@@ -378,7 +378,7 @@ local function test_in_process_build()
       ["cmd/artifact-inproc/main.tl"] = "print('x')\n",
       ["cmd/tool/main.tl"] = "print('tool')\n",
     })
-  local cwd = check.must(fs.getcwd())
+  local cwd = check.must(fs.cwd())
   cenv.set("COSMIC_MAKE_ROOT", root)
   cenv.set("COSMIC_MAKE", make_bin)
   local code = mk.run({"build"})
@@ -386,8 +386,8 @@ local function test_in_process_build()
   cenv.unset("COSMIC_MAKE")
   assert(fs.chdir(cwd))
   assert(code == 0, "in-process build should succeed")
-  assert(fs.isfile(fs.join(root, "o/bin/artifact-inproc")), "one binary")
-  assert(fs.isfile(fs.join(root, "o/bin/tool")), "the other binary")
+  assert(fs.is_file(fs.join(root, "o/bin/artifact-inproc")), "one binary")
+  assert(fs.is_file(fs.join(root, "o/bin/tool")), "the other binary")
 end
 test_in_process_build()
 
@@ -458,14 +458,14 @@ local function test_generated_payload_stages_like_committed()
   -- What a generator would have produced, where it produces it: under
   -- the GENERATOR's directory, because `o/cmd/tool/` is the build's.
   local unit = "o/cmd/tool/embed_gen/embed"
-  assert(fs.makedirs(fs.join(root, unit .. "/.types")))
+  assert(fs.make_dirs(fs.join(root, unit .. "/.types")))
   assert(fs.write(fs.join(root, unit .. "/tl.lua"), "return 'teal'\n"))
   assert(fs.write(fs.join(root, unit .. "/.types/cosmo.d.tl"), "return {}\n"))
-  assert(fs.makedirs(fs.join(root, "o/embed_gen/embed")))
+  assert(fs.make_dirs(fs.join(root, "o/embed_gen/embed")))
   assert(fs.write(fs.join(root, "o/embed_gen/embed/shared.lua"), "return {}\n"))
   -- The build's own notes share `o/<unit>/`, and must not ship: the
   -- collision that is why generated payload has its own directory.
-  assert(fs.makedirs(fs.join(root, "o/cmd/tool/embed")))
+  assert(fs.make_dirs(fs.join(root, "o/cmd/tool/embed")))
   assert(fs.write(fs.join(root, "o/cmd/tool/embed/committed.txt.lint.got"), "0"))
 
   local proj = scan(root)

--- a/_make/build_test.tl
+++ b/_make/build_test.tl
@@ -17,7 +17,7 @@ local check = require("cosmic.check")
 local cenv = require("cosmic.env")
 local fs = require("cosmic.fs")
 local mk = require("_make")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 
 local cosmic = fs.abspath(fs.join(os.getenv("TEST_BIN"), "cosmic"))
 local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
@@ -30,7 +30,7 @@ local make_bin = fs.abspath(os.getenv("COSMIC_MAKE")
 -- a build; CI always provisions the engine, so its absence there means
 -- provisioning broke -- and the whole `--make` graph-test surface
 -- silently becoming green skips is the failure this guards (029).
-check.needs("the make engine at " .. make_bin, fs.isfile(make_bin))
+check.needs("the make engine at " .. make_bin, fs.is_file(make_bin))
 
 local record Run
   code: integer
@@ -41,19 +41,19 @@ end
 --- Build a fixture tree, returning its absolute root.
 local function fixture(name: string, files: {string: string}): string
   local root = fs.join(tmpdir, "build-" .. name)
-  fs.rmrf(root)
-  assert(fs.makedirs(root))
+  fs.remove_all(root)
+  assert(fs.make_dirs(root))
   for rel, content in pairs(files) do
     local path = fs.join(root, rel)
-    assert(fs.makedirs(fs.dirname(path)))
+    assert(fs.make_dirs(fs.dirname(path)))
     assert(fs.write(path, content))
   end
   -- A directory is not a project until it says so. Fixtures that
   -- declare a root themselves keep theirs; the rest get the marker
   -- that means "yes, this one" so the fixture tests what it is about.
-  if not fs.isfile(fs.join(root, "main.tl"))
-  and not fs.isfile(fs.join(root, "main.lua"))
-  and not fs.isfile(fs.join(root, ".cosmicignore")) then
+  if not fs.is_file(fs.join(root, "main.tl"))
+  and not fs.is_file(fs.join(root, "main.lua"))
+  and not fs.is_file(fs.join(root, ".cosmicignore")) then
     assert(fs.write(fs.join(root, ".cosmicignore"), ""))
   end
   return root
@@ -72,7 +72,7 @@ local function make(dir: string, ...: string): Run
     "NO_COLOR=1",
     "COSMIC_NO_WELCOME=1",
   }
-  local h = check.must(spawn.spawn(argv, {cwd = dir, env = env}))
+  local h = check.must(child.start(argv, {cwd = dir, env = env}))
   local r = check.must(h:wait())
   return {code = r.code or 128, out = r.stdout or "", err = r.stderr or ""}
 end
@@ -106,7 +106,7 @@ local function test_build_compiles_the_tree()
   for _, rel in ipairs({"o/cmd/build-compile/main.lua", "o/db/init.lua",
       "o/db/db_test.lua",
       "o/legacy.lua", "o/cosmic.mk", "o/project.mk"}) do
-    assert(fs.isfile(fs.join(root, rel)), "expected " .. rel)
+    assert(fs.is_file(fs.join(root, rel)), "expected " .. rel)
   end
   -- schema.sql is not a module, so the graph does not compile it -- and
   -- it is not under `embed/`, so it does not ship either. Shipping is
@@ -178,7 +178,7 @@ local function test_a_failing_test_does_not_stop_the_run()
   -- Every test ran: three .got files, not one and an abort.
   for _, rel in ipairs({"o/db/bad_test.tl.test.got", "o/db/also_test.tl.test.got",
       "o/db/db_test.tl.test.got"}) do
-    assert(fs.isfile(fs.join(root, rel)), "expected " .. rel .. " to exist")
+    assert(fs.is_file(fs.join(root, rel)), "expected " .. rel .. " to exist")
   end
 end
 test_a_failing_test_does_not_stop_the_run()
@@ -238,7 +238,7 @@ test_validation_gates_the_graph()
 -- is asserted in pin_test.tl, which needs no engine for it.)
 local function test_build_never_resolves_a_pin()
   local root = app("pinned")
-  assert(fs.makedirs(fs.join(root, "3p")))
+  assert(fs.make_dirs(fs.join(root, "3p")))
   assert(fs.write(fs.join(root, "3p/blob_pin.tl"),
       'return {\n  url = "http://127.0.0.1:1/blob.bin",\n' ..
       '  sha256 = "e0997b6447e07ef18b6304a2b88ded9b24106e5bd67b40fab' ..
@@ -258,7 +258,7 @@ test_build_never_resolves_a_pin()
 local function test_builds_with_no_engine_named()
   local root = app("embedded")
   local argv: {string} = {cosmic, "--make", "build"}
-  local h = check.must(spawn.spawn(argv, {
+  local h = check.must(child.start(argv, {
         cwd = root,
         -- PATH stays: the extracted engine is a fat APE whose shell
         -- stub needs a POSIX environment to reach its loader. What is
@@ -271,9 +271,9 @@ local function test_builds_with_no_engine_named()
   local r = check.must(h:wait())
   local out = (r.stdout or "") .. (r.stderr or "")
   assert(r.code == 0, "a build with no engine named must work: " .. out)
-  assert(fs.isfile(fs.join(root, "o/make")),
+  assert(fs.is_file(fs.join(root, "o/make")),
     "the engine should have extracted itself to o/make")
-  assert(fs.isfile(fs.join(root, "o/bin/build-embedded")),
+  assert(fs.is_file(fs.join(root, "o/bin/build-embedded")),
     "…and produced the artifact")
 end
 test_builds_with_no_engine_named()
@@ -429,7 +429,7 @@ test_a_test_gets_its_own_scratch_directory()
 -- --make ci` from a committed binary), which is why it is asserted
 -- rather than left to the CLI tests, where the path is absolute.
 local function in_process(root: string, ...: string): integer
-  local cwd = check.must(fs.getcwd())
+  local cwd = check.must(fs.cwd())
   cenv.set("COSMIC_MAKE_ROOT", root)
   cenv.set("COSMIC_MAKE", make_bin)
   local argv: {string} = {}
@@ -456,7 +456,7 @@ local function test_a_variant_base_ships_the_payload_twice()
   -- The base lives in the binary's OWN payload-gen dir, which for a
   -- cmd/<name> unit is o/cmd/<name>/embed_gen, not the root's o/embed_gen.
   local gendir = fs.join(root, "o/cmd/build-variant/embed_gen")
-  assert(fs.makedirs(gendir))
+  assert(fs.make_dirs(gendir))
   for _, name in ipairs({"base", "base-debug"}) do
     local path = fs.join(gendir, name)
     assert(fs.write(path, runtime))
@@ -466,8 +466,8 @@ local function test_a_variant_base_ships_the_payload_twice()
   assert(in_process(root, "build") == 0, "build should succeed")
   for _, rel in ipairs({"o/bin/build-variant", "o/bin/build-variant-debug"}) do
     local path = fs.join(root, rel)
-    assert(fs.isfile(path), rel .. " should be built")
-    local done = check.must(check.must(spawn.spawn({path})):wait())
+    assert(fs.is_file(path), rel .. " should be built")
+    local done = check.must(check.must(child.start({path})):wait())
     assert(done.ok and (done.stdout or ""):find("ran", 1, true),
       rel .. " should run its payload, got: " .. tostring(done.stdout))
   end

--- a/_make/check_test.tl
+++ b/_make/check_test.tl
@@ -22,7 +22,7 @@ local mk = require("_make")
 local mtypes = require("_make.types")
 
 local type File = mtypes.File
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 
 local cosmic = fs.abspath(fs.join(os.getenv("TEST_BIN"), "cosmic"))
 local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
@@ -36,19 +36,19 @@ end
 --- Build a fixture tree, returning its absolute root.
 local function fixture(name: string, files: {string: string}): string
   local root = fs.join(tmpdir, "check-" .. name)
-  fs.rmrf(root)
-  assert(fs.makedirs(root))
+  fs.remove_all(root)
+  assert(fs.make_dirs(root))
   for rel, content in pairs(files) do
     local path = fs.join(root, rel)
-    assert(fs.makedirs(fs.dirname(path)))
+    assert(fs.make_dirs(fs.dirname(path)))
     assert(fs.write(path, content))
   end
   -- A directory is not a project until it says so. Fixtures that
   -- declare a root themselves keep theirs; the rest get the marker
   -- that means "yes, this one" so the fixture tests what it is about.
-  if not fs.isfile(fs.join(root, "main.tl"))
-  and not fs.isfile(fs.join(root, "main.lua"))
-  and not fs.isfile(fs.join(root, ".cosmicignore")) then
+  if not fs.is_file(fs.join(root, "main.tl"))
+  and not fs.is_file(fs.join(root, "main.lua"))
+  and not fs.is_file(fs.join(root, ".cosmicignore")) then
     assert(fs.write(fs.join(root, ".cosmicignore"), ""))
   end
   return root
@@ -60,7 +60,7 @@ local function make(dir: string, ...: string): Run
   for _, a in ipairs({...}) do
     argv[#argv + 1] = a
   end
-  local h = check.must(spawn.spawn(argv, {cwd = dir}))
+  local h = check.must(child.start(argv, {cwd = dir}))
   local r = check.must(h:wait())
   return {code = r.code or 128, out = r.stdout or "", err = r.stderr or ""}
 end
@@ -307,7 +307,7 @@ test_help_is_a_verb()
 -- silently doing something with no verb is worse than saying so.
 local function test_bare_make_is_a_usage_error()
   local root = app("bare")
-  local h = check.must(spawn.spawn({cosmic, "--make"}, {cwd = root}))
+  local h = check.must(child.start({cosmic, "--make"}, {cwd = root}))
   local r = check.must(h:wait())
   assert(r.code ~= 0, "bare --make must not exit 0")
   assert((r.stderr or ""):find("--make requires", 1, true),
@@ -320,7 +320,7 @@ test_bare_make_is_a_usage_error()
 local function test_root_override()
   local root = app("override")
   local elsewhere = fixture("override-elsewhere", {})
-  local h = check.must(spawn.spawn({cosmic, "--make", "check"}, {
+  local h = check.must(child.start({cosmic, "--make", "check"}, {
         cwd = elsewhere,
         env = {"PATH=" .. (os.getenv("PATH") or ""),
           "COSMIC_MAKE_ROOT=" .. root},
@@ -338,7 +338,7 @@ test_root_override()
 -- call: a verb that leaves the process somewhere else is a verb no
 -- caller can use twice.
 local function in_process(root: string, ...: string): integer
-  local cwd = check.must(fs.getcwd())
+  local cwd = check.must(fs.cwd())
   cenv.set("COSMIC_MAKE_ROOT", root)
   local argv: {string} = {}
   for _, a in ipairs({...}) do
@@ -406,7 +406,7 @@ test_the_verbs_refuse_a_bad_selection_on_their_own()
 -- nothing must reach the selection and be refused, not ignored.
 local function test_make_equals_form_keeps_its_selection()
   local root = app("equals")
-  local h = check.must(spawn.spawn({cosmic, "--make=check", "nope.tl"},
+  local h = check.must(child.start({cosmic, "--make=check", "nope.tl"},
       {cwd = root}))
   local r = check.must(h:wait())
   local out = (r.stdout or "") .. (r.stderr or "")
@@ -427,11 +427,11 @@ local function test_the_graph_proof_and_what_unmakes_it()
       ["3p/dep/dep_pin.tl"] = "return { version = \"1\" }\n",
     })
   local proj = check.must(mk.scan(root))
-  local cwd = check.must(fs.getcwd())
+  local cwd = check.must(fs.cwd())
   assert(fs.chdir(root))
   for _, rel in ipairs({"o/db/init.lua", "o/3p/dep/dep_pin.lua",
       "o/.stamp/compile", "o/_types/types_gen.stamp"}) do
-    assert(fs.makedirs(fs.dirname(rel)))
+    assert(fs.make_dirs(fs.dirname(rel)))
     assert(fs.write(rel, "x\n"))
     assert(fs.set_times(rel, {atime = {secs = 1000}, mtime = {secs = 1000}}))
   end
@@ -467,11 +467,11 @@ local function test_check_skips_what_the_graph_proved()
       ["bad.tl"] = "local x: integer = 'nope'\nreturn x\n",
     })
   local proj = check.must(mk.scan(root))
-  local cwd = check.must(fs.getcwd())
+  local cwd = check.must(fs.cwd())
   assert(fs.chdir(root))
   for _, rel in ipairs({"o/bad.lua", "o/.stamp/compile",
       "o/_types/types_gen.stamp"}) do
-    assert(fs.makedirs(fs.dirname(rel)))
+    assert(fs.make_dirs(fs.dirname(rel)))
     assert(fs.write(rel, "x\n"))
     assert(fs.set_times(rel, {atime = {secs = 1000}, mtime = {secs = 1000}}))
   end

--- a/_make/clean.tl
+++ b/_make/clean.tl
@@ -47,7 +47,7 @@ local function run(_proj: Project, _paths: {string},
     if KEEP[fs.basename(path)] then
       kept = kept + 1
     else
-      local ok, err = fs.rmrf(path)
+      local ok, err = fs.remove_all(path)
       if not ok then
         io.stderr:write("make: cannot remove " .. path .. ": " ..
           (err or "unknown error") .. "\n")
@@ -61,7 +61,7 @@ local function run(_proj: Project, _paths: {string},
   -- an empty `o/` would be a difference with no meaning that every
   -- caller then has to know about.
   if kept == 0 then
-    local ok, err = fs.rmrf(project.BUILD_DIR)
+    local ok, err = fs.remove_all(project.BUILD_DIR)
     if not ok then
       io.stderr:write("make: cannot remove " .. project.BUILD_DIR .. ": " ..
         (err or "unknown error") .. "\n")

--- a/_make/clean_test.tl
+++ b/_make/clean_test.tl
@@ -10,7 +10,7 @@
 
 local check = require("cosmic.check")
 local fs = require("cosmic.fs")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 
 local cosmic = fs.abspath(fs.join(os.getenv("TEST_BIN"), "cosmic"))
 local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
@@ -23,7 +23,7 @@ local make_bin = fs.abspath(os.getenv("COSMIC_MAKE")
 -- a build; CI always provisions the engine, so its absence there means
 -- provisioning broke -- and the whole `--make` graph-test surface
 -- silently becoming green skips is the failure this guards (029).
-check.needs("the make engine at " .. make_bin, fs.isfile(make_bin))
+check.needs("the make engine at " .. make_bin, fs.is_file(make_bin))
 
 local record Run
   code: integer
@@ -34,19 +34,19 @@ end
 --- Build a fixture tree, returning its absolute root.
 local function fixture(name: string, files: {string: string}): string
   local root = fs.join(tmpdir, "clean-" .. name)
-  fs.rmrf(root)
-  assert(fs.makedirs(root))
+  fs.remove_all(root)
+  assert(fs.make_dirs(root))
   for rel, content in pairs(files) do
     local path = fs.join(root, rel)
-    assert(fs.makedirs(fs.dirname(path)))
+    assert(fs.make_dirs(fs.dirname(path)))
     assert(fs.write(path, content))
   end
   -- A directory is not a project until it says so. Fixtures that
   -- declare a root themselves keep theirs; the rest get the marker
   -- that means "yes, this one" so the fixture tests what it is about.
-  if not fs.isfile(fs.join(root, "main.tl"))
-  and not fs.isfile(fs.join(root, "main.lua"))
-  and not fs.isfile(fs.join(root, ".cosmicignore")) then
+  if not fs.is_file(fs.join(root, "main.tl"))
+  and not fs.is_file(fs.join(root, "main.lua"))
+  and not fs.is_file(fs.join(root, ".cosmicignore")) then
     assert(fs.write(fs.join(root, ".cosmicignore"), ""))
   end
   return root
@@ -65,7 +65,7 @@ local function make(dir: string, ...: string): Run
     "NO_COLOR=1",
     "COSMIC_NO_WELCOME=1",
   }
-  local h = check.must(spawn.spawn(argv, {cwd = dir, env = env}))
+  local h = check.must(child.start(argv, {cwd = dir, env = env}))
   local r = check.must(h:wait())
   return {code = r.code or 128, out = r.stdout or "", err = r.stderr or ""}
 end
@@ -89,7 +89,7 @@ end
 local function test_clean_removes_the_build_directory()
   local root = app("clean")
   assert(make(root, "build").code == 0, "build first")
-  assert(fs.isdir(fs.join(root, "o")), "o/ should exist")
+  assert(fs.is_dir(fs.join(root, "o")), "o/ should exist")
   local r = make(root, "clean")
   assert(r.code == 0, "clean should succeed: " .. r.err)
   assert(not fs.exists(fs.join(root, "o")), "o/ should be gone")
@@ -108,12 +108,12 @@ local function test_clean_keeps_the_verified_bootstrap()
   local root = app("cleanboot")
   assert(make(root, "build").code == 0, "build first")
   local boot = fs.join(root, "o/bootstrap")
-  assert(fs.makedirs(boot))
+  assert(fs.make_dirs(boot))
   assert(fs.write(fs.join(boot, "cosmic"), "pretend binary\n"))
 
   local r = make(root, "clean")
   assert(r.code == 0, "clean should succeed: " .. r.err)
-  assert(fs.isfile(fs.join(boot, "cosmic")),
+  assert(fs.is_file(fs.join(boot, "cosmic")),
     "the verified bootstrap survives: " .. r.out)
   assert(r.out:find("kept the verified bootstrap", 1, true),
     "and clean says so: " .. r.out)

--- a/_make/converge.tl
+++ b/_make/converge.tl
@@ -168,7 +168,7 @@ end
 --- @param path string The candidate artifact
 --- @return boolean Whether it answers as a cosmic engine
 local function drives_a_build(path: string): boolean
-  local h, serr = child.spawn({path, "--make", "help"}, {stdin = ""})
+  local h, serr = child.start({path, "--make", "help"}, {stdin = ""})
   if not (h is child.Handle) then
     local _ = serr
     return false
@@ -203,7 +203,7 @@ local function to_the_tree(proj: Project, argv: {string},
     (tool as Binary).name) -- cast: record union after the guard
   local gen = math.tointeger(tonumber(env.get_or(GEN_ENV, "0")) or 0) or 0
 
-  local was_us = fs.isfile(built) and same_file(built, self)
+  local was_us = fs.is_file(built) and same_file(built, self)
   local before = stamp_of(built)
   local r = child.run({self, "--make", "build"},
     {stdout = "inherit", stderr = "inherit"})
@@ -211,7 +211,7 @@ local function to_the_tree(proj: Project, argv: {string},
     return false, "make: " ..
     (r.spawn_error or "the converging build failed"), "build failed"
   end
-  if not fs.isfile(built) then
+  if not fs.is_file(built) then
     return false, "make: " .. built .. ": the build produced no artifact",
     "no artifact"
   end

--- a/_make/converge_test.tl
+++ b/_make/converge_test.tl
@@ -18,11 +18,11 @@ local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
 --- A scanned project from a file map.
 local function scan(name: string, files: {string: string}): types.Project
   local root = fs.join(tmpdir, "converge-" .. name)
-  fs.rmrf(root)
-  assert(fs.makedirs(root))
+  fs.remove_all(root)
+  assert(fs.make_dirs(root))
   for rel, body in pairs(files) do
     local path = fs.join(root, rel)
-    assert(fs.makedirs(fs.dirname(path)))
+    assert(fs.make_dirs(fs.dirname(path)))
     assert(fs.write(path, body))
   end
   -- Bound before must(): scan returns more than one value, and a
@@ -90,14 +90,14 @@ test_refusals_name_which_one_they_are()
 -- traceback is visible.
 local function test_the_probe_reads_the_answer()
   local engine = fs.join(os.getenv("TEST_BIN") or "", "cosmic")
-  check.needs("a built cosmic at " .. engine, fs.isfile(engine))
+  check.needs("a built cosmic at " .. engine, fs.is_file(engine))
   assert(converge.drives_a_build(engine),
     "the real engine answers `--make help`")
 
   -- A look-alike: succeeds, says nothing an engine says.
   local dir = fs.join(tmpdir, "converge-probe")
-  fs.rmrf(dir)
-  assert(fs.makedirs(dir))
+  fs.remove_all(dir)
+  assert(fs.make_dirs(dir))
   local fake = fs.join(dir, "lookalike")
   assert(fs.write(fake, "#!/bin/sh\necho 'usage: lookalike [options]'\nexit 0\n"))
   assert(fs.chmod(fake, tonumber("755", 8) as integer)) -- cast: octal literal
@@ -135,7 +135,7 @@ test_the_probe_mark_is_help_usages_own_constant()
 
 --- An executable `#!/bin/sh` script at `path`.
 local function script(path: string, body: string): string
-  assert(fs.makedirs(fs.dirname(path)))
+  assert(fs.make_dirs(fs.dirname(path)))
   assert(fs.write(path, "#!/bin/sh\n" .. body))
   assert(fs.chmod(path, tonumber("755", 8) as integer)) -- cast: octal literal
   return path
@@ -144,8 +144,8 @@ end
 --- A scratch directory that is a project root and a working directory.
 local function scratch(name: string): string
   local dir = fs.join(tmpdir, "converge-" .. name)
-  fs.rmrf(dir)
-  assert(fs.makedirs(dir))
+  fs.remove_all(dir)
+  assert(fs.make_dirs(dir))
   return dir
 end
 
@@ -157,7 +157,7 @@ end
 --- below gets a directory arranged for it.
 local function converge_in(dir: string, proj: types.Project,
     self: string): boolean, string, string
-  local was = check.must(fs.getcwd())
+  local was = check.must(fs.cwd())
   assert(fs.chdir(dir))
   local ok, err, why = converge.to_the_tree(proj, {"check"}, self)
   assert(fs.chdir(was))
@@ -179,7 +179,7 @@ end
 local function test_a_build_that_makes_no_artifact_refuses()
   local dir = scratch("no-artifact")
   local self = script(fs.join(dir, "quiet"), "exit 0\n")
-  assert(not fs.isfile(fs.join(dir, "o/bin/cosmic")),
+  assert(not fs.is_file(fs.join(dir, "o/bin/cosmic")),
     "the fixture must not start with an artifact")
 
   local ok, err, why = converge_in(dir, toolchain("no-artifact-proj"), self)
@@ -201,7 +201,7 @@ local function test_a_build_that_never_settles_refuses()
   local self = script(fs.join(dir, "quiet"), "exit 0\n")
   -- An artifact that exists and is not what is running, so the fixpoint
   -- test below cannot fire and the cap is what answers.
-  assert(fs.makedirs(fs.join(dir, "o/bin")))
+  assert(fs.make_dirs(fs.join(dir, "o/bin")))
   assert(fs.write(fs.join(dir, "o/bin/cosmic"), "not the running binary\n"))
 
   cenv.set("COSMIC_MAKE_GEN", "2", true)

--- a/_make/deps_test.tl
+++ b/_make/deps_test.tl
@@ -21,11 +21,11 @@ local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
 --- Build a fixture tree and scan it.
 local function fixture(name: string, files: {string: string}): Project
   local root = fs.join(tmpdir, "deps-" .. name)
-  fs.rmrf(root)
-  assert(fs.makedirs(root))
+  fs.remove_all(root)
+  assert(fs.make_dirs(root))
   for rel, content in pairs(files) do
     local path = fs.join(root, rel)
-    assert(fs.makedirs(fs.dirname(path)))
+    assert(fs.make_dirs(fs.dirname(path)))
     assert(fs.write(path, content))
   end
   local proj = check.must(project.scan(root))

--- a/_make/docs.tl
+++ b/_make/docs.tl
@@ -67,7 +67,7 @@ local function render(proj: Project, paths?: {string}): integer, string
       return written, "make: " .. f.path .. ": " .. tostring(rerr)
     end
     local out = page_of(f.path)
-    if not fs.makedirs(fs.dirname(out)) then
+    if not fs.make_dirs(fs.dirname(out)) then
       return written, "make: cannot create " .. fs.dirname(out)
     end
     local wok, werr = fs.write(out, output)

--- a/_make/extract.tl
+++ b/_make/extract.tl
@@ -65,7 +65,7 @@ local function strip_into(from: string, to: string, strip: integer,
       end
       local dest = fs.join(to, stripped)
       out[#out + 1] = stripped
-      local mok, merr = fs.makedirs(fs.dirname(dest))
+      local mok, merr = fs.make_dirs(fs.dirname(dest))
       if not mok then
         failure = "cannot create " .. fs.dirname(dest) .. ": " ..
         (merr or "unknown error")
@@ -109,8 +109,8 @@ end
 local function unpack(archive: string, dest: string, format: string,
     strip: integer): {string} | nil, string
   local staging = fs.join(dest, ".unpack")
-  fs.rmrf(staging)
-  local mok, merr = fs.makedirs(staging)
+  fs.remove_all(staging)
+  local mok, merr = fs.make_dirs(staging)
   if not mok then
     return nil, "make: cannot create " .. staging .. ": " ..
     (merr or "unknown error")
@@ -118,31 +118,31 @@ local function unpack(archive: string, dest: string, format: string,
   local ok: boolean = false
   local err: string = nil
   if format == "zip" then
-    local reader, oerr = zip.reader(archive)
-    if not (reader is zip.Reader) then
-      fs.rmrf(staging)
+    local reader, oerr = zip.open(archive)
+    if not (reader is zip.Archive) then
+      fs.remove_all(staging)
       return nil, "make: cannot open " .. archive .. ": " ..
       (oerr or "unknown error")
     end
     -- cast: narrowing does not survive the early-exit guard above
-    local r = reader as zip.Reader
+    local r = reader as zip.Archive
     ok, err = zip.extract(r, staging)
     r:close()
   elseif format == "tar.gz" then
     ok, err = untar.extract(archive, staging)
   else
-    fs.rmrf(staging)
+    fs.remove_all(staging)
     return nil, "make: " .. archive .. ": unknown format '" .. format ..
     "'; a pin unpacks as zip or tar.gz"
   end
   if not ok then
-    fs.rmrf(staging)
+    fs.remove_all(staging)
     return nil, "make: cannot unpack " .. archive .. ": " ..
     (err or "unknown error")
   end
   local produced: {string} = {}
   local sok, serr = strip_into(staging, dest, strip, produced)
-  fs.rmrf(staging)
+  fs.remove_all(staging)
   if not sok then
     return nil, serr
   end

--- a/_make/fetch.tl
+++ b/_make/fetch.tl
@@ -104,7 +104,7 @@ local function unpacked(p: Pin, archive: string): boolean, string
   end
   -- Clear any previous run's manifest first, so a re-unpack that fails
   -- cannot leave the old claim standing over a tree it did not produce.
-  fs.rmrf(manifest_of(archive))
+  fs.remove_all(manifest_of(archive))
   local produced, err = extract.unpack(archive, fs.dirname(archive), p.format,
     p.strip_components)
   if not produced then
@@ -157,7 +157,7 @@ local function one(p: Pin): boolean, string
     io.write("unpack " .. p.output .. "\n")
     return unpacked(p, out)
   end
-  local ok, merr = fs.makedirs(fs.dirname(out))
+  local ok, merr = fs.make_dirs(fs.dirname(out))
   if not ok then
     return false, "make: cannot create " .. fs.dirname(out) .. ": " ..
     (merr or "unknown error")

--- a/_make/fixpoint_test.tl
+++ b/_make/fixpoint_test.tl
@@ -32,7 +32,7 @@
 local check = require("cosmic.check")
 local fs = require("cosmic.fs")
 local hash = require("cosmic.hash")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 
 local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
 local repo = fs.abspath(".")
@@ -41,7 +41,7 @@ local cosmic = fs.abspath(fs.join(os.getenv("TEST_BIN") or "o/bin", "cosmic"))
 --- Copy one file, creating the destination's directory.
 local function copy(from: string, to: string)
   local body = check.must(fs.read(from))
-  assert(fs.makedirs(fs.dirname(to)))
+  assert(fs.make_dirs(fs.dirname(to)))
   assert(fs.write(to, body))
   local st = fs.stat(from)
   if st then
@@ -57,7 +57,7 @@ end
 --- the copy larger, never the assertion weaker.
 --- @param dest string Directory to populate
 local function copy_tree(dest: string)
-  assert(fs.makedirs(dest))
+  assert(fs.make_dirs(dest))
   local failure: string = nil
   fs.walk(repo, function(path: string, entry: string,
         st: fs.WalkStat): fs.WalkAction
@@ -74,7 +74,7 @@ local function copy_tree(dest: string)
         return "stop"
       end
       local out = fs.join(dest, rel)
-      if not fs.makedirs(fs.dirname(out)) or not fs.write(out, body) then
+      if not fs.make_dirs(fs.dirname(out)) or not fs.write(out, body) then
         failure = "cannot write " .. rel
         return "stop"
       end
@@ -105,7 +105,7 @@ local function seed_pins(dest: string): boolean
     -- writes (`o/staged/**` is the retired candidate) is not a
     -- fallback, it is a branch that can only ever return nil.
     local from = fs.join(repo, w[3])
-    if not fs.isfile(from) then
+    if not fs.is_file(from) then
       return false
     end
     copy(from, fs.join(dest, w[3]))
@@ -135,7 +135,7 @@ local function build_with(bin: string, dir: string): integer, string
     -- unrecorded precondition that holds only while both generations
     -- happen to be stamped the same way.
   }
-  local h = check.must(spawn.spawn({bin, "--make", "build"},
+  local h = check.must(child.start({bin, "--make", "build"},
       {cwd = dir, env = env}))
   local r = check.must(h:wait())
   return r.code or 128, (r.stdout or "") .. (r.stderr or "")
@@ -153,7 +153,7 @@ local function run(bin: string, ...: string): integer, string
     "NO_COLOR=1",
     "COSMIC_NO_WELCOME=1",
   }
-  local h = check.must(spawn.spawn(argv, {env = env}))
+  local h = check.must(child.start(argv, {env = env}))
   local r = check.must(h:wait())
   return r.code or 128, (r.stdout or "") .. (r.stderr or "")
 end
@@ -164,7 +164,7 @@ end
 --- @return string The path to the produced binary
 local function generation(label: string, with: string): string
   local dir = fs.join(tmpdir, "fixpoint-" .. label)
-  fs.rmrf(dir)
+  fs.remove_all(dir)
   copy_tree(dir)
   -- The version as a tree input. `copy_tree` skips dotfiles, so this is
   -- the copy's own declaration and never the developer's.
@@ -174,7 +174,7 @@ local function generation(label: string, with: string): string
   local code, out = build_with(with, dir)
   assert(code == 0, label .. ": --make build should succeed:\n" .. out)
   local built = fs.join(dir, "o/bin/cosmic")
-  assert(fs.isfile(built), label .. ": no artifact at o/bin/cosmic:\n" .. out)
+  assert(fs.is_file(built), label .. ": no artifact at o/bin/cosmic:\n" .. out)
   return built
 end
 
@@ -192,9 +192,9 @@ end
 -- Both halves need the pinned inputs. Skipping when they are absent
 -- keeps a cold checkout usable; in CI they are always there, because
 -- the lane runs after the ordinary build.
-check.needs("a built cosmic at " .. cosmic, fs.isfile(cosmic))
+check.needs("a built cosmic at " .. cosmic, fs.is_file(cosmic))
 check.needs("fetched pins to seed from",
-  fs.isfile(fs.join(repo, "o/3p/tl/tl.lua")))
+  fs.is_file(fs.join(repo, "o/3p/tl/tl.lua")))
 
 -- gen2: the product works. Every check here is a capability the binary
 -- only has if its payload arrived -- running a `.tl` needs tl.lua,

--- a/_make/fixtures_test.tl
+++ b/_make/fixtures_test.tl
@@ -14,7 +14,7 @@
 
 local check = require("cosmic.check")
 local fs = require("cosmic.fs")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 
 local cosmic = fs.abspath(fs.join(os.getenv("TEST_BIN"), "cosmic"))
 local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
@@ -28,7 +28,7 @@ local make_bin = fs.abspath(os.getenv("COSMIC_MAKE")
 -- a build; CI always provisions the engine, so its absence there means
 -- provisioning broke -- and the whole `--make` graph-test surface
 -- silently becoming green skips is the failure this guards (029).
-check.needs("the make engine at " .. make_bin, fs.isfile(make_bin))
+check.needs("the make engine at " .. make_bin, fs.is_file(make_bin))
 
 --- Copy a fixture out of the tree and return its scratch root.
 ---
@@ -39,9 +39,9 @@ check.needs("the make engine at " .. make_bin, fs.isfile(make_bin))
 --- exists to hold.
 local function staged(name: string): string
   local root = fs.join(tmpdir, "fixtures", name)
-  fs.rmrf(root)
-  assert(fs.makedirs(fs.dirname(root)))
-  local ok, err = fs.copytree(fs.join(here, name), root)
+  fs.remove_all(root)
+  assert(fs.make_dirs(fs.dirname(root)))
+  local ok, err = fs.copy_tree(fs.join(here, name), root)
   assert(ok, "cannot stage fixture " .. name .. ": " .. tostring(err))
   return root
 end
@@ -55,7 +55,7 @@ local function make(dir: string, verb: string): integer, string
     "NO_COLOR=1",
     "COSMIC_NO_WELCOME=1",
   }
-  local h = check.must(spawn.spawn({cosmic, "--make", verb}, {cwd = dir, env = env}))
+  local h = check.must(child.start({cosmic, "--make", verb}, {cwd = dir, env = env}))
   local r = check.must(h:wait())
   return r.code or 128, (r.stdout or "") .. (r.stderr or "")
 end
@@ -64,7 +64,7 @@ end
 --- environment is named rather than inherited).
 local function run(path: string): integer, string
   local env: {string} = {"PATH=" .. (os.getenv("PATH") or ""), "NO_COLOR=1"}
-  local h = check.must(spawn.spawn({fs.abspath(path)}, {env = env}))
+  local h = check.must(child.start({fs.abspath(path)}, {env = env}))
   local r = check.must(h:wait())
   return r.code or 128, (r.stdout or "") .. (r.stderr or "")
 end
@@ -83,7 +83,7 @@ local function fixture(name: string, want: {string: string}): string
 
   for bin, expect in pairs(want) do
     local path = fs.join(root, "o/bin/" .. bin)
-    assert(fs.isfile(path), name .. ": expected artifact " .. path .. "\n" .. out)
+    assert(fs.is_file(path), name .. ": expected artifact " .. path .. "\n" .. out)
     local rc, ran = run(path)
     assert(rc == 0, name .. "/" .. bin .. ": artifact should run, got " ..
       rc .. ": " .. ran)
@@ -118,7 +118,7 @@ local function test_lua_markers_are_first_class()
     "and be counted, got: " .. out)
 
   local zip = require("cosmic.zip")
-  local reader = check.must(zip.reader(fs.join(luaonly_root, "o/bin/luaonly")))
+  local reader = check.must(zip.open(fs.join(luaonly_root, "o/bin/luaonly")))
   local shipped = false
   for _, e in ipairs(reader:list()) do
     if e.name:find("main_test", 1, true) then shipped = true end
@@ -137,7 +137,7 @@ local assets_root = fixture("assets",
 
 local function test_only_declared_payload_ships()
   local zip = require("cosmic.zip")
-  local reader = check.must(zip.reader(fs.join(assets_root, "o/bin/assets")))
+  local reader = check.must(zip.open(fs.join(assets_root, "o/bin/assets")))
   local saw: {string: boolean} = {}
   for _, e in ipairs(reader:list()) do
     saw[e.name] = true

--- a/_make/generate.tl
+++ b/_make/generate.tl
@@ -72,10 +72,10 @@ end
 local function source_of(proj: Project, built: string): string | nil, string
   local rel = built:sub(#project.BUILD_DIR + 2)
   local tl = (rel:gsub("%.lua$", ".tl"))
-  if fs.isfile(fs.join(proj.root, tl)) then
+  if fs.is_file(fs.join(proj.root, tl)) then
     return tl, "compile"
   end
-  if fs.isfile(fs.join(proj.root, rel)) then
+  if fs.is_file(fs.join(proj.root, rel)) then
     return rel, "copy"
   end
   return nil, ""
@@ -229,13 +229,13 @@ local function run_generator(proj: Project, gen: string, dest: string,
     return true
   end
   if fs.exists(at) then
-    local rok, rerr = fs.rmrf(at)
+    local rok, rerr = fs.remove_all(at)
     if not rok then
       return false, "make: cannot clear " .. dest .. ": " ..
       (rerr or "unknown error")
     end
   end
-  local mok, merr = fs.makedirs(at)
+  local mok, merr = fs.make_dirs(at)
   if not mok then
     return false, "make: cannot create " .. dest .. ": " ..
     (merr or "unknown error")
@@ -291,7 +291,7 @@ local TYPES_STAMP < const > = TYPES_GEN_DIR .. ".stamp"
 --- @return string Hex digest; a fixed sentinel when the directory has
 --- nothing (absent, or a project with no generator at all)
 local function digest_of(dir: string): string
-  local found = fs.collect_all(dir)
+  local found = fs.find_info(dir)
   if not found then
     return "empty"
   end
@@ -330,7 +330,7 @@ local function stamp_types(proj: Project): boolean, string
   if fs.read(path) == content then
     return true
   end
-  if not fs.makedirs(fs.dirname(path)) then
+  if not fs.make_dirs(fs.dirname(path)) then
     return false, "make: cannot create " .. fs.dirname(TYPES_STAMP)
   end
   local wok, werr = fs.write(path, content)
@@ -399,7 +399,7 @@ end
 ---
 --- Asks the MODEL, not the disk: `proj.files` is what `.cosmicignore`
 --- and every other scan rule already filtered, so a payload generator
---- excluded there stays excluded here too. Probing `fs.isfile` directly
+--- excluded there stays excluded here too. Probing `fs.is_file` directly
 --- would run a generator the model does not know about -- silently, on
 --- output the engine can't attribute to any project file.
 --- @param proj Project The scanned project

--- a/_make/generate_test.tl
+++ b/_make/generate_test.tl
@@ -17,7 +17,7 @@ local check = require("cosmic.check")
 local fs = require("cosmic.fs")
 local mk = require("_make")
 local project = require("_make.project")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 local types = require("_make.types")
 
 local type Binary = types.Binary
@@ -30,24 +30,24 @@ local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
 -- else the copy `--make` extracts from its own binary.
 local make_bin = fs.abspath(os.getenv("COSMIC_MAKE")
   or "o/make")
-check.needs("the make engine at " .. make_bin, fs.isfile(make_bin))
+check.needs("the make engine at " .. make_bin, fs.is_file(make_bin))
 
 --- Build a fixture tree, returning its absolute root.
 local function fixture(name: string, files: {string: string}): string
   local root = fs.join(tmpdir, "generate-" .. name)
-  fs.rmrf(root)
-  assert(fs.makedirs(root))
+  fs.remove_all(root)
+  assert(fs.make_dirs(root))
   for rel, content in pairs(files) do
     local path = fs.join(root, rel)
-    assert(fs.makedirs(fs.dirname(path)))
+    assert(fs.make_dirs(fs.dirname(path)))
     assert(fs.write(path, content))
   end
   -- A directory is not a project until it says so. Fixtures that
   -- declare a root themselves keep theirs; the rest get the marker
   -- that means "yes, this one" so the fixture tests what it is about.
-  if not fs.isfile(fs.join(root, "main.tl"))
-  and not fs.isfile(fs.join(root, "main.lua"))
-  and not fs.isfile(fs.join(root, ".cosmicignore")) then
+  if not fs.is_file(fs.join(root, "main.tl"))
+  and not fs.is_file(fs.join(root, "main.lua"))
+  and not fs.is_file(fs.join(root, ".cosmicignore")) then
     assert(fs.write(fs.join(root, ".cosmicignore"), ""))
   end
   return root
@@ -82,7 +82,7 @@ local function make(dir: string, ...: string): integer, string
     "NO_COLOR=1",
     "COSMIC_NO_WELCOME=1",
   }
-  local h = check.must(spawn.spawn(argv, {cwd = dir, env = env}))
+  local h = check.must(child.start(argv, {cwd = dir, env = env}))
   local r = check.must(h:wait())
   return r.code or 128, (r.stdout or "") .. (r.stderr or "")
 end
@@ -104,7 +104,7 @@ local function seed_pins(repo: string): boolean
     {"cosmos", "lua-debug", "o/3p/cosmos/lua-debug"},
   }
   for _, w in ipairs(want) do
-    if not fs.isfile(fs.join(repo, w[3])) then
+    if not fs.is_file(fs.join(repo, w[3])) then
       return false
     end
   end
@@ -121,7 +121,7 @@ local function test_build_runs_the_units_generator()
       ["cmd/tool/embed_gen.tl"] = [[
 local fs = require("cosmic.fs")
 local out = arg[1]
-assert(fs.makedirs(fs.join(out, "embed")))
+assert(fs.make_dirs(fs.join(out, "embed")))
 assert(fs.write(fs.join(out, "embed/generated.txt"), "made by the generator\n"))
 ]],
     })
@@ -132,7 +132,7 @@ assert(fs.write(fs.join(out, "embed/generated.txt"), "made by the generator\n"))
 
   local produced = fs.join(root,
     "o/cmd/tool/embed_gen/embed/generated.txt")
-  assert(fs.isfile(produced),
+  assert(fs.is_file(produced),
     "the generator wrote into the directory it owns")
 
   local proj = scan(root)
@@ -153,7 +153,7 @@ local function test_base_is_the_units_own_when_it_declares_one()
       ["cmd/tool/main.tl"] = "print('tool')\n",
       ["cmd/lean/main.tl"] = "print('lean')\n",
     })
-  assert(fs.makedirs(fs.join(root, "o/cmd/tool/embed_gen")))
+  assert(fs.make_dirs(fs.join(root, "o/cmd/tool/embed_gen")))
   assert(fs.write(fs.join(root, "o/cmd/tool/embed_gen/base"),
       "not really a runtime\n"))
 
@@ -210,7 +210,7 @@ local function test_the_root_generator_runs_for_cmd_binaries()
       ["embed_gen.tl"] = [[
 local fs = require("cosmic.fs")
 local out = arg[1]
-assert(fs.makedirs(fs.join(out, "embed")))
+assert(fs.make_dirs(fs.join(out, "embed")))
 assert(fs.write(fs.join(out, "embed/shared.txt"), "from the root generator\n"))
 ]],
       -- Only cmd binaries: no root main.tl at all, which is the shape
@@ -220,7 +220,7 @@ assert(fs.write(fs.join(out, "embed/shared.txt"), "from the root generator\n"))
     })
   local code, out = make(root, "build")
   assert(code == 0, "build should succeed: " .. out)
-  assert(fs.isfile(fs.join(root, "o/embed_gen/embed/shared.txt")),
+  assert(fs.is_file(fs.join(root, "o/embed_gen/embed/shared.txt")),
     "the root generator ran even with no root binary: " .. out)
 
   local proj = scan(root)
@@ -244,7 +244,7 @@ local function test_a_cosmicignored_generator_does_not_run()
       ["cmd/tool/embed_gen.tl"] = [[
 local fs = require("cosmic.fs")
 local out = arg[1]
-assert(fs.makedirs(fs.join(out, "embed")))
+assert(fs.make_dirs(fs.join(out, "embed")))
 assert(fs.write(fs.join(out, "embed/generated.txt"), "made by the generator\n"))
 ]],
     })
@@ -282,12 +282,12 @@ local fs = require("cosmic.fs")
 local note = require("note")
 local mark = require("mark")
 local out = arg[1]
-assert(fs.makedirs(fs.join(out, "embed")))
+assert(fs.make_dirs(fs.join(out, "embed")))
 assert(fs.write(fs.join(out, "embed/note.txt"), note.text() .. mark.tag() .. "\n"))
 ]],
       ["cmd/lean/main.tl"] = "print('lean')\n",
     })
-  local cwd = check.must(fs.getcwd())
+  local cwd = check.must(fs.cwd())
   cenv.set("COSMIC_MAKE_ROOT", root)
   cenv.set("COSMIC_MAKE", make_bin)
   local code = mk.run({"build"})
@@ -296,10 +296,10 @@ assert(fs.write(fs.join(out, "embed/note.txt"), note.text() .. mark.tag() .. "\n
   assert(fs.chdir(cwd))
   assert(code == 0, "in-process build should succeed")
   local note = fs.join(root, "o/cmd/tool/embed_gen/embed/note.txt")
-  assert(fs.isfile(note), "build ran the unit's generator")
+  assert(fs.is_file(note), "build ran the unit's generator")
   assert(check.must(fs.read(note)):find("from the generator!", 1, true),
     "and the generator resolved BOTH its imports from the tree")
-  assert(fs.isfile(fs.join(root, "o/mark.lua")),
+  assert(fs.is_file(fs.join(root, "o/mark.lua")),
     "the mini-graph copies a `.lua` closure member rather than skipping it")
   -- Again, with everything already built: the mini-graph's freshness
   -- check is what keeps a no-op verb from paying one subprocess compile
@@ -311,8 +311,8 @@ assert(fs.write(fs.join(out, "embed/note.txt"), note.text() .. mark.tag() .. "\n
   cenv.unset("COSMIC_MAKE")
   assert(fs.chdir(cwd))
   assert(again == 0, "a second in-process build should succeed")
-  assert(fs.isfile(fs.join(root, "o/bin/tool")), "and still produced the binary")
-  assert(fs.isfile(fs.join(root, "o/bin/lean")),
+  assert(fs.is_file(fs.join(root, "o/bin/tool")), "and still produced the binary")
+  assert(fs.is_file(fs.join(root, "o/bin/lean")),
     "a sibling with no generator builds unchanged")
 end
 test_in_process_build_runs_the_generator()
@@ -348,15 +348,15 @@ local function test_the_real_payload_generator()
   local repo = fs.abspath(".")
   local gen = fs.join(repo, "cmd/cosmic/embed_gen.tl")
   check.needs("the cosmic tree (cmd/cosmic/embed_gen.tl)",
-    fs.isfile(gen))
+    fs.is_file(gen))
   -- The generator reads its pinned inputs from `o/3p/**`, which only
   -- `--make fetch` writes. CI fetches before it gates, so this runs
   -- there; a cold checkout skips rather than failing.
   check.needs("fetched pins", seed_pins(repo))
   local out = fs.join(tmpdir, "real-payload")
-  fs.rmrf(out)
-  assert(fs.makedirs(out))
-  local h = check.must(spawn.spawn({cosmic, gen, out},
+  fs.remove_all(out)
+  assert(fs.make_dirs(out))
+  local h = check.must(child.start({cosmic, gen, out},
       {cwd = repo, env = {"PATH=" .. (os.getenv("PATH") or ""), "NO_COLOR=1"}}))
   local r = check.must(h:wait())
   assert(r.code == 0, "the generator should succeed: " ..
@@ -374,7 +374,7 @@ local function test_the_real_payload_generator()
       "embed/.tl/cosmic/fs/init.tl",
       "embed/.tl/_make/artifact.tl",
     }) do
-    assert(fs.isfile(fs.join(out, want)), "payload is missing " .. want)
+    assert(fs.is_file(fs.join(out, want)), "payload is missing " .. want)
   end
 end
 test_the_real_payload_generator()
@@ -410,7 +410,7 @@ local function test_a_generator_reads_its_helpers_from_the_tree()
   -- A fixture project does not claim the `cosmic` namespace, so it does
   -- not converge: this is ONE pass, and a second could not hide a stale
   -- first one.
-  local h = check.must(spawn.spawn({cosmic, "--make", "build"},
+  local h = check.must(child.start({cosmic, "--make", "build"},
       {cwd = root, env = {"PATH=" .. (os.getenv("PATH") or ""),
           "HOME=" .. root, "TMPDIR=" .. tmpdir, "NO_COLOR=1"}}))
   local r = check.must(h:wait())
@@ -444,8 +444,8 @@ local function test_a_lua_module_in_a_generators_closure()
       .. 'fs.write(fs.join(arg[1], "out.txt"), helper.mark())\n',
     })
   -- COLD: nothing built yet, which is the only state that showed it.
-  fs.rmrf(fs.join(root, "o"))
-  local h = check.must(spawn.spawn({cosmic, "--make", "build"},
+  fs.remove_all(fs.join(root, "o"))
+  local h = check.must(child.start({cosmic, "--make", "build"},
       {cwd = root, env = {"PATH=" .. (os.getenv("PATH") or ""),
           "HOME=" .. root, "TMPDIR=" .. tmpdir, "NO_COLOR=1"}}))
   local r = check.must(h:wait())
@@ -456,7 +456,7 @@ local function test_a_lua_module_in_a_generators_closure()
   -- The manifest names it, and the mini-graph produced what it names.
   local mf = check.must(fs.read(fs.join(root, "o/thing_gen.modules")))
   assert(mf:find("mod helper ", 1, true), "the manifest names it: " .. mf)
-  assert(fs.isfile(fs.join(root, "o/helper.lua")),
+  assert(fs.is_file(fs.join(root, "o/helper.lua")),
     "and the mini-graph copied it, rather than naming a file it skipped")
 end
 test_a_lua_module_in_a_generators_closure()

--- a/_make/graph.tl
+++ b/_make/graph.tl
@@ -100,7 +100,7 @@ local function write_if_changed(path: string, content: string): boolean, string
   if fs.read(path) == content then
     return true
   end
-  local ok, err = fs.makedirs(fs.dirname(path))
+  local ok, err = fs.make_dirs(fs.dirname(path))
   if not ok then
     return false, "make: cannot create " .. fs.dirname(path) .. ": " ..
     (err or "unknown error")
@@ -305,7 +305,7 @@ local function extract_make(to: string): boolean, string
   if not bytes then
     return false, "make: this cosmic carries no engine at " .. MAKE_ZIP
   end
-  local ok, merr = fs.makedirs(fs.dirname(to))
+  local ok, merr = fs.make_dirs(fs.dirname(to))
   if not ok then
     return false, "make: cannot create " .. fs.dirname(to) .. ": " ..
     (merr or "unknown error")
@@ -329,7 +329,7 @@ local function extract_make(to: string): boolean, string
     fs.unlink(tmp)
     -- Losing the race is not a failure: the winner installed the same
     -- embedded bytes this process was about to.
-    if fs.isfile(to) then
+    if fs.is_file(to) then
       return true
     end
     return false, "make: cannot install " .. to .. ": " .. (rerr or "unknown error")
@@ -349,13 +349,13 @@ local function find_make(): string | nil, string
   local named = os.getenv(MAKE_ENV)
   if named and named ~= "" then
     local abs = fs.abspath(named)
-    if not fs.isfile(abs) then
+    if not fs.is_file(abs) then
       return nil, "make: " .. MAKE_ENV .. " names no such file: " .. named
     end
     return abs
   end
   local extracted = fs.abspath(fs.join(project.BUILD_DIR, "make"))
-  if fs.isfile(extracted) then
+  if fs.is_file(extracted) then
     return extracted
   end
   local ok, err = extract_make(extracted)
@@ -447,7 +447,7 @@ local function run(proj: Project, target: string, overrides: {string},
   -- target list, and it stopped with "no rule to make target" naming a
   -- file in a project it had never heard of. A nested `--make` is a
   -- different project's build, not a recursive step of this one.
-  local h, serr = child.spawn(argv, {
+  local h, serr = child.start(argv, {
       cwd = proj.root,
       stdout = "inherit",
       stderr = "inherit",

--- a/_make/graph_test.tl
+++ b/_make/graph_test.tl
@@ -22,11 +22,11 @@ local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
 --- Build a fixture tree and scan it.
 local function fixture(name: string, files: {string: string}): Project
   local root = fs.join(tmpdir, "graph-" .. name)
-  fs.rmrf(root)
-  assert(fs.makedirs(root))
+  fs.remove_all(root)
+  assert(fs.make_dirs(root))
   for rel, content in pairs(files) do
     local path = fs.join(root, rel)
-    assert(fs.makedirs(fs.dirname(path)))
+    assert(fs.make_dirs(fs.dirname(path)))
     assert(fs.write(path, content))
   end
   local proj = check.must(project.scan(root))
@@ -35,7 +35,7 @@ end
 
 --- Run fn with cwd inside dir, restoring it afterward.
 local function in_dir<T>(dir: string, fn: function(): T): T
-  local cwd = check.must(fs.getcwd())
+  local cwd = check.must(fs.cwd())
   assert(fs.chdir(dir))
   local got = fn()
   assert(fs.chdir(cwd))
@@ -186,8 +186,8 @@ test_materialize_does_not_touch_unchanged_files()
 -- host is a build nobody can reproduce.
 local function test_find_make_never_searches_path()
   local box = fs.join(tmpdir, "graph-nomake")
-  fs.rmrf(box)
-  assert(fs.makedirs(fs.join(box, "bin")))
+  fs.remove_all(box)
+  assert(fs.make_dirs(fs.join(box, "bin")))
   assert(fs.write(fs.join(box, "bin", "make"), "#!/bin/sh\nexit 0\n",
       tonumber("755", 8) as integer)) -- cast: octal is integral
   local saved_path = cenv.get("PATH")
@@ -251,10 +251,10 @@ test_the_engine_ships_in_the_binary()
 -- permissions problem.
 local function test_extract_make_is_executable()
   local to = fs.join(tmpdir, "graph-engine", "make")
-  fs.rmrf(fs.dirname(to))
+  fs.remove_all(fs.dirname(to))
   local ok, err = graph.extract_make(to)
   assert(ok, "extraction should succeed: " .. tostring(err))
-  assert(fs.isfile(to), "the engine should land at " .. to)
+  assert(fs.is_file(to), "the engine should land at " .. to)
   local st = check.must(fs.stat(to))
   local exec_bit = tonumber("100", 8) as integer -- cast: octal is integral
   assert(st:mode() & exec_bit ~= 0, "the extracted engine must be executable")
@@ -266,8 +266,8 @@ test_extract_make_is_executable()
 -- the difference between --make being usable and being a demo.
 local function test_find_make_extracts_when_nothing_is_named()
   local box = fs.join(tmpdir, "graph-embedded")
-  fs.rmrf(box)
-  assert(fs.makedirs(box))
+  fs.remove_all(box)
+  assert(fs.make_dirs(box))
   local saved = cenv.get("COSMIC_MAKE")
   cenv.unset("COSMIC_MAKE")
   local found = in_dir(box, function(): string
@@ -279,7 +279,7 @@ local function test_find_make_extracts_when_nothing_is_named()
   end
   assert(found ~= "", "find_make must extract the embedded engine")
   assert(found == fs.join(box, "o/make"), "got: " .. found)
-  assert(fs.isfile(found), "…and it must be there")
+  assert(fs.is_file(found), "…and it must be there")
 end
 test_find_make_extracts_when_nothing_is_named()
 

--- a/_make/imports.tl
+++ b/_make/imports.tl
@@ -173,15 +173,15 @@ local function reads_of_file(root: string, path: string): {string} | nil, string
   local out: {string} = {}
   for _, declared in ipairs(reads_scan(content as string)) do -- cast: scalar narrowing
     local abs = fs.join(root, declared)
-    if fs.isdir(abs) then
+    if fs.is_dir(abs) then
       -- cast: `or` keeps the nil in the union
-      local under = (fs.collect(abs, "*") or {}) as {string}
+      local under = (fs.find(abs) or {}) as {string}
       for _, f in ipairs(under) do
         -- collect returns root-joined paths; keep them root-relative
         -- like every other project.mk entry
         out[#out + 1] = (f:sub(1, #root + 1) == root .. "/") and f:sub(#root + 2) or f
       end
-    elseif fs.isfile(abs) then
+    elseif fs.is_file(abs) then
       out[#out + 1] = declared
     else
       return nil, path .. " declares `reads: " .. declared ..

--- a/_make/pin.tl
+++ b/_make/pin.tl
@@ -60,7 +60,7 @@ end
 --- @return {string: any}|nil The declared table
 --- @return string The error message when the file is not a literal pin
 local function extract(source: string, where: string): {string: any} | nil, string
-  return literal.of_source(source, {file = where, noun = "pin"})
+  return literal.parse(source, {file = where, noun = "pin"})
 end
 
 --- One platform's half of a pin: the fields that may differ per host.

--- a/_make/pin_test.tl
+++ b/_make/pin_test.tl
@@ -84,7 +84,7 @@ test_a_pin_cannot_be_code()
 --- Write a pin file and read it.
 local function read_pin(name: string, body: string): pin.Pin | nil, string
   local dir = fs.join(tmpdir, "pin-" .. name)
-  assert(fs.makedirs(dir))
+  assert(fs.make_dirs(dir))
   local path = fs.join(dir, name .. "_pin.tl")
   assert(fs.write(path, body))
   return pin.read(path)
@@ -155,8 +155,8 @@ end
 --- A project holding one pin pointing at `url`.
 local function pinned(name: string, url: string, sha: string): string
   local root = fs.join(tmpdir, "fetch-" .. name)
-  fs.rmrf(root)
-  assert(fs.makedirs(fs.join(root, "3p")))
+  fs.remove_all(root)
+  assert(fs.make_dirs(fs.join(root, "3p")))
   assert(fs.write(fs.join(root, "main.tl"), "print('x')\n"))
   assert(fs.write(fs.join(root, "3p/blob_pin.tl"),
       'return {\n  url = "' .. url .. '",\n  sha256 = "' .. sha .. '",\n}\n'))
@@ -165,7 +165,7 @@ end
 
 --- Run a verb in process against a named root.
 local function run(root: string, ...: string): integer
-  local cwd = check.must(fs.getcwd())
+  local cwd = check.must(fs.cwd())
   cenv.set("COSMIC_MAKE_ROOT", root)
   local argv: {string} = {}
   for _, a in ipairs({...}) do
@@ -240,7 +240,7 @@ local function test_a_satisfied_pin_does_not_fetch()
   local body = "already here\n"
   local root = pinned("satisfied", "http://127.0.0.1:1/blob.bin",
     hash.sha256_hex(body))
-  assert(fs.makedirs(fs.join(root, "o/3p")))
+  assert(fs.make_dirs(fs.join(root, "o/3p")))
   assert(fs.write(fs.join(root, "o/3p/blob.bin"), body))
   local code = run(root, "fetch")
   assert(code == 0,
@@ -260,7 +260,7 @@ test_a_satisfied_pin_does_not_fetch()
 -- and this file is the proof of that.
 local function test_only_fetch_can_open_a_socket()
   local networked: {string} = {}
-  local found, cerr = fs.collect("_make", "*.tl")
+  local found, cerr = fs.find("_make", {glob = "*.tl"})
   assert(found, "cannot scan _make: " .. tostring(cerr))
   for _, path in ipairs(found as {string}) do -- cast: record union after the guard
     if not path:find("_test%.tl$") then
@@ -297,7 +297,7 @@ test_selection()
 -- else, which is why fetch needs no compiled tree.
 local function test_resolve_reads_only_the_pin()
   local root = pinned("scope", "https://x.test/a.bin", "abababababababababababababababababababababababababababababababab")
-  local cwd = check.must(fs.getcwd())
+  local cwd = check.must(fs.cwd())
   assert(fs.chdir(root))
   local proj = check.must(project.scan("."))
   local pins = check.must(mfetch.resolve(project.of_kind(proj, {"pin"})))
@@ -318,7 +318,7 @@ local function test_a_declared_format_is_unpacked()
   -- under a wrapper directory, which is what strip_components exists
   -- for (a release tarball names its wrapper after the tag).
   local archive = fs.join(tmpdir, "payload.zip")
-  local w = check.must(czip.writer(archive))
+  local w = check.must(czip.create(archive))
   assert(w:add("wrapper-1.0/tl.lua", "return 'teal'\n"))
   assert(w:add("wrapper-1.0/deep/other.txt", "x\n"))
   w:close()
@@ -338,9 +338,9 @@ local function test_a_declared_format_is_unpacked()
 
   local got = check.must(fs.read(fs.join(root, "o/3p/tl.lua")))
   assert(got == "return 'teal'\n", "the wrapper directory is stripped away")
-  assert(fs.isfile(fs.join(root, "o/3p/deep/other.txt")),
+  assert(fs.is_file(fs.join(root, "o/3p/deep/other.txt")),
     "and the rest of the tree keeps its shape")
-  assert(fs.isfile(fs.join(root, "o/3p/payload.zip")),
+  assert(fs.is_file(fs.join(root, "o/3p/payload.zip")),
     "the verified archive stays beside what came out of it")
   assert(not fs.exists(fs.join(root, "o/3p/.unpack")),
     "and the staging directory does not survive")
@@ -389,7 +389,7 @@ test_a_pin_may_name_its_digest_per_platform()
 -- over a missing tree.
 local function test_a_missing_unpack_is_redone()
   local archive = fs.join(tmpdir, "redo.zip")
-  local w = check.must(czip.writer(archive))
+  local w = check.must(czip.create(archive))
   assert(w:add("tl.lua", "return 'teal'\n"))
   w:close()
   local body = check.must(fs.read(archive))
@@ -403,15 +403,15 @@ local function test_a_missing_unpack_is_redone()
   assert(run(root, "fetch") == 0, "the first fetch should unpack")
   proc.wait(pid)
   local out = fs.join(root, "o/3p/tl.lua")
-  assert(fs.isfile(out), "unpack produced the tree")
+  assert(fs.is_file(out), "unpack produced the tree")
 
   -- Delete the unpacked tree, keep the archive: the exact poisoned
   -- state a failed unpack leaves behind. No server is listening now,
   -- so a re-download would fail -- repairing from the verified archive
   -- is the assertion.
-  assert(fs.rmrf(out))
+  assert(fs.remove_all(out))
   assert(run(root, "fetch") == 0, "the second fetch should repair, not refetch")
-  assert(fs.isfile(out), "the unpacked tree is restored")
+  assert(fs.is_file(out), "the unpacked tree is restored")
 end
 test_a_missing_unpack_is_redone()
 

--- a/_make/pins_test.tl
+++ b/_make/pins_test.tl
@@ -32,7 +32,7 @@ local PINS < const >: {string} = {
 --- @param path string The pin file
 --- @return {string} The declared keys
 local function platform_keys(path: string): {string}
-  local fields = check.must(literal.of_file(path, {noun = "pin"}))
+  local fields = check.must(literal.parse_file(path, {noun = "pin"}))
   local platforms = fields.platforms
   if not (platforms is {string: any}) then
     return {""}
@@ -51,7 +51,7 @@ end
 -- invisible until the day it is the one being built.
 local function test_every_declared_platform_resolves()
   for _, path in ipairs(PINS) do
-    assert(fs.isfile(path), "missing committed pin: " .. path)
+    assert(fs.is_file(path), "missing committed pin: " .. path)
     for _, key in ipairs(platform_keys(path)) do
       local host = key ~= "" and key or "x86_64-linux"
       local p, err = pin.read(path, host)
@@ -128,7 +128,7 @@ test_an_undeclared_platform_is_refused()
 -- point of that spelling.
 local function test_the_star_row_matches_every_host()
   for _, path in ipairs(PINS) do
-    local fields = check.must(literal.of_file(path, {noun = "pin"}))
+    local fields = check.must(literal.parse_file(path, {noun = "pin"}))
     local platforms = fields.platforms
     if platforms is {string: any} and platforms["*"] ~= nil then
       for _, host in ipairs({"x86_64-linux", "aarch64-macos", "x86_64-windows"}) do

--- a/_make/policy.tl
+++ b/_make/policy.tl
@@ -67,7 +67,7 @@ local function run_coverage(v: Verb, proj: Project, paths: {string},
   if not ok then
     return stage.verdict(v.name, false, detail)
   end
-  if not fs.isfile(BASELINE) then
+  if not fs.is_file(BASELINE) then
     io.write("coverage: no " .. BASELINE ..
       "; write one with `--make coverage --baseline` to start a ratchet\n")
     return stage.verdict(v.name, true, detail)

--- a/_make/policy_test.tl
+++ b/_make/policy_test.tl
@@ -116,10 +116,10 @@ local function test_the_baseline_is_a_convention()
   assert(policy.BASELINE == ".cosmic-coverage",
     "the floor is a dot-file at the root, got: " .. policy.BASELINE)
   local dir = fs.join(tmpdir, "policy-nobaseline")
-  check.must(fs.makedirs(dir))
-  local cwd = check.must(fs.getcwd())
+  check.must(fs.make_dirs(dir))
+  local cwd = check.must(fs.cwd())
   check.must(fs.chdir(dir))
-  local absent = not fs.isfile(policy.BASELINE)
+  local absent = not fs.is_file(policy.BASELINE)
   check.must(fs.chdir(cwd))
   assert(absent, "the fixture must not have a floor")
 end

--- a/_make/project.tl
+++ b/_make/project.tl
@@ -358,7 +358,7 @@ end
 --- @return string An error message when the scan failed
 local function scan(root: string): Project | nil, string
   local abs = fs.abspath(root)
-  if not fs.isdir(abs) then
+  if not fs.is_dir(abs) then
     return nil, "make: not a directory: " .. root
   end
   -- A scan is the start of a model build, and the import memo's

--- a/_make/project_test.tl
+++ b/_make/project_test.tl
@@ -20,11 +20,11 @@ local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
 --- Build a fixture tree from a path -> contents map and scan it.
 local function fixture(name: string, files: {string: string}): Project
   local root = fs.join(tmpdir, name)
-  fs.rmrf(root)
-  assert(fs.makedirs(root))
+  fs.remove_all(root)
+  assert(fs.make_dirs(root))
   for rel, content in pairs(files) do
     local path = fs.join(root, rel)
-    assert(fs.makedirs(fs.dirname(path)))
+    assert(fs.make_dirs(fs.dirname(path)))
     assert(fs.write(path, content))
   end
   local proj = check.must(project.scan(root))

--- a/_make/resolution_test.tl
+++ b/_make/resolution_test.tl
@@ -13,7 +13,7 @@ local check = require("cosmic.check")
 local cenv = require("cosmic.env")
 local fs = require("cosmic.fs")
 local mk = require("_make")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 
 local cosmic = fs.abspath(fs.join(os.getenv("TEST_BIN"), "cosmic"))
 local tmp = os.getenv("TEST_TMPDIR") or "/tmp"
@@ -24,12 +24,12 @@ local tmp = os.getenv("TEST_TMPDIR") or "/tmp"
 --- @return string The project root
 local function fixture(name: string): string
   local root = fs.join(tmp, "res-" .. name)
-  fs.rmrf(root)
-  assert(fs.makedirs(fs.join(root, "greet")))
+  fs.remove_all(root)
+  assert(fs.make_dirs(fs.join(root, "greet")))
   -- The run target is a binary at cmd/app/, so `run` builds it before
   -- executing o/cmd/app/main.lua; a bare root main.tl is refused. Tests
   -- write the entry's body here.
-  assert(fs.makedirs(fs.join(root, "cmd", "app")))
+  assert(fs.make_dirs(fs.join(root, "cmd", "app")))
   assert(fs.write(fs.join(root, ".cosmicignore"), ""))
   assert(fs.write(fs.join(root, "greet", "init.tl"), [[
 local record G
@@ -63,7 +63,7 @@ local function make(root: string, argv: {string},
   for _, e in ipairs(extra or {}) do
     env[#env + 1] = e
   end
-  local h = check.must(spawn.spawn(full, {cwd = root, env = env}))
+  local h = check.must(child.start(full, {cwd = root, env = env}))
   local r = check.must(h:wait())
   return r.code or 128, (r.stdout or "") .. (r.stderr or "")
 end
@@ -160,23 +160,23 @@ io.write("CHILD " .. debug.getinfo(greet.hi, "S").source .. "\n")
 ]]))
   assert(fs.write(fs.join(root, "cmd/app/main.tl"), [[
 local greet = require("greet")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 local check = require("cosmic.check")
 io.write("PARENT " .. debug.getinfo(greet.hi, "S").source .. "\n")
-local h = check.must(spawn.spawn({arg[0] and os.getenv("COSMIC_BIN"), "child.tl"}))
+local h = check.must(child.start({arg[0] and os.getenv("COSMIC_BIN"), "child.tl"}))
 local r = check.must(h:wait())
 io.write(r.stdout or "")
 ]]))
   local code, out = make(root, {"run", "cmd/app/main.tl"}, {"COSMIC_BIN=" .. cosmic})
   assert(code == 0, "the fixture must run: " .. out)
   local parent = out:match("PARENT @(%S+)")
-  local child = out:match("CHILD @(%S+)")
-  assert(parent and child, "both must report a source: " .. out)
+  local child_src = out:match("CHILD @(%S+)")
+  assert(parent and child_src, "both must report a source: " .. out)
   assert(parent:find("/o/greet/init.lua", 1, true),
     "the target resolves against the build, got: " .. parent)
-  assert(child:find("greet/init.tl", 1, true) and
-    not child:find("/o/", 1, true),
-    "a grandchild must NOT inherit the resolution, got: " .. child)
+  assert(child_src:find("greet/init.tl", 1, true) and
+    not child_src:find("/o/", 1, true),
+    "a grandchild must NOT inherit the resolution, got: " .. child_src)
 end
 test_resolution_does_not_inherit()
 
@@ -189,7 +189,7 @@ local function test_run_in_process()
 local greet = require("greet")
 io.write("SAYS " .. greet.hi("x") .. "\n")
 ]]))
-  local cwd = check.must(fs.getcwd())
+  local cwd = check.must(fs.cwd())
   cenv.set("COSMIC_MAKE_ROOT", root)
   local code = mk.run({"run", "cmd/app/main.tl"})
   cenv.unset("COSMIC_MAKE_ROOT")
@@ -203,7 +203,7 @@ test_run_in_process()
 local function test_run_refusals_in_process()
   local root = fixture("refuse")
   assert(fs.write(fs.join(root, "cmd/app/main.tl"), 'io.write("x")\n'))
-  local cwd = check.must(fs.getcwd())
+  local cwd = check.must(fs.cwd())
   cenv.set("COSMIC_MAKE_ROOT", root)
   local none = mk.run({"run"})
   local missing = mk.run({"run", "nosuch.tl"})
@@ -226,8 +226,8 @@ test_run_refusals_in_process()
 -- was never compiled and died with "cannot open".
 local function test_run_builds_a_target_with_no_binary()
   local root = fs.join(tmp, "res-nobinary")
-  fs.rmrf(root)
-  assert(fs.makedirs(fs.join(root, "greet")))
+  fs.remove_all(root)
+  assert(fs.make_dirs(fs.join(root, "greet")))
   assert(fs.write(fs.join(root, ".cosmicignore"), ""))
   assert(fs.write(fs.join(root, "greet", "init.tl"), [[
 local record G
@@ -251,8 +251,8 @@ test_run_builds_a_target_with_no_binary()
 -- than spawning an o/ file the failed build never wrote.
 local function test_run_reports_a_binaryless_build_failure()
   local root = fs.join(tmp, "res-buildfail")
-  fs.rmrf(root)
-  assert(fs.makedirs(root))
+  fs.remove_all(root)
+  assert(fs.make_dirs(root))
   assert(fs.write(fs.join(root, ".cosmicignore"), ""))
   assert(fs.write(fs.join(root, "bad.tl"),
       "local x: integer = 'nope'\nreturn x\n"))
@@ -274,7 +274,7 @@ io.write("GOT " .. tostring(io.read("l")) .. "\n")
     "PATH=" .. (os.getenv("PATH") or ""),
     "HOME=" .. root, "TMPDIR=" .. tmp, "NO_COLOR=1", "COSMIC_NO_WELCOME=1",
   }
-  local h = check.must(spawn.spawn(full,
+  local h = check.must(child.start(full,
       {cwd = root, env = env, stdin = "the-real-stdin"}))
   local r = check.must(h:wait())
   local out = (r.stdout or "") .. (r.stderr or "")

--- a/_make/root.tl
+++ b/_make/root.tl
@@ -41,8 +41,8 @@ local ROOT_ENV < const > = "COSMIC_MAKE_ROOT"
 --- @param dir string Absolute directory to test
 --- @return boolean True when dir is a `--make` output tree
 local function is_build_dir(dir: string): boolean
-  return fs.isfile(fs.join(dir, "cosmic.mk")) and
-  fs.isfile(fs.join(dir, "project.mk"))
+  return fs.is_file(fs.join(dir, "cosmic.mk")) and
+  fs.is_file(fs.join(dir, "project.mk"))
 end
 
 --- Files and directories a project declares itself with. A stray `.tl`
@@ -55,14 +55,14 @@ local function is_root(dir: string): boolean
   if is_build_dir(dir) then
     return false
   end
-  if fs.isfile(fs.join(dir, ".cosmicignore")) then
+  if fs.is_file(fs.join(dir, ".cosmicignore")) then
     return true
   end
-  if fs.isfile(fs.join(dir, "main.tl")) or fs.isfile(fs.join(dir, "main.lua")) then
+  if fs.is_file(fs.join(dir, "main.tl")) or fs.is_file(fs.join(dir, "main.lua")) then
     return true
   end
   local cmd = fs.join(dir, "cmd")
-  if fs.isdir(cmd) then
+  if fs.is_dir(cmd) then
     for _, pattern in ipairs({"*/main.tl", "*/main.lua"}) do
       local hits = (fs.glob(cmd, pattern) or {}) as {string} -- cast: or keeps the nil union
       if #hits > 0 then
@@ -157,7 +157,7 @@ local function discover(verb: string): string | nil, string
   local override = os.getenv(ROOT_ENV)
   if override and override ~= "" then
     local named = fs.abspath(override)
-    if not fs.isdir(named) then
+    if not fs.is_dir(named) then
       return nil, "make: not a directory: " .. override
     end
     local bad = unnameable(named)
@@ -166,7 +166,7 @@ local function discover(verb: string): string | nil, string
     end
     return named
   end
-  local cwd, err = fs.getcwd()
+  local cwd, err = fs.cwd()
   if not cwd then
     return nil, "make: cannot determine the current directory: " ..
     (err or "unknown error")
@@ -223,10 +223,10 @@ end
 --- @return string|nil The absolute path, or nil when unresolvable
 local function resolve_self(argv0: string): string | nil
   local abs = fs.abspath(argv0)
-  if fs.isfile(abs) then
+  if fs.is_file(abs) then
     return abs
   end
-  return (proc.commandv(argv0))
+  return (proc.which(argv0))
 end
 
 local record RootModule

--- a/_make/root_test.tl
+++ b/_make/root_test.tl
@@ -17,11 +17,11 @@ local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
 --- Make a directory tree, returning its root.
 local function tree(name: string, files: {string: string}): string
   local dir = fs.join(tmpdir, "root-" .. name)
-  fs.rmrf(dir)
-  assert(fs.makedirs(dir))
+  fs.remove_all(dir)
+  assert(fs.make_dirs(dir))
   for rel, content in pairs(files) do
     local path = fs.join(dir, rel)
-    assert(fs.makedirs(fs.dirname(path)))
+    assert(fs.make_dirs(fs.dirname(path)))
     assert(fs.write(path, content))
   end
   return dir
@@ -70,7 +70,7 @@ local function test_refusal_names_the_command()
     })
   local saved = env.get("COSMIC_MAKE_ROOT")
   env.unset("COSMIC_MAKE_ROOT")
-  local cwd = fs.getcwd()
+  local cwd = fs.cwd()
   assert(fs.chdir(fs.join(proj, "db")))
   local got, err = root.discover("check")
   assert(fs.chdir(cwd as string)) -- cast: scalar narrowing through the guard
@@ -159,7 +159,7 @@ local function test_no_ambiguity_under_a_build_directory()
       ["cmd/tool/main.lua"] = "return 0\n",
     })
   local scratch = fs.join(out, "some_test.tl.test.tmp.d")
-  assert(fs.makedirs(scratch))
+  assert(fs.make_dirs(scratch))
   assert(not root.ancestor_root(scratch),
     "a build directory must not be reported as the ancestor project")
 end
@@ -193,7 +193,7 @@ test_the_walk_stops_at_an_output_directory()
 -- asks about ancestors, this one asks about the cwd.
 local function test_a_bare_directory_is_not_a_project()
   local dir = tree("bare-dir", {["notes.tl"] = "return {}\n"})
-  local saved = fs.getcwd() as string -- cast: cwd exists in a test
+  local saved = fs.cwd() as string -- cast: cwd exists in a test
   assert(fs.chdir(dir))
   local found, err = root.discover("build")
   assert(fs.chdir(saved))
@@ -243,7 +243,7 @@ test_a_root_with_a_metacharacter_is_refused()
 -- binary": a real file at (or under) the cwd wins as-is.
 local function test_resolve_self_resolves_a_real_path()
   local dir = tree("self-real", {["cosmic"] = "print('x')\n"})
-  local saved = fs.getcwd() as string -- cast: cwd exists in a test
+  local saved = fs.cwd() as string -- cast: cwd exists in a test
   assert(fs.chdir(dir))
   local self = root.resolve_self("cosmic")
   assert(fs.chdir(saved))
@@ -257,11 +257,11 @@ test_resolve_self_resolves_a_real_path()
 -- not to contain the binary silently degraded the tool stamps.
 local function test_resolve_self_falls_back_to_path_search()
   local dir = tree("self-path", {})
-  local saved = fs.getcwd() as string -- cast: cwd exists in a test
+  local saved = fs.cwd() as string -- cast: cwd exists in a test
   assert(fs.chdir(dir))
   local self = root.resolve_self("ls")
   assert(fs.chdir(saved))
-  assert(self == proc.commandv("ls"), "got: " .. tostring(self))
+  assert(self == proc.which("ls"), "got: " .. tostring(self))
   assert(self ~= fs.join(dir, "ls"), "must not be the cwd-relative phantom")
 end
 test_resolve_self_falls_back_to_path_search()

--- a/_make/selection_test.tl
+++ b/_make/selection_test.tl
@@ -15,7 +15,7 @@
 
 local check = require("cosmic.check")
 local fs = require("cosmic.fs")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 
 local cosmic = fs.abspath(fs.join(os.getenv("TEST_BIN"), "cosmic"))
 local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
@@ -26,7 +26,7 @@ local make_bin = fs.abspath(os.getenv("COSMIC_MAKE")
   or "o/make")
 -- Skip locally, FAIL in CI (029): a graph-test surface that silently
 -- becomes green skips is the failure this guards.
-check.needs("the make engine at " .. make_bin, fs.isfile(make_bin))
+check.needs("the make engine at " .. make_bin, fs.is_file(make_bin))
 
 local record Run
   code: integer
@@ -37,19 +37,19 @@ end
 --- Build a fixture tree, returning its absolute root.
 local function fixture(name: string, files: {string: string}): string
   local root = fs.join(tmpdir, "select-" .. name)
-  fs.rmrf(root)
-  assert(fs.makedirs(root))
+  fs.remove_all(root)
+  assert(fs.make_dirs(root))
   for rel, content in pairs(files) do
     local path = fs.join(root, rel)
-    assert(fs.makedirs(fs.dirname(path)))
+    assert(fs.make_dirs(fs.dirname(path)))
     assert(fs.write(path, content))
   end
   -- A directory is not a project until it says so. Fixtures that
   -- declare a root themselves keep theirs; the rest get the marker
   -- that means "yes, this one" so the fixture tests what it is about.
-  if not fs.isfile(fs.join(root, "main.tl"))
-  and not fs.isfile(fs.join(root, "main.lua"))
-  and not fs.isfile(fs.join(root, ".cosmicignore")) then
+  if not fs.is_file(fs.join(root, "main.tl"))
+  and not fs.is_file(fs.join(root, "main.lua"))
+  and not fs.is_file(fs.join(root, ".cosmicignore")) then
     assert(fs.write(fs.join(root, ".cosmicignore"), ""))
   end
   return root
@@ -68,7 +68,7 @@ local function make(dir: string, ...: string): Run
     "NO_COLOR=1",
     "COSMIC_NO_WELCOME=1",
   }
-  local h = check.must(spawn.spawn(argv, {cwd = dir, env = env}))
+  local h = check.must(child.start(argv, {cwd = dir, env = env}))
   local r = check.must(h:wait())
   return {code = r.code or 128, out = r.stdout or "", err = r.stderr or ""}
 end
@@ -119,13 +119,13 @@ local function test_build_selects_binaries()
     })
   local r = make(root, "build", "cmd/tool")
   assert(r.code == 0, "selecting a binary should build it: " .. r.err)
-  assert(fs.isfile(fs.join(root, "o/bin/tool")),
+  assert(fs.is_file(fs.join(root, "o/bin/tool")),
     "the selected binary is built, not merely compiled: " .. r.out)
   assert(not fs.exists(fs.join(root, "o/bin/buildsel")),
     "and the one that was not selected is not")
   -- The whole tree still compiled: staging must not depend on which
   -- binary was asked for.
-  assert(fs.isfile(fs.join(root, "o/lib/x.lua")), "the tree compiled")
+  assert(fs.is_file(fs.join(root, "o/lib/x.lua")), "the tree compiled")
 
   local byname = make(root, "build", "tool")
   assert(byname.code == 0, "a binary is selectable by name too: " .. byname.err)
@@ -153,7 +153,7 @@ local function test_docs_restricts_to_its_selection()
   local root = app("docssel")
   local r = make(root, "docs", "db")
   assert(r.code == 0, "selected docs should succeed: " .. r.err)
-  assert(fs.isfile(fs.join(root, "o/docs/db/init.md")),
+  assert(fs.is_file(fs.join(root, "o/docs/db/init.md")),
     "the selected page is written: " .. r.out)
   assert(not fs.exists(fs.join(root, "o/docs/main.md")),
     "and the unselected one is not: " .. r.out)

--- a/_make/stage_test.tl
+++ b/_make/stage_test.tl
@@ -11,7 +11,7 @@
 local check = require("cosmic.check")
 local fs = require("cosmic.fs")
 local project = require("_make.project")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 local stage = require("_make.stage")
 local types = require("_make.types")
 
@@ -155,10 +155,10 @@ test_binaries_on_path_without_a_path()
 local function test_a_dead_stage_does_not_report_a_stale_summary()
   local cosmic = fs.abspath(fs.join(os.getenv("TEST_BIN") or "", "cosmic"))
   local make_bin = fs.abspath(os.getenv("COSMIC_MAKE") or "o/make")
-  check.needs("the make engine at " .. make_bin, fs.isfile(make_bin))
+  check.needs("the make engine at " .. make_bin, fs.is_file(make_bin))
   local root = fs.join(tmpdir, "stage-stale-summary")
-  fs.rmrf(root)
-  assert(fs.makedirs(root))
+  fs.remove_all(root)
+  assert(fs.make_dirs(root))
   assert(fs.write(fs.join(root, "mod.tl"), "return {}\n"))
   assert(fs.write(fs.join(root, "a_test.tl"),
       "local m = require('mod')\nassert(m ~= nil)\n"))
@@ -170,7 +170,7 @@ local function test_a_dead_stage_does_not_report_a_stale_summary()
     "PATH=" .. (os.getenv("PATH") or ""), "COSMIC_MAKE=" .. make_bin,
     "TMPDIR=" .. tmpdir, "NO_COLOR=1", "COSMIC_NO_WELCOME=1",
   }
-  local h1 = check.must(spawn.spawn({cosmic, "--make", "test"},
+  local h1 = check.must(child.start({cosmic, "--make", "test"},
       {cwd = root, env = env}))
   local r1 = check.must(h1:wait())
   assert(r1.code ~= 0, "the first run has one genuine failure")
@@ -184,7 +184,7 @@ local function test_a_dead_stage_does_not_report_a_stale_summary()
   -- failure's numbers (from b_test, untouched here) are the only ones
   -- on disk.
   assert(fs.write(fs.join(root, "mod.tl"), "local x: string = 5\nreturn {}\n"))
-  local h2 = check.must(spawn.spawn({cosmic, "--make", "test"},
+  local h2 = check.must(child.start({cosmic, "--make", "test"},
       {cwd = root, env = env}))
   local r2 = check.must(h2:wait())
   assert(r2.code ~= 0, "a broken compile still fails")

--- a/_make/stamp.tl
+++ b/_make/stamp.tl
@@ -112,7 +112,7 @@ local function closure_of(roots: {string}): {string} | nil
   local seen: {string: boolean} = {}
   local queue: {string} = {}
   for _, r in ipairs(roots) do
-    if not fs.isfile(zip_path(r)) then
+    if not fs.is_file(zip_path(r)) then
       return nil
     end
     queue[#queue + 1] = r
@@ -123,7 +123,7 @@ local function closure_of(roots: {string}): {string} | nil
     if not seen[name] then
       seen[name] = true
       local path = zip_path(name)
-      if fs.isfile(path) then
+      if fs.is_file(path) then
         out[#out + 1] = path
         for _, dep in ipairs(imports.of_file(path)) do
           if not seen[dep] then
@@ -200,7 +200,7 @@ local function write_if_changed(path: string, content: string): boolean, string
   if fs.read(path) == content then
     return true
   end
-  local ok, err = fs.makedirs(fs.dirname(path))
+  local ok, err = fs.make_dirs(fs.dirname(path))
   if not ok then
     return false, "make: cannot create " .. fs.dirname(path) .. ": " ..
     (err or "unknown error")

--- a/_make/stamp_test.tl
+++ b/_make/stamp_test.tl
@@ -14,7 +14,7 @@ local fs = require("cosmic.fs")
 local graph = require("_make.graph")
 local project = require("_make.project")
 local stamp = require("_make.stamp")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 local types = require("_make.types")
 
 local type Project = types.Project
@@ -26,16 +26,16 @@ local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
 -- build_test): a cold checkout stays usable, CI treats absence as
 -- provisioning broken.
 local cosmic_bin = fs.abspath(fs.join(os.getenv("TEST_BIN") or "o/bin", "cosmic"))
-check.needs("a built cosmic at " .. cosmic_bin, fs.isfile(cosmic_bin))
+check.needs("a built cosmic at " .. cosmic_bin, fs.is_file(cosmic_bin))
 
 --- Build a fixture tree and scan it.
 local function fixture(name: string, files: {string: string}): Project
   local root = fs.join(tmpdir, "stamp-" .. name)
-  fs.rmrf(root)
-  assert(fs.makedirs(root))
+  fs.remove_all(root)
+  assert(fs.make_dirs(root))
   for rel, content in pairs(files) do
     local path = fs.join(root, rel)
-    assert(fs.makedirs(fs.dirname(path)))
+    assert(fs.make_dirs(fs.dirname(path)))
     assert(fs.write(path, content))
   end
   local proj = check.must(project.scan(root))
@@ -44,7 +44,7 @@ end
 
 --- Run fn with cwd inside dir, restoring it afterward.
 local function in_dir<T>(dir: string, fn: function(): T): T
-  local cwd = check.must(fs.getcwd())
+  local cwd = check.must(fs.cwd())
   assert(fs.chdir(dir))
   local got = fn()
   assert(fs.chdir(cwd))
@@ -152,7 +152,7 @@ local function test_boot_list_covers_a_live_child()
     "NO_COLOR=1",
     "COSMIC_NO_WELCOME=1",
   }
-  local h = check.must(spawn.spawn({cosmic_bin, script}, {env = env}))
+  local h = check.must(child.start({cosmic_bin, script}, {env = env}))
   local r = check.must(h:wait())
   assert(r.ok, "the child must run: " .. (r.stderr or ""))
   local listed: {string: boolean} = {}
@@ -161,7 +161,7 @@ local function test_boot_list_covers_a_live_child()
   end
   for name in (r.stdout or ""):gmatch("[^\n]+") do
     local zipped = "/zip/" .. name:gsub("%.", "/") .. ".lua"
-    assert(listed[name] or not fs.isfile(zipped),
+    assert(listed[name] or not fs.is_file(zipped),
       name .. " is loaded at boot but missing from BOOT_MODULES; " ..
       "add it in _make/stamp.tl or every stamp under-approximates")
   end

--- a/_make/types_stamp_test.tl
+++ b/_make/types_stamp_test.tl
@@ -13,7 +13,7 @@ local cenv = require("cosmic.env")
 local check = require("cosmic.check")
 local fs = require("cosmic.fs")
 local mk = require("_make")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 
 local cosmic = fs.abspath(fs.join(os.getenv("TEST_BIN"), "cosmic"))
 local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
@@ -22,16 +22,16 @@ local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
 -- else the copy `--make` extracts from its own binary.
 local make_bin = fs.abspath(os.getenv("COSMIC_MAKE")
   or "o/make")
-check.needs("the make engine at " .. make_bin, fs.isfile(make_bin))
+check.needs("the make engine at " .. make_bin, fs.is_file(make_bin))
 
 --- Build a fixture tree, returning its absolute root.
 local function fixture(name: string, files: {string: string}): string
   local root = fs.join(tmpdir, "typestamp-" .. name)
-  fs.rmrf(root)
-  assert(fs.makedirs(root))
+  fs.remove_all(root)
+  assert(fs.make_dirs(root))
   for rel, content in pairs(files) do
     local path = fs.join(root, rel)
-    assert(fs.makedirs(fs.dirname(path)))
+    assert(fs.make_dirs(fs.dirname(path)))
     assert(fs.write(path, content))
   end
   assert(fs.write(fs.join(root, ".cosmicignore"), ""))
@@ -51,14 +51,14 @@ local function make(dir: string, ...: string): integer, string
     "NO_COLOR=1",
     "COSMIC_NO_WELCOME=1",
   }
-  local h = check.must(spawn.spawn(argv, {cwd = dir, env = env}))
+  local h = check.must(child.start(argv, {cwd = dir, env = env}))
   local r = check.must(h:wait())
   return r.code or 128, (r.stdout or "") .. (r.stderr or "")
 end
 
 --- One in-process `--make build` against root, restoring cwd after.
 local function build_in_process(root: string): integer
-  local cwd = check.must(fs.getcwd())
+  local cwd = check.must(fs.cwd())
   cenv.set("COSMIC_MAKE_ROOT", root)
   cenv.set("COSMIC_MAKE", make_bin)
   local code = mk.run({"build"})
@@ -71,7 +71,7 @@ end
 --- A stand-in types generator whose output bytes carry `version`.
 local function gen_script(version: string): string
   return "local fs = require('cosmic.fs')\nlocal out = arg[1]\n" ..
-  "assert(fs.makedirs(out))\nassert(fs.write(fs.join(out, 'gen.d.tl'), '-- " ..
+  "assert(fs.make_dirs(out))\nassert(fs.write(fs.join(out, 'gen.d.tl'), '-- " ..
   version .. "'))\n"
 end
 
@@ -125,7 +125,7 @@ local function test_stamp_sentinel_without_generated_types()
   local root = fixture("sentinel", {
       ["cmd/tool/main.tl"] = "print('tool')\n",
     })
-  assert(fs.makedirs(fs.join(root, "o/_types/types_gen")))
+  assert(fs.make_dirs(fs.join(root, "o/_types/types_gen")))
   assert(build_in_process(root) == 0, "build should succeed")
   local stamp = check.must(fs.read(fs.join(root, "o/_types/types_gen.stamp")))
   assert(stamp == "empty\n",

--- a/_make/validate_test.tl
+++ b/_make/validate_test.tl
@@ -21,11 +21,11 @@ local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
 --- Build a fixture tree and scan it.
 local function fixture(name: string, files: {string: string}): Project
   local root = fs.join(tmpdir, "validate-" .. name)
-  fs.rmrf(root)
-  assert(fs.makedirs(root))
+  fs.remove_all(root)
+  assert(fs.make_dirs(root))
   for rel, content in pairs(files) do
     local path = fs.join(root, rel)
-    assert(fs.makedirs(fs.dirname(path)))
+    assert(fs.make_dirs(fs.dirname(path)))
     assert(fs.write(path, content))
   end
   local proj = check.must(project.scan(root))

--- a/_perf/bench/embed_bench.tl
+++ b/_perf/bench/embed_bench.tl
@@ -8,7 +8,7 @@ local fs = require("cosmic.fs")
 local czip = require("cosmic.zip")
 local pt = require("_perf.perf_types")
 
--- Deliberately dir-heavy: embed.run()'s dominant, roughly-fixed cost is
+-- Deliberately dir-heavy: embed.embed()'s dominant, roughly-fixed cost is
 -- copying the whole source executable (megabytes) into the output file,
 -- which would swamp small per-entry syscall differences measured over
 -- just a handful of directories. A large DIRS count makes collect_dir's
@@ -48,7 +48,7 @@ local function find_bin(): string
   local test_bin = os.getenv("TEST_BIN")
   if test_bin and #test_bin > 0 then
     local p = fs.join(test_bin, "cosmic")
-    if fs.isfile(p) then
+    if fs.is_file(p) then
       return p
     end
   end
@@ -60,7 +60,7 @@ end
 local function init_tree(): string
   for d = 1, DIRS do
     local sub = fs.join(srcdir, "dir-" .. d)
-    local ok, merr = fs.makedirs(sub)
+    local ok, merr = fs.make_dirs(sub)
     if not ok then
       return "makedirs: " .. tostring(merr)
     end
@@ -87,11 +87,11 @@ local function count_zip_files(exe_path: string): integer, string
   if not data then
     return nil, "slurp: " .. tostring(rerr)
   end
-  local reader, zerr = czip.from(data)
+  local reader, zerr = czip.open_bytes(data)
   if not reader then
-    return nil, "zip.from: " .. tostring(zerr)
+    return nil, "zip.open_bytes: " .. tostring(zerr)
   end
-  local rr = reader as czip.Reader -- cast: record union after guard
+  local rr = reader as czip.Archive -- cast: record union after guard
   local count = 0
   for _, entry in ipairs(rr:list()) do
     if entry.name:sub(-1) ~= "/" then
@@ -108,13 +108,13 @@ local function scenarios(): {pt.Scenario}, string
     return nil, "cannot locate cosmic binary (set PERF_BIN)"
   end
 
-  local dir, derr = fs.mkdtemp(fs.join(tmp_base(), "perf-embed-XXXXXX"))
+  local dir, derr = fs.temp_dir(fs.join(tmp_base(), "perf-embed-XXXXXX"))
   if dir == nil then
     return nil, "mkdtemp: " .. tostring(derr)
   end
   tmpdir = dir
   srcdir = fs.join(tmpdir, "src")
-  local mok, merr = fs.makedirs(srcdir)
+  local mok, merr = fs.make_dirs(srcdir)
   if not mok then
     return nil, "makedirs: " .. tostring(merr)
   end
@@ -135,12 +135,12 @@ local function scenarios(): {pt.Scenario}, string
       -- per-file slurp/embed cost.
       name = "embed_run_tree",
       fn = function(_: any): any
-        return embed.run({srcdir}, {output = packed_exe, exe_path = bin})
+        return embed.embed({srcdir}, {output = packed_exe, exe_path = bin})
       end,
       check = function(_: any, res: any): boolean, string
         local r = res as EmbedResult -- cast: from any
         if not r.ok then
-          return false, "embed.run failed"
+          return false, "embed.embed failed"
         end
         if r.file_count ~= total_files then
           return false, string.format("embedded %d files, want %d",
@@ -156,9 +156,9 @@ local function scenarios(): {pt.Scenario}, string
       -- from the archive read/write cost.
       name = "embed_extract_tree",
       setup = function(): any, string
-        local result = embed.run({srcdir}, {output = packed_exe, exe_path = bin})
+        local result = embed.embed({srcdir}, {output = packed_exe, exe_path = bin})
         if not result.ok then
-          return nil, "embed.run: " .. tostring(result.message)
+          return nil, "embed.embed: " .. tostring(result.message)
         end
         local expected, cerr = count_zip_files(packed_exe)
         if not expected then
@@ -187,7 +187,7 @@ end
 
 local function cleanup()
   if tmpdir then
-    fs.rmrf(tmpdir)
+    fs.remove_all(tmpdir)
     tmpdir = nil
   end
 end

--- a/_perf/bench/embed_startup_bench.tl
+++ b/_perf/bench/embed_startup_bench.tl
@@ -1,6 +1,6 @@
---- Startup of an embed.run()-produced executable.
+--- Startup of an embed.embed()-produced executable.
 ---
---- embed.run() bundles a user app into a copy of the cosmic binary; the
+--- embed.embed() bundles a user app into a copy of the cosmic binary; the
 --- produced executable boots into the embedded main.lua, which loads the
 --- app's other embedded .lua modules. Whatever compression those modules
 --- carry is paid back as inflate() calls on every launch of the app — the
@@ -42,7 +42,7 @@ local function find_bin(): string
   local test_bin = os.getenv("TEST_BIN")
   if test_bin and #test_bin > 0 then
     local p = fs.join(test_bin, "cosmic")
-    if fs.isfile(p) then
+    if fs.is_file(p) then
       return p
     end
   end
@@ -108,13 +108,13 @@ local function scenarios(): {pt.Scenario}, string
   if bin == nil or #bin == 0 then
     return nil, "cannot locate cosmic binary (set PERF_BIN)"
   end
-  local dir, derr = fs.mkdtemp(fs.join(tmp_base(), "perf-embed-startup-XXXXXX"))
+  local dir, derr = fs.temp_dir(fs.join(tmp_base(), "perf-embed-startup-XXXXXX"))
   if dir == nil then
     return nil, "mkdtemp: " .. tostring(derr)
   end
   tmpdir = dir
   local appdir = fs.join(tmpdir, "app")
-  local mok, merr = fs.makedirs(appdir)
+  local mok, merr = fs.make_dirs(appdir)
   if not mok then
     return nil, "makedirs: " .. tostring(merr)
   end
@@ -126,9 +126,9 @@ local function scenarios(): {pt.Scenario}, string
   -- Build the embedded executable once: the per-op cost is its startup,
   -- not the (fixed, megabyte-scale) embed operation.
   packed_exe = fs.join(tmpdir, "packed")
-  local res = embed.run({appdir}, {output = packed_exe, exe_path = bin})
+  local res = embed.embed({appdir}, {output = packed_exe, exe_path = bin})
   if not res.ok then
-    return nil, "embed.run: " .. tostring(res.message)
+    return nil, "embed.embed: " .. tostring(res.message)
   end
 
   local want = SENTINEL .. ":" .. tostring(expected_sum)
@@ -153,7 +153,7 @@ end
 
 local function cleanup()
   if tmpdir then
-    fs.rmrf(tmpdir)
+    fs.remove_all(tmpdir)
     tmpdir = nil
   end
 end

--- a/_perf/bench/fs_bench.tl
+++ b/_perf/bench/fs_bench.tl
@@ -21,14 +21,14 @@ end
 --- Create the scratch tree: DIRS directories of FILES_PER_DIR small files.
 --- @return string Error message, or nil on success
 local function init_tree(): string
-  local dir, derr = fs.mkdtemp(fs.join(tmp_base(), "perf-fs-XXXXXX"))
+  local dir, derr = fs.temp_dir(fs.join(tmp_base(), "perf-fs-XXXXXX"))
   if dir == nil then
     return "mkdtemp: " .. tostring(derr)
   end
   tmpdir = dir
   for d = 1, DIRS do
     local sub = fs.join(dir, "dir-" .. d)
-    local ok, merr = fs.makedirs(sub)
+    local ok, merr = fs.make_dirs(sub)
     if not ok then
       return "makedirs: " .. tostring(merr)
     end
@@ -77,14 +77,14 @@ local function scenarios(): {pt.Scenario}, string
       end,
     },
     {
-      -- Iterate matching files without ever needing stat data (fs.files()
+      -- Iterate matching files without ever needing stat data (fs.find_iter()
       -- only returns paths), so this is the scenario a d_type fast path
       -- (skip stat(2) when the dirent already says "not a directory")
       -- should show up in most clearly.
       name = "fs_files_tree",
       fn = function(_: any): any
         local count = 0
-        for _ in check.must(fs.files(tmpdir, "*.txt")) do
+        for _ in check.must(fs.find_iter(tmpdir, {glob = "*.txt"})) do
           count = count + 1
         end
         return count
@@ -167,7 +167,7 @@ end
 
 local function cleanup()
   if tmpdir then
-    fs.rmrf(tmpdir)
+    fs.remove_all(tmpdir)
     tmpdir = nil
   end
 end

--- a/_perf/bench/sqlite_bench.tl
+++ b/_perf/bench/sqlite_bench.tl
@@ -21,7 +21,7 @@ end
 --- Create the scratch database and seed deterministic rows.
 --- @return string Error message, or nil on success
 local function init_db(): string
-  local dir, derr = fs.mkdtemp(fs.join(tmp_base(), "perf-sqlite-XXXXXX"))
+  local dir, derr = fs.temp_dir(fs.join(tmp_base(), "perf-sqlite-XXXXXX"))
   if dir == nil then
     return "mkdtemp: " .. tostring(derr)
   end
@@ -154,7 +154,7 @@ local function cleanup()
     db = nil
   end
   if tmpdir then
-    fs.rmrf(tmpdir)
+    fs.remove_all(tmpdir)
     tmpdir = nil
   end
 end

--- a/_perf/bench/startup_bench.tl
+++ b/_perf/bench/startup_bench.tl
@@ -44,7 +44,7 @@ local function find_bin(): string
   local test_bin = os.getenv("TEST_BIN")
   if test_bin and #test_bin > 0 then
     local p = fs.join(test_bin, "cosmic")
-    if fs.isfile(p) then
+    if fs.is_file(p) then
       return p
     end
   end
@@ -72,7 +72,7 @@ local function scenarios(): {pt.Scenario}, string
   if bin == nil or #bin == 0 then
     return nil, "cannot locate cosmic binary (set PERF_BIN)"
   end
-  local dir, derr = fs.mkdtemp(fs.join(tmp_base(), "perf-startup-XXXXXX"))
+  local dir, derr = fs.temp_dir(fs.join(tmp_base(), "perf-startup-XXXXXX"))
   if dir == nil then
     return nil, "mkdtemp: " .. tostring(derr)
   end
@@ -143,7 +143,7 @@ end
 
 local function cleanup()
   if tmpdir then
-    fs.rmrf(tmpdir)
+    fs.remove_all(tmpdir)
     tmpdir = nil
   end
 end

--- a/_types/gentype_defs.tl
+++ b/_types/gentype_defs.tl
@@ -38,13 +38,13 @@ local function read(): string | nil, string
     return source
   end
   local runtime = runtime_path()
-  local reader, oerr = zip.reader(runtime)
+  local reader, oerr = zip.open(runtime)
   if not reader then
     return nil, "Failed to open " .. runtime ..
     " (run `cosmic --make fetch`): " .. (oerr or "unknown error")
   end
   -- cast: Reader | nil, and an early-exit guard does not narrow
-  local source, rerr = (reader as zip.Reader):read(".lua/definitions.lua")
+  local source, rerr = (reader as zip.Archive):read(".lua/definitions.lua")
   if not source then
     return nil, "Failed to read .lua/definitions.lua from " .. runtime ..
     ": " .. (rerr or "unknown error")

--- a/_types/gentype_test.tl
+++ b/_types/gentype_test.tl
@@ -401,7 +401,7 @@ test_valid_types_pass_validation()
 local function test_generated_valid_teal()
   for _, m in ipairs(gentype.get_modules()) do
     local path = generated_path(m)
-    assert(fs.isfile(path), path .. " was not generated — the graph runs "
+    assert(fs.is_file(path), path .. " was not generated — the graph runs "
       .. "_types/types_gen.tl before anything reads cosmo.*")
     local result = teal.check(path, {include_dirs = {"o/_types/types_gen"}})
     assert(result.ok, "generated " .. path .. " is not valid Teal:\n"

--- a/_types/tl_conformance_test.tl
+++ b/_types/tl_conformance_test.tl
@@ -115,7 +115,7 @@ test_probe_passes_against_shim()
 -- warnings-as-errors policy; type ERRORS are the conformance signal.
 local function test_probe_passes_against_staged_tl()
   local staged = staged_tl_dir()
-  assert(fs.isfile(fs.join(staged, "tl.tl")),
+  assert(fs.is_file(fs.join(staged, "tl.tl")),
     "staged tl source missing at " .. staged .. " (run `cosmic --make fetch`)")
   local r = teal.check(probe_path, {include_dirs = {staged}, werror = false})
   assert(#r.errors == 0,

--- a/_types/types_gen.tl
+++ b/_types/types_gen.tl
@@ -43,7 +43,7 @@ end
 --- @param body string What to write
 --- @return string|nil The error message, nil on success
 local function put(path: string, body: string): string | nil
-  if not fs.makedirs(fs.dirname(path)) then
+  if not fs.make_dirs(fs.dirname(path)) then
     return "cannot create " .. fs.dirname(path)
   end
   local ok, err = fs.write(path, body)

--- a/bin/cosmic.pin
+++ b/bin/cosmic.pin
@@ -4,5 +4,5 @@
 # `*_pin.tl` — those are resolved by `cosmic --make fetch`, which needs a
 # cosmic to run, which is the thing this pin provides. Bump both fields
 # together; the sha is what is verified before anything is executed.
-url = https://github.com/whilp/cosmic/releases/download/2026-07-27-a5bbc34/cosmic-lua
-sha256 = 507a2ba5c9ebb4cfb1d44e4a8e7cbc71fc6de0c236b637ec14bb7ce0aaed29bc
+url = https://github.com/whilp/cosmic/releases/download/2026-08-05-54f3e88/cosmic-lua
+sha256 = 2bc5d95d86910204e167337752bb36ea685c289944598853f108a912d19d91a9

--- a/cmd/cosmic/embed_gen.tl
+++ b/cmd/cosmic/embed_gen.tl
@@ -93,7 +93,7 @@ local function put(from: string, to: string, dest: string): boolean, string
     return false, from .. ": " .. (rerr or "cannot read")
   end
   local out = fs.join(dest, to)
-  local mok, merr = fs.makedirs(fs.dirname(out))
+  local mok, merr = fs.make_dirs(fs.dirname(out))
   if not mok then
     return false, fs.dirname(out) .. ": " .. (merr or "cannot create")
   end
@@ -112,7 +112,7 @@ end
 --- @param dest string The payload directory
 --- @return boolean, string Success, or false plus the reason
 local function put_tree(dir: string, dest: string): boolean, string
-  local found, lerr = fs.collect(dir, "*")
+  local found, lerr = fs.find(dir)
   if not found then
     return false, dir .. ": " .. (lerr or "cannot list")
   end
@@ -209,7 +209,7 @@ end
 --- it, this would ship it.
 --- @return {string} Paths under TYPES_DIR, sorted
 local function generated_types(): {string}
-  local found = fs.collect(TYPES_DIR, "*")
+  local found = fs.find(TYPES_DIR)
   if not found then
     return {}
   end
@@ -283,7 +283,7 @@ local function write_index(proj: Project, dest: string): boolean, string
     return false, "doc index: " .. (err or "unknown error")
   end
   local out = fs.join(dest, ".docs/index.lua")
-  local mok, merr = fs.makedirs(fs.dirname(out))
+  local mok, merr = fs.make_dirs(fs.dirname(out))
   if not mok then
     return false, fs.dirname(out) .. ": " .. (merr or "cannot create")
   end
@@ -299,8 +299,8 @@ end
 --- else unknown.
 --- @return string The version string
 local function declared_version(): string
-  if fs.isfile(VERSION_PIN) then
-    local declared, derr = literal.of_file(VERSION_PIN)
+  if fs.is_file(VERSION_PIN) then
+    local declared, derr = literal.parse_file(VERSION_PIN)
     if not declared then
       io.stderr:write("embed_gen: " .. VERSION_PIN .. ": " ..
         (derr or "cannot read") .. "; falling back to the environment\n")
@@ -341,7 +341,7 @@ end
 --- @param dest string The payload directory
 --- @return boolean, string Success, or false plus the reason
 local function write_version(dest: string): boolean, string
-  local pin, perr = literal.of_file(COSMOS_PIN)
+  local pin, perr = literal.parse_file(COSMOS_PIN)
   if not pin then
     return false, COSMOS_PIN .. ": " .. (perr or "cannot read")
   end
@@ -355,7 +355,7 @@ local function write_version(dest: string): boolean, string
       cosmos = cosmos is string and cosmos or "unknown",
     }) .. "\n"
   local out = fs.join(dest, VERSION_STORED)
-  local mok, merr = fs.makedirs(fs.dirname(out))
+  local mok, merr = fs.make_dirs(fs.dirname(out))
   if not mok then
     return false, fs.dirname(out) .. ": " .. (merr or "cannot create")
   end
@@ -400,12 +400,12 @@ local function generate(out: string): string
   -- be this file's job only if the directory were the unit's output,
   -- shared with the compiled entry the build puts there; it is not.
   local dest = fs.join(out, PAYLOAD_DIR)
-  local mok, merr = fs.makedirs(dest)
+  local mok, merr = fs.make_dirs(dest)
   if not mok then
     return dest .. ": " .. (merr or "cannot create")
   end
   for _, pair in ipairs(BASES) do
-    if not fs.isfile(pair[2]) then
+    if not fs.is_file(pair[2]) then
       return pair[2] .. ": missing; run `cosmic --make fetch` first"
     end
     local bok, berr = put(pair[2], pair[1], out)
@@ -433,7 +433,7 @@ local function generate(out: string): string
     end
   end
   for _, pair in ipairs(PINNED) do
-    if not fs.isfile(pair[2]) then
+    if not fs.is_file(pair[2]) then
       return pair[2] .. ": missing; run `cosmic --make fetch` first"
     end
     local ok, err = put(pair[2], pair[1], dest)

--- a/cosmic/benchmark_test.tl
+++ b/cosmic/benchmark_test.tl
@@ -3,7 +3,7 @@
 
 local check = require("cosmic.check")
 local fs = require("cosmic.fs")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 local benchmark = require("cosmic.benchmark")
 local env = require("cosmic.env")
 
@@ -105,7 +105,7 @@ local function Benchmark_cmd()
   local x = 1 + 1
 end
 ]])
-  local h1 = check.must(spawn.start({cosmic, "--benchmark", input}))
+  local h1 = check.must(child.start({cosmic, "--benchmark", input}))
   local __r1 = check.must(h1:wait())
   local ok, out = __r1.ok, __r1.stdout
   assert(ok, "cosmic --benchmark should succeed")
@@ -119,7 +119,7 @@ local function test_cosmic_benchmark_skip()
   local input = write_temp("cmd_bench_skip.tl", [[
 local x = 1
 ]])
-  local r = check.must(spawn.run({cosmic, "--benchmark", input}))
+  local r = check.must(child.run({cosmic, "--benchmark", input}))
   assert(r.code == 2, "should return skip code 2")
   assert(r.stdout:find("SKIP"), "output should show SKIP")
 end
@@ -302,7 +302,7 @@ local function Benchmark_beta()
   local y = 2
 end
 ]])
-  local h2 = check.must(spawn.start({cosmic, "--benchmark", input .. ":alpha"}))
+  local h2 = check.must(child.start({cosmic, "--benchmark", input .. ":alpha"}))
   local __r2 = check.must(h2:wait())
   local ok, out = __r2.ok, __r2.stdout
   assert(ok, "cosmic --benchmark with filter should succeed")

--- a/cosmic/check_assertions_test.tl
+++ b/cosmic/check_assertions_test.tl
@@ -269,7 +269,7 @@ test_must_passes_false_through()
 
 local type Iter = function(): string
 
--- mimic fs.files' shape: iterator, err, control, to-be-closed guard
+-- mimic fs.find_iter's shape: iterator, err, control, to-be-closed guard
 local function fake_files(fail: boolean, guard: any): Iter | nil, string, any, any
   if fail then
     return nil, "cannot open"

--- a/cosmic/child/init.tl
+++ b/cosmic/child/init.tl
@@ -485,15 +485,12 @@ local record ChildModule
 
   -- High-level spawn API
   start: function(argv: {string}, opts?: Options): Handle | nil, string
-  --- DEPRECATED alias for start() (api-review-8 pin-advance transition)
-  spawn: function(argv: {string}, opts?: Options): Handle | nil, string
   run: function(argv: {string}, opts?: Options): Result
 
 end
 
 local M: ChildModule = {
   start = start,
-  spawn = start,
   run = run,
 }
 

--- a/cosmic/cosmic_test.tl
+++ b/cosmic/cosmic_test.tl
@@ -30,12 +30,12 @@ local function test_require_cosmic()
 end
 test_require_cosmic()
 
-local function test_require_cosmic_spawn()
-  local spawn_mod = require("cosmic.child")
-  assert(spawn_mod ~= nil, "spawn_mod should not be nil")
-  assert(spawn_mod.spawn ~= nil, "spawn_mod.spawn should not be nil")
+local function test_require_cosmic_child()
+  local child_mod = require("cosmic.child")
+  assert(child_mod ~= nil, "child_mod should not be nil")
+  assert(child_mod.start ~= nil, "child_mod.start should not be nil")
 end
-test_require_cosmic_spawn()
+test_require_cosmic_child()
 
 local function test_require_cosmic_fs()
   assert(fs ~= nil, "fs should not be nil")
@@ -45,9 +45,9 @@ local function test_require_cosmic_fs()
   assert(fs.join ~= nil, "fs.join should not be nil")
   -- Walk functions
   assert(fs.walk ~= nil, "fs.walk should not be nil")
-  assert(fs.collect ~= nil, "fs.collect should not be nil")
-  assert(fs.collect_all ~= nil, "fs.collect_all should not be nil")
-  assert(fs.files ~= nil, "fs.files should not be nil")
+  assert(fs.find ~= nil, "fs.find should not be nil")
+  assert(fs.find_info ~= nil, "fs.find_info should not be nil")
+  assert(fs.find_iter ~= nil, "fs.find_iter should not be nil")
 end
 test_require_cosmic_fs()
 

--- a/cosmic/doc/init.tl
+++ b/cosmic/doc/init.tl
@@ -327,9 +327,6 @@ local record DocModule
 
   -- Query: the index embedded in the binary (`--docs`).
   query: function(q?: string): DocsResult
-  --- DEPRECATED alias for query() (api-review-8 transition; tooling
-  --- executes under the pinned binary until the pin advances)
-  run: function(q?: string): DocsResult
   has_docs: function(): boolean
   list_topics: function(include_cosmo?: boolean): {{string, string}}
   embedded_index: function(): DocIndex | nil, string
@@ -352,7 +349,6 @@ local M: DocModule = {
   load_index = load_index,
 
   query = query.run,
-  run = query.run,
   has_docs = query.has_docs,
   list_topics = query.list_topics,
   embedded_index = query.embedded_index,

--- a/cosmic/doc/public_test.tl
+++ b/cosmic/doc/public_test.tl
@@ -67,7 +67,7 @@ local function test_directory_modules_indexed_under_their_name()
     "directory module must be indexed, not cosmic.fs.init")
   assert(not idx.modules["cosmic.fs.init"],
     "init shard must not appear own module")
-  local result = docs.run("fs")
+  local result = docs.query("fs")
   assert(result.ok, "--docs fs must resolve to the fs module page")
   print("test_directory_modules_indexed_under_their_name: PASS")
 end
@@ -91,11 +91,11 @@ end
 test_internal_modules_stay_searchable_with_badge()
 
 local function test_internal_doc_page_carries_header()
-  local result = docs.run("cosmic.child.io")
+  local result = docs.query("cosmic.child.io")
   assert(result.ok, "--docs cosmic.child.io must still render a page")
   assert(result.output:find("internal module — not API, may change without notice", 1, true),
     "internal module page must carry the internal-module header")
-  local public_page = docs.run("cosmic.json")
+  local public_page = docs.query("cosmic.json")
   assert(public_page.ok, "--docs cosmic.json must render")
   assert(not public_page.output:find("internal module — not API", 1, true),
     "public module page must not carry the internal-module header")

--- a/cosmic/doc/query_test.tl
+++ b/cosmic/doc/query_test.tl
@@ -8,7 +8,7 @@ local doc_types = require("cosmic.doc.types")
 -- Test module loads correctly
 local function test_module_loads()
   assert(docs, "docs module should load")
-  assert(docs.run, "docs.run should exist")
+  assert(docs.query, "docs.query should exist")
   assert(docs.has_docs, "docs.has_docs should exist")
   assert(docs.list_topics, "docs.list_topics should exist")
   assert(docs.embedded_index, "docs.embedded_index should exist")
@@ -42,7 +42,7 @@ end
 test_load_index()
 
 local function test_run_list()
-  local result = docs.run()
+  local result = docs.query()
   assert(result, "run should return a result")
   assert(type(result.ok) == "boolean", "result.ok should be a boolean")
   assert(type(result.output) == "string", "result.output should be a string")
@@ -56,7 +56,7 @@ test_run_list()
 
 -- Test run with a module query
 local function test_run_module()
-  local result = docs.run("cosmic.doc")
+  local result = docs.query("cosmic.doc")
   assert(result, "run should return a result")
   assert(type(result.ok) == "boolean", "result.ok should be a boolean")
   assert(type(result.output) == "string", "result.output should be a string")
@@ -70,7 +70,7 @@ end
 test_run_module()
 
 local function test_run_symbol()
-  local result = docs.run("cosmic.doc.parse")
+  local result = docs.query("cosmic.doc.parse")
   assert(result, "run should return a result")
   assert(type(result.ok) == "boolean", "result.ok should be a boolean")
   assert(type(result.output) == "string", "result.output should be a string")
@@ -84,7 +84,7 @@ test_run_symbol()
 
 -- Test run with invalid query
 local function test_run_invalid()
-  local result = docs.run("nonexistent.module.that.does.not.exist")
+  local result = docs.query("nonexistent.module.that.does.not.exist")
   assert(result, "run should return a result")
   assert(type(result.output) == "string", "result.output should be a string")
   -- Should return an error for nonexistent module
@@ -167,7 +167,7 @@ test_search_methods()
 
 -- Test run with method lookup (module.Record.method pattern)
 local function test_run_method()
-  local result = docs.run("cosmo.lsqlite3.Database.exec")
+  local result = docs.query("cosmo.lsqlite3.Database.exec")
   assert(result, "run should return a result")
   assert(type(result.ok) == "boolean", "result.ok should be a boolean")
   assert(type(result.output) == "string", "result.output should be a string")
@@ -181,7 +181,7 @@ test_run_method()
 
 -- Test cosmo module shows tip about cosmic equivalent
 local function test_cosmic_equivalent_tip()
-  local result = docs.run("cosmo.lsqlite3")
+  local result = docs.query("cosmo.lsqlite3")
   assert(result, "run should return a result")
   if result.ok then
     assert(result.output:find("cosmic.sqlite", 1, true),
@@ -338,7 +338,7 @@ test_search_includes_cosmo_when_requested()
 
 -- Test that explicit cosmo module lookup still works
 local function test_explicit_cosmo_access()
-  local result = docs.run("cosmo.unix")
+  local result = docs.query("cosmo.unix")
   assert(result, "run should return a result")
   if docs.has_docs() then
     assert(result.ok, "explicit cosmo.unix lookup should succeed")
@@ -353,7 +353,7 @@ test_explicit_cosmo_access()
 -- Test symbol lookup finds re-exported record methods (bug 1) and quick example (bug 3)
 local function test_run_reexported_and_quick_example()
   if not docs.has_docs() then print("test_run_reexported_and_quick_example: PASS (skipped)"); return end
-  local r = docs.run("cosmic.sqlite.query")
+  local r = docs.query("cosmic.sqlite.query")
   assert(r, "run should return result")
   if r.ok then assert(r.output:match("query"), "should find query method") end
   local idx = check.must(docs.embedded_index())
@@ -362,7 +362,7 @@ local function test_run_reexported_and_quick_example()
     if mod_doc.examples and #mod_doc.examples > 0 then test_mod = mod_name; break end
   end
   if test_mod then
-    local mr = docs.run(test_mod)
+    local mr = docs.query(test_mod)
     assert(mr and mr.ok, "module lookup should succeed")
     assert(mr.output:match("Quick example"), "should have Quick example section")
   end

--- a/cosmic/embed/init.tl
+++ b/cosmic/embed/init.tl
@@ -196,7 +196,7 @@ local function base_entries(exe_path: string): {string}
   if rd == nil then
     return names
   end
-  local reader = rd as czip.Reader -- cast: record union after guard
+  local reader = rd as czip.Archive -- cast: record union after guard
   for _, e in ipairs(reader:list()) do
     names[#names + 1] = e.name
   end
@@ -230,7 +230,7 @@ local function wrap_user_main(files_to_embed: {FileToEmbed}, exe_path: string): 
   end
   local exe_reader = czip.open(exe_path)
   if exe_reader ~= nil then
-    local rd = exe_reader as czip.Reader -- cast: record union after guard
+    local rd = exe_reader as czip.Archive -- cast: record union after guard
     local exe_main = rd:read("main.lua")
     rd:close()
     if exe_main == main_entry.content then
@@ -428,15 +428,12 @@ local record EmbedModule
 
   EPOCH: integer
   embed: function(paths: {string}, opts?: Options): EmbedResult
-  --- DEPRECATED alias for embed() (api-review-8 transition)
-  run: function(paths: {string}, opts?: Options): EmbedResult
   extract: function(output_dir: string, exe_path?: string): EmbedResult
 end
 
 local M: EmbedModule = {
   EPOCH = floor.epoch(),
   embed = embed,
-  run = embed,
   extract = extract_mod.extract,
 }
 

--- a/cosmic/embed_example.tl
+++ b/cosmic/embed_example.tl
@@ -10,7 +10,7 @@
 local function Example_embed_directory()
   local check = require("cosmic.check")
   local fs = require("cosmic.fs")
-  local spawn = require("cosmic.child")
+  local child = require("cosmic.child")
   local cosmic = arg[-1]
 
   local tmpdir = fs.temp_dir("/tmp/embed_example_XXXXXX")
@@ -22,11 +22,11 @@ local function Example_embed_directory()
 
   -- Build it
   local output = fs.join(tmpdir, "hello")
-  local r = check.must(spawn.run({cosmic, "--embed", appdir, "--output", output}))
+  local r = check.must(child.run({cosmic, "--embed", appdir, "--output", output}))
   assert(r.ok, r.stderr)
 
   -- Run it
-  r = check.must(spawn.run({output}))
+  r = check.must(child.run({output}))
   fs.remove_all(tmpdir)
   print(r.stdout)
   -- Output:
@@ -37,14 +37,14 @@ end
 local function Example_extract_roundtrip()
   local check = require("cosmic.check")
   local fs = require("cosmic.fs")
-  local spawn = require("cosmic.child")
+  local child = require("cosmic.child")
   local cosmic = arg[-1]
 
   local tmpdir = fs.temp_dir("/tmp/embed_example_XXXXXX")
 
   -- Extract the running executable's zip contents
   local extractdir = fs.join(tmpdir, "extracted")
-  local r = check.must(spawn.run({cosmic, "--extract", extractdir}))
+  local r = check.must(child.run({cosmic, "--extract", extractdir}))
   assert(r.ok, r.stderr)
 
   -- The extracted directory contains main.lua and all bundled files
@@ -59,7 +59,7 @@ end
 local function Example_embed_with_libraries()
   local check = require("cosmic.check")
   local fs = require("cosmic.fs")
-  local spawn = require("cosmic.child")
+  local child = require("cosmic.child")
   local cosmic = arg[-1]
 
   local tmpdir = fs.temp_dir("/tmp/embed_example_XXXXXX")
@@ -74,10 +74,10 @@ io.write(r.stdout)
 ]])
 
   local output = fs.join(tmpdir, "myapp")
-  local r = check.must(spawn.run({cosmic, "--embed", appdir, "--output", output}))
+  local r = check.must(child.run({cosmic, "--embed", appdir, "--output", output}))
   assert(r.ok, r.stderr)
 
-  r = check.must(spawn.run({output}))
+  r = check.must(child.run({output}))
   fs.remove_all(tmpdir)
   print(r.stdout)
   -- Output:
@@ -90,7 +90,7 @@ end
 local function Example_embed_from_teal()
   local check = require("cosmic.check")
   local fs = require("cosmic.fs")
-  local spawn = require("cosmic.child")
+  local child = require("cosmic.child")
   local cosmic = arg[-1]
 
   local tmpdir = fs.temp_dir("/tmp/embed_example_XXXXXX")
@@ -102,7 +102,7 @@ local function Example_embed_from_teal()
   fs.write(tl_file, 'local msg: string = "hello from teal"\nprint(msg)\n')
 
   -- Compile .tl to .lua using cosmic --compile
-  local r = check.must(spawn.run({cosmic, "--compile", tl_file}))
+  local r = check.must(child.run({cosmic, "--compile", tl_file}))
   assert(r.ok, r.stderr)
   local lua_source = r.stdout
 
@@ -111,10 +111,10 @@ local function Example_embed_from_teal()
 
   -- Embed and run
   local output = fs.join(tmpdir, "from_teal")
-  r = check.must(spawn.run({cosmic, "--embed", appdir, "--output", output}))
+  r = check.must(child.run({cosmic, "--embed", appdir, "--output", output}))
   assert(r.ok, r.stderr)
 
-  r = check.must(spawn.run({output}))
+  r = check.must(child.run({output}))
   fs.remove_all(tmpdir)
   print(r.stdout)
   -- Output:

--- a/cosmic/fs/init.tl
+++ b/cosmic/fs/init.tl
@@ -335,17 +335,14 @@ local record FsModule
   --- Expand a glob pattern without recursing; components ("src/*.lua")
   --- are each globs, and matches of every entry type are returned sorted.
   glob: function(dir: string, pattern: string): {string} | nil, string
-  --- Recursively collect files under dir whose names match a glob
-  --- pattern (collect's pattern is ALWAYS a glob).
   type FindOptions = fs_walk.FindOptions
+  --- Recursively collect files under dir; opts selects basenames by
+  --- glob or Lua pattern (default: all files).
   find: function(dir: string, opts?: fs_walk.FindOptions): {string} | nil, string
-  --- Recursively collect files under dir whose names match a Lua pattern.
+  --- Iterate files under dir lazily; same selection as find().
   find_iter: function(dir: string, opts?: fs_walk.FindOptions): FileIter | nil, string, any, any
+  --- Recursively collect files under dir with their FileInfo (mode).
   find_info: function(dir: string): {string: FileInfo} | nil, string
-  -- DEPRECATED aliases (api-review-8 pin-advance transition)
-  collect: function(dir: string, pattern: string): {string} | nil, string
-  collect_all: function(dir: string): {string: FileInfo} | nil, string
-  files: function(dir: string, pattern?: string): FileIter | nil, string, any, any
 
   -- Access mode constants
   F_OK: integer
@@ -362,18 +359,6 @@ local record FsModule
   DT_REG: integer
   DT_SOCK: integer
   DT_UNKNOWN: integer
-
-  -- DEPRECATED aliases (api-review-8 transition; see bottom of file)
-  isfile: function(path: string): boolean
-  isdir: function(path: string): boolean
-  islink: function(path: string): boolean
-  makedirs: function(path: string, mode?: integer): boolean, string
-  rmrf: function(path: string): boolean, string
-  copytree: function(src: string, dst: string): boolean, string
-  getcwd: function(): string | nil, string
-  mkdtemp: function(template: string): string | nil, string
-  tmpfile: function(template?: string): fs_ops.TmpFile | nil, string
-  tmpfd: function(): integer | nil, string
 end
 
 local M: FsModule = {
@@ -473,27 +458,5 @@ local M: FsModule = {
   DT_SOCK = unix.DT_SOCK,
   DT_UNKNOWN = unix.DT_UNKNOWN,
 }
-
--- DEPRECATED transitional aliases (api-review-8): the pinned cosmic
--- that cold-starts a build EXECUTES tree tooling against its embedded
--- pre-rename cosmic.*, so tooling may only use names both generations
--- share. Tooling flips and these die once the pin carries the renames.
-M.collect = function(dir: string, pattern: string): {string} | nil, string
-  return fs_walk.find(dir, {glob = pattern})
-end
-M.collect_all = fs_walk.find_info
-M.files = function(dir: string, pattern?: string): FileIter | nil, string, any, any
-  return fs_walk.find_iter(dir, {glob = pattern or "*"})
-end
-M.isfile = fs_path.is_file
-M.isdir = fs_path.is_dir
-M.islink = fs_path.is_link
-M.makedirs = M.make_dirs
-M.rmrf = fs_ops.remove_all
-M.copytree = fs_tree.copy_tree
-M.getcwd = M.cwd
-M.mkdtemp = fs_ops.temp_dir
-M.tmpfile = fs_ops.temp_file
-M.tmpfd = fs_ops.temp_fd
 
 return M

--- a/cosmic/fs/path_test.tl
+++ b/cosmic/fs/path_test.tl
@@ -197,10 +197,10 @@ local function test_walk_with_visitor()
 end
 test_walk_with_visitor()
 
-local function test_collect_all()
+local function test_find_info()
   local walk_dir = setup_walk()
   local collected = fs.find_info(walk_dir)
-  assert(collected, "collect_all should succeed")
+  assert(collected, "find_info should succeed")
   local found = collected as {string: fs_types.FileInfo} -- cast: record union after guard
 
   assert(found["file1.lua"] ~= nil, "expected file1.lua")
@@ -210,7 +210,7 @@ local function test_collect_all()
   assert(found["file1.lua"].mode ~= nil, "expected mode property")
   teardown(walk_dir)
 end
-test_collect_all()
+test_find_info()
 
 local function test_files_iterator()
   local walk_dir = setup_walk()

--- a/cosmic/fs/walk_test.tl
+++ b/cosmic/fs/walk_test.tl
@@ -57,21 +57,21 @@ local function test_walk_symlink_cycle_terminates()
 end
 test_walk_symlink_cycle_terminates()
 
--- FIX 1b: collect_all() must not recurse into symlinked directories
+-- FIX 1b: find_info() must not recurse into symlinked directories
 local function test_find_all_symlink_cycle_terminates()
-  local base = mksubdir("collect_all_cycle")
+  local base = mksubdir("find_info_cycle")
   local subdir = fs.join(base, "sub")
   fs.make_dirs(subdir)
   write_file(fs.join(subdir, "real.txt"), "data")
   fs.symlink("..", fs.join(subdir, "loop"))
 
   local collected = fs_walk.find_info(base)
-  assert(collected, "collect_all should succeed")
+  assert(collected, "find_info should succeed")
   local files = collected as {string: any} -- cast: record union after guard
   -- Should contain sub/real.txt but NOT any path with loop/ in it
   for rel_path in pairs(files) do
     assert(not rel_path:match("loop"),
-      "collect_all should not recurse into symlink loop, found: " .. rel_path)
+      "find_info should not recurse into symlink loop, found: " .. rel_path)
   end
   assert(files["sub/real.txt"] ~= nil, "real.txt should be found")
 end
@@ -142,9 +142,9 @@ test_find_missing_root_errors()
 local function test_find_all_missing_root_errors()
   local missing = fs.join(tmpdir, "no", "such", "dir")
   local results, err = fs_walk.find_info(missing)
-  assert(results == nil, "collect_all of a missing root should return nil")
+  assert(results == nil, "find_info of a missing root should return nil")
   assert(err and err:match("ENOENT"),
-    "collect_all error should name ENOENT: " .. tostring(err))
+    "find_info error should name ENOENT: " .. tostring(err))
 end
 test_find_all_missing_root_errors()
 

--- a/cosmic/literal.tl
+++ b/cosmic/literal.tl
@@ -14,7 +14,7 @@
 --- is refused by name, with the line it was found on.
 ---
 ---     local literal = require("cosmic.literal")
----     local cfg = literal.of_file("config.tl")
+---     local cfg = literal.parse_file("config.tl")
 
 local fs = require("cosmic.fs")
 
@@ -418,12 +418,12 @@ local function parse_table(toks: {Token}, i: integer, where: string,
   return nil, 0, where .. ": unterminated table in " .. noun
 end
 
---- Options for of_source/of_file: how errors talk about the file.
+--- Options for parse/parse_file: how errors talk about the file.
 --- (api-review-6: these were two message-wording positionals. The
 --- field is `file`, not `where`: `where` opens a record invariant
 --- clause in Teal and cannot name a field.)
 local record Options
-  --- File name to prefix messages with (of_source only — of_file
+  --- File name to prefix messages with (parse only — parse_file
   --- always uses the path it read). Default "literal".
   file: string
   --- What to call the file in errors — `cosmic --make` reads pins with
@@ -486,15 +486,11 @@ local record LiteralModule
   type Options = Options
   parse: function(source: string, opts?: Options): {string: any} | nil, string
   parse_file: function(path: string, opts?: Options): {string: any} | nil, string
-  --- DEPRECATED aliases (api-review-8 pin-advance transition)
-  of_source: function(source: string, opts?: Options): {string: any} | nil, string
-  of_file: function(path: string, opts?: Options): {string: any} | nil, string
 end
 
 local M: LiteralModule = {
   parse = parse,
   parse_file = parse_file,
-  of_source = parse, of_file = parse_file,
 }
 
 return M

--- a/cosmic/proc/init.tl
+++ b/cosmic/proc/init.tl
@@ -288,9 +288,6 @@ local record ProcModule
 
   -- Exec
   which: function(prog: string): string | nil, string
-  --- DEPRECATED alias for which() (api-review-8 transition; tooling
-  --- executes under the pinned binary until the pin advances)
-  commandv: function(prog: string): string | nil, string
   execve: function(prog: string, args: {string}, env: {string}): nil, string
   execvp: function(prog: string, argv?: {string}): nil, string
   execvpe: function(prog: string, argv: {string}, envp?: {string}): nil, string
@@ -370,7 +367,6 @@ local M: ProcModule = {
 
   -- Exec
   which = which,
-  commandv = which,
   execve = execve,
   execvp = execvp,
   execvpe = execvpe,

--- a/cosmic/proc_test.tl
+++ b/cosmic/proc_test.tl
@@ -38,13 +38,13 @@ local function test_getppid_different_from_pid()
 end
 test_getppid_different_from_pid()
 
--- commandv tests --
+-- which tests --
 
-local function test_commandv_finds_ls()
+local function test_which_finds_ls()
   local path_to_ls = check.must(proc.which("ls"), "expected to find 'ls' command")
   assert(path_to_ls:find("/", 1, true), "expected absolute path, got " .. tostring(path_to_ls))
 end
-test_commandv_finds_ls()
+test_which_finds_ls()
 
 local function test_commandv_returns_nil_for_nonexistent()
   local result = proc.which("nonexistent_command_xyz_12345")

--- a/cosmic/quicksand/caps_test.tl
+++ b/cosmic/quicksand/caps_test.tl
@@ -3,7 +3,7 @@ local caps = require("cosmic.quicksand.caps")
 local quicksand = require("cosmic.quicksand")
 local check = require("cosmic.check")
 local fs = require("cosmic.fs")
-local spawn = require("cosmic.child")
+local child = require("cosmic.child")
 
 local test_bin = os.getenv("TEST_BIN")
 
@@ -137,7 +137,7 @@ local function test_drop_bounding_child()
     return
   end
   local cosmic = fs.join(test_bin, "cosmic")
-  local h = check.must(spawn.start({cosmic, "-e", CHILD_DROP}))
+  local h = check.must(child.start({cosmic, "-e", CHILD_DROP}))
   local __r1 = check.must(h:wait())
   local ok, out = __r1.ok, __r1.stdout
   if not ok then

--- a/cosmic/surface_test.tl
+++ b/cosmic/surface_test.tl
@@ -85,7 +85,7 @@ local function test_directory_module_entry_points()
     doc = "parse_file",
     fetch = "fetch",
     net = "socket",
-    child = "spawn",
+    child = "start",
     format = "format",
     fs = "read",
   }
@@ -97,7 +97,7 @@ local function test_directory_module_entry_points()
   -- doc carries both halves of the converged family: extraction
   -- (parse_file, checked above) and the embedded-index query surface.
   local doc = require("cosmic.doc") as {string: any} -- cast: from any
-  assert(type(doc["run"]) == "function", "cosmic.doc must expose run()")
+  assert(type(doc["query"]) == "function", "cosmic.doc must expose query()")
   assert(type(doc["search"]) == "function", "cosmic.doc must expose search()")
 end
 test_directory_module_entry_points()

--- a/cosmic/tty.tl
+++ b/cosmic/tty.tl
@@ -52,11 +52,6 @@ local record TtyModule
   VTIME: integer
 
   is_tty: function(fd?: integer): boolean
-  -- DEPRECATED aliases (api-review-8 pin-advance transition)
-  isatty: function(fd: integer): boolean
-  stdin_isatty: function(): boolean
-  stdout_isatty: function(): boolean
-  stderr_isatty: function(): boolean
   winsize: function(fd: integer): WinSize | nil, string
   getattr: function(fd: integer): Termios | nil, string
   setattr: function(fd: integer, action: integer, termios: Termios): boolean, string
@@ -296,10 +291,6 @@ end
 
 local M: TtyModule = {
   is_tty = is_tty,
-  isatty = is_tty,
-  stdin_isatty = function(): boolean return is_tty(0) end,
-  stdout_isatty = function(): boolean return is_tty(1) end,
-  stderr_isatty = function(): boolean return is_tty(2) end,
   winsize = winsize,
   getattr = getattr,
   setattr = setattr,

--- a/cosmic/zip.tl
+++ b/cosmic/zip.tl
@@ -247,14 +247,6 @@ local record ZipModule
   append: function(path: string, opts?: OpenOptions): Appender | nil, string
   open_bytes: function(data: string, opts?: OpenOptions): Archive | nil, string
   extract: function(archive: Archive, destdir: string, opts?: ExtractOptions): boolean, string
-
-  -- DEPRECATED aliases (api-review-8 pin-advance transition)
-  type Reader = Archive
-  type Writer = Builder
-  reader: function(path: string | integer, opts?: OpenOptions): Archive | nil, string
-  writer: function(path: string | integer, opts?: OpenOptions): Builder | nil, string
-  appender: function(path: string, opts?: OpenOptions): Appender | nil, string
-  from: function(data: string, opts?: OpenOptions): Archive | nil, string
 end
 
 local M: ZipModule = {
@@ -263,10 +255,6 @@ local M: ZipModule = {
   append = append,
   open_bytes = open_bytes,
   extract = extract,
-  reader = open,
-  writer = create,
-  appender = append,
-  from = open_bytes,
 }
 
 return M

--- a/docs/decisions/d20-naming-charter.md
+++ b/docs/decisions/d20-naming-charter.md
@@ -43,10 +43,15 @@
   modules carry typed DEPRECATED aliases under the old names, and
   tooling keeps calling the old names, until a release carrying the
   new names becomes `bin/cosmic.pin`. Then a cleanup change flips
-  tooling to the new names and deletes the aliases. The aliased set:
+  tooling to the new names and deletes the aliases. That cleanup
+  landed with the 2026-08-05 pin advance: the aliased set —
   `fs.isfile/isdir/islink/makedirs/rmrf/copytree/getcwd/mkdtemp/
-  tmpfile/tmpfd`, `child.spawn`, `embed.run`, `doc.run`,
-  `literal.of_source/of_file`, `proc.commandv`.
+  tmpfile/tmpfd/collect/collect_all/files`, `tty.isatty` and the three
+  per-stream wrappers, `zip.reader/writer/appender/from` and the
+  `Reader`/`Writer` type aliases, `child.spawn`, `embed.run`,
+  `doc.run`, `literal.of_source/of_file`, `proc.commandv` — is gone,
+  and tooling calls the charter names everywhere. The protocol above
+  remains the template for any future public rename.
 - **consequences:** the rename wave landed in two parts — the
   mechanical applications of rules 1–4 and 8–9 (this record), with the
   semantic redesigns (re subject-first argument order and match/find

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -187,10 +187,10 @@ fs.join("/usr", "local", "bin")     -- "/usr/local/bin"
 fs.basename("/usr/local/bin")       -- "bin"
 fs.dirname("/usr/local/bin")        -- "/usr/local"
 fs.make_dirs("/tmp/a/b/c")          -- create parents
-fs.remove_all("/tmp/test")               -- recursive delete
+fs.remove_all("/tmp/test")          -- recursive delete
 
 -- walk directory tree
-for path in fs.files("src", "*.tl") do
+for path in fs.find_iter("src", {glob = "*.tl"}) do
   print(path)
 end
 ```


### PR DESCRIPTION
Closes out the api-review ledger. The [2026-08-05-54f3e88 release](https://github.com/whilp/cosmic/releases/download/2026-08-05-54f3e88/cosmic-lua) is the first pin whose embedded `cosmic.*` modules carry the rename wave, which unblocks the two-sided cleanup D20's transition section promised:

**Pin** — `bin/cosmic.pin` advances to 2026-08-05-54f3e88 (sha256 verified against the release artifact, and probed to carry both the new names and the aliases before the bump).

**Tooling flip** — every tree the pinned binary executes at cold start (`_cli`, `_make`, `_perf`, `_docs`, `_build`, `_types`, `cmd`, `embed`, `3p`) now calls the charter names:
- `fs.is_file`/`is_dir`/`is_link`/`make_dirs`/`remove_all`/`copy_tree`/`cwd`/`temp_dir`, and `fs.find`/`find_iter`/`find_info` with `FindOptions` (`collect(dir, pat)` sites became `find(dir, {glob = pat})`)
- `child.start`, with the ~20 `local spawn = require("cosmic.child")` aliases renamed to `child` (one shadowing conflict in `_make/resolution_test.tl` resolved)
- `zip.open`/`create`/`append`/`open_bytes` and the `Archive` type (`_make/extract.tl`, `_types/gentype_defs.tl`, perf benches)
- `doc.query`, `embed.embed`, `literal.parse`/`parse_file`, `proc.which`

**Alias deletion** — the DEPRECATED surface is gone, typed record fields and runtime assignments both: fs ×13 (incl. the `collect`/`collect_all`/`files` adapter functions), tty ×4 (`isatty` + three per-stream wrappers), zip ×4 + the `Reader`/`Writer` type aliases, `child.spawn`, `embed.run`, `doc.run`, `literal.of_source`/`of_file`, `proc.commandv`. Tests that asserted the aliased surface (`cosmic_test`, `surface_test`, `doc/query_test`) now assert the charter names.

**D20** — the transition section records that the cleanup landed; the protocol stays as the template for future public renames. `docs/stdlib.md`'s `fs.files` snippet updated.

Net −71 lines. `bin/cosmic --make ci` under the new pin: `ci: PASS (5 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FP31Qs2Ei4uJUsimFMpvkS

---
_Generated by [Claude Code](https://claude.ai/code/session_01FP31Qs2Ei4uJUsimFMpvkS)_