### PR TITLE
quicksand: keep_caps merges as a list; guard drop_privs' nil binding

### DIFF
--- a/cosmic/quicksand/box/merge.tl
+++ b/cosmic/quicksand/box/merge.tl
@@ -5,8 +5,8 @@
 --- new policy table. No syscalls, no side effects.
 ---
 --- Field classes:
----   scalar   hostname, cwd, uid, gid, pledge, log_level, ...
----   list     fs.ro, fs.rw, fs.exec, env.keep
+---   scalar   hostname, cwd, uid, gid, log_level, ...
+---   list     fs.ro, fs.rw, fs.exec, env.keep, proc.keep_caps
 ---   map      net.allow, env.set
 ---
 --- Merge rules:
@@ -28,6 +28,10 @@ local schema: Schema = {
     ["fs.rw"] = true,
     ["fs.exec"] = true,
     ["env.keep"] = true,
+    -- Absent from the schema, keep_caps fell into the recursive branch and
+    -- merged BY INDEX: {A,B} over {C} yielded {C,B}, silently retaining a
+    -- capability the overlay never granted.
+    ["proc.keep_caps"] = true,
   },
   maps = {
     ["net.allow"] = true,

--- a/cosmic/quicksand/box/merge_test.tl
+++ b/cosmic/quicksand/box/merge_test.tl
@@ -136,3 +136,18 @@ local function test_scalar_false_in_a_survives_absent_b_key()
   assert(proc.uid == 1000, "uid preserved")
 end
 test_scalar_false_in_a_survives_absent_b_key()
+
+local function test_proc_keep_caps_merges_as_list()
+  -- Regression: absent from the list schema, keep_caps fell into the
+  -- recursive branch and merged BY INDEX — {CAP_A,CAP_B} over {CAP_C}
+  -- yielded {CAP_C,CAP_B}, silently retaining a capability the overlay
+  -- never granted. It concatenates and dedupes like every other list.
+  local out = m.merge(
+    {proc = {keep_caps = {"CAP_NET_BIND_SERVICE", "CAP_CHOWN"}}},
+    {proc = {keep_caps = {"CAP_CHOWN", "CAP_SETUID"}}})
+  local caps = (out.proc as {string: any}).keep_caps as {string} -- cast: from any
+  assert(#caps == 3, "got: " .. tostring(#caps))
+  assert(caps[1] == "CAP_NET_BIND_SERVICE" and caps[2] == "CAP_CHOWN"
+    and caps[3] == "CAP_SETUID", "order+dedupe wrong for keep_caps")
+end
+test_proc_keep_caps_merges_as_list()

--- a/cosmic/quicksand/proc.tl
+++ b/cosmic/quicksand/proc.tl
@@ -70,6 +70,11 @@ local function drop_privs(uid: integer, gid: integer): boolean, string
   if uid == nil then return true end
   if gid == nil then gid = uid end
   if uid ~= 0 then
+    if unix.prctl == nil or unix.PR_SET_KEEPCAPS == nil then
+      -- Calling a nil binding would throw; report the absence instead
+      -- (the same guard no_new_privs carries above).
+      return false, "drop_privs unsupported on this host"
+    end
     local kok, kerr = unix.prctl(unix.PR_SET_KEEPCAPS, 1)
     if not kok then return false, errno.wrap(kerr, "PR_SET_KEEPCAPS") end
     local gok, gerr = unix.setresgid(gid, gid, gid)


### PR DESCRIPTION
Fixes #990 (the bug half).

**The bug:** `Box.merge`'s list schema (`quicksand/box/merge.tl`) named `fs.ro`/`fs.rw`/`fs.exec`/`env.keep` but not `proc.keep_caps`, so that field fell into the recursive section branch and merged **by index**: `{CAP_A, CAP_B}` overlaid with `{CAP_C}` yielded `{CAP_C, CAP_B}` — silently retaining a capability the overlay never granted, in the security-policy composition path. No test covered it.

The fix adds `proc.keep_caps` to the list schema (concat + dedupe like every other list), with a regression test asserting the exact failure shape, and drops the retired `pledge` field from the merge doc's scalar examples (that field now raises a migration error on use).

Also included, same family: `quicksand/proc.tl`'s `drop_privs` called `unix.prctl` unguarded while `no_new_privs` three lines up guards the identical nil-binding case with a comment explaining why — `drop_privs` now carries the same guard.

Deferred to #989 (containment consolidation), as noted in the issue: the `caps.bounding_read` return-shape fix and the `bounding_read`/`drop_bounding` naming collision — those are API-shape changes, not bugs, and belong in the surface redesign.

Part of the api-review backlog (#1007), phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_