### PR TITLE
json: typed decode accessors, so the common shapes need no cast

### DIFF
--- a/cosmic/json.tl
+++ b/cosmic/json.tl
@@ -74,6 +74,69 @@ local function encode(value: any, opts?: Options): string | nil, string
   return result, err
 end
 
+-- The shared marker metatable decode() applies to every array it
+-- decodes (and array() applies on demand); objects carry no metatable,
+-- so the marker is what tells the two apart after a decode.
+-- typed any: metatable<T>s for different T are not comparable
+local array_marker: any = getmetatable(cosmo.jsonarray({}))
+
+--- Describe a decoded value's JSON kind, for wrong-shape error messages.
+local function decoded_kind(v: any): string
+  if v == nil then
+    return "null"
+  end
+  local t = type(v)
+  if t ~= "table" then
+    return t
+  end
+  if getmetatable(v) == array_marker then
+    return "array"
+  end
+  return "object"
+end
+
+--- Decode a JSON object into a `{string: any}` map.
+--- Fails when the input is invalid JSON OR valid JSON whose top-level
+--- value is not an object, so the wrong-shape case is a real error
+--- instead of a downstream indexing surprise. Nested values are `any`;
+--- narrow uncertain shapes with `is`. Use decode() for the genuinely
+--- dynamic case.
+--- @param str string The JSON string to decode
+--- @return {string: any} | nil The decoded object
+--- @return string? Error message if decoding failed or the value is not an object
+local function decode_object(str: string): {string: any} | nil, string
+  local result, err = cosmo.DecodeJson(str)
+  if err then
+    return nil, err
+  end
+  if result is {string: any} then
+    if getmetatable(result) ~= array_marker then
+      return result
+    end
+  end
+  return nil, "expected a JSON object, got " .. decoded_kind(result)
+end
+
+--- Decode a JSON array into a `{any}` list.
+--- Fails when the input is invalid JSON OR valid JSON whose top-level
+--- value is not an array. Elements are `any`; narrow uncertain shapes
+--- with `is`. Use decode() for the genuinely dynamic case.
+--- @param str string The JSON string to decode
+--- @return {any} | nil The decoded array
+--- @return string? Error message if decoding failed or the value is not an array
+local function decode_array(str: string): {any} | nil, string
+  local result, err = cosmo.DecodeJson(str)
+  if err then
+    return nil, err
+  end
+  if result is {any} then
+    if getmetatable(result) == array_marker then
+      return result
+    end
+  end
+  return nil, "expected a JSON array, got " .. decoded_kind(result)
+end
+
 --- Mark a table as a JSON array so encode() serializes it as `[]` even
 --- when it is empty (an unmarked empty table encodes as `{}`). decode()
 --- applies the same marker to every array it decodes, which is how an
@@ -89,12 +152,16 @@ local record JsonModule
   type Options = Options
 
   decode: function(str: string): any, string
+  decode_object: function(str: string): {string: any} | nil, string
+  decode_array: function(str: string): {any} | nil, string
   encode: function(value: any, opts?: Options): string | nil, string
   array: function(t?: {any}): {any}
 end
 
 local M: JsonModule = {
   decode = decode,
+  decode_object = decode_object,
+  decode_array = decode_array,
   encode = encode,
   array = array,
 }

--- a/cosmic/json_example.tl
+++ b/cosmic/json_example.tl
@@ -20,6 +20,28 @@ local function Example_encode()
   -- {"a":1}
 end
 
+-- Example_decode_object demonstrates typed decoding of a JSON object
+local function Example_decode_object()
+  local json = require("cosmic.json")
+  local obj = json.decode_object('{"name":"ada","age":36}')
+  if obj is {string: any} then
+    print(obj["name"])
+  end
+  -- Output:
+  -- ada
+end
+
+-- Example_decode_array demonstrates typed decoding of a JSON array
+local function Example_decode_array()
+  local json = require("cosmic.json")
+  local items = json.decode_array("[10,20,30]")
+  if items is {any} then
+    print(#items)
+  end
+  -- Output:
+  -- 3
+end
+
 -- Example_decode_error demonstrates error handling for invalid JSON
 local function Example_decode_error()
   local json = require("cosmic.json")
@@ -43,4 +65,5 @@ local function Example_encode_error()
 end
 
 -- Suppress unused warnings for examples
-local _ = {Example_decode, Example_encode, Example_decode_error, Example_encode_error}
+local _ = {Example_decode, Example_encode, Example_decode_object,
+  Example_decode_array, Example_decode_error, Example_encode_error}

--- a/cosmic/json_test.tl
+++ b/cosmic/json_test.tl
@@ -19,6 +19,55 @@ local function test_decode_array()
 end
 test_decode_array()
 
+local function test_decode_object_typed()
+  local obj = check.must(json.decode_object('{"a":1,"b":"hello"}'))
+  assert(obj["a"] == 1, "expected a=1")
+  assert(obj["b"] == "hello", "expected b='hello'")
+  local empty = check.must(json.decode_object("{}"))
+  assert(next(empty) == nil, "expected empty object")
+end
+test_decode_object_typed()
+
+local function test_decode_object_wrong_shape()
+  for input, kind in pairs({["[1,2]"] = "array", ["[]"] = "array",
+      ["42"] = "number", ['"s"'] = "string", ["true"] = "boolean",
+      ["null"] = "null"}) do
+    local obj, err = json.decode_object(input)
+    assert(obj == nil, "expected nil for " .. input)
+    assert(err and err:find(kind, 1, true),
+      "error should name the kind '" .. kind .. "', got: " .. tostring(err))
+  end
+  local invalid, invalid_err = json.decode_object("{nope")
+  assert(invalid == nil, "expected nil for invalid JSON")
+  assert(invalid_err ~= nil, "expected a decode error for invalid JSON")
+end
+test_decode_object_wrong_shape()
+
+local function test_decode_array_typed()
+  local items = check.must(json.decode_array('[1,"two",true]'))
+  assert(#items == 3, "expected 3 items")
+  assert(items[1] == 1 and items[2] == "two" and items[3] == true,
+    "elements should decode in order")
+  local empty = check.must(json.decode_array("[]"))
+  assert(#empty == 0, "expected empty array")
+  assert(json.encode(empty) == "[]", "typed empty array should re-encode as []")
+end
+test_decode_array_typed()
+
+local function test_decode_array_wrong_shape()
+  for input, kind in pairs({['{"a":1}'] = "object", ["{}"] = "object",
+      ["42"] = "number", ["null"] = "null"}) do
+    local items, err = json.decode_array(input)
+    assert(items == nil, "expected nil for " .. input)
+    assert(err and err:find(kind, 1, true),
+      "error should name the kind '" .. kind .. "', got: " .. tostring(err))
+  end
+  local invalid, invalid_err = json.decode_array("[nope")
+  assert(invalid == nil, "expected nil for invalid JSON")
+  assert(invalid_err ~= nil, "expected a decode error for invalid JSON")
+end
+test_decode_array_wrong_shape()
+
 local function test_decode_primitives()
   assert(json.decode("42") == 42, "expected 42")
   assert(json.decode('"hello"') == "hello", "expected 'hello'")

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -30,21 +30,16 @@ local code: number = child.WEXITSTATUS(status)
 
 ## 2. traversing `any` from json.decode
 
-`json.decode` returns `any`. you cannot index or iterate `any` directly — you must cast to a concrete type first.
+for the two common top-level shapes, skip `any` entirely:
+`json.decode_object` returns `{string: any} | nil, string` and
+`json.decode_array` returns `{any} | nil, string` — the checker sees a
+concrete type with no cast, and input of the wrong shape is a real
+error instead of a downstream indexing surprise.
 
-**wrong:**
 ```teal
-local data = json.decode(input)
-for _, item in ipairs(data) do -- error: attempting ipairs on something that's not an array: <any type>
-```
-
-**right — `is` when the shape is uncertain** (narrows in the positive
-branch, compiles to one `type()` check, and untrusted input that isn't
-the expected shape takes the other branch instead of misbehaving later):
-```teal
-local data = json.decode(input)
-if data is {any} then
-  for _, raw in ipairs(data) do
+local items = json.decode_array(input)
+if items is {any} then
+  for _, raw in ipairs(items) do
     if raw is {string: any} then
       print(raw["name"] as string)
     end
@@ -52,14 +47,11 @@ if data is {any} then
 end
 ```
 
-**right — `as` when the shape is trusted** (a schema you control):
-```teal
-local obj = json.decode(input) as {string: any}
-local tags = obj["tags"] as {string}
-```
-
-new casts count against the cast ratchet (`_build/casts.txt`); prefer
-the `is` form where the code branches anyway.
+`json.decode` still returns `any`, for the genuinely-dynamic case: you
+cannot index or iterate `any` directly — narrow with `is` where the
+shape is uncertain (as with the nested values above), or cast
+(`local obj = json.decode(input) as {string: any}`) when the shape is
+trusted. new casts count against the cast ratchet (`_build/casts.txt`).
 
 ## 3. `arg` elements are `string | nil`
 

--- a/skills/cosmic/recipes.md
+++ b/skills/cosmic/recipes.md
@@ -26,30 +26,32 @@ local function main(): integer
   if not data then
     die("cannot read '" .. tostring(path) .. "': " .. read_err)
   end
-  local decoded, decode_err = json.decode(data)
-  if decode_err then
-    die("invalid JSON: " .. decode_err)
-  end
-  local items = decoded as {any}
+  local items, decode_err = json.decode_array(data)
+  if items is {any} then
+    -- transform: count the items
+    local result = {count = #items}
 
-  -- transform: count the items
-  local result = {count = #items}
-
-  local encoded, encode_err = json.encode(result)
-  if encode_err then
-    die("encode failed: " .. encode_err)
+    local encoded, encode_err = json.encode(result)
+    if encode_err then
+      die("encode failed: " .. encode_err)
+    end
+    print(encoded)
+    return 0
   end
-  print(encoded)
-  return 0
+  die("invalid JSON: " .. decode_err)
+  return 1
 end
 
 os.exit(main())
 ```
 
-key details: `arg[1]` is `string | nil` (guard before use), `json.decode`
-returns `any` (cast before iterating), capture `encode`'s error return
-instead of passing the call straight to `print`, and `main` returns
-`integer` because `os.exit` rejects `number`.
+key details: `arg[1]` is `string | nil` (guard before use),
+`json.decode_array` returns a typed `{any} | nil` — no cast needed, and a
+top-level value that is not an array is a real error (`decode_object` is
+the sibling for objects; plain `decode` returns `any` for the dynamic
+case) — `is` narrows it in the positive branch, capture `encode`'s error
+return instead of passing the call straight to `print`, and `main`
+returns `integer` because `os.exit` rejects `number`.
 
 ## index files into sqlite (walk + hash + sqlite)
 


### PR DESCRIPTION
Implements #944: two typed accessors beside `json.decode`, honest-nil shaped, so the two shapes that appear in practice need zero casts at the call site.

```teal
decode_object: function(s: string): {string: any} | nil, string
decode_array: function(s: string): {any} | nil, string
```

- Both fail on invalid JSON **and** on valid JSON whose top-level value is not the requested shape, with an error that names the shape found (`expected a JSON array, got object`) — a real error message instead of a downstream `attempt to index` surprise. `decode` stays for the genuinely-dynamic case.
- Shape detection uses the shared array-marker metatable `decode()` already applies to every array it decodes (verified at runtime: decoded arrays — empty or not — carry it; decoded objects carry no metatable).
- The recipes' CLI skeleton drops its `as {any}` cast: `decode_array` + `is`-narrowing in the positive branch, and a non-array input now dies with the shape error. (Verified: the skeleton type-checks and runs, `[1,2,3]` → `{"count":3}`, `{"a":1}` → `error: invalid JSON: expected a JSON array, got object`.)
- Gotcha #2 shrinks to the accessors plus the nested-value `is` note.
- Tests cover success, empty object/array, every wrong-shape kind (array/object/number/string/boolean/null), and invalid JSON; `json_example.tl` gains `Example_decode_object` / `Example_decode_array`.

`--make ci` passes (5 stages).

Closes #944; part of #949.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWCMuPQkSAomijVdve6V8D

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWCMuPQkSAomijVdve6V8D)_