### PR TITLE
docs: ci is the inner loop, not just the gate

### DIFF
--- a/skills/cosmic/make.md
+++ b/skills/cosmic/make.md
@@ -51,6 +51,12 @@ make: root=/home/you/myapp
 check: PASS (12 files)
 ```
 
+`ci` is the gate, but warm it is also the inner loop: every stage
+skips what its stamps already proved, so a rerun after a one-file edit
+re-does only that file's work — about a second in a small project.
+rerunning the whole gate after each edit is cheaper than remembering
+which verb checks what.
+
 `clean` spares `o/bootstrap` on purpose: that is the verified copy
 `bin/cosmic` fetched from the pin, and removing it makes the next
 command reach for the network. cleaning a build should not have network

--- a/skills/cosmic/quickstart.md
+++ b/skills/cosmic/quickstart.md
@@ -137,6 +137,10 @@ cosmic --make coverage --baseline    # writes .cosmic-coverage
   still fail `ci` on formatting drift or an unjustified `as` cast.
   `--check fmt <file>` and `--check lint <file>` are those same gates
   per file — run them in the inner loop too, not first at `ci` time
+- simpler still: make `--make ci` ITSELF the inner loop. every stage
+  skips what already passed, so a warm rerun in a small project costs
+  about a second — rerunning the whole gate after each edit is
+  cheaper than remembering which verb checks what
 
 ## where to go next
 


### PR DESCRIPTION
## What

Both round-6 eval agents asked for build-system machinery that already exists:

- agent B: *"a trivial whitespace fixup means rerunning the entire `ci` pipeline from scratch rather than just the failed stage"* — wanting per-stage rerun.
- agent D: *"a `--make build --strict` or similar single flag that also ran fmt+lint would shorten the inner loop."*

Measured: a warm `ci` rerun in a hello-sized project is **~2s**, and **~0.9s** after touching one file — every stage stamp-skips what already passed (the #875–#878 incremental work). So the verb both agents wanted exists and is spelled `ci`; per-stage resume would be machinery for a solved problem, and folding lint into build would stop you producing a runnable work-in-progress binary over a missing cast comment.

What's actually missing is the docs saying so: quickstart frames `ci` as the whole gate you run at the end, and the per-file `--check fmt`/`--check lint` discipline it recommends instead is exactly what both agents forgot under pressure.

## Changes

- **guide.quickstart** ("when something fails"): a bullet saying it plainly — make `--make ci` itself the inner loop; a warm rerun costs about a second, cheaper than remembering which verb checks what.
- **guide.make**: the same property stated where the verbs are defined, after the verdict-line example.

## Verification

`--make ci`: PASS (5 stages).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5w8Z2AhYQ3LXTBZT1Awya)_