### PR TITLE
teal: hint the unannotated `= nil` local, the round-4 stall

### DIFF
--- a/cosmic/_teal_hints.tl
+++ b/cosmic/_teal_hints.tl
@@ -23,6 +23,19 @@ local function hint_for_message(msg: string): string | nil
   if msg:find("got number, expected integer") then
     return "  hint: annotate the variable `: number`, or convert with math.tointeger; integer is required for string indices/lengths"
   end
+  -- Pattern 1b: a local declared `= nil` with no annotation. Its type
+  -- is inferred as nil FOREVER — every later assignment and comparison
+  -- fails, no guard helps, and nothing in either message says the
+  -- declaration is the problem. Two shapes: assigning into it, and
+  -- using it as an operand. The `| nil` exclusion keeps the operand
+  -- shape off honest unions, which are narrowing problems, not
+  -- declaration problems.
+  local nil_operand = (msg:match("for types .+ and nil$") ~= nil
+    or msg:find("for types nil and", 1, true) ~= nil)
+  and not msg:find("| nil", 1, true)
+  if msg:match("in assignment: got .+, expected nil$") or nil_operand then
+    return "  hint: a local declared `= nil` without a type annotation has type nil forever — annotate the optional (`local x: integer | nil = nil`) — see `cosmic --docs guide.checking`"
+  end
   -- Pattern 2: nil union not narrowed (X | nil where X expected)
   if msg:find("%| nil") and msg:find("expected") then
     return "  hint: narrow first: `if v is Rec then ... end` (plain-table records), or cast after a guard for userdata handles — see `cosmic --docs guide.checking`"

--- a/cosmic/teal_test.tl
+++ b/cosmic/teal_test.tl
@@ -210,6 +210,28 @@ print(add(store, "x"), use(store))
 end
 test_hint_colon_call_on_module_function()
 
+local function test_hint_unannotated_nil_local()
+  -- `local x = nil` infers the type nil itself; the assignment error is
+  -- the shape everyone hits first (the operator shape rides the same
+  -- hint).
+  local msg, hint = first_hinted_error("h_nil_local.tl", [[
+local function lowest(ts: {integer}): integer | nil
+  local earliest = nil
+  for _, t in ipairs(ts) do
+    if not earliest or t < earliest then
+      earliest = t
+    end
+  end
+  return earliest
+end
+print(lowest({3, 1}))
+]])
+  assert(msg:find("expected nil", 1, true) or msg:find("and nil", 1, true),
+    "wrong error: " .. msg)
+  assert(hint:find("type nil forever", 1, true), "wrong hint: " .. hint)
+end
+test_hint_unannotated_nil_local()
+
 local function test_hint_excess_return_values()
   local msg, hint = first_hinted_error("h_excess.tl", [[
 local function f(): string

--- a/skills/cosmic/checking.md
+++ b/skills/cosmic/checking.md
@@ -49,7 +49,11 @@ end
 local value: string = nil  -- ERROR: string cannot be nil
 ```
 
-use `?` on parameters to make them optional. for nullable local variables, use the nil-returning pattern from the function signature.
+use `?` on parameters to make them optional. a nullable LOCAL must be
+annotated at its declaration: `local x: integer | nil = nil`. a bare
+`local x = nil` infers the type `nil` itself — every later assignment
+fails with `in assignment: got ..., expected nil`, and no guard can
+recover it.
 
 ### Narrowing and Casting
 

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -301,7 +301,34 @@ with function fields taking `self` and construct values of it — see how
 `cosmic.fd`'s `Handle` does it. mixing the two (module functions over a
 foreign type) is the common, simpler shape; call them with a dot.
 
-## 13. `os.exit` requires `integer | boolean`, not `number`
+## 13. `local x = nil` means type nil, forever
+
+a local initialized with `= nil` and NO type annotation is inferred as
+the type `nil` — not "unknown yet", not `T | nil`. every later
+assignment and use then fails, no guard helps, and neither error names
+the declaration as the cause:
+
+**wrong:**
+```teal
+local earliest = nil            -- type: nil
+for _, e in ipairs(entries) do
+  if not earliest or e.timestamp < earliest then
+    -- error: cannot use operator '<' for types integer and nil
+    earliest = e.timestamp
+    -- error: in assignment: got integer, expected nil
+  end
+end
+```
+
+**right — annotate the optional at the declaration:**
+```teal
+local earliest: integer | nil = nil
+```
+
+with the annotation, the running-min/max idiom above compiles as
+written — scalars narrow through the `not earliest or ...` guard fine.
+
+## 14. `os.exit` requires `integer | boolean`, not `number`
 
 a `main` function declared to return `number` breaks `os.exit(main())`
 with `got number, expected integer | boolean`.


### PR DESCRIPTION
The one real stall in the round-4 eval (3 failed builds), diagnosed on repro — and the diagnosis matters: the agent wrote a running-min accumulator with `local earliest = nil` and read the resulting errors as a narrowing limitation. It wasn't. A local declared `= nil` **with no annotation is inferred as the type `nil` forever**, and neither error names the declaration:

```
cannot use operator '<' for types integer and nil
in assignment: got integer, expected nil
```

With the annotation (`local earliest: integer | nil = nil`), the agent's exact original idiom — `if not earliest or e.timestamp < earliest then` — compiles as written; the "restructure around narrowing" it landed on was never needed.

- Both error shapes now carry an error-site hint naming the declaration and the fix. The operand shape excludes messages containing `| nil` — an honest union is a narrowing problem with its own hints, not a declaration problem.
- New gotcha with the checker-verified wrong/right pair, plus a note at the point where `guide.checking` introduces optional types.
- Canary test through the real checker, same style as the others.

Stacked on #913 (contains its commit) — merge that first and this rebases clean; it's included here because local `ci` cannot go green without it.

`--make ci` green: `ci: PASS (5 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS)_