### PR TITLE
hash: one naming scheme, honest verify, hex twins

### DIFF
--- a/cosmic/hash.tl
+++ b/cosmic/hash.tl
@@ -6,13 +6,13 @@
 ---   local hash = require("cosmic.hash")
 ---   local digest = hash.sha256_hex("hello")
 ---   local d = hash.digest("sha512", "hello")
+---   local d_hex = hash.digest_hex("sha512", "hello")
 ---   local tag = hash.hmac("sha256", "secret", "message")
 ---   local encoded = hash.hash_password("password123")
 ---   local valid = hash.verify_password(encoded, "password123")
 ---
---- Digest and HMAC functions return raw bytes; hex-encode with
---- cosmic.codec.encode_hex if needed. For CRC-32 checksums, see
---- cosmic.codec.crc32. For random bytes, use cosmic.rand.bytes(n).
+--- Every raw-bytes function has a `_hex` twin. For CRC-32 checksums,
+--- see cosmic.codec.crc32. For random bytes, use cosmic.rand.bytes(n).
 ---
 --- Reserved name: hash.new(algo): Hasher — a streaming digest object
 --- API (update/final) is reserved for a post-stable battery. Do not
@@ -46,19 +46,28 @@ local valid_algos < total >: {Algo: boolean} = {
   blake2b256 = true,
 }
 
+--- Argon2 variants accepted by hash_password. A cosmic-owned enum
+--- (rule 10): the generated cosmo.argon2.Variant stays an internal
+--- detail of the binding boundary.
+local enum Variant
+  "argon2id"
+  "argon2i"
+  "argon2d"
+end
+
 --- Options for password hashing with Argon2.
 --- All fields are optional and have sensible defaults.
-local record PasswordOptions
+local record Options
   --- Memory cost in kibibytes (default: 19456, i.e. 19 MiB per OWASP minimum)
-  m_cost: integer
-  --- Time cost / iterations (default: 3)
-  t_cost: integer
+  memory_kb: integer
+  --- Iteration count / Argon2 time cost (default: 3)
+  iterations: integer
   --- Parallelism factor (default: 1)
   parallelism: integer
   --- Output hash length in bytes (default: 32)
-  hash_len: integer
+  hash_bytes: integer
   --- Variant: "argon2id" (default), "argon2i", or "argon2d"
-  variant: argon2.Variant
+  variant: Variant
 end
 
 --- Compute SHA-256 hash of data.
@@ -80,40 +89,53 @@ local function sha256_hex(data: string): string
 end
 
 --- Compute a message digest of data with the given algorithm.
---- Returns raw bytes; hex-encode with cosmic.codec.encode_hex if
---- needed. For the common case, sha256 / sha256_hex are equivalent
---- conveniences. MD5 and SHA-1 are provided for interoperability with
---- existing formats only — do not use them for new security purposes.
+--- Returns raw bytes; digest_hex is the hex twin. For the common case,
+--- sha256 / sha256_hex are equivalent conveniences. MD5 and SHA-1 are
+--- provided for interoperability with existing formats only — do not
+--- use them for new security purposes.
+---
+--- Infallible: `algo` is the typed enum, so the checker already rejects
+--- every bad value; a value smuggled past it through a cast is a
+--- contract violation and throws (D22).
 --- @param algo Algo The digest algorithm
 --- @param data string The data to hash
---- @return string | nil The digest as raw bytes, or nil on error
---- @return string? Error message if the algorithm is unknown
-local function digest(algo: Algo, data: string): string | nil, string
+--- @return string The digest as raw bytes
+local function digest(algo: Algo, data: string): string
   if not valid_algos[algo] then
-    return nil, "unknown hash algorithm: " .. tostring(algo)
+    error("hash.digest: unknown algorithm: " .. tostring(algo), 2)
   end
   local d, err = cosmo.GetCryptoHash(
     string.upper(algo) as cosmo.CryptoHashName, data) -- cast: enum widening
   if not d then
-    return nil, err
+    error("hash.digest: " .. tostring(err), 2)
   end
   return d
 end
 
