### PR TITLE
docs: testing a built binary end to end is supported — say so

### DIFF
--- a/skills/cosmic/testing.md
+++ b/skills/cosmic/testing.md
@@ -122,6 +122,34 @@ what that means for a test author:
 - **DNS and egress do NOT work**. a lookup or outbound connect fails or the child is killed. only write such a call if the test expects the failure (e.g. asserting that a dial to a non-allowed host errors).
 - **process control works**: fork/exec are granted (`proc exec`), so `cosmic.child` spawns are fine — but the child inherits the same sandbox.
 
+### testing the built binary end to end
+
+the sandbox does not wall off the artifact under test. exec is granted
+and binaries are built before tests run, so a test may spawn its own
+project's `o/bin/<name>` and assert on the real stdout and exit code —
+no grant to request, no configuration:
+
+```teal
+#!/usr/bin/env cosmic
+local check = require("cosmic.check")
+local child = require("cosmic.child")
+
+local function test_cli_greets()
+  local r = check.must(child.run({"o/bin/greet", "world"}))
+  check.ok(r.ok, "expected exit zero")
+  check.eq(r.stdout, "hello, world!\n", "stdout")
+end
+test_cli_greets()
+```
+
+for a server binary, have it print a readiness line (`READY <port>`)
+and block on reading it from the handle instead of sleeping — the
+readiness pattern in `cosmic --docs guide.recipes`.
+
+keep logic tests at the library layer, where functions are called
+directly; the binary spawn is for the argv-parsing and
+output-formatting skin that exists only in `cmd/<name>/main.tl`.
+
 ### opting out
 
 two escalation paths exist; prefer the tight default whenever the test can live with it:


### PR DESCRIPTION
## What

Round-5 clean-room eval, agent D (friction #2): *"I couldn't find a documented, supported way to say 'in this test, also grant read+exec on `o/bin/tokend`' so that a test could spawn the actual compiled CLI and assert on its stdout/exit code."* It read the sandbox docs' emphasis on what tests *can't* reach as a prohibition and shipped `cmd/tokend/main.tl` with zero coverage.

Agent A, same round, just did it — spawned its own freshly built `o/bin/kvwire` from a sandboxed test, and it worked with no configuration. The gap is documentation, not capability.

`guide.testing`'s sandbox section gains the subsection D went looking for: exec is granted and binaries are built before tests run, so spawn `o/bin/<name>` with `child.run` and assert on the real stdout/exit code; use a readiness line (not sleep) for server binaries; keep logic tests at the library layer — the spawn is for the argv/formatting skin that exists only in `cmd/<name>/main.tl`.

## Verification

The snippet's pattern was verified against the `hello` fixture: a `hello/cli_test.tl` spawning `o/bin/hello` passes under `--make test` from a clean `o/` (the test verb builds the binary first).

`--make ci`: PASS (5 stages).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya)_