### PR TITLE
poll: one wait, honest errors, a deadline that holds under signals

### DIFF
--- a/cosmic/child/io.tl
+++ b/cosmic/child/io.tl
@@ -165,10 +165,9 @@ local function pump(state: PumpState, deadline_ms: number): boolean
   -- Read whatever is ready on fd into buf; on EOF, a read error, or a hangup
   -- with no pending data, drop it from the set and close/nil it in `state`.
   -- When both readable and hangup are set, data still remains, so read.
-  local function read_ready(fd: integer, buf: {string}, which: string)
-    local ev0 = p:events(fd)
-    if not ev0 then return end
-    local ev = ev0
+  local function read_ready(ready: {integer: poll.Events}, fd: integer, buf: {string}, which: string)
+    local ev = ready[fd]
+    if not ev then return end
     if ev.readable then
       local chunk, rerr, reno = unix.read(fd, CHUNK)
       if chunk == nil then
@@ -191,26 +190,25 @@ local function pump(state: PumpState, deadline_ms: number): boolean
   end
 
   while not p:is_empty() do
-    local timeout: integer = -1
+    local wait_ms: integer = nil
     if deadline_ms then
       local rem = deadline_ms - now_ms()
       if rem <= 0 then return true end
       -- poll wants an integer millisecond count; floor the remaining time
       -- (any sub-millisecond remainder is caught by the next deadline check).
-      timeout = math.floor(rem)
+      wait_ms = math.floor(rem)
     end
-    local ready, perr = p:poll(timeout)
+    local ready, perr = p:wait(wait_ms)
     if ready == nil then
       state.io_err = state.io_err or perr
       break
     end
-    if ready == 0 then
-      -- poll timed out with nothing ready: the deadline expired.
+    if next(ready) == nil then
+      -- wait timed out with nothing ready: the deadline expired.
       return true
     end
     if state.stdin_fd then
-      -- cast: record union, nil handled
-      local ev = p:events(state.stdin_fd) as {string: boolean}
+      local ev = ready[state.stdin_fd]
       if ev and ev.writable then
         local slice = state.stdin_data:sub(state.stdin_off + 1, state.stdin_off + CHUNK)
         local n, werr, weno = unix.write(state.stdin_fd, slice)
@@ -233,8 +231,8 @@ local function pump(state: PumpState, deadline_ms: number): boolean
         p:remove(state.stdin_fd); unix.close(state.stdin_fd); state.stdin_fd = nil
       end
     end
-    if state.stdout_fd then read_ready(state.stdout_fd, state.out, "out") end
-    if state.stderr_fd then read_ready(state.stderr_fd, state.err_out, "err") end
+    if state.stdout_fd then read_ready(ready, state.stdout_fd, state.out, "out") end
+    if state.stderr_fd then read_ready(ready, state.stderr_fd, state.err_out, "err") end
   end
 
   return false

--- a/cosmic/child/io.tl
+++ b/cosmic/child/io.tl
@@ -199,40 +199,43 @@ local function pump(state: PumpState, deadline_ms: number): boolean
       wait_ms = math.floor(rem)
     end
     local ready, perr = p:wait(wait_ms)
-    if ready == nil then
+    -- The POSITIVE branch is what narrows `ready` past nil (a `== nil`
+    -- guard before a `break` does not survive the loop's flow join).
+    if ready ~= nil then
+      if next(ready) == nil then
+        -- wait timed out with nothing ready: the deadline expired.
+        return true
+      end
+      if state.stdin_fd then
+        local ev = ready[state.stdin_fd]
+        if ev and ev.writable then
+          local slice = state.stdin_data:sub(state.stdin_off + 1, state.stdin_off + CHUNK)
+          local n, werr, weno = unix.write(state.stdin_fd, slice)
+          if n ~= nil then
+            state.stdin_off = state.stdin_off + (n)
+            if state.stdin_off >= #state.stdin_data then
+              p:remove(state.stdin_fd); unix.close(state.stdin_fd); state.stdin_fd = nil
+            end
+          elseif errno.is(weno, "EAGAIN") or errno.is(weno, "EINTR") then
+            -- Not actually writable yet (EAGAIN), or a signal interrupted the
+            -- write EINTR: try again on the next poll.
+          elseif errno.is(weno, "EPIPE") then
+            -- The child stopped reading stdin; stop feeding it (not an error).
+            p:remove(state.stdin_fd); unix.close(state.stdin_fd); state.stdin_fd = nil
+          else
+            state.io_err = state.io_err or errno.wrap(werr, "write stdin")
+            p:remove(state.stdin_fd); unix.close(state.stdin_fd); state.stdin_fd = nil
+          end
+        elseif ev and (ev.error or ev.hangup or ev.invalid) then
+          p:remove(state.stdin_fd); unix.close(state.stdin_fd); state.stdin_fd = nil
+        end
+      end
+      if state.stdout_fd then read_ready(ready, state.stdout_fd, state.out, "out") end
+      if state.stderr_fd then read_ready(ready, state.stderr_fd, state.err_out, "err") end
+    else
       state.io_err = state.io_err or perr
       break
     end
-    if next(ready) == nil then
-      -- wait timed out with nothing ready: the deadline expired.
-      return true
-    end
-    if state.stdin_fd then
-      local ev = ready[state.stdin_fd]
-      if ev and ev.writable then
-        local slice = state.stdin_data:sub(state.stdin_off + 1, state.stdin_off + CHUNK)
-        local n, werr, weno = unix.write(state.stdin_fd, slice)
-        if n ~= nil then
-          state.stdin_off = state.stdin_off + (n)
-          if state.stdin_off >= #state.stdin_data then
-            p:remove(state.stdin_fd); unix.close(state.stdin_fd); state.stdin_fd = nil
-          end
-        elseif errno.is(weno, "EAGAIN") or errno.is(weno, "EINTR") then
-          -- Not actually writable yet (EAGAIN), or a signal interrupted the
-          -- write EINTR: try again on the next poll.
-        elseif errno.is(weno, "EPIPE") then
-          -- The child stopped reading stdin; stop feeding it (not an error).
-          p:remove(state.stdin_fd); unix.close(state.stdin_fd); state.stdin_fd = nil
-        else
-          state.io_err = state.io_err or errno.wrap(werr, "write stdin")
-          p:remove(state.stdin_fd); unix.close(state.stdin_fd); state.stdin_fd = nil
-        end
-      elseif ev and (ev.error or ev.hangup or ev.invalid) then
-        p:remove(state.stdin_fd); unix.close(state.stdin_fd); state.stdin_fd = nil
-      end
-    end
-    if state.stdout_fd then read_ready(ready, state.stdout_fd, state.out, "out") end
-    if state.stderr_fd then read_ready(ready, state.stderr_fd, state.err_out, "err") end
   end
 
   return false

--- a/cosmic/net/init_test.tl
+++ b/cosmic/net/init_test.tl
@@ -169,9 +169,9 @@ local function test_poll_readiness()
 
   local poller = poll.new()
   assert(poller:add(sock2.fd, poll.POLLIN))
-  local ready, poll_err = poller:poll(1000)
-  assert(ready == 1, "expected one ready fd: " .. tostring(poll_err))
-  local ev = check.must(poller:events(sock2.fd))
+  local ready, poll_err = poller:wait(1000)
+  assert(ready ~= nil, "wait failed: " .. tostring(poll_err))
+  local ev = check.must(ready[sock2.fd], "expected one ready fd")
   assert(ev.readable, "expected socket to be readable")
 
   assert(sock1:close())

--- a/cosmic/poll.tl
+++ b/cosmic/poll.tl
@@ -9,6 +9,7 @@
 --- must never be registered here.
 local unix = require("cosmo.unix")
 local errno = require("cosmic.errno")
+local time = require("cosmic.time")
 
 --- Poll event flags.
 --- Use these to specify which events to monitor.
@@ -52,35 +53,19 @@ local record Poller
   remove: function(Poller, integer)
   --- Clear all file descriptors from the set.
   clear: function(Poller)
-  --- Poll for events with optional timeout.
-  --- Returns an iterator over (fd, events) pairs for ready descriptors.
-  --- EINTR is retried internally by reissuing the same timeout_ms, so the
-  --- deadline is not preserved across retries: repeated signals can make
-  --- the effective wait exceed timeout_ms. On a hard poll error the
-  --- iterator is empty; check err() after the loop — the old second
-  --- return was consumed as loop state by the generic `for`, so no
-  --- caller ever saw it (the Rows:err() pattern, for the same reason).
-  --- @param timeout_ms integer Timeout in ms (-1 for infinite, 0 for non-blocking)
-  --- @return function Iterator yielding (fd: integer, events: Events)
-  wait: function(Poller, integer): function(): (integer, Events)
-  --- The error from the last wait(), or nil when it polled cleanly.
-  --- Cleared by the next wait().
-  err: function(Poller): string | nil
-  --- Poll and return count of ready descriptors. EINTR is retried
-  --- internally by reissuing the same timeout_ms (the deadline is not
-  --- preserved across retries).
-  --- @param timeout_ms integer Timeout in ms (-1 for infinite, 0 for non-blocking)
-  --- @return integer | nil Count of ready descriptors
-  --- @return string Error message on failure
-  poll: function(Poller, integer): integer | nil, string
-  --- Get events for a specific fd after poll().
-  --- @param fd integer The file descriptor
-  --- @return Events | nil The events for this fd, or nil if not ready
-  events: function(Poller, integer): Events | nil
+  --- Wait for events, up to timeout_ms. Returns the ready set as a
+  --- {fd: Events} map — an empty map on timeout, `nil, err` on a hard
+  --- poll failure — so `for fd, ev in pairs(ready) do` iterates it and
+  --- the error arrives in slot 2 the house way (the old iterator ate
+  --- it as loop state, patched by a stateful err() sidecar; both are
+  --- gone). EINTR is retried against an absolute deadline, so repeated
+  --- signals can no longer stretch the wait past timeout_ms.
+  --- @param timeout_ms integer? Timeout in ms; nil blocks forever, 0 polls
+  --- @return {integer: Events} | nil Ready set (empty on timeout)
+  --- @return string? Error message on failure
+  wait: function(Poller, timeout_ms?: integer): {integer: Events} | nil, string
   --- Returns true if the poller has no registered fds.
   is_empty: function(Poller): boolean
-  --- Returns the number of registered fds.
-  count: function(Poller): integer
 end
 
 --- Make Events from raw revents bitmask.
@@ -102,15 +87,14 @@ end
 ---   p:add(sock.fd, poll.POLLIN)           -- net.Socket: .fd field
 ---   p:add(h:fd(), poll.POLLIN)            -- fd.Handle: :fd() method
 ---   p:add(pipe.reader:fd(), poll.POLLIN)  -- fd.Pipe ends are Handles
----   for fd, events in p:wait(30000) do
+---   local ready = assert(p:wait(30000))
+---   for fd, events in pairs(ready) do
 ---     if events.readable then
 ---       -- read from fd
 ---     end
 ---   end
 local function new(): Poller
   local fds: {integer: integer} = {}
-  local results: {integer: integer} = {}
-  local wait_err: string = nil
 
   local poller: Poller = {}
 
@@ -132,89 +116,49 @@ local function new(): Poller
   poller.remove = function(_self: Poller, fd: integer)
     if fd then
       fds[fd] = nil
-      results[fd] = nil
     end
   end
 
   poller.clear = function(_self: Poller)
     fds = {}
-    results = {}
   end
 
   poller.is_empty = function(_self: Poller): boolean
     return next(fds) == nil
   end
 
-  poller.count = function(_self: Poller): integer
-    local n = 0
-    for _ in pairs(fds) do
-      n = n + 1
-    end
-    return n
-  end
-
-  poller.poll = function(_self: Poller, timeout_ms: integer): integer | nil, string
+  poller.wait = function(_self: Poller, timeout_ms?: integer): {integer: Events} | nil, string
     -- Retry when a signal interrupts the wait: an unretried EINTR otherwise
     -- surfaces as a poll failure, and a caller that loops on it (e.g. a drain
-    -- loop waiting on a child that raised SIGCHLD) spins at 100% CPU.
-    -- Retrying reissues the same timeout_ms rather than tracking elapsed
-    -- time, so the effective wait can exceed timeout_ms under repeated
-    -- signals (see the doc comment on wait/poll above).
+    -- loop waiting on a child that raised SIGCHLD) spins at 100% CPU. The
+    -- retry reissues the REMAINDER of an absolute deadline, not the full
+    -- timeout, so repeated signals cannot stretch the wait (the posture
+    -- child.io and shm already took).
+    local deadline_ms: integer = nil
+    if timeout_ms and timeout_ms >= 0 then
+      deadline_ms = time.monotonic_ms() + timeout_ms
+    end
     local res: {integer: integer}
     local err: string
     local eno: integer
     while true do
-      res, err, eno = unix.poll(fds, timeout_ms or -1)
+      local wait_ms = -1
+      if deadline_ms then
+        wait_ms = math.max(0, deadline_ms - time.monotonic_ms())
+      end
+      res, err, eno = unix.poll(fds, wait_ms)
       if res ~= nil or not errno.is(eno, "EINTR") then
         break
       end
     end
     if not res then
-      -- Leave results empty rather than nil: events() indexes results
-      -- unconditionally, so a stale or nil table there would crash the
-      -- next events() call instead of just reporting no events.
-      results = {}
       return nil, errno.wrap(err, "poll")
     end
-    results = res
-    local ready = 0
-    for _ in pairs(results) do
-      ready = ready + 1
+    local ready: {integer: Events} = {}
+    for fd, revents in pairs(res) do
+      ready[fd] = make_events(revents)
     end
     return ready
-  end
-
-  poller.events = function(_self: Poller, fd: integer): Events | nil
-    local revents = results[fd]
-    if revents then
-      return make_events(revents)
-    end
-    return nil
-  end
-
-  poller.wait = function(self: Poller, timeout_ms: integer): function(): (integer, Events)
-    local n, err = self:poll(timeout_ms)
-    if n == nil then
-      wait_err = err
-      return function(): (integer, Events)
-        return nil, nil
-      end
-    end
-    wait_err = nil
-    local iter_results = results
-    local k: integer = nil
-    return function(): (integer, Events)
-      local v: integer
-      k, v = next(iter_results, k)
-      if k then
-        return k, make_events(v)
-      end
-      return nil, nil
-    end
-  end
-
-  poller.err = function(_self: Poller): string | nil
-    return wait_err
   end
 
   return poller

--- a/cosmic/poll_example.tl
+++ b/cosmic/poll_example.tl
@@ -2,9 +2,9 @@
 --- Demonstrates monitoring file descriptors for readiness with a
 --- Poller, using a pipe from cosmic.fd as a deterministic fd source.
 
--- Example_pipe_readiness demonstrates the poll/events pattern: an
+-- Example_pipe_readiness demonstrates the wait pattern: an
 -- empty pipe is writable but not readable; after a write, both ends
--- are ready. A timeout of 0 makes poll() non-blocking.
+-- are ready. A timeout of 0 makes wait() non-blocking.
 local function Example_pipe_readiness()
   local check = require("cosmic.check")
   local fd = require("cosmic.fd")
@@ -15,11 +15,18 @@ local function Example_pipe_readiness()
   assert(set:add(p.writer:fd(), poll.POLLOUT))
   assert(set:add(p.reader:fd(), poll.POLLIN))
 
-  print(check.must(set:poll(0))) -- only the writer is ready
+  local function ready_count(ready: {integer: poll.Events}): integer
+    local n = 0
+    for _ in pairs(ready) do n = n + 1 end
+    return n
+  end
+  local ready = check.must(set:wait(0))
+  print(ready_count(ready)) -- only the writer is ready
   assert(p.writer:write("ping"))
-  print(check.must(set:poll(0))) -- now the reader is ready too
+  ready = check.must(set:wait(0))
+  print(ready_count(ready)) -- now the reader is ready too
 
-  local ev = check.must(set:events(p.reader:fd()))
+  local ev = check.must(ready[p.reader:fd()])
   print(ev.readable)
   print(check.must(p.reader:read(4)))
   assert(p:close())

--- a/cosmic/poll_example.tl
+++ b/cosmic/poll_example.tl
@@ -37,10 +37,10 @@ local function Example_pipe_readiness()
   -- ping
 end
 
--- Example_wait_iterator demonstrates wait(), which yields each ready
--- fd with its resolved Events record instead of requiring a follow-up
--- events() lookup per descriptor.
-local function Example_wait_iterator()
+-- Example_wait_ready_set demonstrates wait(), which returns the ready
+-- set as a {fd: Events} map: iterate it with pairs, or index a specific
+-- descriptor directly.
+local function Example_wait_ready_set()
   local check = require("cosmic.check")
   local fd = require("cosmic.fd")
   local poll = require("cosmic.poll")
@@ -50,7 +50,8 @@ local function Example_wait_iterator()
 
   local set = poll.new()
   assert(set:add(p.reader:fd(), poll.POLLIN))
-  for ready_fd, ev in set:wait(0) do
+  local ready = check.must(set:wait(0))
+  for ready_fd, ev in pairs(ready) do
     print(ready_fd == p.reader:fd(), ev.readable)
   end
   assert(p:close())
@@ -59,4 +60,4 @@ local function Example_wait_iterator()
 end
 
 -- Suppress unused warnings for examples
-local _ = {Example_pipe_readiness, Example_wait_iterator}
+local _ = {Example_pipe_readiness, Example_wait_ready_set}

--- a/cosmic/poll_test.tl
+++ b/cosmic/poll_test.tl
@@ -5,6 +5,13 @@ local cfd = require("cosmic.fd")
 local net = require("cosmic.net")
 local child = require("cosmic.child")
 
+-- wait() returns the ready set as {fd: Events}; count entries directly.
+local function ready_count(ready: {integer: poll.Events}): integer
+  local n = 0
+  for _ in pairs(ready) do n = n + 1 end
+  return n
+end
+
 local function test_poll_constants()
   assert(poll.POLLIN ~= nil, "POLLIN not defined")
   assert(poll.POLLOUT ~= nil, "POLLOUT not defined")
@@ -24,23 +31,18 @@ local function test_poller_new()
   assert(p.remove ~= nil, "remove method missing")
   assert(p.wait ~= nil, "wait method missing")
   assert(p:is_empty(), "new poller should be empty")
-  assert(p:count() == 0, "new poller count should be 0")
 end
 test_poller_new()
 
 local function test_poller_add_remove_raw_fd()
   local p = poll.new()
-  -- Add a raw fd number
   assert(p:add(1, poll.POLLOUT)) -- stdout
   assert(not p:is_empty(), "poller should not be empty after add")
-  assert(p:count() == 1, "count should be 1")
-
   assert(p:add(2, poll.POLLOUT)) -- stderr
-  assert(p:count() == 2, "count should be 2")
-
   p:remove(1)
-  assert(p:count() == 1, "count should be 1 after remove")
-
+  p:remove(2)
+  assert(p:is_empty(), "poller should be empty after removing both")
+  assert(p:add(1, poll.POLLOUT))
   p:clear()
   assert(p:is_empty(), "poller should be empty after clear")
 end
@@ -54,19 +56,14 @@ local function test_poll_pipe_readable()
   assert(n == 5, "expected 5 bytes written")
 
   local p = poll.new()
-  -- Add the reader using its fd() method
   assert(p:add(pipe.reader:fd(), poll.POLLIN))
-  assert(p:count() == 1, "count should be 1")
 
-  -- Poll with short timeout - should return immediately since data is available
-  local count = 0
-  for fd, events in p:wait(100) do
-    assert(fd == pipe.reader:fd(), "expected reader fd")
-    assert(events.readable, "expected readable event")
-    assert(not events.error, "unexpected error event")
-    count = count + 1
-  end
-  assert(count == 1, "expected 1 ready fd, got " .. count)
+  -- Short timeout - returns immediately since data is available
+  local ready = check.must(p:wait(100))
+  assert(ready_count(ready) == 1, "expected 1 ready fd")
+  local events = check.must(ready[pipe.reader:fd()], "reader should be ready")
+  assert(events.readable, "expected readable event")
+  assert(not events.error, "unexpected error event")
 
   assert(pipe:close())
 end
