### PR TITLE
teal: truthiness narrows nil unions, via a carried patch on the pinned compiler

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -1,5 +1,6 @@
 # coverage ratchet baseline: `cosmic --make coverage --baseline` rewrites this file.
 # columns: path covered-lines total-lines
+3p/tl/tl_patch.tl 0 1
 _build/ratchet.tl 36 36
 _cli/args.tl 0 31
 _cli/build/init.tl 43 47
@@ -29,13 +30,14 @@ _make/converge.tl 34 62
 _make/deps.tl 73 73
 _make/docs.tl 13 31
 _make/extract.tl 51 72
-_make/fetch.tl 102 112
+_make/fetch.tl 118 148
 _make/generate.tl 40 50
 _make/graph.tl 184 210
 _make/help.tl 21 22
 _make/imports.tl 60 63
 _make/init.tl 166 222
 _make/law.tl 54 56
+_make/patch.tl 81 87
 _make/pin.tl 80 81
 _make/policy.tl 45 106
 _make/project.tl 181 193
@@ -78,7 +80,7 @@ cmd/cosmic/main.tl 0 276
 cosmic/_script_cache.tl 72 79
 cosmic/_seal_coverage.tl 9 10
 cosmic/_teal_discard.tl 130 148
-cosmic/_teal_hints.tl 32 32
+cosmic/_teal_hints.tl 34 34
 cosmic/ansi.tl 86 86
 cosmic/benchmark.tl 146 173
 cosmic/check.tl 110 113
@@ -191,4 +193,4 @@ cosmic/user.tl 48 61
 cosmic/uuid.tl 9 9
 cosmic/zip.tl 72 85
 tlconfig.lua 7 7
-total 14237 18715
+total 14336 18841

