### PR TITLE
sse: last_event_id says nil where nil happens, and the docs iterate honestly

### DIFF
--- a/cosmic/sse.tl
+++ b/cosmic/sse.tl
@@ -21,11 +21,16 @@ local record Stream
   --- Iterator over parsed events: yields Event values; on a mid-stream
   --- transport failure yields nil plus the error message once, then
   --- plain nil — so truncation is distinguishable from a graceful close.
+  --- Event is a record, so narrow each yield in a positive branch:
+  ---   while true do
+  ---     local ev = s.next()
+  ---     if ev is sse.Event then handle(ev) else break end
+  ---   end
   next: function(): Event | nil, string
   --- The last seen event ID (nil until an id: line is seen), for
   --- reconnecting with a Last-Event-ID request header. Updates as soon
   --- as an id: line is parsed, even when no event is dispatched.
-  last_event_id: function(): string
+  last_event_id: function(): string | nil
 end
 
 --- Parse a single field line into name and value.
@@ -60,13 +65,19 @@ end
 local line_iter = stream.lines
 
 --- Parse SSE events from a streaming reader.
---- Returns a Stream whose next() yields Event values (iterate with
---- `for ev in stream.next do`); when the underlying reader fails
---- mid-body (reset, truncation, TLS error) next() yields nil plus the
---- error message once, then nil — so a truncated stream is
---- distinguishable from a graceful close. A partially accumulated event
---- at end-of-stream is discarded per the SSE spec, not dispatched.
---- stream.last_event_id() exposes the id for reconnects.
+--- Returns a Stream whose next() yields Event values. Event is a
+--- record, so `for ev in s.next do` leaves ev un-narrowed (`Event |
+--- nil`) — iterate with a positive `is` branch instead:
+---   while true do
+---     local ev = s.next()
+---     if ev is sse.Event then handle(ev) else break end
+---   end
+--- When the underlying reader fails mid-body (reset, truncation, TLS
+--- error) next() yields nil plus the error message once, then nil — so
+--- a truncated stream is distinguishable from a graceful close. A
+--- partially accumulated event at end-of-stream is discarded per the
+--- SSE spec, not dispatched. stream.last_event_id() exposes the id for
+--- reconnects.
 --- @param reader stream.Reader the reader to parse events from
 --- @return Stream the open event stream
 local function events(reader: stream.Reader): Stream
@@ -146,7 +157,7 @@ local function events(reader: stream.Reader): Stream
     end
   end
 
-  local function last_event_id(): string
+  local function last_event_id(): string | nil
     return last_id
   end
 

--- a/cosmic/sse_test.tl
+++ b/cosmic/sse_test.tl
@@ -80,7 +80,7 @@ end
 
 --- Collect every event; return the events, the terminal error (if any),
 --- and the stream's final last_event_id.
-local function collect(content: string, fail_with?: string): {sse.Event}, string, string
+local function collect(content: string, fail_with?: string): {sse.Event}, string, string | nil
   local stream = sse.events(mock_reader(content, fail_with))
   local events_list: {sse.Event} = {}
   local terminal_err: string
@@ -118,6 +118,16 @@ end
 test_event_type()
 
 local function test_event_id()
+
+  -- The honest-nil contract: before any id: line arrives, last_event_id
+  -- is bare nil, and its declared type says so (string | nil) — code
+  -- concatenating it unguarded should fail the checker, not crash at
+  -- runtime on an id-less stream.
+  local function test_last_event_id_nil_before_any_id()
+    local _events, _err, last = collect("data: no ids here\n\n")
+    assert(last == nil, "no id: line seen, last_event_id must return nil")
+  end
+  test_last_event_id_nil_before_any_id()
   local events_list = collect("id: 123\ndata: test\n\n")
   assert(#events_list == 1, "should have 1 event")
   assert(events_list[1].id == "123", "id should be '123', got: " .. tostring(events_list[1].id))


### PR DESCRIPTION
## What

Round-6 clean-room eval (agent D, building an SSE replayer), top-ranked friction — a genuine honest-nil violation:

> *"The prose docs say 'nil until an id: line is seen,' but the `Stream` record's field signature says `last_event_id: function(): string` — no `| nil`. Teal's strict checker takes the signature at face value, so nothing forces a nil check at the call site... This is the one place where trusting the type signature instead of testing would have shipped a latent bug."*

`last_event_id` now returns `string | nil` at both the record declaration and the implementation.

Second finding on the same page: the module doc's recommended iteration — `for ev in stream.next do` — does not type-check (`Event` is a record, so `ev` stays `Event | nil` in the loop body; verified, the narrowing hint fires on it). Both doc sites now show the positive-`is` form:

```teal
while true do
  local ev = s.next()
  if ev is sse.Event then handle(ev) else break end
end
```

## Verification

- New `test_last_event_id_nil_before_any_id` pins the nil-before-any-id behavior; the `collect` helper's third return follows the new type.
- `--make ci`: PASS (5 stages).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya)_