@@ -76,16 +73,13 @@ local function test_poll_pipe_writable()
   local pipe = check.must(cfd.pipe())
 
   local p = poll.new()
-  -- Check if writer is writable (should be, since buffer is empty)
+  -- Writer is writable, since the pipe buffer is empty
   assert(p:add(pipe.writer:fd(), poll.POLLOUT))
 
-  local count = 0
-  for fd, events in p:wait(100) do
-    assert(fd == pipe.writer:fd(), "expected writer fd")
-    assert(events.writable, "expected writable event")
-    count = count + 1
-  end
-  assert(count == 1, "expected 1 ready fd")
+  local ready = check.must(p:wait(100))
+  assert(ready_count(ready) == 1, "expected 1 ready fd")
+  local events = check.must(ready[pipe.writer:fd()], "writer should be ready")
+  assert(events.writable, "expected writable event")
 
   assert(pipe:close())
 end
@@ -93,7 +87,6 @@ test_poll_pipe_writable()
 
 local function test_poll_multiple_fds()
   local pipe1 = check.must(cfd.pipe())
-
   local pipe2 = check.must(cfd.pipe())
 
   -- Write to both pipes
@@ -103,16 +96,13 @@ local function test_poll_multiple_fds()
   local p = poll.new()
   assert(p:add(pipe1.reader:fd(), poll.POLLIN))
   assert(p:add(pipe2.reader:fd(), poll.POLLIN))
-  assert(p:count() == 2, "count should be 2")
 
-  local ready_fds: {number: boolean} = {}
-  for fd, events in p:wait(100) do
+  local ready = check.must(p:wait(100))
+  for _, events in pairs(ready) do
     assert(events.readable, "expected readable")
-    ready_fds[fd] = true
   end
-
-  assert(ready_fds[pipe1.reader:fd()], "pipe1 reader should be ready")
-  assert(ready_fds[pipe2.reader:fd()], "pipe2 reader should be ready")
+  assert(ready[pipe1.reader:fd()], "pipe1 reader should be ready")
+  assert(ready[pipe2.reader:fd()], "pipe2 reader should be ready")
 
   assert(pipe1:close())
   assert(pipe2:close())
@@ -123,14 +113,13 @@ local function test_poll_timeout()
   local pipe = check.must(cfd.pipe())
 
   local p = poll.new()
-  -- Poll for read on empty pipe - should timeout
+  -- Poll for read on empty pipe - should time out with an EMPTY map,
+  -- which is a successful wait, not an error.
   assert(p:add(pipe.reader:fd(), poll.POLLIN))
 
-  local count = 0
-  for _, _ in p:wait(10) do -- 10ms timeout
-    count = count + 1
-  end
-  assert(count == 0, "expected no ready fds on timeout")
+  local ready, err = p:wait(10)
+  assert(ready ~= nil, "timeout is not an error: " .. tostring(err))
+  assert(ready_count(ready) == 0, "expected no ready fds on timeout")
 
   assert(pipe:close())
 end
@@ -148,13 +137,10 @@ local function test_poll_with_socket()
   -- Socket has fd field directly
   assert(p:add(sock2.fd, poll.POLLIN))
 
-  local count = 0
-  for fd, events in p:wait(100) do
-    assert(fd == sock2.fd, "expected sock2 fd")
-    assert(events.readable, "expected readable")
-    count = count + 1
-  end
-  assert(count == 1, "expected 1 ready socket")
+  local ready = check.must(p:wait(100))
+  assert(ready_count(ready) == 1, "expected 1 ready socket")
+  local events = check.must(ready[sock2.fd], "sock2 should be ready")
+  assert(events.readable, "expected readable")
 
   assert(sock1:close())
   assert(sock2:close())
