### PR TITLE
docs: an init shard's example lands on the directory module

### DIFF
--- a/cosmic/doc/index.tl
+++ b/cosmic/doc/index.tl
@@ -221,6 +221,15 @@ local function generate(files: {string},
 
   -- Merge examples from _example files into corresponding modules
   for base_name, example_doc in pairs(example_files) do
+    -- An example beside an init shard (cosmic/fs/init_example.tl)
+    -- documents the DIRECTORY module, whose entry normalize_init just
+    -- renamed to the name users require. Without this retarget the
+    -- orphan branch below re-registers the stranded `.init` name — and
+    -- the example never reaches the module's page.
+    local init_parent = base_name:match("^(.+)%.init$")
+    if init_parent and not modules[base_name] and modules[init_parent] then
+      base_name = init_parent
+    end
     local mod = modules[base_name]
     if mod then
       -- Merge examples into the module's examples

--- a/cosmic/doc/index_test.tl
+++ b/cosmic/doc/index_test.tl
@@ -225,3 +225,53 @@ return {}
   assert(examples and #examples == 1, "the example merges onto the same page")
 end
 test_example_beside_directory_module()
+
+-- An example file beside an init shard (gizmo/init_example.tl)
+-- documents the directory module: it must land on the normalized
+-- parent entry, not re-register a stranded `.init` module. The shipped
+-- index regressed exactly this way (seven stranded .init entries) when
+-- normalization moved ahead of the example merge.
+local function test_init_example_lands_on_directory_module()
+  local pdir = fs.join(tmpdir, "gizmo")
+  assert(fs.make_dirs(pdir))
+  local init_path = fs.join(pdir, "init.tl")
+  assert(fs.write(init_path, [[
+--- Gizmo module.
+
+--- Turn a gizmo.
+--- @param n number Turns
+--- @return number The turned value
+local function turn(n: number): number
+  return n + 1
+end
+
+return { turn = turn }
+]]))
+  local example_path = fs.join(pdir, "init_example.tl")
+  assert(fs.write(example_path, [[
+--- Examples for gizmo.
+local function Example_turn()
+  print("turned")
+  -- Output:
+  -- turned
+end
+return {}
+]]))
+
+  local encoded = check.must(index.generate(
+      {init_path, example_path},
+      {
+        [init_path] = "gizmo.init",
+        [example_path] = "gizmo.init_example",
+      }))
+  local data = check.must(codec.decode_lua_unsafe(encoded))
+  local modules = (data as {string: any}).modules as {string: any} -- cast: from any
+  assert(modules["gizmo"], "gizmo.init should normalize to gizmo")
+  assert(modules["gizmo.init"] == nil,
+    "the init name must not be re-registered by its example")
+  local parent = modules["gizmo"] as {string: any} -- cast: from any
+  local examples = parent.examples as {any} -- cast: from any
+  assert(examples and #examples == 1,
+    "the init example lands on the directory module's page")
+end
+test_init_example_lands_on_directory_module()


### PR DESCRIPTION
#910's normalize-before-examples reorder traded one collision for another: an example file **beside** an init shard (`cosmic/fs/init_example.tl`, base name `cosmic.fs.init`) now finds its module already renamed to `cosmic.fs`, falls into the orphan-example branch, and re-registers the stranded `.init` name — **seven** of them in the shipped index (`fs`, `net`, `child`, `fetch`, `sqlite`, `coverage`, `quicksand.box`) — while the example never reaches the module's page.

`cosmic/doc/public_test.tl` catches it, but only on a warm tree whose running binary carries the new index module — which is why CI's cold-start lanes stayed green on #910 while every warm local `ci` afterwards broke. (Discovered while validating the round-4 eval follow-ups.)

The example merge now retargets a `.init` base name to the normalized parent when the parent exists and the `.init` entry does not. Regression test covers the pair: the example lands on the directory module's page, and no `.init` entry is re-registered. Verified against the freshly shipped index: zero stranded `.init` modules, `public_test` green.

`--make ci` green: `ci: PASS (5 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS)_