### PR TITLE
docs: a type alias renders as a Types entry pointing at its target

### DIFF
--- a/cosmic/doc/init.tl
+++ b/cosmic/doc/init.tl
@@ -256,6 +256,37 @@ local function parse(source: string, file_path: string): ModuleDoc
         fields = fields, line = line_num,
       })
   end
+  -- Type aliases: `local type Name = target`. The alias IS the public
+  -- name (api-review-8: zip's Archive aliases the generated
+  -- cosmo.zip.Reader) while the target holds the field/method table, so
+  -- without an entry the public name is invisible in the rendered Types
+  -- section and unresolvable per-symbol. The alias renders as its own
+  -- doc comment plus a pointer at the resolved target's docs.
+  local require_paths: {string: string} = {}
+  for req_name, req_mod in source:gmatch("local%s+([%w_]+)%s*=%s*require%(\"([^\"]+)\"%)") do
+    require_paths[req_name] = req_mod
+  end
+  for alias_start, alias_name, target in source:gmatch("()local%s+type%s+([%w_]+)%s*=%s*([%w_%.]+)") do
+    local alias_doc = extract_doc_comment(source, alias_start)
+    local _, _, alias_description = parse_annotations(alias_doc)
+    local base, rest = target:match("^([%w_]+)%.(.+)$")
+    local resolved = target
+    if base and require_paths[base] then
+      resolved = require_paths[base] .. "." .. rest
+    end
+    local pointer = "alias of `" .. resolved .. "`"
+    if resolved:find(".", 1, true) then
+      pointer = pointer .. " — field and method table: `cosmic --docs " .. resolved .. "`"
+    end
+    local full_description = pointer
+    if alias_description then
+      full_description = alias_description .. "\n\n" .. pointer
+    end
+    table.insert(doc.records, {
+        name = alias_name, description = full_description,
+        fields = {}, line = 0,
+      })
+  end
   -- Examples
   line_num = 1
   last_pos = 1

--- a/cosmic/doc/init_test.tl
+++ b/cosmic/doc/init_test.tl
@@ -118,6 +118,29 @@ end
 end
 test_parse_record_keyword_in_strings_and_long_comments()
 
+-- A `local type Name = target` alias is a public name whose fields live
+-- on the target (zip's Archive = cosmo.zip.Reader): it must render as a
+-- Types entry with the target resolved through the file's requires.
+local function test_parse_type_alias_points_at_target()
+  local source = [[
+local zip = require("gen.zip")
+
+--- Reader for extracting files from an archive.
+local type Archive = zip.Reader
+]]
+
+  local result = doc.parse(source, "test.tl")
+  assert(#result.records == 1, "alias should produce a Types entry")
+  local rec = result.records[1]
+  assert(rec.name == "Archive", "alias name")
+  assert(rec.description:find("extracting files", 1, true), "keeps its doc comment")
+  assert(rec.description:find("alias of `gen.zip.Reader`", 1, true),
+    "resolves the local require binding: " .. rec.description)
+  assert(rec.description:find("cosmic --docs gen.zip.Reader", 1, true),
+    "points at the target's own docs")
+end
+test_parse_type_alias_points_at_target()
+
 -- Test parsing Example_* functions
 local function test_parse_example()
   local source = [[


### PR DESCRIPTION
## What

`cosmic.zip`'s public types are aliases (api-review-8): `Archive` *is* `cosmo.zip.Reader`, `Builder` *is* `cosmo.zip.Writer`. The doc extractor only understood `local record`, so the aliases — and their doc comments about zip-slip and entry-name validation — never rendered. `--docs cosmic.zip` stopped at the top-level functions whose signatures name types the page never defines.

Round-5 eval (agent C, friction #5): *"`cosmic --docs zip` stops short of the `Archive`/`Builder`/`Appender` method tables — I had to fall back to `cosmic --docs cosmo.zip`, the documented-as-internal low-level layer, to find the actual method signatures."* Its wished-for fix: the tables inline "or a clear forward pointer to cosmo.zip".

## How

`parse` now emits a Types entry for each `local type Name = target`: the alias's own doc comment, then ``alias of `X` — field and method table: `cosmic --docs X` ``, with the target resolved through the file's require bindings (`zip.Reader` → `cosmo.zip.Reader`, because `local zip = require("cosmo.zip")`). This is generic — `fs.WalkStat`'s alias gains the same treatment — and per-symbol lookup resolves the alias names too: `--docs cosmic.zip.Archive` now answers instead of "symbol not found".

## Verification

- New `test_parse_type_alias_points_at_target` covers alias extraction and require-path resolution.
- `--docs cosmic.zip` now renders `### Archive` (full doc comment + pointer), `### Builder`, etc.; `--docs cosmo.zip.Reader` (the pointer target) resolves.
- `--make ci`: PASS (5 stages).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya)_