@@ -170,42 +156,16 @@ local function test_poll_with_child_pipes()
   local p = poll.new()
   assert(p:add(pp.reader:fd(), poll.POLLIN))
 
-  local count = 0
-  for fd, events in p:wait(1000) do
-    assert(fd == pp.reader:fd(), "expected reader fd")
-    assert(events.readable or events.hangup, "expected readable or hangup")
-    count = count + 1
-  end
-  assert(count >= 1, "expected at least 1 event from child stdout")
+  local ready = check.must(p:wait(1000))
+  assert(ready_count(ready) >= 1, "expected at least 1 event from child stdout")
+  local events = check.must(ready[pp.reader:fd()], "reader should be ready")
+  assert(events.readable or events.hangup, "expected readable or hangup")
+  assert(events.revents ~= nil, "revents should be set")
 
   assert(pp.reader:close())
   assert(h:wait())
 end
 test_poll_with_child_pipes()
-
-local function test_poll_events_method()
-  local pipe = check.must(cfd.pipe())
-
-  assert(pipe.writer:write("test"))
-
-  local p = poll.new()
-  assert(p:add(pipe.reader:fd(), poll.POLLIN))
-
-  local ready, poll_err = p:poll(100)
-  assert(ready ~= nil, "poll failed: " .. tostring(poll_err))
-  assert(ready == 1, "expected 1 ready fd")
-
-  local events = check.must(p:events(pipe.reader:fd()),
-    "raw_events should not be nil for ready fd")
-  assert(events.readable, "expected readable")
-  assert(events.revents ~= nil, "revents should be set")
-
-  local no_events = p:events(999)
-  assert(no_events == nil, "events should be nil for non-ready fd")
-
-  assert(pipe:close())
-end
-test_poll_events_method()
 
 local function test_poll_nonblocking()
   local pipe = check.must(cfd.pipe())
@@ -213,9 +173,10 @@ local function test_poll_nonblocking()
   local p = poll.new()
   assert(p:add(pipe.reader:fd(), poll.POLLIN))
 
-  -- Non-blocking poll (timeout = 0)
-  local ready, _ = p:poll(0)
-  assert(ready == 0, "expected 0 ready fds for non-blocking poll on empty pipe")
+  -- Non-blocking wait (timeout = 0) on an empty pipe: empty map
+  local ready = check.must(p:wait(0))
+  assert(ready_count(ready) == 0, "expected 0 ready fds for non-blocking wait")
+  assert(ready[999] == nil, "an unready fd simply has no entry")
 
   assert(pipe:close())
 end
@@ -230,20 +191,19 @@ local function test_poll_hangup()
   local p = poll.new()
   assert(p:add(pipe.reader:fd(), poll.POLLIN))
 
-  for fd, events in p:wait(100) do
-    assert(fd == pipe.reader:fd(), "expected reader fd")
-    -- When writer closes, reader gets POLLHUP
-    assert(events.hangup or events.readable, "expected hangup or readable on closed pipe")
-  end
+  local ready = check.must(p:wait(100))
+  local events = check.must(ready[pipe.reader:fd()], "reader should report")
+  -- When writer closes, reader gets POLLHUP
+  assert(events.hangup or events.readable, "expected hangup or readable on closed pipe")
 
   assert(pipe.reader:close())
 end
 test_poll_hangup()
 
 -- Error fidelity: add(nil)/add(-1) return false + err instead of
--- silently doing nothing (or, before the error-shape wave, throwing
--- from library code), and wait() surfaces a hard poll error through
--- err() instead of an indistinguishable empty iterator.
+-- silently doing nothing, and wait() surfaces a hard poll error in
+-- slot 2 — the old iterator ate it as loop state, patched by a
+-- stateful err() sidecar; both are gone.
 
 local function test_add_bad_fd_errors()
   local p = poll.new()
@@ -263,25 +223,12 @@ local function test_wait_surfaces_hard_error()
   for i = 1, 100000 do
     assert(p:add(i, poll.POLLIN))
   end
