### PR TITLE
perf: bump cosmos to 2026.08.07-9873eddc9; base64 decode and re iteration ride the new bindings

### DIFF
--- a/3p/cosmos/cosmos_pin.tl
+++ b/3p/cosmos/cosmos_pin.tl
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "1e2563b79a0d7317c2eb1196c776283adf7b385a6fea73defdaa774525cff470"}},
+  platforms = {["*"] = {sha = "dd3a166b68d689a6d2ca64aaf6007c22a13b826187623e77fb6cc313e0a0257c"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.08.04-7276edf51"
+  version = "2026.08.07-9873eddc9"
 }

--- a/cosmic/codec.tl
+++ b/cosmic/codec.tl
@@ -109,11 +109,15 @@ end
 --- @return string | nil The decoded binary data, or nil on error
 --- @return string? Error message if decoding failed
 local function decode_base64(str: string): string | nil, string
-  local _, err = validate_base64_family(str, "[A-Za-z0-9+/]*", "[^A-Za-z0-9+/=]", "base64")
-  if err then
-    return nil, err
+  -- Happy path: one C-speed structural scan instead of the Lua pattern
+  -- scan (which measured 2/3 of the whole decode round trip). The Lua
+  -- validation runs only on the failure branch, to classify the error
+  -- with the documented messages.
+  if cosmo.IsBase64(str) then
+    return cosmo.DecodeBase64(str)
   end
-  return cosmo.DecodeBase64(str)
+  local _, err = validate_base64_family(str, "[A-Za-z0-9+/]*", "[^A-Za-z0-9+/=]", "base64")
+  return nil, err or "invalid base64"
 end
 
 --- Encode binary data as base64url (RFC 4648 section 5).
@@ -136,14 +140,15 @@ end
 --- @return string | nil The decoded binary data, or nil on error
 --- @return string? Error message if decoding failed
 local function decode_base64url(str: string): string | nil, string
-  local padding, err = validate_base64_family(str, "[A-Za-z0-9%-_]*", "[^A-Za-z0-9%-_=]", "base64url")
-  if err then
-    return nil, err
+  -- Same failure-branch-only Lua validation as decode_base64. On the
+  -- happy path no alphabet translation is needed either: DecodeBase64
+  -- reads the url-safe alphabet natively, and IsBase64(str, true) has
+  -- already rejected mid-string padding and cross-alphabet characters.
+  if cosmo.IsBase64(str, true) then
+    return cosmo.DecodeBase64(str)
   end
-  local content = string.sub(str, 1, #str - #padding)
-  local b64 = string.gsub(content, "%-", "+")
-  b64 = string.gsub(b64, "_", "/")
-  return cosmo.DecodeBase64(b64)
+  local _, err = validate_base64_family(str, "[A-Za-z0-9%-_]*", "[^A-Za-z0-9%-_=]", "base64url")
+  return nil, err or "invalid base64url"
 end
 
 --- Encode binary data as base32.

--- a/cosmic/re.tl
+++ b/cosmic/re.tl
@@ -31,6 +31,21 @@ local record Regex
   --- @return {string} | nil Capture groups on match (error string on engine failure)
   --- @return string | nil Error message on engine failure
   search: function(self: Regex, text: string, flags?: integer): string | nil, {string} | nil, string | nil
+
+  --- Like search, but reports WHERE: absolute 1-based inclusive start
+  --- and end offsets into text, plus the capture table. init starts
+  --- the search at that offset while keeping the returned offsets
+  --- absolute, which is what lets iteration advance in O(n) instead of
+  --- re-slicing the subject per match. A no-match is a single bare
+  --- nil; an engine failure puts the error string in the second
+  --- position.
+  --- @param text string The text to search
+  --- @param flags integer? Optional flags: NOTBOL, NOTEOL
+  --- @param init integer? 1-based offset to start searching at
+  --- @return integer | nil Absolute start offset, or nil
+  --- @return integer | string | nil End offset (error string when start is nil)
+  --- @return {string} Capture groups on match
+  find: function(self: Regex, text: string, flags?: integer, init?: integer): integer | nil, integer | string | nil, {string}
 end
 
 --- Compile a regular expression pattern.
@@ -164,52 +179,10 @@ local record Span
   caps: {string}
 end
 
---- Locate the absolute start of a match whose text is m, at or after
---- pos. The binding reports matched text without offsets, so candidate
---- positions (plain-text occurrences of m) are verified by re-running
---- the pattern anchored to exactly that window, with NOTBOL/NOTEOL
---- supplying the line-boundary context. The engine's leftmost-match
---- guarantee makes the first verified candidate the true position.
----
---- KNOWN LIMITATION: the verification window is exactly #m characters
---- (found .. found + #m - 1), so it never includes the character before
---- or after a candidate. Under the NEWLINE compile flag, `^` and `$`
---- can be satisfied by an EMBEDDED newline rather than true text
---- start/end ("regardless of NOTBOL/NOTEOL" per POSIX) -- but that
---- newline byte falls outside this window, so the re-verification
---- search can never see it and always fails to confirm. The result
---- is not a silent undercount: all_matches gives up entirely (its
---- caller sees nil, "failed to locate ..."/a short match count)
---- as soon as a NEWLINE-anchored match past the first line is hit.
---- See find_all's doc for the concrete case. A fix needs the
---- verification window widened to include that neighboring byte,
---- which reintroduces its own edge case (an off-by-one window can
---- itself contain another literal occurrence of m); not attempted here.
-local function locate(regex: Regex, text: string, pos: integer, m: string): integer | nil
-  local q = pos
-  while true do
-    local found = text:find(m, q, true)
-    if not found then
-      return nil
-    end
-    local vflags: integer = 0
-    if found > 1 then
-      vflags = vflags | re.NOTBOL
-    end
-    if found + #m - 1 < #text then
-      vflags = vflags | re.NOTEOL
-    end
-    local vm = regex:search(text:sub(found, found + #m - 1), vflags)
-    if vm == m then
-      return found
-    end
-    q = found + 1
-  end
-end
-
 --- Compile a pattern for iteration and reject patterns that can match
---- the empty string: without offsets from the engine a zero-length
---- match cannot be positioned or advanced past.
+--- the empty string: a zero-length match cannot be advanced past
+--- (its end offset sits before its start, so iteration would not
+--- move).
 local function compile_for_iter(pattern: string, flags?: integer): Regex | nil, string
   local entry = cache_entry(pattern, flags)
   if entry.rx == nil then
@@ -230,8 +203,10 @@ local function compile_for_iter(pattern: string, flags?: integer): Regex | nil, 
 end
 
 --- Collect every non-overlapping match of regex in text, leftmost
---- first, as absolute spans. Returns nil + error on engine failure or
---- when a match cannot be located.
+--- first, as absolute spans. The engine reports offsets directly
+--- (Regex:find with init), so each step is one search from the
+--- previous match's end -- no subject re-slicing, no relocation pass.
+--- Returns nil + error on engine failure.
 local function all_matches(regex: Regex, text: string): {Span} | nil, string
   local spans: {Span} = {}
   local pos = 1
@@ -240,20 +215,16 @@ local function all_matches(regex: Regex, text: string): {Span} | nil, string
     if pos > 1 then
       sflags = re.NOTBOL
     end
-    local m, caps = regex:search(text:sub(pos), sflags)
-    if not m then
-      if caps then
-        return nil, tostring(caps)
+    local s, e, caps = regex:find(text, sflags, pos)
+    if s == nil then
+      if e is string then
+        return nil, e
       end
       break
     end
-    local s = locate(regex, text, pos, m)
-    if not s then
-      return nil, "failed to locate match position for: " .. m
-    end
-    local si = s
-    spans[#spans + 1] = {s = si, e = si + #m - 1, m = m, caps = caps}
-    pos = si + #m
+    local ei = e as integer -- cast: tuple element (integer whenever start is non-nil)
+    spans[#spans + 1] = {s = s, e = ei, m = text:sub(s, ei), caps = caps}
+    pos = ei + 1
   end
   return spans
 end
@@ -272,29 +243,29 @@ local function find(text: string, pattern: string, flags?: integer): Span | nil,
   if not regex then
     return nil, cerr
   end
-  local m, caps = regex:search(text)
-  if not m then
-    if caps then
-      return nil, tostring(caps)
+  -- Explicit flags and init: also keeps the lexer-based find-needle
+  -- lint (which cannot know the receiver is a Regex, not a string)
+  -- from reading this as a two-argument string find.
+  local s, e, caps = regex:find(text, 0, 1)
+  if s == nil then
+    if e is string then
+      return nil, e
     end
     return nil
   end
-  local start = locate(regex, text, 1, m)
-  if not start then
-    return nil, "failed to locate match position for: " .. m
-  end
-  return {s = start, e = start + #m - 1, m = m, caps = caps}
+  local ei = e as integer -- cast: tuple element (integer whenever start is non-nil)
+  return {s = s, e = ei, m = text:sub(s, ei), caps = caps}
 end
 
 --- Every non-overlapping match of pattern in text, leftmost first, as
 --- Spans. Patterns that can match the empty string are rejected.
 ---
---- KNOWN LIMITATION with the NEWLINE flag: `^`/`$` anchors that only
---- match via an embedded newline (not the true start/end of text) fail
---- to be re-confirmed past the first line (see locate's doc), so
---- find_all("foo\nfoo", "^foo", re.NEWLINE) returns nil, "failed to
---- locate match position for: foo" instead of two spans -- use
---- split plus a per-line match instead when this matters.
+--- Under the NEWLINE compile flag, `^`/`$` anchors match at embedded
+--- newlines as POSIX specifies: find_all("foo\nfoo", "^foo",
+--- re.NEWLINE) returns both spans. (The engine reports offsets
+--- directly, which removed the relocation pass whose verification
+--- window historically could not see those anchors past the first
+--- line.)
 --- @param text string The text to search in
 --- @param pattern string The regex pattern to match
 --- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE
@@ -339,8 +310,6 @@ end
 --- are kept verbatim, including empty ones from adjacent or
 --- leading/trailing matches; text with no match yields one field.
 --- Patterns that can match the empty string are rejected.
---- Shares find_all's KNOWN LIMITATION with a NEWLINE-anchored `^`/`$`
---- past the first line (see find_all's doc).
 --- @param text string The text to split
 --- @param pattern string The regex pattern to split on
 --- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE
@@ -372,8 +341,6 @@ local type Repl = string | function(string, {string}): string
 
 --- Replace every non-overlapping match of pattern in text.
 --- Patterns that can match the empty string are rejected.
---- Shares find_all's KNOWN LIMITATION with a NEWLINE-anchored `^`/`$`
---- past the first line (see find_all's doc).
 --- @param text string The text to operate on
 --- @param pattern string The regex pattern to match
 --- @param repl Repl A literal replacement string, or function(match, caps)

--- a/cosmic/re_ops_test.tl
+++ b/cosmic/re_ops_test.tl
@@ -80,35 +80,29 @@ local function test_anchor_caret_only_start()
 end
 test_anchor_caret_only_start()
 
--- DOCUMENTED LIMITATION (see re.tl locate/find_all doc comments): a
--- `^`/`$` anchor satisfied only via an embedded newline under the
--- NEWLINE flag (not true text start/end) cannot be re-confirmed by
--- locate()'s exact-width verification window, so all_matches gives up
--- as soon as it hits one. This pins today's (regrettable but known)
--- behavior for both flag states, so a future fix changes this test
--- deliberately instead of silently regressing an untested path.
-local function test_newline_anchor_past_first_line_is_a_known_limitation()
+-- The NEWLINE flag's `^`/`$` anchors at embedded newlines now behave
+-- as POSIX specifies. This was a DOCUMENTED LIMITATION of the old
+-- locate()-based iteration (its exact-width verification window could
+-- not see the newline byte, so all_matches gave up or undercounted);
+-- the engine reporting offsets directly (Regex:find) deleted that
+-- machinery, and this test changed deliberately with it, as the old
+-- test's comment asked.
+local function test_newline_anchor_matches_past_first_line()
   -- Without NEWLINE, `^` only matches true text start: one match.
   local ms = check.must(matches_of("foo\nfoo", "^foo"))
   assert(#ms == 1 and ms[1] == "foo", "expected a single match without NEWLINE")
 
-  -- With NEWLINE, `^` should also match right after the embedded \n
-  -- (regardless of NOTBOL, per POSIX) -- but locate() cannot verify
-  -- that second candidate, so the whole call fails instead of
-  -- returning {"foo", "foo"}.
-  local ms2, err2 = matches_of("foo\nfoo", "^foo", re.NEWLINE)
-  assert(ms2 == nil, "expected the known limitation to surface as nil, not a silent undercount")
-  assert(err2 and err2:find("failed to locate", 1, true),
-    "expected a 'failed to locate' error, got: " .. tostring(err2))
+  -- With NEWLINE, `^` also matches right after the embedded \n
+  -- (regardless of NOTBOL, per POSIX): both lines match.
+  local ms2 = check.must(matches_of("foo\nfoo", "^foo", re.NEWLINE))
+  assert(#ms2 == 2 and ms2[1] == "foo" and ms2[2] == "foo",
+    "expected both NEWLINE-anchored matches, got " .. #ms2)
 
-  -- The symmetric $ case fails differently (a short list, not nil),
-  -- which is exactly why this is documented rather than papered over
-  -- with one special case.
-  local ms3, err3 = matches_of("foo\nfoo\nfoo", "foo$", re.NEWLINE)
-  assert(ms3 ~= nil and #ms3 == 1, "expected the documented undercount, got: "
-    .. tostring(ms3) .. " " .. tostring(err3))
+  -- The symmetric $ case: every line end matches.
+  local ms3 = check.must(matches_of("foo\nfoo\nfoo", "foo$", re.NEWLINE))
+  assert(#ms3 == 3, "expected all three $-anchored matches, got " .. #ms3)
 end
-test_newline_anchor_past_first_line_is_a_known_limitation()
+test_newline_anchor_matches_past_first_line()
 
 -- split tests
 


### PR DESCRIPTION
## What

The pin bump that completes the two-repo dance for this week's C-layer perf work, landing the wrapper halves staged on whilp/cosmopolitan#227 and whilp/cosmopolitan#228.

**Pin: `2026.08.04-7276edf51` → `2026.08.07-9873eddc9`**, picking up whilp/cosmopolitan#225 (bytecode `freopen` removal — every module load pays one fewer zipos open) plus whilp/cosmopolitan#229 (`cosmo.IsBase64`, `re.Regex:find` offsets).

**`cosmic/codec.tl`** — `decode_base64`/`decode_base64url` gate the decode on one C-speed `IsBase64` scan; the Lua pattern validation (measured at 2/3 of the round trip) runs only on the failure branch, preserving the exact documented error strings. `decode_base64url` also drops its strip-and-translate pass — `DecodeBase64` reads the url-safe alphabet natively. An 8000-case fuzz against the old wrapper: byte-identical outputs on every accepted input, agreement on every reject.

**`cosmic/re.tl`** — `all_matches` and `find` iterate on `Regex:find` offsets: no per-match `text:sub` re-slicing, and `locate()`'s relocation pass (42 lines) is deleted. That also **lifts the documented NEWLINE limitation**: `^`/`$` anchors at embedded newlines now return correct spans instead of `failed to locate` errors/undercounts. `re_ops_test`'s limitation-pinning test changed deliberately with it, exactly as its comment asked a future fix to do.

## Measured (same-sitting `gate.tl compare` vs the old pin)

```
codec_base64_roundtrip_64k  515.03 µs -> 124.88 µs  -75.8%  faster
re_gsub_redact_numbers      175.48 µs -> 122.72 µs  -30.1%  faster  (alloc 181 → 38 KB/op)
re_split_colon_list           6.43 µs ->   4.54 µs  -29.4%  faster
re_match_log_line             2.83 µs ->   3.17 µs  +11.8%  flagged
```

The flagged row is a fixed-overhead microbench on a path neither wrapper touches (`match` still calls `:search`, whose C is unchanged); a relinked runtime shifts code layout — the documented false-alarm class for these scenarios (whilp/cosmopolitan#136). `json_decode_large` +16.7% was auto-triaged as machine noise by the gate's A/A self-check.

## Correctness

- `--make ci` PASS (fmt, check, example, lint, coverage — 190 files) on the new pin.
- Binding contracts: both bindings are additive; `:search` and `DecodeBase64` untouched. Types regenerate from the pinned binary's `definitions.lua` — no committed type changes.

Closes whilp/cosmopolitan#227
Closes whilp/cosmopolitan#228

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxJBYMrq98S9cNHVdTM6rc

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxJBYMrq98S9cNHVdTM6rc)_