### PR TITLE
child: say the capture default out loud, and show the supervisor shape

### DIFF
--- a/cosmic/child/init.tl
+++ b/cosmic/child/init.tl
@@ -63,10 +63,13 @@ local record Handle is stream.Reader
 end
 
 --- Options for spawning a process.
---- stdout/stderr Handles (cosmic.fd) become the child's fd 1/2 (the
---- matching Result field is then ""); spawn does not take ownership —
---- the child gets its own copy, so close your end when done (see
---- Example_run_pipe). Raw integer fds are not part of this surface
+--- Leave stdout/stderr nil (the default) and the output is captured for
+--- you: wait/run drain the child and return the bytes in Result.stdout
+--- and Result.stderr. Set these fields only to send a stream somewhere
+--- else. stdout/stderr Handles (cosmic.fd) become the child's fd 1/2
+--- (the matching Result field is then ""); spawn does not take
+--- ownership — the child gets its own copy, so close your end when done
+--- (see Example_run_pipe). Raw integer fds are not part of this surface
 --- (api-review-2); wrap one with fd.wrap() first. "inherit" writes to
 --- THIS process's fd 1/2 so output streams as it runs; Result stays "".
 local record Options

--- a/cosmic/child/init_example.tl
+++ b/cosmic/child/init_example.tl
@@ -100,6 +100,74 @@ local function Example_run_pipe()
   -- exit:	0
 end
 
+-- Example_supervisor demonstrates the N-at-a-time pattern: run a queue of
+-- commands with a bounded number of live children and a per-command
+-- deadline. The three Handle primitives compose into the whole shape:
+-- start() launches into a free slot, try_wait() reaps whoever finished
+-- without blocking (and pumps the pipes, so a chatty child never stalls
+-- the loop), and kill() enforces the deadline. Output left nil is
+-- captured into each Result automatically.
+local function Example_supervisor()
+  local check = require("cosmic.check")
+  local child = require("cosmic.child")
+  local time = require("cosmic.time")
+
+  local commands = {
+    {"echo", "first"},
+    {"sh", "-c", "exit 3"},
+    {"sleep", "10"}, -- overruns its deadline; the supervisor kills it
+    {"echo", "last"},
+  }
+  local max_live = 2
+  local deadline_ms = 200
+
+  local statuses: {string} = {}
+  local live: {integer: child.Handle} = {}
+  local started_ms: {integer: integer} = {}
+  local live_count = 0
+  local next_command = 1
+  local done = 0
+
+  while done < #commands do
+    -- Fill free slots while commands remain.
+    while live_count < max_live and next_command <= #commands do
+      live[next_command] = check.must(child.start(commands[next_command]))
+      started_ms[next_command] = time.monotonic_ms()
+      live_count = live_count + 1
+      next_command = next_command + 1
+    end
+    for index, handle in pairs(live) do
+      local finished = handle:try_wait()
+      if not finished and time.monotonic_ms() - started_ms[index] > deadline_ms then
+        handle:kill() -- SIGTERM; wait() below reaps and reports the signal
+        finished = check.must(handle:wait())
+      end
+      if finished is child.Result then
+        local status = "fail"
+        if finished.ok then
+          status = "ok"
+        elseif finished.signal then
+          status = "timeout"
+        end
+        statuses[index] = status
+        live[index] = nil
+        live_count = live_count - 1
+        done = done + 1
+      end
+    end
+    time.sleep(0, 5 * 1000 * 1000) -- 5ms between polls: reap, don't spin
+  end
+
+  for index, status in ipairs(statuses) do
+    print(index, status)
+  end
+  -- Output:
+  -- 1	ok
+  -- 2	fail
+  -- 3	timeout
+  -- 4	ok
+end
+
 -- Suppress unused warnings for examples
 local _ = {
   Example_run,
@@ -108,4 +176,5 @@ local _ = {
   Example_kill,
   Example_wait_timeout,
   Example_run_pipe,
+  Example_supervisor,
 }


### PR DESCRIPTION
## What

Two asks from the round-5 clean-room eval (agent B, building a parallel command runner on `cosmic.child`):

1. **The capture default was never stated.** `Options`' doc comment described every redirect case (Handle → fd 1/2, `"inherit"`, pipes) but not what happens when you set nothing. The agent inferred it from the *absence* of options in `run()`'s example and asked for one explicit sentence — quote: *"I'd have liked one explicit sentence."* The doc now leads with it: leave `stdout`/`stderr` nil and `wait`/`run` capture into `Result.stdout`/`Result.stderr`; set the fields only to redirect.

2. **The N-way supervisor pattern lived nowhere while each primitive did.** Quote: *"the pattern (poll loop, capacity window, per-job deadline) isn't spelled out anywhere the way the single-child kill/wait-timeout examples are."* New `Example_supervisor` shows the whole shape — fill free slots with `start()`, reap non-blocking with `try_wait()` (which also pumps pipes), enforce a per-command deadline with `kill()`, 5ms poll between rounds — with deterministic `ok`/`fail`/`timeout` output, sitting next to the single-child examples it composes from.

## Verification

- `--check example cosmic/child/init_example.tl`: all 7 examples PASS (the supervisor's killed-by-deadline child included).
- `--make ci`: PASS (5 stages).

Noticed while verifying, deliberately not fixed here: the docs *renderer* keeps `  -- ` prefixes on the second and later lines of any multi-line `-- Output:` block (pre-existing — `Example_run_pipe` shows it too). Separate PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya)_