### PR TITLE
lint: nil-declaration — gotcha 13 caught at the declaration, where the fix is

### DIFF
--- a/_cli/lint.tl
+++ b/_cli/lint.tl
@@ -249,6 +249,90 @@ local function check_call_after_define(file: string, content: string,
   return diagnostics
 end
 
+--- Declarations of the form `local x = nil` with no type annotation.
+---
+--- Teal infers such a local as the type `nil` — not "unknown yet", not
+--- `T | nil` — so every later assignment and comparison fails, no
+--- guard helps, and neither downstream error names the declaration as
+--- the cause (gotcha 13). Flagging the declaration itself turns a
+--- confusing far-away error into a one-line fix at the actual defect.
+---
+--- Scope: an unannotated declaration whose whole right-hand side is
+--- `nil` (single or multi). A `:` anywhere before the `=` is an
+--- annotation and passes; a mixed RHS (`local a, b = nil, 1`) is left
+--- to the checker's error-site hint. Token-exact, so fixtures quoting
+--- the trap inside strings never count.
+--- @param file string Path, for the diagnostic
+--- @param content string The file's bytes
+--- @return {Diagnostic} One per nil-typed declaration
+local function check_nil_declaration(file: string, content: string): {Diagnostic}
+  local tokens = tl.lex(content, file)
+  if not tokens then
+    return {}
+  end
+  local diagnostics: {Diagnostic} = {}
+  local i = 1
+  while i <= #tokens do
+    local t = tokens[i]
+    if t.tk == "local" then
+      -- Walk the declaration head: names, commas, and <attribute>
+      -- groups. A `:` is an annotation (pass); anything else that is
+      -- not a plain name list (local function, local record, ...) is
+      -- some other statement (pass).
+      local j = i + 1
+      local head_ok = true
+      while j <= #tokens do
+        local tk = tokens[j].tk
+        if tk == "=" then
+          break
+        elseif tk == ":" then
+          head_ok = false
+          break
+        elseif tokens[j].kind == "identifier" or tk == ","
+        or tk == "<" or tk == ">" or tk == "const" or tk == "close" then
+          j = j + 1
+        else
+          head_ok = false
+          break
+        end
+      end
+      if head_ok and j <= #tokens and tokens[j].tk == "=" then
+        -- The RHS, on the declaration's own line: all-nil means the
+        -- inferred type is nil forever.
+        local line = tokens[j].y
+        local k = j + 1
+        local saw_nil = false
+        local all_nil = true
+        while k <= #tokens and tokens[k].y == line do
+          local tk = tokens[k].tk
+          if tk == "nil" then
+            saw_nil = true
+          elseif tk ~= "," then
+            all_nil = false
+            break
+          end
+          k = k + 1
+        end
+        if saw_nil and all_nil then
+          diagnostics[#diagnostics + 1] = {
+            file = file,
+            line = t.y,
+            col = 1,
+            rule = "nil-declaration",
+            message = string.format(
+              "%s:%d: a local initialized to nil with no type annotation"
+              .. " has type nil FOREVER — every later assignment fails;"
+              .. " annotate the optional: `local x: T | nil = nil`",
+              file, t.y),
+          }
+        end
+      end
+    end
+    i = i + 1
+  end
+  return diagnostics
+end
+
 --- Every style check, for one file.
 ---
 --- `.d.tl` declarations are exempt: they describe C binding interfaces
@@ -324,6 +408,9 @@ local function lint_file(path: string): {Diagnostic} | nil, string
     for _, d in ipairs(check_gsub_replacement(path, content, lines)) do
       diagnostics[#diagnostics + 1] = d
     end
+    for _, d in ipairs(check_nil_declaration(path, content)) do
+      diagnostics[#diagnostics + 1] = d
+    end
     for _, d in ipairs(visibility.check_shard_require(path, lines)) do
       diagnostics[#diagnostics + 1] = d
     end
@@ -337,6 +424,7 @@ local record LintModule
   check_call_after_define: function(file: string, content: string, lines: {string}): {Diagnostic}
   check_find_needle: function(file: string, content: string): {Diagnostic}
   check_gsub_replacement: function(file: string, content: string, lines: {string}): {Diagnostic}
+  check_nil_declaration: function(file: string, content: string): {Diagnostic}
   lint_file: function(path: string): {Diagnostic} | nil, string
 end
 
@@ -346,6 +434,7 @@ local M: LintModule = {
   check_call_after_define = check_call_after_define,
   check_find_needle = check_find_needle,
   check_gsub_replacement = check_gsub_replacement,
+  check_nil_declaration = check_nil_declaration,
   lint_file = lint_file,
 }
 

--- a/_cli/lint_test.tl
+++ b/_cli/lint_test.tl
@@ -288,6 +288,34 @@ end
 test_find_needle_wants_the_intent_stated()
 
 local function test_gsub_replacement_wants_the_intent_stated()
+
+  -- nil-declaration: `local x = nil` with no annotation is the type nil
+  -- forever (gotcha 13); the rule fires at the declaration, where the fix
+  -- is. The trap spelled inside a string fixture must never count.
+  local function test_nil_declaration_flags_the_bare_form()
+    local diags = lint.check_nil_declaration("m.tl", "local earliest = nil\n")
+    assert(#diags == 1, "the bare form is flagged")
+    assert(diags[1].rule == "nil-declaration", "rule name")
+    assert(diags[1].line == 1, "flagged at the declaration")
+    assert(diags[1].message:find("nil FOREVER", 1, true),
+      "the message names the trap")
+
+    local multi = lint.check_nil_declaration("m.tl", "local a, b = nil, nil\n")
+    assert(#multi == 1, "an all-nil multi declaration is flagged")
+
+    for _, ok in ipairs({
+        "local x: integer | nil = nil\n", -- annotated: the honest optional
+        "local x = nil_value\n", -- an identifier, not the nil keyword
+        "local x = nil and true\n", -- an expression, inferred boolean
+        "local a, b = nil, 1\n", -- mixed RHS: the checker's hint covers it
+        "local x = 1\n",
+        "local function f()\nend\nf()\n",
+        'local s = "local x = nil"\n', -- the trap quoted in a string
+      }) do
+      assert(#lint.check_nil_declaration("m.tl", ok) == 0, "should pass: " .. ok)
+    end
+  end
+  test_nil_declaration_flags_the_bare_form()
   local bare = 'local x = s:gsub("{{name}}", user_name)\n'
   assert(#lint.check_gsub_replacement("m.tl", bare, lines_of(bare)) == 1,
     "a variable replacement is flagged")

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -107,27 +107,13 @@ binding a module to a local that shadows a Lua builtin
 so the runtime surprise this entry described is unreachable. rename the
 local (`fd`, `fs`, ...); Lua's `io.stderr` stays available.
 
-## 7. `arg[0]` is not the interpreter — use `proc.interpreter()` to re-invoke cosmic
+## 7. retired — `proc.interpreter()` is the one-call answer
 
-when a script needs to spawn the cosmic binary itself (e.g. to run
-another script as a child process), `arg[0]` is the script path as the
-runtime sees it (`/zip/main.lua` for the embedded entry point), not the
-interpreter. `proc.interpreter()` returns the running interpreter's
-absolute path, typed and resolved.
-
-**wrong:**
-```teal
-local child = require("cosmic.child")
-local h = child.start({arg[0], "worker.tl"}) -- spawns /zip/main.lua: fails
-```
-
-**right:**
-```teal
-local check = require("cosmic.check")
-local child = require("cosmic.child")
-local proc = require("cosmic.proc")
-local h = child.start({check.must(proc.interpreter()), "worker.tl"})
-```
+`arg[0]` is the script path as the runtime sees it (`/zip/main.lua` in
+a packed binary), not the interpreter. to re-invoke cosmic, call
+`require("cosmic.proc").interpreter()` — typed, resolved, cached; the
+self-reinvocation recipe in `cosmic --docs guide.recipes` shows the
+whole shape.
 
 ## 8. retired — the checker flags discarded errors
 
@@ -249,31 +235,13 @@ db:add("alice") -- error: invalid key 'add' in record 'db' of type sqlite.Databa
 store.add(db, "alice") -- right: module function, dot-called, value first
 ```
 
-## 13. `local x = nil` means type nil, forever
+## 13. retired — the lint catches it at the declaration
 
-a local initialized with `= nil` and NO type annotation is inferred as
-the type `nil` — not "unknown yet", not `T | nil`. every later
-assignment and use then fails, no guard helps, and neither error names
-the declaration as the cause:
-
-**wrong:**
-```teal
-local earliest = nil -- type: nil
-for _, e in ipairs(entries) do
-  if not earliest or e.timestamp < earliest then
-    -- error: cannot use operator '<' for types integer and nil
-    earliest = e.timestamp
-    -- error: in assignment: got integer, expected nil
-  end
-end
-```
-
-**right — annotate the optional at the declaration:**
-```teal
-local earliest: integer | nil = nil
-```
-
-with the annotation, the running-min/max idiom above compiles as
+a local initialized with `= nil` and no type annotation is inferred as
+the type `nil` — forever. the `nil-declaration` lint now flags the
+declaration itself with the fix (`local x: integer | nil = nil`), so
+the far-away assignment errors this entry used to explain are never
+reached. with the annotation, the running-min/max idiom compiles as
 written — scalars narrow through the `not earliest or ...` guard fine.
 
 ## 14. retired — the taught path never calls `os.exit`

--- a/skills/cosmic/lint.md
+++ b/skills/cosmic/lint.md
@@ -124,6 +124,20 @@ are function and table replacements — those forms do not interpolate.
 the marker is `-- gsub: <reason>`, trailing or on the line above, same
 positions as `-- cast:`.
 
+## nil-declaration
+
+a local initialized to `nil` with no type annotation is inferred as the
+type `nil` — not "unknown yet" — so every later assignment fails, far
+from the cause. the rule fires at the declaration, where the fix is:
+
+```teal
+local earliest = nil -- flagged: type nil forever
+local earliest: integer | nil = nil -- the honest optional
+```
+
+an all-nil multi declaration (`local a, b = nil, nil`) is flagged too;
+a mixed right-hand side is left to the checker's error-site hint.
+
 ## visibility
 
 a module under `cosmic/` may only be required from outside `cosmic/`


### PR DESCRIPTION
Two more ledger entries retire, one with a mechanism, one already earned.

**The rule** (`nil-declaration`, in `_cli/lint.tl` beside its lexer-based siblings): `local x = nil` with no type annotation is inferred as the type `nil` — forever — and today the failure surfaces as confusing assignment errors far from the cause. The rule flags the *declaration*, with the fix in the message (`local x: T | nil = nil`). Token-exact, so the trap quoted inside a string fixture never counts (the tree's one textual match is exactly that — a heredoc fixture in `teal_test.tl` that tests the error-site hint).

Scope is deliberate: the all-nil right-hand side (single and multi, attributes handled). A mixed RHS (`local a, b = nil, 1`) stays with the checker's error-site hint, which keeps firing for the shapes the lint leaves alone — the rule and the hint compose rather than overlap.

- **Gotcha 13 retires** to a stub naming the rule.
- **Gotcha 7 retires** too — no code needed: `proc.interpreter()` (landed in #952) is the one-call answer and the recipe teaches it; the entry was a pointer wearing a gotcha costume.

Tests cover the bare form, the all-nil multi form, and seven passing shapes (annotated optional, identifier named `nil_value`, expressions, mixed RHS, `local function`, string-quoted trap). `guide.lint` documents the rule.

The live ledger is now 6 entries: 1, 2, 3, 4, 12 (inherent, hint-covered) and 9 (narrowing — the carried-patch spike is next, reporting separately).

`--make ci` passes (5 stages).

Part of #949.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWCMuPQkSAomijVdve6V8D

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWCMuPQkSAomijVdve6V8D)_