### PR TITLE
entry point: cosmic.main is the taught path, and forgiving about number

### DIFF
--- a/cosmic/cosmic_test.tl
+++ b/cosmic/cosmic_test.tl
@@ -90,3 +90,41 @@ local function test_cosmic_main_runs_fn_and_exits_with_its_code()
     "the error string goes to stderr, got: " .. tostring(r.stderr))
 end
 test_cosmic_main_runs_fn_and_exits_with_its_code()
+
+-- main is forgiving about number: any numeric return exits honestly
+-- (math.tointeger), a fractional one exits 1 instead of throwing after
+-- the program's real work already happened.
+local function test_cosmic_main_tolerates_a_fractional_code()
+  local script = fs.join(tmpdir, "cosmic_main_frac.tl")
+  assert(fs.write(script, table.concat({
+          'local cosmic = require("cosmic")',
+          'cosmic.main(function(): number, string',
+          '    io.stdout:write("ran\\n")',
+          '    return 1.5',
+          '  end)',
+        }, "\n") .. "\n"))
+  local h = check.must(child.start({bin_path(), script}))
+  local r = check.must(h:wait())
+  assert(r.code == 1, "a fractional code should exit 1, got " .. tostring(r.code))
+  assert(not (r.stderr or ""):find("exit", 1, true),
+    "and never throw from os.exit, got: " .. tostring(r.stderr))
+end
+test_cosmic_main_tolerates_a_fractional_code()
+
+-- An error return with no code must not exit 0: the error already said
+-- the run failed.
+local function test_cosmic_main_error_without_code_exits_nonzero()
+  local script = fs.join(tmpdir, "cosmic_main_err.tl")
+  assert(fs.write(script, table.concat({
+          'local cosmic = require("cosmic")',
+          'cosmic.main(function(): number, string',
+          '    return nil, "boom"',
+          '  end)',
+        }, "\n") .. "\n"))
+  local h = check.must(child.start({bin_path(), script}))
+  local r = check.must(h:wait())
+  assert(r.code == 1, "error with no code should exit 1, got " .. tostring(r.code))
+  assert((r.stderr or ""):find("boom", 1, true),
+    "the error string still reaches stderr, got: " .. tostring(r.stderr))
+end
+test_cosmic_main_error_without_code_exits_nonzero()

--- a/cosmic/embed/floor.tl
+++ b/cosmic/embed/floor.tl
@@ -21,6 +21,11 @@ local DOS_EPOCH < const > = 315532800
 --- artifact anyone builds.
 local FLOOR < const >: {string} = {
   "cosmic/", -- the standard library, compiled
+  -- the `cosmic` module itself: cosmic/init.tl flattens to the zip
+  -- root, OUTSIDE the cosmic/ prefix, and without it a stripped
+  -- artifact cannot require("cosmic") (cosmic.main, the taught entry
+  -- point)
+  "cosmic.lua",
   "usr/", -- TLS roots and zoneinfo
   ".args", -- default argv
   ".cosmo", -- cosmopolitan's own marker
@@ -64,9 +69,11 @@ end
 local function in_floor(name: string, provides?: {string: boolean}): boolean
   if provides then
     for ns, prefix in pairs(SUPERSEDABLE) do
+      -- The flattened module file (`cosmic.lua`) is part of the
+      -- namespace a claim supersedes, same as the directory.
       if provides[ns] and
       (name == prefix or name:sub(1, #prefix) == prefix or
-        name == prefix:sub(1, -2)) then
+        name == prefix:sub(1, -2) or name == ns .. ".lua") then
         return false
       end
     end

--- a/cosmic/embed_test.tl
+++ b/cosmic/embed_test.tl
@@ -384,3 +384,18 @@ local function test_floor_matches_files_exactly()
     "but not a sibling whose name starts the same way")
 end
 test_floor_matches_files_exactly()
+
+-- cosmic/init.tl flattens to cosmic.lua at the zip root — outside the
+-- cosmic/ prefix — and a stripped artifact must still boot cosmic.main.
+local function test_floor_keeps_the_cosmic_module_itself()
+  local floor = require("cosmic.embed.floor")
+  assert(floor.in_floor("cosmic.lua"), "require('cosmic') must survive a strip")
+  assert(not floor.in_floor("cosmic.luaX"), "file-shaped: exact match only")
+  -- A project that provides the namespace supersedes the module file
+  -- along with the directory.
+  assert(not floor.in_floor("cosmic.lua", {cosmic = true}),
+    "a cosmic claim supersedes the flattened module file too")
+  assert(not floor.in_floor("cosmic/fs.lua", {cosmic = true}),
+    "and the directory, as before")
+end
+test_floor_keeps_the_cosmic_module_itself()

--- a/cosmic/init.tl
+++ b/cosmic/init.tl
@@ -35,7 +35,10 @@ local function main(fn: function(args: {string}, env: Env): number, string)
   local env: Env = {stderr = io.stderr, stdout = io.stdout}
   local code, err = fn(arg, env)
   if err then env.stderr:write(err .. "\n") end
-  os.exit((code or 0) as integer) -- cast: os.exit wants integer
+  -- Any numeric return exits honestly: a fractional code (a stray
+  -- average, a division) exits 1 instead of throwing at the very end,
+  -- and an error return with no code exits 1, never a clean 0.
+  os.exit(math.tointeger(code or (err and 1 or 0)) or 1)
 end
 
 --- The build-injected version string, or "unknown" outside a packed
@@ -52,6 +55,10 @@ local function version(): string
 end
 
 local record cosmic
