### PR TITLE
lint: name the .cosmicignore escape when length gates a non-source file

### DIFF
--- a/_cli/lint.tl
+++ b/_cli/lint.tl
@@ -385,6 +385,23 @@ local function lint_file(path: string): {Diagnostic} | nil, string
   end
 
   local diagnostics = style.check_file_length(path, n, style.DEFAULT_FILE_LINES)
+  -- A length failure on something that is not Teal/Lua source is almost
+  -- never fixed by splitting the file: it is a binary or a data file the
+  -- project walk swept in (lint reads bytes, deliberately), and the fix
+  -- the model already provides is `.cosmicignore`. Say so in the
+  -- diagnostic, where the reader is — the rule alone reads as "split
+  -- your 90,000-line file" when the file is an ELF binary.
+  if not (path:match("%.tl$") or path:match("%.lua$")) then
+    local nature = content:find("\0", 1, true)
+    and "a binary file, not text" or "not Teal/Lua source"
+    for _, d in ipairs(diagnostics) do
+      if d.rule == "file-length" then
+        d.message = d.message .. " — " .. nature .. "; lint gates every"
+        .. " file the project walk sees, so if this one should not be"
+        .. " judged, list it in .cosmicignore"
+      end
+    end
+  end
   if path:match("%.tl$") then
     for _, d in ipairs(check_cast_justification(path, content, lines)) do
       diagnostics[#diagnostics + 1] = d

--- a/_cli/lint_test.tl
+++ b/_cli/lint_test.tl
@@ -56,6 +56,59 @@ local function test_lint_file_over_default()
 end
 test_lint_file_over_default()
 
+-- A binary (or any non-Teal/Lua file) over the length limit gets the
+-- .cosmicignore hint: "split this file" is not actionable advice for an
+-- ELF binary the walk swept in.
+local function test_lint_file_hints_cosmicignore_for_binary()
+  local path = fs.join(tmpdir, "toolbinary")
+  local chunk = "\0\1\2ELF junk line\n"
+  fs.write(path, chunk:rep(600))
+
+  local diagnostics = check.must(lint.lint_file(path))
+  assert(#diagnostics == 1, "expected 1 diagnostic, got: " .. tostring(#diagnostics))
+  assert(diagnostics[1].rule == "file-length", "expected file-length rule")
+  assert(diagnostics[1].message:find("a binary file", 1, true),
+    "expected the binary nature named, got: " .. diagnostics[1].message)
+  assert(diagnostics[1].message:find(".cosmicignore", 1, true),
+    "expected a .cosmicignore hint, got: " .. diagnostics[1].message)
+end
+test_lint_file_hints_cosmicignore_for_binary()
+
+local function test_lint_file_hints_cosmicignore_for_non_source_text()
+  local path = fs.join(tmpdir, "data.csv")
+  local lines: {string} = {}
+  for i = 1, 501 do
+    table.insert(lines, "row," .. tostring(i))
+  end
+  fs.write(path, table.concat(lines, "\n") .. "\n")
+
+  local diagnostics = check.must(lint.lint_file(path))
+  assert(#diagnostics == 1, "expected 1 diagnostic, got: " .. tostring(#diagnostics))
+  assert(diagnostics[1].message:find("not Teal/Lua source", 1, true),
+    "expected the nature named, got: " .. diagnostics[1].message)
+  assert(diagnostics[1].message:find(".cosmicignore", 1, true),
+    "expected a .cosmicignore hint, got: " .. diagnostics[1].message)
+end
+test_lint_file_hints_cosmicignore_for_non_source_text()
+
+-- Teal/Lua source over the limit keeps the plain message: the fix for
+-- source really is to split it, and a .cosmicignore hint there would
+-- teach people to ignore their own code.
+local function test_lint_file_no_ignore_hint_for_source()
+  local path = fs.join(tmpdir, "long2.tl")
+  local lines: {string} = {}
+  for i = 1, 501 do
+    table.insert(lines, "-- line " .. tostring(i))
+  end
+  fs.write(path, table.concat(lines, "\n") .. "\n")
+
+  local diagnostics = check.must(lint.lint_file(path))
+  assert(#diagnostics == 1, "expected 1 diagnostic, got: " .. tostring(#diagnostics))
+  assert(not diagnostics[1].message:find(".cosmicignore", 1, true),
+    "source files should not get the ignore hint: " .. diagnostics[1].message)
+end
+test_lint_file_no_ignore_hint_for_source()
+
 local function test_lint_file_skips_dtl()
   -- .d.tl files are type declarations for C bindings and are exempt from length checks
   local path = fs.join(tmpdir, "types.d.tl")


### PR DESCRIPTION
lint reads bytes, deliberately, so the project walk gates every file it sees — including a stray binary or data file sitting in the project root. The failure that produces is real but unreadable: `cosmic has 90633 lines (limit: 500)` asks the reader to split an ELF executable. Two of four agents in a from-scratch usability eval hit exactly this on their first full `ci` run (they'd copied the `cosmic` binary into their project directory), and the `.cosmicignore` fix is only discoverable from prose in `guide.make`.

The file-length diagnostic now names what the file is and points at the escape hatch:

```
toolbinary has 9000 lines (limit: 500) — a binary file, not text; lint gates every file the project walk sees, so if this one should not be judged, list it in .cosmicignore
```

Non-Teal/Lua text files get the same hint with `not Teal/Lua source`. Source files (`.tl`/`.lua`) keep the plain message: the fix for source really is to split it, and hinting the ignore file there would teach people to ignore their own code.

Tests: three new cases in `_cli/lint_test.tl` (binary hinted, non-source text hinted, source not hinted). `--make ci` green: `ci: PASS (5 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS)_