### PR TITLE
proc: interpreter() retires the rawget(arg, -1) dance

### DIFF
--- a/cosmic/child/init.tl
+++ b/cosmic/child/init.tl
@@ -218,8 +218,8 @@ end
 --- Spawns a child process with I/O control. Uses fexecve for /zip/ paths.
 --- Returns a Handle on success. If the program cannot be executed, spawn
 --- itself fails with `nil, "exec failed: ENOENT: ..."`, not a bogus exit
---- code from a later wait(). To spawn cosmic itself, use `rawget(arg, -1)`
---- — NOT arg[0], the script path (/zip/main.lua), not the interpreter.
+--- code from a later wait(). To spawn cosmic itself, use cosmic.proc's
+--- `interpreter()` — NOT arg[0] (/zip/main.lua), not the interpreter.
 --- @param argv {string} Command and arguments
 --- @param opts Options? Spawn options
 --- @return Handle | nil, string? Process handle or nil + error

--- a/cosmic/proc/init.tl
+++ b/cosmic/proc/init.tl
@@ -2,14 +2,14 @@
 --- Identity, session/group control, exec, and resource usage.
 ---
 --- The global `arg` table layout when running a script: arg[-1] is the
---- cosmic interpreter binary's path (re-invoke it to spawn a child); arg[0]
---- is the script path as the runtime sees it (/zip/main.lua when dispatched
---- by the embedded entry point — NOT the interpreter path); arg[1..] are
---- user arguments. `arg` is typed {string}: negative indices need
---- `rawget(arg, -1) as string` to pass the strict type checker.
+--- cosmic interpreter binary's path (use interpreter() to reach it
+--- typed and resolved); arg[0] is the script path as the runtime sees
+--- it (/zip/main.lua when dispatched by the embedded entry point — NOT
+--- the interpreter path); arg[1..] are user arguments.
 local unix = require("cosmo.unix")
 local cosmo = require("cosmo")
 local errstr = require("cosmic.errno").wrap
+local fs_path = require("cosmic.fs.path")
 
 --- Process resource usage statistics (the generated unix.Rusage record):
 --- CPU time, memory usage, I/O, and context switch counters.
@@ -131,6 +131,41 @@ local function which(prog: string): string | nil, string
     return nil, errstr(err, "which")
   end
   return p
+end
+
+--- Resolved-interpreter cache: argv0 is resolved against the cwd (and
+--- $PATH) of the FIRST call, so a program that chdirs should call
+--- interpreter() before doing so when it was started via a relative path.
+local interpreter_path: string | nil = nil
+
+--- Absolute path of the running cosmic interpreter — for re-invoking it
+--- to run another script as a child: `child.start({proc.interpreter(),
+--- "worker.tl"})`. This is `arg[-1]` resolved, NOT `arg[0]` (the script
+--- path as the runtime sees it, `/zip/main.lua` in a packed binary). A
+--- bare PATH-invoked argv0 (`cosmic`, the shebang shape) is resolved
+--- with a real $PATH search. The result is cached across calls.
+--- @return string | nil The interpreter's absolute path
+--- @return string? Error message when argv0 is missing or unresolvable
+local function interpreter(): string | nil, string
+  if interpreter_path then
+    return interpreter_path
+  end
+  local argv0 = rawget(arg, -1)
+  if argv0 == nil or argv0 == "" then
+    return nil, "interpreter: arg[-1] is not set"
+  end
+  local abs = fs_path.abspath(argv0)
+  if fs_path.is_file(abs) then
+    interpreter_path = abs
+    return abs
+  end
+  -- A bare name found on $PATH (which() reports the errno when not).
+  local found, err = which(argv0)
+  if not found then
+    return nil, "interpreter: cannot resolve '" .. argv0 .. "': " .. tostring(err)
+  end
+  interpreter_path = found
+  return found
 end
 
 --- Replaces current process with new program; never returns on success.
@@ -287,6 +322,7 @@ local record ProcModule
   exit: function(exitcode?: integer)
 
   -- Exec
+  interpreter: function(): string | nil, string
   which: function(prog: string): string | nil, string
   execve: function(prog: string, args: {string}, env: {string}): nil, string
   execvp: function(prog: string, argv?: {string}): nil, string
@@ -366,6 +402,7 @@ local M: ProcModule = {
   exit = exit,
 
   -- Exec
+  interpreter = interpreter,
   which = which,
   execve = execve,
   execvp = execvp,

--- a/cosmic/proc_test.tl
+++ b/cosmic/proc_test.tl
@@ -445,3 +445,25 @@ local function test_execve_error_names_errno()
     "execve error should name the program, got: " .. tostring(err))
 end
 test_execve_error_names_errno()