+--- Compute a message digest and return it as a lowercase hex string.
+--- The hex twin of digest.
+--- @param algo Algo The digest algorithm
+--- @param data string The data to hash
+--- @return string The digest as a hex string
+local function digest_hex(algo: Algo, data: string): string
+  return codec.encode_hex(digest(algo, data))
+end
+
 --- Compute an HMAC (RFC 2104) of data with a secret key using the
---- given digest algorithm. Returns raw bytes; hex-encode with
---- cosmic.codec.encode_hex if needed. Compare MACs with
---- constant_time_equal, not ==. The key must be non-empty: the C
---- binding treats an empty key as "no key" and would silently compute
---- a plain digest instead of an HMAC.
+--- given digest algorithm. Returns raw bytes; hmac_hex is the hex
+--- twin. Compare MACs with is_equal_constant_time, not ==. The key
+--- must be non-empty: the C binding treats an empty key as "no key"
+--- and would silently compute a plain digest instead of an HMAC —
+--- and keys arrive from config at runtime, so the empty key reports
+--- as an error rather than throwing.
 --- @param algo Algo The digest algorithm
 --- @param key string The secret key (must be non-empty)
 --- @param data string The message to authenticate
 --- @return string | nil The HMAC tag as raw bytes, or nil on error
---- @return string? Error message if the algorithm is unknown or the key is empty
+--- @return string? Error message when the key is empty
 local function hmac(algo: Algo, key: string, data: string): string | nil, string
   if not valid_algos[algo] then
-    return nil, "unknown hash algorithm: " .. tostring(algo)
+    error("hash.hmac: unknown algorithm: " .. tostring(algo), 2)
   end
   if #key == 0 then
     return nil, "hmac: key must be non-empty"
@@ -126,17 +148,19 @@ local function hmac(algo: Algo, key: string, data: string): string | nil, string
   return d
 end
 
---- Compute HMAC-SHA256 of data with a secret key (RFC 2104).
---- Returns raw bytes (32 bytes); hex-encode with cosmic.codec.encode_hex
---- if needed. Compare MACs with constant_time_equal, not ==. The key
---- must be non-empty: the C binding treats an empty key as "no key"
---- and would silently compute a plain digest instead of an HMAC.
+--- Compute an HMAC and return it as a lowercase hex string.
+--- The hex twin of hmac.
+--- @param algo Algo The digest algorithm
 --- @param key string The secret key (must be non-empty)
 --- @param data string The message to authenticate
---- @return string | nil The HMAC-SHA256 tag as raw bytes, or nil on error
---- @return string? Error message if the key is empty
-local function hmac_sha256(key: string, data: string): string | nil, string
-  return hmac("sha256", key, data)
+--- @return string | nil The HMAC tag as a hex string, or nil on error
+--- @return string? Error message when the key is empty
+local function hmac_hex(algo: Algo, key: string, data: string): string | nil, string
+  local d, err = hmac(algo, key, data)
+  if not d then
+    return nil, err
+  end
+  return codec.encode_hex(d)
 end
 
 --- Compare two strings in constant time (for digests and MACs).
@@ -147,7 +171,7 @@ end
 --- @param a string First string
 --- @param b string Second string
 --- @return boolean True when a and b are equal
-local function constant_time_equal(a: string, b: string): boolean
+local function is_equal_constant_time(a: string, b: string): boolean
   if #a ~= #b then
     return false
   end
@@ -161,25 +185,25 @@ end
 --- Hash a password using Argon2.
 --- Returns an encoded string suitable for storage.
 --- @param pwd string The password to hash
---- @param opts PasswordOptions? Optional configuration for the hash
+--- @param opts Options? Optional configuration for the hash
 --- @return string? The encoded hash string, or nil on error
 --- @return string? Error message if hashing failed
-local function hash_password(pwd: string, opts?: PasswordOptions): string | nil, string
+local function hash_password(pwd: string, opts?: Options): string | nil, string
   -- Build config from opts
-  -- Default m_cost to 19456 KiB (19 MiB) per OWASP minimum recommendation.
+  -- Default memory to 19456 KiB (19 MiB) per OWASP minimum recommendation.
   local config: argon2.Config = {m_cost = 19456}
   if opts then
