### PR TITLE
perf: embed copies the base executable with the buffered fs.copy

### DIFF
--- a/cosmic/embed/init.tl
+++ b/cosmic/embed/init.tl
@@ -326,16 +326,10 @@ local function embed(paths: {string}, opts?: Options): EmbedResult
   end
   unix.close(tmp_fd)
 
-  local exe_data = fs.read(exe_path)
-  if not exe_data then
+  local copy_ok, copy_err = fs.copy(exe_path, tmp_path)
+  if not copy_ok then
     fs.unlink(tmp_path)
-    return {ok = false, message = "error: cannot read executable '" .. exe_path .. "'", file_count = 0}
-  end
-
-  local barf_ok = fs.write(tmp_path, exe_data)
-  if not barf_ok then
-    fs.unlink(tmp_path)
-    return {ok = false, message = "error: cannot write to '" .. tmp_path .. "'", file_count = 0}
+    return {ok = false, message = "error: cannot copy '" .. exe_path .. "' to '" .. tmp_path .. "': " .. (copy_err or "unknown error"), file_count = 0}
   end
   unix.chmod(tmp_path, tonumber("755", 8))
 


### PR DESCRIPTION
Closes #940.

`embed()` read the whole ~11MB base binary into one Lua string and wrote it back in a single call — two full-size allocations and two monolithic syscalls — when `fs.copy`, the chunked EINTR-retried pump the stdlib already ships, does the same job. The two failure branches merge into one copy-failure branch that still names both paths; the trailing `unix.chmod` stays as a harmless safety net.

Gates: `ci: PASS (5 stages)`; back-to-back A/B via `gate.tl compare`, exit 0:

```
embed_run_tree                   43.33 ms ->     33.61 ms    -22.4%  (noise  ±10.0%)  faster
```

(For the record: sibling hypothesis #939 — path-based `czip.open` in `extract` — was implemented, measured **+29.6% slower**, reverted, and closed as not planned: the in-memory slurp there is load-bearing for member reads. This PR's copy is not — the temp file is consumed by path either way.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhorrSa46REGc9vbKN6Sa1

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhorrSa46REGc9vbKN6Sa1)_