### PR TITLE
docs: retire gotchas the toolchain already prevents

### DIFF
--- a/skills/cosmic/SKILL.md
+++ b/skills/cosmic/SKILL.md
@@ -57,7 +57,7 @@ return {greet = greet}
 run `cosmic --docs guide.<topic>` or see the files below for deeper coverage:
 
 - [quickstart](quickstart.md) — your first project: binary + module + test, built and gated
-- [gotchas](gotchas.md) — Teal gotchas for newcomers (integer vs number, any casts, io shadowing)
+- [gotchas](gotchas.md) — Teal gotchas for newcomers (integer vs number, any casts, arg layout)
 - [recipes](recipes.md) — end-to-end patterns (CLI skeleton, walk+hash+sqlite, self-spawn, TCP echo)
 - [testing](testing.md) — writing and running tests (`cosmic --test`, assert patterns)
 - [checking](checking.md) — type checking with `cosmic --check types`

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -4,29 +4,22 @@ common errors that trip up agents and developers new to Teal. each entry shows t
 
 ## 1. integer vs number
 
-Teal distinguishes `integer` from `number`. string indices (`string.sub`, `string.byte`, `table` lookups) and some C bindings require `integer`. arithmetic and C status returns are `number`.
+Teal distinguishes `integer` from `number`: string indices
+(`string.sub`, `string.byte`, table lookups) require `integer`, and
+arithmetic yields `number`. the `got number, expected integer` error
+carries the fix as a hint — annotate the variable `: integer`, or
+convert at the call site with `math.tointeger`.
 
-**wrong:**
 ```teal
-local n: number = 5
-local s = ("hello"):sub(n, n) -- error: got number, expected integer
-```
-
-**right:**
-```teal
--- option A: annotate the literal as integer
 local n: integer = 5
 local s = ("hello"):sub(n, n)
-
--- option B: convert at call site
-local n: number = some_computation()
-local s = ("hello"):sub(math.tointeger(n), math.tointeger(n))
+-- from a computation: convert first
+local m = ("hello"):sub(math.tointeger(x) or 1, 5)
 ```
 
-`WEXITSTATUS` and similar status-decoding functions return `number`, not `integer`:
-```teal
-local code: number = child.WEXITSTATUS(status)
-```
+(bindings that return integral values — exit statuses, fds, pids,
+sizes — are annotated `integer` at the source of truth, so no
+conversion dance is needed on that side.)
 
 ## 2. traversing `any` from json.decode
 

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -82,23 +82,12 @@ end
 local name = (arg[1] as string):upper()
 ```
 
-## 4. multi-return capture — `db:query` and similar
+## 4. multi-return capture
 
-functions that return `(iterator, state, initial)` (like `db:query`) cannot be wrapped inside another expression — the extra returns are discarded.
+the checker's `excess return values` error carries the fix as a hint:
+capture multiple returns first — `local v, err = f(...)`. wrapping a
+multi-return call inside another expression discards the extra returns.
 
-**wrong:**
-```teal
-for row in db:query("SELECT * FROM t"), nil, nil do -- syntax error / wrong returns
-```
-
-**right:**
-```teal
-for row in db:query("SELECT * FROM t") do
-  print(row.id)
-end
-```
-
-if you need to capture both the iterator and an error return, assign to locals first:
 ```teal
 local rows, err = db:query("SELECT * FROM t")
 if not rows then
@@ -109,39 +98,18 @@ for row in rows do
 end
 ```
 
-## 5. local modules — `require` path resolution
+## 5. retired — moved to guide.modules
 
-`require("mymod")` resolves relative to the script's directory, not the current working directory. you do not need a `./` prefix (both work).
+how `require` resolves local module paths is information, not a trap;
+it now lives in `cosmic --docs guide.modules`.
 
-```teal
--- both are equivalent when mymod.tl is in the same directory:
-local m = require("mymod")
-local m2 = require("./mymod") -- also works
-```
+## 6. retired — the checker prevents it
 
-if your module is in a subdirectory:
-```teal
-local m = require("subdir.mymod") -- loads subdir/mymod.tl
-```
-
-## 6. naming `cosmic.fd` as `io`
-
-`require("cosmic.fd")` returns the cosmic.fd module. if you bind it to a local named `io` you shadow Lua's built-in `io` library and lose access to `io.stderr`, `io.stdin`, `io.stdout`.
-
-**wrong:**
-```teal
-local io = require("cosmic.fd") -- hides io.stderr!
-io.stderr:write("error\n") -- runtime error: attempt to index nil
-```
-
-**right:**
-```teal
-local fs = require("cosmic.fs") -- keep built-in io accessible
-fs.write("out.txt", data)
-io.stderr:write("error: " .. msg .. "\n") -- standard Lua io still works
-```
-
-cosmic.fd has no stderr/stdout/stdin handles — use Lua's `io.stderr` directly for stream output.
+binding a module to a local that shadows a Lua builtin
+(`local io = require("cosmic.fd")`) is a `--check types` error today
+(`variable shadows previous declaration of 'io'`, warnings are errors),
+so the runtime surprise this entry described is unreachable. rename the
+local (`fd`, `fs`, ...); Lua's `io.stderr` stays available.
 
 ## 7. `arg[0]` is not the interpreter — use `arg[-1]` to re-invoke cosmic
 
@@ -278,36 +246,25 @@ end
 works when the record must stay standalone for internal reasons — see
 how `cosmic.fs` re-exports `Stat`.)
 
-## 11. shadowing a Lua builtin
+## 11. retired — the checker prevents it
 
-`--check types` warns on any shadowed declaration, including Lua's own
-globals — a `local function load(...)` shadows the builtin `load()`,
-`local type = ...` shadows `type()`. the warning
-(`function shadows previous declaration of 'load'`) fails the strict
-check because warnings are errors; rename yours (`load_data`,
-`kind`, ...). the same trap at module level is gotcha #6's `io` example:
-binding `require("cosmic.fd")` to a local named `io` hides `io.stderr`.
+shadowing any declaration, including Lua builtins (`local function
+load(...)`, `local type = ...`), is a `--check types` error today
+(warnings are errors). the error names the shadowed declaration; rename
+yours (`load_data`, `kind`, ...).
 
 ## 12. colon-call only works on the value's own record type
 
-`db:exec(sql)` works because `exec` is declared on `sqlite.Database`
-itself. a function YOUR module declares that merely takes such a value
-as its first argument is not a method of that value — calling it with a
-colon fails:
+the checker's `invalid key 'add' in record 'db'` error carries the fix
+as a hint: a function on your MODULE's record is dot-called with the
+value first (`store.add(db, ...)`), never colon-called (`db:add(...)`).
+colon-call works only for functions declared on the value's own record
+type (like `db:exec` on `sqlite.Database`).
 
 ```teal
