### PR TITLE
docs+hints: the three traps the clean-room round-3 agents still hit

### DIFF
--- a/cosmic/_teal_hints.tl
+++ b/cosmic/_teal_hints.tl
@@ -29,9 +29,10 @@ local function hint_for_message(msg: string): string | nil
   end
   -- Pattern 2b: indexing through an un-narrowed nil union. The trap is
   -- that `if not x then return end` narrows scalars but not records,
-  -- maps or arrays, and this error is all the checker says about it.
+  -- maps or arrays — and even a narrowed SCALAR cannot be method-called
+  -- (`data:gmatch(...)` on `string | nil` lands here too).
   if msg:find("cannot index") and msg:find("| nil", 1, true) then
-    return "  hint: `T | nil` does not narrow through `if not x` for records/maps/arrays: branch with `if x is T then ... end`, or cast after the guard (`local v = x as T`) — see `cosmic --docs guide.checking`"
+    return "  hint: `T | nil` does not narrow through `if not x` for records/maps/arrays, and a narrowed scalar cannot be method-called (use `string.gmatch(x, ...)`): branch with `if x is T then ... end`, or cast after the guard (`local v = x as T`) — see `cosmic --docs guide.checking`"
   end
   -- Pattern 2c: for-in over a value the checker cannot call. The message
   -- names no type, and the usual cause is an iterator still `T | nil`
@@ -44,6 +45,11 @@ local function hint_for_message(msg: string): string | nil
   -- types nested in (or aliased into) the module's interface record.
   if msg:find("unknown type %w+%.%w+") then
     return "  hint: a type other files use must be nested in the module's interface record (`record StoreModule record Task ... end end`), or aliased in with `type Task = Task` — see `cosmic --docs guide.checking`"
+  end
+  -- Pattern 2e: colon-calling a name the value's record does not
+  -- declare. Also fires on a plain typo, so the hint covers both.
+  if msg:find("invalid key '[%w_]+' in record") then
+    return "  hint: the value's record type does not declare this key — check the spelling; and a function on your MODULE's record is dot-called with the value first (`store.add(db, ...)`), never colon-called (`db:add(...)`) — see `cosmic --docs guide.gotchas`"
   end
   -- Pattern 3: excess return values (wrong number of returns)
   if msg:find("excess return values") then

--- a/cosmic/teal_test.tl
+++ b/cosmic/teal_test.tl
@@ -165,6 +165,51 @@ print(label(depmod.make()))
 end
 test_hint_unexported_type()
 
