### PR TITLE
docs: say which gates build and test do NOT run, before ci says it

### DIFF
--- a/skills/cosmic/lint.md
+++ b/skills/cosmic/lint.md
@@ -47,6 +47,13 @@ remove — prefer `is` narrowing where the code branches, or `check.must`
 in tests and examples. the narrowing patterns are in
 `cosmic --docs guide.checking`.
 
+this rule fires at lint time only: `--check types`, `--make build`, and
+`--make test` all accept an unjustified cast, so the first complaint
+comes from `--make lint`/`--make ci` — or from `--check lint <file>`,
+the same gate early. it applies to every file the walk gates, test
+files included: a cast added to satisfy the checker in a `*_test.tl`
+needs its `-- cast:` reason like any other.
+
 ## call-after-define
 
 in a `*_test.tl` file, a top-level `local function test_*()` must be

--- a/skills/cosmic/quickstart.md
+++ b/skills/cosmic/quickstart.md
@@ -132,6 +132,11 @@ cosmic --make coverage --baseline    # writes .cosmic-coverage
   every rule with its fix
 - `--check types <file>` type-checks one file in isolation — the fast
   inner loop while a file is still taking shape
+- know what each verb does NOT say: `--make build` and `--make test`
+  run neither fmt nor lint, so a tree that builds and tests clean can
+  still fail `ci` on formatting drift or an unjustified `as` cast.
+  `--check fmt <file>` and `--check lint <file>` are those same gates
+  per file — run them in the inner loop too, not first at `ci` time
 
 ## where to go next
 

--- a/skills/cosmic/testing.md
+++ b/skills/cosmic/testing.md
@@ -72,6 +72,12 @@ assert(not failed, "should not fail")
 assert(output:find("expected"), "output should contain 'expected'")
 ```
 
+test files pass through the same lint gate as library code: an `as`
+cast in a test needs its `-- cast: <reason>` comment (the cast-justify
+rule in `cosmic --docs guide.lint`), and `--make test` passing says
+nothing about lint — prefer `check.must` for narrowing fallible
+returns in tests, which needs no cast at all.
+
 ## Using TEST_TMPDIR
 
 `cosmic --test` sets the `TEST_TMPDIR` environment variable to an isolated temp directory for each test. tests that create files should use it:


### PR DESCRIPTION
## What

All four round-5 clean-room eval agents lost a ci round to the same shape: a tree that type-checked, built, and tested clean failed `--make ci` on `cast-justify` or `fmt`. Two of them had read `guide.lint` in full beforehand and still tripped — in test files, because nothing connected "you'll write casts in tests too" to the rule, and because nothing states that `--make build`/`--make test` run neither fmt nor lint.

Representative journal quotes:

- agent A: *"The cast-justify lint rule isn't mentioned anywhere near guide.testing... I did read guide.lint beforehand and still tripped on it in test code."*
- agent B: *"`--make build` passing doesn't mean `--make ci` will."*
- agent C: *"I wrote and 'type checked' the whole project, felt done, and only then hit nine lint failures at once."*

## Changes

Three surfaces, each saying the fact where its reader is:

- **guide.quickstart** ("when something fails"): a bullet naming what build/test do NOT say, and `--check fmt <file>` / `--check lint <file>` as the same gates run early, in the inner loop.
- **guide.lint** (cast-justify): states the rule's timing — types/build/test all accept an unjustified cast; first complaint is at lint/ci — and that test files are gated like any other.
- **guide.testing** (assert patterns): test files pass through the same lint gate; prefer `check.must`, which needs no cast at all.

## Verification

`--make ci`: PASS (5 stages).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya)_