### PR TITLE
docs: guide.lint enumerates every lint rule; testing.md reserves test_*

### DIFF
--- a/cosmic/doc/guide_test.tl
+++ b/cosmic/doc/guide_test.tl
@@ -52,6 +52,18 @@ local function test_guide_formatting()
 end
 test_guide_formatting()
 
+local function test_guide_lint()
+  local __r11 = check.must(check.must(child.start({cosmic, "--docs", "guide.lint"}, {env = clean_env()})):wait())
+  local ok, out = __r11.ok, __r11.stdout
+  assert(ok, "cosmic --docs guide.lint should succeed")
+  local s = out
+  assert(s:find("Lint Rules", 1, true), "lint guide should contain Lint Rules header")
+  assert(s:find("cast-justify", 1, true), "lint guide should document cast-justify")
+  assert(s:find("call-after-define", 1, true), "lint guide should document call-after-define")
+  assert(s:find("find-needle", 1, true), "lint guide should document find-needle")
+end
+test_guide_lint()
+
 -- There is no guide.makefile: one flag, one guide, and the Makefile
 -- generator it would document does not exist. A topic with nothing
 -- behind it must fail like any other unknown one -- a guide that still

--- a/skills/cosmic/SKILL.md
+++ b/skills/cosmic/SKILL.md
@@ -61,6 +61,7 @@ run `cosmic --docs guide.<topic>` or see the files below for deeper coverage:
 - [testing](testing.md) — writing and running tests (`cosmic --test`, assert patterns)
 - [checking](checking.md) — type checking with `cosmic --check types`
 - [formatting](formatting.md) — code formatting with `cosmic --format` / `--check fmt`
+- [lint](lint.md) — every lint rule, with the failure it produces and the fix
 - [make](make.md) — building a project with `cosmic --make`
 - [modules](modules.md) — the standard library (`cosmic.*` modules)
 - [docs](docs.md) — accessing documentation and getting help

