### PR TITLE
lint: point cast-justify at guide.checking, not AGENTS.md

### DIFF
--- a/_cli/lint.tl
+++ b/_cli/lint.tl
@@ -74,8 +74,9 @@ local function check_cast_justification(file: string, content: string,
         rule = "cast-justify",
         message = string.format(
           "%s:%d: `as` cast without justification: prefer `is` narrowing"
-          .. " or check.must (see AGENTS.md); a deliberate cast takes a"
-          .. " trailing `-- cast: <reason>` (or on the line above)",
+          .. " or check.must (see `cosmic --docs guide.checking`); a"
+          .. " deliberate cast takes a trailing `-- cast: <reason>` (or on"
+          .. " the line above)",
           file, y),
       }
     end


### PR DESCRIPTION
The cast-justify lint message told the reader to "see AGENTS.md" — a file a user of the shipped binary cannot open: it is not embedded and not a `--docs` topic, so the pointer is a dead end exactly where the rule most needs explaining. This came out of an agent usability eval (four agents learning cosmic from the binary alone): one agent hit the message, went looking for AGENTS.md, and had to fall back to `guide.gotchas` to get unstuck.

The message now points at `cosmic --docs guide.checking`, which is embedded, reachable offline, and is where the recommended alternatives (`is` narrowing, `check.must`) are actually documented.

`--make ci` green: `ci: PASS (5 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS)_