### PR TITLE
docs: HTTP without a framework is a recipe, not a scavenger hunt

### DIFF
--- a/cosmic/child/init.tl
+++ b/cosmic/child/init.tl
@@ -1,19 +1,19 @@
 --- Child process management.
 ---
---- The high-level spawn API. `start` starts a process and hands back a
---- `Handle` you can `kill`, `wait` on (with an optional timeout), poll with
---- `try_wait`, or stream from with `read`. `run` is the one-shot form that
---- spawns, waits, and returns a structured `Result`. Low-level syscall
---- passthroughs (fork/wait/kill/posix_spawn, the W* status helpers) live in
---- `cosmic.proc`; this module builds the ergonomic layer on top.
+--- The high-level spawn API: `start` hands back a `Handle` you can `kill`,
+--- `wait` on (with an optional timeout), poll with `try_wait`, or stream
+--- from with `read`; `run` is the one-shot spawn-wait-`Result` form. The
+--- raw syscalls (fork/wait/kill, W* helpers) live in `cosmic.proc`.
 ---
---- A Handle owns the child: `wait`/`run` reap it and cache the `Result`, so a
---- second `wait` returns the same value instead of failing. An abandoned
---- handle is not leaked — its `__gc`/`__close` metamethods SIGKILL and reap an
---- un-waited child and close its pipes, so `local h <close> = start{...}` (or
---- simply dropping the handle) never leaves a zombie. Side effect: requiring
---- cosmic.child.io sets SIGPIPE to SIG_IGN process-wide (a child closing
---- stdin early gets EPIPE on the write, not a dead parent).
+--- A Handle owns the child: `wait`/`run` reap it and cache the `Result`, so
+--- a second `wait` returns the same value instead of failing. An abandoned
+--- handle is not leaked — its `__gc`/`__close` metamethods SIGKILL and reap
+--- an un-waited child and close its pipes, so `local h <close> = start{...}`
+--- (or simply dropping the handle) never leaves a zombie. Side effect:
+--- requiring cosmic.child.io sets SIGPIPE to SIG_IGN process-wide (a child
+--- closing stdin early gets EPIPE on the write, not a dead parent).
+--- Testing a server you spawn? Have it print `READY <port>` and block on
+--- reading that line — the readiness pattern in `cosmic --docs guide.recipes`.
 local unix = require("cosmo.unix")
 local cfd = require("cosmic.fd")
 local childio = require("cosmic.child.io")

--- a/skills/cosmic/recipes.md
+++ b/skills/cosmic/recipes.md
@@ -111,5 +111,61 @@ and block on `h.stdout:read(64)` instead of sleeping. see
 ## TCP echo pair (net)
 
 see `cosmic --examples net` for a runnable single-process echo exchange:
-`listen_tcp(0x7f000001, 0)` for an OS-assigned port, `connect_tcp`,
-`accept`, then `send`/`recv`. `recv` returns `""` on peer close.
+`listen_tcp("127.0.0.1", 0)` for an OS-assigned port, `connect_tcp`,
+`accept`, then `send`/`recv`. `recv` returns bare nil on peer close
+(end of stream); `""` only ever means a zero-byte datagram.
+
+## HTTP without a framework (net + fetch)
+
+there is no HTTP server module, on purpose: at this scale HTTP/1.1 is a
+request line, a header drain, and a `Content-Length` you compute — serve
+it by hand over a `net` socket, and let `cosmic.fetch` (a full HTTP
+client: retries, redirects, streaming) be the client side. this is the
+sanctioned shape; `cosmic --examples fetch` runs exactly this pair.
+
+```teal
+local check = require("cosmic.check")
+local net = require("cosmic.net")
+
+-- serve one request: read the request line, drain headers, answer
+-- with a computed Content-Length. loop it for a real server.
+local function serve_one(srv: net.Socket): boolean, string
+  local accepted, accept_err = srv:accept()
+  if not accepted then
+    return false, accept_err
+  end
+  local conn = accepted as net.Socket -- cast: record union after guard
+  local request_line = conn:readline()
+  local path = "/"
+  if request_line is string then
+    path = request_line:match("^%u+%s+(%S+)") or "/"
+  end
+  while true do
+    local header = conn:readline()
+    if not header or header == "" then break end -- blank line ends headers
+  end
+  local body = "hello from " .. path .. "\n"
+  local ok, send_err = conn:sendall("HTTP/1.1 200 OK\r\n"
+    .. "Content-Length: " .. #body .. "\r\n"
+    .. "Connection: close\r\n\r\n" .. body)
+  conn:close()
+  return ok, send_err
+end
+
+local srv = check.must(net.listen_tcp("127.0.0.1", 0))
+print("READY " .. check.must(srv:getsockname()).port) -- a test blocks on this line
+serve_one(srv)
+srv:close()
+```
+
+client side, one call: `fetch.fetch("http://127.0.0.1:" .. port ..
+"/status", {allow_private = true})` — `allow_private` opts out of the
+SSRF guard that otherwise blocks loopback/private addresses; the
+returned record carries `status`, `body`, and `headers`. to test the
+pair end to end, spawn the built server binary from a test, block on
+the `READY <port>` line (the readiness pattern above), then point the
+real client at it — the sandbox grants loopback TCP.
+
+note `--docs http` will not find this page's shape: the matches it
+returns (proxy internals, `time.format_http`) are not an HTTP server.
+this recipe is the answer.


### PR DESCRIPTION
## What

Round-6 clean-room eval (agent A, building an HTTP status service + client):

> *"a newcomer specifically looking for 'how do I serve HTTP' would search `--docs http` (which surfaces only internal `quicksand.proxy` modules and `time.format_http`, both red herrings) before realizing the answer is 'roll your own with `net` + the `fetch` example as a template.'"*

Its wished-for fix, verbatim: a "HTTP without a framework" recipe in `guide.recipes` promoting the shape the `fetch` module's example already uses.

## Changes

- **New recipe** in `guide.recipes`: serve one GET correctly — request line, header drain, computed `Content-Length` — using `Socket:readline` (visible in the docs since #917), announcing `READY <port>` for the readiness pattern, with `cosmic.fetch` (+`allow_private`) as the client side and an end-to-end testing pointer. It also states outright that `--docs http` won't find this shape, so the next searcher lands here.
- **Staleness fix on the same page**: the TCP echo recipe still said `listen_tcp(0x7f000001, 0)` (integer addresses were removed by api-review-2) and claimed `recv` returns `""` on peer close (it returns bare nil).
- **`cosmic.child` header** now cross-references the readiness pattern (the round's third ask — nothing near the module hinted at it). The file sat exactly at the 500-line lint limit, so the header prose is tightened by the same two lines the pointer adds.

## Verification

`--make ci`: PASS (5 stages) — includes the guide-snippet gate compiling the new recipe code.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya)_