### PR TITLE
perf: relpath returns normalize(p) when p cannot escape the base

### DIFF
--- a/cosmic/fs/path.tl
+++ b/cosmic/fs/path.tl
@@ -248,6 +248,14 @@ local function relpath(p: string, base?: string): string
     abs_p = normalize(p)
     abs_base = unix.getcwd() or "."
   else
+    -- Fast path: when p never climbs above cwd, cwd's own components are
+    -- always a strict prefix of normalize(cwd .. "/" .. p) and contribute
+    -- nothing to the result, so the relative path is just normalize(p).
+    -- The guard mirrors normalize()'s own "does this escape upward" check.
+    local norm_p = normalize(p)
+    if norm_p ~= ".." and norm_p:sub(1, 3) ~= "../" then
+      return norm_p
+    end
     local cwd = unix.getcwd() or "."
     abs_p = normalize(cwd .. "/" .. p)
     abs_base = cwd

--- a/cosmic/fs/path_test.tl
+++ b/cosmic/fs/path_test.tl
@@ -414,3 +414,57 @@ local function test_relpath_go_up_more()
   assert(result == "../..", "expected '../..', got '" .. result .. "'")
 end
 test_relpath_go_up_more()
+
+-- relpath implicit-base (cwd) tests: p is relative, base is omitted.
+-- These exercise the fast path added for cosmopolitan#928, which returns
+-- normalize(p) directly when p never climbs above cwd.
+
+local function test_relpath_implicit_empty()
+  local result = fs.relpath("")
+  assert(result == ".", "expected '.', got '" .. result .. "'")
+end
+test_relpath_implicit_empty()
+
+local function test_relpath_implicit_dot()
+  local result = fs.relpath(".")
+  assert(result == ".", "expected '.', got '" .. result .. "'")
+end
+test_relpath_implicit_dot()
+
+local function test_relpath_implicit_internal_cancel()
+  local result = fs.relpath("a/../b")
+  assert(result == "b", "expected 'b', got '" .. result .. "'")
+end
+test_relpath_implicit_internal_cancel()
+
+local function test_relpath_implicit_dot_segments()
+  local result = fs.relpath("./a/./b")
+  assert(result == "a/b", "expected 'a/b', got '" .. result .. "'")
+end
+test_relpath_implicit_dot_segments()
+
+local function test_relpath_implicit_trailing_slash()
+  local result = fs.relpath("a/b/")
+  assert(result == "a/b", "expected 'a/b', got '" .. result .. "'")
+end
+test_relpath_implicit_trailing_slash()
+
+local function test_relpath_implicit_plain()
+  local result = fs.relpath("a/b/c")
+  assert(result == "a/b/c", "expected 'a/b/c', got '" .. result .. "'")
+end
+test_relpath_implicit_plain()
+
+-- These must take the slow (walk-up-from-cwd) path: p escapes above cwd.
+
+local function test_relpath_implicit_parent()
+  local result = fs.relpath("..")
+  assert(result == "..", "expected '..', got '" .. result .. "'")
+end
+test_relpath_implicit_parent()
+
+local function test_relpath_implicit_parent_child()
+  local result = fs.relpath("../x")
+  assert(result == "../x", "expected '../x', got '" .. result .. "'")
+end
+test_relpath_implicit_parent_child()


### PR DESCRIPTION
Closes #928. Split out of #934.

In the implicit-base branch, `relpath` built `abs_p` by prefixing `cwd` onto `p`, so `cwd`'s components could only ever form a strict, non-contributing prefix — unless `normalize(p)` comes out as `".."` or leads with `"../"`, the `getcwd()` fetch, both component splits, and the prefix walk always reduce to exactly `normalize(p)`. This takes that fast path (mirroring normalize's own upward-escape guard); escaping paths fall through to the existing algorithm unchanged. The implicit-base branch, previously untested, gains eight cases including both slow-path ones.

Gates: `ci: PASS (5 stages)`; back-to-back A/B via `gate.tl compare`, exit 0:

```
fs_relpath_relative               6.84 µs ->      1.42 µs    -79.2%  (noise  ±10.0%)  faster
alloc  1.81 KB/op -> 0.00 KB/op
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhorrSa46REGc9vbKN6Sa1

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhorrSa46REGc9vbKN6Sa1)_