### PR TITLE
docs+hints: exporting types across files, and builtin shadowing

### DIFF
--- a/cosmic/_teal_hints.tl
+++ b/cosmic/_teal_hints.tl
@@ -39,6 +39,12 @@ local function hint_for_message(msg: string): string | nil
   if msg:find("for loop does not return an iterator", 1, true) then
     return "  hint: often the iterator is still `T | nil` from a fallible call: narrow with `is` or cast after a nil-guard before the loop — see `cosmic --docs guide.checking`"
   end
+  -- Pattern 2d: naming another module's type that is not exported. A
+  -- standalone top-level record is file-local; importers can only name
+  -- types nested in (or aliased into) the module's interface record.
+  if msg:find("unknown type %w+%.%w+") then
+    return "  hint: a type other files use must be nested in the module's interface record (`record StoreModule record Task ... end end`), or aliased in with `type Task = Task` — see `cosmic --docs guide.checking`"
+  end
   -- Pattern 3: excess return values (wrong number of returns)
   if msg:find("excess return values") then
     return "  hint: capture multiple returns first: `local v, err = f(...)`"

--- a/cosmic/teal_test.tl
+++ b/cosmic/teal_test.tl
@@ -135,6 +135,36 @@ use()
 end
 test_hint_ipairs_on_nil_union()
 
+local function test_hint_unexported_type()
+  -- The dep module declares its record standalone (file-local), so the
+  -- user file's `depmod.Widget` cannot resolve; both land in tmpdir so
+  -- the require resolves relative to the checked file.
+  local ok, werr = fs.write(fs.join(tmpdir, "depmod.tl"), [[
+local record Widget
+  id: integer
+end
+local record DepModule
+  make: function(): Widget
+end
+local function make(): Widget
+  return {id = 1}
+end
+local M: DepModule = {make = make}
+return M
+]])
+  assert(ok, "write depmod.tl: " .. tostring(werr))
+  local msg, hint = first_hinted_error("h_unexported.tl", [[
+local depmod = require("depmod")
+local function label(w: depmod.Widget): string
+  return tostring(w.id)
+end
+print(label(depmod.make()))
+]])
+  assert(msg:find("unknown type", 1, true), "wrong error: " .. msg)
+  assert(hint:find("interface record", 1, true), "wrong hint: " .. hint)
+end
+test_hint_unexported_type()
+
 local function test_hint_excess_return_values()
   local msg, hint = first_hinted_error("h_excess.tl", [[
 local function f(): string

--- a/skills/cosmic/checking.md
+++ b/skills/cosmic/checking.md
@@ -161,6 +161,12 @@ local M: JsonModule = { decode = decode, encode = encode }
 return M
 ```
 
+a TYPE another file needs must be part of that record too: a standalone
+top-level `local record Task` is visible only inside its own file, so an
+importer writing `store.Task` gets `unknown type store.Task`. nest the
+record inside the interface record (`record StoreModule record Task ...
+end ... end`), or alias it in with a `type Task = Task` member.
+
 ### Function Types
 
 ```teal

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -229,7 +229,51 @@ record fields don't narrow either, even scalar ones — copy the field to
 a local and guard the local. the full pattern set is in
 `cosmic --docs guide.checking`.
 
-## 10. `os.exit` requires `integer | boolean`, not `number`
+## 10. a record other files use must be nested in the module's interface record
+
+a standalone top-level `local record` is visible only inside its own
+file. another file writing `store.Task` gets `unknown type store.Task` —
+at every use site — even though the value-level API works fine. to
+export a type, nest it inside the module's returned interface record.
+
+**wrong** (`store.tl`):
+```teal
+local record Task        -- file-local: importers cannot name it
+  id: integer
+  text: string
+end
+
+local record StoreModule
+  add: function(path: string, text: string): Task | nil, string
+end
+```
+
+**right:**
+```teal
+local record StoreModule
+  record Task            -- nested: importers write store.Task
+    id: integer
+    text: string
+  end
+  add: function(path: string, text: string): Task | nil, string
+end
+```
+
+(a `type Task = Task` alias member inside the interface record also
+works when the record must stay standalone for internal reasons — see
+how `cosmic.fs` re-exports `Stat`.)
+
+## 11. shadowing a Lua builtin
+
+`--check types` warns on any shadowed declaration, including Lua's own
+globals — a `local function load(...)` shadows the builtin `load()`,
+`local type = ...` shadows `type()`. the warning
+(`function shadows previous declaration of 'load'`) fails the strict
+check because warnings are errors; rename yours (`load_data`,
+`kind`, ...). the same trap at module level is gotcha #6's `io` example:
+binding `require("cosmic.fd")` to a local named `io` hides `io.stderr`.
+
+## 12. `os.exit` requires `integer | boolean`, not `number`
 
 a `main` function declared to return `number` breaks `os.exit(main())`
 with `got number, expected integer | boolean`.


### PR DESCRIPTION
Two traps from the isolated usability re-run, both hit by the same agent building a two-module project:

- **A standalone top-level record is file-local.** An importer writing `store.Task` gets `unknown type store.Task` at every use site, with nothing pointing at the fix (nest the record inside the module's interface record, or alias it in with a `type Task = Task` member). The agent inferred the rule from the error alone, restructured, and asked for exactly one sentence of documentation. It now gets: a gotcha entry with wrong/right code, a note in `guide.checking`'s Module Interface Records section, and a **hint on the `unknown type X.Y` error itself** (new pattern in `cosmic/_teal_hints.tl`), canary-tested through the real checker with a two-file fixture.
- **`function shadows previous declaration of 'load'`** names the collision but not that `load` is Lua's builtin or that warnings fail the strict check. A short gotcha now covers shadowing builtins generally, tied to the existing `io`-shadowing entry.

Both doc snippets are verified against the checker: the wrong shape produces the quoted error, the right shape passes.

`--make ci` green: `ci: PASS (5 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS)_