### PR TITLE
docs: guide snippets survive being copied into a gated project

### DIFF
--- a/_build/skills_test.tl
+++ b/_build/skills_test.tl
@@ -273,32 +273,64 @@ test_everything_else_teaches_never_embedded()
 print("all skill ratchet tests passed")
 
 -- Every teal/lua snippet in the guides must survive being copied into
--- a gated project: the formatter collapses a trailing comment to one
--- space after the code, so an aligned comment column in a guide is a
--- fmt failure shipped as advice (a round-4 eval agent hit exactly
--- that, from guide.lint's own cast-justify example). Full-line
--- comments are exempt — they are prose, not trailing.
-local function test_guide_snippets_use_single_space_trailing_comments()
-  local offenders: {string} = {}
+-- a gated project, and the authority on what survives is the FORMATTER
+-- itself, not a hand-kept rule list: every fence that parses must be a
+-- formatter fixpoint. Fragments and deliberate syntax errors do not
+-- parse, so they skip themselves; a fence that deliberately shows
+-- WRONG formatting opts out with a `nofmt` word on its info string
+-- (```teal nofmt). The single textual rule that still runs on every
+-- fence, parseable or not, is trailing-comment spacing — the one a
+-- round-4 eval agent hit from guide.lint's own example.
+local record Fence
+  file: string
+  line: integer
+  lang: string
+  info: string
+  body: string
+end
+
+local function guide_fences(): {Fence}
+  local fences: {Fence} = {}
   for _, name in ipairs(check.must(fs.find(SKILLS_DIR, {glob = "*.md"})) as {string}) do -- cast: find returns paths
     local text = check.must(fs.read(name))
     local in_code = false
-    local lang = ""
     local lineno = 0
+    local current: Fence = nil
+    local body: {string} = {}
     for line in (text .. "\n"):gmatch("([^\n]*)\n") do
       lineno = lineno + 1
-      local fence = line:match("^```(%w*)")
-      if fence then
+      local lang, info = line:match("^```(%w*)(.*)$")
+      if lang then
         if in_code then
+          current.body = table.concat(body, "\n")
+          fences[#fences + 1] = current
+          current = nil
           in_code = false
         else
           in_code = true
-          lang = fence
+          body = {}
+          current = {file = name, line = lineno, lang = lang, info = info}
         end
-      elseif in_code and (lang == "teal" or lang == "lua") then
+      elseif in_code then
+        body[#body + 1] = line
+      end
+    end
+  end
+  return fences
+end
+
+local function test_guide_snippets_use_single_space_trailing_comments()
+  local offenders: {string} = {}
+  for _, fence in ipairs(guide_fences()) do
+    local applicable = (fence.lang == "teal" or fence.lang == "lua")
+    and not fence.info:find("nofmt", 1, true)
+    if applicable then
+      local n = fence.line
+      for line in (fence.body .. "\n"):gmatch("([^\n]*)\n") do
+        n = n + 1
         local trimmed = line:match("^%s*(.*)$")
         if not trimmed:match("^%-%-") and line:match("%S%s%s+%-%-") then
-          offenders[#offenders + 1] = name .. ":" .. lineno .. ": " .. line
+          offenders[#offenders + 1] = fence.file .. ":" .. n .. ": " .. line
         end
       end
     end
@@ -309,3 +341,32 @@ local function test_guide_snippets_use_single_space_trailing_comments()
     "fails fmt:\n  " .. table.concat(offenders, "\n  "))
 end
 test_guide_snippets_use_single_space_trailing_comments()
+
+local function test_guide_snippets_are_formatter_fixpoints()
+  local format = require("cosmic.format")
+  local offenders: {string} = {}
+  local checked = 0
+  for _, fence in ipairs(guide_fences()) do
+    local applicable = (fence.lang == "teal" or fence.lang == "lua")
+    and not fence.info:find("nofmt", 1, true)
+    if applicable then
+      local ext = fence.lang == "lua" and ".lua" or ".tl"
+      local result = format.format(fence.body .. "\n", "snippet" .. ext)
+      -- A fence that does not parse is a fragment or a deliberate
+      -- syntax-error example; there is nothing to hold it to.
+      if result.ok then
+        checked = checked + 1
+        if result.code ~= fence.body .. "\n" then
+          offenders[#offenders + 1] = fence.file .. ":" .. fence.line ..
+          ": formatter disagrees; formatted form:\n" .. result.code
+        end
+      end
+    end
+  end
+  assert(checked > 0, "no guide fence parsed; the harness is broken")
+  assert(#offenders == 0,
+    "guide snippet(s) the formatter would rewrite — advice must pass " ..
+    "the gate it teaches (mark a deliberate wrong-formatting example " ..
+    "with ```teal nofmt):\n" .. table.concat(offenders, "\n"))
+end
+test_guide_snippets_are_formatter_fixpoints()

--- a/_build/skills_test.tl
+++ b/_build/skills_test.tl
@@ -271,3 +271,41 @@ end
 test_everything_else_teaches_never_embedded()
 
 print("all skill ratchet tests passed")
+
+-- Every teal/lua snippet in the guides must survive being copied into
+-- a gated project: the formatter collapses a trailing comment to one
+-- space after the code, so an aligned comment column in a guide is a
+-- fmt failure shipped as advice (a round-4 eval agent hit exactly
+-- that, from guide.lint's own cast-justify example). Full-line
+-- comments are exempt — they are prose, not trailing.
+local function test_guide_snippets_use_single_space_trailing_comments()
+  local offenders: {string} = {}
+  for _, name in ipairs(check.must(fs.find(SKILLS_DIR, {glob = "*.md"})) as {string}) do -- cast: find returns paths
+    local text = check.must(fs.read(name))
+    local in_code = false
+    local lang = ""
+    local lineno = 0
+    for line in (text .. "\n"):gmatch("([^\n]*)\n") do
+      lineno = lineno + 1
+      local fence = line:match("^```(%w*)")
+      if fence then
+        if in_code then
+          in_code = false
+        else
+          in_code = true
+          lang = fence
+        end
+      elseif in_code and (lang == "teal" or lang == "lua") then
+        local trimmed = line:match("^%s*(.*)$")
+        if not trimmed:match("^%-%-") and line:match("%S%s%s+%-%-") then
+          offenders[#offenders + 1] = name .. ":" .. lineno .. ": " .. line
+        end
+      end
+    end
+  end
+  assert(#offenders == 0,
+    "guide snippet(s) with multi-space trailing comments — the " ..
+    "formatter collapses these to one space, so copying the snippet " ..
+    "fails fmt:\n  " .. table.concat(offenders, "\n  "))
+end
+test_guide_snippets_use_single_space_trailing_comments()

--- a/skills/cosmic/SKILL.md
+++ b/skills/cosmic/SKILL.md
@@ -49,7 +49,7 @@ end
 if proc.is_main() then
   print(greet(arg[1] or "world"))
 end
-return { greet = greet }
+return {greet = greet}
 ```
 
 ## Detailed Guides

--- a/skills/cosmic/checking.md
+++ b/skills/cosmic/checking.md
@@ -35,8 +35,8 @@ messages.
 local x: number = 42
 local name: string = "hello"
 local flag: boolean = true
-local items: {string} = {"a", "b"}        -- array of strings
-local map: {string: number} = {x = 1}     -- map
+local items: {string} = {"a", "b"} -- array of strings
+local map: {string: number} = {x = 1} -- map
 ```
 
 ### Optional Types
@@ -46,7 +46,7 @@ local function read(path: string, size?: number): string, string
   -- size is optional (may be nil)
 end
 
-local value: string = nil  -- ERROR: string cannot be nil
+local value: string = nil -- ERROR: string cannot be nil
 ```
 
 use `?` on parameters to make them optional. for nullable local variables, use the nil-returning pattern from the function signature.
@@ -60,7 +60,7 @@ to a single `type()` check:
 ```teal
 local sock = net.connect_tcp(host, port) -- Socket | nil
 if sock is net.Socket then
-  sock:send("hello")                     -- narrowed, no cast
+  sock:send("hello") -- narrowed, no cast
 end
 ```
 
@@ -90,18 +90,18 @@ not return an iterator`, `attempting ipairs on something that's not an
 array: {T} | nil`):
 
 ```teal
-local r = make()        -- r: R | nil
+local r = make() -- r: R | nil
 
 -- WRONG: r stays R | nil below this guard
 if not r then
   return nil, "no r"
 end
-print(r.x)              -- error: cannot index key 'x' ... R | nil
+print(r.x) -- error: cannot index key 'x' ... R | nil
 
 -- RIGHT (branching): do the work inside the positive branch, handing
 -- it to a helper that takes the narrowed type
 if r is R then
-  return run(r)         -- run(r: R) receives a plain R
+  return run(r) -- run(r: R) receives a plain R
 end
 return nil, "no r"
 
@@ -109,7 +109,7 @@ return nil, "no r"
 if not r then
   return nil, "no r"
 end
-local rr = r as R       -- cast: record union after guard
+local rr = r as R -- cast: record union after guard
 print(rr.x)
 ```
 
@@ -126,9 +126,9 @@ after `if report.earliest ~= nil then`, `report.earliest` is still
 the local narrows normally:
 
 ```teal
-local earliest = report.earliest   -- integer | nil
+local earliest = report.earliest -- integer | nil
 if earliest ~= nil then
-  print(earliest + 1)              -- narrowed; the field read would not be
+  print(earliest + 1) -- narrowed; the field read would not be
 end
 ```
 
@@ -213,7 +213,7 @@ global TEST_BIN: string
 ```teal
 -- WRONG: data might be nil
 local data = fs.read(path)
-print(#data)  -- error if data is nil
+print(#data) -- error if data is nil
 
 -- RIGHT: handle the nil case
 local data, err = fs.read(path)

--- a/skills/cosmic/checking.md
+++ b/skills/cosmic/checking.md
@@ -168,7 +168,7 @@ local record JsonModule
   encode: function(value: any): string, string
 end
 
-local M: JsonModule = { decode = decode, encode = encode }
+local M: JsonModule = {decode = decode, encode = encode}
 return M
 ```
 

--- a/skills/cosmic/docs.md
+++ b/skills/cosmic/docs.md
@@ -25,7 +25,7 @@ cosmic -i                         # start interactive REPL
 inside the REPL:
 
 ```lua
-help()                            -- list all modules
-help("json")                      -- look up a module
-help("fs.join")                   -- look up a specific function
+help() -- list all modules
+help("json") -- look up a module
+help("fs.join") -- look up a specific function
 ```

--- a/skills/cosmic/formatting.md
+++ b/skills/cosmic/formatting.md
@@ -12,7 +12,7 @@ cosmic enforces consistent code formatting via `cosmic --format` and `cosmic --c
   aligned comment columns are collapsed by the formatter
 - no spaces inside table braces:
 
-```teal
+```teal nofmt
 local t = { a = 1 } -- wrong
 local t = {a = 1} -- right
 ```

--- a/skills/cosmic/formatting.md
+++ b/skills/cosmic/formatting.md
@@ -8,11 +8,13 @@ cosmic enforces consistent code formatting via `cosmic --format` and `cosmic --c
 - LF line endings (no CRLF)
 - consistent spacing around operators and keywords
 - all `.tl` files must be <=500 lines
+- a trailing comment sits ONE space after the code (`x = 1 -- note`);
+  aligned comment columns are collapsed by the formatter
 - no spaces inside table braces:
 
 ```teal
-local t = { a = 1 }   -- wrong
-local t = {a = 1}     -- right
+local t = { a = 1 } -- wrong
+local t = {a = 1} -- right
 ```
 
 - a table constructor passed as a function argument indents its contents

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -9,7 +9,7 @@ Teal distinguishes `integer` from `number`. string indices (`string.sub`, `strin
 **wrong:**
 ```teal
 local n: number = 5
-local s = ("hello"):sub(n, n)  -- error: got number, expected integer
+local s = ("hello"):sub(n, n) -- error: got number, expected integer
 ```
 
 **right:**
@@ -35,7 +35,7 @@ local code: number = child.WEXITSTATUS(status)
 **wrong:**
 ```teal
 local data = json.decode(input)
-for _, item in ipairs(data) do  -- error: attempting ipairs on something that's not an array: <any type>
+for _, item in ipairs(data) do -- error: attempting ipairs on something that's not an array: <any type>
 ```
 
 **right — `is` when the shape is uncertain** (narrows in the positive
@@ -67,7 +67,7 @@ the global `arg` table has type `{string | nil}`. accessing `arg[1]` without a g
 
 **wrong:**
 ```teal
-local name = arg[1]:upper()  -- error: cannot index nil
+local name = arg[1]:upper() -- error: cannot index nil
 ```
 
 **right:**
@@ -88,7 +88,7 @@ functions that return `(iterator, state, initial)` (like `db:query`) cannot be w
 
 **wrong:**
 ```teal
-for row in db:query("SELECT * FROM t"), nil, nil do  -- syntax error / wrong returns
+for row in db:query("SELECT * FROM t"), nil, nil do -- syntax error / wrong returns
 ```
 
 **right:**
@@ -116,12 +116,12 @@ end
 ```teal
 -- both are equivalent when mymod.tl is in the same directory:
 local m = require("mymod")
-local m2 = require("./mymod")  -- also works
+local m2 = require("./mymod") -- also works
 ```
 
 if your module is in a subdirectory:
 ```teal
-local m = require("subdir.mymod")   -- loads subdir/mymod.tl
+local m = require("subdir.mymod") -- loads subdir/mymod.tl
 ```
 
 ## 6. naming `cosmic.fd` as `io`
@@ -130,15 +130,15 @@ local m = require("subdir.mymod")   -- loads subdir/mymod.tl
 
 **wrong:**
 ```teal
-local io = require("cosmic.fd")   -- hides io.stderr!
-io.stderr:write("error\n")        -- runtime error: attempt to index nil
+local io = require("cosmic.fd") -- hides io.stderr!
+io.stderr:write("error\n") -- runtime error: attempt to index nil
 ```
 
 **right:**
 ```teal
-local fs = require("cosmic.fs")  -- keep built-in io accessible
+local fs = require("cosmic.fs") -- keep built-in io accessible
 fs.write("out.txt", data)
-io.stderr:write("error: " .. msg .. "\n")  -- standard Lua io still works
+io.stderr:write("error: " .. msg .. "\n") -- standard Lua io still works
 ```
 
 cosmic.fd has no stderr/stdout/stdin handles — use Lua's `io.stderr` directly for stream output.
@@ -154,13 +154,13 @@ the interpreter path lives at `arg[-1]`, and because `arg` is typed
 **wrong:**
 ```teal
 local child = require("cosmic.child")
-local h = child.start({arg[0], "worker.tl"})  -- spawns /zip/main.lua: fails
+local h = child.start({arg[0], "worker.tl"}) -- spawns /zip/main.lua: fails
 ```
 
 **right:**
 ```teal
 local child = require("cosmic.child")
-local cosmic_bin = rawget(arg, -1) as string  -- e.g. "./cosmic"
+local cosmic_bin = rawget(arg, -1) as string -- e.g. "./cosmic"
 local h = child.start({cosmic_bin, "worker.tl"})
 ```
 
@@ -201,17 +201,17 @@ R | nil`, `expression in for loop does not return an iterator`,
 
 **wrong:**
 ```teal
-local db = sqlite.open(path)   -- Database | nil
+local db = sqlite.open(path) -- Database | nil
 if not db then
   return nil, "open failed"
 end
-db:exec(sql)  -- error: cannot index key 'exec' ... Database | nil
+db:exec(sql) -- error: cannot index key 'exec' ... Database | nil
 ```
 
 **right — branch with `is` and do the work inside the positive branch:**
 ```teal
 if db is sqlite.Database then
-  return run(db)   -- run(db: sqlite.Database) receives it narrowed
+  return run(db) -- run(db: sqlite.Database) receives it narrowed
 end
 return nil, "open failed"
 ```
@@ -221,7 +221,7 @@ return nil, "open failed"
 if not db then
   return nil, "open failed"
 end
-local d = db as sqlite.Database  -- cast: record union after guard
+local d = db as sqlite.Database -- cast: record union after guard
 d:exec(sql)
 ```
 
@@ -245,7 +245,7 @@ export a type, nest it inside the module's returned interface record.
 
 **wrong** (`store.tl`):
 ```teal
-local record Task        -- file-local: importers cannot name it
+local record Task -- file-local: importers cannot name it
   id: integer
   text: string
 end
@@ -258,7 +258,7 @@ end
 **right:**
 ```teal
 local record StoreModule
-  record Task            -- nested: importers write store.Task
+  record Task -- nested: importers write store.Task
     id: integer
     text: string
   end
@@ -292,8 +292,8 @@ local record StoreModule
   add: function(db: sqlite.Database, name: string): boolean, string
 end
 
-db:add("alice")     -- error: invalid key 'add' in record 'db' of type sqlite.Database
-store.add(db, "alice")  -- right: module function, dot-called, value first
+db:add("alice") -- error: invalid key 'add' in record 'db' of type sqlite.Database
+store.add(db, "alice") -- right: module function, dot-called, value first
 ```
 
 to get colon-call ergonomics for your own type, declare your own record

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -310,7 +310,7 @@ the declaration as the cause:
 
 **wrong:**
 ```teal
-local earliest = nil            -- type: nil
+local earliest = nil -- type: nil
 for _, e in ipairs(entries) do
   if not earliest or e.timestamp < earliest then
     -- error: cannot use operator '<' for types integer and nil

--- a/skills/cosmic/lint.md
+++ b/skills/cosmic/lint.md
@@ -35,7 +35,7 @@ line directly above when 90 columns will not fit it. one comment covers
 the whole line, however many casts the line holds.
 
 ```teal
-local d = db as sqlite.Database  -- cast: record union after guard
+local d = db as sqlite.Database -- cast: record union after guard
 
 -- cast: from any (json.decode result)
 local obj = json.decode(input) as {string: any}
@@ -89,9 +89,9 @@ meant: `, 1, true` for a plain substring, `, 1, false` to mean the
 pattern.
 
 ```teal
-s:find(path, 1, true)   -- substring: a dash in path stays a dash
-s:find(pat, 1, false)   -- pattern, on purpose
-s:find("%d+")           -- literals are exempt: this reads as a pattern
+s:find(path, 1, true) -- substring: a dash in path stays a dash
+s:find(pat, 1, false) -- pattern, on purpose
+s:find("%d+") -- literals are exempt: this reads as a pattern
 ```
 
 there is no plain flag on `match`/`gmatch`/`gsub`, so a variable needle

--- a/skills/cosmic/platforms.md
+++ b/skills/cosmic/platforms.md
@@ -48,7 +48,7 @@ the sandbox family is where OSes differ most. all four modules are **fail-closed
 ```teal
 local sandbox = require("cosmic.sandbox")
 if sandbox.available().fs then
-  assert(sandbox.apply{fs = {ro = {"/usr"}, rw = {"/tmp"}}})
+  assert(sandbox.apply {fs = {ro = {"/usr"}, rw = {"/tmp"}}})
 end
 ```
 

--- a/skills/cosmic/platforms.md
+++ b/skills/cosmic/platforms.md
@@ -4,7 +4,7 @@ cosmic ships one fat binary that runs on Linux, macOS, Windows, FreeBSD, OpenBSD
 
 ```teal
 local sys = require("cosmic.sys")
-sys.host_os()  -- "linux" | "macos" | "windows" | "freebsd" | "openbsd" | "netbsd"
+sys.host_os() -- "linux" | "macos" | "windows" | "freebsd" | "openbsd" | "netbsd"
 sys.platform() -- "linux-x86_64", "macos-aarch64", ...
 ```
 

--- a/skills/cosmic/recipes.md
+++ b/skills/cosmic/recipes.md
@@ -97,7 +97,7 @@ run another script in a child process and read its output through a pipe.
 ```teal
 local child = require("cosmic.child")
 
-local cosmic_bin = rawget(arg, -1) as string  -- NOT arg[0]; see gotchas #7
+local cosmic_bin = rawget(arg, -1) as string -- NOT arg[0]; see gotchas #7
 local h, err = child.start({cosmic_bin, "worker.tl"})
 assert(h, err)
 local _, out = h:read()

--- a/skills/cosmic/testing.md
+++ b/skills/cosmic/testing.md
@@ -45,7 +45,7 @@ the preferred way to write assertions is with `cosmic.check`, which produces aut
 ```teal
 local check = require("cosmic.check")
 
-check.eq(result, "expected", "label")      -- equality with diff on failure
+check.eq(result, "expected", "label") -- equality with diff on failure
 check.ne(result, nil, "should not be nil")
 check.ok(result > 0, "expected positive")
 ```


### PR DESCRIPTION
A round-4 eval agent copied `guide.lint`'s cast-justify example verbatim and failed its first `ci` on it: the guides wrote trailing comments with aligned or double-spaced columns, and the formatter collapses a trailing comment to exactly one space. Advice that fails the gate it teaches is worse than no advice.

This PR makes the **formatter itself** the gate on guide snippets, rather than a hand-kept rule list:

- **Every `teal`/`lua` fence that parses must be a formatter fixpoint** — checked by running `cosmic.format` over the fence body, so the whole rulebook applies and a formatter change re-gates the docs automatically. Fragments and deliberate syntax-error examples don't parse and skip themselves; a fence that exists to show *wrong* formatting opts out with a `nofmt` word on its info string (`guide.formatting`'s wrong/right pair is the one).
- The trailing-comment rule still runs textually on every fence, parseable or not — the wrong-examples it protects are often unparseable on purpose.
- All 44 multi-space trailing comments across the guides normalized; `guide.formatting` states the one-space rule.
- The stronger gate immediately caught **three more snippets teaching off-style code**: padded module-table braces in `SKILL.md` and `guide.checking`, and a missing space before an argument table in `guide.platforms` — all normalized to the formatter's own output.

Also proof it works: this PR's first CI run failed because the ratchet caught #914's freshly-merged gotcha snippet on the merge ref — its first real catch, fixed here by the same normalization.

`--make ci` green: `ci: PASS (5 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pr9m7vaj7se7rdqDyw6XWS