### PR TITLE
stream: from_string and buffer — the in-memory Reader/Writer pair

### DIFF
--- a/cosmic/stream.tl
+++ b/cosmic/stream.tl
@@ -43,11 +43,18 @@ local record stream
     write: function(self: Writer, data: string): number | nil, string
   end
 
+  --- A Writer that accumulates in memory (the sink from_string is the
+  --- source of): contents() returns everything written so far.
+  record Buffer is Writer
+    contents: function(self: Buffer): string
+  end
+
   write_all: function(w: Writer, data: string): boolean, string
   read_all: function(r: Reader, max?: integer): string | nil, string
   copy: function(dst: Writer, src: Reader, buf_size?: integer): integer | nil, string
   lines: function(r: Reader): function(): string | nil, string
   from_string: function(data: string): Reader
+  buffer: function(): Buffer
 end
 
 --- Write all of data, retrying short writes until done. The two
@@ -153,6 +160,25 @@ function stream.from_string(data: string): stream.Reader
     end,
   }
   return reader as stream.Reader -- cast: table implements the Reader interface
+end
+
+--- Collect writes in memory: the Writer half of from_string. write()
+--- appends and reports the chunk fully written; contents() returns
+--- everything written so far. Point stream.copy (or any Writer taker)
+--- at one to materialize a pipeline's output as a string.
+--- @return Buffer The in-memory writer
+function stream.buffer(): stream.Buffer
+  local parts: {string} = {}
+  local buf = {
+    write = function(_self: stream.Writer, data: string): number | nil, string
+      parts[#parts + 1] = data
+      return #data
+    end,
+    contents = function(_self: stream.Buffer): string
+      return table.concat(parts)
+    end,
+  }
+  return buf as stream.Buffer -- cast: table implements the Buffer record
 end
 
 --- Iterate complete lines from a Reader, buffering partial lines

--- a/cosmic/stream.tl
+++ b/cosmic/stream.tl
@@ -47,6 +47,7 @@ local record stream
   read_all: function(r: Reader, max?: integer): string | nil, string
   copy: function(dst: Writer, src: Reader, buf_size?: integer): integer | nil, string
   lines: function(r: Reader): function(): string | nil, string
+  from_string: function(data: string): Reader
 end
 
 --- Write all of data, retrying short writes until done. The two
@@ -121,6 +122,37 @@ function stream.copy(dst: stream.Writer, src: stream.Reader, buf_size?: integer)
     end
     copied = copied + #chunk
   end
+end
+
+--- Wrap bytes already in hand as a Reader, so in-memory data (a file
+--- read whole, a decompressed buffer, a test fixture) feeds any stream
+--- consumer — stream.lines, sse.events, stream.copy — without a
+--- hand-rolled adapter. read(n?) returns successive chunks (at most n
+--- bytes when n is given, the whole remainder otherwise), then bare
+--- nil at end of stream, per the Reader contract; n must be positive
+--- when given.
+--- @param data string The bytes to serve
+--- @return Reader A reader over the bytes
+function stream.from_string(data: string): stream.Reader
+  local pos = 1
+  local reader = {
+    read = function(_self: stream.Reader, n?: number): string | nil, string
+      if pos > #data then
+        return nil
+      end
+      local last = #data
+      if n then
+        if n <= 0 then
+          return nil, "read: size must be positive"
+        end
+        last = math.min(last, pos + math.floor(n) - 1)
+      end
+      local chunk = data:sub(pos, last)
+      pos = last + 1
+      return chunk
+    end,
+  }
+  return reader as stream.Reader -- cast: table implements the Reader interface
 end
 
 --- Iterate complete lines from a Reader, buffering partial lines

--- a/cosmic/stream_example.tl
+++ b/cosmic/stream_example.tl
@@ -55,5 +55,19 @@ local function Example_writer()
   -- ten bytes!
 end
 
+-- Example_from_string demonstrates wrapping bytes already in hand as a
+-- Reader: in-memory data drives any stream consumer — here the shared
+-- line iterator — without touching a descriptor.
+local function Example_from_string()
+  local stream = require("cosmic.stream")
+
+  local iter = stream.lines(stream.from_string("alpha\nbeta\n"))
+  print(iter())
+  print(iter())
+  -- Output:
+  -- alpha
+  -- beta
+end
+
 -- Suppress unused warnings for examples
-local _ = {Example_reader, Example_writer}
+local _ = {Example_reader, Example_writer, Example_from_string}

--- a/cosmic/stream_example.tl
+++ b/cosmic/stream_example.tl
@@ -69,5 +69,20 @@ local function Example_from_string()
   -- beta
 end
 
+-- Example_buffer demonstrates the in-memory Writer: point any
+-- Reader-to-Writer plumbing at it and read the result back as a
+-- string. With from_string on the other end, a whole pipeline runs
+-- without touching a descriptor.
+local function Example_buffer()
+  local check = require("cosmic.check")
+  local stream = require("cosmic.stream")
+
+  local buf = stream.buffer()
+  check.must(stream.copy(buf, stream.from_string("round trip")))
+  print(buf:contents())
+  -- Output:
+  -- round trip
+end
+
 -- Suppress unused warnings for examples
-local _ = {Example_reader, Example_writer, Example_from_string}
+local _ = {Example_reader, Example_writer, Example_from_string, Example_buffer}

--- a/cosmic/stream_test.tl
+++ b/cosmic/stream_test.tl
@@ -173,3 +173,21 @@ local function test_from_string_feeds_lines()
   check.eq(iter(), nil, "then nil")
 end
 test_from_string_feeds_lines()
+
+local function test_buffer_collects_writes()
+  local buf = stream.buffer()
+  check.eq(buf:contents(), "", "empty before any write")
+  check.eq(buf:write("collected "), 10, "write reports the chunk written")
+  buf:write("bytes")
+  check.eq(buf:contents(), "collected bytes", "contents is everything written")
+  check.eq(buf:contents(), "collected bytes", "contents is repeatable")
+end
+test_buffer_collects_writes()
+
+local function test_buffer_round_trips_through_copy()
+  local buf = stream.buffer()
+  local copied = check.must(stream.copy(buf, stream.from_string("round trip")))
+  check.eq(copied, 10, "copy reports the byte count")
+  check.eq(buf:contents(), "round trip", "from_string -> buffer round-trips")
+end
+test_buffer_round_trips_through_copy()

--- a/cosmic/stream_test.tl
+++ b/cosmic/stream_test.tl
@@ -139,3 +139,37 @@ local function test_fetch_reader_conforms()
   proc.wait(pid)
 end
 test_fetch_reader_conforms()
+
+local function test_from_string_conforms()
+  check_reader(stream.from_string("in-memory bytes"), "in-memory bytes",
+    "stream.from_string")
+end
+test_from_string_conforms()
+
+local function test_from_string_chunks_and_edges()
+  -- n bounds each chunk; the tail chunk may be short.
+  local r = stream.from_string("abcdef")
+  check.eq(r:read(4), "abcd", "first bounded chunk")
+  check.eq(r:read(4), "ef", "short tail chunk")
+  check.eq(r:read(4), nil, "then end of stream")
+
+  -- An empty string is an empty stream: bare nil immediately.
+  local empty = stream.from_string("")
+  local chunk, err = empty:read()
+  assert(chunk == nil and err == nil, "empty string reads as clean EOF")
+
+  -- A non-positive bound is an honest error, not a sneaky EOF.
+  local bad = stream.from_string("data")
+  local got, bad_err = bad:read(0)
+  assert(got == nil and bad_err ~= nil, "n must be positive")
+end
+test_from_string_chunks_and_edges()
+
+local function test_from_string_feeds_lines()
+  local iter = stream.lines(stream.from_string("one\ntwo\nthree"))
+  check.eq(iter(), "one", "first line")
+  check.eq(iter(), "two", "second line")
+  check.eq(iter(), "three", "final unterminated line")
+  check.eq(iter(), nil, "then nil")
+end
+test_from_string_feeds_lines()


### PR DESCRIPTION
## What

Round-6 clean-room eval (agent D, building an SSE replayer over possibly-compressed captures):

> *"For a CLI tool whose input is 'read a whole file, maybe decompress it, then parse,' the natural shape is an in-memory buffer, and I had to hand-write a ~15-line adapter record to bridge `fs.read()`'s `string` result to what `sse.events` needs. A `stream.reader_from_string(data)` (mirrored by `stream.buffer_writer()` for the write side) would directly serve exactly this task's shape and is probably common beyond it."*

It is common beyond it — this repo's own `sse_test.tl` carries exactly such a mock.

Both halves of the pair:

- **`stream.from_string(data)`** returns a Reader over the string: bounded chunks when `read(n)` asks (short tail allowed), the whole remainder otherwise, bare nil at end of stream, and an honest error for a non-positive `n`.
- **`stream.buffer()`** returns the Writer half — a `Buffer is Writer` whose `contents()` reads back everything written. Point `stream.copy` (or any Writer taker) at one to materialize a pipeline's output as a string; with `from_string` on the other end, a whole pipeline runs in memory without touching a descriptor.

## Verification

- The stream conformance suite's `check_reader` runs against `from_string` like every other producer; edge tests cover bounded chunks, empty-string-as-clean-EOF, non-positive `n`, and composition with `stream.lines`.
- `buffer` tests cover accumulation, repeatable `contents()`, and the `from_string → copy → buffer` round trip.
- New `Example_from_string` and `Example_buffer` render under `--docs stream`.
- `--make ci`: PASS (5 stages).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya