### PR TITLE
rand: infallible CSPRNG surface — contract violations throw, values are bare

### DIFF
--- a/cosmic/fetch/extras.tl
+++ b/cosmic/fetch/extras.tl
@@ -147,11 +147,7 @@ local function encode_multipart(parts: {Part}): string | nil, string
   if #parts == 0 then
     return nil, "multipart: no parts"
   end
-  local raw, rerr = rand.bytes(12)
-  if not raw then
-    return nil, rerr
-  end
-  local boundary = "cosmic" .. codec.encode_hex(raw)
+  local boundary = "cosmic" .. codec.encode_hex(rand.bytes(12))
   local out: {string} = {}
   for _, part in ipairs(parts) do
     if not part.name or part.name == "" then

--- a/cosmic/rand.tl
+++ b/cosmic/rand.tl
@@ -2,21 +2,29 @@
 --- Wraps cosmo.GetRandomBytes for cryptographically secure randomness, and
 --- cosmo.Rand64 for fast non-cryptographic use cases.
 ---
+--- Every function here is INFALLIBLE (D22): on every supported platform
+--- the kernel CSPRNG cannot fail once the system has booted, so there is
+--- no runtime failure for a return slot to carry. Out-of-range arguments
+--- are contract violations and throw — the one thing that must never
+--- happen is code limping on without entropy. Callers check nothing.
+---
 --- Example usage:
 ---   local rand = require("cosmic.rand")
----   local key, err = rand.bytes(32)     -- cryptographically secure
+---   local key = rand.bytes(32)          -- cryptographically secure
 ---   local roll = rand.int(1, 6)         -- crypto-grade, unbiased
----   local n = rand.insecure64()             -- fast pseudo-random (not secure)
+---   local n = rand.insecure64()         -- fast pseudo-random (not secure)
 local cosmo = require("cosmo")
 
 --- Generate cryptographically secure random bytes.
 --- @param n integer The number of random bytes to generate (1..4194304)
---- @return string | nil Random bytes, or nil on failure
---- @return string? Error message on failure
-local function bytes(n: integer): string | nil, string
+--- @return string n random bytes
+local function bytes(n: integer): string
   local data, err = cosmo.GetRandomBytes(n)
   if not data then
-    return nil, err or "GetRandomBytes failed"
+    -- A failing CSPRNG is unrecoverable and an error return invites
+    -- proceeding insecurely; the binding only fails on an out-of-range
+    -- n (a contract violation) or a genuinely broken host (D22).
+    error("rand.bytes: " .. (err or "GetRandomBytes failed"), 2)
   end
   return data
 end
@@ -34,19 +42,18 @@ end
 --- The range size (max - min + 1) must not exceed 2^53.
 --- @param min integer Lower bound (inclusive)
 --- @param max integer Upper bound (inclusive)
---- @return integer | nil The random integer, or nil on failure
---- @return string? Error message on failure
-local function int(min: integer, max: integer): integer | nil, string
+--- @return integer The random integer
+local function int(min: integer, max: integer): integer
   if math.type(min) ~= "integer" or math.type(max) ~= "integer" then
-    return nil, "rand.int: min and max must be integers"
+    error("rand.int: min and max must be integers", 2)
   end
   if min > max then
-    return nil, "rand.int: min must be <= max"
+    error("rand.int: min must be <= max", 2)
   end
   local range = max - min + 1
   -- range <= 0 means max - min overflowed the signed 64-bit space.
   if range <= 0 or range > (1 << 53) then
-    return nil, "rand.int: range too large (max 2^53)"
+    error("rand.int: range too large (max 2^53)", 2)
   end
   -- Smallest byte count whose value space covers the range.
   local nbytes = 1
@@ -60,10 +67,7 @@ local function int(min: integer, max: integer): integer | nil, string
   -- accepts with probability > 1/2, so the expected iteration count is < 2.
   local limit = space - (space % range)
   while true do
-    local data, err = bytes(nbytes)
-    if not data then
-      return nil, err
-    end
+    local data = bytes(nbytes)
     local v = 0
     for i = 1, nbytes do
       v = v * 256 + string.byte(data, i)
@@ -76,44 +80,29 @@ end
 
 --- Generate a cryptographically secure uniform float in [0, 1).
 --- Uses 53 random bits, so the result has full double precision.
---- @return number | nil The random float, or nil on failure
---- @return string? Error message on failure
-local function float(): number | nil, string
-  local v, err = int(0, (1 << 53) - 1)
-  if not v then
-    return nil, err
-  end
-  return v / (1 << 53)
+--- @return number The random float
+local function float(): number
+  return int(0, (1 << 53) - 1) / (1 << 53)
 end
 
 --- Pick one element of a list uniformly at random (crypto-grade).
 --- @param list {any} The list to pick from
---- @return any The chosen element, or nil on failure or empty list
---- @return string? Error message on failure or empty list
-local function choice(list: {any}): any, string
+--- @return any The chosen element; nil only when the list is empty
+local function choice(list: {any}): any
   if #list == 0 then
-    return nil, "rand.choice: empty list"
+    return nil
   end
-  local i, err = int(1, #list)
-  if not i then
-    return nil, err
-  end
-  return list[i]
+  return list[int(1, #list)]
 end
 
 --- Shuffle a list in place with an unbiased Fisher-Yates pass
 --- (crypto-grade). Returns the same list for call chaining.
 --- @param list {any} The list to shuffle (mutated in place)
---- @return {any} | nil The shuffled list, or nil on failure
---- @return string? Error message on failure
-local function shuffle(list: {any}): {any} | nil, string
+--- @return {any} The shuffled list
+local function shuffle(list: {any}): {any}
   for i = #list, 2, -1 do
-    local j, err = int(1, i)
-    if not j then
-      return nil, err
-    end
-    local jj = j
-    list[i], list[jj] = list[jj], list[i]
+    local j = int(1, i)
+    list[i], list[j] = list[j], list[i]
   end
   return list
 end
@@ -123,33 +112,28 @@ local TOKEN_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123
 --- Generate a random alphanumeric token (crypto-grade, unbiased).
 --- Tokens are URL- and filename-safe. Each character carries ~5.95 bits
 --- of entropy, so the default 32 characters give ~190 bits.
---- @param len integer? Token length in characters (default 32)
---- @return string | nil The token, or nil on failure
---- @return string? Error message on failure
-local function token(len?: integer): string | nil, string
+--- @param len integer? Token length in characters (default 32, must be positive)
+--- @return string The token
+local function token(len?: integer): string
   len = len or 32
   if len < 1 then
-    return nil, "rand.token: len must be positive"
+    error("rand.token: len must be positive", 2)
   end
   local chars: {string} = {}
   for i = 1, len do
-    local j, err = int(1, #TOKEN_ALPHABET)
-    if not j then
-      return nil, err
-    end
-    local jj = j
-    chars[i] = TOKEN_ALPHABET:sub(jj, jj)
+    local j = int(1, #TOKEN_ALPHABET)
+    chars[i] = TOKEN_ALPHABET:sub(j, j)
   end
   return table.concat(chars)
 end
 
 local record RandModule
-  bytes: function(n: integer): string | nil, string
-  int: function(min: integer, max: integer): integer | nil, string
-  float: function(): number | nil, string
-  choice: function(list: {any}): any, string
-  shuffle: function(list: {any}): {any} | nil, string
-  token: function(len?: integer): string | nil, string
+  bytes: function(n: integer): string
+  int: function(min: integer, max: integer): integer
+  float: function(): number
+  choice: function(list: {any}): any
+  shuffle: function(list: {any}): {any}
+  token: function(len?: integer): string
   insecure64: function(): integer
 end
 

--- a/cosmic/rand_test.tl
+++ b/cosmic/rand_test.tl
@@ -3,8 +3,7 @@ local check = require("cosmic.check")
 local rand = require("cosmic.rand")
 
 local function test_bytes_returns_requested_length()
-  local b, err = rand.bytes(16)
-  assert(b, "bytes(16) failed: " .. tostring(err))
+  local b = rand.bytes(16)
   assert(#b == 16, "bytes(16) should return 16 bytes, got " .. #b)
 end
 test_bytes_returns_requested_length()
@@ -18,8 +17,7 @@ test_bytes_different_each_call()
 
 local function test_bytes_various_sizes()
   for _, size in ipairs({1, 8, 16, 32, 64, 128}) do
-    local b, err = rand.bytes(size)
-    assert(b, "bytes(" .. size .. ") failed: " .. tostring(err))
+    local b = rand.bytes(size)
     assert(#b == size, "bytes(" .. size .. ") should return " .. size .. " bytes, got " .. #b)
   end
 end
@@ -97,17 +95,18 @@ end
 test_int_wide_range()
 
 local function test_int_invalid_args()
-  local n, err = rand.int(10, 1)
-  assert(n == nil, "min > max should fail")
-  assert(err and err:match("min"), "expected min/max error, got: " .. tostring(err))
+  -- Contract violations throw (D22): a caller error is not a runtime
+  -- failure, so it does not get a return slot.
+  local ok, err = pcall(rand.int, 10, 1)
+  assert(not ok, "min > max must throw")
+  assert(tostring(err):match("min"), "expected min/max error, got: " .. tostring(err))
 
-  n, err = rand.int(1.5 as integer, 3) -- cast: deliberate invalid input
-  assert(n == nil, "non-integer min should fail")
-  assert(err, "expected error for non-integer min")
+  ok = pcall(rand.int, 1.5 as integer, 3) -- cast: deliberate invalid input
+  assert(not ok, "non-integer min must throw")
 
-  n, err = rand.int(math.mininteger, math.maxinteger)
-  assert(n == nil, "full 64-bit span should be rejected")
-  assert(err and err:match("range"), "expected range error, got: " .. tostring(err))
+  ok, err = pcall(rand.int, math.mininteger, math.maxinteger)
+  assert(not ok, "overflowing range must throw")
+  assert(tostring(err):match("range"), "expected range error, got: " .. tostring(err))
 end
 test_int_invalid_args()
 
@@ -151,8 +150,8 @@ test_choice_covers_all()
 
 local function test_choice_single_and_empty()
   assert(rand.choice({42}) == 42, "single-element choice must return it")
-  local v, err = rand.choice({})
-  assert(v == nil and err ~= nil, "empty list should fail with an error")
+  local v = rand.choice({})
+  assert(v == nil, "empty list yields nil, the one nil this module returns")
 end
 test_choice_single_and_empty()
 
@@ -222,7 +221,8 @@ end
 test_token_length_and_uniqueness()
 
 local function test_token_invalid_length()
-  local t, err = rand.token(0)
-  assert(t == nil and err ~= nil, "token(0) should fail")
+  local ok, err = pcall(rand.token, 0)
+  assert(not ok, "token(0) must throw")
+  assert(tostring(err):match("positive"), "got: " .. tostring(err))
 end
 test_token_invalid_length()

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -33,3 +33,4 @@ than editing the record it replaces.
 | D19 | what "public" means for toolchain modules, and the visibility lint | [→](d19-toolchain-visibility.md) |
 | D20 | the naming charter: ten rules, and the renames that applied them | [→](d20-naming-charter.md) |
 | D21 | carried patches: the middle path between pin and fork | [→](d21-carried-tl-patch.md) |
+| D22 | the CSPRNG surface is infallible; a broken one crashes | [→](d22-infallible-csprng.md) |

--- a/docs/decisions/d22-infallible-csprng.md
+++ b/docs/decisions/d22-infallible-csprng.md
@@ -1,0 +1,34 @@
+# D22 — the CSPRNG surface is infallible; a broken one crashes
+
+- **date:** 2026-08
+- **context:** `cosmic.rand` was fallible end to end — even
+  `rand.float(): number | nil, string`, which calls `int(0, 2^53-1)`
+  with constants and cannot fail — because one argument-range check on
+  `bytes` propagated `| nil, string` through the whole module. Meanwhile
+  `uuid.v4()` draws from the same kernel CSPRNG and returns bare
+  `string`. One of the two was wrong about the same operation, and the
+  fallible one taxed every call site with a dead nil-check. Go tried
+  both answers and settled this in Go 1.24: `crypto/rand.Read` never
+  returns an error (it crashes if the kernel CSPRNG is truly broken,
+  because error returns invited limping on insecurely), and argument
+  errors panic. Python and Rust land the same way.
+- **decision:** the CSPRNG surface (`rand.*`, `uuid.*`) is infallible.
+  - Runtime failure of the kernel CSPRNG is treated as impossible on
+    supported platforms; if the binding ever reports one, the wrapper
+    **throws** — the one sanctioned violation of "never throw from
+    library code" outside `cosmic.check`, because no caller may proceed
+    without the entropy it asked for.
+  - Out-of-range arguments (`bytes(0)`, `int(10, 1)`, `token(0)`) are
+    contract violations and throw with a message naming the contract.
+  - `choice({})` returns `nil` — an honest answer about an empty list,
+    not a failure; it is the module's only nil.
+- **rejected:** leveling `uuid` up to `string | nil, string` (adds a
+  dead nil-check to every uuid call for a failure that cannot happen);
+  keeping per-argument `nil, string` (the checker cannot distinguish
+  "caller bug" from "runtime failure", so both were handled, badly, at
+  every site).
+- **consequences:** `rand.bytes/int/float/token/shuffle` return bare
+  values; callers deleted their nil-checks. The doctrine sentence to
+  carry: a *contract violation* is the caller's bug and may throw; a
+  *runtime failure* belongs in the return channel — and a module whose
+  only failures are contract violations is infallible.


### PR DESCRIPTION
Fixes #984. Decided in the api-review Q&A: option (a), the Go 1.24 posture, with the crash-on-impossible carve-out.

**Before:** `rand` was fallible end to end — one argument-range check on `bytes` propagated `| nil, string` through the whole module. `rand.float(): number | nil, string` calls `int(0, 2^53-1)` with constants and *cannot* fail, yet forced a nil-check at every site; meanwhile `uuid.v4()` draws from the same kernel CSPRNG and returns bare `string`. One of the two was wrong about the same operation.

**After** (`cosmic/rand.tl`):
- `bytes(n)`, `int(min, max)`, `float()`, `token(len?)`, `shuffle(list)` return bare values.
- Out-of-range arguments (`int(10, 1)`, the >2^53 range, `token(0)`) are contract violations and **throw** with a message naming the contract — they are caller bugs, not runtime failures, so they get no return slot.
- A genuinely broken kernel CSPRNG also throws rather than returning an error a caller might limp past — precedent: Go 1.24's `crypto/rand.Read` (never errors; crashes on the impossible), Python's `os.urandom`, Rust's `OsRng`.
- `choice({})` returns `nil` — an honest answer about an empty list, the module's only nil, no error string attached.

The decision and its carve-out from "never throw from library code" are recorded as `docs/decisions/d22-infallible-csprng.md`, including the doctrine sentence worth keeping: *a contract violation is the caller's bug and may throw; a runtime failure belongs in the return channel — and a module whose only failures are contract violations is infallible.*

Call-site impact: exactly one production caller existed (`fetch/extras.tl`'s multipart boundary), which drops its dead nil-check; `rand_test.tl` moves the invalid-argument cases to `pcall`.

Part of the api-review backlog (#1007), phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_