-    if opts.m_cost then config.m_cost = opts.m_cost end
-    if opts.t_cost then config.t_cost = opts.t_cost end
+    if opts.memory_kb then config.m_cost = opts.memory_kb end
+    if opts.iterations then config.t_cost = opts.iterations end
     if opts.parallelism then config.parallelism = opts.parallelism end
-    if opts.hash_len then config.hash_len = opts.hash_len end
+    if opts.hash_bytes then config.hash_len = opts.hash_bytes end
     if opts.variant then
-      -- The generated argon2.Variant enum checks literals statically;
-      -- runtime strings smuggled in through casts still get nil, err
-      -- rather than the binding's raise (never throw from library code).
+      -- The Variant enum checks literals statically; runtime strings
+      -- smuggled in through casts still get nil, err rather than the
+      -- binding's raise (never throw from library code).
       if opts.variant == "argon2id" or opts.variant == "argon2i"
       or opts.variant == "argon2d" then
-        config.variant = opts.variant
+        config.variant = opts.variant as argon2.Variant -- cast: same literal set
       else
         return nil, "invalid variant: " .. tostring(opts.variant)
         .. " (expected argon2id, argon2i, or argon2d)"
@@ -196,43 +220,48 @@ local function hash_password(pwd: string, opts?: PasswordOptions): string | nil,
 end
 
 --- Verify a password against an Argon2 encoded hash.
---- Returns true on match, false (no error) on clean mismatch, or
---- false plus an error string when the hash is malformed or the binding
---- reports an error (e.g. "Decoding failed").
---- @param encoded string The encoded hash string (from password)
+--- Three honest outcomes, no conflation: `true` on match, `false` (no
+--- error) on a clean mismatch, and `nil` plus an error string when the
+--- stored hash is malformed or the binding reports an error — so
+--- `if hash.verify_password(stored, input) then` can never treat a
+--- corrupt credential store as a failed login.
+--- @param encoded string The encoded hash string (from hash_password)
 --- @param pwd string The password to verify
---- @return boolean True if the password matches, false otherwise
---- @return string? Error message if the hash is malformed or another error occurred
-local function verify_password(encoded: string, pwd: string): boolean, string
+--- @return boolean | nil True on match, false on mismatch, nil on error
+--- @return string? Error message when the hash is malformed
+local function verify_password(encoded: string, pwd: string): boolean | nil, string
   local ok, err = argon2.verify(encoded, pwd)
   if err then
     -- Malformed encoded string or another binding error.
-    return false, err
+    return nil, err
   end
   return ok
 end
 
 local record HashModule
   type Algo = Algo
-  type PasswordOptions = PasswordOptions
+  type Variant = Variant
+  type Options = Options
 
-  digest: function(algo: Algo, data: string): string | nil, string
+  digest: function(algo: Algo, data: string): string
+  digest_hex: function(algo: Algo, data: string): string
   hmac: function(algo: Algo, key: string, data: string): string | nil, string
+  hmac_hex: function(algo: Algo, key: string, data: string): string | nil, string
   sha256: function(data: string): string
   sha256_hex: function(data: string): string
-  hmac_sha256: function(key: string, data: string): string | nil, string
-  constant_time_equal: function(a: string, b: string): boolean
-  hash_password: function(pwd: string, opts?: PasswordOptions): string | nil, string
-  verify_password: function(encoded: string, pwd: string): boolean, string
+  is_equal_constant_time: function(a: string, b: string): boolean
+  hash_password: function(pwd: string, opts?: Options): string | nil, string
+  verify_password: function(encoded: string, pwd: string): boolean | nil, string
 end
 
 local M: HashModule = {
   digest = digest,
+  digest_hex = digest_hex,
   hmac = hmac,
+  hmac_hex = hmac_hex,
   sha256 = sha256,
   sha256_hex = sha256_hex,
-  hmac_sha256 = hmac_sha256,
-  constant_time_equal = constant_time_equal,
+  is_equal_constant_time = is_equal_constant_time,
   hash_password = hash_password,
   verify_password = verify_password,
 }