+
+-- interpreter tests --
+
+local function test_interpreter_resolves_running_binary()
+  local exe = check.must(proc.interpreter())
+  assert(fs.is_absolute(exe), "interpreter path should be absolute, got: " .. exe)
+  assert(fs.is_file(exe), "interpreter path should name a real file, got: " .. exe)
+  assert(exe ~= "/zip/main.lua", "interpreter must not be the embedded script path")
+end
+test_interpreter_resolves_running_binary()
+
+local function test_interpreter_is_cached_and_spawnable()
+  local exe = check.must(proc.interpreter())
+  assert(exe == check.must(proc.interpreter()), "repeat calls should agree")
+  local child = require("cosmic.child")
+  local h = check.must(child.start({exe, "-e", "print('from child')"}))
+  local out = h:read()
+  check.must(h:wait())
+  assert(tostring(out):find("from child", 1, true),
+    "spawned interpreter should run code, got: " .. tostring(out))
+end
+test_interpreter_is_cached_and_spawnable()

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -143,13 +143,13 @@ io.stderr:write("error: " .. msg .. "\n") -- standard Lua io still works
 
 cosmic.fd has no stderr/stdout/stdin handles — use Lua's `io.stderr` directly for stream output.
 
-## 7. `arg[0]` is not the interpreter — use `arg[-1]` to re-invoke cosmic
+## 7. `arg[0]` is not the interpreter — use `proc.interpreter()` to re-invoke cosmic
 
-when a script needs to spawn the cosmic binary itself (e.g. to run another
-script as a child process), `arg[0]` is the script path as the runtime sees
-it (`/zip/main.lua` for the embedded entry point), not the interpreter.
-the interpreter path lives at `arg[-1]`, and because `arg` is typed
-`{string}`, negative indices need `rawget` in strict mode.
+when a script needs to spawn the cosmic binary itself (e.g. to run
+another script as a child process), `arg[0]` is the script path as the
+runtime sees it (`/zip/main.lua` for the embedded entry point), not the
+interpreter. `proc.interpreter()` returns the running interpreter's
+absolute path, typed and resolved.
 
 **wrong:**
 ```teal
@@ -159,9 +159,10 @@ local h = child.start({arg[0], "worker.tl"}) -- spawns /zip/main.lua: fails
 
 **right:**
 ```teal
+local check = require("cosmic.check")
 local child = require("cosmic.child")
-local cosmic_bin = rawget(arg, -1) as string -- e.g. "./cosmic"
-local h = child.start({cosmic_bin, "worker.tl"})
+local proc = require("cosmic.proc")
+local h = child.start({check.must(proc.interpreter()), "worker.tl"})
 ```
 
 ## 8. `print(f(...))` prints every return value

--- a/skills/cosmic/recipes.md
+++ b/skills/cosmic/recipes.md
@@ -94,12 +94,13 @@ rule refuses it from outside `cosmic/`.)
 run another script in a child process and read its output through a pipe.
 
 ```teal
+local check = require("cosmic.check")
 local child = require("cosmic.child")
+local proc = require("cosmic.proc")
 
-local cosmic_bin = rawget(arg, -1) as string -- NOT arg[0]; see gotchas #7
-local h, err = child.start({cosmic_bin, "worker.tl"})
-assert(h, err)
-local _, out = h:read()
+-- proc.interpreter() is arg[-1] resolved — NOT arg[0], the script path
+local h = check.must(child.start({check.must(proc.interpreter()), "worker.tl"}))
+local out = h:read()
 print(out)
 h:wait()
 ```


### PR DESCRIPTION
Implements #945: one typed accessor for the running interpreter's path, resolution included.

```teal
proc.interpreter: function(): string | nil, string
```

- `arg[-1]` absolutized when it names a real file; a real `$PATH` search for the bare PATH-invoked shape (`cosmic` via shebang) — the same rule `_make`'s `root.resolve_self` implements. Result cached across calls; the doc comment tells relative-argv0 programs to call it before any chdir.
- Honest-nil shaped rather than the issue's bare `string`, since resolution can genuinely fail (argv0 unset under an embedder, bare name not on `$PATH`); a scalar return means the guard narrows fine, and `check.must(proc.interpreter())` is one call in tests/recipes.
- **Naming per D20** (left open in the issue): went with `interpreter` — spelled out, names what it returns. Easy to rename in review.
- Gotcha #7's wrong/right pair becomes `child.start({check.must(proc.interpreter()), "worker.tl"})`; the self-reinvocation recipe and the `child.start` doc comment drop the `rawget(arg, -1) as string` idiom; the proc module header stops teaching the dance.
- Drive-by in the recipe: `local _, out = h:read()` was capturing `read()`'s **error** slot into `out` (signature is `string | nil, string`), i.e. printing the wrong return — now `local out = h:read()`.
- Tests: interpreter path is absolute, a real file, not `/zip/main.lua`; repeat calls agree; and the resolved path actually spawns (`-e print(...)` round-trip through `cosmic.child`).

Deliberately not switched in this PR: `_make/init.tl` (keeps its `or "cosmic"` fallback-name semantics) and the `_perf` bench helpers — the issue's "eventually" tail.

`--make ci` passes (5 stages).

Closes #945; part of #949.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWCMuPQkSAomijVdve6V8D

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWCMuPQkSAomijVdve6V8D)_