### PR TITLE
flags: name the ordering when an option precedes the command

### DIFF
--- a/cosmic/flags/command.tl
+++ b/cosmic/flags/command.tl
@@ -70,8 +70,10 @@ end
 --- argv[1] selects the command; the rest parses against that command's
 --- own Spec. `prog --help`/`prog help` and `prog help <command>` come
 --- back as help requests (never printed here), --version likewise when
---- the spec carries a version. No command, an unknown command, or a
---- failed sub-parse is nil plus a one-line message naming the commands.
+--- the spec carries a version. No command, an unknown command, options
+--- before the command, or a failed sub-parse is nil plus a one-line
+--- message — already prefixed with the program name, so print it
+--- as-is; adding your own prefix doubles it ("todo: todo: ...").
 --- @param cspec CommandSpec The declared interface
 --- @param argv {string} The argument list (typically the global arg)
 --- @return Dispatched | nil The dispatch result, or nil on any error
@@ -103,6 +105,12 @@ local function command(cspec: CommandSpec, argv: {string}): Dispatched | nil, st
   end
   if cspec.version and first == "--version" then
     return {help = false, version = true}
+  end
+  -- An option before any command was the one mistake the generic
+  -- "unknown command '--file'" error obscured; name the ordering.
+  if first:sub(1, 1) == "-" then
+    return nil, pname .. ": options follow the command (" .. pname
+    .. " <command> [options]); commands: " .. command_names(cspec)
   end
   local cmd = find_command(cspec, first)
   if not cmd then

--- a/cosmic/flags/init.tl
+++ b/cosmic/flags/init.tl
@@ -38,7 +38,9 @@
 --- CommandSpec — one Spec per subcommand — and dispatch with
 --- flags.command(cspec, arg); flags.command_help renders the overview
 --- or a command's page. Same contract as parse: never prints, never
---- exits.
+--- exits. Options follow the command (`todo add --file x`), and error
+--- strings arrive already prefixed with the program name — print them
+--- as-is, or a caller's own prefix doubles it.
 ---
 ---   local cspec: flags.CommandSpec = {
 ---     name = "todo",

--- a/cosmic/flags_test.tl
+++ b/cosmic/flags_test.tl
@@ -214,6 +214,18 @@ local function test_command_errors_name_the_commands()
 end
 test_command_errors_name_the_commands()
 
+local function test_command_option_before_command_names_the_order()
+  -- The generic "unknown command '--file'" read like a spec problem;
+  -- the ordering error says what to type instead. --help/-h/--version
+  -- keep their meanings (covered below), so only OTHER leading options
+  -- take this path.
+  local d, err = flags.command(make_cspec(), {"--all", "list"})
+  assert(d == nil, "an option before the command is an error")
+  assert(err:find("options follow the command", 1, true), "got: " .. err)
+  assert(err:find("add, list", 1, true), "the commands are still named: " .. err)
+end
+test_command_option_before_command_names_the_order()
+
 local function test_command_help_and_version_forms()
   for _, argv in ipairs({{"--help"}, {"-h"}, {"help"}}) do
     local d = check.must(flags.command(make_cspec(), argv))


### PR DESCRIPTION
Round-4 feedback from the first eval agent to use `flags.command` in anger: `todo --file x add` produced `unknown command '--file'`, which reads like a spec problem — and the agent also re-prefixed error strings in its `die()` helper, printing `todo: todo: unknown command ...`.

- An option in the command position now gets its own error naming the grammar: `todo: options follow the command (todo <command> [options]); commands: add, list`. `--help`/`-h`/`--version` keep their meanings; only *other* leading options take the new path.
- The doc contract now states both conventions where the API is introduced (`command`'s doc and the module header): options follow the command, and error strings arrive **already prefixed** with the program name — print them as-is, or a caller's own prefix doubles it.

Test covers the new error (order named, commands still listed) alongside the existing help/version forms. `--make ci` green: `ci: PASS (5 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS)_