### PR TITLE
perf: stream lines ride cosmos read_until; pin 2026.08.07-b922daeb1

### DIFF
--- a/3p/cosmos/cosmos_pin.tl
+++ b/3p/cosmos/cosmos_pin.tl
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "dd3a166b68d689a6d2ca64aaf6007c22a13b826187623e77fb6cc313e0a0257c"}},
+  platforms = {["*"] = {sha = "d3e7b4f5ded80f3854a44d49313287d1f108a910b5c31f8c2bf7219ed3afc145"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.08.07-9873eddc9"
+  version = "2026.08.07-b922daeb1"
 }

--- a/cosmic/fetch/init.tl
+++ b/cosmic/fetch/init.tl
@@ -108,6 +108,8 @@ end
 local record Reader is stream_mod.Reader
   metamethod __close: function(self: Reader)
   read: function(self: Reader): string | nil, string
+  --- Read up to (and consuming) the next delim; stream.DelimReader.
+  read_until: function(self: Reader, delim: string): string | nil, string
   --- Close the reader; boolean, string like every stdlib close.
   close: function(self: Reader): boolean, string
   closed: function(self: Reader): boolean
@@ -312,6 +314,28 @@ local function make_reader(raw_reader: cosmo.StreamReader): Reader
       return nil, err
     end
     return chunk
+  end
+
+  --- Read the bytes before the next occurrence of delim, consuming
+  --- the delimiter (multi-byte allowed, never included in the result).
+  --- Buffered in C by cosmo.StreamReader, so per-line consumers pay no
+  --- per-chunk Lua rebuilds; this is the stream.DelimReader capability
+  --- lines() rides. At end of stream an unterminated remainder is
+  --- returned once, then bare nil. Mixing with read() is safe: read()
+  --- drains the C carry-over first, so bytes are never reordered.
+  --- @param delim string non-empty delimiter to scan for
+  --- @return string | nil bytes before the delimiter, or nil on EOF or failure
+  --- @return string error message on failure (nil on clean EOF)
+  function reader:read_until(delim: string): string | nil, string
+    if is_closed then
+      return nil, "reader closed"
+    end
+    if delim == "" then
+      -- The C binding rejects an empty delimiter by throwing; keep the
+      -- library contract of nil + message instead.
+      return nil, "read_until: delimiter must be non-empty"
+    end
+    return raw_reader:read_until(delim)
   end
 
   --- Close the reader. Idempotent; cannot fail today.

--- a/cosmic/fetch/stream_test.tl
+++ b/cosmic/fetch/stream_test.tl
@@ -152,6 +152,58 @@ local function test_stream_reader_close_idempotent()
 end
 test_stream_reader_close_idempotent()
 
+local function test_read_until_multibyte_and_mixing()
+  -- "alpha\r\n\r\nbravo\r\ncharlie": a multi-byte delimiter, adjacent
+  -- delimiters yielding an empty field, then read() draining the C
+  -- carry-over in order — bytes must continue exactly after the last
+  -- consumed delimiter, never reordered or dropped.
+  local port, pid = serve({body_response("alpha\r\n\r\nbravo\r\ncharlie")})
+  local result = fetch.stream("http://127.0.0.1:" .. port .. "/", {allow_private = true})
+  assert(result.ok == true, "stream opens: " .. tostring(result.error))
+  local first, err1 = result.reader:read_until("\r\n")
+  assert(first == "alpha" and err1 == nil,
+    "bytes before the first delimiter, got: " .. tostring(first))
+  local second, err2 = result.reader:read_until("\r\n")
+  assert(second == "" and err2 == nil,
+    "adjacent delimiters yield an empty field, got: " .. tostring(second))
+  local rest: {string} = {}
+  while true do
+    local chunk, rerr = result.reader:read()
+    assert(rerr == nil, "no read error expected, got: " .. tostring(rerr))
+    if not chunk then break end
+    table.insert(rest, chunk)
+  end
+  assert(table.concat(rest) == "bravo\r\ncharlie",
+    "read() drains the carry-over in order, got: " .. table.concat(rest))
+  assert(result.reader:close())
+  assert(proc.wait(pid))
+end
+test_read_until_multibyte_and_mixing()
+
+local function test_read_until_remainder_guards_and_close()
+  -- A delimiter-free body arrives whole as the EOF remainder, once;
+  -- the empty-delimiter guard returns nil + message (never throws);
+  -- read_until after close is the same error read() gives.
+  local port, pid = serve({body_response("no newline here")})
+  local result = fetch.stream("http://127.0.0.1:" .. port .. "/", {allow_private = true})
+  assert(result.ok == true, "stream opens: " .. tostring(result.error))
+  local bad, baderr = result.reader:read_until("")
+  assert(bad == nil and baderr ~= nil
+    and baderr:find("non-empty", 1, true) ~= nil,
+    "empty delimiter is nil + message, got: " .. tostring(baderr))
+  local whole, werr = result.reader:read_until("\n")
+  assert(whole == "no newline here" and werr == nil,
+    "delimiter-free body returned whole as remainder, got: " .. tostring(whole))
+  local after, aerr = result.reader:read_until("\n")
+  assert(after == nil and aerr == nil, "EOF after the remainder stays clean nil")
+  assert(result.reader:close())
+  local closed, cerr = result.reader:read_until("\n")
+  assert(closed == nil and cerr == "reader closed",
+    "read_until after close errors like read, got: " .. tostring(cerr))
+  assert(proc.wait(pid))
+end
+test_read_until_remainder_guards_and_close()
+
 local function test_stream_validation_and_error_kind()
   local result = fetch.stream("ftp://example.com/x")
   assert(result.ok == false, "ftp scheme must be rejected")

--- a/cosmic/stream.tl
+++ b/cosmic/stream.tl
@@ -49,6 +49,17 @@ local record stream
     contents: function(self: Buffer): string
   end
 
+  --- Optional capability: a Reader that can scan for a delimiter
+  --- natively (fetch.Reader buffers it in C). read_until(delim)
+  --- returns the bytes before the next occurrence of delim, consuming
+  --- the delimiter (never included); at end of stream an unterminated
+  --- remainder is returned once, then bare nil; nil plus an error
+  --- message on failure. lines() prefers this over its own buffering,
+  --- so line iteration costs no per-chunk Lua rebuilds.
+  interface DelimReader is Reader
+    read_until: function(self: DelimReader, delim: string): string | nil, string
+  end
+
   write_all: function(w: Writer, data: string): boolean, string
   read_all: function(r: Reader, max?: integer): string | nil, string
   copy: function(dst: Writer, src: Reader, buf_size?: integer): integer | nil, string
@@ -181,15 +192,45 @@ function stream.buffer(): stream.Buffer
   return buf as stream.Buffer -- cast: table implements the Buffer record
 end
 
+--- Line iteration over a DelimReader: one C-buffered read_until("\n")
+--- per line, so no Lua-side chunk buffering at all. Same contract as
+--- the buffering path below: unterminated final line yielded once,
+--- nil + error once on failure, then plain nil forever.
+--- @param dr DelimReader The source
+--- @return function Iterator yielding lines without the trailing newline
+local function lines_via_read_until(dr: stream.DelimReader): function(): string | nil, string
+  local done = false
+  return function(): string | nil, string
+    if done then
+      return nil
+    end
+    local line, err = dr:read_until("\n")
+    if err then
+      done = true
+      return nil, err
+    end
+    if line == nil then
+      done = true
+      return nil
+    end
+    return line
+  end
+end
+
 --- Iterate complete lines from a Reader, buffering partial lines
 --- across chunks. On clean EOF a final unterminated line is yielded
 --- once, then nil. On a read error the buffered partial line is
 --- truncated data and is discarded — the iterator yields nil plus the
 --- error once, then plain nil forever. (Promoted from fetch.Reader's
---- lines(); cosmic.sse consumes the same iterator.)
+--- lines(); cosmic.sse consumes the same iterator.) A reader carrying
+--- the DelimReader capability skips the Lua buffering entirely.
 --- @param r Reader The source
 --- @return function Iterator yielding lines without the trailing newline
 function stream.lines(r: stream.Reader): function(): string | nil, string