-local record StoreModule
-  add: function(db: sqlite.Database, name: string): boolean, string
-end
-
 db:add("alice") -- error: invalid key 'add' in record 'db' of type sqlite.Database
 store.add(db, "alice") -- right: module function, dot-called, value first
 ```
-
-to get colon-call ergonomics for your own type, declare your own record
-with function fields taking `self` and construct values of it — see how
-`cosmic.fd`'s `Handle` does it. mixing the two (module functions over a
-foreign type) is the common, simpler shape; call them with a dot.
 
 ## 13. `local x = nil` means type nil, forever
 
@@ -372,12 +329,20 @@ local page = template:gsub("{{name}}", user_name)
 -- user_name = "50%" → runtime error: invalid use of '%' in replacement string
 ```
 
-**right — escape `%` in the replacement first:**
+**right — for literal text, use `str.replace`** (both sides literal, no
+magic characters on either):
+```teal
+local str = require("cosmic.string")
+local page = str.replace(template, "{{name}}", user_name)
+```
+
+when you genuinely need `gsub` (a real pattern on the needle side),
+escape `%` in the replacement first:
 ```teal
 local safe = user_name:gsub("%%", "%%%%")
-local page = template:gsub("{{name}}", safe)
+local page = template:gsub(needle_pattern, safe)
 ```
 
 (the needle side has the same property — see the find-needle lint rule
-for `find`; on `gsub` both arguments are magic, and only the
-replacement side is fixable by doubling `%`.)
+for `find`; on `gsub` both arguments are magic, and `str.replace` is the
+literal-on-both-sides answer.)

--- a/skills/cosmic/modules.md
+++ b/skills/cosmic/modules.md
@@ -15,10 +15,25 @@ all standard library modules are imported as `cosmic.*`:
 ```teal
 local json = require("cosmic.json")
 local fs = require("cosmic.fs")
-local fs = require("cosmic.fs")
 ```
 
 prefer `cosmic.*` modules over raw `cosmo.*` C bindings. use `cosmo.*` only when no `cosmic.*` alternative exists yet.
+
+## Local Modules — `require` path resolution
+
+`require("mymod")` resolves relative to the script's directory, not the
+current working directory. you do not need a `./` prefix (both work).
+
+```teal
+-- both are equivalent when mymod.tl is in the same directory:
+local m = require("mymod")
+local m2 = require("./mymod") -- also works
+```
+
+if your module is in a subdirectory:
+```teal
+local m = require("subdir.mymod") -- loads subdir/mymod.tl
+```
 
 ## Error Handling
 


### PR DESCRIPTION
The no-code-needed slice of #949: the ledger shrinks where the toolchain already closed the trap.

- **Gotcha 6** (binding `cosmic.fd` as `io`) and **gotcha 11** (shadowing a builtin): retired. `--check types` errors on any shadowed declaration today (warnings are errors) — verified against the built checker: `local io = require("cosmic.fd")` produces the shadow warning plus an `invalid key 'stderr'` error, so the runtime surprise both entries described is unreachable. Each shrinks to a short retirement stub so the ledger numbering other issues and eval rounds reference stays stable.
- **Gotcha 5** (`require` path resolution): information, not a trap — moved to `guide.modules` next to the import rules (also drops an accidental duplicated line there).
- **Gotcha 15**: now leads with `str.replace` — the literal-on-both-sides answer already in `cosmic.string` — and keeps the `%%`-escape only for the genuine-pattern case. (The lint half of this is #947 → PR #954.)
- **Gotchas 4 and 12**: shrunk to their error-site hint text plus one example — `_teal_hints` patterns 3 and 2e already deliver the fix at the error site.
- **Gotcha 1** (added in a follow-up commit): drops its `WEXITSTATUS`-shaped paragraph. The binding half of #943 turns out to be already complete at the current pin — the pinned cosmos release's `definitions.lua` carries **zero** `@return number` annotations (`WEXITSTATUS` generates as `function(wstatus: integer): integer`, and the generated `cosmo/unix.d.tl` has no `: number` returns at all; the one `number` left in the cosmo surface is fetch's fractional timeout-in-seconds, a genuine float). The entry's claim was stale; what remains is the Lua-core fact, shrunk to the hint text plus one example. No cosmopolitan change is needed — **closes #943** as well.

`--make ci` passes (5 stages).

Part of #949. Closes #943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWCMuPQkSAomijVdve6V8D