### PR TITLE
lint: gsub-replacement — find-needle's missing sibling

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -13,6 +13,7 @@ _cli/help.tl 46 48
 _cli/lint.tl 190 215
 _cli/lint_render.tl 26 26
 _cli/main_handlers.tl 11 220
+_cli/pattern_args.tl 132 135
 _cli/require_hints.tl 104 124
 _cli/run.tl 28 33
 _cli/visibility.tl 23 23
@@ -188,4 +189,4 @@ cosmic/user.tl 48 61
 cosmic/uuid.tl 9 9
 cosmic/zip.tl 72 85
 tlconfig.lua 7 7
-total 13776 18202
+total 13908 18337

--- a/_cli/lint.tl
+++ b/_cli/lint.tl
@@ -15,9 +15,13 @@
 --- convention exactly.
 
 local fs = require("cosmic.fs")
+local pattern_args = require("_cli.pattern_args")
 local style = require("cosmic.style")
 local tl = require("tl")
 local visibility = require("_cli.visibility")
+
+local check_find_needle = pattern_args.check_find_needle
+local check_gsub_replacement = pattern_args.check_gsub_replacement
 
 local type Diagnostic = style.Diagnostic
 
@@ -245,105 +249,6 @@ local function check_call_after_define(file: string, content: string,
   return diagnostics
 end
 
---- Calls of `find` whose needle is a VARIABLE and which never say
---- whether they meant a pattern.
----
---- `s:find(x)` treats x as a Lua pattern, so a `-`, `.`, `(` or `%` in
---- it silently changes what matches. When x is a path, a name, or a
---- filter the author almost always meant a substring, and the failure is
---- invisible: the assertion still runs, it just compares the wrong
---- thing. A test that plants a file under `/tmp/a-b/` and greps for it
---- passes everywhere except where the path has a dash.
----
---- Literal needles are exempt — `s:find("%d+")` is a pattern on purpose
---- and reads as one. The rule is only for needles the reader cannot see.
---- @param content string The file's bytes
---- @param file string Path, for the lexer's error messages
---- @return {integer} 1-based line numbers, each at most once
-local function unguarded_find_lines(content: string, file: string): {integer}
-  local tokens = tl.lex(content, file)
-  if not tokens then
-    return {}
-  end
-  local seen: {integer: boolean} = {}
-  local out: {integer} = {}
-  for i, t in ipairs(tokens) do
-    local prev = i > 1 and tokens[i - 1] or nil
-    local open = tokens[i + 1]
-    -- Method form takes the subject as the receiver, so its needle is
-    -- first and plain is third; `string.find(s, needle, init, plain)`
-    -- passes the subject too, shifting both by one. A `.` on anything
-    -- but `string` is some other function that happens to be named
-    -- find, and is none of this rule's business.
-    local needle_at = 0
-    local plain_at = 0
-    if t.tk == "find" and open and open.tk == "(" and prev then
-      if prev.tk == ":" then
-        needle_at = 1
-        plain_at = 3
-      elseif prev.tk == "." and i > 2 and tokens[i - 2].tk == "string" then
-        needle_at = 2
-        plain_at = 4
-      end
-    end
-    if plain_at > 0 and not seen[t.y] then
-      local depth = 1
-      local argno = 1
-      local literal_needle = true
-      local empty = true
-      local j = i + 2
-      while j <= #tokens and depth > 0 do
-        local tk = tokens[j].tk
-        local separator = tk == "," and depth == 1
-        if tk == "(" or tk == "[" or tk == "{" then
-          depth = depth + 1
-        elseif tk == ")" or tk == "]" or tk == "}" then
-          depth = depth - 1
-        elseif separator then
-          argno = argno + 1
-        end
-        -- The separator belongs to no argument: counting it as one made
-        -- every `string.find(s, "literal")` look non-literal, because
-        -- the comma before the needle is not a string token.
-        if depth > 0 and not separator then
-          empty = false
-          if argno == needle_at and tokens[j].kind ~= "string" and tk ~= ".." then
-            literal_needle = false
-          end
-        end
-        j = j + 1
-      end
-      if not empty and not literal_needle and argno < plain_at then
-        seen[t.y] = true
-        out[#out + 1] = t.y
-      end
-    end
-  end
-  return out
-end
-
---- Report each `find` that leaves pattern-vs-substring unsaid.
---- @param file string Path, for the diagnostic
---- @param content string The file's bytes
---- @return {Diagnostic} One per unguarded call
-local function check_find_needle(file: string, content: string): {Diagnostic}
-  local diagnostics: {Diagnostic} = {}
-  for _, y in ipairs(unguarded_find_lines(content, file)) do
-    diagnostics[#diagnostics + 1] = {
-      file = file,
-      line = y,
-      col = 1,
-      rule = "find-needle",
-      message = string.format(
-        "%s:%d: `find` with a non-literal needle is a PATTERN, so a `-`,"
-        .. " `.` or `%%` in it silently changes the match: pass `, 1, true`"
-        .. " for a substring, or `, 1, false` to mean the pattern",
-        file, y),
-    }
-  end
-  return diagnostics
-end
-
 --- Every style check, for one file.
 ---
 --- `.d.tl` declarations are exempt: they describe C binding interfaces
@@ -416,6 +321,9 @@ local function lint_file(path: string): {Diagnostic} | nil, string
     for _, d in ipairs(check_find_needle(path, content)) do
       diagnostics[#diagnostics + 1] = d
     end
+    for _, d in ipairs(check_gsub_replacement(path, content, lines)) do
+      diagnostics[#diagnostics + 1] = d
+    end
     for _, d in ipairs(visibility.check_shard_require(path, lines)) do
       diagnostics[#diagnostics + 1] = d
     end
@@ -428,6 +336,7 @@ local record LintModule
   check_cosmo_require: function(file: string, lines: {string}): {Diagnostic}
   check_call_after_define: function(file: string, content: string, lines: {string}): {Diagnostic}
   check_find_needle: function(file: string, content: string): {Diagnostic}
+  check_gsub_replacement: function(file: string, content: string, lines: {string}): {Diagnostic}
   lint_file: function(path: string): {Diagnostic} | nil, string
 end
 
@@ -436,6 +345,7 @@ local M: LintModule = {
   check_cosmo_require = check_cosmo_require,
   check_call_after_define = check_call_after_define,
   check_find_needle = check_find_needle,
+  check_gsub_replacement = check_gsub_replacement,
   lint_file = lint_file,
 }
 

--- a/_cli/lint_test.tl
+++ b/_cli/lint_test.tl
@@ -287,6 +287,40 @@ local function test_find_needle_wants_the_intent_stated()
 end
 test_find_needle_wants_the_intent_stated()
 
+local function test_gsub_replacement_wants_the_intent_stated()
+  local bare = 'local x = s:gsub("{{name}}", user_name)\n'
+  assert(#lint.check_gsub_replacement("m.tl", bare, lines_of(bare)) == 1,
+    "a variable replacement is flagged")
+  local diag = lint.check_gsub_replacement("m.tl", bare, lines_of(bare))[1]
+  assert(diag.rule == "gsub-replacement", "rule name")
+  assert(diag.message:find("str.replace", 1, true),
+    "the message names the literal-intent fix")
+
+  for _, ok in ipairs({
+      'local x = s:gsub(pat, "%1!")\n', -- literal: deliberate splicing
+      'local x = s:gsub(pat, "a" .. "b")\n', -- concat of literals
+      'local x = s:gsub("%s+", "")\n', -- empty literal
+      'local x = s:gsub("%d", function(d: string): string return d end)\n',
+      'local x = s:gsub("%a", {a = "b"})\n', -- table form does not interpolate
+      'local x = s:gsub(pat)\n', -- no replacement argument at all
+      'local x = s:gsub(pat, v) -- gsub: v is %%-escaped upstream\n',
+      '-- gsub: v is a deliberate %1 template\nlocal x = s:gsub(pat, v)\n',
+      'local x = list.gsub(t, a, b)\n', -- some other gsub entirely
+    }) do
+    assert(#lint.check_gsub_replacement("m.tl", ok, lines_of(ok)) == 0,
+      "should pass: " .. ok)
+  end
+
+  -- string.gsub passes the subject too, so its replacement is THIRD.
+  local dotted = 'local x = string.gsub(s, pat, v)\n'
+  assert(#lint.check_gsub_replacement("m.tl", dotted, lines_of(dotted)) == 1,
+    "the dot form is checked at its own replacement position")
+  local dotted_lit = 'local x = string.gsub(s, pat, "lit")\n'
+  assert(#lint.check_gsub_replacement("m.tl", dotted_lit, lines_of(dotted_lit)) == 0,
+    "and a literal there passes")
+end
+test_gsub_replacement_wants_the_intent_stated()
+
 -- A `check.needs` guard that returns is the failure the rule is named
 -- for: the file runs on, exits 0, and the runner grades 0 as a pass, so
 -- a test that opted out of running contributes a green tick. Only the

--- a/_cli/pattern_args.tl
+++ b/_cli/pattern_args.tl
@@ -1,0 +1,255 @@
+--- The Lua-pattern-magic argument rules: find-needle and
+--- gsub-replacement.
+---
+--- Split from `_cli/lint.tl` for the 500-line cap. The two rules are
+--- one trap family: `string.find` treats its needle as a pattern, and
+--- `string.gsub` interpolates `%` in its replacement — in both, a
+--- value the reader cannot see silently changes what the call does.
+--- Both rules are token-exact (the lexer, never source matching), both
+--- exempt literals, and both ask the author to say what they mean
+--- rather than forbid the call.
+
+local style = require("cosmic.style")
+local tl = require("tl")
+
+local type Diagnostic = style.Diagnostic
+
+--- Whether line `y` carries a `-- <tag>: <reason>` marker, trailing or
+--- on the line directly above — the same two positions cast-justify
+--- reads.
+--- @param lines {string} The file's lines
+--- @param y integer The line the flagged call is on
+--- @param tag string The marker name (e.g. "gsub")
+--- @return boolean True when marked here or on the line above
+local function is_marked(lines: {string}, y: integer, tag: string): boolean
+  local marker = "%-%- " .. tag .. ": %S"
+  local here = lines[y]
+  if here and here:match(marker) then
+    return true
+  end
+  local above = lines[y - 1]
+  return above ~= nil and above:match("^%s*" .. marker) ~= nil
+end
+
+--- Calls of `find` whose needle is a VARIABLE and which never say
+--- whether they meant a pattern.
+---
+--- `s:find(x)` treats x as a Lua pattern, so a `-`, `.`, `(` or `%` in
+--- it silently changes what matches. When x is a path, a name, or a
+--- filter the author almost always meant a substring, and the failure is
+--- invisible: the assertion still runs, it just compares the wrong
+--- thing. A test that plants a file under `/tmp/a-b/` and greps for it
+--- passes everywhere except where the path has a dash.
+---
+--- Literal needles are exempt — `s:find("%d+")` is a pattern on purpose
+--- and reads as one. The rule is only for needles the reader cannot see.
+--- @param content string The file's bytes
+--- @param file string Path, for the lexer's error messages
+--- @return {integer} 1-based line numbers, each at most once
+local function unguarded_find_lines(content: string, file: string): {integer}
+  local tokens = tl.lex(content, file)
+  if not tokens then
+    return {}
+  end
+  local seen: {integer: boolean} = {}
+  local out: {integer} = {}
+  for i, t in ipairs(tokens) do
+    local prev = i > 1 and tokens[i - 1] or nil
+    local open = tokens[i + 1]
+    -- Method form takes the subject as the receiver, so its needle is
+    -- first and plain is third; `string.find(s, needle, init, plain)`
+    -- passes the subject too, shifting both by one. A `.` on anything
+    -- but `string` is some other function that happens to be named
+    -- find, and is none of this rule's business.
+    local needle_at = 0
+    local plain_at = 0
+    if t.tk == "find" and open and open.tk == "(" and prev then
+      if prev.tk == ":" then
+        needle_at = 1
+        plain_at = 3
+      elseif prev.tk == "." and i > 2 and tokens[i - 2].tk == "string" then
+        needle_at = 2
+        plain_at = 4
+      end
+    end
+    if plain_at > 0 and not seen[t.y] then
+      local depth = 1
+      local argno = 1
+      local literal_needle = true
+      local empty = true
+      local j = i + 2
+      while j <= #tokens and depth > 0 do
+        local tk = tokens[j].tk
+        local separator = tk == "," and depth == 1
+        if tk == "(" or tk == "[" or tk == "{" then
+          depth = depth + 1
+        elseif tk == ")" or tk == "]" or tk == "}" then
+          depth = depth - 1
+        elseif separator then
+          argno = argno + 1
+        end
+        -- The separator belongs to no argument: counting it as one made
+        -- every `string.find(s, "literal")` look non-literal, because
+        -- the comma before the needle is not a string token.
+        if depth > 0 and not separator then
+          empty = false
+          if argno == needle_at and tokens[j].kind ~= "string" and tk ~= ".." then
+            literal_needle = false
+          end
+        end
+        j = j + 1
+      end
+      if not empty and not literal_needle and argno < plain_at then
+        seen[t.y] = true
+        out[#out + 1] = t.y
+      end
+    end
+  end
+  return out
+end
+
+--- Report each `find` that leaves pattern-vs-substring unsaid.
+--- @param file string Path, for the diagnostic
+--- @param content string The file's bytes
+--- @return {Diagnostic} One per unguarded call
+local function check_find_needle(file: string, content: string): {Diagnostic}
+  local diagnostics: {Diagnostic} = {}
+  for _, y in ipairs(unguarded_find_lines(content, file)) do
+    diagnostics[#diagnostics + 1] = {
+      file = file,
+      line = y,
+      col = 1,
+      rule = "find-needle",
+      message = string.format(
+        "%s:%d: `find` with a non-literal needle is a PATTERN, so a `-`,"
+        .. " `.` or `%%` in it silently changes the match: pass `, 1, true`"
+        .. " for a substring, or `, 1, false` to mean the pattern",
+        file, y),
+    }
+  end
+  return diagnostics
+end
+
+--- Calls of `gsub` whose REPLACEMENT is a variable, a field, or a call
+--- — anything the reader cannot see is `%`-safe.
+---
+--- `gsub`'s replacement argument interpolates `%`: `%1`–`%9` splice in
+--- captures, `%0` the whole match, and a lone `%` before anything else
+--- is a runtime error. Templating an untrusted value in corrupts the
+--- output — or crashes — the first time the value contains a `%`.
+--- find-needle covers the needle side of this trap family; this is the
+--- replacement side, and unlike the needle it has a clean library
+--- answer: `str.replace` (cosmic.string) is literal on both sides.
+---
+--- Exempt: literal replacements (a literal `"%1"` reads as deliberate
+--- capture splicing), function and table replacements (those forms do
+--- not interpolate), and a call that says what it means with a trailing
+--- `-- gsub: <reason>` (or one on the line above) — the deliberate
+--- pattern-template case, where the author vouches the value is
+--- escaped or meant to splice.
+--- @param content string The file's bytes
+--- @param file string Path, for the lexer's error messages
+--- @param lines {string} The file's lines, for the justification comment
+--- @return {integer} 1-based line numbers, each at most once
+local function unguarded_gsub_lines(content: string, file: string,
+    lines: {string}): {integer}
+  local tokens = tl.lex(content, file)
+  if not tokens then
+    return {}
+  end
+  local seen: {integer: boolean} = {}
+  local out: {integer} = {}
+  for i, t in ipairs(tokens) do
+    local prev = i > 1 and tokens[i - 1] or nil
+    local open = tokens[i + 1]
+    -- Method form takes the subject as the receiver, so its replacement
+    -- is second; `string.gsub(s, pattern, repl)` passes the subject
+    -- too, shifting it to third. A `.gsub` on anything but `string` is
+    -- some other function and none of this rule's business.
+    local repl_at = 0
+    if t.tk == "gsub" and open and open.tk == "(" and prev then
+      if prev.tk == ":" then
+        repl_at = 2
+      elseif prev.tk == "." and i > 2 and tokens[i - 2].tk == "string" then
+        repl_at = 3
+      end
+    end
+    if repl_at > 0 and not seen[t.y] then
+      local depth = 1
+      local argno = 1
+      local literal_repl = true
+      local repl_seen = false
+      local exempt = false
+      local j = i + 2
+      while j <= #tokens and depth > 0 do
+        local tk = tokens[j].tk
+        local separator = tk == "," and depth == 1
+        if tk == "(" or tk == "[" or tk == "{" then
+          depth = depth + 1
+        elseif tk == ")" or tk == "]" or tk == "}" then
+          depth = depth - 1
+        elseif separator then
+          argno = argno + 1
+        end
+        if depth > 0 and not separator and argno == repl_at then
+          -- The argument's FIRST token decides the exempt forms: an
+          -- anonymous function or a table constructor does not
+          -- interpolate anything.
+          if not repl_seen and (tk == "function" or tk == "{") then
+            exempt = true
+          end
+          repl_seen = true
+          local kind = tokens[j].kind
+          if kind ~= "string" and kind ~= "number" and kind ~= "integer"
+          and tk ~= ".." then
+            literal_repl = false
+          end
+        end
+        j = j + 1
+      end
+      if repl_seen and not exempt and not literal_repl
+      and not is_marked(lines, t.y, "gsub") then
+        seen[t.y] = true
+        out[#out + 1] = t.y
+      end
+    end
+  end
+  return out
+end
+
+--- Report each `gsub` whose replacement's `%`-safety is unstated.
+--- @param file string Path, for the diagnostic
+--- @param content string The file's bytes
+--- @param lines {string} The file's lines
+--- @return {Diagnostic} One per unguarded call
+local function check_gsub_replacement(file: string, content: string,
+    lines: {string}): {Diagnostic}
+  local diagnostics: {Diagnostic} = {}
+  for _, y in ipairs(unguarded_gsub_lines(content, file, lines)) do
+    diagnostics[#diagnostics + 1] = {
+      file = file,
+      line = y,
+      col = 1,
+      rule = "gsub-replacement",
+      message = string.format(
+        "%s:%d: a non-literal gsub replacement interpolates %% — for"
+        .. " literal text use str.replace (cosmic.string); a deliberate"
+        .. " template takes an escape (value:gsub(\"%%%%\", \"%%%%%%%%\"))"
+        .. " and a trailing `-- gsub: <reason>` (or on the line above)",
+        file, y),
+    }
+  end
+  return diagnostics
+end
+
+local record PatternArgsModule
+  check_find_needle: function(file: string, content: string): {Diagnostic}
+  check_gsub_replacement: function(file: string, content: string, lines: {string}): {Diagnostic}
+end
+
+local M: PatternArgsModule = {
+  check_find_needle = check_find_needle,
+  check_gsub_replacement = check_gsub_replacement,
+}
+
+return M

--- a/_cli/require_hints.tl
+++ b/_cli/require_hints.tl
@@ -14,9 +14,12 @@ local function module_exists(name: string): boolean
   if package.preload[name] then
     return true
   end
-  -- Check package.path for .lua and .tl files
+  -- Check package.path for .lua and .tl files. cosmic.string is
+  -- required lazily: this only runs on the require-failure path, and a
+  -- boot-time require would put the module on the boot surface.
+  local str = original_require("cosmic.string")
   for path_pattern in package.path:gmatch("[^;]+") do
-    local file_path = path_pattern:gsub("%?", (name:gsub("%.", "/")))
+    local file_path = str.replace(path_pattern, "?", (name:gsub("%.", "/")))
     local f = io.open(file_path, "r")
     if f then
       f:close()

--- a/_docs/derive.tl
+++ b/_docs/derive.tl
@@ -131,6 +131,7 @@ local function rewrite(path: string, head: string,
   end
   local pattern = (current:gsub("%p", "%%%1"))
   local replacement = (rendered:gsub("%%", "%%%%"))
+  -- gsub: replacement %%-escaped on the line above; the needle is a real pattern
   local ok, werr = fs.write(path, (string.gsub(text, pattern, replacement, 1)))
   if not ok then
     return false, path .. ": " .. (werr or "cannot write")

--- a/_make/pin.tl
+++ b/_make/pin.tl
@@ -22,6 +22,7 @@
 
 local fs = require("cosmic.fs")
 local literal = require("cosmic.literal")
+local str = require("cosmic.string")
 local sys = require("cosmic.sys")
 
 --- A resolved pin.
@@ -170,10 +171,10 @@ local function read(path: string, host?: string): Pin | nil, string
   end
   local resolved = url
   if version then
-    resolved = (url:gsub("{version}", version))
+    resolved = str.replace(url, "{version}", version)
   end
   if platform ~= "" then
-    resolved = (resolved:gsub("{platform}", platform))
+    resolved = str.replace(resolved, "{platform}", platform)
   end
   -- The output name comes from the URL, not the pin's position: a pin
   -- fetches a named artifact and its extension matters to whatever

--- a/cosmic/zip_test.tl
+++ b/cosmic/zip_test.tl
@@ -3,6 +3,7 @@
 
 local check = require("cosmic.check")
 local fs = require("cosmic.fs")
+local str = require("cosmic.string")
 local zip = require("cosmic.zip")
 
 local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
@@ -338,7 +339,7 @@ local function crafted_archive(patch_to: string): string
   w:close()
   local raw = check.must(fs.read(safe))
   assert(#patch_to == #"XX/escaped.txt", "patch must preserve name length")
-  local patched = string.gsub(raw, "XX/escaped%.txt", patch_to)
+  local patched = str.replace(raw, "XX/escaped.txt", patch_to)
   return patched
 end
 

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -358,26 +358,16 @@ os.exit(main())
 -- or convert at the call site: os.exit(math.tointeger(code) or 1)
 ```
 
-## 15. `gsub`'s replacement string interprets `%` — dangerous with untrusted values
+## 15. `gsub`'s replacement string interprets `%` — use `str.replace` for literal text
 
-`string.gsub`'s third argument is not plain text: `%1`–`%9` splice in
-captures, `%0` the whole match, and a lone `%` followed by anything
-else is an error. substituting an untrusted value into a template this
-way corrupts output — or crashes — the first time the value contains a
-`%` (a URL-encoded string, a printf format, a literal percentage).
+`string.gsub`'s replacement is not plain text (`%1` splices a capture,
+a lone `%` is a runtime error), so templating an untrusted value in
+breaks on the first `%`. for literal text use `str.replace`
+(cosmic.string) — literal on both sides, nothing to escape. the
+`gsub-replacement` lint flags a non-literal replacement and
+`cosmic --docs guide.lint` documents the deliberate-template escape.
 
-**wrong:**
 ```teal
-local page = template:gsub("{{name}}", user_name)
--- user_name = "50%" → runtime error: invalid use of '%' in replacement string
+local str = require("cosmic.string")
+local page = str.replace(template, "{{name}}", user_name)
 ```
-
-**right — escape `%` in the replacement first:**
-```teal
-local safe = user_name:gsub("%%", "%%%%")
-local page = template:gsub("{{name}}", safe)
-```
-
-(the needle side has the same property — see the find-needle lint rule
-for `find`; on `gsub` both arguments are magic, and only the
-replacement side is fixable by doubling `%`.)

--- a/skills/cosmic/lint.md
+++ b/skills/cosmic/lint.md
@@ -104,6 +104,26 @@ s:find("%d+") -- literals are exempt: this reads as a pattern
 there is no plain flag on `match`/`gmatch`/`gsub`, so a variable needle
 there is a pattern by construction; escape it if it isn't one.
 
+## gsub-replacement
+
+`gsub`'s replacement side is magic too: `%1`–`%9` splice in captures,
+`%0` the whole match, and a lone `%` before anything else is a runtime
+error — so templating an untrusted value in corrupts output or crashes
+on the first `%`. when the replacement is not a string literal, say
+what you mean:
+
+```teal
+str.replace(template, "{{name}}", user_name) -- literal on BOTH sides
+-- deliberate template: escape, and say so
+local safe = user_name:gsub("%%", "%%%%")
+local page = template:gsub(pat, safe) -- gsub: safe is %%-escaped above
+```
+
+literals are exempt (a literal `"%1"` reads as deliberate splicing), as
+are function and table replacements — those forms do not interpolate.
+the marker is `-- gsub: <reason>`, trailing or on the line above, same
+positions as `-- cast:`.
+
 ## visibility
 
 a module under `cosmic/` may only be required from outside `cosmic/`


### PR DESCRIPTION
Implements #947: the replacement side of the `%`-magic trap family, mirroring find-needle's shape (token-exact via the lexer, literals exempt, ask-don't-forbid).

- **Flagged**: a `gsub` replacement that is a variable, field, or call — anything the reader cannot see is `%`-safe. Method form checks arg 2, `string.gsub` arg 3; `list.gsub(...)` is none of the rule's business.
- **Exempt**: string/number literals and concats of literals (a literal `"%1"` reads as deliberate capture splicing); function and table replacements (those forms don't interpolate).
- **Escape hatch** (the design question the issue left open): a comment marker — `-- gsub: <reason>`, trailing or on the line above, the same two positions `-- cast:` reads. The same-expression-escape spelling loses to a subtlety: an inline `value:gsub("%%","%%%%")` as the replacement argument spills gsub's *count* return into the next parameter unless parenthesized, so the idiomatic escape lives on a prior line where a token rule can't see it. A marker keeps the rule honest without inviting that bug.

**The spike**: on this tree the rule finds exactly **5 sites**. Four had literal intent and now use `str.replace` — `require_hints`' `package.path` probe (where a module name containing `%1` would previously have *thrown* mid-hint: no captures in the pattern), `_make/pin`'s `{version}`/`{platform}` substitution, and `zip_test`'s name patch. One (`_docs/derive.tl`) is the correctly-escaped deliberate-template case and now carries the marker. That rate says the rule's shape is right.

Plumbing:
- find-needle + the new rule move to `_cli/pattern_args.tl` (`lint.tl` crossed the 500-line cap); `_cli.lint` re-exports both so callers are unchanged.
- `require_hints` requires `cosmic.string` lazily (only on the require-failure path) to stay off the boot surface — a boot-time require tripped the stamp's BOOT_MODULES ratchet and skewed the coverage denominator.
- `.cosmic-coverage` gains only the new file's row (hand-added; a full `--baseline` rewrite wanted to lower five unrelated floors from run noise, which a floor shouldn't do silently).
- Gotcha #15 shrinks to the `str.replace` pointer; `guide.lint` documents the rule with the escape.

Tests cover: variable flagged (both call forms), literal/concat/empty-literal pass, function and table forms pass, missing replacement passes, marker (both positions) passes, other-table `gsub` ignored.

`--make ci` passes (5 stages).

Closes #947; part of #949.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWCMuPQkSAomijVdve6V8D

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWCMuPQkSAomijVdve6V8D)_