### PR TITLE
teal: assert(x) and == nil narrow nil unions — two more carried edits

### DIFF
--- a/3p/tl/tl_patch.tl
+++ b/3p/tl/tl_patch.tl
@@ -1,15 +1,112 @@
 -- The carried patch riding 3p/tl/tl_pin.tl (see _make/patch.tl for the
--- mechanism). One edit: teach the checker that truthiness narrows a
--- union of nil with non-boolean members. Lua has no falsy tables, so
--- for `local r: Rec | nil`, `if r then` (and the early-return shape
--- `if not r then return end`) means exactly "r is not nil" — the fact
--- machinery already narrows `is` guards this way; the edit stamps the
--- same IsFact on a plain variable read in boolean context. Unions
--- containing boolean/any/unknown are skipped: `false` is truthy-unsafe.
--- Carried, not forked: the anchor must match the pinned tl.lua exactly
+-- mechanism). Three edits teach the checker that a plain variable's nil
+-- union narrows through the guards Lua programmers actually write:
+--
+-- - narrow-truthiness: `if r then` / `if not r then return end`. Lua
+--   has no falsy tables, so for a union of nil with non-boolean
+--   members, truthy means exactly "r is not nil" — the edit stamps the
+--   same IsFact the fact machinery already uses for `is` guards. Unions
+--   containing boolean/any/unknown are skipped: `false` is
+--   truthy-unsafe.
+-- - narrow-assert: `assert(x)` applies the same fact — assert already
+--   forwards its argument's facts to the following statements; the
+--   edit gives a bare variable argument one.
+-- - narrow-eq-nil: `x == nil` / `x ~= nil` is an exact type test
+--   (`__eq` never fires with a nil operand), so it carries an IsFact —
+--   whose negation narrows — instead of an EqFact, whose negation is
+--   deliberately information-free. Sound for boolean unions too, which
+--   truthiness cannot narrow.
+--
+-- Carried, not forked: each anchor must match the pinned tl.lua exactly
 -- once, so a tl pin bump that moves this code fails the fetch loudly
 -- until the patch is re-audited (or dropped, once upstream lands it).
 return {
+  ["narrow-assert"] = {
+    file = "tl.lua",
+    note = "whilp/cosmic#942: assert(x) on a plain variable narrows its nil union",
+    find = [=====[
+      ["assert"] = function(self, node, a, b, argdelta)
+         node.known = FACT_TRUTHY
+         local r = self:type_check_function_call(node, a, b, argdelta)
+         self:apply_facts(node, node.e2[1].known)
+         return r
+      end,]=====],
+    replace = [=====[
+      ["assert"] = function(self, node, a, b, argdelta)
+         node.known = FACT_TRUTHY
+         local r = self:type_check_function_call(node, a, b, argdelta)
+         -- cosmic carried patch (whilp/cosmic#942): assert(x) on a plain
+         -- variable of a nil union narrows like a truthiness guard --
+         -- assert already applies its argument's facts to the statements
+         -- that follow; this gives the argument one when it is a bare
+         -- variable read. Same union rules as the boolean-context edit:
+         -- unions containing boolean/any/unknown are skipped.
+         local arg1 = node.e2[1]
+         if arg1 and arg1.kind == "variable" and not arg1.known and b.tuple[1] then
+            local rt = b.tuple[1]
+            if rt.typename == "nominal" then
+               rt = self:resolve_nominal(rt)
+            end
+            if rt.typename == "union" then
+               local has_nil, safe, members = false, true, {}
+               for _, m in ipairs(rt.types) do
+                  local rm = m
+                  if rm.typename == "nominal" then
+                     rm = self:resolve_nominal(rm)
+                  end
+                  if rm.typename == "nil" then
+                     has_nil = true
+                  else
+                     if rm.typename == "boolean" or rm.typename == "any" or
+                        rm.typename == "unknown" or rm.typename == "boolean_context" then
+                        safe = false
+                     end
+                     table.insert(members, m)
+                  end
+               end
+               if has_nil and safe and #members > 0 then
+                  local typ = #members == 1 and members[1] or unite(arg1, members)
+                  arg1.known = IsFact({ var = arg1.tk, typ = typ, w = arg1 })
+               end
+            end
+         end
+         self:apply_facts(node, node.e2[1].known)
+         return r
+      end,]=====],
+  },
+  ["narrow-eq-nil"] = {
+    file = "tl.lua",
+    note = "whilp/cosmic#942: == nil / ~= nil on a plain variable is an exact nil test",
+    find = [=====[
+               elseif self:is_a(ub, ua) or ua.typename == "typevar" then
+                  if node.op.op == "==" and node.e1.kind == "variable" then
+                     node.known = EqFact({ var = node.e1.tk, typ = ub, w = node })
+                  end
+               elseif self:is_a(ua, ub) or ub.typename == "typevar" then
+                  if node.op.op == "==" and node.e2.kind == "variable" then
+                     node.known = EqFact({ var = node.e2.tk, typ = ua, w = node })
+                  end]=====],
+    replace = [=====[
+               elseif self:is_a(ub, ua) or ua.typename == "typevar" then
+                  -- cosmic carried patch (whilp/cosmic#942): comparing a
+                  -- variable against nil is an exact type test -- __eq
+                  -- never fires with a nil operand -- so it carries an
+                  -- IsFact, whose negation narrows, instead of an EqFact,
+                  -- whose negation is deliberately information-free.
+                  if node.e1.kind == "variable" and rb.typename == "nil" then
+                     local f = IsFact({ var = node.e1.tk, typ = rb, w = node })
+                     node.known = node.op.op == "==" and f or NotFact({ f1 = f, w = node })
+                  elseif node.op.op == "==" and node.e1.kind == "variable" then
+                     node.known = EqFact({ var = node.e1.tk, typ = ub, w = node })
+                  end
+               elseif self:is_a(ua, ub) or ub.typename == "typevar" then
+                  if node.e2.kind == "variable" and ra.typename == "nil" then
+                     local f = IsFact({ var = node.e2.tk, typ = ra, w = node })
+                     node.known = node.op.op == "==" and f or NotFact({ f1 = f, w = node })
+                  elseif node.op.op == "==" and node.e2.kind == "variable" then
+                     node.known = EqFact({ var = node.e2.tk, typ = ua, w = node })
+                  end]=====],
+  },
   ["narrow-truthiness"] = {
     file = "tl.lua",
     note = "whilp/cosmic#942: truthiness narrows nil-unions of records/maps/arrays",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,12 +179,12 @@ formatted string plus the numeric errno), wrappers add context with
 `errno.wrap(err, prefix)`, and branch on the numeric errno via
 `errno.is(errno_value, "EINTR")`.
 
-**Narrowing nil unions.** Truthiness narrows `T | nil` for every `T` — records,
-maps, arrays and scalars, positive branch and negated early return (`if not r then
-return end`) alike — via the carried tl patch (`3p/tl/tl_patch.tl`; mechanism in
-`_make/patch.tl`). What still does NOT narrow: `assert(x)`, `== nil`/`~= nil`
-comparisons, record FIELDS (copy the field to a local and guard the local), and
-unions containing `boolean`. The other tools:
+**Narrowing nil unions.** A guard on a plain variable narrows `T | nil` for every
+`T`: truthiness (`if not r then return end`), `assert(r)`, and `== nil`/`~= nil` —
+which is exact, so it narrows boolean unions the other two deliberately skip — via
+the carried tl patch (`3p/tl/tl_patch.tl`; mechanism in `_make/patch.tl`). What
+still does NOT narrow: record FIELDS (copy the field to a local and guard the
+local) and `is` early-exit guards (`if not (x is Rec) then return end`). The other tools:
 
 - **In tests and examples, use `check.must`** for fallible returns: `local db =
   check.must(sqlite.open(path))` yields a plain `Database` — no cast, no assert. Lua

--- a/cosmic/_teal_hints.tl
+++ b/cosmic/_teal_hints.tl
@@ -10,9 +10,10 @@
 --- Matches the most common traps:
 ---   1. got number, expected integer (string index/length requires integer)
 ---   2. X | nil used un-narrowed: passed where X is expected, indexed,
----      or looped over — truthiness (`if not x`) narrows a nil union
----      (the carried tl patch, 3p/tl/tl_patch.tl), but `assert(x)` and
----      `== nil` comparisons do not, and nothing else tells the author
+---      or looped over — truthiness, `assert(x)` and `== nil` all
+---      narrow a plain variable (the carried tl patch,
+---      3p/tl/tl_patch.tl), but record FIELDS never narrow, and
+---      nothing else tells the author
 ---   3. excess return values (multiple returns captured incorrectly)
 ---   4. <any type> operations (ipairs, index, concat on any)
 
@@ -41,19 +42,19 @@ local function hint_for_message(msg: string): string | nil
   if msg:find("%| nil") and msg:find("expected") then
     return "  hint: narrow first: `if v is Rec then ... end` (plain-table records), or cast after a guard for userdata handles — see `cosmic --docs guide.checking`"
   end
-  -- Pattern 2b: indexing through an un-narrowed nil union. Truthiness
-  -- (`if x`, `if not x then return end`) narrows a nil union since the
-  -- carried tl patch (3p/tl/tl_patch.tl), so what lands here is the
-  -- shapes that still do not narrow: `assert(x)` and `== nil` /
-  -- `~= nil` comparisons, which newcomers expect to narrow.
+  -- Pattern 2b: indexing through an un-narrowed nil union. A guard on
+  -- a plain variable — truthiness, `assert(x)`, `== nil` — narrows it
+  -- since the carried tl patch (3p/tl/tl_patch.tl), so what lands here
+  -- is a record FIELD (guarding `o.sub` never narrows `o.sub`) or a
+  -- value that was never guarded at all.
   if msg:find("cannot index") and msg:find("| nil", 1, true) then
-    return "  hint: `assert(x)` and `== nil` comparisons do not narrow `T | nil` — guard with truthiness (`if not x then return end`), branch with `if x is T then ... end`, or cast (`local v = x as T`) — see `cosmic --docs guide.checking`"
+    return "  hint: record fields do not narrow — copy the field to a local and guard the local (`local v = o.sub; if v then ... end`); an unguarded `T | nil` needs its guard first — see `cosmic --docs guide.checking`"
   end
   -- Pattern 2c: for-in over a value the checker cannot call. The message
   -- names no type, and the usual cause is an iterator still `T | nil`
   -- from a fallible call.
   if msg:find("for loop does not return an iterator", 1, true) then
-    return "  hint: often the iterator is still `T | nil` from a fallible call: guard with truthiness (`if not it then return end`) before the loop — `assert(it)` does not narrow — see `cosmic --docs guide.checking`"
+    return "  hint: often the iterator is still `T | nil` from a fallible call: guard it before the loop (`if not it then return end`, or `assert(it)`) — see `cosmic --docs guide.checking`"
   end
   -- Pattern 2d: naming another module's type that is not exported. A
   -- standalone top-level record is file-local; importers can only name
@@ -74,7 +75,7 @@ local function hint_for_message(msg: string): string | nil
   -- `{T} | nil` needs narrowing, a plain `any` needs a cast.
   if msg:find("attempting ipairs on something that's not an array") then
     if msg:find("| nil", 1, true) then
-      return "  hint: `assert(xs)` does not narrow `{T} | nil` — guard with truthiness (`if not xs then return end`), branch with `is`, or cast (`local xs = v as {T}`) — see `cosmic --docs guide.checking`"
+      return "  hint: `{T} | nil` needs its guard before the loop (`if not xs then return end`, or `assert(xs)`); a record FIELD does not narrow — copy it to a local and guard the local — see `cosmic --docs guide.checking`"
     end
     return "  hint: cast first, e.g. `local items = data as {any}`"
   end

--- a/cosmic/fs/dir_test.tl
+++ b/cosmic/fs/dir_test.tl
@@ -36,15 +36,19 @@ local function test_dir_has_close_metamethod()
 
   local dir = fs.opendir(test_dir)
   assert(dir, "opendir should succeed")
-  local d = dir as fs_types.Dir -- cast: record union after guard
+  -- cast: pin bootstrap (the pinned compiler that cold-builds this tree predates the narrowing patch)
+  local d = dir as fs_types.Dir
 
   -- Verify __close metamethod exists
   local mt = getmetatable(dir)
   assert(mt, "dir should have a metatable")
   assert(mt.__close, "dir metatable should have __close")
 
-  -- Call __close directly to verify it works
-  mt.__close(dir)
+  -- Call __close directly to verify it works, the way <close> would: a
+  -- plain function call, not a method send (the patched checker narrows
+  -- `dir` here and would flag the method-as-function invocation).
+  local close = mt.__close as function(fs_types.Dir) -- cast: metamethod as plain function
+  close(d)
   assert(d:closed(), "dir should be closed after __close")
 
   teardown(test_dir)

--- a/cosmic/teal_test.tl
+++ b/cosmic/teal_test.tl
@@ -63,12 +63,14 @@ print(g(f()))
 end
 test_hint_nil_union_not_narrowed()
 
--- The carried tl patch's canary (3p/tl/tl_patch.tl): truthiness narrows
--- a nil union of records, maps and arrays, positive branch and negated
--- early-return alike. A tl pin bump that lands without the patch — or a
+-- The carried tl patch's canary (3p/tl/tl_patch.tl): a plain variable's
+-- nil union narrows through truthiness (positive branch and negated
+-- early-return alike), through `assert(x)`, and through `== nil` /
+-- `~= nil` — which is exact, so it narrows boolean unions truthiness
+-- cannot touch. A tl pin bump that lands without the patch — or a
 -- patch whose anchor drifted — fails HERE, not as a hundred downstream
 -- type errors.
-local function test_truthiness_narrows_nil_union()
+local function test_narrowing_canary()
   local path = fs.join(tmpdir, "narrow_ok.tl")
   assert(fs.write(path, [[
 local record R
@@ -102,31 +104,52 @@ local function arr(): integer
   end
   return sum
 end
-print(early() + positive() + arr())
-]]))
-  local result = teal.check(path)
-  assert(result.ok, "truthiness must narrow a nil union (carried tl patch): "
-    .. (result.ok and "" or teal.format_issues(result.errors)))
-end
-test_truthiness_narrows_nil_union()
-
--- `assert(x)` and `== nil` comparisons still do NOT narrow; the errors
--- they leave behind name the un-narrowed type but nothing else, so each
--- shape carries a hint at the fix.
-local function test_hint_index_through_nil_union()
-  local msg, hint = first_hinted_error("h_idx_union.tl", [[
-local record R
-  x: integer
-end
-local function make(): R | nil
-  return nil
-end
-local function use(): integer
+local function via_assert(): integer
   local r = make()
-  assert(r)
+  assert(r, "make failed")
   return r.x
 end
-print(use())
+local function via_eq_nil(): integer
+  local r = make()
+  if r == nil then
+    return 0
+  end
+  return r.x
+end
+local function via_ne_nil_boolean(): integer
+  local b: boolean | nil = false
+  if b ~= nil then
+    return b and 1 or 2
+  end
+  return 0
+end
+print(early() + positive() + arr() + via_assert() + via_eq_nil()
+  + via_ne_nil_boolean())
+]]))
+  local result = teal.check(path)
+  assert(result.ok, "guards must narrow a nil union (carried tl patch): "
+    .. (result.ok and "" or teal.format_issues(result.errors)))
+end
+test_narrowing_canary()
+
+-- Record FIELDS still do not narrow — a guard on `o.sub` leaves `o.sub`
+-- un-narrowed at the use; the error names the type but not the cause,
+-- so the shape carries a hint at the fix (copy the field to a local).
+local function test_hint_index_through_nil_union()
+  local msg, hint = first_hinted_error("h_idx_union.tl", [[
+local record Inner
+  x: integer
+end
+local record Outer
+  sub: Inner | nil
+end
+local function use(o: Outer): integer
+  if o.sub then
+    return o.sub.x
+  end
+  return 0
+end
+print(use({}))
 ]])
   assert(msg:find("cannot index", 1, true) and msg:find("| nil", 1, true),
     "wrong error: " .. msg)
@@ -143,7 +166,6 @@ local function rows(): Iter | nil
 end
 local function use()
   local it = rows()
-  assert(it)
   for x in it do
     print(x)
   end
@@ -163,7 +185,6 @@ local function list(): {string} | nil
 end
 local function use()
   local xs = list()
-  assert(xs)
   for _, x in ipairs(xs) do
     print(x)
   end
@@ -206,18 +227,17 @@ print(label(depmod.make()))
 end
 test_hint_unexported_type()
 
-local function test_hint_scalar_method_call_after_assert()
-  -- A truthiness guard narrows the scalar and the method call works;
-  -- after `assert(data)` the value is still `string | nil`, and the
-  -- method call is the use that fails first — the same "cannot index
-  -- ... | nil" error shape as records, so it carries the same hint.
+local function test_hint_scalar_method_call_unguarded()
+  -- Any guard on the variable narrows it and the method call works;
+  -- with no guard at all the method call is the use that fails first —
+  -- the same "cannot index ... | nil" error shape as records, so it
+  -- carries the same hint.
   local msg, hint = first_hinted_error("h_scalar_method.tl", [[
 local function readish(): string | nil, string
   return nil, "nope"
 end
 local function use(): integer
   local data = readish()
-  assert(data)
   for word in data:gmatch("%a+") do
     print(word)
   end
@@ -229,7 +249,7 @@ print(use())
     "wrong error: " .. msg)
   assert(hint:find("do not narrow", 1, true), "wrong hint: " .. hint)
 end
-test_hint_scalar_method_call_after_assert()
+test_hint_scalar_method_call_unguarded()
 
 local function test_hint_colon_call_on_module_function()
   local msg, hint = first_hinted_error("h_colon.tl", [[

--- a/docs/decisions/d21-carried-tl-patch.md
+++ b/docs/decisions/d21-carried-tl-patch.md
@@ -20,10 +20,10 @@
   on disk is the source), which is also what bootstraps a patch through
   CI's pinned-release fetch. Patches ride archive pins only: editing a
   formatless pin's single output would fail its own digest forever.
-  The first cargo is the tl truthiness-narrowing edit
-  (`3p/tl/tl_patch.tl`), with its own canary test
-  (`cosmic/teal_test.tl`) so a lost patch fails as one named test, not
-  a hundred downstream type errors.
+  The first cargo is the tl narrowing patch (`3p/tl/tl_patch.tl`:
+  truthiness, then `assert(x)` and `== nil`/`~= nil`), with its own
+  canary test (`cosmic/teal_test.tl`) so a lost patch fails as one
+  named test, not a hundred downstream type errors.
 - **rejected:** forking tl for one edit (a compiler of maintenance for
   a function of change); waiting for upstream (unbounded, and the scar
   tissue compounds while waiting); diff files and an external patch

--- a/skills/cosmic/checking.md
+++ b/skills/cosmic/checking.md
@@ -57,9 +57,10 @@ recover it.
 
 ### Narrowing and Casting
 
-truthiness narrows a nil union: records, maps, arrays and scalars all
-narrow through an ordinary guard, in the positive branch and below a
-negated early return alike (the carried tl patch, `3p/tl/tl_patch.tl`):
+a guard on a plain variable narrows its nil union: truthiness,
+`assert(x)`, and `== nil` / `~= nil` all narrow `T | nil` for records,
+maps, arrays and scalars, in the positive branch and below a negated
+early return alike (the carried tl patch, `3p/tl/tl_patch.tl`):
 
 ```teal
 local r = make() -- r: R | nil
@@ -69,23 +70,23 @@ end
 print(r.x) -- r is R below the guard
 
 local sock = net.connect_tcp(host, port) -- Socket | nil
-if sock then
-  sock:send("hello") -- narrowed, method call included
+assert(sock, "connect failed")
+sock:send("hello") -- narrowed, method call included
+```
+
+`~= nil` is exact, so it also narrows unions containing `boolean`,
+which truthiness and `assert` deliberately skip (`false` is falsy, so
+truthy does not mean "not nil" there):
+
+```teal
+local b: boolean | nil = flag()
+if b ~= nil then
+  return b -- narrowed to boolean; `if b then` would not narrow
 end
 ```
 
-what does NOT narrow:
-
-- **`assert(x, "msg")`** — it terminates control flow at runtime, but
-  the checker still sees `T | nil` on every line after it. guard with
-  truthiness instead, cast once after the assert, or in tests and
-  examples use `check.must`, which guards and narrows in one call.
-- **`== nil` / `~= nil` comparisons** — `if r ~= nil then r.x end`
-  still errors. write the truthiness form (`if r then`).
-- **unions containing `boolean`** — `false` is falsy, so truthy does
-  not mean "not nil" there; branch with `is`.
-- **record FIELDS**, even scalar ones — copy the field to a local and
-  guard the local:
+what does NOT narrow: **record FIELDS**, even scalar ones — copy the
+field to a local and guard the local:
 
 ```teal
 local earliest = report.earliest -- integer | nil

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -127,10 +127,11 @@ literal `nil`). capture the returns — `local v, err = f(...)`, or
 `assert`/`check.must` in tests and examples. the details are in
 `cosmic --docs guide.checking`.
 
-## 9. `assert(x)` and `== nil` don't narrow a nil union — truthiness does
+## 9. record fields don't narrow — copy the field to a local
 
-an ordinary truthiness guard narrows `T | nil` for every `T` — records,
-maps, arrays and scalars alike (the carried tl patch,
+a guard on a plain variable narrows it: truthiness (`if r then`, `if
+not r then return end`), `assert(r, "msg")`, and `== nil` / `~= nil`
+comparisons all narrow `T | nil` for every `T` (the carried tl patch,
 `3p/tl/tl_patch.tl`):
 
 ```teal
@@ -141,27 +142,27 @@ end
 db:exec(sql) -- db is Database below the guard
 ```
 
-what still does NOT narrow:
+`~= nil` is exact, so it also narrows unions containing `boolean`,
+where truthiness and `assert` deliberately do nothing (`false` is
+falsy, so truthy does not mean "not nil" there).
 
-- **`assert(x, "msg")`**: it terminates control flow at runtime, but the
-  checker still sees `T | nil` on every line after it — do not expect
-  the narrowing other typed languages attach to assert. guard with
-  truthiness instead, or cast once after the assert (`local d = db as
-  sqlite.Database`). in tests and examples, `local db =
-  check.must(sqlite.open(path))` does guard and narrowing in one call,
-  with no cast to justify.
-- **`== nil` / `~= nil` comparisons**: `if r ~= nil then r.x end` still
-  errors. write the truthiness form (`if r then`).
-- **record fields**, even scalar ones — copy the field to a local and
-  guard the local.
-- **unions containing `boolean`** — `false` is falsy, so truthy does not
-  mean "not nil" there; branch with `is` instead.
+what still does NOT narrow is a record FIELD, even a scalar one: after
+`if o.sub then`, `o.sub` is still `Inner | nil` at the use. copy the
+field to a local and guard the local:
 
-the errors these shapes produce name the un-narrowed type but not the
-cause: `cannot index key 'x' in variable 'r' of type R | nil`,
-`expression in for loop does not return an iterator`, `attempting
-ipairs on something that's not an array: {T} | nil`. the full pattern
-set is in `cosmic --docs guide.checking`.
+```teal
+local sub = o.sub -- Inner | nil
+if sub then
+  print(sub.x) -- narrowed; the field read would not be
+end
+```
+
+(`is` narrowing also does not survive an early-exit guard — `if not (x
+is Rec) then return end` does not narrow below it; write the plain
+truthiness form instead.) the errors these shapes produce name the
+un-narrowed type but not the cause: `cannot index key 'x' in ... of
+type Inner | nil`. the full pattern set is in
+`cosmic --docs guide.checking`.
 
 ## 10. a record other files use must be nested in the module's interface record
 


### PR DESCRIPTION
The follow-ons from #961 (#942, tracked under #949): `assert(x)` and `== nil`/`~= nil` now narrow a plain variable's nil union, via two more edits in the carried tl patch.

## The edits

- **narrow-assert**: upstream `assert` already applies its first argument's facts to the statements that follow — it just never stamps one for a bare variable read. The edit synthesizes the same `IsFact` the truthiness edit uses, under the same union rules (nil member required; `boolean`/`any`/`unknown` members skip). `assert(f())` and `local f = assert(io.open(...))` are untouched.
- **narrow-eq-nil**: comparing a variable against `nil` is an exact type test — `__eq` never fires with a nil operand — so it now carries an `IsFact`, whose negation narrows, instead of an `EqFact`, whose negation is deliberately information-free (`no_infer`). Exactness makes it sound for **boolean unions** too, which truthiness and assert must skip: `if b ~= nil then return b end` narrows `boolean | nil`.

Validated by an 11-case matrix (positive/negative branches, flipped `nil == x`, `while x ~= nil` loops, soundness of the `== nil` positive branch reporting `type nil`). The canary test now asserts all three narrowings, so a tl pin bump that loses any of them fails as one named test. Hint fixtures move to the one shape that still does not narrow — **record fields** — and the hints, gotcha 9, `guide.checking` and AGENTS.md now teach exactly that residue.

## Why the cast sweep is not in this PR

I ran the sweep (184 casts removable, verified per file) — and then reverted it, because it cannot bootstrap yet: a gate converges from the **pinned** release, whose embedded compiler predates these edits, so a swept tree fails the generation-zero build (`--make ci` from a cold `o/` reproduces this). The tree must always compile under its own bootstrap pin — the same discipline as any self-hosting toolchain.

Verified green: full `ci` from a cold `o/` under the current pin (casts intact compile under both compilers; the gates run post-convergence under the fully-patched checker).

## Follow-up sequencing for the sweep

1. Merge this PR.
2. The next release cut from main carries all three edits in its embedded compiler (the release build's repair patches `o/3p/tl/tl.lua` before packing).
3. A follow-up PR bumps `bin/cosmic.pin` to that release and lands the sweep — the removal script re-verifies every cast against the then-current checker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWCMuPQkSAomijVdve6V8D

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWCMuPQkSAomijVdve6V8D)_