### PR TITLE
flags: implement command — subcommand dispatch over per-command specs

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -107,7 +107,10 @@ cosmic/fd.tl 95 118
 cosmic/fetch/extras.tl 196 220
 cosmic/fetch/headers.tl 23 23
 cosmic/fetch/init.tl 0 139
-cosmic/flags.tl 140 142
+cosmic/flags/command.tl 102 105
+cosmic/flags/init.tl 9 9
+cosmic/flags/parse.tl 142 144
+cosmic/flags/types.tl 2 2
 cosmic/format/init.tl 185 224
 cosmic/format/rules.tl 208 220
 cosmic/format/types.tl 98 113

--- a/cosmic/flags/command.tl
+++ b/cosmic/flags/command.tl
@@ -1,0 +1,176 @@
+--- The multi-command half of the flags family: dispatch argv[1] to one
+--- of a program's subcommands, each with its own Spec, and render the
+--- overview help. Shard of cosmic.flags; the public surface is
+--- init.tl's. Same contract as parse: never prints, never exits.
+local flags_parse = require("cosmic.flags.parse")
+local types = require("cosmic.flags.types")
+
+local type Spec = types.Spec
+local type Parsed = types.Parsed
+local type Command = types.Command
+local type CommandSpec = types.CommandSpec
+local type Dispatched = types.Dispatched
+
+local function find_command(cspec: CommandSpec, name: string): Command
+  for _, cmd in ipairs(cspec.commands or {}) do
+    if cmd.name == name then
+      return cmd
+    end
+  end
+  return nil
+end
+
+local function command_names(cspec: CommandSpec): string
+  local names: {string} = {}
+  for _, cmd in ipairs(cspec.commands or {}) do
+    names[#names + 1] = cmd.name
+  end
+  return table.concat(names, ", ")
+end
+
+--- Validate a command spec. nil when sound, else a message naming the
+--- defect — the same never-throw shape as everything here.
+local function validate_commands(cspec: CommandSpec): string
+  local pname = cspec.name or "program"
+  if not cspec.commands or #cspec.commands == 0 then
+    return pname .. ": invalid spec: no commands declared"
+  end
+  local seen: {string: boolean} = {}
+  for _, cmd in ipairs(cspec.commands) do
+    if not cmd.name or #cmd.name == 0 then
+      return pname .. ": invalid spec: command without a name"
+    end
+    if seen[cmd.name] then
+      return pname .. ": invalid spec: duplicate command '" .. cmd.name .. "'"
+    end
+    seen[cmd.name] = true
+    if not cmd.spec then
+      return pname .. ": invalid spec: command '" .. cmd.name .. "' has no spec"
+    end
+  end
+  return nil
+end
+
+--- The command's spec with its name defaulted to "<program> <command>",
+--- copied rather than mutated — the caller's spec is data, not scratch.
+local function qualified_spec(cspec: CommandSpec, cmd: Command): Spec
+  if cmd.spec.name then
+    return cmd.spec
+  end
+  return {
+    name = (cspec.name or "program") .. " " .. cmd.name,
+    summary = cmd.spec.summary or cmd.summary,
+    usage = cmd.spec.usage,
+    version = cmd.spec.version,
+    options = cmd.spec.options,
+  }
+end
+
+--- Dispatch a command line to one of a program's subcommands.
+--- argv[1] selects the command; the rest parses against that command's
+--- own Spec. `prog --help`/`prog help` and `prog help <command>` come
+--- back as help requests (never printed here), --version likewise when
+--- the spec carries a version. No command, an unknown command, or a
+--- failed sub-parse is nil plus a one-line message naming the commands.
+--- @param cspec CommandSpec The declared interface
+--- @param argv {string} The argument list (typically the global arg)
+--- @return Dispatched | nil The dispatch result, or nil on any error
+--- @return string? Error message when the spec or command line is invalid
+local function command(cspec: CommandSpec, argv: {string}): Dispatched | nil, string
+  local invalid = validate_commands(cspec)
+  if invalid then
+    return nil, invalid
+  end
+  local pname = cspec.name or "program"
+  local first = argv and argv[1]
+  if not first then
+    return nil, pname .. ": expected a command: " .. command_names(cspec)
+    .. " (try --help)"
+  end
+  if first == "--help" or first == "-h" or first == "help" then
+    local target: string = nil
+    if first == "help" then
+      target = argv[2]
+    end
+    if target then
+      if not find_command(cspec, target) then
+        return nil, pname .. ": unknown command '" .. target .. "': "
+        .. command_names(cspec)
+      end
+      return {command = target, help = true, version = false}
+    end
+    return {help = true, version = false}
+  end
+  if cspec.version and first == "--version" then
+    return {help = false, version = true}
+  end
+  local cmd = find_command(cspec, first)
+  if not cmd then
+    return nil, pname .. ": unknown command '" .. first .. "': "
+    .. command_names(cspec) .. " (try --help)"
+  end
+  local rest: {string} = {}
+  for i = 2, #argv do
+    rest[#rest + 1] = argv[i]
+  end
+  local parsed, perr = flags_parse.parse(qualified_spec(cspec, cmd), rest)
+  if not parsed then
+    return nil, perr
+  end
+  local p = parsed as Parsed -- cast: record union after guard
+  return {command = first, parsed = p, help = p.help, version = false}
+end
+
+--- Render help for a multi-command program: the overview (usage,
+--- summary, aligned command list) or, given a command's name, that
+--- command's own page. Returns text without a trailing newline.
+--- @param cspec CommandSpec The declared interface
+--- @param name? string A command's name, for its own page
+--- @return string The rendered help text
+local function command_help(cspec: CommandSpec, name?: string): string
+  local pname = cspec.name or "program"
+  if name then
+    local cmd = find_command(cspec, name)
+    if cmd then
+      return flags_parse.help(qualified_spec(cspec, cmd))
+    end
+  end
+  local lines: {string} = {
+    "usage: " .. pname .. " <command> [options]",
+  }
+  if cspec.summary then
+    lines[#lines + 1] = ""
+    lines[#lines + 1] = cspec.summary
+  end
+  local width = 0
+  for _, cmd in ipairs(cspec.commands or {}) do
+    if #cmd.name > width then
+      width = #cmd.name
+    end
+  end
+  lines[#lines + 1] = ""
+  lines[#lines + 1] = "commands:"
+  for _, cmd in ipairs(cspec.commands or {}) do
+    local row = "  " .. cmd.name .. string.rep(" ", width - #cmd.name)
+    local desc = cmd.summary or (cmd.spec and cmd.spec.summary)
+    if desc then
+      row = row .. "  " .. desc
+    end
+    lines[#lines + 1] = row
+  end
+  lines[#lines + 1] = ""
+  lines[#lines + 1] = "run '" .. pname .. " help <command>' for command options"
+  return table.concat(lines, "\n")
+end
+
+local record CommandModule
+  command: function(cspec: CommandSpec, argv: {string}): Dispatched | nil, string
+  command_help: function(cspec: CommandSpec, name?: string): string
+end
+
+local M: CommandModule = {
+  command = command,
+  command_help = command_help,
+}
+
+return M

--- a/cosmic/flags/init.tl
+++ b/cosmic/flags/init.tl
@@ -1,0 +1,86 @@
+--- Declarative command-line flag parsing.
+--- Describe a program's options once as data — names, value
+--- placeholders, defaults, help text — and get parsing, validation,
+--- and rendered --help from the one spec. Built over cosmic.getopt,
+--- which supplies the underlying short/long option grammar; reach for
+--- getopt directly when you need its lower-level control.
+---
+--- Example usage:
+---   local flags = require("cosmic.flags")
+---   local spec: flags.Spec = {
+---     name = "greet",
+---     summary = "Greet people from the command line",
+---     usage = "[options] <name...>",
+---     options = {
+---       {long = "verbose", short = "v", help = "print more detail"},
+---       {long = "output", short = "o", arg = "FILE",
+---        help = "write to FILE", default = "-"},
+---     },
+---   }
+---   local parsed, err = flags.parse(spec, arg)
+---   if not parsed then
+---     io.stderr:write(err .. "\n")
+---   elseif parsed.help then
+---     print(flags.help(spec))
+---   else
+---     local out = parsed.values["output"]
+---     local loud = parsed.flags["verbose"]
+---   end
+---
+--- An option with an `arg` placeholder takes a required value;
+--- without one it is a boolean flag. --help/-h is recognized
+--- automatically (and --version when the spec carries a version)
+--- unless the spec claims those names itself; parse never prints or
+--- exits — it reports help/version requests as fields on the result
+--- and the caller decides what to do.
+---
+--- Multi-command programs (`todo add`, `todo list`, ...) declare a
+--- CommandSpec — one Spec per subcommand — and dispatch with
+--- flags.command(cspec, arg); flags.command_help renders the overview
+--- or a command's page. Same contract as parse: never prints, never
+--- exits.
+---
+---   local cspec: flags.CommandSpec = {
+---     name = "todo",
+---     summary = "manage a todo list",
+---     commands = {
+---       {name = "add", summary = "add a task", spec = {
+---         usage = "<text...>", options = {}}},
+---       {name = "list", summary = "list tasks", spec = {options = {
+---         {long = "all", short = "a", help = "include done tasks"}}}},
+---     },
+---   }
+---   local d, derr = flags.command(cspec, arg)
+---   if not d then
+---     io.stderr:write(derr .. "\n")
+---   elseif d.help then
+---     print(flags.command_help(cspec, d.command))
+---   elseif d.command == "add" then
+---     add_task(d.parsed.args)
+---   end
+local flags_command = require("cosmic.flags.command")
+local flags_parse = require("cosmic.flags.parse")
+local types = require("cosmic.flags.types")
+
+local record FlagsModule
+  type Option = types.Option
+  type Spec = types.Spec
+  type Parsed = types.Parsed
+  type Command = types.Command
+  type CommandSpec = types.CommandSpec
+  type Dispatched = types.Dispatched
+
+  parse: function(spec: Spec, argv: {string}): Parsed | nil, string
+  help: function(spec: Spec): string
+  command: function(cspec: CommandSpec, argv: {string}): Dispatched | nil, string
+  command_help: function(cspec: CommandSpec, name?: string): string
+end
+
+local M: FlagsModule = {
+  parse = flags_parse.parse,
+  help = flags_parse.help,
+  command = flags_command.command,
+  command_help = flags_command.command_help,
+}
+
+return M

--- a/cosmic/flags/parse.tl
+++ b/cosmic/flags/parse.tl
@@ -1,88 +1,12 @@
---- Declarative command-line flag parsing.
---- Describe a program's options once as data — names, value
---- placeholders, defaults, help text — and get parsing, validation,
---- and rendered --help from the one spec. Built over cosmic.getopt,
---- which supplies the underlying short/long option grammar; reach for
---- getopt directly when you need its lower-level control.
----
---- Example usage:
----   local flags = require("cosmic.flags")
----   local spec: flags.Spec = {
----     name = "greet",
----     summary = "Greet people from the command line",
----     usage = "[options] <name...>",
----     options = {
----       {long = "verbose", short = "v", help = "print more detail"},
----       {long = "output", short = "o", arg = "FILE",
----        help = "write to FILE", default = "-"},
----     },
----   }
----   local parsed, err = flags.parse(spec, arg)
----   if not parsed then
----     io.stderr:write(err .. "\n")
----   elseif parsed.help then
----     print(flags.help(spec))
----   else
----     local out = parsed.values["output"]
----     local loud = parsed.flags["verbose"]
----   end
----
---- An option with an `arg` placeholder takes a required value;
---- without one it is a boolean flag. --help/-h is recognized
---- automatically (and --version when the spec carries a version)
---- unless the spec claims those names itself; parse never prints or
---- exits — it reports help/version requests as fields on the result
---- and the caller decides what to do.
----
---- Reserved name: flags.command(spec): subcommand dispatch is
---- reserved for a post-stable battery. Do not reuse this name.
+--- The single-spec half of the flags family: validate a Spec, parse an
+--- argument vector against it, render its help. Shard of cosmic.flags;
+--- the public surface is init.tl's.
 local getopt = require("cosmic.getopt")
+local types = require("cosmic.flags.types")
 
---- One option declaration.
-local record Option
-  --- Long name, without dashes (e.g. "output" for --output). Required.
-  long: string
-  --- Optional single-letter short alias, without the dash.
-  short: string
-  --- Value placeholder shown in help (e.g. "FILE"). Its presence
-  --- makes the option take a required value; absent means boolean.
-  arg: string
-  --- One-line description shown in help.
-  help: string
-  --- Default value, applied when the option is absent (valued only).
-  default: string
-  --- Reject the command line when the option is absent (valued only).
-  required: boolean
-end
-
---- A program's declared interface.
-local record Spec
-  --- Program name, used in error messages and help (default "program").
-  name: string
-  --- One-line description shown in help.
-  summary: string
-  --- Usage tail shown after the name (default "[options]").
-  usage: string
-  --- Version string; when set, --version is recognized automatically.
-  version: string
-  --- The declared options, in help-display order.
-  options: {Option}
-end
-
---- A successful parse.
-local record Parsed
-  --- Boolean options by long name; every declared flag is present
-  --- (false when absent), so lookups never need a nil check.
-  flags: {string: boolean}
-  --- Valued options by long name, with defaults applied.
-  values: {string: string}
-  --- Positional (non-option) arguments, in order.
-  args: {string}
-  --- True when --help / -h was given.
-  help: boolean
-  --- True when --version was given (specs with a version only).
-  version: boolean
-end
+local type Option = types.Option
+local type Spec = types.Spec
+local type Parsed = types.Parsed
 
 local function prog(spec: Spec): string
   return spec.name or "program"
@@ -311,16 +235,12 @@ local function help(spec: Spec): string
   return table.concat(lines, "\n")
 end
 
-local record FlagsModule
-  type Option = Option
-  type Spec = Spec
-  type Parsed = Parsed
-
+local record ParseModule
   parse: function(spec: Spec, argv: {string}): Parsed | nil, string
   help: function(spec: Spec): string
 end
 
-local M: FlagsModule = {
+local M: ParseModule = {
   parse = parse,
   help = help,
 }

--- a/cosmic/flags/types.tl
+++ b/cosmic/flags/types.tl
@@ -1,0 +1,91 @@
+--- Shared type definitions for the flags module family: the option and
+--- spec vocabulary `parse` consumes, and the command vocabulary
+--- `command` dispatches over. Types only — behavior lives in the
+--- sibling shards, assembled by init.tl.
+local record flags_types
+
+  --- One option declaration.
+  record Option
+    --- Long name, without dashes (e.g. "output" for --output). Required.
+    long: string
+    --- Optional single-letter short alias, without the dash.
+    short: string
+    --- Value placeholder shown in help (e.g. "FILE"). Its presence
+    --- makes the option take a required value; absent means boolean.
+    arg: string
+    --- One-line description shown in help.
+    help: string
+    --- Default value, applied when the option is absent (valued only).
+    default: string
+    --- Reject the command line when the option is absent (valued only).
+    required: boolean
+  end
+
+  --- A program's declared interface.
+  record Spec
+    --- Program name, used in error messages and help (default "program").
+    name: string
+    --- One-line description shown in help.
+    summary: string
+    --- Usage tail shown after the name (default "[options]").
+    usage: string
+    --- Version string; when set, --version is recognized automatically.
+    version: string
+    --- The declared options, in help-display order.
+    options: {Option}
+  end
+
+  --- A successful parse.
+  record Parsed
+    --- Boolean options by long name; every declared flag is present
+    --- (false when absent), so lookups never need a nil check.
+    flags: {string: boolean}
+    --- Valued options by long name, with defaults applied.
+    values: {string: string}
+    --- Positional (non-option) arguments, in order.
+    args: {string}
+    --- True when --help / -h was given.
+    help: boolean
+    --- True when --version was given (specs with a version only).
+    version: boolean
+  end
+
+  --- One subcommand of a multi-command program.
+  record Command
+    --- Name as typed on the command line. Required, unique.
+    name: string
+    --- One-line description shown in the command list.
+    summary: string
+    --- The command's own interface. Its `name` defaults to
+    --- "<program> <command>", so errors and help name the full invocation.
+    spec: Spec
+  end
+
+  --- A multi-command program's declared interface.
+  record CommandSpec
+    --- Program name, used in error messages and help (default "program").
+    name: string
+    --- One-line description shown in the overview help.
+    summary: string
+    --- Version string; when set, --version is recognized at the top level.
+    version: string
+    --- The commands, in help-display order.
+    commands: {Command}
+  end
+
+  --- A successful dispatch.
+  record Dispatched
+    --- The selected command's name; nil on a bare help/version request.
+    command: string
+    --- The command's own parse; nil on a help/version request.
+    parsed: Parsed
+    --- True when help was requested — bare (`prog --help`, `prog help`),
+    --- per-command (`prog help add`), or by the command's own --help;
+    --- `command` says which page command_help should render.
+    help: boolean
+    --- True when --version was given at the top level.
+    version: boolean
+  end
+end
+
+return flags_types

--- a/cosmic/flags_test.tl
+++ b/cosmic/flags_test.tl
@@ -163,3 +163,102 @@ local function test_help_rows_align()
   assert(verbose_col == output_col, "descriptions are not column-aligned")
 end
 test_help_rows_align()
+
+-- flags.command: dispatch on argv[1], each command its own Spec.
+local function make_cspec(): flags.CommandSpec
+  return {
+    name = "todo",
+    summary = "manage a todo list",
+    version = "1.0",
+    commands = {
+      {name = "add", summary = "add a task", spec = {
+          usage = "<text...>",
+          options = {},
+        }},
+      {name = "list", summary = "list tasks", spec = {
+          options = {
+            {long = "all", short = "a", help = "include done tasks"},
+          },
+        }},
+    },
+  }
+end
+
+local function test_command_dispatches_with_options()
+  local d = check.must(flags.command(make_cspec(), {"list", "--all"}))
+  assert(d.command == "list", "command: " .. tostring(d.command))
+  assert(d.parsed.flags["all"] == true, "sub-option should parse")
+  assert(not d.help and not d.version, "plain dispatch is not help/version")
+
+  local d2 = check.must(flags.command(make_cspec(), {"add", "buy", "milk"}))
+  assert(d2.command == "add", "command: " .. tostring(d2.command))
+  assert(#d2.parsed.args == 2 and d2.parsed.args[1] == "buy",
+    "positionals reach the subcommand")
+end
+test_command_dispatches_with_options()
+
+local function test_command_errors_name_the_commands()
+  local d, err = flags.command(make_cspec(), {})
+  assert(d == nil, "no command is an error")
+  assert(err:find("add, list", 1, true), "error names the commands: " .. err)
+
+  local d2, err2 = flags.command(make_cspec(), {"frob"})
+  assert(d2 == nil, "unknown command is an error")
+  assert(err2:find("unknown command 'frob'", 1, true), "got: " .. err2)
+
+  -- A sub-parse failure carries the qualified program name, so the
+  -- reader knows which command's options were wrong.
+  local d3, err3 = flags.command(make_cspec(), {"list", "--bogus"})
+  assert(d3 == nil, "unknown sub-option is an error")
+  assert(err3:find("todo list:", 1, true), "qualified name: " .. err3)
+end
+test_command_errors_name_the_commands()
+
+local function test_command_help_and_version_forms()
+  for _, argv in ipairs({{"--help"}, {"-h"}, {"help"}}) do
+    local d = check.must(flags.command(make_cspec(), argv))
+    assert(d.help and d.command == nil, "bare help request")
+  end
+
+  local d = check.must(flags.command(make_cspec(), {"help", "list"}))
+  assert(d.help and d.command == "list", "help for one command")
+
+  local bad, err = flags.command(make_cspec(), {"help", "frob"})
+  assert(bad == nil and err:find("unknown command", 1, true),
+    "help for an unknown command is an error")
+
+  local sub = check.must(flags.command(make_cspec(), {"list", "--help"}))
+  assert(sub.help and sub.command == "list",
+    "a command's own --help propagates")
+
+  local v = check.must(flags.command(make_cspec(), {"--version"}))
+  assert(v.version and not v.help, "top-level --version")
+end
+test_command_help_and_version_forms()
+
+local function test_command_validates_the_spec()
+  local none, err = flags.command({name = "x", commands = {}}, {"y"})
+  assert(none == nil and err:find("no commands", 1, true), "got: " .. tostring(err))
+
+  local dup, err2 = flags.command({name = "x", commands = {
+        {name = "a", spec = {options = {}}},
+        {name = "a", spec = {options = {}}},
+      }}, {"a"})
+  assert(dup == nil and err2:find("duplicate command", 1, true),
+    "got: " .. tostring(err2))
+end
+test_command_validates_the_spec()
+
+local function test_command_help_renders_overview_and_page()
+  local overview = flags.command_help(make_cspec())
+  assert(overview:find("usage: todo <command>", 1, true), "usage line")
+  assert(overview:find("add", 1, true) and overview:find("list tasks", 1, true),
+    "command list with summaries")
+  assert(overview:find("todo help <command>", 1, true), "help pointer")
+
+  local page = flags.command_help(make_cspec(), "list")
+  assert(page:find("usage: todo list", 1, true),
+    "per-command page carries the qualified name: " .. page)
+  assert(page:find("--all", 1, true), "per-command page lists its options")
+end
+test_command_help_renders_overview_and_page()


### PR DESCRIPTION
The name was reserved for exactly this ("subcommand dispatch is reserved for a post-stable battery"), and both CLI agents in the usability evals hand-rolled argv[1] dispatch plus per-subcommand flag extraction — and asked for the battery by name.

**API** — same contract as `parse`: never prints, never exits.

```teal
local cspec: flags.CommandSpec = {
  name = "todo", summary = "manage a todo list",
  commands = {
    {name = "add", summary = "add a task", spec = {usage = "<text...>", options = {}}},
    {name = "list", summary = "list tasks", spec = {options = {
      {long = "all", short = "a", help = "include done tasks"}}}},
  },
}
local d, err = flags.command(cspec, arg)
if not d then io.stderr:write(err .. "\n")
elseif d.help then print(flags.command_help(cspec, d.command))
elseif d.command == "add" then add_task(d.parsed.args) end
```

- `argv[1]` selects the command; the rest parses against that command's own `Spec`, whose `name` defaults to `"<program> <command>"` so errors read `todo list: unknown option: --bogus (try --help)`.
- Help arrives as fields: bare `--help`/`-h`/`help`, per-command `help add`, or a command's own `--help` — `Dispatched.command` says which page `command_help` should render. `--version` recognized when the spec carries a version.
- Spec defects (no commands, duplicate names, missing sub-spec) are named, never thrown.

**Structure**: the addition pushed `flags.tl` past the 500-line law, so it becomes a directory module the way `fs` is: `types.tl` (shared vocabulary), `parse.tl` (single-spec half, moved verbatim — git tracks it as a rename), `command.tl` (new), `init.tl` (public surface — unchanged for existing callers plus the four new names). The pre-existing test suite passes unchanged.

New tests cover dispatch with options/positionals, error naming (commands listed, qualified sub-errors), every help/version form, spec validation, and both help renderings. Coverage: `flags.tl`'s row replaced by the four shards' measured floors; all other rows untouched.

Note: `--docs flags` currently lists shard helpers on the page — that's a pre-existing index bug (example-file/directory-module collision) fixed separately in the follow-up PR.

`--make ci` green: `ci: PASS (5 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS)_