### PR TITLE
perf: embed.extract opens the archive by path instead of slurping the executable

### DIFF
--- a/cosmic/embed/extract.tl
+++ b/cosmic/embed/extract.tl
@@ -27,13 +27,17 @@ local function extract(output_dir: string, exe_path?: string): EmbedResult
     return {ok = false, message = "error: could not determine executable path", file_count = 0}
   end
 
-  local exe_data = fs.read(exe_path)
-  if not exe_data then
-    return {ok = false, message = "error: cannot read executable '" .. exe_path .. "'", file_count = 0}
-  end
-
-  local archive_maybe = czip.open_bytes(exe_data)
+  -- Open straight from the path: reading the whole executable into a
+  -- Lua string first (czip.open_bytes) cost the binary's size in
+  -- allocation per call. The failure branch re-probes with fs.read to
+  -- keep the two documented messages distinguishable — an unreadable
+  -- file stays "cannot read executable", a readable non-archive stays
+  -- "no zip archive found".
+  local archive_maybe = czip.open(exe_path)
   if not archive_maybe then
+    if not fs.read(exe_path) then
+      return {ok = false, message = "error: cannot read executable '" .. exe_path .. "'", file_count = 0}
+    end
     return {ok = false, message = "error: no zip archive found in '" .. exe_path .. "'", file_count = 0}
   end
   local archive = archive_maybe

--- a/cosmic/embed_advanced_test.tl
+++ b/cosmic/embed_advanced_test.tl
@@ -308,6 +308,28 @@ local function test_extract_rejects_path_traversal()
 end
 test_extract_rejects_path_traversal()
 
+-- The two extract failure messages are contract: a missing/unreadable
+-- executable reports "cannot read executable"; a readable file with no
+-- archive reports "no zip archive found". extract() opens by path now,
+-- so both come from its failure-branch classification.
+local function test_extract_failure_messages_distinguish_causes()
+  local outdir = fs.join(tmpdir, "extract-fail-target")
+
+  local missing = fs.join(tmpdir, "does-not-exist.bin")
+  local result = embed.extract(outdir, missing)
+  assert(not result.ok, "extract of a missing path must fail")
+  assert(result.message:find("cannot read executable", 1, true),
+    "missing file reports the read error, got: " .. result.message)
+
+  local notzip = fs.join(tmpdir, "not-an-archive.bin")
+  assert(fs.write(notzip, "just some bytes, no zip here"))
+  local result2 = embed.extract(outdir, notzip)
+  assert(not result2.ok, "extract of a non-archive must fail")
+  assert(result2.message:find("no zip archive found", 1, true),
+    "readable non-archive reports the archive error, got: " .. result2.message)
+end
+test_extract_failure_messages_distinguish_causes()
+
 -- FIX 2: collect_dir must not recurse into symlinked directories.
 -- A symlink loop inside the embed dir must terminate without error.
 local function test_embed_symlink_loop_terminates()


### PR DESCRIPTION
Works #968. Independent of the tl lazy-env work — reviewable and mergeable on its own.

## What changed

`extract()` read the **entire packed executable** into a Lua string (`fs.read` + `czip.open_bytes`) solely to open it as a zip. `czip.open(path)` reads from the file directly, and `embed/init.tl` already opens executables that way, so the bytes form was not load-bearing.

The failure branch re-probes with `fs.read` so the two documented `EmbedResult` messages stay distinguishable — an unreadable file still reports `cannot read executable '<path>'`, a readable non-archive still reports `no zip archive found in '<path>'`. A new test pins both messages (neither was covered before).

## Numbers

perf-compare vs main (pin `2026.08.07-b922daeb1`):

```
embed_extract_tree   117.41 ms -> 87.41 ms   -25.6%  faster
  alloc 17779.6 KB -> 7019.1 KB/op  (-60.5%)
  spread ±6.8% -> ±1.2%
```

The alloc drop is the packed executable's size (~10.8 MB) no longer allocated per call; the spread collapse is the GC churn going with it. 39 scenarios: 0 regression, 1 faster.

## Gates

- `ci: PASS (5 stages)` including the new failure-message tests
- perf-compare: 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQZgh4AsGFiQdzcXi4aeD1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQZgh4AsGFiQdzcXi4aeD1)_