### PR TITLE
docs: strip the comment prefix from every Output line, not just the first

### DIFF
--- a/cosmic/doc/init.tl
+++ b/cosmic/doc/init.tl
@@ -275,7 +275,10 @@ local function parse(source: string, file_path: string): ModuleDoc
       if line_end then
         output_pos = line_end + 1
         while true do
-          local cs, _, prefix, content = body:find("^(%s*%-%-%s?)(.*)\n?", output_pos)
+          -- One line per iteration: `.` matches newlines in Lua patterns,
+          -- so a `(.*)` here swallowed the whole remaining body as "line
+          -- one" and every later output line kept its `-- ` prefix.
+          local cs, _, prefix, content = body:find("^(%s*%-%-%s?)([^\n]*)", output_pos)
           if cs == output_pos and prefix then
             table.insert(output_lines, content)
             output_pos = output_pos + #prefix + #content

--- a/cosmic/doc/init_test.tl
+++ b/cosmic/doc/init_test.tl
@@ -136,6 +136,27 @@ end
 end
 test_parse_example()
 
+-- Every line of a multi-line Output block must lose its `-- ` prefix:
+-- `.` matches newlines in Lua patterns, so the extraction used to take
+-- the whole rest of the body as line one and leave later lines raw.
+local function test_parse_example_multiline_output()
+  local source = [[
+local function Example_multi()
+  print("a")
+  print("b:", 1)
+  -- Output:
+  -- a
+  -- b:	1
+end
+]]
+
+  local result = doc.parse(source, "test.tl")
+  assert(#result.examples == 1, "should find one example")
+  local got = result.examples[1].expected_output
+  assert(got == "a\nb:\t1", "prefixes stripped on every line, got: " .. string.format("%q", got))
+end
+test_parse_example_multiline_output()
+
 -- Test that regular `--` comments (not `---`) directly above an
 -- Example_* function are picked up as its description: doc.parse is
 -- the one caller that passes allow_regular_comments=true to


### PR DESCRIPTION
## What

Lua's `.` matches newlines, so the Output-block extraction's `(.*)` captured the whole remaining example body as "line one" — the per-line loop never looped. Every multi-line `-- Output:` block in the rendered docs showed its second and later lines with the raw `  -- ` prefix still attached:

```
Output:
```
from pipe
  -- exit:	0
```
```

Visible on `child`'s run-pipe and supervisor examples and every other multi-line expected output. One line per iteration now — `([^\n]*)`.

Found while adding the supervisor example in #921. The example *gate* was never wrong (the runner extracts expected output independently); only the rendered doc pages were.

## Verification

- New `test_parse_example_multiline_output` asserts every line loses its prefix (including a tab-containing line).
- `--examples child` now renders `from pipe` / `exit:	0` clean.
- `--make ci`: PASS (5 stages).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya)_