-  local n, perr = p:poll(0)
-  if n ~= nil then
+  local ready, perr = p:wait(0)
+  if ready ~= nil then
     io.stderr:write("SKIP: test_wait_surfaces_hard_error (could not provoke poll failure)\n")
     return
   end
-  assert(perr:match("E%u+"), "poll error should name the errno, got: " .. perr)
-  -- Regression: results must never be left nil after a failed poll --
-  -- events() indexes it unconditionally, so a nil there crashes instead
-  -- of reporting "no events for this fd".
-  local ev = p:events(1)
-  assert(ev == nil, "events() should return nil (not crash) after a failed poll")
-  local iter = p:wait(0)
-  assert(type(iter) == "function", "wait must still return an iterator on error")
-  for _ in iter do
-    assert(false, "the error iterator must be empty")
-  end
-  local werr = p:err()
-  assert(type(werr) == "string" and string.match(werr, "E%u+"),
-    "err() should surface the poll error, got: " .. tostring(werr))
+  assert(perr:match("E%u+"), "wait error should name the errno, got: " .. perr)
 end
 test_wait_surfaces_hard_error()
 

--- a/cosmic/quicksand/proxy/http_test.tl
+++ b/cosmic/quicksand/proxy/http_test.tl
@@ -177,8 +177,8 @@ local function test_pump_relays_data_across_eintr()
 
   local pp = pollmod.new()
   assert(pp:add(u1.fd, pollmod.POLLIN))
-  local n = check.must(pp:poll(2000))
-  assert(n == 1, "pump should have relayed the payload across the EINTR")
+  local ready = check.must(pp:wait(2000))
+  assert(ready[u1.fd], "pump should have relayed the payload across the EINTR")
   local got = u1:recv(64)
   assert(got == payload, "expected relayed payload, got: " .. tostring(got))
 

--- a/cosmic/tty_pty_test.tl
+++ b/cosmic/tty_pty_test.tl
@@ -159,8 +159,8 @@ local function echo_observed(pty: tty.Pty): boolean
   assert(mgr:write("x"))
   local set = poll.new()
   assert(set:add(pty.manager, poll.POLLIN))
-  local n = set:poll(300)
-  if n and n > 0 then
+  local ready = set:wait(300)
+  if ready and next(ready) ~= nil then
     assert(mgr:read(64))
     return true
   end
@@ -260,8 +260,8 @@ local function test_getpass_reads_without_echoing()
   local set = poll.new()
   assert(set:add(pty.manager, poll.POLLIN))
   while true do
-    local n = set:poll(300)
-    if not n or n == 0 then break end
+    local ready = set:wait(300)
+    if not ready or next(ready) == nil then break end
     local chunk = mgr:read(4096)
     if not chunk or #chunk == 0 then break end
     seen = seen .. chunk


### PR DESCRIPTION
Fixes #980.

**Before:** the Poller had two ways to run the same poll plus a sidecar to patch one of them — `poll()` (honest errors), `wait()` (an iterator whose error return the generic `for` consumed as loop state), `err()` (the stateful sidecar surfacing what the iterator ate — its own doc explained the machinery), `events()` (post-poll lookup), and `count()` (redundant with `is_empty`).

**After:** one method. `wait(timeout_ms?: integer): {integer: Events} | nil, string` — the ready set as a map (`for fd, ev in pairs(ready)`), empty on timeout, `nil, err` on a hard failure, so the error arrives in slot 2 the house way. `poll`/`events`/`err`/`count` are deleted; net −104 lines.

**The deadline bug rides along:** EINTR was retried by reissuing the *full* `timeout_ms`, so repeated signals stretched the effective wait without bound — documented in three places instead of fixed. `wait` retries against an absolute deadline (the posture `child.io` and `shm` already took), and `nil` now means block forever, aligning with the tree's other timeouts (the old convention required the argument and used `-1`).

All five in-tree call sites migrate: `child.io`'s pump (which loses a cast — `ready[fd]` is typed where `p:events()` wasn't at one site), the example, and the net/tty/quicksand tests. The hard-error test keeps its RLIMIT_NOFILE provocation, now asserting the slot-2 error directly.

Part of the api-review backlog (#1007), phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_