+  --- The environment main() hands your function, exported so callers
+  --- can annotate the parameter (`env: cosmic.Env`).
+  type Env = Env
+
   _VERSION: string
   _DESCRIPTION: string
   main: function(fn: function(args: {string}, env: Env): number, string)

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -63,7 +63,10 @@ the `is` form where the code branches anyway.
 
 ## 3. `arg` elements are `string | nil`
 
-the global `arg` table has type `{string | nil}`. accessing `arg[1]` without a guard may give you `nil`, which causes a type error when used where a `string` is expected.
+the global `arg` table has type `{string | nil}`: accessing `arg[1]`
+without a guard may give you `nil`, a type error where a `string` is
+expected. (a missing argument is `nil` at runtime either way — guard
+before use.)
 
 **wrong:**
 ```teal
@@ -73,13 +76,21 @@ local name = arg[1]:upper() -- error: cannot index nil
 **right:**
 ```teal
 local name = (arg[1] or "default"):upper()
+```
 
--- or with an explicit check:
-if not arg[1] then
-  io.stderr:write("usage: myscript <name>\n")
-  os.exit(1)
-end
-local name = (arg[1] as string):upper()
+inside `cosmic.main`, a usage guard is an early return, and the scalar
+narrows through it for plain (non-method) uses:
+
+```teal
+cosmic.main(function(args: {string}, env: cosmic.Env): number, string
+    local name = args[1]
+    if not name then
+      env.stderr:write("usage: myscript <name>\n")
+      return 1
+    end
+    print("hello, " .. name)
+    return 0
+  end)
 ```
 
 ## 4. multi-return capture — `db:query` and similar
@@ -336,27 +347,14 @@ local earliest: integer | nil = nil
 with the annotation, the running-min/max idiom above compiles as
 written — scalars narrow through the `not earliest or ...` guard fine.
 
-## 14. `os.exit` requires `integer | boolean`, not `number`
+## 14. retired — the taught path never calls `os.exit`
 
-a `main` function declared to return `number` breaks `os.exit(main())`
-with `got number, expected integer | boolean`.
-
-**wrong:**
-```teal
-local function main(): number
-  return 0
-end
-os.exit(main())
-```
-
-**right:**
-```teal
-local function main(): integer
-  return 0
-end
-os.exit(main())
--- or convert at the call site: os.exit(math.tointeger(code) or 1)
-```
+`cosmic.main(fn)` (the entry-point shape the quickstart teaches) does
+the exit itself and accepts any numeric return, so this trap no longer
+appears on the taught path. if you call `os.exit` yourself, it requires
+`integer | boolean`, not `number` — convert at the call site
+(`os.exit(math.tointeger(code) or 1)`); the error-site hint names the
+same fix.
 
 ## 15. `gsub`'s replacement string interprets `%` — dangerous with untrusted values
 

--- a/skills/cosmic/quickstart.md
+++ b/skills/cosmic/quickstart.md
@@ -52,23 +52,23 @@ return M
 
 ## the binary
 
-`cmd/greet/main.tl` — guard `arg[1]` (it is `string | nil`), return an
-`integer` from main (`os.exit` rejects `number`):
+`cmd/greet/main.tl` — hand your main function to `cosmic.main`: it
+passes the arguments in, writes your error return to stderr, and exits
+with your code (no `os.exit` bookkeeping in your file):
 
 ```teal
+local cosmic = require("cosmic")
 local text = require("greet.text")
 
-local function main(): integer
-  local name = arg[1]
-  if not name then
-    io.stderr:write("usage: greet <name>\n")
-    return 1
-  end
-  print(text.greeting(name))
-  return 0
-end
-
-os.exit(main())
+cosmic.main(function(args: {string}, env: cosmic.Env): number, string
+    local name = args[1]
+    if not name then
+      env.stderr:write("usage: greet <name>\n")
+      return 1
+    end
+    print(text.greeting(name))
+    return 0
+  end)
 ```
 
 ## the test


### PR DESCRIPTION
Implements #946, plus the packaging fix that turned out to be load-bearing for it.

1. **Teach the helper.** The quickstart's binary example becomes `cosmic.main(function(args, env) ...)` — the `args` parameter replaces the bare `arg` global, `env.stderr` replaces `io.stderr`, and the `os.exit` bookkeeping leaves the user's file. `Env` is now exported on the module record so the parameter is annotatable as `cosmic.Env`.
2. **Make it forgiving.** `os.exit(math.tointeger(code or (err and 1 or 0)) or 1)`: any numeric return exits honestly, a fractional one exits 1 instead of throwing after the program's work already happened. One deliberate behavior change beyond the issue's spelling, flagged for review: an error return with **no** code now exits 1 instead of a clean 0 — the run printed an error, the exit status should agree. Both cases are pinned by new spawn-based tests in `cosmic_test.tl`.
3. **The taught path actually boots.** Found while verifying acceptance end to end: `cosmic/init.tl` flattens to `cosmic.lua` at the **zip root**, outside the `cosmic/` strip floor, so a stripped user artifact could not `require("cosmic")` at all — the quickstart's own build-and-run flow would fail on its first program. The floor now keeps `cosmic.lua`, and a project claiming the `cosmic` namespace supersedes the flattened module file along with the directory (`embed_test.tl` pins both).

Gotcha #14 shrinks to a retirement stub (the taught path never calls `os.exit`; the error-site hint still names `math.tointeger` for those who do); gotcha #3 shows the `cosmic.main` shape. `os.exit`'s declared type is deliberately unchanged, per the issue.

Verified end to end: a fixture project using the new quickstart binary builds, `o/bin/greet world` → `hello, world!` (exit 0), `o/bin/greet` → usage on stderr (exit 1).

`--make ci` passes (5 stages).

Closes #946; part of #949.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWCMuPQkSAomijVdve6V8D

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWCMuPQkSAomijVdve6V8D)_