### PR TITLE
docs: record scanner skips comments and strings, so no field hides

### DIFF
--- a/cosmic/doc/init.tl
+++ b/cosmic/doc/init.tl
@@ -82,6 +82,11 @@ local function parse_record_fields(source: string, body: string, body_start: int
 end
 
 --- Find the end of a record block via record/enum vs end depth tracking.
+--- Skips string literals and comments, and matches full identifiers, so a
+--- keyword inside either never closes the block early: an `end` in a
+--- field's doc comment ("bare nil at end of stream") used to truncate
+--- cosmic.net's Socket record right there, hiding every later field from
+--- the rendered docs and the per-symbol index.
 --- @param text string The text to scan
 --- @param start integer Position just inside the record (after its header line)
 --- @return integer Position of the last body character (before `end`)
@@ -91,15 +96,38 @@ local function find_record_end(text: string, start: integer): integer, integer
   local i = start
   local rec_end = i
   while i <= #text and depth > 0 do
-    local word_start, word_end, word = text:find("(%a+)", i)
-    if word_start == i then
-      if word == "record" or word == "enum" then depth = depth + 1
-      elseif word == "end" then
-        depth = depth - 1
-        if depth == 0 then rec_end = word_start - 1 end
+    local c = text:sub(i, i)
+    if c == '"' or c == "'" then
+      i = i + 1
+      while i <= #text do
+        if text:sub(i, i) == "\\" then
+          i = i + 2
+        elseif text:sub(i, i) == c then
+          i = i + 1
+          break
+        else
+          i = i + 1
+        end
       end
-      i = word_end + 1
-    else i = i + 1 end
+    elseif text:sub(i, i + 1) == "--" then
+      if text:sub(i + 2, i + 3) == "[[" then
+        local close = text:find("]]", i + 4, true)
+        i = close and close + 2 or #text + 1
+      else
+        local newline = text:find("\n", i)
+        i = newline and newline + 1 or #text + 1
+      end
+    else
+      local word_start, word_end, word = text:find("([%a_][%w_]*)", i)
+      if word_start == i then
+        if word == "record" or word == "enum" then depth = depth + 1
+        elseif word == "end" then
+          depth = depth - 1
+          if depth == 0 then rec_end = word_start - 1 end
+        end
+        i = word_end + 1
+      else i = i + 1 end
+    end
   end
   return rec_end, i
 end

--- a/cosmic/doc/init_test.tl
+++ b/cosmic/doc/init_test.tl
@@ -69,6 +69,55 @@ end
 end
 test_parse_record()
 
+-- A keyword inside a field's doc comment must not close the record: an
+-- "end" in a comment used to truncate Socket at that field, dropping
+-- every later field from the docs. Identifiers like end_time must not
+-- count either.
+local function test_parse_record_keyword_in_comment()
+  local source = [[
+--- A stream endpoint.
+local record Conn
+  --- Returns bare nil at end of stream, per the record contract.
+  recv: function(self: Conn): string | nil, string
+  --- Ends after end_time elapses.
+  deadline: function(self: Conn): integer
+  close: function(self: Conn): boolean, string
+end
+]]
+
+  local result = doc.parse(source, "test.tl")
+  assert(#result.records == 1, "should find one record")
+  local rec = result.records[1]
+  assert(#rec.fields == 3, "expected 3 fields, got " .. #rec.fields)
+  assert(rec.fields[3][1] == "close", "field after keyword comments should survive")
+end
+test_parse_record_keyword_in_comment()
+
+-- Keywords inside string literals (nested enum values) and long comments
+-- must not close the record either.
+local function test_parse_record_keyword_in_strings_and_long_comments()
+  local source = [[
+--- Connection settings.
+local record Config
+  --[==[ a long comment: end record enum ]==]
+  enum Mode
+    "fast end"
+    "safe \"end\" mode"
+  end
+  mode: Mode
+  retries: integer
+end
+]]
+  source = source:gsub("%[==%[", "[["):gsub("%]==%]", "]]")
+
+  local result = doc.parse(source, "test.tl")
+  assert(#result.records >= 1, "should find the record")
+  local rec = result.records[1]
+  local last = rec.fields[#rec.fields]
+  assert(last and last[1] == "retries", "fields after strings/comments should survive")
+end
+test_parse_record_keyword_in_strings_and_long_comments()
+
 -- Test parsing Example_* functions
 local function test_parse_example()
   local source = [[

--- a/cosmic/doc/lookup_test.tl
+++ b/cosmic/doc/lookup_test.tl
@@ -1,0 +1,86 @@
+#!/usr/bin/env cosmic
+-- test cosmic.doc.lookup: scoring, symbol location, and not-found messages
+
+local lookup = require("cosmic.doc.lookup")
+local types = require("cosmic.doc.types")
+local ModuleDoc = types.ModuleDoc
+local DocIndex = types.DocIndex
+
+local function make_index(): DocIndex
+  local net: ModuleDoc = {
+    file = "net.tl",
+    functions = {
+      {name = "listen_tcp", description = "Listen on a TCP port",
+        params = {}, returns = {}, signature = "()", line = 1, is_local = false},
+    },
+    records = {
+      {name = "Socket", description = "A socket", line = 10, fields = {
+          {"fd", "integer", "descriptor"},
+          {"accept", "function(self: Socket): Socket | nil, string", "accept one"},
+          {"recv", "function(self: Socket): string | nil, string", "receive"},
+        }},
+    },
+    examples = {},
+  }
+  local empty: ModuleDoc = {
+    file = "empty.tl", functions = {}, records = {}, examples = {},
+  }
+  return {modules = {net = net, empty = empty}}
+end
+
+local function test_calc_score_ranks_exact_partial_desc()
+  assert(lookup.calc_score("accept", nil, "accept", 9, 5, 2) == 9, "exact name")
+  assert(lookup.calc_score("accept_load", nil, "accept", 9, 5, 2) == 5, "partial name")
+  assert(lookup.calc_score("other", "will accept peers", "accept", 9, 5, 2) == 2, "desc")
+  assert(lookup.calc_score("other", "unrelated", "accept", 9, 5, 2) == 0, "no match")
+end
+test_calc_score_ranks_exact_partial_desc()
+
+local function test_find_symbol_locations_sees_functions_and_methods()
+  local index = make_index()
+  local funcs = lookup.find_symbol_locations("listen_tcp", index)
+  assert(#funcs == 1 and funcs[1] == "net.listen_tcp", "function location")
+  local recs = lookup.find_symbol_locations("Socket", index)
+  assert(#recs == 1 and recs[1] == "net.Socket", "record location")
+  local methods = lookup.find_symbol_locations("accept", index)
+  assert(#methods == 1 and methods[1] == "net.accept", "method field location")
+  local none = lookup.find_symbol_locations("fd", index)
+  assert(#none == 0, "non-function fields are not addressable")
+end
+test_find_symbol_locations_sees_functions_and_methods()
+
+local function test_list_symbols_includes_record_methods()
+  local index = make_index()
+  local symbols = lookup.list_symbols(index.modules["net"])
+  local seen: {string: boolean} = {}
+  for _, s in ipairs(symbols) do seen[s] = true end
+  assert(seen["listen_tcp"], "functions listed")
+  assert(seen["Socket"], "records listed")
+  assert(seen["accept"] and seen["recv"], "record methods listed")
+  assert(not seen["fd"], "plain fields not listed")
+end
+test_list_symbols_includes_record_methods()
+
+local function test_symbol_not_found_suggests_locations()
+  local index = make_index()
+  local msg = lookup.symbol_not_found("accept", "empty", index)
+  assert(msg:find("not found in 'empty'", 1, true), "names the module searched")
+  assert(msg:find("Did you mean?", 1, true), "suggests other locations")
+  assert(msg:find("cosmic --docs net.accept", 1, true), "points at the real home")
+end
+test_symbol_not_found_suggests_locations()
+
+local function test_symbol_not_found_lists_available_symbols()
+  local index = make_index()
+  local msg = lookup.symbol_not_found("nosuchname", "net", index)
+  assert(msg:find("Available symbols in net", 1, true), "lists the module's symbols")
+  assert(msg:find("accept", 1, true), "record methods appear in the listing")
+end
+test_symbol_not_found_lists_available_symbols()
+
+local function test_symbol_not_found_empty_module_points_at_docs()
+  local index = make_index()
+  local msg = lookup.symbol_not_found("nosuchname", "empty", index)
+  assert(msg:find("cosmic --docs empty", 1, true), "empty module points at its doc page")
+end
+test_symbol_not_found_empty_module_points_at_docs()


### PR DESCRIPTION
## What

`find_record_end` in `cosmic/doc/init.tl` counted bare `record`/`enum`/`end` words with no comment or string awareness, and matched with `%a+`. Any record whose field doc comment contains the word "end" truncated at that field.

Concretely, before this fix:

- `--docs cosmic.net` rendered `Socket` with only 9 of its 25 methods — everything from `recv` onward (whose comment says "**end** of stream") was hidden: `accept`, `recv`, `readline`, `recv_exact`, `getsockname`, `getpeername`, `bind`, `listen`, `connect`, `set_timeout`, ...
- `--docs cosmic.net.accept` answered "symbol not found" for a method that exists, because the per-symbol index is built from the same parse.
- `child.Handle` lost `read` the same way ("bare nil at **end** of file").

The scanner now skips string literals and comments and matches full identifiers (`end_time` no longer lexes as `end`) — the same three rules `cosmic/doc/scan.tl` documents as "fixed once here" for block scanning; this was the remaining hand-rolled copy.

## Why it matters

Round-5 clean-room eval finding (agent A, top-ranked friction): the agent had to reverse-engineer `accept`/`recv`/`getsockname` signatures from example code, and hand-rolled a newline-buffering line reader for its TCP line protocol because `Socket:readline` never appeared in any doc surface it could find.

## Tests

- `test_parse_record_keyword_in_comment`: fields after a comment containing `end`/`end_time` survive.
- `test_parse_record_keyword_in_strings_and_long_comments`: keywords inside nested-enum string values (with escapes) and long comments don't close the record.
- New `cosmic/doc/lookup_test.tl`: the not-found suggestion paths (`Did you mean?` / available-symbols listing) were previously covered only incidentally — by real symbols failing to resolve, i.e. by this very bug — so the coverage ratchet flagged the fix as a decline. They're now covered deterministically against a synthetic index.

`--make ci`: PASS (5 stages). After the fix, `--docs cosmic.net` renders all 25 `Socket` methods and `--docs cosmic.net.accept` resolves.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya)_