### PR TITLE
docs: normalize init shards before example docs merge

### DIFF
--- a/cosmic/doc/index.tl
+++ b/cosmic/doc/index.tl
@@ -210,6 +210,15 @@ local function generate(files: {string},
     end
   end
 
+  -- Init shards normalize to the name users require BEFORE examples
+  -- merge: a directory module with a sibling example file
+  -- (cosmic/flags/init.tl + cosmic/flags_example.tl) otherwise loses
+  -- the race — the example doc registers itself as `cosmic.flags`, the
+  -- init rename then finds the name taken and skips, and the module's
+  -- real doc is stranded under `cosmic.flags.init` while the page
+  -- users see is the bare example.
+  normalize_init(modules)
+
   -- Merge examples from _example files into corresponding modules
   for base_name, example_doc in pairs(example_files) do
     local mod = modules[base_name]
@@ -231,7 +240,6 @@ local function generate(files: {string},
     end
   end
 
-  normalize_init(modules)
   flatten_shards(modules)
   mark_visibility(modules)
 

--- a/cosmic/doc/index_test.tl
+++ b/cosmic/doc/index_test.tl
@@ -147,3 +147,81 @@ return { spin = spin, internal_only = internal_only }
   assert(shard_mod, "the shard stays addressable under its own name")
 end
 test_shards_flatten_into_parent()
+
+-- A directory module WITH a sibling example file: init must normalize
+-- before examples merge, or the example doc registers itself under the
+-- module's name first, the init rename finds the name taken, and the
+-- page users see is a bare example with every shard helper merged
+-- unfiltered (cosmic.flags was the in-tree case).
+local function test_example_beside_directory_module()
+  local pdir = fs.join(tmpdir, "widgetdir")
+  assert(fs.make_dirs(pdir))
+  local init_path = fs.join(pdir, "init.tl")
+  assert(fs.write(init_path, [[
+--- Widgetdir module.
+local shard = require("widgetdir.shard")
+
+local record WidgetdirModule
+  spin: function(n: number): number
+end
+
+local M: WidgetdirModule = {
+  spin = shard.spin,
+}
+
+return M
+]]))
+  local shard_path = fs.join(pdir, "shard.tl")
+  assert(fs.write(shard_path, [[
+--- Widgetdir internals.
+
+--- Spin a widget.
+--- @param n number Revolutions
+--- @return number The spun value
+local function spin(n: number): number
+  return n * 2
+end
+
+--- Private helper.
+--- @return number Zero
+local function internal_only(): number
+  return 0
+end
+
+return { spin = spin, internal_only = internal_only }
+]]))
+  local example_path = fs.join(tmpdir, "widgetdir_example.tl")
+  assert(fs.write(example_path, [[
+--- Examples for widgetdir.
+local function Example_spin()
+  print("spun")
+  -- Output:
+  -- spun
+end
+return {}
+]]))
+
+  local encoded = check.must(index.generate(
+      {init_path, shard_path, example_path},
+      {
+        [init_path] = "widgetdir.init",
+        [shard_path] = "widgetdir.shard",
+        [example_path] = "widgetdir_example",
+      }))
+  local data = check.must(codec.decode_lua_unsafe(encoded))
+  local modules = (data as {string: any}).modules as {string: any} -- cast: from any
+  local parent = modules["widgetdir"] as {string: any} -- cast: from any
+  assert(parent, "widgetdir.init should normalize to widgetdir")
+  assert(modules["widgetdir.init"] == nil,
+    "the init shard must not survive under its own name")
+  local names: {string: boolean} = {}
+  for _, func in ipairs((parent.functions or {}) as {any}) do -- cast: from any
+    names[(func as {string: any}).name as string] = true -- cast: from any
+  end
+  assert(names["spin"], "the module's real doc reaches the page")
+  assert(not names["internal_only"],
+    "the export filter survives the example merge")
+  local examples = parent.examples as {any} -- cast: from any
+  assert(examples and #examples == 1, "the example merges onto the same page")
+end
+test_example_beside_directory_module()


### PR DESCRIPTION
A directory module with a sibling example file lost a race in the doc index: examples merged **before** init-normalization, so the example doc registered itself under the module's require name (`cosmic.flags`), the init rename then found the name taken and skipped, and the page users saw was the bare example with every shard helper merged unfiltered — the export filter (from #906) lives on the init doc, which was stranded under `cosmic.flags.init`. `fs` never showed it because there is no `fs_example.tl`; the flags directory-module restructure (#909) surfaced it.

`normalize_init` now runs before the example merge, so the example lands on the module's real entry and the export filter survives. Regression test covers the triple — init + shard + sibling example: the module's real doc reaches the page, the private helper stays off it, the example merges onto the same page, and no stranded `.init` entry remains.

Composes with #909: once both merge, `--docs flags` shows exactly `parse`, `help`, `command`, `command_help` plus the example.

`--make ci` green: `ci: PASS (5 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS)_