### PR TITLE
sqlite: honest shapes — values() dies, query_value gains found, closes report

### DIFF
--- a/cosmic/sqlite/advanced_test.tl
+++ b/cosmic/sqlite/advanced_test.tl
@@ -47,7 +47,7 @@ local function test_bind_trailing_nils()
   local ok, err = stmt:bind("first", 42, nil)
   assert(ok, "bind with trailing nil should succeed: " .. tostring(err))
   assert(stmt:exec())
-  stmt:close()
+  assert(stmt:close())
 
   for row in check.must(db:query("SELECT * FROM t")) do
     assert(row.a == "first", "a should be 'first'")
@@ -69,7 +69,7 @@ local function test_bind_list()
   local ok, err = stmt:bind_list(values)
   assert(ok, "bind_list should succeed: " .. tostring(err))
   assert(stmt:exec())
-  stmt:close()
+  assert(stmt:close())
 
   for row in check.must(db:query("SELECT * FROM t")) do
     assert(row.a == "hello", "a should be 'hello'")
@@ -365,7 +365,7 @@ local function test_bind_named()
   local ok, err = stmt:bind_named({a = "hello", c = "world"})
   assert(ok, "bind_named should succeed: " .. tostring(err))
   assert(stmt:exec())
-  stmt:close()
+  assert(stmt:close())
 
   for row in check.must(db:query("SELECT * FROM t")) do
     assert(row.a == "hello", "a should be 'hello'")

--- a/cosmic/sqlite/close_test.tl
+++ b/cosmic/sqlite/close_test.tl
@@ -17,7 +17,7 @@ local function test_query_close_releases_early()
   local rows = check.must(db:query("SELECT * FROM t ORDER BY id"))
   local first = rows()
   assert(first and first.name == "a", "should get first row")
-  rows:close()
+  assert(rows:close())
   assert(rows() == nil, "closed iterator must yield nil")
   assert(rows:err() == nil, "close is not a step error")
 
@@ -37,12 +37,12 @@ local function test_query_close_idempotent()
   assert(db:exec("INSERT INTO t DEFAULT VALUES"))
 
   local rows = check.must(db:query("SELECT * FROM t"))
-  rows:close()
-  rows:close()
+  assert(rows:close())
+  assert(rows:close())
 
   local drained = check.must(db:query("SELECT * FROM t"))
   while drained() ~= nil do end
-  drained:close()
+  assert(drained:close())
   assert(db:close())
 end
 test_query_close_idempotent()
@@ -103,7 +103,7 @@ local function test_query_list_close_early()
   local rows = check.must(db:query_list("SELECT * FROM t WHERE name != ? ORDER BY id", {"z"}))
   local first = rows()
   assert(first and first.name == "a", "should get first row")
-  rows:close()
+  assert(rows:close())
   assert(rows() == nil, "closed query_list iterator must yield nil")
   assert(db:close())
 end
@@ -133,7 +133,7 @@ local function test_statement_rows_basic_iteration()
   assert(names[1] == "Alice" and names[2] == "Bob" and names[3] == "Carol",
     "rows should be in insertion order, got: " .. table.concat(names, ","))
   assert(rows:err() == nil, "clean iteration should report no step error")
-  stmt:close()
+  assert(stmt:close())
   assert(db:close())
 end
 test_statement_rows_basic_iteration()
@@ -147,7 +147,7 @@ local function test_statement_rows_close_does_not_finalize_statement()
   local rows = stmt:rows()
   local first = rows()
   assert(first and first.name == "a", "should get first row")
-  rows:close()
+  assert(rows:close())
   assert(rows() == nil, "closed iterator must yield nil")
   assert(rows:err() == nil, "close is not a step error")
 
@@ -160,7 +160,7 @@ local function test_statement_rows_close_does_not_finalize_statement()
     n = n + 1
   end
   assert(n == 3, "statement must be reusable after rows():close(), got: " .. tostring(n))
-  stmt:close()
+  assert(stmt:close())
   assert(db:close())
 end
 test_statement_rows_close_does_not_finalize_statement()
@@ -190,7 +190,7 @@ local function test_statement_rows_to_be_closed_scope()
     n = n + 1
   end
   assert(n == 2, "statement must be reusable after rows() <close>, got: " .. tostring(n))
-  stmt:close()
+  assert(stmt:close())
   assert(db:close())
 end
 test_statement_rows_to_be_closed_scope()
@@ -202,9 +202,9 @@ local function test_statement_rows_close_idempotent()
 
   local stmt = check.must(db:prepare("SELECT * FROM t"))
   local rows = stmt:rows()
-  rows:close()
-  rows:close()
-  stmt:close()
+  assert(rows:close())
+  assert(rows:close())
+  assert(stmt:close())
   assert(db:close())
 end
 test_statement_rows_close_idempotent()

--- a/cosmic/sqlite/data_test.tl
+++ b/cosmic/sqlite/data_test.tl
@@ -56,7 +56,7 @@ local function test_blob_bind_and_bind_list()
   local ok, err = stmt:bind(sqlite.blob("x"), "y")
   assert(ok, "bind should succeed: " .. tostring(err))
   assert(stmt:exec(), "exec should succeed")
-  stmt:close()
+  assert(stmt:close())
 
   ok, err = db:exec_list("INSERT INTO t (a, b) VALUES (?, ?)", {sqlite.blob("p"), "q"})
   assert(ok, "exec_list with blob should succeed: " .. tostring(err))

--- a/cosmic/sqlite/extras.tl
+++ b/cosmic/sqlite/extras.tl
@@ -4,15 +4,17 @@
 
 -- Mirrors of cosmic.sqlite's records (Teal records are nominal, so the
 -- boundary crosses through `any`; same convention as cosmic.sqlite.params).
-local record Values
-  metamethod __call: function(self: Values): any ...
-  err: function(self: Values): string | nil
+local record Rows
+  metamethod __call: function(self: Rows): {string: any}
+  err: function(self: Rows): string | nil
+  close: function(self: Rows): boolean, string
 end
 
 local record Stmt
   bind: function(self: Stmt, ...: any): boolean, string
-  values: function(self: Stmt): Values
-  close: function(self: Stmt)
+  rows: function(self: Stmt): Rows
+  column_name: function(self: Stmt, n: integer): string
+  close: function(self: Stmt): boolean, string
 end
 
 -- The transaction/savepoint callback: `false` or `nil, err` rolls
@@ -25,7 +27,7 @@ local type TxFn = function(any): any ...
 local record Db
   prepare: function(self: Db, sql: string): Stmt | nil, string
   exec: function(self: Db, sql: string, ...: any): boolean, string
-  query_value: function(self: Db, sql: string, ...: any): any, string
+  query_value: function(self: Db, sql: string, ...: any): any, boolean, string
   transaction: function(self: Db, fn: TxFn): boolean, string
   savepoint: function(self: Db, fn: TxFn): boolean, string
 end
@@ -38,33 +40,41 @@ local function attach(db_any: any)
   local db = db_any as Db -- cast: from any
 
   --- Return the first column of the first row, for scalar lookups like
-  --- COUNT(*) or a single-value SELECT. Returns nil with no error both
-  --- when no row matches and when the value is SQL NULL; use query_one
-  --- when that distinction matters.
-  function db:query_value(sql: string, ...: any): any, string
+  --- COUNT(*) or a single-value SELECT. Three outcomes, three answers:
+  --- (value, true) when a row matched — value nil means the value is
+  --- SQL NULL — (nil, false) when no row matched, and (nil, false, err)
+  --- on failure. The `found` flag is what separates "no row" from
+  --- "NULL value", which two return slots could not.
+  function db:query_value(sql: string, ...: any): any, boolean, string
     local stmt, err = self:prepare(sql)
     if not stmt then
-      return nil, "query failed: " .. (err or "unknown error")
+      return nil, false, "query failed: " .. (err or "unknown error")
     end
     local st = stmt
     local ok, bind_err = st:bind(...)
     if not ok then
-      st:close()
-      return nil, "bind failed: " .. (bind_err or "unknown error")
+      local _ok, _err = st:close()
+      return nil, false, "bind failed: " .. (bind_err or "unknown error")
     end
-    -- Dodges Values' NULL-first-column/generic-for hazard: this calls the
-    -- iterator directly for exactly one row instead of a `for ... in`
-    -- loop, so a NULL column 1 (the common case here -- query_value IS the
-    -- first column) returns cleanly as v == nil rather than being read as
-    -- end-of-iteration.
-    local vals = st:values()
-    local v = vals()
-    st:close()
-    local step_err = vals:err()
-    if step_err then
-      return nil, step_err
+    -- One direct iterator call, not a `for` loop: the row arrives as a
+    -- {column: value} map, so a NULL first column cannot be mistaken
+    -- for end-of-iteration.
+    local rows = st:rows()
+    local row = rows()
+    if row == nil then
+      local step_err = rows:err()
+      local _ok, _err = st:close()
+      if step_err then
+        return nil, false, step_err
+      end
+      return nil, false
     end
-    return v
+    -- column_name is valid only after the first step, which the row
+    -- above performed.
+    local name = st:column_name(1)
+    local _rok, _rerr = rows:close()
+    local _ok, _err = st:close()
+    return row[name], true
   end
 
   --- Execute fn within a transaction. BEGIN before fn; COMMIT if fn returns

--- a/cosmic/sqlite/extras_test.tl
+++ b/cosmic/sqlite/extras_test.tl
@@ -13,8 +13,8 @@ end
 
 local function test_query_value_count()
   local db = open_db()
-  local n, err = db:query_value("SELECT COUNT(*) FROM t")
-  assert(n == 2, "expected 2, got " .. tostring(n) .. " (" .. tostring(err) .. ")")
+  local n, found = db:query_value("SELECT COUNT(*) FROM t")
+  assert(n == 2 and found, "expected 2, got " .. tostring(n))
   assert(db:close())
 end
 test_query_value_count()
@@ -25,6 +25,8 @@ local function test_query_value_with_params()
   assert(name == "bob", "expected bob, got " .. tostring(name))
   local score = db:query_value("SELECT score FROM t WHERE name = ?", "alice")
   assert(score == 1.5, "expected 1.5, got " .. tostring(score))
