### PR TITLE
make: tests run under a runner that carries the root payload

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -42,6 +42,7 @@ _make/runverb.tl 72 89
 _make/select.tl 33 35
 _make/stage.tl 88 96
 _make/stamp.tl 109 118
+_make/testrun.tl 50 58
 _make/types.tl 39 39
 _make/validate.tl 244 249
 _perf/bench/child_bench.tl 0 11

--- a/_make/artifact.tl
+++ b/_make/artifact.tl
@@ -480,6 +480,7 @@ local record ArtifactModule
   plan: function(proj: Project, binary: Binary): {Staged}
   stage: function(proj: Project, binary: Binary): string | nil, string
   build: function(proj: Project, binary: Binary, cosmic: string): string | nil, string
+  replace_if_changed: function(staged: string, out: string): string | nil
 end
 
 local M: ArtifactModule = {
@@ -488,6 +489,7 @@ local M: ArtifactModule = {
   plan = plan,
   stage = stage,
   build = build,
+  replace_if_changed = replace_if_changed,
 }
 
 return M

--- a/_make/fixtures_test.tl
+++ b/_make/fixtures_test.tl
@@ -136,6 +136,18 @@ local assets_root = fixture("assets",
   {assets = "asset: shipped\n\nreadme: absent\n"})
 
 local function test_only_declared_payload_ships()
+
+  -- The other side of the payload promise: a TEST sees `/zip/R` too. The
+  -- fixture's note_test.tl reads /zip/data/note.txt directly — under the
+  -- test runner (this cosmic plus the root payload), not by spawning the
+  -- artifact — so `--make test` passing here is the whole claim.
+  local function test_tests_see_the_payload_at_zip()
+    local code, out = make(assets_root, "test")
+    assert(code == 0, "a test reading /zip payload should pass:\n" .. out)
+    assert(fs.is_file(fs.join(assets_root, "o/.testrun/cosmic")),
+      "the payload test runner should exist after --make test")
+  end
+  test_tests_see_the_payload_at_zip()
   local zip = require("cosmic.zip")
   local reader = check.must(zip.open(fs.join(assets_root, "o/bin/assets")))
   local saw: {string: boolean} = {}

--- a/_make/graph.tl
+++ b/_make/graph.tl
@@ -22,6 +22,7 @@ local deps = require("_make.deps")
 local imports = require("_make.imports")
 local project = require("_make.project")
 local stamp = require("_make.stamp")
+local testrun = require("_make.testrun")
 local types = require("_make.types")
 
 local type Kind = types.Kind
@@ -236,11 +237,9 @@ local function project_mk(proj: Project, cosmic: string): string | nil, string
     "COSMIC := " .. cosmic,
     -- No COSMIC_DEP any more: the rules name per-tool stamp files
     -- (`o/.stamp/<tool>`, written by materialize below) instead of the
-    -- binary, so a rule's result is still only as fresh as its tool --
-    -- a formatter fix still invalidates every formatting verdict --
-    -- without every edit to any embedded module invalidating the whole
-    -- graph. The rationale and the traded edge live in _make/stamp.tl
-    -- and docs/decisions/d17-tool-stamps.md.
+    -- binary, so a result is as fresh as its tool without every edit
+    -- invalidating the whole graph — _make/stamp.tl and d17 have the
+    -- rationale and the traded edge.
     "O := " .. project.BUILD_DIR,
     "project := " .. fs.basename(proj.root),
     assign("tl_sources", tl_sources),
@@ -252,6 +251,8 @@ local function project_mk(proj: Project, cosmic: string): string | nil, string
     assign("assets", assets),
     assign("lint_sources", lint_sources),
     assign("coverage_dirs", source_dirs(proj)),
+    -- The runner tests exec, and its prerequisite: _make/testrun.tl.
+    testrun.mk_facts(proj),
   }
   for _, l in ipairs(dep_lines) do
     lines[#lines + 1] = l

--- a/_make/init.tl
+++ b/_make/init.tl
@@ -29,6 +29,7 @@ local generate = require("_make.generate")
 local graph = require("_make.graph")
 local policy = require("_make.policy")
 local stage = require("_make.stage")
+local testrun = require("_make.testrun")
 local types = require("_make.types")
 local validate = require("_make.validate")
 
@@ -179,20 +180,17 @@ end
 --- @return boolean True when the stage is ready
 --- @return string The error message
 local function prepare_stage(proj: Project, cosmic: string): boolean, string
-  if #proj.binaries == 0 then
-    return true, ""
+  if #proj.binaries > 0 then
+    local b = by_name("build") as Verb -- cast: the registry defines it
+    local ok, detail = stage.graph_stage(b, proj, {}, cosmic)
+    if not ok then return false, detail end
+    local aok, adetail = assemble(proj, proj.binaries, cosmic, false)
+    if not aok then return false, adetail end
+    stage.binaries_on_path(proj)
   end
-  local b = by_name("build") as Verb -- cast: the registry defines it
-  local ok, detail = stage.graph_stage(b, proj, {}, cosmic)
-  if not ok then
-    return false, detail
-  end
-  local aok, adetail = assemble(proj, proj.binaries, cosmic, false)
-  if not aok then
-    return false, adetail
-  end
-  stage.binaries_on_path(proj)
-  return true, ""
+  -- The runner is stage too: with root payload, tests exec a cosmic
+  -- that carries it, so `/zip/R` resolves in a test as in the artifact.
+  return testrun.build(proj, cosmic)
 end
 
 local function run_against_stage(v: Verb, proj: Project, paths: {string},

--- a/_make/testdata/assets/note_test.tl
+++ b/_make/testdata/assets/note_test.tl
@@ -1,0 +1,12 @@
+#!/usr/bin/env cosmic
+-- A test sees the root payload at its artifact path: `--make test` runs
+-- tests under a cosmic carrying `embed/**`, so `/zip/data/note.txt`
+-- resolves here exactly as it does inside `o/bin/assets`.
+local check = require("cosmic.check")
+local fs = require("cosmic.fs")
+
+local function test_payload_visible_at_zip()
+  local note = check.must(fs.read("/zip/data/note.txt"))
+  check.eq(note, "shipped\n", "payload bytes at their artifact path")
+end
+test_payload_visible_at_zip()

--- a/_make/testrun.tl
+++ b/_make/testrun.tl
@@ -1,0 +1,135 @@
+--- The test runner: this cosmic with the project's ROOT payload
+--- appended, so `/zip/R` resolves inside a test exactly as inside the
+--- artifact (`embed/R` -> `/zip/R`). Assembled by `prepare_stage`
+--- before the graph runs, like a generator; the graph's test rules
+--- name it as command and prerequisite (project.mk's `testrun` and
+--- `testrun_dep` facts), and replace-if-changed keeps its mtime still
+--- when neither the toolchain nor the payload moved, so nothing
+--- re-runs for an identical runner.
+---
+--- Root payload only. A per-binary payload (`cmd/<name>/embed/**`) is
+--- that artifact's private cargo: two binaries may store different
+--- bytes at one zip path, so one shared runner cannot carry either
+--- without lying about the other. Spawning `o/bin/<name>` covers
+--- those, and stays the way to exercise a binary's CLI surface.
+
+local embed = require("cosmic.embed")
+local fs = require("cosmic.fs")
+local artifact = require("_make.artifact")
+local project = require("_make.project")
+local types = require("_make.types")
+
+local type Project = types.Project
+
+--- Where the runner lives, relative to the project root. Dot-prefixed
+--- like every engine-owned entry under `o/`: the mirror cannot reach it.
+local PATH < const > = project.BUILD_DIR .. "/.testrun/cosmic"
+
+--- The project's root payload files, in walk order.
+--- @param proj Project The scanned project
+--- @return {string} Paths under the root `embed/`, relative to the root
+local function root_payload(proj: Project): {string}
+  local out: {string} = {}
+  for _, f in ipairs(proj.files) do
+    if f.kind == "payload"
+    and project.payload_depth(project.segments(f.path)) == 1 then
+      out[#out + 1] = f.path
+    end
+  end
+  return out
+end
+
+--- Does this project get a runner at all?
+--- @param proj Project The scanned project
+--- @return boolean True when the root `embed/` has payload
+local function enabled(proj: Project): boolean
+  return #root_payload(proj) > 0
+end
+
+--- The two project.mk facts in one string: the command every test rule
+--- execs, and the prerequisite naming it. The command is ABSOLUTE, like
+--- COSMIC — a test re-invoking its interpreter through `arg[-1]` after
+--- a chdir must still resolve it. The prerequisite is empty without
+--- payload, so the d17 rule against naming the binary as a prerequisite
+--- stands untouched; the runner file is content-addressed, so as a
+--- prerequisite it moves exactly when the toolchain or the payload did.
+--- @param proj Project The scanned project
+--- @return string `testrun := …` and `testrun_dep := …`, newline-joined
+local function mk_facts(proj: Project): string
+  if not enabled(proj) then
+    return "testrun := $(COSMIC)\ntestrun_dep :="
+  end
+  return "testrun := " .. fs.join(proj.root, PATH)
+  .. "\ntestrun_dep := " .. PATH
+end
+
+--- Assemble the runner, or do nothing for a payload-free project.
+--- @param proj Project The scanned project
+--- @param cosmic string Absolute path to the running cosmic binary
+--- @return boolean True when the runner is ready (or not needed)
+--- @return string The error message on failure
+local function build(proj: Project, cosmic: string): boolean, string
+  local files = root_payload(proj)
+  if #files == 0 then
+    return true, ""
+  end
+  -- Stage at stored names, so embed's directory walk stores the
+  -- artifact layout — the same one-code-path trade artifact.stage
+  -- makes. Clear rather than merge: a payload file removed from the
+  -- project must not survive in the runner.
+  local dir = fs.join(project.BUILD_DIR, ".testrun", "stage")
+  if fs.exists(dir) then
+    local rok, rerr = fs.remove_all(dir)
+    if not rok then
+      return false, "make: cannot clear " .. dir .. ": " ..
+      (rerr or "unknown error")
+    end
+  end
+  for _, rel in ipairs(files) do
+    local stored = (rel:gsub("^[^/]+/", ""))
+    local dst = fs.join(dir, stored)
+    local mok, merr = fs.make_dirs(fs.dirname(dst))
+    if not mok then
+      return false, "make: cannot create " .. fs.dirname(dst) .. ": " ..
+      (merr or "unknown error")
+    end
+    local content, cerr = fs.read(rel)
+    if not content then
+      return false, "make: cannot read " .. rel .. ": " ..
+      (cerr or "unknown error")
+    end
+    local wok, werr = fs.write(dst, content)
+    if not wok then
+      return false, "make: cannot write " .. dst .. ": " ..
+      (werr or "unknown error")
+    end
+  end
+  local staged_out = PATH .. ".new"
+  local result = embed.embed({dir},
+    {output = staged_out, exe_path = cosmic, mtime = embed.EPOCH})
+  if not result.ok then
+    fs.unlink(staged_out)
+    return false, "make: test runner: " .. result.message
+  end
+  local rerr = artifact.replace_if_changed(staged_out, PATH)
+  if rerr then
+    return false, "make: " .. rerr
+  end
+  return true, ""
+end
+
+local record TestrunModule
+  PATH: string
+  enabled: function(proj: Project): boolean
+  mk_facts: function(proj: Project): string
+  build: function(proj: Project, cosmic: string): boolean, string
+end
+
+local M: TestrunModule = {
+  PATH = PATH,
+  enabled = enabled,
+  mk_facts = mk_facts,
+  build = build,
+}
+
+return M

--- a/_make/testrun_test.tl
+++ b/_make/testrun_test.tl
@@ -1,0 +1,92 @@
+#!/usr/bin/env cosmic
+-- Tests for the test runner: a cosmic carrying the project's root
+-- payload, so `/zip/R` resolves inside a test as inside the artifact.
+-- The end-to-end half (a fixture test actually reading `/zip/...`
+-- under `--make test`) lives in fixtures_test; these assert the
+-- assembly itself: what the runner carries, what it costs when nothing
+-- changed, and that a payload-free project builds none.
+
+local check = require("cosmic.check")
+local fs = require("cosmic.fs")
+local project = require("_make.project")
+local testrun = require("_make.testrun")
+local types = require("_make.types")
+local zip = require("cosmic.zip")
+
+local type Project = types.Project
+
+local cosmic = fs.abspath(fs.join(os.getenv("TEST_BIN"), "cosmic"))
+local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
+
+--- Build a fixture tree, returning its absolute root.
+local function fixture(name: string, files: {string: string}): string
+  local root = fs.join(tmpdir, "testrun-" .. name)
+  fs.remove_all(root)
+  assert(fs.make_dirs(root))
+  for rel, content in pairs(files) do
+    local path = fs.join(root, rel)
+    assert(fs.make_dirs(fs.dirname(path)))
+    assert(fs.write(path, content))
+  end
+  return root
+end
+
+--- Scan and build the runner from inside the fixture root, restoring
+--- the cwd either way: testrun's paths are root-relative, like every
+--- graph path.
+local function build_in(root: string): boolean, string
+  local proj: Project = check.must(project.scan(root))
+  local cwd = check.must(fs.cwd())
+  assert(fs.chdir(root))
+  local ok, err = testrun.build(proj, cosmic)
+  assert(fs.chdir(cwd))
+  return ok, err
+end
+
+local function test_runner_carries_root_payload()
+  local root = fixture("payload", {
+      ["cmd/app/main.tl"] = "print('x')\n",
+      ["embed/data/note.txt"] = "carried\n",
+    })
+  local ok, err = build_in(root)
+  assert(ok, "runner should assemble: " .. tostring(err))
+  local runner = fs.join(root, testrun.PATH)
+  assert(fs.is_file(runner), "runner exists at " .. testrun.PATH)
+  local reader = check.must(zip.open(runner))
+  local saw: {string: boolean} = {}
+  for _, e in ipairs(reader:list()) do
+    saw[e.name] = true
+  end
+  reader:close()
+  assert(saw["data/note.txt"], "payload at its artifact path, prefix stripped")
+  assert(saw["cosmic/fs.lua"], "the toolchain rides along un-stripped")
+end
+test_runner_carries_root_payload()
+
+local function test_unchanged_runner_keeps_its_mtime()
+  local root = fixture("still", {
+      ["cmd/app/main.tl"] = "print('x')\n",
+      ["embed/asset.txt"] = "bytes\n",
+    })
+  check.must(build_in(root))
+  local runner = fs.join(root, testrun.PATH)
+  local before = check.must(fs.stat(runner)):mtim()
+  check.must(build_in(root))
+  local after = check.must(fs.stat(runner)):mtim()
+  check.eq(after, before, "identical payload must not move the runner")
+end
+test_unchanged_runner_keeps_its_mtime()
+
+local function test_no_payload_no_runner()
+  local root = fixture("plain", {
+      ["cmd/app/main.tl"] = "print('x')\n",
+    })
+  local proj: Project = check.must(project.scan(root))
+  assert(not testrun.enabled(proj), "no root payload, no runner")
+  check.must(build_in(root))
+  assert(not fs.exists(fs.join(root, testrun.PATH)),
+    "a payload-free project assembles nothing")
+end
+test_no_payload_no_runner()
+
+print("all testrun tests passed")

--- a/embed/cosmic.mk
+++ b/embed/cosmic.mk
@@ -155,15 +155,23 @@ test: $(O)/test-summary.txt
 # case). What IS narrow is the write grant: only the test's own `.got`
 # base and TMPDIR. One answer, two consumers: the argument positions
 # are the declaration.
-$(O)/%.tl.test.got: $(O)/%.lua $(O)/.stamp/record $$(deps_$$*)
-	record $(basename $@) $(COSMIC) $< --deps $(deps_$*) ;
+# Tests exec `$(testrun)`: with root `embed/` payload that is
+# `o/.testrun/cosmic` — this cosmic plus the payload at its artifact
+# paths, assembled before the graph runs — so `/zip/R` resolves inside
+# a test exactly as inside the artifact. Without payload it is
+# `$(COSMIC)` and `testrun_dep` is empty: the d17 rule against naming
+# the binary as a prerequisite stands, while the runner file is
+# content-addressed, so as a prerequisite it moves exactly when the
+# toolchain or the payload did.
+$(O)/%.tl.test.got: $(O)/%.lua $(O)/.stamp/record $$(deps_$$*) $(testrun_dep)
+	record $(basename $@) $(testrun) $< --deps $(deps_$*) ;
 
 # A `.lua` test is a test. The marker suffixes are extension-agnostic
 # in the model, so the rules have to be too -- otherwise a Lua-only
 # project's tests are listed and never run, which is worse than not
 # supporting them.
-$(O)/%.lua.test.got: $(O)/%.lua $(O)/.stamp/record $$(deps_$$*)
-	record $(basename $@) $(COSMIC) $< --deps $(deps_$*) ;
+$(O)/%.lua.test.got: $(O)/%.lua $(O)/.stamp/record $$(deps_$$*) $(testrun_dep)
+	record $(basename $@) $(testrun) $< --deps $(deps_$*) ;
 
 $(O)/test-summary.txt: $(test_got)
 	tee $@ $(COSMIC) --report $(test_got) ;
@@ -179,11 +187,11 @@ example: $(O)/example-summary.txt
 # closure, same fence, `Example_*` instead of `test_*`. That is what the
 # model says everywhere else, so the rules say it too — the only
 # difference from the test rules above is the flag.
-$(O)/%.tl.example.got: $(O)/%.lua $(O)/.stamp/record $$(deps_$$*)
-	record $(basename $@) $(COSMIC) --check example $< --deps $(deps_$*) ;
+$(O)/%.tl.example.got: $(O)/%.lua $(O)/.stamp/record $$(deps_$$*) $(testrun_dep)
+	record $(basename $@) $(testrun) --check example $< --deps $(deps_$*) ;
 
-$(O)/%.lua.example.got: $(O)/%.lua $(O)/.stamp/record $$(deps_$$*)
-	record $(basename $@) $(COSMIC) --check example $< --deps $(deps_$*) ;
+$(O)/%.lua.example.got: $(O)/%.lua $(O)/.stamp/record $$(deps_$$*) $(testrun_dep)
+	record $(basename $@) $(testrun) --check example $< --deps $(deps_$*) ;
 
 $(O)/example-summary.txt: $(example_got)
 	tee $@ $(COSMIC) --report $(example_got) ;
@@ -200,11 +208,11 @@ benchmark: $(O)/benchmark-summary.txt
 # generation unit — a generator's output is a build INPUT, derived from
 # sources and stale when they change, while a measurement is of one
 # binary on one machine at one moment and is never stale, just old.
-$(O)/%.tl.benchmark.got: $(O)/%.lua $(O)/.stamp/record $$(deps_$$*)
-	record $(basename $@) $(COSMIC) --benchmark $< --deps $(deps_$*) ;
+$(O)/%.tl.benchmark.got: $(O)/%.lua $(O)/.stamp/record $$(deps_$$*) $(testrun_dep)
+	record $(basename $@) $(testrun) --benchmark $< --deps $(deps_$*) ;
 
-$(O)/%.lua.benchmark.got: $(O)/%.lua $(O)/.stamp/record $$(deps_$$*)
-	record $(basename $@) $(COSMIC) --benchmark $< --deps $(deps_$*) ;
+$(O)/%.lua.benchmark.got: $(O)/%.lua $(O)/.stamp/record $$(deps_$$*) $(testrun_dep)
+	record $(basename $@) $(testrun) --benchmark $< --deps $(deps_$*) ;
 
 $(O)/benchmark-summary.txt: $(benchmark_got)
 	tee $@ $(COSMIC) --report $(benchmark_got) ;
@@ -251,11 +259,11 @@ coverage: $(O)/coverage-summary.txt
 # reach, and the reserved set is a rule rather than a word list.
 $(O)/.coverage/%.test.got: export COSMIC_COVERAGE := 1
 
-$(O)/.coverage/%.tl.test.got: $(O)/%.lua $(O)/.stamp/record $$(deps_$$*)
-	record $(basename $@) $(COSMIC) $< --deps $(deps_$*) ;
+$(O)/.coverage/%.tl.test.got: $(O)/%.lua $(O)/.stamp/record $$(deps_$$*) $(testrun_dep)
+	record $(basename $@) $(testrun) $< --deps $(deps_$*) ;
 
-$(O)/.coverage/%.lua.test.got: $(O)/%.lua $(O)/.stamp/record $$(deps_$$*)
-	record $(basename $@) $(COSMIC) $< --deps $(deps_$*) ;
+$(O)/.coverage/%.lua.test.got: $(O)/%.lua $(O)/.stamp/record $$(deps_$$*) $(testrun_dep)
+	record $(basename $@) $(testrun) $< --deps $(deps_$*) ;
 
 $(O)/coverage-summary.txt: $(coverage_got)
 	tee $@ $(COSMIC) --report $(coverage_got) ;

--- a/skills/cosmic/make.md
+++ b/skills/cosmic/make.md
@@ -115,6 +115,12 @@ the zip root **is** the module root, so "path relative to the root =
 import path" holds inside the artifact too — `require("db.query")`
 resolves the same way at build time and at run time.
 
+these `/zip/...` paths exist inside the ARTIFACT, and only there: a
+`*_test.tl` executed by `--make test` runs under the toolchain's own
+zip and does not see your `embed/` payload — test embedded-asset code
+by spawning the built `o/bin/<name>` (see `cosmic --docs
+guide.testing`).
+
 each `cmd/<name>` artifact carries the root packages plus its own
 subtree, and nothing from a sibling `cmd/` — the same boundary the
 validator refuses imports across.

--- a/skills/cosmic/make.md
+++ b/skills/cosmic/make.md
@@ -115,11 +115,12 @@ the zip root **is** the module root, so "path relative to the root =
 import path" holds inside the artifact too — `require("db.query")`
 resolves the same way at build time and at run time.
 
-these `/zip/...` paths exist inside the ARTIFACT, and only there: a
-`*_test.tl` executed by `--make test` runs under the toolchain's own
-zip and does not see your `embed/` payload — test embedded-asset code
-by spawning the built `o/bin/<name>` (see `cosmic --docs
-guide.testing`).
+these `/zip/...` paths hold inside tests too: `--make test` runs tests
+under a runner carrying the root `embed/` payload (`o/.testrun/cosmic`),
+so `/zip/R` resolves in a test exactly as in the artifact. a
+per-binary `cmd/<name>/embed/**` is the exception — one artifact's
+private cargo — covered by spawning the built `o/bin/<name>` (see
+`cosmic --docs guide.testing`).
 
 each `cmd/<name>` artifact carries the root packages plus its own
 subtree, and nothing from a sibling `cmd/` — the same boundary the

--- a/skills/cosmic/testing.md
+++ b/skills/cosmic/testing.md
@@ -156,13 +156,15 @@ keep logic tests at the library layer, where functions are called
 directly; the binary spawn is for the argv-parsing and
 output-formatting skin that exists only in `cmd/<name>/main.tl`.
 
-the spawn is also the ONLY way to test embedded-payload code: a
-`*_test.tl` runs under the toolchain's own zip, so `/zip/...` inside a
-test is cosmic's payload, not your artifact's — `/zip/<your asset>`
-exists only inside the built `o/bin/<name>`, and a unit test calling
-your `/zip`-reading functions directly gets ENOENT. keep the reading
-thin, unit-test the pure logic on either side of it, and cover the
-embedded path by spawning the binary as above.
+embedded payload is visible in tests too: with a root `embed/`
+directory, `--make test` runs every test under a runner that carries
+it (`o/.testrun/cosmic` — this cosmic plus the payload at its
+artifact paths), so `/zip/R` resolves inside a test exactly as inside
+the artifact and your `/zip`-reading functions unit-test directly.
+the one payload tests do NOT see is a per-binary
+`cmd/<name>/embed/**`: that is one artifact's private cargo (two
+binaries may store different bytes at one zip path), so cover it by
+spawning `o/bin/<name>` as above.
 
 ### opting out
 

--- a/skills/cosmic/testing.md
+++ b/skills/cosmic/testing.md
@@ -156,6 +156,14 @@ keep logic tests at the library layer, where functions are called
 directly; the binary spawn is for the argv-parsing and
 output-formatting skin that exists only in `cmd/<name>/main.tl`.
 
+the spawn is also the ONLY way to test embedded-payload code: a
+`*_test.tl` runs under the toolchain's own zip, so `/zip/...` inside a
+test is cosmic's payload, not your artifact's — `/zip/<your asset>`
+exists only inside the built `o/bin/<name>`, and a unit test calling
+your `/zip`-reading functions directly gets ENOENT. keep the reading
+thin, unit-test the pure logic on either side of it, and cover the
+embedded path by spawning the binary as above.
+
 ### opting out
 
 two escalation paths exist; prefer the tight default whenever the test can live with it:


### PR DESCRIPTION
## What

Round-6 eval, agent B's top friction: unit tests calling `/zip`-reading functions got ENOENT because a test ran under the toolchain's zip, not the artifact's. The first commit here documented that gap; review asked the better question — *why not make `/zip` reflect the payload in tests?* — so now it does.

With a root `embed/` directory, `prepare_stage` assembles **`o/.testrun/cosmic`**: this cosmic with `embed/**` appended at its artifact paths (`embed.embed` already replaces colliding entries, which keeps the self-hosted repo's own `/zip/cosmic.mk` coherent). The eight test/example/benchmark/coverage recipes exec `$(testrun)` with `$(testrun_dep)` as a prerequisite — both are project.mk *facts*, `$(COSMIC)` and empty for a payload-free project, so the constant-rules discipline and d17's no-binary-prerequisite rule stand, and an ordinary project pays nothing.

Design points:

- **Absolute runner path**, like `COSMIC`: a test re-invoking its interpreter via `arg[-1]` after a chdir must still resolve it (caught by `resolution_test` during development).
- **Content-addressed** via `replace_if_changed`: as a prerequisite the runner moves exactly when the toolchain or the payload changed — no spurious test re-runs, no staleness.
- **Root payload only.** `cmd/<name>/embed/**` is one artifact's private cargo — two binaries may store different bytes at one zip path — so a shared runner cannot carry it honestly. Spawning `o/bin/<name>` covers those, and stays the way to test a CLI surface.

## Verification

- `assets` fixture gains `note_test.tl` reading `/zip/data/note.txt` **directly from a test**; `fixtures_test` drives `--make test` over it.
- New `_make/testrun_test.tl`: payload lands at stored paths with the toolchain un-stripped, an unchanged runner keeps its mtime, a payload-free project assembles nothing.
- Self-hosted proof: this repo has root payload (`embed/cosmic.mk`), so every test in this ci run already executed under the runner. `--make ci`: PASS (5 stages), from a cold `o/` as well.
- `.cosmic-coverage` gains exactly one row (the new module); the floor is otherwise untouched.

`guide.testing` and `guide.make` now state the positive semantics in place of the gap the first commit documented.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya