### PR TITLE
[integration] all five usability-eval fixes, for re-eval validation

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -73,6 +73,7 @@ cmd/cosmic/embed_gen.tl 0 166
 cmd/cosmic/main.tl 0 276
 cosmic/_script_cache.tl 72 79
 cosmic/_seal_coverage.tl 9 10
+cosmic/_teal_hints.tl 23 23
 cosmic/ansi.tl 86 86
 cosmic/benchmark.tl 146 173
 cosmic/check.tl 110 113

--- a/_cli/lint.tl
+++ b/_cli/lint.tl
@@ -385,6 +385,23 @@ local function lint_file(path: string): {Diagnostic} | nil, string
   end
 
   local diagnostics = style.check_file_length(path, n, style.DEFAULT_FILE_LINES)
+  -- A length failure on something that is not Teal/Lua source is almost
+  -- never fixed by splitting the file: it is a binary or a data file the
+  -- project walk swept in (lint reads bytes, deliberately), and the fix
+  -- the model already provides is `.cosmicignore`. Say so in the
+  -- diagnostic, where the reader is — the rule alone reads as "split
+  -- your 90,000-line file" when the file is an ELF binary.
+  if not (path:match("%.tl$") or path:match("%.lua$")) then
+    local nature = content:find("\0", 1, true)
+    and "a binary file, not text" or "not Teal/Lua source"
+    for _, d in ipairs(diagnostics) do
+      if d.rule == "file-length" then
+        d.message = d.message .. " — " .. nature .. "; lint gates every"
+        .. " file the project walk sees, so if this one should not be"
+        .. " judged, list it in .cosmicignore"
+      end
+    end
+  end
   if path:match("%.tl$") then
     for _, d in ipairs(check_cast_justification(path, content, lines)) do
       diagnostics[#diagnostics + 1] = d

--- a/_cli/lint.tl
+++ b/_cli/lint.tl
@@ -74,8 +74,9 @@ local function check_cast_justification(file: string, content: string,
         rule = "cast-justify",
         message = string.format(
           "%s:%d: `as` cast without justification: prefer `is` narrowing"
-          .. " or check.must (see AGENTS.md); a deliberate cast takes a"
-          .. " trailing `-- cast: <reason>` (or on the line above)",
+          .. " or check.must (see `cosmic --docs guide.checking`); a"
+          .. " deliberate cast takes a trailing `-- cast: <reason>` (or on"
+          .. " the line above)",
           file, y),
       }
     end

--- a/_cli/lint_test.tl
+++ b/_cli/lint_test.tl
@@ -56,6 +56,59 @@ local function test_lint_file_over_default()
 end
 test_lint_file_over_default()
 
+-- A binary (or any non-Teal/Lua file) over the length limit gets the
+-- .cosmicignore hint: "split this file" is not actionable advice for an
+-- ELF binary the walk swept in.
+local function test_lint_file_hints_cosmicignore_for_binary()
+  local path = fs.join(tmpdir, "toolbinary")
+  local chunk = "\0\1\2ELF junk line\n"
+  fs.write(path, chunk:rep(600))
+
+  local diagnostics = check.must(lint.lint_file(path))
+  assert(#diagnostics == 1, "expected 1 diagnostic, got: " .. tostring(#diagnostics))
+  assert(diagnostics[1].rule == "file-length", "expected file-length rule")
+  assert(diagnostics[1].message:find("a binary file", 1, true),
+    "expected the binary nature named, got: " .. diagnostics[1].message)
+  assert(diagnostics[1].message:find(".cosmicignore", 1, true),
+    "expected a .cosmicignore hint, got: " .. diagnostics[1].message)
+end
+test_lint_file_hints_cosmicignore_for_binary()
+
+local function test_lint_file_hints_cosmicignore_for_non_source_text()
+  local path = fs.join(tmpdir, "data.csv")
+  local lines: {string} = {}
+  for i = 1, 501 do
+    table.insert(lines, "row," .. tostring(i))
+  end
+  fs.write(path, table.concat(lines, "\n") .. "\n")
+
+  local diagnostics = check.must(lint.lint_file(path))
+  assert(#diagnostics == 1, "expected 1 diagnostic, got: " .. tostring(#diagnostics))
+  assert(diagnostics[1].message:find("not Teal/Lua source", 1, true),
+    "expected the nature named, got: " .. diagnostics[1].message)
+  assert(diagnostics[1].message:find(".cosmicignore", 1, true),
+    "expected a .cosmicignore hint, got: " .. diagnostics[1].message)
+end
+test_lint_file_hints_cosmicignore_for_non_source_text()
+
+-- Teal/Lua source over the limit keeps the plain message: the fix for
+-- source really is to split it, and a .cosmicignore hint there would
+-- teach people to ignore their own code.
+local function test_lint_file_no_ignore_hint_for_source()
+  local path = fs.join(tmpdir, "long2.tl")
+  local lines: {string} = {}
+  for i = 1, 501 do
+    table.insert(lines, "-- line " .. tostring(i))
+  end
+  fs.write(path, table.concat(lines, "\n") .. "\n")
+
+  local diagnostics = check.must(lint.lint_file(path))
+  assert(#diagnostics == 1, "expected 1 diagnostic, got: " .. tostring(#diagnostics))
+  assert(not diagnostics[1].message:find(".cosmicignore", 1, true),
+    "source files should not get the ignore hint: " .. diagnostics[1].message)
+end
+test_lint_file_no_ignore_hint_for_source()
+
 local function test_lint_file_skips_dtl()
   -- .d.tl files are type declarations for C bindings and are exempt from length checks
   local path = fs.join(tmpdir, "types.d.tl")

--- a/_cli/main_handlers.tl
+++ b/_cli/main_handlers.tl
@@ -136,7 +136,10 @@ local function handle_compile(file: string, output?: string, write_if_changed?: 
   if result.ok then
     exit_code, err_msg = write_output(result.code, output, write_if_changed)
   else
-    io.stderr:write(teal.format_issues(result.errors) .. "\n")
+    -- With hints, like --check types: `--make build` compiles through
+    -- this path, so it is where a project author actually meets the
+    -- un-narrowed `T | nil` errors.
+    io.stderr:write(teal.format_issues_with_hints(result.errors) .. "\n")
     exit_code = 1
   end
   instrument.finish(span, exit_code)

--- a/cosmic/_script_cache.tl
+++ b/cosmic/_script_cache.tl
@@ -213,7 +213,10 @@ local function compile_cached(input_path: string,
   local result = teal.compile(input_path,
     strict and {strict = true, werror = false} or {})
   if not result.ok then
-    return nil, teal.format_issues(result.errors)
+    -- With hints: a script run is many authors' first contact with the
+    -- checker, and the un-narrowed `T | nil` traps have known fixes the
+    -- bare message does not teach.
+    return nil, teal.format_issues_with_hints(result.errors)
   end
   local generated = result.code as string -- cast: set whenever ok
   store(input_path, source, generated, mode)

--- a/cosmic/_teal_hints.tl
+++ b/cosmic/_teal_hints.tl
@@ -1,0 +1,73 @@
+--- Fix-hints for known Teal type-check error patterns.
+---
+--- Split from `cosmic.teal` for room: teal.tl sits at the file-length
+--- limit, and this is the part that grows — every recurring trap that
+--- costs edit-check cycles earns a pattern here. The hints ride along
+--- wherever errors are formatted (`--check types`, `--compile`, the
+--- script runner), so this module must stay requireable from all of
+--- them: message matching only, no compiler state.
+---
+--- Matches the most common traps:
+---   1. got number, expected integer (string index/length requires integer)
+---   2. X | nil used un-narrowed: passed where X is expected, indexed,
+---      or looped over — `if not x` narrows scalars but not records,
+---      maps or arrays, and nothing else tells the author that
+---   3. excess return values (multiple returns captured incorrectly)
+---   4. <any type> operations (ipairs, index, concat on any)
+
+--- Return a fix-hint line for a known error message, or nil.
+--- @param msg string The error message to match
+--- @return string|nil A short hint string, or nil if no hint applies
+local function hint_for_message(msg: string): string | nil
+  -- Pattern 1: number/integer mismatch
+  if msg:find("got number, expected integer") then
+    return "  hint: annotate the variable `: number`, or convert with math.tointeger; integer is required for string indices/lengths"
+  end
+  -- Pattern 2: nil union not narrowed (X | nil where X expected)
+  if msg:find("%| nil") and msg:find("expected") then
+    return "  hint: narrow first: `if v is Rec then ... end` (plain-table records), or cast after a guard for userdata handles — see `cosmic --docs guide.checking`"
+  end
+  -- Pattern 2b: indexing through an un-narrowed nil union. The trap is
+  -- that `if not x then return end` narrows scalars but not records,
+  -- maps or arrays, and this error is all the checker says about it.
+  if msg:find("cannot index") and msg:find("| nil", 1, true) then
+    return "  hint: `T | nil` does not narrow through `if not x` for records/maps/arrays: branch with `if x is T then ... end`, or cast after the guard (`local v = x as T`) — see `cosmic --docs guide.checking`"
+  end
+  -- Pattern 2c: for-in over a value the checker cannot call. The message
+  -- names no type, and the usual cause is an iterator still `T | nil`
+  -- from a fallible call.
+  if msg:find("for loop does not return an iterator", 1, true) then
+    return "  hint: often the iterator is still `T | nil` from a fallible call: narrow with `is` or cast after a nil-guard before the loop — see `cosmic --docs guide.checking`"
+  end
+  -- Pattern 3: excess return values (wrong number of returns)
+  if msg:find("excess return values") then
+    return "  hint: capture multiple returns first: `local v, err = f(...)`"
+  end
+  -- Pattern 4a: ipairs on a nil union or on any — different fixes: a
+  -- `{T} | nil` needs narrowing, a plain `any` needs a cast.
+  if msg:find("attempting ipairs on something that's not an array") then
+    if msg:find("| nil", 1, true) then
+      return "  hint: `{T} | nil` does not narrow through `if not x`: branch with `is` or cast after the guard (`local xs = v as {T}`) — see `cosmic --docs guide.checking`"
+    end
+    return "  hint: cast first, e.g. `local items = data as {any}`"
+  end
+  -- Pattern 4b: concat with any type
+  if msg:find("cannot use operator '%.%.'") and msg:find("<any type>") then
+    return "  hint: cast first, e.g. `local s = val as string`"
+  end
+  -- Pattern 4c: index on any type
+  if msg:find("cannot index") and msg:find("<any type>") then
+    return "  hint: cast first, e.g. `local obj = val as {string: any}`"
+  end
+  return nil
+end
+
+local record TealHintsModule
+  hint_for_message: function(msg: string): string | nil
+end
+
+local M: TealHintsModule = {
+  hint_for_message = hint_for_message,
+}
+
+return M

--- a/cosmic/doc/guide_test.tl
+++ b/cosmic/doc/guide_test.tl
@@ -52,6 +52,18 @@ local function test_guide_formatting()
 end
 test_guide_formatting()
 
+local function test_guide_lint()
+  local __r11 = check.must(check.must(child.start({cosmic, "--docs", "guide.lint"}, {env = clean_env()})):wait())
+  local ok, out = __r11.ok, __r11.stdout
+  assert(ok, "cosmic --docs guide.lint should succeed")
+  local s = out
+  assert(s:find("Lint Rules", 1, true), "lint guide should contain Lint Rules header")
+  assert(s:find("cast-justify", 1, true), "lint guide should document cast-justify")
+  assert(s:find("call-after-define", 1, true), "lint guide should document call-after-define")
+  assert(s:find("find-needle", 1, true), "lint guide should document find-needle")
+end
+test_guide_lint()
+
 -- There is no guide.makefile: one flag, one guide, and the Makefile
 -- generator it would document does not exist. A topic with nothing
 -- behind it must fail like any other unknown one -- a guide that still

--- a/cosmic/doc/guide_test.tl
+++ b/cosmic/doc/guide_test.tl
@@ -52,6 +52,18 @@ local function test_guide_formatting()
 end
 test_guide_formatting()
 
+local function test_guide_quickstart()
+  local __r12 = check.must(check.must(child.start({cosmic, "--docs", "guide.quickstart"}, {env = clean_env()})):wait())
+  local ok, out = __r12.ok, __r12.stdout
+  assert(ok, "cosmic --docs guide.quickstart should succeed")
+  local s = out
+  assert(s:find("Quickstart", 1, true), "quickstart guide should contain Quickstart header")
+  assert(s:find("cmd/greet/main.tl", 1, true), "quickstart guide should lay out a binary")
+  assert(s:find("--make build", 1, true), "quickstart guide should build the project")
+  assert(s:find("--make ci", 1, true), "quickstart guide should run the gate")
+end
+test_guide_quickstart()
+
 -- There is no guide.makefile: one flag, one guide, and the Makefile
 -- generator it would document does not exist. A topic with nothing
 -- behind it must fail like any other unknown one -- a guide that still

--- a/cosmic/teal.tl
+++ b/cosmic/teal.tl
@@ -383,41 +383,9 @@ local function format_issues(issues: {Issue}): string
   return table.concat(lines, "\n")
 end
 
---- Return a fix-hint line for a known Teal type-check error pattern, or nil.
---- Matches the three most common traps that cost edit-check cycles:
----   1. got number, expected integer (string index/length requires integer)
----   2. got X | nil, expected X (nil not narrowed before use)
----   3. excess return values (multiple returns captured incorrectly)
----   4. <any type> operations (ipairs, index, concat on any)
---- @param msg string The error message to match
---- @return string|nil A short hint string, or nil if no hint applies
-local function hint_for_message(msg: string): string | nil
-  -- Pattern 1: number/integer mismatch
-  if msg:find("got number, expected integer") then
-    return "  hint: annotate the variable `: number`, or convert with math.tointeger; integer is required for string indices/lengths"
-  end
-  -- Pattern 2: nil union not narrowed (X | nil where X expected)
-  if msg:find("%| nil") and msg:find("expected") then
-    return "  hint: narrow first: `if v is Rec then ... end` (plain-table records), or cast after a guard for userdata handles"
-  end
-  -- Pattern 3: excess return values (wrong number of returns)
-  if msg:find("excess return values") then
-    return "  hint: capture multiple returns first: `local v, err = f(...)`"
-  end
-  -- Pattern 4a: ipairs on any
-  if msg:find("attempting ipairs on something that's not an array") then
-    return "  hint: cast first, e.g. `local items = data as {any}`"
-  end
-  -- Pattern 4b: concat with any type
-  if msg:find("cannot use operator '%.%.'") and msg:find("<any type>") then
-    return "  hint: cast first, e.g. `local s = val as string`"
-  end
-  -- Pattern 4c: index on any type
-  if msg:find("cannot index") and msg:find("<any type>") then
-    return "  hint: cast first, e.g. `local obj = val as {string: any}`"
-  end
-  return nil
-end
+-- The hint patterns live in their own module for room: this file sits
+-- at the file-length limit and the pattern set is the part that grows.
+local hint_for_message = require("cosmic._teal_hints").hint_for_message
 
 --- Format issues with optional fix-hints for known Teal type-check traps.
 --- Appends one hint line after each matching error. No duplicate hints per error.

--- a/cosmic/teal_test.tl
+++ b/cosmic/teal_test.tl
@@ -63,6 +63,78 @@ print(g(f()))
 end
 test_hint_nil_union_not_narrowed()
 
+-- The `if not x then return end` guard narrows scalars but not records,
+-- maps or arrays; the errors it leaves behind name the un-narrowed type
+-- but nothing else, so each shape carries a hint at the fix.
+local function test_hint_index_through_nil_union()
+  local msg, hint = first_hinted_error("h_idx_union.tl", [[
+local record R
+  x: integer
+end
+local function make(): R | nil
+  return nil
+end
+local function use(): integer
+  local r = make()
+  if not r then
+    return 1
+  end
+  return r.x
+end
+print(use())
+]])
+  assert(msg:find("cannot index", 1, true) and msg:find("| nil", 1, true),
+    "wrong error: " .. msg)
+  assert(hint:find("does not narrow through", 1, true), "wrong hint: " .. hint)
+  assert(hint:find("guide.checking", 1, true), "wrong hint: " .. hint)
+end
+test_hint_index_through_nil_union()
+
+local function test_hint_for_loop_nil_union_iterator()
+  local msg, hint = first_hinted_error("h_for_union.tl", [[
+local type Iter = function(): string
+local function rows(): Iter | nil
+  return nil
+end
+local function use()
+  local it = rows()
+  if not it then
+    return
+  end
+  for x in it do
+    print(x)
+  end
+end
+use()
+]])
+  assert(msg:find("for loop does not return an iterator", 1, true),
+    "wrong error: " .. msg)
+  assert(hint:find("fallible call", 1, true), "wrong hint: " .. hint)
+end
+test_hint_for_loop_nil_union_iterator()
+
+local function test_hint_ipairs_on_nil_union()
+  local msg, hint = first_hinted_error("h_ipairs_union.tl", [[
+local function list(): {string} | nil
+  return nil
+end
+local function use()
+  local xs = list()
+  if not xs then
+    return
+  end
+  for _, x in ipairs(xs) do
+    print(x)
+  end
+end
+use()
+]])
+  assert(msg:find("attempting ipairs", 1, true) and msg:find("| nil", 1, true),
+    "wrong error: " .. msg)
+  assert(hint:find("does not narrow through", 1, true), "wrong hint: " .. hint)
+end
+test_hint_ipairs_on_nil_union()
+
 local function test_hint_excess_return_values()
   local msg, hint = first_hinted_error("h_excess.tl", [[
 local function f(): string

--- a/skills/cosmic/SKILL.md
+++ b/skills/cosmic/SKILL.md
@@ -61,6 +61,7 @@ run `cosmic --docs guide.<topic>` or see the files below for deeper coverage:
 - [testing](testing.md) — writing and running tests (`cosmic --test`, assert patterns)
 - [checking](checking.md) — type checking with `cosmic --check types`
 - [formatting](formatting.md) — code formatting with `cosmic --format` / `--check fmt`
+- [lint](lint.md) — every lint rule, with the failure it produces and the fix
 - [make](make.md) — building a project with `cosmic --make`
 - [modules](modules.md) — the standard library (`cosmic.*` modules)
 - [docs](docs.md) — accessing documentation and getting help

--- a/skills/cosmic/SKILL.md
+++ b/skills/cosmic/SKILL.md
@@ -56,6 +56,7 @@ return { greet = greet }
 
 run `cosmic --docs guide.<topic>` or see the files below for deeper coverage:
 
+- [quickstart](quickstart.md) — your first project: binary + module + test, built and gated
 - [gotchas](gotchas.md) — Teal gotchas for newcomers (integer vs number, any casts, io shadowing)
 - [recipes](recipes.md) — end-to-end patterns (CLI skeleton, walk+hash+sqlite, self-spawn, TCP echo)
 - [testing](testing.md) — writing and running tests (`cosmic --test`, assert patterns)

--- a/skills/cosmic/checking.md
+++ b/skills/cosmic/checking.md
@@ -81,6 +81,50 @@ local result = json.decode(input) as {string: any}
 local count = value as integer
 ```
 
+the early-exit caveat bites hardest in the most idiomatic-looking shape,
+so here is the fix, concretely. `if not x then return end` narrows
+scalars but NOT records, maps or arrays — below the guard `x` is still
+`T | nil`, and the errors that produces do not say why (`cannot index
+key 'x' in variable 'r' of type R | nil`, `expression in for loop does
+not return an iterator`, `attempting ipairs on something that's not an
+array: {T} | nil`):
+
+```teal
+local r = make()        -- r: R | nil
+
+-- WRONG: r stays R | nil below this guard
+if not r then
+  return nil, "no r"
+end
+print(r.x)              -- error: cannot index key 'x' ... R | nil
+
+-- RIGHT (branching): do the work inside the positive branch, handing
+-- it to a helper that takes the narrowed type
+if r is R then
+  return run(r)         -- run(r: R) receives a plain R
+end
+return nil, "no r"
+
+-- RIGHT (linear): keep the guard, cast once immediately after it
+if not r then
+  return nil, "no r"
+end
+local rr = r as R       -- cast: record union after guard
+print(rr.x)
+```
+
+record FIELDS do not narrow either, even when the field is a scalar:
+after `if report.earliest ~= nil then`, `report.earliest` is still
+`integer | nil` at the point of use. copy the field to a local first —
+the local narrows normally:
+
+```teal
+local earliest = report.earliest   -- integer | nil
+if earliest ~= nil then
+  print(earliest + 1)              -- narrowed; the field read would not be
+end
+```
+
 per-file `as` counts are pinned by the cast ratchet (`_build/casts.txt`,
 enforced by `--make lint`). every cast carries its own `-- cast: <reason>`
 on the line or the line above, so there is no baseline to raise: a cast

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -190,7 +190,46 @@ print(encoded)
 (parenthesizing the call — `print((json.encode(result)))` — also truncates
 to one value, but capturing lets you check the error.)
 
-## 9. `os.exit` requires `integer | boolean`, not `number`
+## 9. records, maps and arrays don't narrow through `if not x`
+
+scalars (`string | nil`, `integer | nil`) narrow through an ordinary
+truthiness guard. records, maps and arrays do not — below the guard the
+value is still `T | nil`. the errors this produces name the un-narrowed
+type but not the cause: `cannot index key 'x' in variable 'r' of type
+R | nil`, `expression in for loop does not return an iterator`,
+`attempting ipairs on something that's not an array: {T} | nil`.
+
+**wrong:**
+```teal
+local db = sqlite.open(path)   -- Database | nil
+if not db then
+  return nil, "open failed"
+end
+db:exec(sql)  -- error: cannot index key 'exec' ... Database | nil
+```
+
+**right — branch with `is` and do the work inside the positive branch:**
+```teal
+if db is sqlite.Database then
+  return run(db)   -- run(db: sqlite.Database) receives it narrowed
+end
+return nil, "open failed"
+```
+
+**right — keep the guard, cast once immediately after it:**
+```teal
+if not db then
+  return nil, "open failed"
+end
+local d = db as sqlite.Database  -- cast: record union after guard
+d:exec(sql)
+```
+
+record fields don't narrow either, even scalar ones — copy the field to
+a local and guard the local. the full pattern set is in
+`cosmic --docs guide.checking`.
+
+## 10. `os.exit` requires `integer | boolean`, not `number`
 
 a `main` function declared to return `number` breaks `os.exit(main())`
 with `got number, expected integer | boolean`.

--- a/skills/cosmic/lint.md
+++ b/skills/cosmic/lint.md
@@ -1,0 +1,118 @@
+# Lint Rules
+
+`cosmic --make lint` (and its per-file form `cosmic --check lint <file>`)
+runs the style gate. every rule it can fire is enumerated here, with the
+failure it produces and the fix — so the first time you meet a rule is
+not the moment you have to reverse-engineer it.
+
+lint reads BYTES, deliberately: the project walk feeds it every file the
+model sees, not just `.tl`/`.lua` sources — a `.md`, a `.mk`, a vendored
+payload are all held to the same standard. `testdata/` is the one
+exempt kind (fixtures are often deliberately wrong), and a file that
+should not be judged at all is listed in `.cosmicignore` (one glob per
+line; see `cosmic --docs guide.make`).
+
+## file-length
+
+every file must be ≤500 lines. no exceptions for source: the fix for a
+long `.tl` file is to split it. `.d.tl` type-declaration files are
+exempt (they describe C binding interfaces and cannot be split under
+Teal's record system).
+
+```
+db/query.tl:501:1: file-length: db/query.tl has 512 lines (limit: 500)
+```
+
+a length failure on a NON-source file (a stray binary, a data file) is
+the walk telling you it swept in something you did not mean to gate —
+the fix is `.cosmicignore`, not splitting the file.
+
+## cast-justify
+
+every `as` cast is an unchecked hole in the type system, so each one
+must say why: a trailing `-- cast: <reason>` on the same line, or on the
+line directly above when 90 columns will not fit it. one comment covers
+the whole line, however many casts the line holds.
+
+```teal
+local d = db as sqlite.Database  -- cast: record union after guard
+
+-- cast: from any (json.decode result)
+local obj = json.decode(input) as {string: any}
+```
+
+write the actual reason (`from any`, `userdata boundary`, `record union
+after guard`, `tuple element`, ...). a cast you cannot justify is one to
+remove — prefer `is` narrowing where the code branches, or `check.must`
+in tests and examples. the narrowing patterns are in
+`cosmic --docs guide.checking`.
+
+## call-after-define
+
+in a `*_test.tl` file, a top-level `local function test_*()` must be
+called on the line after its `end`, so a failing run names the function
+that failed rather than just the file:
+
+```teal
+local function test_decode()
+  assert(json.decode("1") == 1)
+end
+test_decode()
+```
+
+the rule keys on the `test_` name prefix: any top-level function named
+`test_*` in a `*_test.tl` is treated as a test that must call itself.
+name your helpers something else (`make_fixture`, `db_path_for`, ...) —
+an uncalled helper that happens to start with `test_` is flagged.
+`Example_*` functions are exempt (the example runner calls them), and
+the rule does not apply outside `*_test.tl` files.
+
+## cosmo-require
+
+tests and examples must use the typed `cosmic.*` wrappers, never the
+raw `cosmo.*` C bindings:
+
+```
+cosmic/foo_test.tl:3: require("cosmo...") forbidden in tests/examples; use cosmic.* wrappers
+```
+
+library internals implementing wrappers are the one place
+`require("cosmo")` is expected; everywhere else, the wrapper exists and
+is the API (see `cosmic --docs guide.modules`).
+
+## find-needle
+
+`s:find(x)` treats `x` as a Lua pattern, so a `-`, `.`, `(` or `%` in it
+silently changes what matches — and the call still returns, just about
+the wrong thing. when the needle is not a string literal, say which you
+meant: `, 1, true` for a plain substring, `, 1, false` to mean the
+pattern.
+
+```teal
+s:find(path, 1, true)   -- substring: a dash in path stays a dash
+s:find(pat, 1, false)   -- pattern, on purpose
+s:find("%d+")           -- literals are exempt: this reads as a pattern
+```
+
+there is no plain flag on `match`/`gmatch`/`gsub`, so a variable needle
+there is a pattern by construction; escape it if it isn't one.
+
+## visibility
+
+a module under `cosmic/` may only be required from outside `cosmic/`
+through its public parent: `require("cosmic.fs")` is API,
+`require("cosmic.fs.types")` from outside is reaching into a shard, and
+`require("cosmic._anything")` from outside is reaching into an
+internal. inside `cosmic/`, shards require each other freely — that is
+what shards are for.
+
+## running one rule's worth of output
+
+```bash
+cosmic --check lint file.tl     # one file, all rules
+cosmic --make lint              # the whole project
+cosmic --make lint db/          # …or one subtree
+```
+
+each diagnostic is `file:line: rule: message`, and the gate ends in a
+verdict line (`lint: PASS (12 files)`).

--- a/skills/cosmic/quickstart.md
+++ b/skills/cosmic/quickstart.md
@@ -1,0 +1,147 @@
+# Quickstart: Your First Project
+
+the smallest real cosmic project, end to end: one binary, one library
+module, one test — built, run, tested and gated with four commands. the
+pieces are each documented in depth elsewhere (`guide.make`,
+`guide.testing`, `guide.checking`); this page assembles them once so
+you do not have to.
+
+## the layout
+
+a project is a directory of conventionally named files. there is no
+manifest, no build spec, nothing to register — position declares what
+each file is:
+
+```
+myproj/
+  cmd/greet/main.tl    a binary: cmd/<name>/main.tl builds to o/bin/<name>
+  greet/text.tl        a library module: require("greet.text")
+  greet/text_test.tl   its test: *_test.tl, discovered by --make test
+```
+
+a source's path relative to the project root IS its import path —
+`greet/text.tl` is `require("greet.text")`. run every command below
+from the project root (the `cosmic` binary itself is written here as
+`cosmic`; use the path you have it at).
+
+one caution before you start: keep the `cosmic` binary OUTSIDE the
+project directory (or list it in a `.cosmicignore` file). the lint gate
+reads every file the project walk sees, and a 10MB executable fails the
+file-length rule in a confusing way.
+
+## the library module
+
+`greet/text.tl` — a module is a record describing its API, returned at
+the bottom:
+
+```teal
+local record TextModule
+  greeting: function(name: string): string
+end
+
+local function greeting(name: string): string
+  return "hello, " .. name .. "!"
+end
+
+local M: TextModule = {
+  greeting = greeting,
+}
+
+return M
+```
+
+## the binary
+
+`cmd/greet/main.tl` — guard `arg[1]` (it is `string | nil`), return an
+`integer` from main (`os.exit` rejects `number`):
+
+```teal
+local text = require("greet.text")
+
+local function main(): integer
+  local name = arg[1]
+  if not name then
+    io.stderr:write("usage: greet <name>\n")
+    return 1
+  end
+  print(text.greeting(name))
+  return 0
+end
+
+os.exit(main())
+```
+
+## the test
+
+`greet/text_test.tl` — shebang on line 1, `test_*` functions called
+immediately after their definition (the `test_` prefix is reserved for
+tests; name helpers something else):
+
+```teal
+#!/usr/bin/env cosmic
+local text = require("greet.text")
+
+local function test_greeting()
+  local got = text.greeting("world")
+  assert(got == "hello, world!", "got: " .. got)
+end
+test_greeting()
+```
+
+## build, run, test, gate
+
+```bash
+cosmic --make build
+# compile o/greet/text.lua
+# compile o/greet/text_test.lua
+# compile o/cmd/greet/main.lua
+# make: o/bin/greet
+# build: PASS (3 files, 1 binary)
+
+o/bin/greet world
+# hello, world!
+
+cosmic --make test
+# test: PASS (1 file)
+
+cosmic --make ci        # fmt, check, example, lint, coverage — the whole gate
+# ci: PASS (4 stages)
+```
+
+(4 stages, not 5: the `example` stage reports "nothing to do" until the
+project has a `*_example.tl` file.)
+
+`o/bin/greet` is a standalone fat binary: copy it anywhere — another
+directory, another machine, another OS — and it runs with no dependency
+on the project tree or on `cosmic` itself.
+
+the first `ci` run will note there is no coverage baseline; write one
+and commit it to start the ratchet:
+
+```bash
+cosmic --make coverage --baseline    # writes .cosmic-coverage
+```
+
+## when something fails
+
+- a TYPE error names the file, line and type; the recurring traps carry
+  a `hint:` line, and `cosmic --docs guide.gotchas` walks the rest
+- a FMT failure prints a have/want diff and the exact fix command:
+  `cosmic --fix <file>`
+- a LINT failure names its rule; `cosmic --docs guide.lint` documents
+  every rule with its fix
+- `--check types <file>` type-checks one file in isolation — the fast
+  inner loop while a file is still taking shape
+
+## where to go next
+
+- `cosmic --docs guide.make` — the full project model: more binaries
+  (`cmd/<other>/main.tl`), embedded payload (`embed/`), pinned deps
+  (`*_pin.tl`), what ships and what does not
+- `cosmic --docs guide.modules` — the `cosmic.*` standard library
+  (json, sqlite, fs, net, child, ...); `cosmic --docs <module>` for any
+  one of them, with runnable examples
+- `cosmic --docs guide.testing` — TEST_TMPDIR, the test sandbox,
+  `check.eq`/`check.must` assertion helpers
+- `cosmic --docs guide.recipes` — worked end-to-end programs (a CLI
+  skeleton, sqlite indexing, TCP echo)

--- a/skills/cosmic/testing.md
+++ b/skills/cosmic/testing.md
@@ -28,6 +28,12 @@ test_decode_error()
 key rules:
 - shebang `#!/usr/bin/env cosmic` on line 1
 - define a `local function test_*()` then call it on the next line
+  (enforced by lint's `call-after-define` rule, so a failing run names
+  the function)
+- the `test_` prefix is reserved for tests: the linter treats ANY
+  top-level `local function test_*()` in a `*_test.tl` as a test that
+  must call itself. name helpers something else (`make_fixture`,
+  `db_path_for`, ...)
 - use `assert(condition, "message")` for assertions — there is no test framework
 - each test function runs independently at file scope
 - a test fails if any assert fails or the script exits nonzero

--- a/sys/help.md
+++ b/sys/help.md
@@ -74,6 +74,7 @@ Environment variables:
 Documentation:
   cosmic --docs [query]      look up docs from the command line
   cosmic --docs guide        list available guides
+  cosmic --docs guide.quickstart  your first project, end to end
   cosmic --docs guide.testing  show a specific guide
   cosmic --docs guide.gotchas  common pitfalls (integer vs number, any casts, arg)
   help(<query>)              look up docs in the REPL (interactive only)

--- a/sys/help.md
+++ b/sys/help.md
@@ -76,6 +76,7 @@ Documentation:
   cosmic --docs guide        list available guides
   cosmic --docs guide.testing  show a specific guide
   cosmic --docs guide.gotchas  common pitfalls (integer vs number, any casts, arg)
+  cosmic --docs guide.lint   every lint rule, its failure and its fix
   help(<query>)              look up docs in the REPL (interactive only)
 
 Low-level cosmo.* bindings are available but hidden by default.


### PR DESCRIPTION
Integration branch: the merge of the five individual fix PRs, used to build the binary for the follow-up usability re-eval. **Not intended to merge** — land the individual PRs instead and close this one:

- #900 lint: point cast-justify at guide.checking, not AGENTS.md
- #901 lint: name the .cosmicignore escape when length gates a non-source file
- #902 teal: hint the un-narrowed nil-union traps, on every error path
- #903 docs: guide.lint enumerates every lint rule; testing.md reserves test_*
- #904 docs: guide.quickstart assembles the first project end to end

`--make ci` on the merge: `ci: PASS (5 stages)`. The built `o/bin/cosmic` from this branch is the artifact handed to the round-2 eval agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS)_