--- a/3p/tl/tl_patch.tl
+++ b/3p/tl/tl_patch.tl
@@ -1,0 +1,67 @@
+-- The carried patch riding 3p/tl/tl_pin.tl (see _make/patch.tl for the
+-- mechanism). One edit: teach the checker that truthiness narrows a
+-- union of nil with non-boolean members. Lua has no falsy tables, so
+-- for `local r: Rec | nil`, `if r then` (and the early-return shape
+-- `if not r then return end`) means exactly "r is not nil" — the fact
+-- machinery already narrows `is` guards this way; the edit stamps the
+-- same IsFact on a plain variable read in boolean context. Unions
+-- containing boolean/any/unknown are skipped: `false` is truthy-unsafe.
+-- Carried, not forked: the anchor must match the pinned tl.lua exactly
+-- once, so a tl pin bump that moves this code fails the fetch loudly
+-- until the patch is re-audited (or dropped, once upstream lands it).
+return {
+  ["narrow-truthiness"] = {
+    file = "tl.lua",
+    note = "whilp/cosmic#942: truthiness narrows nil-unions of records/maps/arrays",
+    find = [=====[
+            if t.typename == "typedecl" then
+               t = typedecl_to_nominal(node, node.tk, t, t)
+            end
+
+            return t]=====],
+    replace = [=====[
+            if t.typename == "typedecl" then
+               t = typedecl_to_nominal(node, node.tk, t, t)
+            end
+
+            -- cosmic carried patch (whilp/cosmic#942): a plain variable
+            -- read in boolean context carries a truthiness fact. Lua has
+            -- no falsy tables, so for a union of nil with non-boolean
+            -- members, truthy exactly means "not nil": the positive
+            -- branch narrows to the members, and the negated
+            -- early-return shape narrows below the guard. Unions
+            -- containing boolean (or any/unknown) are skipped -- false
+            -- is truthy-unsafe.
+            do
+               local rt = t
+               if rt.typename == "nominal" then
+                  rt = self:resolve_nominal(rt)
+               end
+               if node.expected and node.expected.typename == "boolean_context" and
+                  rt.typename == "union" then
+                  local has_nil, safe, members = false, true, {}
+                  for _, m in ipairs(rt.types) do
+                     local rm = m
+                     if rm.typename == "nominal" then
+                        rm = self:resolve_nominal(rm)
+                     end
+                     if rm.typename == "nil" then
+                        has_nil = true
+                     else
+                        if rm.typename == "boolean" or rm.typename == "any" or
+                           rm.typename == "unknown" or rm.typename == "boolean_context" then
+                           safe = false
+                        end
+                        table.insert(members, m)
+                     end
+                  end
+                  if has_nil and safe and #members > 0 then
+                     local typ = #members == 1 and members[1] or unite(node, members)
+                     node.known = IsFact({ var = node.tk, typ = typ, w = node })
+                  end
+               end
+            end
+
+            return t]=====],
+  },
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,8 +179,12 @@ formatted string plus the numeric errno), wrappers add context with
 `errno.wrap(err, prefix)`, and branch on the numeric errno via
 `errno.is(errno_value, "EINTR")`.
 
-**Narrowing record/map unions.** Teal (0.24.8) does not flow-narrow record
-or map unions through truthiness (`if not x`). Three sanctioned tools:
+**Narrowing nil unions.** Truthiness narrows `T | nil` for every `T` — records,
+maps, arrays and scalars, positive branch and negated early return (`if not r then
+return end`) alike — via the carried tl patch (`3p/tl/tl_patch.tl`; mechanism in
+`_make/patch.tl`). What still does NOT narrow: `assert(x)`, `== nil`/`~= nil`
+comparisons, record FIELDS (copy the field to a local and guard the local), and
+unions containing `boolean`. The other tools:
 
 - **In tests and examples, use `check.must`** for fallible returns: `local db =
   check.must(sqlite.open(path))` yields a plain `Database` — no cast, no assert. Lua
@@ -188,24 +192,20 @@ or map unions through truthiness (`if not x`). Three sanctioned tools:
   string. `must` narrows nil only (`false` passes through), and it throws, so it is for
   tests/examples, never library code. Like `assert`, must forwards extra returns past
   the second, so `for p in check.must(fs.find_iter(d)) do` keeps the 4th return (the to-be-
-  closed guard that releases directory handles on early break); a plain `value, err`
-  pair still collapses to the value alone. Never write `assert(x) as T` in a test; that
-  pattern is retired.
-- **Prefer `is` where the code branches, for table-backed records**: `if sock is
-  net.Socket then sock:send(...) end` narrows `Socket | nil` inside the positive branch
-  (compiles to one `type(x) == "table"` check). Also works for dispatch over `any` (`if
-  v is {string: any} then`). A record whose runtime values are userdata needs Teal's
-  `userdata` member in its OWN source (see re.tl's Regex) — then `is` compiles to the
-  correct `type(x) == "userdata"` test everywhere (`fs.Stat` is one: always the raw
-  stat userdata since the representation unification, so `st is fs.Stat` narrows).
-  Caveat: narrowing does NOT survive an early-exit guard (`if not (x is Rec) then
-  return end` does not narrow below). `is` works with required `cosmo.*` classes too — the cosmic searcher is the
-  only loader cosmic installs, and it resolves `.d.tl` markers. The one unsupported path
-  is user code calling `require("tl").loader()`, which shadows it with tl's silent one.
-- **Cast in linear code and at userdata boundaries**: after an assert or
-  early-exit guard, `(x as Rec).field`, `(x as {K:V})[k]`. Scalars
-  (`string | nil`) narrow normally, except method-call syntax: use
-  `string.sub(x, …)` not `x:sub(…)` on a narrowed value.
+  closed guard that releases directory handles on early break); a plain `value, err` pair
+  still collapses to the value alone. Never write `assert(x) as T` in a test; that pattern is retired.
+- **Use `is` for dispatch past nil**: `if sock is net.Socket then sock:send(...)
+  end` narrows inside the positive branch (one `type(x) == "table"` check); also
+  dispatch over `any` (`if v is {string: any} then`). A record whose runtime
+  values are userdata needs Teal's `userdata` member in its OWN source (see
+  re.tl's Regex) — then `is` compiles to a `type(x) == "userdata"` test
+  everywhere (`fs.Stat` is one, so `st is fs.Stat` narrows). Caveat: `is`
+  narrowing does NOT survive an early-exit guard (`if not (x is Rec) then return
+  end` does not narrow below — unlike the plain truthiness guard). `is` works
+  with required `cosmo.*` classes too — the cosmic searcher is the only loader
+  cosmic installs, and it resolves `.d.tl` markers. The one unsupported path is
+  user code calling `require("tl").loader()`, which shadows it with tl's silent one.
+- **Cast in linear code and at userdata boundaries**: after an assert, `(x as Rec).field`, `(x as {K:V})[k]`.
 
 Every `as` cast must carry a justification (enforced by `--make lint`):
 a line containing a cast needs `-- cast: <reason>` trailing on the line,

--- a/_make/fetch.tl
+++ b/_make/fetch.tl
@@ -14,12 +14,14 @@ local env = require("cosmic.env")
 local extract = require("_make.extract")
 local fs = require("cosmic.fs")
 local hash = require("cosmic.hash")
+local patch = require("_make.patch")
 local pin = require("_make.pin")
 local project = require("_make.project")
 local records = require("cosmic.records")
 local selection = require("_make.select")
 local types = require("_make.types")
 
+local type Edit = patch.Edit
 local type File = types.File
 local type Pin = pin.Pin
 local type Project = types.Project
@@ -90,15 +92,43 @@ local function products_present(archive: string): boolean
   return true
 end
 
+--- The pin's carried patch, read, or nil when it carries none.
+---
+--- A patch is only admitted on a pin that unpacks: a formatless pin's
+--- single output IS the content-addressed file, so editing it would
+--- fail its own digest check on every later fetch, forever. The
+--- archive/products split is what makes patching sound — the archive
+--- stays pristine and verifiable, and the products are re-derivable
+--- from it at any time.
+--- @param p Pin The resolved pin
+--- @return {Edit}|nil The edits, when the pin carries a readable patch
+--- @return string The error when the patch is unreadable or misplaced
+local function patch_of(p: Pin): {Edit} | nil, string
+  local pp = patch.of_pin(p.source)
+  if not pp then
+    return nil
+  end
+  if not p.format then
+    return nil, "make: " .. pp .. ": a patch rides an archive pin only — " ..
+    "editing a bare pinned file would fail its own digest check forever"
+  end
+  return patch.read(pp)
+end
+
 --- Unpack a pin that declares a format, beside the archive.
 ---
 --- Only after the digest matched: an archive is a program for a
 --- decompressor, and running one on unverified bytes is what pinning
---- exists to prevent.
+--- exists to prevent. A carried patch applies last, onto the pristine
+--- products this unpack just produced.
 --- @param p Pin The resolved pin
 --- @param archive string The verified archive's path
 --- @return boolean, string Success, or false plus the reason
 local function unpacked(p: Pin, archive: string): boolean, string
+  local edits, perr = patch_of(p)
+  if perr then
+    return false, perr
+  end
   if not p.format then
     return true
   end
@@ -115,6 +145,9 @@ local function unpacked(p: Pin, archive: string): boolean, string
   if not wok then
     return false, "make: cannot write " .. manifest_of(archive) .. ": " ..
     (werr or "unknown error")
+  end
+  if edits then
+    return patch.apply(fs.dirname(archive), edits as {Edit}) -- cast: record union after guard
   end
   return true
 end
@@ -135,6 +168,17 @@ local function satisfied(p: Pin): boolean
     return false
   end
   if p.format and not products_present(out) then
+    return false
+  end
+  -- A patch is part of the pin's contract: products missing its edits
+  -- are as unsatisfied as products missing outright, and the repair is
+  -- the same — re-unpack pristine, then apply. An unreadable or
+  -- misplaced patch also lands here, so the repair path reports it.
+  local edits, perr = patch_of(p)
+  if perr then
+    return false
+  end
+  if edits and not patch.applied(fs.dirname(out), edits as {Edit}) then -- cast: record union after guard
     return false
   end
   return true
@@ -198,6 +242,41 @@ local function one(p: Pin): boolean, string
     (werr or "unknown error")
   end
   return unpacked(p, out)
+end
+
+--- Repair carried patches locally, without a network.
+---
+--- The bootstrap: a cold tree's fetch may have run under the PINNED
+--- release, which can predate a patch (or the mechanism itself). The
+--- archive it landed is pristine and digest-verified, so applying the
+--- patch needs no network — every graph-touching verb calls this, and
+--- the first build under the tree's own code patches what the pinned
+--- fetch could not. Pins without a patch cost nothing here; a missing
+--- or mismatched archive is left for `fetch` to report.
+--- @param proj Project The scanned project
+--- @return boolean, string Success, or false plus the reason
+local function repair(proj: Project): boolean, string
+  for _, f in ipairs(project.of_kind(proj, {"pin"})) do
+    if patch.of_pin(f.path) then
+      local p, err = pin.read(f.path)
+      if not p then
+        return false, err or ("make: " .. f.path .. ": not a pin")
+      end
+      local rp = p as Pin -- cast: record union after the guard
+      if not satisfied(rp) then
+        local out = landing(rp)
+        local have = fs.read(out)
+        if have and hash.sha256_hex(have) == rp.sha256 then
+          io.write("patch " .. rp.output .. "\n")
+          local uok, uerr = unpacked(rp, out)
+          if not uok then
+            return false, uerr
+          end
+        end
+      end
+    end
+  end
+  return true
 end
 
 --- Every pin in the project, resolved.
@@ -267,12 +346,14 @@ end
 
 local record FetchModule
   satisfied: function(p: Pin): boolean
+  repair: function(proj: Project): boolean, string
   resolve: function(files: {File}): {Pin} | nil, string
   run: function(proj: Project, paths: {string}): integer
 end
 
 local M: FetchModule = {
   satisfied = satisfied,
+  repair = repair,
   resolve = resolve,
   run = run,
 }

--- a/_make/generate.tl
+++ b/_make/generate.tl
@@ -17,6 +17,7 @@ local hash = require("cosmic.hash")
 local build = require("_cli.build")
 local modules = require("_cli.build.modules")
 local deps = require("_make.deps")
+local fetch = require("_make.fetch")
 local project = require("_make.project")
 local types = require("_make.types")
 
@@ -366,6 +367,16 @@ end
 --- @param cosmic string Absolute path to the cosmic binary
 --- @return boolean, string Success, or false plus the reason
 local function sources(proj: Project, cosmic: string): boolean, string
+  -- Carried patches repair first: a cold tree's fetch may have run
+  -- under a pinned release that predates a patch, and the repair is
+  -- local — the digest-verified archive is already on disk (see
+  -- _make.patch). Before the generators, because they read the pinned
+  -- trees this repairs; `fetch` (which applies patches itself) and
+  -- `clean` never reach this phase, so neither pays for it.
+  local rok, rerr = fetch.repair(proj)
+  if not rok then
+    return false, rerr
+  end
   for _, f in ipairs(proj.files) do
     if f.kind == "gen" then
       local dest = project.out_dir(stem_of(f.path))

--- a/_make/patch.tl
+++ b/_make/patch.tl
@@ -1,0 +1,190 @@
+--- Carried patches: `*_patch.tl` is Teal **data**, like the pin it
+--- rides beside.
+---
+--- A pin names bytes; sometimes those bytes need a small, deliberate
+--- change this project cannot yet have upstream — a compiler fix in
+--- flight, a backport. The change is declared, never computed: a patch
+--- file is one `return { … }` of named edits, each an exact `find`
+--- string replaced by an exact `replace` string in one unpacked file.
+--- No diff format, no external tool — and the exactness is the safety:
+---
+--- - `find` must occur EXACTLY ONCE in the target, or the patch fails
+---   loudly. A pin bump that moves the anchor is supposed to fail —
+---   that failure is the "re-audit the patch" signal, never a silent
+---   drift.
+--- - Application is idempotent: a target already containing `replace`
+---   is already patched, and re-fetching skips it.
+--- - `fetch` re-verifies application the same way it re-verifies the
+---   digest, so adding or changing a patch repairs on the next fetch
+---   (the archive's bytes are still pristine; unpack restores them
+---   before edits re-apply).
+---
+--- The patch file sits beside its pin — `3p/tl/tl_pin.tl` carries
+--- `3p/tl/tl_patch.tl` — and edits name files relative to the pin's
+--- unpack directory under `o/`. The literal grammar has no array part,
+--- so edits are named entries, applied in sorted-name order:
+---
+---     return {
+---       ["narrow-truthiness"] = {
+---         file = "tl.lua",
+---         find = [=====[exact anchor text]=====],
+---         replace = [=====[exact replacement text]=====],
+---         note = "why: an issue, an upstream PR",
+---       },
+---     }
+
+local fs = require("cosmic.fs")
+local literal = require("cosmic.literal")
+local str = require("cosmic.string")
+
+--- One declared edit.
+local record Edit
+  --- The entry's key in the patch file, for messages.
+  name: string
+  --- The file to edit, relative to the pin's unpack directory.
+  file: string
+  --- Exact text to replace; must occur exactly once.
+  find: string
+  --- Exact replacement text.
+  replace: string
+  --- Why this edit exists (an issue, an upstream PR).
+  note: string
+end
+
+--- The patch file beside a pin, or nil when the pin carries none.
+--- @param pin_source string The pin's path (`.../<stem>_pin.tl`)
+--- @return string|nil The `<stem>_patch.tl` path when it exists
+local function of_pin(pin_source: string): string | nil
+  if not str.ends_with(pin_source, "_pin.tl") then
+    return nil
+  end
+  local p = string.sub(pin_source, 1, #pin_source - #"_pin.tl") .. "_patch.tl"
+  if fs.is_file(p) then
+    return p
+  end
+  return nil
+end
+
+--- Read a patch file into its edits, in sorted-name order.
+--- @param path string The `*_patch.tl` path
+--- @return {Edit}|nil The edits
+--- @return string The error naming the file
+local function read(path: string): {Edit} | nil, string
+  local data, err = literal.parse_file(path, {noun = "patch"})
+  if not (data is {string: any}) then
+    return nil, (err or (path .. ": not literal data"))
+  end
+  local names: {string} = {}
+  for name in pairs(data) do
+    names[#names + 1] = name
+  end
+  table.sort(names)
+  local edits: {Edit} = {}
+  for _, name in ipairs(names) do
+    local raw = data[name]
+    local where = path .. ": edit '" .. name .. "'"
+    if not (raw is {string: any}) then
+      return nil, where .. ": not a table of fields"
+    end
+    local e = raw as {string: any} -- cast: record union after guard
+    local file = e["file"]
+    local find = e["find"]
+    local replace = e["replace"]
+    local note = e["note"]
+    if not (file is string) or not (find is string)
+    or not (replace is string) or not (note is string) then
+      return nil, where .. ": needs file, find, replace, note (all strings)"
+    end
+    edits[#edits + 1] = {
+      name = name,
+      file = file as string, -- cast: scalar narrowing after guard
+      find = find as string, -- cast: scalar narrowing after guard
+      replace = replace as string, -- cast: scalar narrowing after guard
+      note = note as string, -- cast: scalar narrowing after guard
+    }
+  end
+  if #edits == 0 then
+    return nil, path .. ": a patch with no edits is a patch to delete"
+  end
+  return edits
+end
+
+--- Occurrences of an exact substring.
+local function count(haystack: string, needle: string): integer
+  local n = 0
+  local at = 1
+  while true do
+    local found = string.find(haystack, needle, at, true)
+    if not found then
+      return n
+    end
+    n = n + 1
+    at = found + 1
+  end
+end
+
+--- Are all edits already present in the unpacked tree?
+--- @param dir string The pin's unpack directory
+--- @param edits {Edit} The declared edits
+--- @return boolean True when every target contains its replacement
+local function applied(dir: string, edits: {Edit}): boolean
+  for _, e in ipairs(edits) do
+    local text = fs.read(fs.join(dir, e.file))
+    if not (text is string) then
+      return false
+    end
+    if not string.find(text as string, e.replace, 1, true) then -- cast: scalar narrowing
+      return false
+    end
+  end
+  return true
+end
+
+--- Apply every edit, exact-once, idempotently.
+--- @param dir string The pin's unpack directory
+--- @param edits {Edit} The declared edits
+--- @return boolean, string Success, or false plus the reason
+local function apply(dir: string, edits: {Edit}): boolean, string
+  for _, e in ipairs(edits) do
+    local target = fs.join(dir, e.file)
+    local text = fs.read(target)
+    if not (text is string) then
+      return false, "make: patch edit '" .. e.name .. "': cannot read " .. target
+    end
+    local body = text as string -- cast: scalar narrowing after guard
+    if string.find(body, e.replace, 1, true) then
+      -- Already applied: the idempotent re-fetch path.
+    else
+      local n = count(body, e.find)
+      if n ~= 1 then
+        return false, "make: patch edit '" .. e.name .. "' (" .. e.note ..
+        "): anchor occurs " .. tostring(n) .. " time(s) in " .. target ..
+        ", need exactly 1 — the pin moved; re-audit the patch"
+      end
+      local patched = str.replace(body, e.find, e.replace, 1)
+      local wok, werr = fs.write(target, patched)
+      if not wok then
+        return false, "make: patch edit '" .. e.name .. "': cannot write " ..
+        target .. ": " .. (werr or "unknown error")
+      end
+    end
+  end
+  return true
+end
+
+local record PatchModule
+  type Edit = Edit
+  of_pin: function(pin_source: string): string | nil
+  read: function(path: string): {Edit} | nil, string
+  applied: function(dir: string, edits: {Edit}): boolean
+  apply: function(dir: string, edits: {Edit}): boolean, string
+end
+
+local M: PatchModule = {
+  of_pin = of_pin,
+  read = read,
+  applied = applied,
+  apply = apply,
+}
+
+return M

--- a/_make/patch_test.tl
+++ b/_make/patch_test.tl
@@ -1,0 +1,95 @@
+#!/usr/bin/env cosmic
+-- Unit tests for _make.patch: the carried-patch reader and applier.
+-- The end-to-end path (fetch applies, repair re-applies) is exercised
+-- by the tree itself — 3p/tl/tl_patch.tl rides every build — so what
+-- lives here is the contract: sorted order, exact-once anchors,
+-- idempotent application, loud refusals.
+
+local check = require("cosmic.check")
+local fs = require("cosmic.fs")
+local patch = require("_make.patch")
+
+local tmpdir = os.getenv("TEST_TMPDIR") or "/tmp"
+
+local function write(path: string, text: string)
+  assert(fs.make_dirs(fs.dirname(path)))
+  assert(fs.write(path, text))
+end
+
+local function test_of_pin_names_the_sibling()
+  local dir = check.must(fs.temp_dir(fs.join(tmpdir, "ofpin-XXXXXX")))
+  local pin_path = fs.join(dir, "x_pin.tl")
+  write(pin_path, "return {}\n")
+  assert(patch.of_pin(pin_path) == nil, "no patch file means nil")
+  assert(patch.of_pin(fs.join(dir, "notapin.tl")) == nil,
+    "a non-pin path carries no patch")
+  local patch_path = fs.join(dir, "x_patch.tl")
+  write(patch_path, "return {}\n")
+  assert(patch.of_pin(pin_path) == patch_path, "the sibling patch is found")
+end
+test_of_pin_names_the_sibling()
+
+local function test_read_sorts_and_validates()
+  local dir = check.must(fs.temp_dir(fs.join(tmpdir, "read-XXXXXX")))
+  local p = fs.join(dir, "y_patch.tl")
+  write(p, [[
+return {
+  ["b-second"] = {file = "f", find = "x", replace = "y", note = "n2"},
+  ["a-first"] = {file = "f", find = "p", replace = "q", note = "n1"},
+}
+]])
+  local edits = check.must(patch.read(p))
+  assert(#edits == 2, "two edits")
+  assert(edits[1].name == "a-first" and edits[2].name == "b-second",
+    "edits come out in sorted-name order")
+  assert(edits[1].find == "p" and edits[1].replace == "q")
+
+  write(p, "return {}\n")
+  local none, err = patch.read(p)
+  assert(none == nil and err:find("no edits", 1, true),
+    "an empty patch is refused: " .. tostring(err))
+
+  write(p, [[
+return {
+  ["missing-note"] = {file = "f", find = "x", replace = "y"},
+}
+]])
+  local bad, berr = patch.read(p)
+  assert(bad == nil and berr:find("needs file, find, replace, note", 1, true),
+    "a missing field is named: " .. tostring(berr))
+end
+test_read_sorts_and_validates()
+
+local function test_apply_exact_once_and_idempotent()
+  local dir = check.must(fs.temp_dir(fs.join(tmpdir, "apply-XXXXXX")))
+  write(fs.join(dir, "t.lua"), "local a = 1\nlocal b = 2\nlocal a = 1\n")
+  local twice: {patch.Edit} = {
+    {name = "e", file = "t.lua", find = "local a = 1", replace = "local a = 9",
+      note = "test"},
+  }
+  local ok, err = patch.apply(dir, twice)
+  assert(not ok and err:find("2 time(s)", 1, true),
+    "a twice-occurring anchor is refused: " .. tostring(err))
+
+  local once: {patch.Edit} = {
+    {name = "e", file = "t.lua", find = "local b = 2", replace = "local b = 7",
+      note = "test"},
+  }
+  assert(patch.apply(dir, once))
+  local text = check.must(fs.read(fs.join(dir, "t.lua")))
+  assert(text:find("local b = 7", 1, true), "the edit landed")
+  assert(patch.applied(dir, once), "applied() sees the replacement")
+  assert(patch.apply(dir, once), "re-applying is a no-op, not a failure")
+  assert(check.must(fs.read(fs.join(dir, "t.lua"))) == text,
+    "idempotent: the bytes did not move")
+
+  local absent: {patch.Edit} = {
+    {name = "gone", file = "t.lua", find = "nowhere at all",
+      replace = "still nowhere", note = "test"},
+  }
+  local aok, aerr = patch.apply(dir, absent)
+  assert(not aok and aerr:find("0 time(s)", 1, true),
+    "a missing anchor is refused: " .. tostring(aerr))
+  assert(not patch.applied(dir, absent), "applied() is false for it")
+end
+test_apply_exact_once_and_idempotent()

--- a/cosmic/_teal_hints.tl
+++ b/cosmic/_teal_hints.tl
@@ -10,8 +10,9 @@
 --- Matches the most common traps:
 ---   1. got number, expected integer (string index/length requires integer)
 ---   2. X | nil used un-narrowed: passed where X is expected, indexed,
----      or looped over — `if not x` narrows scalars but not records,
----      maps or arrays, and nothing else tells the author that
+---      or looped over — truthiness (`if not x`) narrows a nil union
+---      (the carried tl patch, 3p/tl/tl_patch.tl), but `assert(x)` and
+---      `== nil` comparisons do not, and nothing else tells the author
 ---   3. excess return values (multiple returns captured incorrectly)
 ---   4. <any type> operations (ipairs, index, concat on any)
 
@@ -40,19 +41,19 @@ local function hint_for_message(msg: string): string | nil
   if msg:find("%| nil") and msg:find("expected") then
     return "  hint: narrow first: `if v is Rec then ... end` (plain-table records), or cast after a guard for userdata handles — see `cosmic --docs guide.checking`"
   end
-  -- Pattern 2b: indexing through an un-narrowed nil union. The trap is
-  -- that `if not x then return end` — and `assert(x)`, which newcomers
-  -- expect to narrow — narrows scalars but not records, maps or arrays;
-  -- and even a narrowed SCALAR cannot be method-called
-  -- (`data:gmatch(...)` on `string | nil` lands here too).
+  -- Pattern 2b: indexing through an un-narrowed nil union. Truthiness
+  -- (`if x`, `if not x then return end`) narrows a nil union since the
+  -- carried tl patch (3p/tl/tl_patch.tl), so what lands here is the
+  -- shapes that still do not narrow: `assert(x)` and `== nil` /
+  -- `~= nil` comparisons, which newcomers expect to narrow.
   if msg:find("cannot index") and msg:find("| nil", 1, true) then
-    return "  hint: `T | nil` does not narrow through `if not x` or `assert(x)` for records/maps/arrays, and a narrowed scalar cannot be method-called (use `string.gmatch(x, ...)`): branch with `if x is T then ... end`, or cast after the guard (`local v = x as T`) — see `cosmic --docs guide.checking`"
+    return "  hint: `assert(x)` and `== nil` comparisons do not narrow `T | nil` — guard with truthiness (`if not x then return end`), branch with `if x is T then ... end`, or cast (`local v = x as T`) — see `cosmic --docs guide.checking`"
   end
   -- Pattern 2c: for-in over a value the checker cannot call. The message
   -- names no type, and the usual cause is an iterator still `T | nil`
   -- from a fallible call.
   if msg:find("for loop does not return an iterator", 1, true) then
-    return "  hint: often the iterator is still `T | nil` from a fallible call: narrow with `is` or cast after a nil-guard before the loop — see `cosmic --docs guide.checking`"
+    return "  hint: often the iterator is still `T | nil` from a fallible call: guard with truthiness (`if not it then return end`) before the loop — `assert(it)` does not narrow — see `cosmic --docs guide.checking`"
   end
   -- Pattern 2d: naming another module's type that is not exported. A
   -- standalone top-level record is file-local; importers can only name
@@ -73,7 +74,7 @@ local function hint_for_message(msg: string): string | nil
   -- `{T} | nil` needs narrowing, a plain `any` needs a cast.
   if msg:find("attempting ipairs on something that's not an array") then
     if msg:find("| nil", 1, true) then
-      return "  hint: `{T} | nil` does not narrow through `if not x` or `assert(x)`: branch with `is` or cast after the guard (`local xs = v as {T}`) — see `cosmic --docs guide.checking`"
+      return "  hint: `assert(xs)` does not narrow `{T} | nil` — guard with truthiness (`if not xs then return end`), branch with `is`, or cast (`local xs = v as {T}`) — see `cosmic --docs guide.checking`"
     end
     return "  hint: cast first, e.g. `local items = data as {any}`"
   end

--- a/cosmic/teal_test.tl
+++ b/cosmic/teal_test.tl
@@ -63,9 +63,56 @@ print(g(f()))
 end
 test_hint_nil_union_not_narrowed()
 
--- The `if not x then return end` guard narrows scalars but not records,
--- maps or arrays; the errors it leaves behind name the un-narrowed type
--- but nothing else, so each shape carries a hint at the fix.
+-- The carried tl patch's canary (3p/tl/tl_patch.tl): truthiness narrows
+-- a nil union of records, maps and arrays, positive branch and negated
+-- early-return alike. A tl pin bump that lands without the patch — or a
+-- patch whose anchor drifted — fails HERE, not as a hundred downstream
+-- type errors.
+local function test_truthiness_narrows_nil_union()
+  local path = fs.join(tmpdir, "narrow_ok.tl")
+  assert(fs.write(path, [[
+local record R
+  x: integer
+end
+local function make(): R | nil
+  return {x = 1}
+end
+local function early(): integer
+  local r = make()
+  if not r then
+    return 1
+  end
+  return r.x
+end
+local function positive(): integer
+  local r = make()
+  if r then
+    return r.x
+  end
+  return 0
+end
+local function arr(): integer
+  local xs: {integer} | nil = {2}
+  if not xs then
+    return 0
+  end
+  local sum = 0
+  for _, v in ipairs(xs) do
+    sum = sum + v
+  end
+  return sum
+end
+print(early() + positive() + arr())
+]]))
+  local result = teal.check(path)
+  assert(result.ok, "truthiness must narrow a nil union (carried tl patch): "
+    .. (result.ok and "" or teal.format_issues(result.errors)))
+end
+test_truthiness_narrows_nil_union()
+
+-- `assert(x)` and `== nil` comparisons still do NOT narrow; the errors
+-- they leave behind name the un-narrowed type but nothing else, so each
+-- shape carries a hint at the fix.
 local function test_hint_index_through_nil_union()
   local msg, hint = first_hinted_error("h_idx_union.tl", [[
 local record R
@@ -76,16 +123,14 @@ local function make(): R | nil
 end
 local function use(): integer
   local r = make()
-  if not r then
-    return 1
-  end
+  assert(r)
   return r.x
 end
 print(use())
 ]])
   assert(msg:find("cannot index", 1, true) and msg:find("| nil", 1, true),
     "wrong error: " .. msg)
-  assert(hint:find("does not narrow through", 1, true), "wrong hint: " .. hint)
+  assert(hint:find("do not narrow", 1, true), "wrong hint: " .. hint)
   assert(hint:find("guide.checking", 1, true), "wrong hint: " .. hint)
 end
 test_hint_index_through_nil_union()
@@ -98,9 +143,7 @@ local function rows(): Iter | nil
 end
 local function use()
   local it = rows()
-  if not it then
-    return
-  end
+  assert(it)
   for x in it do
     print(x)
   end
@@ -120,9 +163,7 @@ local function list(): {string} | nil
 end
 local function use()
   local xs = list()
-  if not xs then
-    return
-  end
+  assert(xs)
   for _, x in ipairs(xs) do
     print(x)
   end
@@ -131,7 +172,7 @@ use()
 ]])
   assert(msg:find("attempting ipairs", 1, true) and msg:find("| nil", 1, true),
     "wrong error: " .. msg)
-  assert(hint:find("does not narrow through", 1, true), "wrong hint: " .. hint)
+  assert(hint:find("does not narrow", 1, true), "wrong hint: " .. hint)
 end
 test_hint_ipairs_on_nil_union()
 
@@ -165,19 +206,18 @@ print(label(depmod.make()))
 end
 test_hint_unexported_type()
 
-local function test_hint_scalar_method_call_after_guard()
-  -- Scalars narrow through a nil-guard for plain uses, but not for
-  -- method-call syntax — the same "cannot index ... | nil" error shape
-  -- as records, so it must carry the same hint.
+local function test_hint_scalar_method_call_after_assert()
+  -- A truthiness guard narrows the scalar and the method call works;
+  -- after `assert(data)` the value is still `string | nil`, and the
+  -- method call is the use that fails first — the same "cannot index
+  -- ... | nil" error shape as records, so it carries the same hint.
   local msg, hint = first_hinted_error("h_scalar_method.tl", [[
 local function readish(): string | nil, string
   return nil, "nope"
 end
 local function use(): integer
   local data = readish()
-  if not data then
-    return 1
-  end
+  assert(data)
   for word in data:gmatch("%a+") do
     print(word)
   end
@@ -187,9 +227,9 @@ print(use())
 ]])
   assert(msg:find("cannot index", 1, true) and msg:find("| nil", 1, true),
     "wrong error: " .. msg)
-  assert(hint:find("method%-called", 1, false), "wrong hint: " .. hint)
+  assert(hint:find("do not narrow", 1, true), "wrong hint: " .. hint)
 end
-test_hint_scalar_method_call_after_guard()
+test_hint_scalar_method_call_after_assert()
 
 local function test_hint_colon_call_on_module_function()
   local msg, hint = first_hinted_error("h_colon.tl", [[

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -32,3 +32,4 @@ than editing the record it replaces.
 | D18 | expensive recipe steps skip on input bytes, not just on mtime | [→](d18-step-skip.md) |
 | D19 | what "public" means for toolchain modules, and the visibility lint | [→](d19-toolchain-visibility.md) |
 | D20 | the naming charter: ten rules, and the renames that applied them | [→](d20-naming-charter.md) |
+| D21 | carried patches: the middle path between pin and fork | [→](d21-carried-tl-patch.md) |

--- a/docs/decisions/d21-carried-tl-patch.md
+++ b/docs/decisions/d21-carried-tl-patch.md
@@ -1,0 +1,39 @@
+# D21 — carried patches: the middle path between pin and fork
+
+- **date:** 2026-08
+- **context:** D5 says upstream-first, fork-if-blocked on Teal. The gap
+  between those two states was unpriced: an improvement this project
+  wants NOW (truthiness narrowing of nil unions, whilp/cosmic#942)
+  takes an upstream review cycle to land and a release to reach the
+  pin, and forking for one edit buys a whole compiler's maintenance to
+  get it. Meanwhile the workaround scar tissue D5 names — casts after
+  guards, `check.must`, the gotcha-9 doc — keeps accruing in every file
+  written while waiting.
+- **decision:** a pin may carry a patch: `<stem>_patch.tl` beside
+  `<stem>_pin.tl`, literal data (named find/replace edits, read by
+  `cosmic.literal`, never executed) applied by `fetch` after the
+  pristine, digest-verified unpack — see `_make/patch.tl`. Safety is
+  exactness: an anchor must occur once in the target or the fetch fails
+  loudly, so a pin bump that moves the anchored code is a forced
+  re-audit, never silent drift. Application is idempotent, and every
+  graph verb repairs patches locally (no network — the archive already
+  on disk is the source), which is also what bootstraps a patch through
+  CI's pinned-release fetch. Patches ride archive pins only: editing a
+  formatless pin's single output would fail its own digest forever.
+  The first cargo is the tl truthiness-narrowing edit
+  (`3p/tl/tl_patch.tl`), with its own canary test
+  (`cosmic/teal_test.tl`) so a lost patch fails as one named test, not
+  a hundred downstream type errors.
+- **rejected:** forking tl for one edit (a compiler of maintenance for
+  a function of change); waiting for upstream (unbounded, and the scar
+  tissue compounds while waiting); diff files and an external patch
+  tool (a format and a dependency where two exact strings suffice);
+  patching at build time only (fetch owns "what the unpacked tree is",
+  and a patch is part of that contract).
+- **consequences:** each carried patch is debt with a written-down
+  maturity date: it must be submitted upstream, and a pin bump that
+  includes it upstream deletes the patch file. Until then every tl pin
+  bump pays a re-audit when the anchor moves — which is the mechanism
+  working, not it failing. The checker the tree gates under is no
+  longer byte-identical to released tl 0.24.8; the divergence is one
+  named, tested, documented edit.

--- a/skills/cosmic/checking.md
+++ b/skills/cosmic/checking.md
@@ -57,9 +57,46 @@ recover it.
 
 ### Narrowing and Casting
 
-record and map nil-unions do not narrow through truthiness. where the code
-branches, prefer `is` — it narrows inside the positive branch and compiles
-to a single `type()` check:
+truthiness narrows a nil union: records, maps, arrays and scalars all
+narrow through an ordinary guard, in the positive branch and below a
+negated early return alike (the carried tl patch, `3p/tl/tl_patch.tl`):
+
+```teal
+local r = make() -- r: R | nil
+if not r then
+  return nil, "no r"
+end
+print(r.x) -- r is R below the guard
+
+local sock = net.connect_tcp(host, port) -- Socket | nil
+if sock then
+  sock:send("hello") -- narrowed, method call included
+end
+```
+
+what does NOT narrow:
+
+- **`assert(x, "msg")`** — it terminates control flow at runtime, but
+  the checker still sees `T | nil` on every line after it. guard with
+  truthiness instead, cast once after the assert, or in tests and
+  examples use `check.must`, which guards and narrows in one call.
+- **`== nil` / `~= nil` comparisons** — `if r ~= nil then r.x end`
+  still errors. write the truthiness form (`if r then`).
+- **unions containing `boolean`** — `false` is falsy, so truthy does
+  not mean "not nil" there; branch with `is`.
+- **record FIELDS**, even scalar ones — copy the field to a local and
+  guard the local:
+
+```teal
+local earliest = report.earliest -- integer | nil
+if earliest then
+  print(earliest + 1) -- narrowed; the field read would not be
+end
+```
+
+where the code dispatches over shapes (`any`, unions past nil), `is` is
+the tool — it narrows inside the positive branch and compiles to a
+single `type()` check:
 
 ```teal
 local sock = net.connect_tcp(host, port) -- Socket | nil
@@ -70,9 +107,10 @@ end
 
 a record whose runtime values are userdata needs Teal's `userdata` member
 in its own source (see `re.tl`'s Regex) — then `is` compiles to a
-`type() == "userdata"` test everywhere. caveats: narrowing does not
+`type() == "userdata"` test everywhere. caveats: `is` narrowing does not
 survive an early-exit guard (`if not (x is Rec) then return end` does not
-narrow below it); do not use `is` with a required `cosmo.*` class — the
+narrow below it — unlike the plain truthiness guard, which does); do not
+use `is` with a required `cosmo.*` class — the
 runtime tl loader can lax-recompile a module where the required `.d.tl`
 marker doesn't resolve, silently degrading `is` to a table test — keep
 casts at those boundaries; and `is` is wrong for mixed-representation
@@ -83,57 +121,6 @@ type checker:
 ```teal
 local result = json.decode(input) as {string: any}
 local count = value as integer
-```
-
-the early-exit caveat bites hardest in the most idiomatic-looking shape,
-so here is the fix, concretely. `if not x then return end` narrows
-scalars but NOT records, maps or arrays — below the guard `x` is still
-`T | nil`, and the errors that produces do not say why (`cannot index
-key 'x' in variable 'r' of type R | nil`, `expression in for loop does
-not return an iterator`, `attempting ipairs on something that's not an
-array: {T} | nil`):
-
-```teal
-local r = make() -- r: R | nil
-
--- WRONG: r stays R | nil below this guard
-if not r then
-  return nil, "no r"
-end
-print(r.x) -- error: cannot index key 'x' ... R | nil
-
--- RIGHT (branching): do the work inside the positive branch, handing
--- it to a helper that takes the narrowed type
-if r is R then
-  return run(r) -- run(r: R) receives a plain R
-end
-return nil, "no r"
-
--- RIGHT (linear): keep the guard, cast once immediately after it
-if not r then
-  return nil, "no r"
-end
-local rr = r as R -- cast: record union after guard
-print(rr.x)
-```
-
-scalars narrow through truthiness for plain uses, with one caveat: a
-narrowed scalar cannot be METHOD-called. after a nil-guard on `data:
-string | nil`, `#data` and `data .. s` work but `data:gmatch(...)`
-still fails (`cannot index key 'gmatch' ... string | nil`). use the
-function form (`string.gmatch(data, ...)`) or branch with
-`if data is string then`.
-
-record FIELDS do not narrow either, even when the field is a scalar:
-after `if report.earliest ~= nil then`, `report.earliest` is still
-`integer | nil` at the point of use. copy the field to a local first —
-the local narrows normally:
-
-```teal
-local earliest = report.earliest -- integer | nil
-if earliest ~= nil then
-  print(earliest + 1) -- narrowed; the field read would not be
-end
 ```
 
 per-file `as` counts are pinned by the cast ratchet (`_build/casts.txt`,

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -127,59 +127,41 @@ literal `nil`). capture the returns — `local v, err = f(...)`, or
 `assert`/`check.must` in tests and examples. the details are in
 `cosmic --docs guide.checking`.
 
-## 9. records, maps and arrays don't narrow through `if not x` — or `assert`
+## 9. `assert(x)` and `== nil` don't narrow a nil union — truthiness does
 
-scalars (`string | nil`, `integer | nil`) narrow through an ordinary
-truthiness guard. records, maps and arrays do not — below the guard the
-value is still `T | nil`. **`assert(x, "msg")` is the same trap**: it
-terminates control flow at runtime, but the checker still sees
-`T | nil` on every line after it — do not expect the narrowing other
-typed languages attach to assert. the errors either shape produces name
-the un-narrowed type but not the cause: `cannot index key 'x' in
-variable 'r' of type R | nil`, `expression in for loop does not return
-an iterator`, `attempting ipairs on something that's not an array:
-{T} | nil`.
+an ordinary truthiness guard narrows `T | nil` for every `T` — records,
+maps, arrays and scalars alike (the carried tl patch,
+`3p/tl/tl_patch.tl`):
 
-**wrong:**
 ```teal
 local db = sqlite.open(path) -- Database | nil
 if not db then
   return nil, "open failed"
 end
-db:exec(sql) -- error: cannot index key 'exec' ... Database | nil
+db:exec(sql) -- db is Database below the guard
 ```
 
-**right — branch with `is` and do the work inside the positive branch:**
-```teal
-if db is sqlite.Database then
-  return run(db) -- run(db: sqlite.Database) receives it narrowed
-end
-return nil, "open failed"
-```
+what still does NOT narrow:
 
-**right — keep the guard, cast once immediately after it:**
-```teal
-if not db then
-  return nil, "open failed"
-end
-local d = db as sqlite.Database -- cast: record union after guard
-d:exec(sql)
-```
+- **`assert(x, "msg")`**: it terminates control flow at runtime, but the
+  checker still sees `T | nil` on every line after it — do not expect
+  the narrowing other typed languages attach to assert. guard with
+  truthiness instead, or cast once after the assert (`local d = db as
+  sqlite.Database`). in tests and examples, `local db =
+  check.must(sqlite.open(path))` does guard and narrowing in one call,
+  with no cast to justify.
+- **`== nil` / `~= nil` comparisons**: `if r ~= nil then r.x end` still
+  errors. write the truthiness form (`if r then`).
+- **record fields**, even scalar ones — copy the field to a local and
+  guard the local.
+- **unions containing `boolean`** — `false` is falsy, so truthy does not
+  mean "not nil" there; branch with `is` instead.
 
-(the same cast-after-guard works after an `assert(db, "open failed")`;
-in tests and examples, `local db = check.must(sqlite.open(path))` does
-guard and narrowing in one call, with no cast to justify.)
-
-record fields don't narrow either, even scalar ones — copy the field to
-a local and guard the local.
-
-and one scalar caveat: a narrowed scalar still cannot be METHOD-called.
-after `if not data then return end`, plain uses of `data` work, but
-`data:gmatch(...)` fails with `cannot index key 'gmatch' in variable
-'data' of type string | nil`. use the function form on the narrowed
-value (`string.gmatch(data, ...)`), or branch with `if data is string
-then ... end`, which narrows for every use. the full pattern set is in
-`cosmic --docs guide.checking`.
+the errors these shapes produce name the un-narrowed type but not the
+cause: `cannot index key 'x' in variable 'r' of type R | nil`,
+`expression in for loop does not return an iterator`, `attempting
+ipairs on something that's not an array: {T} | nil`. the full pattern
+set is in `cosmic --docs guide.checking`.
 
 ## 10. a record other files use must be nested in the module's interface record
 


### PR DESCRIPTION
Closes the main body of gotcha 9 (#942, tracked under #949): `T | nil` now narrows through an ordinary truthiness guard — records, maps, arrays and scalars, positive branch and negated early return (`if not r then return end`) alike — by patching the pinned Teal compiler instead of documenting around it.

## The narrowing edit

A plain variable read in boolean context stamps the same `IsFact` an `is` guard produces. The soundness argument: Lua has no falsy tables, so for a union of nil with non-boolean members, truthy exactly means "not nil". Unions containing `boolean`/`any`/`unknown` are skipped (`false` is truthy-unsafe), and the negative branch reports the precise `type nil`. Validated by an 8-case matrix and a whole-tree `ci` under the patched checker; the artifact's embedded compiler narrows too.

Still not narrowing (the documented residue): `assert(x)`, `== nil`/`~= nil` comparisons, record fields, boolean unions. `assert` and `== nil` ride different fact paths and are plausible follow-on extensions.

## The carry mechanism (D21)

`_make/patch.tl`: `<stem>_patch.tl` beside `<stem>_pin.tl` is literal data — named find/replace edits read by `cosmic.literal`, never executed. Safety is exactness:

- an anchor must occur **exactly once** in the target or the fetch fails loudly — a tl pin bump that moves the anchored code is a forced re-audit, never silent drift;
- application is idempotent, and `fetch` re-verifies it the way it re-verifies the digest (re-unpack restores pristine bytes before edits re-apply);
- archive pins only: patching a formatless pin's single output would fail its own digest check forever.

**Bootstrap:** CI's cold fetch runs under the pinned release, which predates the mechanism. Every graph verb repairs patches locally (no network — the digest-verified archive is already on disk) before the generators run, so the first build under the tree's own code applies what the pinned fetch could not, and converge reaches the fixpoint within its two-generation cap. Verified from a cold `o/`: pin fetch lands pristine → `--make ci` patches at gen1, settles at gen2, `ci: PASS`.

A canary test (`test_truthiness_narrows_nil_union`) asserts narrowing works, so a pin bump that loses the patch fails as one named test rather than a hundred downstream type errors. The hint fixtures move to assert-shaped guards; hints, gotcha 9, `guide.checking` and AGENTS.md now teach the new reality.

**Recovery note:** if a future bad patch ever bricks the embedded compiler mid-converge, `rm o/bin/cosmic && bin/cosmic --make build` falls back to the pin.

## Follow-ons

- extend the patch to `assert(x)` and `== nil` fact paths;
- sweep the tree for now-unneeded `-- cast: record union after guard` casts;
- submit the narrowing upstream to teal-language/tl (the durable path; the patch file deletes on the pin bump that includes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWCMuPQkSAomijVdve6V8D

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWCMuPQkSAomijVdve6V8D)_