### PR TITLE
example: run the gate from source, where the Output blocks are

### DIFF
--- a/cosmic/deploy_example.tl
+++ b/cosmic/deploy_example.tl
@@ -18,7 +18,8 @@ local function Example_shebang()
   local child = require("cosmic.child")
   local cosmic = arg[-1]
 
-  local tmpdir = fs.temp_dir("/tmp/deploy_example_XXXXXX")
+  local base = os.getenv("TEST_TMPDIR") or "/tmp"
+  local tmpdir = check.must(fs.temp_dir(fs.join(base, "deploy_example_XXXXXX")))
   local script = fs.join(tmpdir, "greet.tl")
 
   -- Write a script with a shebang line
@@ -42,7 +43,8 @@ local function Example_script_args()
   local child = require("cosmic.child")
   local cosmic = arg[-1]
 
-  local tmpdir = fs.temp_dir("/tmp/deploy_example_XXXXXX")
+  local base = os.getenv("TEST_TMPDIR") or "/tmp"
+  local tmpdir = check.must(fs.temp_dir(fs.join(base, "deploy_example_XXXXXX")))
   local script = fs.join(tmpdir, "greet.tl")
 
   -- A script that reads arguments from the arg table
@@ -75,7 +77,8 @@ local function Example_install_to_path()
   local child = require("cosmic.child")
   local cosmic = arg[-1]
 
-  local tmpdir = fs.temp_dir("/tmp/deploy_example_XXXXXX")
+  local base = os.getenv("TEST_TMPDIR") or "/tmp"
+  local tmpdir = check.must(fs.temp_dir(fs.join(base, "deploy_example_XXXXXX")))
 
   -- Create a local bin directory (simulating ~/bin or ~/.local/bin)
   local bindir = fs.join(tmpdir, "bin")
@@ -104,7 +107,8 @@ local function Example_portable_executable()
   local child = require("cosmic.child")
   local cosmic = arg[-1]
 
-  local tmpdir = fs.temp_dir("/tmp/deploy_example_XXXXXX")
+  local base = os.getenv("TEST_TMPDIR") or "/tmp"
+  local tmpdir = check.must(fs.temp_dir(fs.join(base, "deploy_example_XXXXXX")))
 
   -- Write a Teal source file
   local tl_file = fs.join(tmpdir, "app.tl")

--- a/cosmic/embed_example.tl
+++ b/cosmic/embed_example.tl
@@ -13,7 +13,8 @@ local function Example_embed_directory()
   local child = require("cosmic.child")
   local cosmic = arg[-1]
 
-  local tmpdir = fs.temp_dir("/tmp/embed_example_XXXXXX")
+  local base = os.getenv("TEST_TMPDIR") or "/tmp"
+  local tmpdir = check.must(fs.temp_dir(fs.join(base, "embed_example_XXXXXX")))
 
   -- Create a simple app directory with a main.lua entry point
   local appdir = fs.join(tmpdir, "myapp")
@@ -40,7 +41,8 @@ local function Example_extract_roundtrip()
   local child = require("cosmic.child")
   local cosmic = arg[-1]
 
-  local tmpdir = fs.temp_dir("/tmp/embed_example_XXXXXX")
+  local base = os.getenv("TEST_TMPDIR") or "/tmp"
+  local tmpdir = check.must(fs.temp_dir(fs.join(base, "embed_example_XXXXXX")))
 
   -- Extract the running executable's zip contents
   local extractdir = fs.join(tmpdir, "extracted")
@@ -62,7 +64,8 @@ local function Example_embed_with_libraries()
   local child = require("cosmic.child")
   local cosmic = arg[-1]
 
-  local tmpdir = fs.temp_dir("/tmp/embed_example_XXXXXX")
+  local base = os.getenv("TEST_TMPDIR") or "/tmp"
+  local tmpdir = check.must(fs.temp_dir(fs.join(base, "embed_example_XXXXXX")))
 
   -- Create an app that uses cosmic.child (a bundled library)
   local appdir = fs.join(tmpdir, "app")
@@ -93,7 +96,8 @@ local function Example_embed_from_teal()
   local child = require("cosmic.child")
   local cosmic = arg[-1]
 
-  local tmpdir = fs.temp_dir("/tmp/embed_example_XXXXXX")
+  local base = os.getenv("TEST_TMPDIR") or "/tmp"
+  local tmpdir = check.must(fs.temp_dir(fs.join(base, "embed_example_XXXXXX")))
   local appdir = fs.join(tmpdir, "myapp")
   assert(fs.make_dirs(appdir))
 

--- a/cosmic/envd_example.tl
+++ b/cosmic/envd_example.tl
@@ -45,7 +45,7 @@ local function Example_extract_update_embed()
   -- 1. extract current executable
   local extractdir = fs.join(tmpdir, "extracted")
   local r = check.must(child.run({cosmic, "--extract", extractdir}))
-  assert(r.ok, r.stderr)
+  assert(r.ok, r.stderr ~= "" and r.stderr or r.stdout)
 
   -- 2. add env.d with a credential
   local envd_dir = fs.join(extractdir, "embed", "env.d")
