### PR TITLE
docs: the walk recipe stops recommending the internal fs.types shard

### DIFF
--- a/cosmic/fs/walk.tl
+++ b/cosmic/fs/walk.tl
@@ -106,9 +106,12 @@ end
 --- IMPORTANT: do NOT join path and name — path is already the full path.
 --- Joining them produces doubled paths like "dir/sub/file.txt/file.txt".
 ---
---- WalkStat is defined in cosmic.fs.types. Import it as:
----   local types = require("cosmic.fs.types")
----   local type WalkStat = types.WalkStat
+--- WalkStat is exported on the public fs module — annotate the visitor's
+--- third parameter as fs.WalkStat:
+---   local fs = require("cosmic.fs")
+---   fs.walk(dir, function(path: string, name: string, st: fs.WalkStat, ctx: any) ... end)
+--- (cosmic.fs.types is an internal shard; requiring it from outside
+--- cosmic/ fails the lint visibility rule.)
 ---
 --- If the root directory cannot be opened, returns nil plus the error.
 --- Failures below the root (unreadable subdirectory, vanished entry) do

--- a/skills/cosmic/recipes.md
+++ b/skills/cosmic/recipes.md
@@ -58,7 +58,6 @@ substring.
 
 ```teal
 local fs = require("cosmic.fs")
-local fs_types = require("cosmic.fs.types")
 local hash = require("cosmic.hash")
 local sqlite = require("cosmic.sqlite")
 
@@ -66,15 +65,14 @@ local db = sqlite.open("index.db")
 db:exec("CREATE TABLE IF NOT EXISTS files (" ..
   "path TEXT PRIMARY KEY, size INTEGER, digest TEXT)")
 
-fs.walk("testdata", function(path: string, _name: string, st: any, _ctx: any)
+fs.walk("testdata", function(path: string, _name: string, st: fs.WalkStat, _ctx: any)
     -- path is the FULL path; do not join it with the basename
-    local stat = st as fs_types.Stat
-    if stat:is_file() then
+    if st:is_file() then
       local data = fs.read(path)
       if data then
         db:exec("INSERT INTO files (path, size, digest) VALUES (?, ?, ?) " ..
           "ON CONFLICT(path) DO UPDATE SET size = excluded.size, " ..
-          "digest = excluded.digest", path, stat:size(), hash.sha256_hex(data))
+          "digest = excluded.digest", path, st:size(), hash.sha256_hex(data))
       end
     end
   end)
@@ -86,9 +84,10 @@ end
 db:close()
 ```
 
-for the precise `WalkStat` type, import it:
-`local types = require("cosmic.fs.types")` and annotate the visitor's third
-parameter as `types.WalkStat`.
+the visitor's third parameter is `fs.WalkStat`, exported on the public
+`cosmic.fs` module — annotate it directly, as above. (do not require
+`cosmic.fs.types`: that is an internal shard, and the lint visibility
+rule refuses it from outside `cosmic/`.)
 
 ## spawn cosmic as a child (self-reinvocation)
 


### PR DESCRIPTION
## What

`guide.recipes`' "index files into sqlite" recipe imported `cosmic.fs.types` and told readers to do the same for `WalkStat` — but the `visibility` lint rule refuses exactly that import from outside `cosmic/`. Following the guide's own advice produced a lint failure. `fs.walk`'s doc comment carried the same recommendation.

Both spots now use the public surface: annotate the walk visitor's third parameter as `fs.WalkStat` (exported on `cosmic.fs`). That also simplifies the recipe — the `st: any` + cast dance disappears because the parameter is just typed. Each spot states why the shard import is off-limits so the contradiction isn't rediscovered.

## Why it matters

Round-5 clean-room eval (agent C, friction #2, quoted): *"The guide and the linter disagree with each other... Following the doc's own advice produces a lint failure. This is a genuine inconsistency in the tool as I found it."* It cost the agent one of its three ci rounds.

## Verification

`--make ci`: PASS (5 stages) — which includes the guide-snippet gate, so the revised recipe snippet is compile-checked.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya)_