### PR TITLE
perf: base64 validation without the discarded capture; relpath fast path (#927, #928)

### DIFF
--- a/cosmic/codec.tl
+++ b/cosmic/codec.tl
@@ -77,17 +77,21 @@ end
 --- anywhere or padding not confined to the end, so a second, cheaper
 --- scan runs only then to tell which. Shared by decode_base64 and
 --- decode_base64url, which differ only in alphabet and error label.
+--- The alphabet portion is matched but not captured, so validation
+--- doesn't materialize an O(n) copy of it; callers that need the
+--- content (decode_base64url) can slice it from str themselves using
+--- the returned padding length.
 --- @param str string The string to validate
 --- @param content_pattern string Lua pattern for the alphabet, zero or more (e.g. "[A-Za-z0-9+/]*")
 --- @param bad_char_pattern string Lua pattern matching a character outside the alphabet and not "=" (e.g. "[^A-Za-z0-9+/=]")
 --- @param label string Name used in error messages ("base64" or "base64url")
---- @return string | nil The alphabet characters with any "=" padding stripped, or nil if invalid
+--- @return string | nil The trailing "=" padding (empty string if none), or nil if invalid
 --- @return string? Error message if invalid
 local function validate_base64_family(
     str: string, content_pattern: string, bad_char_pattern: string, label: string
   ): string | nil, string
-  local content, padding = str:match("^(" .. content_pattern .. ")(%=*)$")
-  if not content then
+  local padding = str:match("^" .. content_pattern .. "(%=*)$")
+  if not padding then
     if str:match(bad_char_pattern) then
       return nil, "invalid " .. label .. " character"
     end
@@ -96,7 +100,7 @@ local function validate_base64_family(
   if #padding > 2 then
     return nil, "invalid " .. label .. " padding"
   end
-  return content
+  return padding
 end
 
 --- Decode a base64 string to binary data.
@@ -132,10 +136,11 @@ end
 --- @return string | nil The decoded binary data, or nil on error
 --- @return string? Error message if decoding failed
 local function decode_base64url(str: string): string | nil, string
-  local content, err = validate_base64_family(str, "[A-Za-z0-9%-_]*", "[^A-Za-z0-9%-_=]", "base64url")
+  local padding, err = validate_base64_family(str, "[A-Za-z0-9%-_]*", "[^A-Za-z0-9%-_=]", "base64url")
   if err then
     return nil, err
   end
+  local content = string.sub(str, 1, #str - #padding)
   local b64 = string.gsub(content, "%-", "+")
   b64 = string.gsub(b64, "_", "/")
   return cosmo.DecodeBase64(b64)

--- a/cosmic/fs/path.tl
+++ b/cosmic/fs/path.tl
@@ -248,6 +248,14 @@ local function relpath(p: string, base?: string): string
     abs_p = normalize(p)
     abs_base = unix.getcwd() or "."
   else
+    -- Fast path: when p never climbs above cwd, cwd's own components are
+    -- always a strict prefix of normalize(cwd .. "/" .. p) and contribute
+    -- nothing to the result, so the relative path is just normalize(p).
+    -- The guard mirrors normalize()'s own "does this escape upward" check.
+    local norm_p = normalize(p)
+    if norm_p ~= ".." and norm_p:sub(1, 3) ~= "../" then
+      return norm_p
+    end
     local cwd = unix.getcwd() or "."
     abs_p = normalize(cwd .. "/" .. p)
     abs_base = cwd

--- a/cosmic/fs/path_test.tl
+++ b/cosmic/fs/path_test.tl
@@ -414,3 +414,57 @@ local function test_relpath_go_up_more()
   assert(result == "../..", "expected '../..', got '" .. result .. "'")
 end
 test_relpath_go_up_more()
+
+-- relpath implicit-base (cwd) tests: p is relative, base is omitted.
+-- These exercise the fast path added for cosmopolitan#928, which returns
+-- normalize(p) directly when p never climbs above cwd.
+
+local function test_relpath_implicit_empty()
+  local result = fs.relpath("")
+  assert(result == ".", "expected '.', got '" .. result .. "'")
+end
+test_relpath_implicit_empty()
+
+local function test_relpath_implicit_dot()
+  local result = fs.relpath(".")
+  assert(result == ".", "expected '.', got '" .. result .. "'")
+end
+test_relpath_implicit_dot()
+
+local function test_relpath_implicit_internal_cancel()
+  local result = fs.relpath("a/../b")
+  assert(result == "b", "expected 'b', got '" .. result .. "'")
+end
+test_relpath_implicit_internal_cancel()
+
+local function test_relpath_implicit_dot_segments()
+  local result = fs.relpath("./a/./b")
+  assert(result == "a/b", "expected 'a/b', got '" .. result .. "'")
+end
+test_relpath_implicit_dot_segments()
+
+local function test_relpath_implicit_trailing_slash()
+  local result = fs.relpath("a/b/")
+  assert(result == "a/b", "expected 'a/b', got '" .. result .. "'")
+end
+test_relpath_implicit_trailing_slash()
+
+local function test_relpath_implicit_plain()
+  local result = fs.relpath("a/b/c")
+  assert(result == "a/b/c", "expected 'a/b/c', got '" .. result .. "'")
+end
+test_relpath_implicit_plain()
+
+-- These must take the slow (walk-up-from-cwd) path: p escapes above cwd.
+
+local function test_relpath_implicit_parent()
+  local result = fs.relpath("..")
+  assert(result == "..", "expected '..', got '" .. result .. "'")
+end
+test_relpath_implicit_parent()
+
+local function test_relpath_implicit_parent_child()
+  local result = fs.relpath("../x")
+  assert(result == "../x", "expected '../x', got '" .. result .. "'")
+end
+test_relpath_implicit_parent_child()


### PR DESCRIPTION
Superseded — split into one PR per finding at the user's request: #936 (base64 validation without the discarded capture, #927) and #937 (relpath fast path, #928). The rejected round (#929) was never part of the diff. Closing without merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhorrSa46REGc9vbKN6Sa1