+  -- The found flag separates "no row" from "NULL value" (three
+  -- outcomes, three answers).
   assert(db:close())
 end
 test_query_value_with_params()
@@ -39,8 +41,9 @@ test_query_value_first_column_first_row()
 
 local function test_query_value_no_rows()
   local db = open_db()
-  local v, err = db:query_value("SELECT name FROM t WHERE id = ?", 999)
+  local v, found, err = db:query_value("SELECT name FROM t WHERE id = ?", 999)
   assert(v == nil, "expected nil for no rows")
+  assert(found == false, "no row must report found = false")
   assert(err == nil, "expected no error for no rows, got " .. tostring(err))
   assert(db:close())
 end
@@ -49,16 +52,18 @@ test_query_value_no_rows()
 local function test_query_value_null()
   local db = open_db()
   assert(db:exec("INSERT INTO t (name, score) VALUES (NULL, 9.0)"))
-  local v, err = db:query_value("SELECT name FROM t WHERE score = 9.0")
+  local v, found, err = db:query_value("SELECT name FROM t WHERE score = 9.0")
   assert(v == nil and err == nil, "expected nil, no error for SQL NULL")
+  assert(found == true, "a matched row with a NULL value must report found = true")
   assert(db:close())
 end
 test_query_value_null()
 
 local function test_query_value_bad_sql()
   local db = open_db()
-  local v, err = db:query_value("SELECT nope FROM missing")
+  local v, found, err = db:query_value("SELECT nope FROM missing")
   assert(v == nil, "expected nil for bad SQL")
+  assert(found == false, "a failure must report found = false")
   assert(err ~= nil, "expected an error message")
   assert(db:close())
 end

--- a/cosmic/sqlite/init.tl
+++ b/cosmic/sqlite/init.tl
@@ -45,30 +45,10 @@ local record Rows
   metamethod __close: function(self: Rows)
   --- Step error from iteration, or nil after a clean SQLITE_DONE.
   err: function(self: Rows): string | nil
-  --- Release the underlying prepared statement early idempotent.
-  close: function(self: Rows)
-end
-
---- Callable positional-value iterator, the `Statement:values()` counterpart
---- to `Rows`. Same `:err()` contract.
----
---- CAVEAT: a row whose FIRST column is SQL NULL returns `nil` as its first
---- (and, to Lua, only visible) value, which a `for ... in` generic-for loop
---- reads as end-of-iteration — the row is silently dropped, `:err()` stays
---- nil, and remaining rows are never stepped. This is inherent to Lua's
---- generic-for protocol (it stops at a nil first return) and the contract
---- cannot change without breaking `local a, b, c = iter()` positional
---- callers. Use `rows()` (or call the iterator directly, `local a, b, c =
---- iter()`, one row at a time) when column 1 may be NULL.
-local record Values
-  metamethod __call: function(self: Values): any ...
-  metamethod __close: function(self: Values)
-  --- Step error from iteration, or nil after a clean SQLITE_DONE.
-  err: function(self: Values): string | nil
-  --- End iteration early (idempotent); also runs on scope exit via
-  --- to-be-closed. Does not finalize the owning Statement — that is
-  --- Statement:close()'s job, since the Statement may be reused.
-  close: function(self: Values)
+  --- Release the underlying prepared statement early (idempotent; a
+  --- second call returns true). Reports a finalize failure instead of
+  --- swallowing it.
+  close: function(self: Rows): boolean, string
 end
 
 --- Statement handle with automatic cleanup.
@@ -86,11 +66,6 @@ local record Statement
   --- Callable iterator over result rows as {column: value} tables;
   --- check `:err()` after the loop for step errors.
   rows: function(self: Statement): Rows
-  --- Callable iterator yielding each row's column values positionally;
-  --- same `:err()` contract as rows(). CAVEAT: a NULL first column ends a
-  --- `for` loop over this early (see Values above) -- prefer rows() when
-  --- column 1 may be NULL.
-  values: function(self: Statement): Values
   --- Step the statement to completion (for INSERT/UPDATE/DDL).
   exec: function(self: Statement): boolean, string
   --- Reset for re-execution; existing bindings are kept.
@@ -99,9 +74,10 @@ local record Statement
   columns: function(self: Statement): integer
   --- Name of result column n (1-indexed).
   column_name: function(self: Statement, n: integer): string
-  --- Finalize the statement (idempotent); also runs on scope exit via
-  --- to-be-closed.
-  close: function(self: Statement)
+  --- Finalize the statement (idempotent; a second call returns true);
+  --- also runs on scope exit via to-be-closed. Reports a finalize
+  --- failure instead of swallowing it.
+  close: function(self: Statement): boolean, string
 end
 
 --- Database handle with automatic cleanup.
@@ -118,12 +94,17 @@ local record Database
   query_list: function(self: Database, sql: string, values: {any}): Rows | nil, string
   --- query() with :name placeholders bound from a key/value table.
   query_named: function(self: Database, sql: string, params: {string: any}): Rows | nil, string
