### PR TITLE
docs: gotcha 15 — gsub's replacement string interprets %

### DIFF
--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -357,3 +357,27 @@ end
 os.exit(main())
 -- or convert at the call site: os.exit(math.tointeger(code) or 1)
 ```
+
+## 15. `gsub`'s replacement string interprets `%` — dangerous with untrusted values
+
+`string.gsub`'s third argument is not plain text: `%1`–`%9` splice in
+captures, `%0` the whole match, and a lone `%` followed by anything
+else is an error. substituting an untrusted value into a template this
+way corrupts output — or crashes — the first time the value contains a
+`%` (a URL-encoded string, a printf format, a literal percentage).
+
+**wrong:**
+```teal
+local page = template:gsub("{{name}}", user_name)
+-- user_name = "50%" → runtime error: invalid use of '%' in replacement string
+```
+
+**right — escape `%` in the replacement first:**
+```teal
+local safe = user_name:gsub("%%", "%%%%")
+local page = template:gsub("{{name}}", safe)
+```
+
+(the needle side has the same property — see the find-needle lint rule
+for `find`; on `gsub` both arguments are magic, and only the
+replacement side is fixable by doubling `%`.)


### PR DESCRIPTION
## What

Round-6 clean-room eval (agent B, building an HTML templating feature):

> *"a greeting-card name containing `%` would silently corrupt output (or error) if substituted naively via `content:gsub("{{name}}", escaped)`. Nothing in `--docs guide.gotchas` calls this out for `gsub` specifically... Caught it only by knowing Lua's `gsub` semantics going in, not from any cosmic prompt."*

A newcomer without that prior Lua knowledge ships the bug. The `find-needle` lint already names the pattern-side magic for `find`; `gsub`'s replacement side has the same property (`%1`–`%9` capture splices, lone `%` errors) and only doubling fixes it.

New gotcha #15 shows the crash (`user_name = "50%"`), the `%%`-doubling escape, and cross-references find-needle for the needle-side sibling.

## Verification

`--make ci`: PASS (5 stages).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya)_