### PR TITLE
perf: cosmic.teal proves tl exists without loading it

### DIFF
--- a/cosmic/teal.tl
+++ b/cosmic/teal.tl
@@ -5,7 +5,17 @@
 --- checked AST — the build uses it for in-tree sources so nothing ships
 --- that did not typecheck. --check types uses strict mode.
 
-local tl = require("tl")
+-- This module must be absent exactly when the compiler is — a stripped
+-- artifact asserts both fail together, and its searcher relies on that
+-- to answer require misses without blaming tl (_make/artifact_test.tl).
+-- But loading tl parses ~435KB of Lua that a warm-cache script run
+-- never needs (#938). So: prove tl EXISTS at load time without loading
+-- it, and require it only where it runs — package.loaded makes the
+-- repeat cost one lookup.
+if not package.loaded["tl"] and not package.preload["tl"]
+and not package.searchpath("tl", package.path) then
+  error("module 'tl' not found: cosmic.teal needs the Teal compiler", 0)
+end
 
 --- A compiler or type checker issue.
 local record Issue
@@ -145,6 +155,7 @@ end
 --- @return ProcessResult Processing result with tl_result or error
 local function process_file(input_path: string, include_dirs: {string}, lax: boolean,
     gen_target?: string, gen_compat?: string): ProcessResult
+  local tl = require("tl")
   local f, open_err = io.open(input_path, "r")
   if not f then
     return process_error(input_path, "cannot open file: " .. (open_err or "unknown error"))
@@ -288,6 +299,7 @@ end
 --- @param include_dirs? {string} Extra include dirs (defaults merged in)
 --- @return string|nil Path to the found source, or nil
 local function search_module(module_name: string, include_dirs?: {string}): string | nil
+  local tl = require("tl")
   local dirs = merge_include_dirs(include_dirs)
   local saved_tl_path = tl.path
   tl.path = assemble_tl_path(dirs)
@@ -309,6 +321,7 @@ end
 --- @param opts CompileOptions Compilation options (include_dirs, gen_target, gen_compat, strict)
 --- @return CompileResult Result with ok status, generated Lua code, and any errors
 local function compile(input_path: string, opts: CompileOptions): CompileResult
+  local tl = require("tl")
   opts = opts or {}
 
   local dirs = merge_include_dirs(opts.include_dirs)


### PR DESCRIPTION
Closes #938.

Requiring `cosmic.teal` loaded the 435KB Teal compiler at module top level, so a warm-cache `.tl` run paid ~7-9ms of `tl.lua` parsing just to reach `compile_cached` — and then never touched `tl`.

The first attempt (plain lazy require) failed the coverage gate for a good reason: the eager require was load-bearing for **stripped artifacts** — `_make/artifact_test.tl` asserts the wrapper is absent exactly when the compiler is, and that a require miss names the missing module instead of blaming `tl`. So the landed shape keeps both properties: a `package.searchpath` probe at module load proves `tl` exists (open+close, no parse) and fails with the same module-not-found shape when it doesn't; the three functions that use `tl` require it where they run, where `package.loaded` makes the repeat cost one table lookup.

Gates: `ci: PASS (5 stages)` including the stripped-artifact assertions; back-to-back A/B via `gate.tl compare`, exit 0:

```
startup_run_teal                 16.84 ms ->      6.07 ms    -64.0%  (noise  ±16.6%)  faster
startup_run_lua                   5.54 ms ->      5.41 ms     -2.4%  (unchanged floor)
```

A warm-cache `--strace` shows exactly one `openat` of `/zip/tl.lua` (the probe) and no load; a cache-miss run still compiles. `startup_compile_teal` is unaffected (`--compile` always loads the compiler, by design) — that path's cost is #941's territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhorrSa46REGc9vbKN6Sa1

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhorrSa46REGc9vbKN6Sa1)_