### PR TITLE
perf: validate base64 without capturing the content portion

### DIFF
--- a/cosmic/codec.tl
+++ b/cosmic/codec.tl
@@ -77,17 +77,21 @@ end
 --- anywhere or padding not confined to the end, so a second, cheaper
 --- scan runs only then to tell which. Shared by decode_base64 and
 --- decode_base64url, which differ only in alphabet and error label.
+--- The alphabet portion is matched but not captured, so validation
+--- doesn't materialize an O(n) copy of it; callers that need the
+--- content (decode_base64url) can slice it from str themselves using
+--- the returned padding length.
 --- @param str string The string to validate
 --- @param content_pattern string Lua pattern for the alphabet, zero or more (e.g. "[A-Za-z0-9+/]*")
 --- @param bad_char_pattern string Lua pattern matching a character outside the alphabet and not "=" (e.g. "[^A-Za-z0-9+/=]")
 --- @param label string Name used in error messages ("base64" or "base64url")
---- @return string | nil The alphabet characters with any "=" padding stripped, or nil if invalid
+--- @return string | nil The trailing "=" padding (empty string if none), or nil if invalid
 --- @return string? Error message if invalid
 local function validate_base64_family(
     str: string, content_pattern: string, bad_char_pattern: string, label: string
   ): string | nil, string
-  local content, padding = str:match("^(" .. content_pattern .. ")(%=*)$")
-  if not content then
+  local padding = str:match("^" .. content_pattern .. "(%=*)$")
+  if not padding then
     if str:match(bad_char_pattern) then
       return nil, "invalid " .. label .. " character"
     end
@@ -96,7 +100,7 @@ local function validate_base64_family(
   if #padding > 2 then
     return nil, "invalid " .. label .. " padding"
   end
-  return content
+  return padding
 end
 
 --- Decode a base64 string to binary data.
@@ -132,10 +136,11 @@ end
 --- @return string | nil The decoded binary data, or nil on error
 --- @return string? Error message if decoding failed
 local function decode_base64url(str: string): string | nil, string
-  local content, err = validate_base64_family(str, "[A-Za-z0-9%-_]*", "[^A-Za-z0-9%-_=]", "base64url")
+  local padding, err = validate_base64_family(str, "[A-Za-z0-9%-_]*", "[^A-Za-z0-9%-_=]", "base64url")
   if err then
     return nil, err
   end
+  local content = string.sub(str, 1, #str - #padding)
   local b64 = string.gsub(content, "%-", "+")
   b64 = string.gsub(b64, "_", "/")
   return cosmo.DecodeBase64(b64)


### PR DESCRIPTION
Closes #927. Split out of #934.

`decode_base64`'s shared validator matched the whole alphabet portion of the input as a capturing group, materializing an O(n) copy it then discarded — only `decode_base64url` needs the content, and it now derives it from the padding length with one `string.sub`. The validator captures only the small padding group; accepted alphabets, error strings, and return shapes are unchanged.

Gates: `ci: PASS (5 stages)`; clean back-to-back A/B via `gate.tl compare`:

```
codec_base64_roundtrip_64k   alloc  230.01 KB/op -> 146.37 KB/op   (-36%, every measured pass)
codec_base64_roundtrip_64k      791.22 µs ->    763.62 µs   -3.5%  (noise  ±10.0%)  ok
```

Wall time is neutral; the win is allocation/GC pressure — the discarded capture's memcpy share was small next to base64's bit-packing, exactly as #927 anticipated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhorrSa46REGc9vbKN6Sa1

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhorrSa46REGc9vbKN6Sa1)_