### PR TITLE
perf: error-path and interactive modules leave the boot chain

### DIFF
--- a/_cli/require_hints.tl
+++ b/_cli/require_hints.tl
@@ -2,7 +2,6 @@
 --- Intercepts module-not-found errors and suggests similar modules.
 
 local original_require = require
-local fuzzy = original_require("cosmic.fuzzy")
 
 --- Cached module mapping, built lazily on first use.
 local module_map: {string: string} = nil
@@ -105,6 +104,10 @@ local function find_similar(name: string, max_distance?: integer): {string}
   -- Compare against both the short name and the full qualified name.
   -- This catches typos in either the prefix (e.g. "cosm.json") or the
   -- suffix (e.g. "cosmic.jsn" -> "cosmic.json", distance 1).
+  -- cosmic.fuzzy is required lazily, like cosmic.string above: this
+  -- only runs on the require-failure path, and a boot-time require
+  -- would put the module on every invocation's boot surface (#973).
+  local fuzzy = original_require("cosmic.fuzzy")
   for _, pair in ipairs(candidates) do
     local full = pair[1]
     local short = pair[2]

--- a/cmd/cosmic/main.tl
+++ b/cmd/cosmic/main.tl
@@ -35,7 +35,6 @@ end
 
 local getopt = require("cosmic.getopt")
 local cli_args = require("_cli.args")
-local help = require("_cli.help")
 local handlers = require("_cli.main_handlers")
 
 -- Parsed options record
@@ -358,15 +357,23 @@ local function main(): integer, string
     opts.extract = extract_env
   end
   if opts.version then return handlers.handle_version() end
-  if opts.help then io.write(help.generate() .. "\n"); return 0 end
+  -- _cli.help is required here, not at the top: --help is a
+  -- human-paced branch, and a boot-time require would put the module
+  -- on every invocation's boot surface (#973)
+  if opts.help then io.write(require("_cli.help").generate() .. "\n"); return 0 end
   if opts.welcome then io.write(handlers.generate_welcome()); return 0 end
 
   -- Show welcome on first invocation (skip when --help/--version/--welcome handled above)
+  -- The tty gate runs first: the banner only ever prints to a
+  -- terminal, so headless boots (CI, builds, scripts) skip the
+  -- was-shown lookup and never load _cli.welcome at all (#973).
+  -- Behavior is unchanged: the banner still prints exactly once, on
+  -- the first invocation whose stderr is a tty.
   if not os.getenv("COSMIC_NO_WELCOME") then
-    local welcome = require("_cli.welcome")
-    if not welcome.was_shown() then
-      local tty = require("cosmic.tty")
-      if tty.is_tty(2) then
+    local tty = require("cosmic.tty")
+    if tty.is_tty(2) then
+      local welcome = require("_cli.welcome")
+      if not welcome.was_shown() then
         io.stderr:write(handlers.generate_welcome())
         welcome.mark_shown()
       end

--- a/cmd/cosmic/main.tl
+++ b/cmd/cosmic/main.tl
@@ -357,18 +357,11 @@ local function main(): integer, string
     opts.extract = extract_env
   end
   if opts.version then return handlers.handle_version() end
-  -- _cli.help is required here, not at the top: --help is a
-  -- human-paced branch, and a boot-time require would put the module
-  -- on every invocation's boot surface (#973)
   if opts.help then io.write(require("_cli.help").generate() .. "\n"); return 0 end
   if opts.welcome then io.write(handlers.generate_welcome()); return 0 end
 
-  -- Show welcome on first invocation (skip when --help/--version/--welcome handled above)
-  -- The tty gate runs first: the banner only ever prints to a
-  -- terminal, so headless boots (CI, builds, scripts) skip the
-  -- was-shown lookup and never load _cli.welcome at all (#973).
-  -- Behavior is unchanged: the banner still prints exactly once, on
-  -- the first invocation whose stderr is a tty.
+  -- First-run welcome, tty gate first: the banner only ever prints to a terminal,
+  -- so headless boots never load _cli.welcome (#973). Still once, on the first tty.
   if not os.getenv("COSMIC_NO_WELCOME") then
     local tty = require("cosmic.tty")
     if tty.is_tty(2) then


### PR DESCRIPTION
Works #973.

## What changed

Three deferrals, each tiny; the cascade is the story — a bare `-e x=1` boot drops from **43 loaded modules to 22**:

- **`_cli/require_hints.tl`**: `cosmic.fuzzy` moves inside the suggestion path, following the `cosmic.string` lazy-require precedent a few lines above it — Levenshtein only runs when a require has already failed.
- **`cmd/cosmic/main.tl`**: `_cli.help` is required in the `opts.help` branch, its only use.
- **`cmd/cosmic/main.tl`**: the first-run welcome block checks the tty gate first. The banner only ever prints to a terminal, so headless boots (CI, builds, scripts, benchmarks) skip the was-shown lookup and never load `_cli.welcome` — which also severs the boot edge into `cosmic.fs` (7 modules), `cosmic.sys`, `cosmic.stream`, `cosmic.fd`, and the **full `cosmo` C registration** (sqlite, argon2, re, zip — ~0.3 ms) that fs internals trigger. Behavior is unchanged: the banner still prints exactly once, on the first invocation whose stderr is a tty.

`cosmic.instrument` was evaluated for deferral and skipped: its deps are already on the chain, so the saving is one module load against a clever facade — noted here so the next round doesn't re-derive it.

## Numbers

perf-compare vs clean main (same machine, fresh baseline):

```
startup_run_lua   2.87 ms -> 1.97 ms   -31.3%  faster
39 scenarios: 0 regression, 3 faster
```

`startup_run_teal` moved only −3.2% (inside noise) as expected — the Teal path loads the compiler stack regardless. The typo-suggestion path was manually verified intact (`require("cosmic.jsn")` still suggests `cosmic.json`), and `--help` output is byte-identical.

## Gates

- `ci: PASS (5 stages)` — including the pty-backed tty tests that exercise the welcome path, and `main.tl` back at exactly the 500-line cap
- perf gate: 0 regressions, target scenario `faster` far beyond its ±10% bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQZgh4AsGFiQdzcXi4aeD1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQZgh4AsGFiQdzcXi4aeD1)_