+local function test_hint_scalar_method_call_after_guard()
+  -- Scalars narrow through a nil-guard for plain uses, but not for
+  -- method-call syntax — the same "cannot index ... | nil" error shape
+  -- as records, so it must carry the same hint.
+  local msg, hint = first_hinted_error("h_scalar_method.tl", [[
+local function readish(): string | nil, string
+  return nil, "nope"
+end
+local function use(): integer
+  local data = readish()
+  if not data then
+    return 1
+  end
+  for word in data:gmatch("%a+") do
+    print(word)
+  end
+  return 0
+end
+print(use())
+]])
+  assert(msg:find("cannot index", 1, true) and msg:find("| nil", 1, true),
+    "wrong error: " .. msg)
+  assert(hint:find("method%-called", 1, false), "wrong hint: " .. hint)
+end
+test_hint_scalar_method_call_after_guard()
+
+local function test_hint_colon_call_on_module_function()
+  local msg, hint = first_hinted_error("h_colon.tl", [[
+local record Store
+  id: integer
+end
+local function add(store: Store, name: string): string
+  return tostring(store.id) .. name
+end
+local function use(store: Store): string
+  return store:add("alice")
+end
+local store: Store = {id = 1}
+print(add(store, "x"), use(store))
+]])
+  assert(msg:find("invalid key", 1, true), "wrong error: " .. msg)
+  assert(hint:find("dot%-called", 1, false), "wrong hint: " .. hint)
+end
+test_hint_colon_call_on_module_function()
+
 local function test_hint_excess_return_values()
   local msg, hint = first_hinted_error("h_excess.tl", [[
 local function f(): string

--- a/skills/cosmic/checking.md
+++ b/skills/cosmic/checking.md
@@ -113,6 +113,13 @@ local rr = r as R       -- cast: record union after guard
 print(rr.x)
 ```
 
+scalars narrow through truthiness for plain uses, with one caveat: a
+narrowed scalar cannot be METHOD-called. after a nil-guard on `data:
+string | nil`, `#data` and `data .. s` work but `data:gmatch(...)`
+still fails (`cannot index key 'gmatch' ... string | nil`). use the
+function form (`string.gmatch(data, ...)`) or branch with
+`if data is string then`.
+
 record FIELDS do not narrow either, even when the field is a scalar:
 after `if report.earliest ~= nil then`, `report.earliest` is still
 `integer | nil` at the point of use. copy the field to a local first —

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -226,7 +226,14 @@ d:exec(sql)
 ```
 
 record fields don't narrow either, even scalar ones — copy the field to
-a local and guard the local. the full pattern set is in
+a local and guard the local.
+
+and one scalar caveat: a narrowed scalar still cannot be METHOD-called.
+after `if not data then return end`, plain uses of `data` work, but
+`data:gmatch(...)` fails with `cannot index key 'gmatch' in variable
+'data' of type string | nil`. use the function form on the narrowed
+value (`string.gmatch(data, ...)`), or branch with `if data is string
+then ... end`, which narrows for every use. the full pattern set is in
 `cosmic --docs guide.checking`.
 
 ## 10. a record other files use must be nested in the module's interface record
@@ -273,7 +280,28 @@ check because warnings are errors; rename yours (`load_data`,
 `kind`, ...). the same trap at module level is gotcha #6's `io` example:
 binding `require("cosmic.fd")` to a local named `io` hides `io.stderr`.
 
-## 12. `os.exit` requires `integer | boolean`, not `number`
+## 12. colon-call only works on the value's own record type
+
+`db:exec(sql)` works because `exec` is declared on `sqlite.Database`
+itself. a function YOUR module declares that merely takes such a value
+as its first argument is not a method of that value — calling it with a
+colon fails:
+
+```teal
+local record StoreModule
+  add: function(db: sqlite.Database, name: string): boolean, string
+end
+
+db:add("alice")     -- error: invalid key 'add' in record 'db' of type sqlite.Database
+store.add(db, "alice")  -- right: module function, dot-called, value first
+```
+
+to get colon-call ergonomics for your own type, declare your own record
+with function fields taking `self` and construct values of it — see how
+`cosmic.fd`'s `Handle` does it. mixing the two (module functions over a
+foreign type) is the common, simpler shape; call them with a dot.
+
+## 13. `os.exit` requires `integer | boolean`, not `number`
 
 a `main` function declared to return `number` breaks `os.exit(main())`
 with `got number, expected integer | boolean`.

--- a/skills/cosmic/testing.md
+++ b/skills/cosmic/testing.md
@@ -94,7 +94,11 @@ end
 test_write_file()
 ```
 
-`TEST_TMPDIR` is cleaned up automatically after each test.
+`TEST_TMPDIR` is cleaned up automatically after each test FILE — the
+functions within one file share it, in definition order. tests that
+would collide on a shared path should each mint their own subdirectory
+(`fs.temp_dir(fs.join(tmpdir, "case_XXXXXX"))`) rather than reuse one
+well-known name.
 
 ## The Test Sandbox
 


### PR DESCRIPTION
One PR rather than three because they share files: all three came out of the round-3 (fully isolated) usability run's journals, and two edit `guide.gotchas`.

- **A narrowed scalar cannot be method-called.** After a nil-guard, `data:gmatch(...)` on `string | nil` still fails with the same `cannot index ... | nil` error records produce, while plain uses (`#data`, concat) work. Gotcha #9 said "scalars narrow" without the caveat, and one agent burned a minimal-repro cycle proving it wasn't their own code. The caveat is now in gotcha #9 and `guide.checking`, and the error-site hint mentions it (`use string.gmatch(x, ...)`).
- **Colon-call resolves on the value's own record type only.** `db:add(...)` against a function declared on the *module* record fails with `invalid key 'add' in record 'db' of type sqlite.Database`, which reads like a typo. New gotcha with the dot-call fix (`store.add(db, ...)`), and a new hint on the `invalid key ... in record` error, worded to serve the plain-typo case too.
- **`TEST_TMPDIR` is per test *file*, not per test function.** `guide.testing` said "cleaned up after each test"; an agent's tests silently shared state until an equality assert caught it. The wording now says which, and shows how to mint per-case subdirectories.

Both new hints are canary-tested through the real checker (same style as the existing hint canaries). `--make ci` green: `ci: PASS (5 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS)_