--- a/cosmic/hash_test.tl
+++ b/cosmic/hash_test.tl
@@ -107,10 +107,10 @@ test_verify_password_wrong()
 
 local function test_password_with_options()
   local encoded, err = hash.hash_password("password", {
-      m_cost = 2048,
-      t_cost = 2,
+      memory_kb = 2048,
+      iterations = 2,
       parallelism = 1,
-      hash_len = 24,
+      hash_bytes = 24,
     })
   assert(encoded, "password with options should succeed: " .. tostring(err))
   local valid = hash.verify_password(encoded, "password")
@@ -140,7 +140,7 @@ test_password_unicode()
 
 local function test_password_argon2i_roundtrip()
   local encoded = check.must(hash.hash_password("pw-i", {
-        variant = "argon2i", m_cost = 2048, t_cost = 1, parallelism = 1,
+        variant = "argon2i", memory_kb = 2048, iterations = 1, parallelism = 1,
       }))
   assert(string.match(encoded, "^%$argon2i%$"),
     "encoded string should carry the argon2i tag, got: " .. tostring(encoded))
@@ -153,7 +153,7 @@ test_password_argon2i_roundtrip()
 
 local function test_password_argon2d_roundtrip()
   local encoded = check.must(hash.hash_password("pw-d", {
-        variant = "argon2d", m_cost = 2048, t_cost = 1, parallelism = 1,
+        variant = "argon2d", memory_kb = 2048, iterations = 1, parallelism = 1,
       }))
   assert(string.match(encoded, "^%$argon2d%$"),
     "encoded string should carry the argon2d tag, got: " .. tostring(encoded))
@@ -166,17 +166,18 @@ test_password_argon2d_roundtrip()
 
 local function test_password_invalid_variant()
   -- cast: deliberate invalid input past Variant enum, for runtime guard
-  local bad = {variant = "invalid"} as hash.PasswordOptions
+  local bad = {variant = "invalid"} as hash.Options
   local encoded, err = hash.hash_password("password", bad)
   assert(encoded == nil, "password should fail with invalid variant")
   assert(err and err:match("invalid variant"), "error should mention invalid variant")
 end
 test_password_invalid_variant()
 
--- FIX 1: verify_password should return false+error on malformed hash
+-- Malformed hash is an error, not a mismatch: nil + message, so a
+-- corrupt credential store can never read as a failed login.
 local function test_verify_password_malformed_hash()
   local ok, err = hash.verify_password("not-a-hash", "password")
-  assert(ok == false, "verify_password should return false for malformed hash, got: " .. tostring(ok))
+  assert(ok == nil, "verify_password should return nil for malformed hash, got: " .. tostring(ok))
   assert(err ~= nil, "verify_password should return error message for malformed hash")
 end
 test_verify_password_malformed_hash()
@@ -189,11 +190,11 @@ local function test_verify_password_returns_two_values_on_mismatch()
 end
 test_verify_password_returns_two_values_on_mismatch()
 
--- FIX 2: default m_cost should be 19456 (OWASP minimum 19 MiB)
+-- Default memory should be 19456 KiB (OWASP minimum 19 MiB)
 local function test_password_default_mcost_is_19456()
-  local encoded, err = hash.hash_password("password", {t_cost = 1})
-  if not encoded then error("password with default m_cost should succeed: " .. tostring(err)) end
-  assert(string.match(encoded, "m=19456"), "default m_cost should be 19456, encoded string: " .. encoded)
+  local encoded, err = hash.hash_password("password", {iterations = 1})
+  if not encoded then error("password with default memory should succeed: " .. tostring(err)) end
+  assert(string.match(encoded, "m=19456"), "default memory_kb should be 19456, encoded string: " .. encoded)
 end
 test_password_default_mcost_is_19456()
 
@@ -201,7 +202,7 @@ test_password_default_mcost_is_19456()
 
 local function test_hmac_sha256_rfc4231_case1()
   local key = string.rep("\x0b", 20)
-  local tag = check.must(hash.hmac_sha256(key, "Hi There"))
+  local tag = check.must(hash.hmac("sha256", key, "Hi There"))
   local hex = codec.encode_hex(tag)
   assert(hex == "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7",
     "RFC 4231 case 1 mismatch: " .. hex)
@@ -209,7 +210,7 @@ end
 test_hmac_sha256_rfc4231_case1()
 
 local function test_hmac_sha256_rfc4231_case2()
-  local tag = check.must(hash.hmac_sha256("Jefe", "what do ya want for nothing?"))
+  local tag = check.must(hash.hmac("sha256", "Jefe", "what do ya want for nothing?"))
   local hex = codec.encode_hex(tag)
   assert(hex == "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843",
     "RFC 4231 case 2 mismatch: " .. hex)
@@ -231,9 +232,7 @@ local function test_digest_known_answers()
     blake2b256 = "bddd813c634239723171ef3fee98579b94964e3bb1cb3e427262c8c068d52319",
   }
   for algo, expected in pairs(vectors) do
-    local d, err = hash.digest(algo, "abc")
-    assert(d, "digest(" .. algo .. ") should succeed: " .. tostring(err))
-    local hex = codec.encode_hex(d)
+    local hex = codec.encode_hex(hash.digest(algo, "abc"))
     assert(hex == expected, "digest(" .. algo .. ", 'abc') mismatch: " .. hex)
   end
 end
@@ -246,7 +245,7 @@ local function test_digest_raw_bytes_length()
   }
   for algo, len in pairs(lengths) do
     local d = hash.digest(algo, "")
-    assert(d and #d == len,
+    assert(#d == len,
       "digest(" .. algo .. ") should return " .. len .. " raw bytes")
   end
 end
@@ -259,9 +258,11 @@ end
 test_digest_matches_sha256_convenience()
 
 local function test_digest_unknown_algo()
-  local d, err = hash.digest("md4" as hash.Algo, "abc") -- cast: deliberate invalid input
-  assert(d == nil, "digest should return nil for unknown algorithm")
-  assert(err and err:match("unknown hash algorithm"),
+  -- A value smuggled past the Algo enum is a contract violation (D22).
+  -- cast: deliberate invalid input
+  local ok, err = pcall(hash.digest, "md4" as hash.Algo, "abc")
+  assert(not ok, "digest must throw for a smuggled unknown algorithm")
+  assert(tostring(err):match("unknown algorithm"),
     "error should name the problem, got: " .. tostring(err))
 end
 test_digest_unknown_algo()
@@ -296,27 +297,11 @@ local function test_hmac_rfc2202_case1_sha1()
 end
 test_hmac_rfc2202_case1_sha1()
 
-local function test_hmac_matches_hmac_sha256_convenience()
-  local tag = hash.hmac("sha256", "key", "message")
-  assert(tag == check.must(hash.hmac_sha256("key", "message")),
-    "hmac('sha256') should match hmac_sha256()")
-end
-test_hmac_matches_hmac_sha256_convenience()
-
-local function test_hmac_sha256_empty_key_rejected()
-  -- hmac_sha256 delegates to hmac("sha256", ...), which refuses an
-  -- empty key rather than silently returning a plain digest.
-  local tag, err = hash.hmac_sha256("", "data")
-  assert(tag == nil, "hmac_sha256 should return nil for empty key")
-  assert(err and err:match("key"), "error should mention the key, got: " .. tostring(err))
-end
-test_hmac_sha256_empty_key_rejected()
-
 local function test_hmac_unknown_algo()
   -- cast: deliberate invalid input
-  local tag, err = hash.hmac("md4" as hash.Algo, "key", "data")
-  assert(tag == nil, "hmac should return nil for unknown algorithm")
-  assert(err and err:match("unknown hash algorithm"),
+  local ok, err = pcall(hash.hmac, "md4" as hash.Algo, "key", "data")
+  assert(not ok, "hmac must throw for a smuggled unknown algorithm")
+  assert(tostring(err):match("unknown algorithm"),
     "error should name the problem, got: " .. tostring(err))
 end
 test_hmac_unknown_algo()
@@ -333,16 +318,35 @@ test_hmac_empty_key_rejected()
 
 -- Constant-time comparison
 
-local function test_constant_time_equal()
-  assert(hash.constant_time_equal("", ""), "empty strings are equal")
-  assert(hash.constant_time_equal("abc", "abc"), "equal strings compare equal")
-  assert(not hash.constant_time_equal("abc", "abd"), "differing last byte")
-  assert(not hash.constant_time_equal("abc", "xbc"), "differing first byte")
-  assert(not hash.constant_time_equal("abc", "abcd"), "different lengths")
+local function test_is_equal_constant_time()
+  assert(hash.is_equal_constant_time("", ""), "empty strings are equal")
+  assert(hash.is_equal_constant_time("abc", "abc"), "equal strings compare equal")
+  assert(not hash.is_equal_constant_time("abc", "abd"), "differing last byte")
+  assert(not hash.is_equal_constant_time("abc", "xbc"), "differing first byte")
+  assert(not hash.is_equal_constant_time("abc", "abcd"), "different lengths")
   local d1 = hash.sha256("a")
   local d2 = hash.sha256("a")
   local d3 = hash.sha256("b")
-  assert(hash.constant_time_equal(d1, d2), "identical digests compare equal")
-  assert(not hash.constant_time_equal(d1, d3), "different digests compare unequal")
+  assert(hash.is_equal_constant_time(d1, d2), "identical digests compare equal")
+  assert(not hash.is_equal_constant_time(d1, d3), "different digests compare unequal")
 end
-test_constant_time_equal()
+test_is_equal_constant_time()
+
+-- Hex twins: every raw-bytes function has one, emitting lowercase hex.
+
+local function test_digest_hex_twin()
+  assert(hash.digest_hex("sha256", "abc")
+    == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+  assert(hash.digest_hex("sha256", "hello") == hash.sha256_hex("hello"),
+    "digest_hex('sha256') should match sha256_hex()")
+end
+test_digest_hex_twin()
+
+local function test_hmac_hex_twin()
+  local hex = check.must(hash.hmac_hex("sha256", "Jefe", "what do ya want for nothing?"))
+  assert(hex == "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843",
+    "hmac_hex should match the RFC 4231 vector: " .. hex)
+  local tag, err = hash.hmac_hex("sha256", "", "data")
+  assert(tag == nil and err ~= nil, "hmac_hex should propagate the empty-key error")
+end
+test_hmac_hex_twin()


### PR DESCRIPTION
Fixes #985.

**The load-bearing fix — `verify_password` stops conflating mismatch and corruption.** `boolean, string` returned `false` both for a wrong password and a malformed stored hash, so `if hash.verify_password(stored, input) then` silently treated credential-store corruption as a failed login. Now `boolean | nil, string`: `true` = match, `false` = clean mismatch, `nil` + error = malformed hash. (The carried tl patch narrows boolean unions via `~= nil`, so the shape is fully usable.)

The rest of the issue, same PR:

- **`PasswordOptions` → `Options {memory_kb, iterations, parallelism, hash_bytes, variant}`** — the old record broke rules 1, 2, and 7 simultaneously (`m_cost` documented in KiB, `hash_len` in bytes, `<Thing>Options` name in a one-record module). A cosmic-owned `Variant` enum is exported (rule 10) instead of leaking the generated `argon2.Variant`.
- **`digest` becomes infallible** — its only error was "unknown algorithm", but `algo` is the typed enum, so the checker already rejects every bad value; a value smuggled past it through a cast is a contract violation and throws (D22's doctrine, recorded in #1012's decision record). `hmac` keeps `| nil, string` for the empty-key case — keys arrive from config at runtime, and the C binding would otherwise silently compute a plain digest.
- **Hex twins:** `digest_hex`, `hmac_hex` — `sha256_hex` is the module's ~20-call-site workhorse and its pattern now generalizes; the docs stop pointing at `codec.encode_hex` four times.
- **`hmac_sha256` dies** (zero callers; `hmac("sha256", …)` is one token longer). **`constant_time_equal` → `is_equal_constant_time`** (rule 3).

Bootstrap note (the #1013 lesson, checked before writing): the only members tooling reaches at gen-0 are `sha256`/`sha256_hex`, unchanged here — so the renamed/removed members break cleanly with no transition aliases.

Part of the api-review backlog (#1007), phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_