### PR TITLE
perf: cosmic.re caches compiled patterns for the convenience surface (+ re scenarios)

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -55,6 +55,7 @@ _perf/bench/fuzzy_bench.tl 0 19
 _perf/bench/http_bench.tl 83 114
 _perf/bench/json_bench.tl 66 76
 _perf/bench/micro_bench.tl 110 120
+_perf/bench/re_bench.tl 59 70
 _perf/bench/sqlite_bench.tl 90 106
 _perf/bench/startup_bench.tl 73 85
 _perf/bench/stream_bench.tl 0 80
@@ -191,4 +192,4 @@ cosmic/user.tl 48 61
 cosmic/uuid.tl 9 9
 cosmic/zip.tl 72 85
 tlconfig.lua 7 7
-total 14237 18715
+total 14296 18785

--- a/_perf/bench/re_bench.tl
+++ b/_perf/bench/re_bench.tl
@@ -1,0 +1,126 @@
+--- POSIX regex scenarios: the cosmic.re wrapper over cosmo.re.
+--- The convenience surface (match, split, gsub) takes a pattern STRING
+--- per call, so these scenarios measure what naive callers pay —
+--- including pattern compilation — while re_search_compiled brackets
+--- the engine's own search cost with compilation hoisted out. Checks
+--- are known-answer, so a faster-but-wrong match path fails instead of
+--- winning.
+
+local re = require("cosmic.re")
+local pt = require("_perf.perf_types")
+
+-- A log-like line and the field-extracting pattern a log scanner
+-- would run against every line.
+local LOG_LINE =
+"2026-08-07T01:23:45 GET /api/v1/users/1234?q=abc 200 173ms"
+local LOG_PATTERN =
+"([0-9]+)-([0-9]+)-([0-9]+)T([0-9:]+) ([A-Z]+) ([^ ]+) ([0-9]+)"
+
+-- A PATH-like list for split, with empty fields at both ends so the
+-- check pins the keep-empty-fields contract: 5 separators, 6 fields.
+local COLON_LIST = ":/usr/bin:/usr/local/bin:/opt/tool/bin:/home/user/.local/bin:"
+local COLON_FIELDS = 6
+
+--- Build a deterministic multi-line block for gsub: 64 lines with a
+--- number in each, so redaction has real work on every line.
+--- @return string The block
+local function build_gsub_text(): string
+  local parts: {string} = {}
+  for i = 1, 64 do
+    parts[i] = "user-" .. (1000 + i) .. " logged in from host-" .. i
+  end
+  return table.concat(parts, "\n")
+end
+
+local GSUB_TEXT = build_gsub_text()
+
+local function scenarios(): {pt.Scenario}, string
+  local compiled, cerr = re.compile(LOG_PATTERN)
+  if not compiled then
+    return nil, "compile: " .. tostring(cerr)
+  end
+
+  return {
+    {
+      -- What a naive per-line log scanner pays: pattern string in,
+      -- captures out, every call.
+      name = "re_match_log_line",
+      fn = function(_: any): any
+        local _m, caps = re.match(LOG_LINE, LOG_PATTERN)
+        return caps
+      end,
+      check = function(_: any, res: any): boolean, string
+        local caps = res as {string} -- cast: from any
+        if caps == nil or #caps ~= 7 then
+          return false, "wrong capture count"
+        end
+        if caps[1] ~= "2026" or caps[5] ~= "GET" or caps[7] ~= "200" then
+          return false, "wrong captures: " .. table.concat(caps, ",")
+        end
+        return true
+      end,
+    },
+    {
+      -- The engine floor: same pattern and text, compilation hoisted.
+      -- The gap between this and re_match_log_line is the wrapper's
+      -- per-call compile cost.
+      name = "re_search_compiled",
+      fn = function(_: any): any
+        local _m, caps = (compiled as re.Regex):search(LOG_LINE) -- cast: record union after guard
+        return caps
+      end,
+      check = function(_: any, res: any): boolean, string
+        local caps = res as {string} -- cast: from any
+        if caps == nil or #caps ~= 7 or caps[5] ~= "GET" then
+          return false, "wrong compiled captures"
+        end
+        return true
+      end,
+    },
+    {
+      name = "re_split_colon_list",
+      fn = function(_: any): any
+        return (re.split(COLON_LIST, ":"))
+      end,
+      check = function(_: any, res: any): boolean, string
+        local fields = res as {string} -- cast: from any
+        if fields == nil or #fields ~= COLON_FIELDS then
+          return false, "wrong field count: " .. tostring(fields and #fields)
+        end
+        if fields[1] ~= "" or fields[2] ~= "/usr/bin" or fields[#fields] ~= "" then
+          return false, "wrong fields"
+        end
+        return true
+      end,
+    },
+    {
+      name = "re_gsub_redact_numbers",
+      fn = function(_: any): any
+        return (re.gsub(GSUB_TEXT, "[0-9]+", "N"))
+      end,
+      check = function(_: any, res: any): boolean, string
+        local out = res as string -- cast: from any
+        if out == nil then
+          return false, "gsub returned nil"
+        end
+        if out:find("%d") then
+          return false, "digits survived redaction"
+        end
+        if not out:find("user-N logged in from host-N", 1, true) then
+          return false, "redacted shape wrong"
+        end
+        return true
+      end,
+    },
+  }
+end
+
+local function cleanup()
+end
+
+local M: pt.BenchModule = {
+  scenarios = scenarios,
+  cleanup = cleanup,
+}
+
+return M

--- a/cosmic/re.tl
+++ b/cosmic/re.tl
@@ -5,7 +5,11 @@
 --- method name — a userdata metatable is the C layer's to name.
 ---
 --- For best performance, compile patterns once and reuse them.
---- The match() convenience function compiles on each call.
+--- The convenience functions (match, test, find, find_all, gmatch,
+--- split, gsub) take a pattern string per call; a bounded module cache
+--- memoizes their compiled patterns, so repeated calls with the same
+--- pattern skip recompilation. compile() itself is never cached: it is
+--- the explicit-lifetime API, and each call returns a fresh handle.
 local re = require("cosmo.re")
 
 --- A compiled regular expression pattern.
@@ -44,8 +48,63 @@ local function compile(pattern: string, flags?: integer): Regex | nil, string
   return result as Regex -- cast: userdata boundary
 end
 
+--- One memoized compilation of a convenience-surface pattern. rx/err
+--- record the compile outcome; iter_ok/iter_err record the (lazy)
+--- empty-match probe compile_for_iter runs on top of it.
+local record CacheEntry
+  rx: Regex
+  err: string
+  iter_ok: boolean
+  iter_err: string
+end
+
+--- Bounded pattern-string -> CacheEntry memo for the convenience
+--- functions. Wiped wholesale when full: eviction bookkeeping isn't
+--- worth it for a cache whose hit case is "the same handful of
+--- patterns in a loop", and a wipe only costs the recompiles the cache
+--- was already paying before it filled.
+local CACHE_MAX = 64
+local cache: {string: CacheEntry} = {}
+local cache_count = 0
+
+--- The memo key. Flags are part of a pattern's identity: the same
+--- source compiled with ICASE is a different regex.
+--- @param pattern string The regex pattern
+--- @param flags integer? Optional compile flags
+--- @return string The cache key
+local function cache_key(pattern: string, flags?: integer): string
+  return tostring(flags or 0) .. "\0" .. pattern
+end
+
+--- Get-or-create the memo entry for a pattern, compiling on miss.
+--- Compile failures are cached too, so a bad pattern in a loop pays
+--- one compile, not one per call.
+--- @param pattern string The regex pattern
+--- @param flags integer? Optional compile flags
+--- @return CacheEntry The entry (rx set on success, err on failure)
+local function cache_entry(pattern: string, flags?: integer): CacheEntry
+  local key = cache_key(pattern, flags)
+  local entry = cache[key]
+  if entry ~= nil then
+    return entry
+  end
+  if cache_count >= CACHE_MAX then
+    cache = {}
+    cache_count = 0
+  end
+  local rx, cerr = compile(pattern, flags)
+  if rx is Regex then
+    entry = {rx = rx}
+  else
+    entry = {err = cerr or "regex compile failed"}
+  end
+  cache[key] = entry
+  cache_count = cache_count + 1
+  return entry
+end
+
 --- Match pattern against text (convenience function; subject first).
---- Compiles pattern on each call - use compile() for repeated matching.
+--- Compiled patterns are cached - compile() gives explicit reuse.
 --- Uses POSIX extended syntax by default.
 --- On a match, returns the matched substring plus a table of the
 --- parenthesized capture groups (an empty table when the pattern has no
@@ -59,7 +118,8 @@ end
 --- @return {string} | nil Capture groups on match
 --- @return string | nil Error message if compilation or the engine failed
 local function match(text: string, pattern: string, flags?: integer): string | nil, {string} | nil, string | nil
-  local regex, cerr = compile(pattern, flags)
+  local entry = cache_entry(pattern, flags)
+  local regex, cerr = entry.rx, entry.err
   if regex is Regex then
     -- Search flags (NOTBOL/NOTEOL) are not passed here; use compile() + :search() for those
     local m, caps = regex:search(text)
@@ -151,15 +211,22 @@ end
 --- the empty string: without offsets from the engine a zero-length
 --- match cannot be positioned or advanced past.
 local function compile_for_iter(pattern: string, flags?: integer): Regex | nil, string
-  local regex, cerr = compile(pattern, flags)
-  if not regex then
-    return nil, cerr
+  local entry = cache_entry(pattern, flags)
+  if entry.rx == nil then
+    return nil, entry.err
   end
-  local em = (regex as Regex):search("") -- cast: record union after guard
-  if em then
-    return nil, "pattern matches the empty string (unsupported): " .. pattern
+  if entry.iter_err ~= nil then
+    return nil, entry.iter_err
   end
-  return regex
+  if not entry.iter_ok then
+    local em = entry.rx:search("")
+    if em then
+      entry.iter_err = "pattern matches the empty string (unsupported): " .. pattern
+      return nil, entry.iter_err
+    end
+    entry.iter_ok = true
+  end
+  return entry.rx
 end
 
 --- Collect every non-overlapping match of regex in text, leftmost


### PR DESCRIPTION
## What

Two commits, scenario-first per the optimize loop:

1. **`_perf/bench/re_bench.tl`** — cosmic.re had no bench coverage. Four known-answer scenarios: `re_match_log_line` (naive pattern-string-per-call path), `re_search_compiled` (engine floor, compilation hoisted — the pair brackets the wrapper's compile cost), `re_split_colon_list`, `re_gsub_redact_numbers`. Plus the coverage-baseline row for the new file.
2. **`cosmic/re.tl`** — every convenience function (`match`, `test`, `find`, `find_all`, `gmatch`, `split`, `gsub`) compiled its pattern on each call, and compile is ~4x a compiled search (18 µs vs 4.4 µs). A bounded module memo (64 entries, wiped wholesale when full, keyed pattern+flags) now caches compilation for the convenience surface. Compile failures and `compile_for_iter`'s empty-match probe are cached too. `compile()` stays uncached — it's the explicit-lifetime API.

## Measured

Same-sitting isolated A/B, `gate.tl compare` verdict (exit 0, 0 regressions):

```
re_match_log_line      16.12 µs -> 4.13 µs   -74.4%  faster
re_search_compiled      3.50 µs -> 3.62 µs    +3.5%  (untouched floor)
re_split_colon_list    10.33 µs -> 9.96 µs    -3.6%
re_gsub_redact_numbers 301.53 µs -> 312.06 µs +3.5%
```

Full-suite compares on this shared runner flagged unrelated scenarios in different directions on every repeat against a fixed baseline (whilp/cosmopolitan#136's runner-variance situation); the isolated pair is the stable verdict.

## Correctness

- `--make ci` PASS (fmt, check, example, lint, coverage — 189 files).
- Contract unchanged: same return shapes and error strings; cached Regex userdata is immutable through `:search`; flags are part of the cache key (same source with ICASE is a different regex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxJBYMrq98S9cNHVdTM6rc

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxJBYMrq98S9cNHVdTM6rc)_