-  --- First matching row, or nil (with no error) when no row matches.
-  --- The statement is always finalized, even when rows remain.
+  --- First matching row. `nil, nil` means NO ROW MATCHED — an ordinary
+  --- empty result, not a failure — so `check.must(db:query_one(...))`
+  --- throws on it; guard with `if row then` instead. `nil, err` is a
+  --- real failure. The statement is always finalized, even when rows
+  --- remain.
   query_one: function(self: Database, sql: string, ...: any): {string: any} | nil, string
-  --- First column of the first row (nil + no error when no row matches
-  --- or the value is SQL NULL); see cosmic.sqlite.extras.
-  query_value: function(self: Database, sql: string, ...: any): any, string
+  --- First column of the first row, plus a `found` flag that separates
+  --- the three outcomes two slots could not: (value, true) on a row —
+  --- value nil means SQL NULL — (nil, false) when no row matched, and
+  --- (nil, false, err) on failure; see cosmic.sqlite.extras.
+  query_value: function(self: Database, sql: string, ...: any): any, boolean, string
   --- Execute sql with positional `?` parameters; use for statements
   --- that return no rows (INSERT/UPDATE/DELETE/DDL). Multi-statement
   --- sql runs only in the no-parameter form; with parameters it is
@@ -143,10 +124,13 @@ local record Database
   --- Run fn in a nestable savepoint with transaction's rollback rules;
   --- see cosmic.sqlite.extras.
   savepoint: function(self: Database, fn: function(Database): any ...): boolean, string
-  --- rowid of the most recent successful INSERT (0 if closed).
-  last_insert_rowid: function(self: Database): integer
-  --- Rows modified by the most recent INSERT/UPDATE/DELETE (0 if closed).
-  changes: function(self: Database): integer
+  --- rowid of the most recent successful INSERT; nil + error once the
+  --- database is closed (0 is a legitimate live value, so it cannot
+  --- double as the closed marker).
+  last_insert_rowid: function(self: Database): integer | nil, string
+  --- Rows modified by the most recent INSERT/UPDATE/DELETE; nil + error
+  --- once the database is closed.
+  changes: function(self: Database): integer | nil, string
   --- Close the database and its cached statements (idempotent); also
   --- runs on scope exit via to-be-closed. Live user-prepared
   --- Statements do not block it: the binding finalizes them during