--- a/skills/cosmic/lint.md
+++ b/skills/cosmic/lint.md
@@ -1,0 +1,118 @@
+# Lint Rules
+
+`cosmic --make lint` (and its per-file form `cosmic --check lint <file>`)
+runs the style gate. every rule it can fire is enumerated here, with the
+failure it produces and the fix — so the first time you meet a rule is
+not the moment you have to reverse-engineer it.
+
+lint reads BYTES, deliberately: the project walk feeds it every file the
+model sees, not just `.tl`/`.lua` sources — a `.md`, a `.mk`, a vendored
+payload are all held to the same standard. `testdata/` is the one
+exempt kind (fixtures are often deliberately wrong), and a file that
+should not be judged at all is listed in `.cosmicignore` (one glob per
+line; see `cosmic --docs guide.make`).
+
+## file-length
+
+every file must be ≤500 lines. no exceptions for source: the fix for a
+long `.tl` file is to split it. `.d.tl` type-declaration files are
+exempt (they describe C binding interfaces and cannot be split under
+Teal's record system).
+
+```
+db/query.tl:501:1: file-length: db/query.tl has 512 lines (limit: 500)
+```
+
+a length failure on a NON-source file (a stray binary, a data file) is
+the walk telling you it swept in something you did not mean to gate —
+the fix is `.cosmicignore`, not splitting the file.
+
+## cast-justify
+
+every `as` cast is an unchecked hole in the type system, so each one
+must say why: a trailing `-- cast: <reason>` on the same line, or on the
+line directly above when 90 columns will not fit it. one comment covers
+the whole line, however many casts the line holds.
+
+```teal
+local d = db as sqlite.Database  -- cast: record union after guard
+
+-- cast: from any (json.decode result)
+local obj = json.decode(input) as {string: any}
+```
+
+write the actual reason (`from any`, `userdata boundary`, `record union
+after guard`, `tuple element`, ...). a cast you cannot justify is one to
+remove — prefer `is` narrowing where the code branches, or `check.must`
+in tests and examples. the narrowing patterns are in
+`cosmic --docs guide.checking`.
+
+## call-after-define
+
+in a `*_test.tl` file, a top-level `local function test_*()` must be
+called on the line after its `end`, so a failing run names the function
+that failed rather than just the file:
+
+```teal
+local function test_decode()
+  assert(json.decode("1") == 1)
+end
+test_decode()
+```
+
+the rule keys on the `test_` name prefix: any top-level function named
+`test_*` in a `*_test.tl` is treated as a test that must call itself.
+name your helpers something else (`make_fixture`, `db_path_for`, ...) —
+an uncalled helper that happens to start with `test_` is flagged.
+`Example_*` functions are exempt (the example runner calls them), and
+the rule does not apply outside `*_test.tl` files.
+
+## cosmo-require
+
+tests and examples must use the typed `cosmic.*` wrappers, never the
+raw `cosmo.*` C bindings:
+
+```
+cosmic/foo_test.tl:3: require("cosmo...") forbidden in tests/examples; use cosmic.* wrappers
+```
+
+library internals implementing wrappers are the one place
+`require("cosmo")` is expected; everywhere else, the wrapper exists and
+is the API (see `cosmic --docs guide.modules`).
+
+## find-needle
+
+`s:find(x)` treats `x` as a Lua pattern, so a `-`, `.`, `(` or `%` in it
+silently changes what matches — and the call still returns, just about
+the wrong thing. when the needle is not a string literal, say which you
+meant: `, 1, true` for a plain substring, `, 1, false` to mean the
+pattern.
+
+```teal
+s:find(path, 1, true)   -- substring: a dash in path stays a dash
+s:find(pat, 1, false)   -- pattern, on purpose
+s:find("%d+")           -- literals are exempt: this reads as a pattern
+```
+
+there is no plain flag on `match`/`gmatch`/`gsub`, so a variable needle
+there is a pattern by construction; escape it if it isn't one.
+
+## visibility
+
+a module under `cosmic/` may only be required from outside `cosmic/`
+through its public parent: `require("cosmic.fs")` is API,
+`require("cosmic.fs.types")` from outside is reaching into a shard, and
+`require("cosmic._anything")` from outside is reaching into an
+internal. inside `cosmic/`, shards require each other freely — that is
+what shards are for.
+
+## running one rule's worth of output
+
+```bash
+cosmic --check lint file.tl     # one file, all rules
+cosmic --make lint              # the whole project
+cosmic --make lint db/          # …or one subtree
+```
+
+each diagnostic is `file:line: rule: message`, and the gate ends in a
+verdict line (`lint: PASS (12 files)`).

--- a/skills/cosmic/testing.md
+++ b/skills/cosmic/testing.md
@@ -28,6 +28,12 @@ test_decode_error()
 key rules:
 - shebang `#!/usr/bin/env cosmic` on line 1
 - define a `local function test_*()` then call it on the next line
+  (enforced by lint's `call-after-define` rule, so a failing run names
+  the function)
+- the `test_` prefix is reserved for tests: the linter treats ANY
+  top-level `local function test_*()` in a `*_test.tl` as a test that
+  must call itself. name helpers something else (`make_fixture`,
+  `db_path_for`, ...)
 - use `assert(condition, "message")` for assertions — there is no test framework
 - each test function runs independently at file scope
 - a test fails if any assert fails or the script exits nonzero

--- a/sys/help.md
+++ b/sys/help.md
@@ -76,6 +76,7 @@ Documentation:
   cosmic --docs guide        list available guides
   cosmic --docs guide.testing  show a specific guide
   cosmic --docs guide.gotchas  common pitfalls (integer vs number, any casts, arg)
+  cosmic --docs guide.lint   every lint rule, its failure and its fix
   help(<query>)              look up docs in the REPL (interactive only)
 
 Low-level cosmo.* bindings are available but hidden by default.


### PR DESCRIPTION
Every lint rule was learnable only by triggering it: nothing in `--help` or the guides listed the rules, and two of them surprised every agent in a from-scratch usability eval — `cast-justify` was undiscoverable until it fired, and `call-after-define`'s literal `test_` prefix keying flagged an innocent helper (`test_db_path`) that one agent then renamed only because the lint failure explained the convention.

- **New `guide.lint`** documents each rule with the failure it produces and the fix: `file-length` (and when `.cosmicignore` is the right answer), `cast-justify` (including that one comment covers the whole line, however many casts it holds), `call-after-define` (the `test_` prefix is reserved — name helpers something else), `cosmo-require`, `find-needle`, `visibility`. The guide list is directory-derived (`--docs` reads embedded `skills/cosmic/*.md`), so `guide.lint` resolves with no registration.
- **`testing.md`** now states the `test_` reservation up front, where test authors are, instead of leaving it to the lint failure.
- **`SKILL.md`** and **`sys/help.md`** gain the pointer; `guide_test.tl` covers the new topic.

`--make ci` green: `ci: PASS (5 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS)_