### PR TITLE
docs: the perf manual becomes the optimize skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ _cli/                 the dispatcher behind every flag (args, help, run, ...)
 _make/                `cosmic --make`: project model, validator, root, verbs
 _build/               ratchets over what the repo ships and derives
 _docs/                doc publishing
-_perf/                performance benchmark harness (see _perf/OPTIMIZE.md)
+_perf/                performance benchmark harness (see skills/optimize/)
 _types/               cosmo.* type declarations (generated) + gentype generator
 3p/
   cosmos/              Cosmopolitan Lua binary + zip tool
@@ -468,14 +468,15 @@ bin/cosmic --make run _perf/gate.tl compare BASE.json CUR.json SELFB.json
 bin/cosmic --make run _perf/gate.tl selfcheck A.json B.json  # A/A noise floor
 ```
 
-all performance work follows the loop in `_perf/OPTIMIZE.md`: baseline →
+all performance work follows the loop in the `optimize` skill
+(`skills/optimize/SKILL.md`): baseline →
 hypothesis → change → `--make ci` (correctness/style gate) →
 the compare gate (regression) → keep or revert. never weaken a
 scenario or its check to make numbers pass; never commit `o/perf/*.json`.
 
-the manual is split by chapter: `_perf/optimize/finding.md` (spotting
-cosmic-layer wins), `_perf/optimize/cosmopolitan.md` (the C layer against
-a local whilp/cosmopolitan build), `_perf/optimize/measurement.md` (noise
+the manual is split by chapter: `skills/optimize/finding.md` (spotting
+cosmic-layer wins), `skills/optimize/cosmopolitan.md` (the C layer against
+a local whilp/cosmopolitan build), `skills/optimize/measurement.md` (noise
 discipline). the backlog is GitHub issues labeled `perf`.
 
 ## CI

--- a/_make/runverb.tl
+++ b/_make/runverb.tl
@@ -11,7 +11,7 @@
 ---
 --- It is `test`'s shape with a different contract: build the stage, then
 --- spawn the target with its own closure as the resolution set. That is
---- what makes `_perf/OPTIMIZE.md`'s "measures whatever `o/` happens to
+--- what makes `skills/optimize/SKILL.md`'s "measures whatever `o/` happens to
 --- hold" warning retire by construction — the run is what makes `o/`
 --- fresh. See docs/design/make/resolution.md.
 

--- a/_perf/compare.tl
+++ b/_perf/compare.tl
@@ -139,7 +139,7 @@ end
 --- scenario (json, sqlite, ...) still fails the gate, and so does a huge
 --- regression in an unstable one. This makes the noise/real call
 --- deterministic instead of a manual judgement (see
---- _perf/optimize/measurement.md).
+--- skills/optimize/measurement.md).
 --- @param base Results Baseline results
 --- @param cur Results Current results
 --- @param noise_a Results First self-check pass (current binary)

--- a/bin/cosmic
+++ b/bin/cosmic
@@ -39,7 +39,7 @@ set -e
 # benchmark cannot tell you it read the wrong subject. Name the binary
 # when the identity is the experiment: `o/bin/cosmic _perf/run.tl`
 # after a build you just did, or the pinned release explicitly. See
-# _perf/optimize/measurement.md.
+# skills/optimize/measurement.md.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"

--- a/docs/design/make/README.md
+++ b/docs/design/make/README.md
@@ -5,7 +5,7 @@ and this repo builds with it. It builds a project **by convention**: the
 tree is the project — no spec file, no `rules.tl`, no `cook.mk` — and
 one binary with no host toolchain does the whole thing.
 
-This design is one chapter per file, the way `_perf/optimize/` is split,
+This design is one chapter per file, the way `skills/optimize/` is split,
 so no chapter has to fight the length cap:
 
 | chapter | what it settles |

--- a/docs/design/make/resolution.md
+++ b/docs/design/make/resolution.md
@@ -95,13 +95,13 @@ and every `_perf/bench/*` are embedded, so:
 
 ```
 $ o/bin/cosmic _perf/run.tl … _perf.bench.json_bench     # tree entry
-$ o/bin/cosmic o/_perf/run.lua …                         # OPTIMIZE.md's form
+$ o/bin/cosmic o/_perf/run.lua …                         # SKILL.md's form
 _perf.harness <- @/zip/_perf/harness.lua                 # both
 ```
 
 Edit `_perf/harness.tl` or a scenario, re-run either command, and
 nothing changes. `o/_perf/harness.lua` is sitting right there, built
-and never loaded. `_perf/OPTIMIZE.md` already warns that a benchmark
+and never loaded. `skills/optimize/SKILL.md` already warns that a benchmark
 "cannot tell you it read the wrong subject"; this is that trap one
 level down, below where naming `$BIN` can reach.
 
@@ -287,7 +287,7 @@ cosmic --make run _perf/run.tl --out o/perf/current.json $BENCH
 ```
 
 — and it retires the "measures whatever `o/` happens to hold" warning
-from `_perf/OPTIMIZE.md` by construction: the run is what makes `o/`
+from `skills/optimize/SKILL.md` by construction: the run is what makes `o/`
 fresh. `_docs/publish.tl`, invoked from `docs.yml` as a bare tree
 script, is the other caller: it imports no siblings so nothing is stale
 today, but it is correct only for as long as `bin/cosmic` happens to

--- a/skills/optimize/SKILL.md
+++ b/skills/optimize/SKILL.md
@@ -1,18 +1,31 @@
+---
+name: optimize
+description: >
+  Measurement-driven performance optimization of cosmic: baseline the
+  _perf scenario harness, change one hypothesis at a time, and gate on
+  correctness (--make ci) plus the noise-aware compare. Use when working
+  a perf-labeled issue, judging whether a change regressed performance,
+  or running a research pass to re-seed the hypothesis backlog.
+---
+
 # Optimizing cosmic performance
 
-this document is the operating manual for performance work on cosmic. it
+this skill is the operating manual for performance work on cosmic. it
 defines a measurement-driven loop with hard gates, so optimization can be
 executed mechanically — including by an agent — without risking functional
 or style regressions. read it top to bottom once before changing anything.
+like `agent-eval`, it is repo tooling for developing cosmic itself — not
+embedded in the binary, not part of the published API.
 
-it is the front door of a small set of documents, each kept in its own
-file so no chapter ever fights the repo's 500-line-per-file cap:
+it is the front door of a small set of chapters, each kept in its own
+file in this directory so no chapter ever fights the repo's
+500-line-per-file cap:
 
-- `_perf/OPTIMIZE.md` — this file: the harness, the loop, the rules.
-- `_perf/optimize/finding.md` — how to find cosmic-layer opportunities.
-- `_perf/optimize/cosmopolitan.md` — how to optimize the C layer
+- `SKILL.md` — this file: the harness, the loop, the rules.
+- `finding.md` — how to find cosmic-layer opportunities.
+- `cosmopolitan.md` — how to optimize the C layer
   (whilp/cosmopolitan) with a local build, no release required.
-- `_perf/optimize/measurement.md` — measurement discipline and noise.
+- `measurement.md` — measurement discipline and noise.
 - the hypothesis backlog — GitHub issues labeled `perf` (whilp/cosmic
   for cosmic-layer work, whilp/cosmopolitan for the C layer). see
   "the hypothesis backlog" below.
@@ -28,7 +41,7 @@ makes a workload faster but wrong FAILS the benchmark.
 The harness is scripts, driven through `--make run` by whichever binary
 you are measuring. `$BIN` is the cosmic under test (`o/bin/cosmic`, or a
 build standing on a locally built cosmopolitan lua — see
-`optimize/cosmopolitan.md`).
+`cosmopolitan.md`).
 
 **Go through `--make run`, and name `$BIN` explicitly.** Two different
 identity traps, and both return a number either way:
@@ -43,7 +56,7 @@ identity traps, and both return a number either way:
   one exists and falls back to the pin when it does not, so measuring
   through `bin/cosmic` measures whatever `o/` happens to hold.
 
-Both are the measurement-identity trap in `optimize/measurement.md`,
+Both are the measurement-identity trap in `measurement.md`,
 reachable without touching a single knob.
 
 ```bash
@@ -75,7 +88,7 @@ reproduces against itself still fails. (`_perf/run.tl --compare` is the
 plain, non-retrying diff the gate builds on — it just diffs two files.)
 `gate.tl selfcheck` runs that same A/A control standalone, for
 interactive use or to profile the machine's noise floor before you
-start. `_perf/optimize/measurement.md` has the full playbook.
+start. `measurement.md` has the full playbook.
 
 knobs: `--samples` (default 5), `--min-secs` (default 0.15),
 `--threshold` (regression bar in percent, default 10). `PERF_BIN` is not
@@ -107,12 +120,12 @@ an optimization can land in either:
 
 - **cosmic layer** — pure-Lua work a C binding could do, redundant
   syscalls, dead allocations, missing caches. fixed in `cosmic/*.tl`
-  here. see `optimize/finding.md`.
+  here. see `finding.md`.
 - **cosmopolitan layer** — the C bindings themselves, the Lua runtime,
   the APE loader and zip filesystem (`startup_*` scenarios). fixed in a
   whilp/cosmopolitan checkout and measured against a locally built
   binary by hand — you do NOT need to cut a release to
-  measure a C change. see `optimize/cosmopolitan.md`.
+  measure a C change. see `cosmopolitan.md`.
 
 after ~20 rounds the cheap cosmic-layer wins are thinning out; check the
 open `perf`-labeled issues (`gh issue list --label perf --state open`, in
@@ -126,8 +139,8 @@ work ONE scenario (or one closely related group) at a time.
 1. **baseline** on a quiet machine, from a clean tree: `git status` must
    be clean, then run the harness into `o/perf/baseline.json`.
    (for cosmopolitan-layer work, baseline the unmodified LOCAL build
-   instead — `optimize/cosmopolitan.md` has the exact commands.)
-2. **pick a target** (see `optimize/finding.md` and the backlog). state
+   instead — `cosmopolitan.md` has the exact commands.)
+2. **pick a target** (see `finding.md` and the backlog). state
    a hypothesis: *"X is slow because Y; changing Z should cut ns/op by
    W%."*
 3. **change the code.** smallest diff that tests the hypothesis. follow
@@ -158,7 +171,7 @@ work ONE scenario (or one closely related group) at a time.
      real; do not re-litigate it as noise.
    - want to see the machine's noise floor yourself → `gate.lua
      selfcheck` runs the same A/A control on demand. see
-     `optimize/measurement.md`.
+     `measurement.md`.
 7. **commit**, quoting before/after numbers for the affected scenarios in
    the commit message (copy the `perf-compare` lines), and update the
    backlog issue in the same round — comment the result and close it
@@ -190,12 +203,12 @@ product code. the workflow that has worked (entries 22-27 came out of
 one such pass):
 
 1. run the harness on current main; read every line of the report.
-2. rank suspects by the signal shapes in `optimize/finding.md`
+2. rank suspects by the signal shapes in `finding.md`
    (alloc-per-op sanity math, sibling mismatches, cpu/wall surprises).
 3. for each suspect, spend a few minutes reading the wrapper source —
    most hypotheses die or crystallize within one code read.
 4. for startup/syscall suspects, use the tracing decomposition recipes
-   in `optimize/cosmopolitan.md` (cosmo `--strace` call counting,
+   in `cosmopolitan.md` (cosmo `--strace` call counting,
    kernel `strace -c`, raw-vs-wrapped binary timing).
 5. cheap probes are allowed and encouraged — rebuild a variant
    artifact in a scratch directory and shell-time it (that's how the

--- a/skills/optimize/cosmopolitan.md
+++ b/skills/optimize/cosmopolitan.md
@@ -1,7 +1,8 @@
 # Optimizing the cosmopolitan layer
 
-chapter of `_perf/OPTIMIZE.md` — read that first. this file makes
-C-layer optimization as mechanical as the cosmic-layer loop: you edit C
+chapter of the `optimize` skill (`SKILL.md` in this directory) — read
+that first. this file makes C-layer optimization as mechanical as the
+cosmic-layer loop: you edit C
 in a whilp/cosmopolitan checkout, rebuild a `lua` binary locally in
 seconds, stand it in as the runtime a cosmic build embeds onto, and
 judge it with the same scenarios and the same compare gate. no release,
@@ -136,7 +137,7 @@ BENCH=$(ls _perf/bench/*_bench.tl | sed 's|/|.|g;s|\.tl$||')
    over it. Confirm with `gate.lua selfcheck` on the same binary (an A/A
    control): if the flagged scenario swings as much
    comparing the modified binary to itself, it is noise, not your change
-   (entry 21 hit exactly this). `optimize/measurement.md` has the
+   (entry 21 hit exactly this). `measurement.md` has the
    playbook.
 
 7. **land it** (see below) and close the backlog issue (comment the

--- a/skills/optimize/finding.md
+++ b/skills/optimize/finding.md
@@ -1,8 +1,9 @@
 # Finding optimization opportunities (cosmic layer)
 
-chapter of `_perf/OPTIMIZE.md` — read that first. this file covers
-spotting wins in the Teal wrapper layer (`cosmic/*.tl`); for the C
-layer see `cosmopolitan.md` in this directory.
+chapter of the `optimize` skill (`SKILL.md` in this directory) — read
+that first. this file covers spotting wins in the Teal wrapper layer
+(`cosmic/*.tl`); for the C layer see `cosmopolitan.md` in this
+directory.
 
 check the hypothesis backlog first (GitHub issues labeled `perf` in
 whilp/cosmic) — it holds vetted, evidence-backed starting points. to

--- a/skills/optimize/measurement.md
+++ b/skills/optimize/measurement.md
@@ -1,6 +1,7 @@
 # Measurement discipline
 
-chapter of `_perf/OPTIMIZE.md` — read that first.
+chapter of the `optimize` skill (`SKILL.md` in this directory) — read
+that first.
 
 - machine noise is real: nothing else heavy runs during measurement;
   baseline and comparison run on the same machine, same power state.


### PR DESCRIPTION
`_perf/OPTIMIZE.md` moves to `skills/optimize/SKILL.md` with trigger frontmatter — the same shape as `agent-eval` — and its three chapters (`finding.md`, `cosmopolitan.md`, `measurement.md`) move beside it, the way `skills/cosmic` keeps its chapters in the skill directory. Intra-manual references become plain in-directory paths, and the chapter headers now name the skill instead of the old file.

Like `agent-eval`, this is repo tooling: `embed_gen.tl`'s `TREES` embeds only `skills/cosmic`, and `_build/skills_test.tl` ratchets only over `skills/cosmic`, so nothing ships or gates differently.

Every reference to the old paths is updated: `AGENTS.md` (layout table + Performance section), `docs/design/make/README.md` and `resolution.md`, and the comments in `bin/cosmic`, `_perf/compare.tl`, and `_make/runverb.tl`. A companion PR in whilp/cosmopolitan updates its `AGENTS.md` pointers.

Gate: `bin/cosmic --make ci` → `ci: PASS (5 stages)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhorrSa46REGc9vbKN6Sa1

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhorrSa46REGc9vbKN6Sa1)_