@@ -226,43 +210,6 @@ local function make_statement(raw_stmt: lsqlite3.Statement, raw_db: lsqlite3.Dat
     return iter as Rows -- cast: row_iter record to public Rows
   end
 
-  -- CAVEAT (see Values above): a `for ... in` loop over this iterator ends
-  -- the moment column 1 comes back NULL, because that's Lua's own signal
-  -- for end-of-iteration. rows() doesn't have this hazard; calling the
-  -- iterator directly one row at a time (`local a, b, c = iter()`) does.
-  function stmt:values(): Values
-    local step_err: string
-    local done = false
-    local col_count = raw_stmt:columns()
-
-    local iter = setmetatable({} as Values, { -- cast: empty table into callable record
-        __call = function(_: Values): any ...
-          if done then
-            return nil
-          end
-          local rc = raw_stmt:step()
-          if rc == sqlite3.ROW then
-            local vals: {integer: any} = {}
-            for idx = 0, col_count - 1 do
-              vals[idx + 1] = raw_stmt:get_value(idx)
-            end
-            -- Bound the unpack: a NULL first column leaves vals[1] == nil,
-            -- and an unbounded unpack would drop the remaining columns.
-            return table.unpack(vals, 1, col_count)
-          end
-          if rc ~= sqlite3.DONE then
-            step_err = raw_db:errmsg()
-          end
-          done = true
-          return nil
-        end,
-        __close = function(self: Values) self:close() end,
-      })
-    iter.err = function(_: Values): string | nil return step_err end
-    iter.close = function(_: Values) done = true end
-    return iter
-  end
-
   function stmt:exec(): boolean, string
     local rc = raw_stmt:step()
     if rc ~= sqlite3.DONE and rc ~= sqlite3.ROW then
@@ -283,23 +230,27 @@ local function make_statement(raw_stmt: lsqlite3.Statement, raw_db: lsqlite3.Dat
     return raw_stmt:get_name(n - 1)
   end
 
-  stmt.close = function(_: Statement)
-    if closed then return end
+  stmt.close = function(_: Statement): boolean, string
+    if closed then return true end
     closed = true
     -- The binding finalizes outstanding statements when the DATABASE
     -- closes; finalize on such a dead vm throws. Guard so close (and
     -- the __gc/__close paths that reach it) never raises.
     if raw_stmt:isopen() then
-      local _ = raw_stmt:finalize()
+      local rc = raw_stmt:finalize()
+      if rc ~= sqlite3.OK then
+        return false, raw_db:errmsg()
+      end
     end
+    return true
   end
 
   -- __gc is the backstop for an abandoned user Statement, matching the
   -- Rows iterator: without it a dropped db:prepare() handle leaks its
   -- raw statement — the very SQLITE_BUSY that makes db:close() fail.
   return setmetatable(stmt, {
-      __close = function(self: Statement) self:close() end,
-      __gc = function(self: Statement) self:close() end,
+      __close = function(self: Statement) local _ok, _err = self:close() end,
+      __gc = function(self: Statement) local _ok, _err = self:close() end,
     })
 end
 
@@ -386,7 +337,7 @@ local function make_database(raw_db: lsqlite3.Database): Database
       first = row
       break
     end
-    it:close()
+    local _cok, _cerr = it:close()
     -- Surface a step error rather than a partial row that looks clean.
     local step_err = it:err()
     if step_err then
@@ -395,16 +346,16 @@ local function make_database(raw_db: lsqlite3.Database): Database
     return first
   end
 
-  function db:last_insert_rowid(): integer
+  function db:last_insert_rowid(): integer | nil, string
     if closed then
-      return 0
+      return nil, "database is closed"
     end
     return raw_db:last_insert_rowid()
   end
 
-  function db:changes(): integer
+  function db:changes(): integer | nil, string
     if closed then
-      return 0
+      return nil, "database is closed"
     end
     return raw_db:changes()
   end
@@ -484,7 +435,6 @@ local record sqlite
   type Database = Database
   type Statement = Statement
   type Rows = Rows
-  type Values = Values
 
   open: function(filename: string, opts?: Options): Database | nil, string
   blob: function(data: string): bind_mod.Blob

--- a/cosmic/sqlite/init_example.tl
+++ b/cosmic/sqlite/init_example.tl
@@ -54,7 +54,7 @@ local function Example_prepared()
   stmt:reset()
   assert(stmt:bind("Bob"))
   assert(stmt:exec())
-  stmt:close()
+  assert(stmt:close())
 
   for row in check.must(db:query("SELECT * FROM users ORDER BY id")) do
     print(row.id, row.name)

--- a/cosmic/sqlite/init_test.tl
+++ b/cosmic/sqlite/init_test.tl
@@ -129,7 +129,7 @@ local function test_prepare_bind_exec()
   assert(ok, "exec should succeed: " .. tostring(err))
 
   assert(db:last_insert_rowid() == 1, "should have inserted row")
-  stmt:close()
+  assert(stmt:close())
   assert(db:close())
 end
 test_prepare_bind_exec()
@@ -153,7 +153,7 @@ local function test_statement_reset()
   stmt:reset()
   assert(stmt:bind("second"))
   assert(stmt:exec())
-  stmt:close()
+  assert(stmt:close())
 
   local count = 0
   for _ in check.must(db:query("SELECT * FROM t")) do
@@ -214,22 +214,25 @@ local function test_query_empty_results()
 end
 test_query_empty_results()
 
-local function test_statement_values()
+local function test_statement_rows_positional_lookup()
+  -- values() is gone (a NULL first column silently ended a generic-for
+  -- over it, #983); rows() plus column_name covers the positional read.
   local db = check.must(sqlite.open(":memory:"))
   assert(db:exec("CREATE TABLE t (a TEXT, b INTEGER, c REAL)"))
   assert(db:exec("INSERT INTO t VALUES ('hello', 42, 3.14)"))
 
   local stmt = check.must(db:prepare("SELECT * FROM t"))
-  local iter = stmt:values()
-  local a, b, c = iter()
+  local rows = stmt:rows()
+  local row = rows()
 
-  assert(a == "hello", "first value should be 'hello'")
-  assert(b == 42, "second value should be 42")
-  assert(math.abs((c as number) - 3.14) < 0.001, "third ~3.14") -- cast: from any
-  stmt:close()
+  assert(row.a == "hello", "first value should be 'hello'")
+  assert(row.b == 42, "second value should be 42")
+  assert(math.abs((row.c as number) - 3.14) < 0.001, "third ~3.14") -- cast: from any
+  assert(stmt:column_name(1) == "a", "column_name maps position to name")
+  assert(stmt:close())
   assert(db:close())
 end
-test_statement_values()
+test_statement_rows_positional_lookup()
 
 -- Iterator error surfacing (step errors must not masquerade as end-of-rows)
 
@@ -270,20 +273,22 @@ local function test_query_one_step_error()
 end
 test_query_one_step_error()
 
--- values(): a NULL first column must not truncate the row (bounded unpack)
-local function test_values_null_first_column()
+-- A NULL first column is an ordinary row through rows(): a map row can
+-- never be mistaken for end-of-iteration (the hazard that killed values()).
+local function test_rows_null_first_column()
   local db = check.must(sqlite.open(":memory:"))
   assert(db:exec("CREATE TABLE t (a TEXT, b INTEGER, c TEXT)"))
   assert(db:exec("INSERT INTO t VALUES (NULL, 42, 'z')"))
   local stmt = check.must(db:prepare("SELECT * FROM t"))
-  local a, b, c = stmt:values()()
-  assert(a == nil, "first column should be nil")
-  assert(b == 42, "second column should survive NULL-first-column unpack")
-  assert(c == "z", "third column should survive NULL-first-column unpack")
-  stmt:close()
+  local row = stmt:rows()()
+  assert(row ~= nil, "a NULL first column must not end iteration")
+  assert(row.a == nil, "first column should be nil (SQL NULL)")
+  assert(row.b == 42, "second column should survive")
+  assert(row.c == "z", "third column should survive")
+  assert(stmt:close())
   assert(db:close())
 end
-test_values_null_first_column()
+test_rows_null_first_column()
 
 -- Use-after-close returns errors instead of throwing/crashing
 local function test_use_after_close()
@@ -313,7 +318,7 @@ local function test_column_name_1indexed()
   assert(stmt:column_name(1) == "first_col", "column 1 should be 'first_col'")
   assert(stmt:column_name(2) == "second_col", "column 2 should be 'second_col'")
   assert(stmt:column_name(3) == "third_col", "column 3 should be 'third_col'")
-  stmt:close()
+  assert(stmt:close())
   assert(db:close())
 end
 test_column_name_1indexed()
@@ -340,7 +345,7 @@ local function test_statement_close()
   local db = check.must(sqlite.open(":memory:"))
   assert(db:exec("CREATE TABLE t (id INTEGER)"))
   local stmt = check.must(db:prepare("SELECT * FROM t"))
-  stmt:close()
+  assert(stmt:close())
   assert(db:close())
 end
 test_statement_close()
@@ -348,8 +353,8 @@ test_statement_close()
 local function test_double_close_safe()
   local db = check.must(sqlite.open(":memory:"))
   local stmt = check.must(db:prepare("SELECT 1"))
-  stmt:close()
-  stmt:close()
+  assert(stmt:close())
+  assert(stmt:close())
   assert(db:close())
   assert(db:close())
 end
@@ -391,7 +396,7 @@ local function test_multiple_params()
   local stmt = check.must(db:prepare("INSERT INTO t (a, b, c) VALUES (?, ?, ?)"))
   assert(stmt:bind("hello", 42, 3.14))
   assert(stmt:exec())
-  stmt:close()
+  assert(stmt:close())
 
   for row in check.must(db:query("SELECT * FROM t")) do
     assert(row.a == "hello", "a should be 'hello'")

--- a/cosmic/sqlite/init_test.tl
+++ b/cosmic/sqlite/init_test.tl
@@ -296,7 +296,6 @@ local function test_use_after_close()
   assert(not ok and type(exec_err) == "string", "exec after close should error")
   local iter, query_err = db:query("SELECT * FROM t")
   assert(iter == nil and type(query_err) == "string", "query after close should error")
-  -- 0 is a legitimate live value, so closed reports nil, err instead.
   local rowid, rerr = db:last_insert_rowid()
   assert(rowid == nil and type(rerr) == "string", "rowid after close: nil, err")
   local nchanged, cerr = db:changes()

--- a/cosmic/sqlite/init_test.tl
+++ b/cosmic/sqlite/init_test.tl
@@ -215,8 +215,6 @@ end
 test_query_empty_results()
 
 local function test_statement_rows_positional_lookup()
-  -- values() is gone (a NULL first column silently ended a generic-for
-  -- over it, #983); rows() plus column_name covers the positional read.
   local db = check.must(sqlite.open(":memory:"))
   assert(db:exec("CREATE TABLE t (a TEXT, b INTEGER, c REAL)"))
   assert(db:exec("INSERT INTO t VALUES ('hello', 42, 3.14)"))
@@ -228,7 +226,6 @@ local function test_statement_rows_positional_lookup()
   assert(row.a == "hello", "first value should be 'hello'")
   assert(row.b == 42, "second value should be 42")
   assert(math.abs((row.c as number) - 3.14) < 0.001, "third ~3.14") -- cast: from any
-  assert(stmt:column_name(1) == "a", "column_name maps position to name")
   assert(stmt:close())
   assert(db:close())
 end
@@ -299,8 +296,11 @@ local function test_use_after_close()
   assert(not ok and type(exec_err) == "string", "exec after close should error")
   local iter, query_err = db:query("SELECT * FROM t")
   assert(iter == nil and type(query_err) == "string", "query after close should error")
-  assert(db:last_insert_rowid() == 0, "last_insert_rowid after close should not crash")
-  assert(db:changes() == 0, "changes after close should not crash")
+  -- 0 is a legitimate live value, so closed reports nil, err instead.
+  local rowid, rerr = db:last_insert_rowid()
+  assert(rowid == nil and type(rerr) == "string", "rowid after close: nil, err")
+  local nchanged, cerr = db:changes()
+  assert(nchanged == nil and type(cerr) == "string", "changes after close: nil, err")
 end
 test_use_after_close()
 

--- a/cosmic/sqlite/lifecycle_test.tl
+++ b/cosmic/sqlite/lifecycle_test.tl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cosmic
 --- Lifecycle tests for cosmic.sqlite: close ordering, the Statement
---- garbage-collection backstop, Values early close, and the
+--- garbage-collection backstop, Rows early close, and the
 --- multi-statement rejection on parameterized paths.
 local sqlite = require("cosmic.sqlite")
 local check = require("cosmic.check")
@@ -22,7 +22,7 @@ local function test_close_with_live_statement()
   local db = open_db()
   local stmt = check.must(db:prepare("SELECT name FROM t"))
   assert(db:close(), "close finalizes live statements and succeeds")
-  stmt:close()
+  assert(stmt:close())
   assert(db:close(), "close stays idempotent after success")
 end
 test_close_with_live_statement()
@@ -43,37 +43,38 @@ local function test_statement_gc_backstop()
 end
 test_statement_gc_backstop()
 
--- Values:close ends iteration early (and <close> drives it); it must
--- not finalize the owning Statement, which stays reusable.
-local function test_values_close_ends_iteration()
+-- Rows:close ends iteration early (and <close> drives it); through
+-- Statement:rows() it must not finalize the owning Statement, which
+-- stays reusable.
+local function test_rows_close_ends_iteration()
   local db = open_db()
   local stmt = check.must(db:prepare("SELECT id, name FROM t ORDER BY id"))
   assert(stmt:bind())
   do
-    local vals < close > = stmt:values()
-    local id, name = vals()
-    check.eq(id, 1)
-    check.eq(name, "alice")
-    vals:close()
-    local after = vals()
-    check.eq(after, nil, "a closed Values yields nothing")
-    check.eq(vals:err(), nil, "close is not an error")
+    local rows < close > = stmt:rows()
+    local row = rows()
+    check.eq(row.id, 1)
+    check.eq(row.name, "alice")
+    assert(rows:close())
+    local after = rows()
+    check.eq(after, nil, "a closed Rows yields nothing")
+    check.eq(rows:err(), nil, "close is not an error")
   end
-  -- The Statement survives its Values: rebind and drain it fully.
+  -- The Statement survives its Rows: rebind and drain it fully.
   assert(stmt:bind())
-  local vals2 = stmt:values()
+  local vals2 = stmt:rows()
   local n = 0
   while true do
     local id = vals2()
     if id == nil then break end
     n = n + 1
   end
-  check.eq(n, 2, "statement must be reusable after Values:close")
+  check.eq(n, 2, "statement must be reusable after Rows:close")
   check.eq(vals2:err(), nil)
-  stmt:close()
+  assert(stmt:close())
   assert(db:close())
 end
-test_values_close_ends_iteration()
+test_rows_close_ends_iteration()
 
 -- Parameterized exec/query of multi-statement SQL is rejected loudly:
 -- sqlite compiles only the first statement, so the old behavior ran a

--- a/cosmic/sqlite/params.tl
+++ b/cosmic/sqlite/params.tl
@@ -12,7 +12,7 @@ local record Rows
   metamethod __call: function(self: Rows): {string: any}
   metamethod __close: function(self: Rows)
   err: function(self: Rows): string | nil
-  close: function(self: Rows)
+  close: function(self: Rows): boolean, string
 end
 
 -- Same rejection as cosmic.sqlite.stmt_cache: prepare compiles only the
@@ -28,7 +28,7 @@ local record Stmt
   bind_named: function(self: Stmt, params: {string: any}): boolean, string
   exec: function(self: Stmt): boolean, string
   rows: function(self: Stmt): Rows
-  close: function(self: Stmt)
+  close: function(self: Stmt): boolean, string
 end
 
 local record Db
@@ -46,12 +46,14 @@ end
 local function make_query_iter(stmt: Stmt): Rows
   local raw_iter = stmt:rows()
   local done = false
-  local function release()
+  -- Reports the statement's finalize outcome (close() forwards it);
+  -- a repeat call is a clean true.
+  local function release(): boolean, string
     if done then
-      return
+      return true
     end
     done = true
-    local _cok, _cerr = stmt:close()
+    return stmt:close()
   end
   local iter = setmetatable({} as Rows, { -- cast: table seeded as record
       __call = function(_: Rows): {string: any}
@@ -60,21 +62,21 @@ local function make_query_iter(stmt: Stmt): Rows
         end
         local row = raw_iter()
         if row == nil then
-          release()
+          local _ok, _err = release()
           return nil
         end
         return row
       end,
       __close = function(_: Rows)
-        release()
+        local _ok, _err = release()
       end,
       __gc = function(_: Rows)
-        release()
+        local _ok, _err = release()
       end,
     })
   iter.err = function(_: Rows): string | nil return raw_iter:err() end
-  iter.close = function(_: Rows)
-    release()
+  iter.close = function(_: Rows): boolean, string
+    return release()
   end
   return iter
 end

--- a/cosmic/sqlite/params.tl
+++ b/cosmic/sqlite/params.tl
@@ -51,7 +51,7 @@ local function make_query_iter(stmt: Stmt): Rows
       return
     end
     done = true
-    stmt:close()
+    local _cok, _cerr = stmt:close()
   end
   local iter = setmetatable({} as Rows, { -- cast: table seeded as record
       __call = function(_: Rows): {string: any}
@@ -100,12 +100,12 @@ local function attach(db_any: any)
 
     local ok, bind_err = st:bind_list(values)
     if not ok then
-      st:close()
+      local _cok, _cerr = st:close()
       return false, bind_err or "bind failed"
     end
 
     local exec_ok, exec_err = st:exec()
-    st:close()
+    local _cok, _cerr = st:close()
     return exec_ok, exec_err
   end
 
@@ -123,12 +123,12 @@ local function attach(db_any: any)
 
     local ok, bind_err = st:bind_named(params)
     if not ok then
-      st:close()
+      local _cok, _cerr = st:close()
       return false, bind_err or "bind failed"
     end
 
     local exec_ok, exec_err = st:exec()
-    st:close()
+    local _cok, _cerr = st:close()
     return exec_ok, exec_err
   end
 
@@ -147,7 +147,7 @@ local function attach(db_any: any)
 
     local ok, bind_err = st:bind_list(values)
     if not ok then
-      st:close()
+      local _cok, _cerr = st:close()
       return nil, "bind failed: " .. (bind_err or "unknown error")
     end
 
@@ -168,7 +168,7 @@ local function attach(db_any: any)
 
     local ok, bind_err = st:bind_named(params)
     if not ok then
-      st:close()
+      local _cok, _cerr = st:close()
       return nil, "bind failed: " .. (bind_err or "unknown error")
     end
 

--- a/cosmic/sqlite/row_iter.tl
+++ b/cosmic/sqlite/row_iter.tl
@@ -17,7 +17,7 @@ local record Rows
   metamethod __call: function(self: Rows): {string: any}
   metamethod __close: function(self: Rows)
   err: function(self: Rows): string | nil
-  close: function(self: Rows)
+  close: function(self: Rows): boolean, string
 end
 
 -- on_close mirrors stmt_cache:checkout — non-nil returns the shared cached
@@ -40,9 +40,11 @@ local function make(raw_stmt: lsqlite3.Statement, raw_db: lsqlite3.Database, on_
 
   -- Release exactly once: return the shared cached slot, or finalize a
   -- throwaway. Reached from drain, from close/<close>, and from __gc.
-  local function release()
+  -- Reports a finalize failure (close() forwards it); a repeat call is
+  -- a clean true.
+  local function release(): boolean, string
     if done then
-      return
+      return true
     end
     done = true
     if on_close then
@@ -51,8 +53,12 @@ local function make(raw_stmt: lsqlite3.Statement, raw_db: lsqlite3.Database, on_
       -- isopen guard: the binding finalizes statements when the
       -- database closes, and finalize on that dead vm throws — from
       -- __gc, no less. Never raise from a release path.
-      local _ = raw_stmt:finalize()
+      local rc = raw_stmt:finalize()
+      if rc ~= 0 then
+        return false, raw_db:errmsg()
+      end
     end
+    return true
   end
 
   local iter = setmetatable({} as Rows, { -- cast: table seeded as record
@@ -80,19 +86,19 @@ local function make(raw_stmt: lsqlite3.Statement, raw_db: lsqlite3.Database, on_
         if rc ~= done_code then
           step_err = raw_db:errmsg()
         end
-        release()
+        local _ok, _err = release()
         return nil
       end,
       __close = function(_: Rows)
-        release()
+        local _ok, _err = release()
       end,
       __gc = function(_: Rows)
-        release()
+        local _ok, _err = release()
       end,
     })
   iter.err = function(_: Rows): string | nil return step_err end
-  iter.close = function(_: Rows)
-    release()
+  iter.close = function(_: Rows): boolean, string
+    return release()
   end
   return iter
 end


### PR DESCRIPTION
Fixes #983.

**`Statement:values()` and the `Values` record are gone.** A row whose first column was SQL NULL was silently dropped — Lua's generic-for reads a nil first return as end-of-iteration — with `:err()` staying nil and remaining rows never stepped. The module documented it as unfixable (`init.tl:55-62`) while its own `extras.tl` routed around it internally; the positional form had no in-tree callers outside tests. `rows()` is strictly safer (a map row can never be mistaken for end-of-iteration), and `column_name` covers positional lookup after the first step.

**`query_value` returns `(value, found, err)`.** The old `any, string` folded three outcomes into two slots — no row, SQL NULL, and error — and its own doc admitted the ambiguity ("returns nil with no error both when no row matches and when the value is SQL NULL"). The `found` flag separates them: `(value, true)` on a row (value nil = SQL NULL), `(nil, false)` on no row, `(nil, false, err)` on failure. Rebuilt on `rows()` since `values()` is gone.

**Closed-database getters stop lying.** `changes()` and `last_insert_rowid()` returned `0` when closed — also a legitimate live value. Now `integer | nil, string` with `nil, "database is closed"`.

**Close symmetry.** `Statement:close` and `Rows:close` (including the `query_list`/`query_named` wrapper, which had the same silent-close hole one layer up) now return `boolean, string`, reporting a finalize failure instead of discarding it — leveling up to `Database:close`'s contract, per its own retry reasoning. Idempotent: a repeat close is a clean `true`. The `__gc`/`__close` paths still never raise.

**`query_one`'s `nil, nil` contract is documented at the function**: no row matched is an ordinary empty result, so `check.must(db:query_one(...))` throws on it — guard with `if row then`.

Deliberately not here (that's #982): the `Params` consolidation, the explicit transaction verdict, and `exec_script`.

Part of the api-review backlog (#1007), phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_