+  local dr = r as stream.DelimReader -- cast: duck-typed capability probe
+  if type(dr.read_until) == "function" then
+    return lines_via_read_until(dr)
+  end
   -- Scan-position index into buffer: `pos` is the first unread byte.
   -- Advancing it instead of slicing off each returned line, and
   -- dropping the consumed prefix only when we must read more, keeps


### PR DESCRIPTION
Completes the cosmic side of whilp/cosmopolitan#230 (C-side landed as whilp/cosmopolitan#234, shipped in release `2026.08.07-b922daeb1`).

## What changed

- **Pin bump** to `2026.08.07-b922daeb1`, which carries `cosmo.StreamReader:read_until(delim)` (C-buffered delimiter reads) and the json-encode escape-scratch skip.
- **`cosmic/stream.tl`**: new optional `DelimReader` capability interface; `stream.lines` probes for `read_until` and, when present, iterates with one C call per line instead of the Lua-side per-chunk compact+concat loop. Readers without the capability keep the existing buffering path unchanged.
- **`cosmic/fetch/init.tl`**: `fetch.Reader` exposes `read_until` (closed-guard, and an empty-delimiter guard returning `nil, message` since the C binding throws — library code never throws). `lines()` still delegates to `stream.lines`, which now picks the C path; `sse` over a fetch reader rides it too.
- **Tests** (`cosmic/fetch/stream_test.tl`): multi-byte delimiter, adjacent delimiters yielding an empty field, `read()` draining the C carry-over in order, delimiter-free EOF remainder, empty-delimiter guard, and read_until-after-close.

## Numbers

perf-compare vs pin `2026.08.07-9873eddc9`, two clean runs:

```
stream_lines_iterate    1.77 ms ->   1.28 ms  -27.2%  ok
  alloc 736.52 KB -> 315.09 KB  (-57%, identical in both runs)
json_roundtrip_small    3.62 µs ->   3.14 µs  -13.1%  faster  (pin's C json change)
time_format_iso8601    684.1 ns ->  607.6 ns  -11.2%  faster
```

The alloc drop is the deterministic signal: the two Lua-side components (~⅔ of 736 KB/op — raw chunk pushes and buffer-concat copies, which scaled with read-call count) are gone; the remaining ~315 KB/op is the per-line substrings the workload requires. Four scenarios tripped the ±10% bar once each across the two compares (`http_fetch_get` +20.2%/+1.3%, `http_tcp_roundtrip` +12.3%/+3.8%, `embed_run_tree` +3.4%/+10.5%, `http_fetch_get_with_headers` +9.1%/+11.3%) — disjoint sets, none reproduced, all loopback/fork scenarios on a shared runner; per `measurement.md` a genuine change reproduces in the same direction every time.

## Gates

- `ci: PASS (5 stages)` (fmt, check, example, lint, coverage ratchet) on the new pin
- `stream_lines_iterate` check pins line count and last-line content; the new tests pin the read_until contract from the wrapper side

Also filed this round: whilp/cosmic#968 (`embed.extract` slurps the whole executable to open it — evidence-backed, not worked here; one hypothesis per commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQZgh4AsGFiQdzcXi4aeD1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQZgh4AsGFiQdzcXi4aeD1)_