### PR TITLE
teal: hint the un-narrowed nil-union traps, on every error path

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -73,6 +73,7 @@ cmd/cosmic/embed_gen.tl 0 166
 cmd/cosmic/main.tl 0 276
 cosmic/_script_cache.tl 72 79
 cosmic/_seal_coverage.tl 9 10
+cosmic/_teal_hints.tl 23 23
 cosmic/ansi.tl 86 86
 cosmic/benchmark.tl 146 173
 cosmic/check.tl 110 113

--- a/_cli/main_handlers.tl
+++ b/_cli/main_handlers.tl
@@ -136,7 +136,10 @@ local function handle_compile(file: string, output?: string, write_if_changed?: 
   if result.ok then
     exit_code, err_msg = write_output(result.code, output, write_if_changed)
   else
-    io.stderr:write(teal.format_issues(result.errors) .. "\n")
+    -- With hints, like --check types: `--make build` compiles through
+    -- this path, so it is where a project author actually meets the
+    -- un-narrowed `T | nil` errors.
+    io.stderr:write(teal.format_issues_with_hints(result.errors) .. "\n")
     exit_code = 1
   end
   instrument.finish(span, exit_code)

--- a/cosmic/_script_cache.tl
+++ b/cosmic/_script_cache.tl
@@ -213,7 +213,10 @@ local function compile_cached(input_path: string,
   local result = teal.compile(input_path,
     strict and {strict = true, werror = false} or {})
   if not result.ok then
-    return nil, teal.format_issues(result.errors)
+    -- With hints: a script run is many authors' first contact with the
+    -- checker, and the un-narrowed `T | nil` traps have known fixes the
+    -- bare message does not teach.
+    return nil, teal.format_issues_with_hints(result.errors)
   end
   local generated = result.code as string -- cast: set whenever ok
   store(input_path, source, generated, mode)

--- a/cosmic/_teal_hints.tl
+++ b/cosmic/_teal_hints.tl
@@ -1,0 +1,73 @@
+--- Fix-hints for known Teal type-check error patterns.
+---
+--- Split from `cosmic.teal` for room: teal.tl sits at the file-length
+--- limit, and this is the part that grows — every recurring trap that
+--- costs edit-check cycles earns a pattern here. The hints ride along
+--- wherever errors are formatted (`--check types`, `--compile`, the
+--- script runner), so this module must stay requireable from all of
+--- them: message matching only, no compiler state.
+---
+--- Matches the most common traps:
+---   1. got number, expected integer (string index/length requires integer)
+---   2. X | nil used un-narrowed: passed where X is expected, indexed,
+---      or looped over — `if not x` narrows scalars but not records,
+---      maps or arrays, and nothing else tells the author that
+---   3. excess return values (multiple returns captured incorrectly)
+---   4. <any type> operations (ipairs, index, concat on any)
+
+--- Return a fix-hint line for a known error message, or nil.
+--- @param msg string The error message to match
+--- @return string|nil A short hint string, or nil if no hint applies
+local function hint_for_message(msg: string): string | nil
+  -- Pattern 1: number/integer mismatch
+  if msg:find("got number, expected integer") then
+    return "  hint: annotate the variable `: number`, or convert with math.tointeger; integer is required for string indices/lengths"
+  end
+  -- Pattern 2: nil union not narrowed (X | nil where X expected)
+  if msg:find("%| nil") and msg:find("expected") then
+    return "  hint: narrow first: `if v is Rec then ... end` (plain-table records), or cast after a guard for userdata handles — see `cosmic --docs guide.checking`"
+  end
+  -- Pattern 2b: indexing through an un-narrowed nil union. The trap is
+  -- that `if not x then return end` narrows scalars but not records,
+  -- maps or arrays, and this error is all the checker says about it.
+  if msg:find("cannot index") and msg:find("| nil", 1, true) then
+    return "  hint: `T | nil` does not narrow through `if not x` for records/maps/arrays: branch with `if x is T then ... end`, or cast after the guard (`local v = x as T`) — see `cosmic --docs guide.checking`"
+  end
+  -- Pattern 2c: for-in over a value the checker cannot call. The message
+  -- names no type, and the usual cause is an iterator still `T | nil`
+  -- from a fallible call.
+  if msg:find("for loop does not return an iterator", 1, true) then
+    return "  hint: often the iterator is still `T | nil` from a fallible call: narrow with `is` or cast after a nil-guard before the loop — see `cosmic --docs guide.checking`"
+  end
+  -- Pattern 3: excess return values (wrong number of returns)
+  if msg:find("excess return values") then
+    return "  hint: capture multiple returns first: `local v, err = f(...)`"
+  end
+  -- Pattern 4a: ipairs on a nil union or on any — different fixes: a
+  -- `{T} | nil` needs narrowing, a plain `any` needs a cast.
+  if msg:find("attempting ipairs on something that's not an array") then
+    if msg:find("| nil", 1, true) then
+      return "  hint: `{T} | nil` does not narrow through `if not x`: branch with `is` or cast after the guard (`local xs = v as {T}`) — see `cosmic --docs guide.checking`"
+    end
+    return "  hint: cast first, e.g. `local items = data as {any}`"
+  end
+  -- Pattern 4b: concat with any type
+  if msg:find("cannot use operator '%.%.'") and msg:find("<any type>") then
+    return "  hint: cast first, e.g. `local s = val as string`"
+  end
+  -- Pattern 4c: index on any type
+  if msg:find("cannot index") and msg:find("<any type>") then
+    return "  hint: cast first, e.g. `local obj = val as {string: any}`"
+  end
+  return nil
+end
+
+local record TealHintsModule
+  hint_for_message: function(msg: string): string | nil
+end
+
+local M: TealHintsModule = {
+  hint_for_message = hint_for_message,
+}
+
+return M

--- a/cosmic/teal.tl
+++ b/cosmic/teal.tl
@@ -383,41 +383,9 @@ local function format_issues(issues: {Issue}): string
   return table.concat(lines, "\n")
 end
 
---- Return a fix-hint line for a known Teal type-check error pattern, or nil.
---- Matches the three most common traps that cost edit-check cycles:
----   1. got number, expected integer (string index/length requires integer)
----   2. got X | nil, expected X (nil not narrowed before use)
----   3. excess return values (multiple returns captured incorrectly)
----   4. <any type> operations (ipairs, index, concat on any)
---- @param msg string The error message to match
---- @return string|nil A short hint string, or nil if no hint applies
-local function hint_for_message(msg: string): string | nil
-  -- Pattern 1: number/integer mismatch
-  if msg:find("got number, expected integer") then
-    return "  hint: annotate the variable `: number`, or convert with math.tointeger; integer is required for string indices/lengths"
-  end
-  -- Pattern 2: nil union not narrowed (X | nil where X expected)
-  if msg:find("%| nil") and msg:find("expected") then
-    return "  hint: narrow first: `if v is Rec then ... end` (plain-table records), or cast after a guard for userdata handles"
-  end
-  -- Pattern 3: excess return values (wrong number of returns)
-  if msg:find("excess return values") then
-    return "  hint: capture multiple returns first: `local v, err = f(...)`"
-  end
-  -- Pattern 4a: ipairs on any
-  if msg:find("attempting ipairs on something that's not an array") then
-    return "  hint: cast first, e.g. `local items = data as {any}`"
-  end
-  -- Pattern 4b: concat with any type
-  if msg:find("cannot use operator '%.%.'") and msg:find("<any type>") then
-    return "  hint: cast first, e.g. `local s = val as string`"
-  end
-  -- Pattern 4c: index on any type
-  if msg:find("cannot index") and msg:find("<any type>") then
-    return "  hint: cast first, e.g. `local obj = val as {string: any}`"
-  end
-  return nil
-end
+-- The hint patterns live in their own module for room: this file sits
+-- at the file-length limit and the pattern set is the part that grows.
+local hint_for_message = require("cosmic._teal_hints").hint_for_message
 
 --- Format issues with optional fix-hints for known Teal type-check traps.
 --- Appends one hint line after each matching error. No duplicate hints per error.

--- a/cosmic/teal_test.tl
+++ b/cosmic/teal_test.tl
@@ -63,6 +63,78 @@ print(g(f()))
 end
 test_hint_nil_union_not_narrowed()
 
+-- The `if not x then return end` guard narrows scalars but not records,
+-- maps or arrays; the errors it leaves behind name the un-narrowed type
+-- but nothing else, so each shape carries a hint at the fix.
+local function test_hint_index_through_nil_union()
+  local msg, hint = first_hinted_error("h_idx_union.tl", [[
+local record R
+  x: integer
+end
+local function make(): R | nil
+  return nil
+end
+local function use(): integer
+  local r = make()
+  if not r then
+    return 1
+  end
+  return r.x
+end
+print(use())
+]])
+  assert(msg:find("cannot index", 1, true) and msg:find("| nil", 1, true),
+    "wrong error: " .. msg)
+  assert(hint:find("does not narrow through", 1, true), "wrong hint: " .. hint)
+  assert(hint:find("guide.checking", 1, true), "wrong hint: " .. hint)
+end
+test_hint_index_through_nil_union()
+
+local function test_hint_for_loop_nil_union_iterator()
+  local msg, hint = first_hinted_error("h_for_union.tl", [[
+local type Iter = function(): string
+local function rows(): Iter | nil
+  return nil
+end
+local function use()
+  local it = rows()
+  if not it then
+    return
+  end
+  for x in it do
+    print(x)
+  end
+end
+use()
+]])
+  assert(msg:find("for loop does not return an iterator", 1, true),
+    "wrong error: " .. msg)
+  assert(hint:find("fallible call", 1, true), "wrong hint: " .. hint)
+end
+test_hint_for_loop_nil_union_iterator()
+
+local function test_hint_ipairs_on_nil_union()
+  local msg, hint = first_hinted_error("h_ipairs_union.tl", [[
+local function list(): {string} | nil
+  return nil
+end
+local function use()
+  local xs = list()
+  if not xs then
+    return
+  end
+  for _, x in ipairs(xs) do
+    print(x)
+  end
+end
+use()
+]])
+  assert(msg:find("attempting ipairs", 1, true) and msg:find("| nil", 1, true),
+    "wrong error: " .. msg)
+  assert(hint:find("does not narrow through", 1, true), "wrong hint: " .. hint)
+end
+test_hint_ipairs_on_nil_union()
+
 local function test_hint_excess_return_values()
   local msg, hint = first_hinted_error("h_excess.tl", [[
 local function f(): string

--- a/skills/cosmic/checking.md
+++ b/skills/cosmic/checking.md
@@ -81,6 +81,50 @@ local result = json.decode(input) as {string: any}
 local count = value as integer
 ```
 
+the early-exit caveat bites hardest in the most idiomatic-looking shape,
+so here is the fix, concretely. `if not x then return end` narrows
+scalars but NOT records, maps or arrays — below the guard `x` is still
+`T | nil`, and the errors that produces do not say why (`cannot index
+key 'x' in variable 'r' of type R | nil`, `expression in for loop does
+not return an iterator`, `attempting ipairs on something that's not an
+array: {T} | nil`):
+
+```teal
+local r = make()        -- r: R | nil
+
+-- WRONG: r stays R | nil below this guard
+if not r then
+  return nil, "no r"
+end
+print(r.x)              -- error: cannot index key 'x' ... R | nil
+
+-- RIGHT (branching): do the work inside the positive branch, handing
+-- it to a helper that takes the narrowed type
+if r is R then
+  return run(r)         -- run(r: R) receives a plain R
+end
+return nil, "no r"
+
+-- RIGHT (linear): keep the guard, cast once immediately after it
+if not r then
+  return nil, "no r"
+end
+local rr = r as R       -- cast: record union after guard
+print(rr.x)
+```
+
+record FIELDS do not narrow either, even when the field is a scalar:
+after `if report.earliest ~= nil then`, `report.earliest` is still
+`integer | nil` at the point of use. copy the field to a local first —
+the local narrows normally:
+
+```teal
+local earliest = report.earliest   -- integer | nil
+if earliest ~= nil then
+  print(earliest + 1)              -- narrowed; the field read would not be
+end
+```
+
 per-file `as` counts are pinned by the cast ratchet (`_build/casts.txt`,
 enforced by `--make lint`). every cast carries its own `-- cast: <reason>`
 on the line or the line above, so there is no baseline to raise: a cast

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -190,7 +190,46 @@ print(encoded)
 (parenthesizing the call — `print((json.encode(result)))` — also truncates
 to one value, but capturing lets you check the error.)
 
-## 9. `os.exit` requires `integer | boolean`, not `number`
+## 9. records, maps and arrays don't narrow through `if not x`
+
+scalars (`string | nil`, `integer | nil`) narrow through an ordinary
+truthiness guard. records, maps and arrays do not — below the guard the
+value is still `T | nil`. the errors this produces name the un-narrowed
+type but not the cause: `cannot index key 'x' in variable 'r' of type
+R | nil`, `expression in for loop does not return an iterator`,
+`attempting ipairs on something that's not an array: {T} | nil`.
+
+**wrong:**
+```teal
+local db = sqlite.open(path)   -- Database | nil
+if not db then
+  return nil, "open failed"
+end
+db:exec(sql)  -- error: cannot index key 'exec' ... Database | nil
+```
+
+**right — branch with `is` and do the work inside the positive branch:**
+```teal
+if db is sqlite.Database then
+  return run(db)   -- run(db: sqlite.Database) receives it narrowed
+end
+return nil, "open failed"
+```
+
+**right — keep the guard, cast once immediately after it:**
+```teal
+if not db then
+  return nil, "open failed"
+end
+local d = db as sqlite.Database  -- cast: record union after guard
+d:exec(sql)
+```
+
+record fields don't narrow either, even scalar ones — copy the field to
+a local and guard the local. the full pattern set is in
+`cosmic --docs guide.checking`.
+
+## 10. `os.exit` requires `integer | boolean`, not `number`
 
 a `main` function declared to return `number` breaks `os.exit(main())`
 with `got number, expected integer | boolean`.


### PR DESCRIPTION
The most expensive newcomer trap, measured: `if not x then return end` narrows scalars but not records, maps or arrays, and the errors it leaves behind read like typos, not like a narrowing rule:

```
cannot index key 'exec' in variable 'db' of type Database | nil
expression in for loop does not return an iterator
attempting ipairs on something that's not an array: {T} | nil
```

In a from-scratch usability eval (four agents learning cosmic from the binary alone), this one trap caused essentially every failed build — ~18 errors and two failed `--make build` attempts for one agent — and every agent independently asked for the same thing: say it at the error site, not only in a guide you have to already know to read.

Three changes:

- **`hint_for_message` covers the three shapes** and points at `cosmic --docs guide.checking`; the existing `| nil`/expected hint gains the same pointer. The pattern set moves to `cosmic/_teal_hints.tl` — `teal.tl` sits at the 500-line limit and the patterns are the part that grows.
- **The compile path hints too.** `--compile`/`--compile-strict` (`main_handlers`) and the script runner (`_script_cache`) formatted errors bare, and `--make build` compiles through them — which is exactly where a project author meets these errors. `--check types` already hinted.

  ```
  cmd/x/main.tl:12:12: error: cannot index key 'x' in variable 'r' of type R | nil
    hint: `T | nil` does not narrow through `if not x` for records/maps/arrays: branch with `if x is T then ... end`, or cast after the guard (`local v = x as T`) — see `cosmic --docs guide.checking`
  ```
- **The docs teach the fix, not just the caveat.** `guide.checking` gains the concrete patterns (positive-branch helper, cast-after-guard, and the field-to-local copy for scalar record fields — a variant one agent had to discover by trial and error); `guide.gotchas` gains the trap as its own numbered entry.

Canary tests provoke each new pattern through the real checker (same style as the existing hint canaries), so a tl bump that rewords a message fails loudly. `.cosmic-coverage` gains one row for the new module; all other floors untouched.

Verified end to end on `--check types`, `--compile-strict`, and inside `--make build`. `--make ci` green: `ci: PASS (5 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS)_