### PR TITLE
fs: write() applies mode on overwrite; extractors agree; closes report

### DIFF
--- a/cosmic/fs/file.tl
+++ b/cosmic/fs/file.tl
@@ -20,16 +20,29 @@ local function read(path: string): string | nil, string
   return data
 end
 
---- Write data to a file, creating or overwriting it.
+--- Write data to a file, creating or overwriting it. A given `mode` is
+--- applied EXACTLY, whether the file is created or overwritten (and not
+--- masked by the umask) — Barf's own mode applies only at creation,
+--- which left zip and tar extraction disagreeing about the permissions
+--- of an overwritten file. Without `mode`, a new file is created 0644
+--- (umask-masked) and an existing file keeps its permissions.
 --- @param path string Path to the file
 --- @param data string Data to write
---- @param mode integer Permission bits when creating (default 0644)
+--- @param mode integer Permission bits, applied exactly (default 0644 on create)
 --- @return boolean True on success
 --- @return string Error message if failed
 local function write(path: string, data: string, mode?: integer): boolean, string
   local ok, err = cosmo.Barf(path, data, {mode = mode})
   if not ok then
     return false, err or ("failed to write file: " .. path)
+  end
+  if mode then
+    -- Same posture as fs.copy: open()/Barf's mode is masked by the
+    -- umask and skipped on overwrite; chmod applies the exact bits.
+    local cok, cerr = unix.chmod(path, mode)
+    if not cok then
+      return false, errstr(cerr, "write: chmod: " .. path)
+    end
   end
   return true
 end

--- a/cosmic/fs/ops.tl
+++ b/cosmic/fs/ops.tl
@@ -68,10 +68,18 @@ local function copy(src: string, dst: string): boolean, string
   local sh = cfd.wrap(srcfd)
   local dh = cfd.wrap(dstfd)
   local copied, pump_err = stream.copy(dh, sh)
-  local _ok, _err = sh:close()
-  local _ok, _err = dh:close()
+  local sok, scerr = sh:close()
+  local dok, dcerr = dh:close()
   if copied == nil then
     return false, "copy: " .. src .. " -> " .. dst .. ": " .. tostring(pump_err)
+  end
+  -- A failed close on the destination is how ENOSPC and write-back
+  -- errors surface; reporting success past it hides a truncated copy.
+  if not dok then
+    return false, "copy: close: " .. dst .. ": " .. tostring(dcerr)
+  end
+  if not sok then
+    return false, "copy: close: " .. src .. ": " .. tostring(scerr)
   end
   -- open()'s mode is masked by the umask; chmod applies the exact bits.
   local ok, cerr = unix.chmod(dst, mode)

--- a/cosmic/fs/ops_test.tl
+++ b/cosmic/fs/ops_test.tl
@@ -473,3 +473,20 @@ local function test_tmpfile_failure_contract()
   assert(err and err:match("ENOENT"), "error should name ENOENT: " .. (err or ""))
 end
 test_tmpfile_failure_contract()
+
+local function test_write_mode_applies_on_overwrite()
+  -- Barf's mode applies only at creation; fs.write enforces the exact
+  -- bits on overwrite too, so zip and tar extraction agree about the
+  -- permissions of a re-extracted file (#986).
+  local base = os.getenv("TEST_TMPDIR") or "/tmp"
+  local path = fs.join(base, "mode_overwrite.txt")
+  assert(fs.write(path, "one", tonumber("644", 8)))
+  assert(fs.write(path, "two", tonumber("600", 8)))
+  local st = check.must(fs.stat(path))
+  local mode = st:mode() & tonumber("777", 8)
+  assert(mode == tonumber("600", 8),
+    string.format("overwrite must apply the mode: got %o", mode))
+  assert(fs.read(path) == "two", "content overwritten")
+  assert(fs.remove_all(path))
+end
+test_write_mode_applies_on_overwrite()

--- a/cosmic/tar.tl
+++ b/cosmic/tar.tl
@@ -146,7 +146,10 @@ local function write_entry(hdr: Header, name: string, payload: string,
       return false, "mkdir " .. dest .. " failed: " .. (err or "unknown error")
     end
   elseif t == "0" or t == "\0" then
-    local _ok, _err = fs.make_dirs(fs.dirname(dest))
+    local dok, derr = fs.make_dirs(fs.dirname(dest))
+    if not dok then
+      return false, "mkdir " .. fs.dirname(dest) .. " failed: " .. (derr or "unknown error")
+    end
     local mode = hdr.mode % 512 -- permission bits only (0777 mask)
     if mode == 0 then mode = tonumber("644", 8) as integer end -- cast: octal is integral
     local ok, err = fs.write(dest, payload, mode)
@@ -157,7 +160,10 @@ local function write_entry(hdr: Header, name: string, payload: string,
     if unsafe_link_target(hdr.linkname) then
       return false, "unsafe symlink target in archive: " .. name .. " -> " .. hdr.linkname
     end
-    local _ok, _err = fs.make_dirs(fs.dirname(dest))
+    local dok, derr = fs.make_dirs(fs.dirname(dest))
+    if not dok then
+      return false, "mkdir " .. fs.dirname(dest) .. " failed: " .. (derr or "unknown error")
+    end
     local ok, err = fs.symlink(hdr.linkname, dest)
     if not ok then
       return false, "symlink " .. dest .. " failed: " .. (err or "unknown error")

--- a/cosmic/zip.tl
+++ b/cosmic/zip.tl
@@ -217,8 +217,6 @@ local function extract(r: Archive, destdir: string, opts?: ExtractOptions): bool
       if not write_ok then
         return false, "cannot write '" .. filepath .. "': " .. (write_err or "unknown error")
       end
-      -- barf's mode only applies on create; force it for overwrites.
-      local _ok, _err = fs.chmod(filepath, file_mode)
     end
   end
   return true


### PR DESCRIPTION
Fixes #986.

**The bug:** `fs.write(path, data, mode?)` forwarded `mode` to `cosmo.Barf`, whose mode applies only at file creation. `zip.extract` knew and patched it with a follow-up chmod whose error was then discarded (`zip.tl:220-221`); `tar.extract` didn't — so extracting the same archive over an existing tree gave archive modes from zip and stale modes from tar.

**The fix:** `fs.write` applies the exact bits on overwrite too — the posture `fs.copy` already documents in the same module ("open()'s mode is masked by the umask; chmod applies the exact bits"), now stated in `write`'s doc: a given `mode` is applied exactly, created or overwritten; without one, existing permissions are kept. zip's workaround is deleted; tar becomes correct with no change to its call.

Also in the discarded-error cluster from the audit:
- `tar.extract` checks its two `fs.make_dirs` calls, so a missing parent reports as the mkdir failure it is instead of blaming the leaf write/symlink.
- `fs.copy` reports close failures — a failed close on the *destination* is how ENOSPC and write-back errors surface, and returning success past it hid a truncated copy. (Its neighbor `write_atomic` already checked its close; same file, opposite discipline.)
- Regression test pins the overwrite mode (write 0644, overwrite with 0600, stat sees 0600).

One audit item found moot while implementing: zip's "ignored `list()` failure" — `Reader:list` is typed infallible (`{Entry}`) in the current binding, so there's no error to discard there.

Part of the api-review backlog (#1007), phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_