### PR TITLE
teal+docs: the narrowing hint and gotcha name assert(x) as a non-guard

### DIFF
--- a/cosmic/_teal_hints.tl
+++ b/cosmic/_teal_hints.tl
@@ -41,11 +41,12 @@ local function hint_for_message(msg: string): string | nil
     return "  hint: narrow first: `if v is Rec then ... end` (plain-table records), or cast after a guard for userdata handles — see `cosmic --docs guide.checking`"
   end
   -- Pattern 2b: indexing through an un-narrowed nil union. The trap is
-  -- that `if not x then return end` narrows scalars but not records,
-  -- maps or arrays — and even a narrowed SCALAR cannot be method-called
+  -- that `if not x then return end` — and `assert(x)`, which newcomers
+  -- expect to narrow — narrows scalars but not records, maps or arrays;
+  -- and even a narrowed SCALAR cannot be method-called
   -- (`data:gmatch(...)` on `string | nil` lands here too).
   if msg:find("cannot index") and msg:find("| nil", 1, true) then
-    return "  hint: `T | nil` does not narrow through `if not x` for records/maps/arrays, and a narrowed scalar cannot be method-called (use `string.gmatch(x, ...)`): branch with `if x is T then ... end`, or cast after the guard (`local v = x as T`) — see `cosmic --docs guide.checking`"
+    return "  hint: `T | nil` does not narrow through `if not x` or `assert(x)` for records/maps/arrays, and a narrowed scalar cannot be method-called (use `string.gmatch(x, ...)`): branch with `if x is T then ... end`, or cast after the guard (`local v = x as T`) — see `cosmic --docs guide.checking`"
   end
   -- Pattern 2c: for-in over a value the checker cannot call. The message
   -- names no type, and the usual cause is an iterator still `T | nil`
@@ -72,7 +73,7 @@ local function hint_for_message(msg: string): string | nil
   -- `{T} | nil` needs narrowing, a plain `any` needs a cast.
   if msg:find("attempting ipairs on something that's not an array") then
     if msg:find("| nil", 1, true) then
-      return "  hint: `{T} | nil` does not narrow through `if not x`: branch with `is` or cast after the guard (`local xs = v as {T}`) — see `cosmic --docs guide.checking`"
+      return "  hint: `{T} | nil` does not narrow through `if not x` or `assert(x)`: branch with `is` or cast after the guard (`local xs = v as {T}`) — see `cosmic --docs guide.checking`"
     end
     return "  hint: cast first, e.g. `local items = data as {any}`"
   end

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -190,14 +190,18 @@ print(encoded)
 (parenthesizing the call — `print((json.encode(result)))` — also truncates
 to one value, but capturing lets you check the error.)
 
-## 9. records, maps and arrays don't narrow through `if not x`
+## 9. records, maps and arrays don't narrow through `if not x` — or `assert`
 
 scalars (`string | nil`, `integer | nil`) narrow through an ordinary
 truthiness guard. records, maps and arrays do not — below the guard the
-value is still `T | nil`. the errors this produces name the un-narrowed
-type but not the cause: `cannot index key 'x' in variable 'r' of type
-R | nil`, `expression in for loop does not return an iterator`,
-`attempting ipairs on something that's not an array: {T} | nil`.
+value is still `T | nil`. **`assert(x, "msg")` is the same trap**: it
+terminates control flow at runtime, but the checker still sees
+`T | nil` on every line after it — do not expect the narrowing other
+typed languages attach to assert. the errors either shape produces name
+the un-narrowed type but not the cause: `cannot index key 'x' in
+variable 'r' of type R | nil`, `expression in for loop does not return
+an iterator`, `attempting ipairs on something that's not an array:
+{T} | nil`.
 
 **wrong:**
 ```teal
@@ -224,6 +228,10 @@ end
 local d = db as sqlite.Database -- cast: record union after guard
 d:exec(sql)
 ```
+
+(the same cast-after-guard works after an `assert(db, "open failed")`;
+in tests and examples, `local db = check.must(sqlite.open(path))` does
+guard and narrowing in one call, with no cast to justify.)
 
 record fields don't narrow either, even scalar ones — copy the field to
 a local and guard the local.


### PR DESCRIPTION
## What

Round-5 clean-room eval, agent D, hit the record-narrowing trap twice — once per shape. First `if not x then return end` (gotcha #9's documented shape), then, after fixing those, `assert(x, ...)`:

> *"I had assumed `assert` narrows a nilable record the way it does in some other typed languages; it does not... a reader skims [gotcha #9], mentally files it under 'guard clauses,' and doesn't generalize to 'and also `assert`,' which is the single most common way to fail fast in a Lua test file."*

## Changes

- **`cosmic/_teal_hints.tl`**: both narrowing hint messages (record/map index, ipairs-on-array) now read "does not narrow through `if not x` or `assert(x)`" — the error site is the surface the eval rounds show actually prevents the second stall, so it carries the fact first.
- **guide.gotchas #9**: title says "— or `assert`"; the first paragraph calls `assert(x, "msg")` out as the same trap explicitly; the cast-after-guard example notes it works after an assert too, and names `check.must` as the test-side answer with no cast to justify.

The existing `teal_test.tl` hint assertions match on the stable prefix ("does not narrow through") and continue to pass unchanged.

## Verification

`--make ci`: PASS (5 stages).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya)_