@@ -54,7 +54,11 @@ local function Example_extract_update_embed()
 
   -- 3. re-embed with a main.lua that loads env.d and prints the var name
   -- No loader prelude: --embed wraps a custom entry with the cosmic
-  -- runtime searcher, so require() just works.
+  -- runtime searcher, so require() just works. The extracted tree
+  -- carries the wrapper's entry PAIR (main.lua + main.user.lua, #687);
+  -- re-embedding requires replacing the pair, so drop the wrapped
+  -- original alongside writing the new entry.
+  assert(fs.unlink(fs.join(extractdir, "main.user.lua")))
   assert(fs.write(fs.join(extractdir, "main.lua"), [[
 local envd = require("cosmic.envd")
 local env = require("cosmic.env")
@@ -66,7 +70,7 @@ print("MY_SECRET_TOKEN is " .. (env.get("MY_SECRET_TOKEN") and "set" or "unset")
   -- 4. build new executable
   local output = fs.join(tmpdir, "myapp")
   r = check.must(child.run({cosmic, "--embed", extractdir, "--output", output}))
-  assert(r.ok, r.stderr)
+  assert(r.ok, r.stderr ~= "" and r.stderr or r.stdout)
 
   -- 5. run it
   r = check.must(child.run({output}))

--- a/cosmic/envd_example.tl
+++ b/cosmic/envd_example.tl
@@ -40,7 +40,8 @@ local function Example_extract_update_embed()
   local child = require("cosmic.child")
   local cosmic = arg[-1]
 
-  local tmpdir = fs.temp_dir("/tmp/envd_example_XXXXXX")
+  local base = os.getenv("TEST_TMPDIR") or "/tmp"
+  local tmpdir = check.must(fs.temp_dir(fs.join(base, "envd_example_XXXXXX")))
 
   -- 1. extract current executable
   local extractdir = fs.join(tmpdir, "extracted")

--- a/cosmic/fd_example.tl
+++ b/cosmic/fd_example.tl
@@ -12,7 +12,8 @@ local function Example_open_write_read()
   local check = require("cosmic.check")
   local fd = require("cosmic.fd")
   local fs = require("cosmic.fs")
-  local dir = fs.temp_dir("/tmp/fd_example_XXXXXX")
+  local base = os.getenv("TEST_TMPDIR") or "/tmp"
+  local dir = check.must(fs.temp_dir(fs.join(base, "fd_example_XXXXXX")))
   local path = fs.join(dir, "note.txt")
 
   local h < close > = check.must(fd.open(path, fd.O_RDWR | fd.O_CREAT, 420))
@@ -32,7 +33,8 @@ local function Example_positional()
   local check = require("cosmic.check")
   local fd = require("cosmic.fd")
   local fs = require("cosmic.fs")
-  local dir = fs.temp_dir("/tmp/fd_example_XXXXXX")
+  local base = os.getenv("TEST_TMPDIR") or "/tmp"
+  local dir = check.must(fs.temp_dir(fs.join(base, "fd_example_XXXXXX")))
   local path = fs.join(dir, "data.txt")
   assert(fs.write(path, "abcdef"))
 

--- a/cosmic/fs/init_example.tl
+++ b/cosmic/fs/init_example.tl
@@ -6,7 +6,8 @@ local function Example_basic()
   local fs = require("cosmic.fs")
 
   -- Create a temp directory
-  local tmpdir = fs.temp_dir("/tmp/fs_example_XXXXXX")
+  local base = os.getenv("TEST_TMPDIR") or "/tmp"
+  local tmpdir = fs.temp_dir(fs.join(base, "fs_example_XXXXXX"))
   if not tmpdir then
     print("failed to create temp dir")
     return

--- a/cosmic/fs/walk_example.tl
+++ b/cosmic/fs/walk_example.tl
@@ -9,7 +9,8 @@ local function Example_walk()
   local types = require("cosmic.fs.types")
 
   -- Build a small tree under a temp directory.
-  local tmpdir = fs.temp_dir("/tmp/walk_ex_XXXXXX")
+  local base = os.getenv("TEST_TMPDIR") or "/tmp"
+  local tmpdir = fs.temp_dir(fs.join(base, "walk_ex_XXXXXX"))
   assert(tmpdir, "temp_dir failed")
 
   local subdir = fs.join(tmpdir, "conf")
@@ -43,7 +44,8 @@ local function Example_collect()
   local check = require("cosmic.check")
   local fs = require("cosmic.fs")
 
-  local tmpdir = fs.temp_dir("/tmp/collect_ex_XXXXXX")
+  local base = os.getenv("TEST_TMPDIR") or "/tmp"
+  local tmpdir = fs.temp_dir(fs.join(base, "collect_ex_XXXXXX"))
   assert(tmpdir, "temp_dir failed")
 
   local subdir = fs.join(tmpdir, "src")
@@ -72,7 +74,8 @@ local function Example_files()
   local check = require("cosmic.check")
   local fs = require("cosmic.fs")
 
-  local tmpdir = fs.temp_dir("/tmp/files_ex_XXXXXX")
+  local base = os.getenv("TEST_TMPDIR") or "/tmp"
+  local tmpdir = fs.temp_dir(fs.join(base, "files_ex_XXXXXX"))
   assert(tmpdir, "temp_dir failed")
 
   assert(fs.write(fs.join(tmpdir, "a.txt"), "a\n"))

--- a/cosmic/shm_example.tl
+++ b/cosmic/shm_example.tl
@@ -41,10 +41,10 @@ local function Example_cmpxchg()
   local shm = require("cosmic.shm")
   local mem = check.must(shm.mapshared(4096))
   assert(mem:store(0, 7))
-  local ok, seen = mem:cmpxchg(0, 7, 8)
-  print(ok, seen, check.must(mem:load(0)))
-  local ok2, seen2 = mem:cmpxchg(0, 7, 9) -- stale expectation: no swap
-  print(ok2, seen2, check.must(mem:load(0)))
+  local r = check.must(mem:cmpxchg(0, 7, 8))
+  print(r.swapped, r.value, check.must(mem:load(0)))
+  local r2 = check.must(mem:cmpxchg(0, 7, 9)) -- stale expectation: no swap
+  print(r2.swapped, r2.value, check.must(mem:load(0)))
   -- Output:
   -- true	7	8
   -- false	8	8

--- a/cosmic/tar_example.tl
+++ b/cosmic/tar_example.tl
@@ -10,7 +10,8 @@ local function Example_extract()
   local fs = require("cosmic.fs")
   local tar = require("cosmic.tar")
 
-  local dir = check.must(fs.temp_dir("/tmp/tar_example_XXXXXX"))
+  local base = os.getenv("TEST_TMPDIR") or "/tmp"
+  local dir = check.must(fs.temp_dir(fs.join(base, "tar_example_XXXXXX")))
 
   -- One ustar header block (name, mode, size, checksum) plus its
   -- payload, padded to the 512-byte block size, then two zero blocks.

--- a/embed/cosmic.mk
+++ b/embed/cosmic.mk
@@ -184,11 +184,14 @@ example_got := $(patsubst %,$(O)/%.example.got,$(examples))
 example: $(O)/example-summary.txt
 
 # An example is a test with a different contract: same staging, same
-# closure, same fence, `Example_*` instead of `test_*`. That is what the
-# model says everywhere else, so the rules say it too — the only
-# difference from the test rules above is the flag.
+# closure, same fence, `Example_*` instead of `test_*`. Two differences
+# from the test rules above: the flag, and the file handed to the
+# runner. Examples carry their expected output in `-- Output:` comments,
+# which compilation strips, so the runner reads the SOURCE — handing it
+# `$<` silently skipped every output check. The compiled prerequisite
+# still gates the run on a clean typecheck.
 $(O)/%.tl.example.got: $(O)/%.lua $(O)/.stamp/record $$(deps_$$*) $(testrun_dep)
-	record $(basename $@) $(testrun) --check example $< --deps $(deps_$*) ;
+	record $(basename $@) $(testrun) --check example $*.tl --deps $(deps_$*) ;
 
 $(O)/%.lua.example.got: $(O)/%.lua $(O)/.stamp/record $$(deps_$$*) $(testrun_dep)
 	record $(basename $@) $(testrun) --check example $< --deps $(deps_$*) ;


### PR DESCRIPTION
Fixes #974.

The example stage handed the runner the compiled `.lua` (`embed/cosmic.mk`'s `--check example $<`), and compilation strips comments — so the runner's "no expected output → skip" branch fired for every example, **before executing it**: all 102 `-- Output:` blocks across 33 example files were skipped, and any example carrying one never ran at all. The stage passed on the crash-freedom of the remaining examples alone.

**The fix:** hand the runner the `.tl` source (`$*.tl`); the compiled `.lua` stays a prerequisite, so the run is still gated on a clean typecheck. The `record` verb already keys argv file-elements by bytes and the fence derives grants from argv, so the source path slots into the existing machinery unchanged.

**What the revived gate caught** (36 files, 34 clean, 2 real failures — both fixed here):

- `cosmic/shm_example.tl` — `Example_cmpxchg` destructured `cmpxchg`'s record return as the retired tuple; its expected `true 7 8` could only match the pre-record API. Now reads `r.swapped`/`r.value`.
- `cosmic/envd_example.tl` — `Example_extract_update_embed`, the documented extract → update → re-embed cycle, has been broken since the entry wrapper landed (#687): the extracted tree carries the `main.lua`/`main.user.lua` pair, and `--embed` refuses a tree containing `main.user.lua`. The example now drops the wrapped original when it replaces the entry, per the wrapper's contract. Its asserts also surface stdout, where `--extract`/`--embed` print their errors (the empty failure message that made this hard to diagnose; the error-channel fix itself is #1001).

Verified locally: `--make example` runs 36 files with output checks live and passes; the two failures above reproduce on main with the gate fix alone.

First PR of the api-review backlog (#1007) — sequenced first because it re-arms the gate that verifies the examples every later PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_