### PR TITLE
re: option records, a Match record, tri-state is_match, sound gmatch

### DIFF
--- a/_perf/bench/re_bench.tl
+++ b/_perf/bench/re_bench.tl
@@ -46,8 +46,9 @@ local function scenarios(): {pt.Scenario}, string
       -- captures out, every call.
       name = "re_match_log_line",
       fn = function(_: any): any
-        local _m, caps = re.match(LOG_LINE, LOG_PATTERN)
-        return caps
+        local m = re.match(LOG_LINE, LOG_PATTERN)
+        if m == nil then return nil end
+        return m.caps
       end,
       check = function(_: any, res: any): boolean, string
         local caps = res as {string} -- cast: from any

--- a/cosmic/re.tl
+++ b/cosmic/re.tl
@@ -1,11 +1,15 @@
 --- Regular expression matching using POSIX extended regex syntax.
 --- Wraps cosmo.re for pattern compilation and matching. Module-level
 --- functions are SUBJECT-FIRST D20: match(text, pattern), like
---- string.match. The compiled Regex keeps the binding's own :search
---- method name — a userdata metatable is the C layer's to name.
+--- string.match. Compile behavior is a CompileOptions record — a search
+--- flag in a compile slot cannot type-check, where the old shared
+--- integer namespace silently ignored it. The compiled Regex keeps the
+--- binding's own :search/:find method names and integer search flags
+--- (NOTBOL/NOTEOL) — a userdata metatable is the C layer's to name, so
+--- renaming them is an upstream change, not a record edit.
 ---
 --- For best performance, compile patterns once and reuse them.
---- The convenience functions (match, test, find, find_all, gmatch,
+--- The convenience functions (match, is_match, find, find_all, gmatch,
 --- split, gsub) take a pattern string per call; a bounded module cache
 --- memoizes their compiled patterns, so repeated calls with the same
 --- pattern skip recompilation. compile() itself is never cached: it is
@@ -48,15 +52,42 @@ local record Regex
   find: function(self: Regex, text: string, flags?: integer, init?: integer): integer | nil, integer | string | nil, {string}
 end
 
+--- Compile behavior. Each field maps to one POSIX cflag; a record
+--- keeps the compile and search namespaces unmixable (the old integer
+--- flags shared one namespace, so a search flag passed at compile time
+--- type-checked and was silently ignored).
+local record CompileOptions
+  --- Basic (obsolete) regex syntax instead of extended.
+  basic: boolean
+  --- Case-insensitive matching.
+  ignore_case: boolean
+  --- Treat newline as special (affects ^ and $).
+  newline: boolean
+  --- Report only success/failure, not match position.
+  no_sub: boolean
+end
+
+--- The binding's integer cflags for a CompileOptions record.
+local function flags_of(opts?: CompileOptions): integer
+  local flags = 0
+  if opts then
+    if opts.basic then flags = flags | re.BASIC end
+    if opts.ignore_case then flags = flags | re.ICASE end
+    if opts.newline then flags = flags | re.NEWLINE end
+    if opts.no_sub then flags = flags | re.NOSUB end
+  end
+  return flags
+end
+
 --- Compile a regular expression pattern.
 --- Compiled patterns can be reused for efficient O(n) matching.
 --- Uses POSIX extended syntax by default.
 --- @param pattern string The regex pattern to compile
---- @param flags integer? Optional flags: BASIC, ICASE, NEWLINE, NOSUB
+--- @param opts CompileOptions? Compile behavior
 --- @return Regex? The compiled regex, or nil on error
 --- @return string? Error message if compilation failed
-local function compile(pattern: string, flags?: integer): Regex | nil, string
-  local result, err = re.compile(pattern, flags)
+local function compile(pattern: string, opts?: CompileOptions): Regex | nil, string
+  local result, err = re.compile(pattern, flags_of(opts))
   if not result then
     return nil, err
   end
@@ -82,22 +113,23 @@ local CACHE_MAX = 64
 local cache: {string: CacheEntry} = {}
 local cache_count = 0
 
---- The memo key. Flags are part of a pattern's identity: the same
---- source compiled with ICASE is a different regex.
+--- The memo key. Options are part of a pattern's identity: the same
+--- source compiled with ignore_case is a different regex.
 --- @param pattern string The regex pattern
---- @param flags integer? Optional compile flags
+--- @param flags integer The resolved compile flags
 --- @return string The cache key
-local function cache_key(pattern: string, flags?: integer): string
-  return tostring(flags or 0) .. "\0" .. pattern
+local function cache_key(pattern: string, flags: integer): string
+  return tostring(flags) .. "\0" .. pattern
 end
 
 --- Get-or-create the memo entry for a pattern, compiling on miss.
 --- Compile failures are cached too, so a bad pattern in a loop pays
 --- one compile, not one per call.
 --- @param pattern string The regex pattern
---- @param flags integer? Optional compile flags
+--- @param opts CompileOptions? Compile behavior
 --- @return CacheEntry The entry (rx set on success, err on failure)
-local function cache_entry(pattern: string, flags?: integer): CacheEntry
+local function cache_entry(pattern: string, opts?: CompileOptions): CacheEntry
+  local flags = flags_of(opts)
   local key = cache_key(pattern, flags)
   local entry = cache[key]
   if entry ~= nil then
@@ -107,7 +139,8 @@ local function cache_entry(pattern: string, flags?: integer): CacheEntry
     cache = {}
     cache_count = 0
   end
-  local rx, cerr = compile(pattern, flags)
+  local rx, cerr = re.compile(pattern, flags) as (Regex | nil, string) -- cast: userdata boundary
+
   if rx is Regex then
     entry = {rx = rx}
   else
@@ -118,50 +151,57 @@ local function cache_entry(pattern: string, flags?: integer): CacheEntry
   return entry
 end
 
+--- One match: the matched text and its parenthesized capture groups
+--- (an empty table when the pattern has none, "" for groups that did
+--- not participate).
+local record Match
+  text: string
+  caps: {string}
+end
+
 --- Match pattern against text (convenience function; subject first).
 --- Compiled patterns are cached - compile() gives explicit reuse.
---- Uses POSIX extended syntax by default.
---- On a match, returns the matched substring plus a table of the
---- parenthesized capture groups (an empty table when the pattern has no
---- groups, "" for groups that did not participate). A no-match returns
---- nil with no error; a bad pattern or an engine failure returns
---- nil, nil, err.
+--- Uses POSIX extended syntax by default. Two slots, three honest
+--- outcomes: a Match on success, bare nil on no match (not an error),
+--- nil + err on a bad pattern or engine failure — the old three-slot
+--- tuple made every call site hand-decode which nil it was looking at.
 --- @param text string The text to search in
 --- @param pattern string The regex pattern to match
---- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE, NOSUB
---- @return string | nil The matched substring, or nil on no match or error
---- @return {string} | nil Capture groups on match
+--- @param opts CompileOptions? Compile behavior
+--- @return Match | nil The match, or nil when none (or on error)
 --- @return string | nil Error message if compilation or the engine failed
-local function match(text: string, pattern: string, flags?: integer): string | nil, {string} | nil, string | nil
-  local entry = cache_entry(pattern, flags)
+local function match(text: string, pattern: string, opts?: CompileOptions): Match | nil, string
+  local entry = cache_entry(pattern, opts)
   local regex, cerr = entry.rx, entry.err
   if regex is Regex then
-    -- Search flags (NOTBOL/NOTEOL) are not passed here; use compile() + :search() for those
     local m, caps = regex:search(text)
     if not m then
       if caps then
         -- Engine failure: the binding reports nil, err.
-        return nil, nil, tostring(caps)
+        return nil, tostring(caps)
       end
       -- No match is not an error.
       return nil
     end
-    return m, caps
+    return {text = m, caps = caps}
   end
-  return nil, nil, cerr
+  return nil, cerr
 end
 
---- Check if pattern matches anywhere in text (subject first).
---- Convenience predicate returning boolean instead of matched text.
+--- Whether pattern matches anywhere in text (subject first).
+--- Three honest outcomes: true, false on a clean no-match, and
+--- nil + err on a bad pattern — the old boolean shape returned false
+--- for both, so "no match" and "your pattern is invalid" were the
+--- same value. Narrow with `~= nil`, which is exact for boolean unions.
 --- @param text string The text to search in
 --- @param pattern string The regex pattern to match
---- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE, NOSUB
---- @return boolean True if pattern matches, false otherwise
+--- @param opts CompileOptions? Compile behavior
+--- @return boolean | nil The verdict, or nil on error
 --- @return string? Error message if compilation or the engine failed
-local function test(text: string, pattern: string, flags?: integer): boolean, string
-  local m, _, err = match(text, pattern, flags)
+local function is_match(text: string, pattern: string, opts?: CompileOptions): boolean | nil, string
+  local m, err = match(text, pattern, opts)
   if err then
-    return false, err
+    return nil, err
   end
   return m ~= nil
 end
@@ -183,8 +223,8 @@ end
 --- the empty string: a zero-length match cannot be advanced past
 --- (its end offset sits before its start, so iteration would not
 --- move).
-local function compile_for_iter(pattern: string, flags?: integer): Regex | nil, string
-  local entry = cache_entry(pattern, flags)
+local function compile_for_iter(pattern: string, opts?: CompileOptions): Regex | nil, string
+  local entry = cache_entry(pattern, opts)
   if entry.rx == nil then
     return nil, entry.err
   end
@@ -235,11 +275,11 @@ end
 --- Patterns that can match the empty string are rejected.
 --- @param text string The text to search in
 --- @param pattern string The regex pattern to match
---- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE
+--- @param opts CompileOptions? Compile behavior
 --- @return Span | nil The first match, or nil when none
 --- @return string? Error message on a bad pattern or engine failure
-local function find(text: string, pattern: string, flags?: integer): Span | nil, string
-  local regex, cerr = compile_for_iter(pattern, flags)
+local function find(text: string, pattern: string, opts?: CompileOptions): Span | nil, string
+  local regex, cerr = compile_for_iter(pattern, opts)
   if not regex then
     return nil, cerr
   end
@@ -268,11 +308,11 @@ end
 --- line.)
 --- @param text string The text to search in
 --- @param pattern string The regex pattern to match
---- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE
+--- @param opts CompileOptions? Compile behavior
 --- @return {Span} | nil The matches (empty when none), or nil on error
 --- @return string? Error message on a bad pattern or engine failure
-local function find_all(text: string, pattern: string, flags?: integer): {Span} | nil, string
-  local regex, cerr = compile_for_iter(pattern, flags)
+local function find_all(text: string, pattern: string, opts?: CompileOptions): {Span} | nil, string
+  local regex, cerr = compile_for_iter(pattern, opts)
   if not regex then
     return nil, cerr
   end
@@ -281,16 +321,17 @@ end
 
 --- Iterate every non-overlapping match, like string.gmatch: each step
 --- yields the matched text and its capture table. Matching is done up
---- front (the engine reports no offsets, so lazy stepping buys
---- nothing); a bad pattern or engine failure returns nil, err instead
---- of an iterator. Shares find_all's NEWLINE limitation.
+--- front over find_all's spans; a bad pattern or engine failure
+--- returns nil, err instead of an iterator — and the signature now
+--- admits that nil, so `for m in re.gmatch(t, p) do` on a bad pattern
+--- is a check error instead of a runtime crash.
 --- @param text string The text to search in
 --- @param pattern string The regex pattern to match
---- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE
+--- @param opts CompileOptions? Compile behavior
 --- @return function | nil Iterator yielding (match, caps), or nil on error
 --- @return string? Error message on a bad pattern or engine failure
-local function gmatch(text: string, pattern: string, flags?: integer): MatchIterator, string
-  local spans, err = find_all(text, pattern, flags)
+local function gmatch(text: string, pattern: string, opts?: CompileOptions): MatchIterator | nil, string
+  local spans, err = find_all(text, pattern, opts)
   if not spans then
     return nil, err
   end
@@ -312,11 +353,11 @@ end
 --- Patterns that can match the empty string are rejected.
 --- @param text string The text to split
 --- @param pattern string The regex pattern to split on
---- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE
+--- @param opts CompileOptions? Compile behavior
 --- @return {string} | nil The fields, or nil on error
 --- @return string? Error message on a bad pattern or engine failure
-local function split(text: string, pattern: string, flags?: integer): {string} | nil, string
-  local regex, cerr = compile_for_iter(pattern, flags)
+local function split(text: string, pattern: string, opts?: CompileOptions): {string} | nil, string
+  local regex, cerr = compile_for_iter(pattern, opts)
   if not regex then
     return nil, cerr
   end
@@ -344,11 +385,11 @@ local type Repl = string | function(string, {string}): string
 --- @param text string The text to operate on
 --- @param pattern string The regex pattern to match
 --- @param repl Repl A literal replacement string, or function(match, caps)
---- @param flags integer? Optional compile flags: BASIC, ICASE, NEWLINE
+--- @param opts CompileOptions? Compile behavior
 --- @return string | nil The result, or nil on error
 --- @return string? Error message on a bad pattern or engine failure
-local function gsub(text: string, pattern: string, repl: Repl, flags?: integer): string | nil, string
-  local regex, cerr = compile_for_iter(pattern, flags)
+local function gsub(text: string, pattern: string, repl: Repl, opts?: CompileOptions): string | nil, string
+  local regex, cerr = compile_for_iter(pattern, opts)
   if not regex then
     return nil, cerr
   end
@@ -381,25 +422,22 @@ local record ReModule
   type Regex = Regex
   type Repl = Repl
   type Span = Span
+  type Match = Match
+  type CompileOptions = CompileOptions
 
   -- Functions (subject first, D20)
-  compile: function(pattern: string, flags?: integer): Regex | nil, string
-  match: function(text: string, pattern: string, flags?: integer): string | nil, {string} | nil, string | nil
-  test: function(text: string, pattern: string, flags?: integer): boolean, string
-  find: function(text: string, pattern: string, flags?: integer): Span | nil, string
-  find_all: function(text: string, pattern: string, flags?: integer): {Span} | nil, string
+  compile: function(pattern: string, opts?: CompileOptions): Regex | nil, string
+  match: function(text: string, pattern: string, opts?: CompileOptions): Match | nil, string
+  is_match: function(text: string, pattern: string, opts?: CompileOptions): boolean | nil, string
+  find: function(text: string, pattern: string, opts?: CompileOptions): Span | nil, string
+  find_all: function(text: string, pattern: string, opts?: CompileOptions): {Span} | nil, string
   type MatchIterator = MatchIterator
-  gmatch: function(text: string, pattern: string, flags?: integer): MatchIterator, string
-  split: function(text: string, pattern: string, flags?: integer): {string} | nil, string
-  gsub: function(text: string, pattern: string, repl: Repl, flags?: integer): string | nil, string
+  gmatch: function(text: string, pattern: string, opts?: CompileOptions): MatchIterator | nil, string
+  split: function(text: string, pattern: string, opts?: CompileOptions): {string} | nil, string
+  gsub: function(text: string, pattern: string, repl: Repl, opts?: CompileOptions): string | nil, string
 
-  -- Compile flags
-  BASIC: integer -- Use basic (obsolete) regex syntax instead of extended
-  ICASE: integer -- Case-insensitive matching
-  NEWLINE: integer -- Treat newline as special (affects ^ and $)
-  NOSUB: integer -- Report only success/failure, not match position
-
-  -- Search flags
+  -- Search flags for the raw Regex layer (:search/:find), whose method
+  -- names and integer flags belong to the binding's userdata metatable.
   NOTBOL: integer -- First character is not at beginning of line
   NOTEOL: integer -- Last character is not at end of line
 end
@@ -407,18 +445,13 @@ end
 local M: ReModule = {
   compile = compile,
   match = match,
-  test = test,
+  is_match = is_match,
   find = find,
   find_all = find_all,
   gmatch = gmatch,
   split = split,
   gsub = gsub,
 
-  -- Expose flags from cosmo.re
-  BASIC = re.BASIC,
-  ICASE = re.ICASE,
-  NEWLINE = re.NEWLINE,
-  NOSUB = re.NOSUB,
   NOTBOL = re.NOTBOL,
   NOTEOL = re.NOTEOL,
 }

--- a/cosmic/re_ops_test.tl
+++ b/cosmic/re_ops_test.tl
@@ -4,8 +4,8 @@ local check = require("cosmic.check")
 
 --- The old findall shape, over find_all: every match's text, in order.
 --- Also exercises Span fields via the m projection.
-local function matches_of(text: string, pat: string, flags?: integer): {string} | nil, string
-  local spans, err = re.find_all(text, pat, flags)
+local function matches_of(text: string, pat: string, opts?: re.CompileOptions): {string} | nil, string
+  local spans, err = re.find_all(text, pat, opts)
   if not spans then
     return nil, err
   end
@@ -45,7 +45,7 @@ end
 test_find_all_leftmost_longest()
 
 local function test_find_all_icase_flag()
-  local ms = check.must(matches_of("Foo foo FOO", "foo", re.ICASE))
+  local ms = check.must(matches_of("Foo foo FOO", "foo", {ignore_case = true}))
   assert(#ms == 3, "expected 3 case-insensitive matches, got " .. #ms)
   assert(ms[1] == "Foo" and ms[3] == "FOO", "expected original casing in results")
 end
@@ -94,12 +94,12 @@ local function test_newline_anchor_matches_past_first_line()
 
   -- With NEWLINE, `^` also matches right after the embedded \n
   -- (regardless of NOTBOL, per POSIX): both lines match.
-  local ms2 = check.must(matches_of("foo\nfoo", "^foo", re.NEWLINE))
+  local ms2 = check.must(matches_of("foo\nfoo", "^foo", {newline = true}))
   assert(#ms2 == 2 and ms2[1] == "foo" and ms2[2] == "foo",
     "expected both NEWLINE-anchored matches, got " .. #ms2)
 
   -- The symmetric $ case: every line end matches.
-  local ms3 = check.must(matches_of("foo\nfoo\nfoo", "foo$", re.NEWLINE))
+  local ms3 = check.must(matches_of("foo\nfoo\nfoo", "foo$", {newline = true}))
   assert(#ms3 == 3, "expected all three $-anchored matches, got " .. #ms3)
 end
 test_newline_anchor_matches_past_first_line()

--- a/cosmic/re_test.tl
+++ b/cosmic/re_test.tl
@@ -100,161 +100,156 @@ test_regex_search_no_match_no_error()
 -- search convenience function tests
 
 local function test_search_simple()
-  local result, caps, err = re.match("hello world", "world")
+  local m, err = re.match("hello world", "world")
   assert(err == nil, "expected no error, got: " .. tostring(err))
-  assert(result == "world", "expected 'world', got '" .. tostring(result) .. "'")
-  local c = check.must(caps)
-  assert(#c == 0, "expected empty captures table for pattern without groups")
+  local got = check.must(m)
+  assert(got.text == "world", "expected 'world', got '" .. tostring(got.text) .. "'")
+  assert(#got.caps == 0, "expected empty captures table for pattern without groups")
 end
 test_search_simple()
 
 local function test_search_no_match()
-  -- No match is not an error: a bare nil, no captures, no error message.
-  local result, caps, err = re.match("hello world", "xyz")
-  assert(result == nil, "expected nil for no match")
-  assert(caps == nil, "expected nil captures for no match")
+  -- No match is not an error: a bare nil, no error message.
+  local m, err = re.match("hello world", "xyz")
+  assert(m == nil, "expected nil for no match")
   assert(err == nil, "expected no error for no match")
 end
 test_search_no_match()
 
 local function test_search_invalid_pattern()
-  local result, caps, err = re.match("hello world", "[invalid")
-  assert(result == nil, "expected nil for invalid pattern")
-  assert(caps == nil, "expected nil captures for invalid pattern")
+  local m, err = re.match("hello world", "[invalid")
+  assert(m == nil, "expected nil for invalid pattern")
   assert(err ~= nil, "expected error message")
   assert(type(err) == "string", "error should be a string")
 end
 test_search_invalid_pattern()
 
 local function test_search_captures()
-  local result, caps, err = re.match("id 42-abc!", "([0-9]+)-([a-z]+)")
+  local m, err = re.match("id 42-abc!", "([0-9]+)-([a-z]+)")
   assert(err == nil, "expected no error, got: " .. tostring(err))
-  assert(result == "42-abc", "expected '42-abc', got '" .. tostring(result) .. "'")
-  local c = check.must(caps, "expected captures table")
-  assert(#c == 2, "expected 2 captures, got " .. tostring(#c))
-  assert(c[1] == "42", "expected first capture '42', got '" .. tostring(c[1]) .. "'")
-  assert(c[2] == "abc", "expected second capture 'abc', got '" .. tostring(c[2]) .. "'")
+  local got = check.must(m, "expected a match")
+  assert(got.text == "42-abc", "expected '42-abc', got '" .. tostring(got.text) .. "'")
+  assert(#got.caps == 2, "expected 2 captures, got " .. tostring(#got.caps))
+  assert(got.caps[1] == "42", "expected first capture '42'")
+  assert(got.caps[2] == "abc", "expected second capture 'abc'")
 end
 test_search_captures()
 
 local function test_search_nonparticipating_group()
-  local result, caps = re.match("xxaaxx", "(aa)|(bb)")
-  assert(result == "aa", "expected 'aa', got '" .. tostring(result) .. "'")
-  local c = check.must(caps)
-  assert(#c == 2, "expected 2 capture slots, got " .. tostring(#c))
-  assert(c[1] == "aa", "expected first capture 'aa', got '" .. tostring(c[1]) .. "'")
-  assert(c[2] == "", "non-participating group should be empty string, got '" .. tostring(c[2]) .. "'")
+  local m = check.must(re.match("xxaaxx", "(aa)|(bb)"))
+  assert(m.text == "aa", "expected 'aa', got '" .. tostring(m.text) .. "'")
+  assert(#m.caps == 2, "expected 2 capture slots, got " .. tostring(#m.caps))
+  assert(m.caps[1] == "aa", "expected first capture 'aa'")
+  assert(m.caps[2] == "", "non-participating group should be empty string")
 end
 test_search_nonparticipating_group()
 
 local function test_search_regex_metacharacters()
-  local result = re.match("hello", "h.llo")
-  assert(result == "hello", "expected 'hello', got '" .. tostring(result) .. "'")
+  local m = check.must(re.match("hello", "h.llo"))
+  assert(m.text == "hello", "expected 'hello', got '" .. tostring(m.text) .. "'")
 end
 test_search_regex_metacharacters()
 
 local function test_search_quantifiers()
-  local result = re.match("heeeello world", "he+llo")
-  assert(result == "heeeello", "expected 'heeeello', got '" .. tostring(result) .. "'")
+  local m = check.must(re.match("heeeello world", "he+llo"))
+  assert(m.text == "heeeello", "expected 'heeeello', got '" .. tostring(m.text) .. "'")
 end
 test_search_quantifiers()
 
 local function test_search_optional()
-  local result = re.match("color", "colou?r")
-  assert(result == "color", "expected 'color', got '" .. tostring(result) .. "'")
+  local m = check.must(re.match("color", "colou?r"))
+  assert(m.text == "color", "expected 'color', got '" .. tostring(m.text) .. "'")
 
-  result = re.match("colour", "colou?r")
-  assert(result == "colour", "expected 'colour', got '" .. tostring(result) .. "'")
+  m = check.must(re.match("colour", "colou?r"))
+  assert(m.text == "colour", "expected 'colour', got '" .. tostring(m.text) .. "'")
 end
 test_search_optional()
 
--- match convenience function tests
+-- is_match predicate tests: three honest outcomes
 
-local function test_match_true()
-  local result, err = re.test("hello world", "world")
+local function test_is_match_true()
+  local result, err = re.is_match("hello world", "world")
   assert(err == nil, "expected no error")
   assert(result == true, "expected true for matching pattern")
 end
-test_match_true()
+test_is_match_true()
 
-local function test_match_false()
-  local result, err = re.test("hello world", "xyz")
+local function test_is_match_false()
+  local result, err = re.is_match("hello world", "xyz")
   assert(err == nil, "expected no error")
   assert(result == false, "expected false for non-matching pattern")
 end
-test_match_false()
+test_is_match_false()
 
-local function test_match_invalid_pattern()
-  local result, err = re.test("hello world", "[invalid")
-  assert(result == false, "expected false for invalid pattern")
+local function test_is_match_invalid_pattern()
+  -- A bad pattern is nil + err, not false: "no match" and "your
+  -- pattern is invalid" are no longer the same value.
+  local result, err = re.is_match("hello world", "[invalid")
+  assert(result == nil, "expected nil for invalid pattern")
   assert(err ~= nil, "expected error message")
 end
-test_match_invalid_pattern()
+test_is_match_invalid_pattern()
 
 -- flag tests
 
-local function test_icase_flag()
-  -- Without ICASE, should not match
-  local result = re.match("hello world", "HELLO")
-  assert(result == nil, "expected nil without ICASE flag")
+local function test_ignore_case_option()
+  -- Without ignore_case, should not match
+  local none = re.match("hello world", "HELLO")
+  assert(none == nil, "expected nil without ignore_case")
 
-  -- With ICASE, should match
-  result = re.match("hello world", "HELLO", re.ICASE)
-  assert(result == "hello", "expected 'hello' with ICASE flag, got '" .. tostring(result) .. "'")
+  -- With ignore_case, should match
+  local m = check.must(re.match("hello world", "HELLO", {ignore_case = true}))
+  assert(m.text == "hello", "expected 'hello' with ignore_case, got '" .. tostring(m.text) .. "'")
 end
-test_icase_flag()
+test_ignore_case_option()
 
-local function test_compile_icase_flag()
-  local regex = check.must(re.compile("WORLD", re.ICASE))
+local function test_compile_ignore_case_option()
+  local regex = check.must(re.compile("WORLD", {ignore_case = true}))
   local result = regex:search("hello world")
-  assert(result == "world", "expected 'world' with ICASE flag")
+  assert(result == "world", "expected 'world' with ignore_case")
 end
-test_compile_icase_flag()
+test_compile_ignore_case_option()
 
--- flag constants existence tests
+-- The raw Regex layer keeps the binding's integer search flags.
 
-local function test_flags_exist()
-  assert(re.BASIC ~= nil, "BASIC flag should exist")
-  assert(re.ICASE ~= nil, "ICASE flag should exist")
-  assert(re.NEWLINE ~= nil, "NEWLINE flag should exist")
-  assert(re.NOSUB ~= nil, "NOSUB flag should exist")
+local function test_search_flags_exist()
   assert(re.NOTBOL ~= nil, "NOTBOL flag should exist")
   assert(re.NOTEOL ~= nil, "NOTEOL flag should exist")
 end
-test_flags_exist()
+test_search_flags_exist()
 
 -- edge case tests
 
 local function test_empty_pattern()
-  local result = re.match("hello", "")
+  local m = check.must(re.match("hello", ""))
   -- Empty pattern matches empty string at start
-  assert(result == "", "expected empty string match, got '" .. tostring(result) .. "'")
+  assert(m.text == "", "expected empty string match, got '" .. tostring(m.text) .. "'")
 end
 test_empty_pattern()
 
 local function test_empty_text()
-  local result = re.match("", "hello")
-  assert(result == nil, "expected nil for empty text")
+  local m = re.match("", "hello")
+  assert(m == nil, "expected nil for empty text")
 end
 test_empty_text()
 
 local function test_full_match()
-  local result = re.match("hello world", "^hello world$")
-  assert(result == "hello world", "expected full match")
+  local m = check.must(re.match("hello world", "^hello world$"))
+  assert(m.text == "hello world", "expected full match")
 end
 test_full_match()
 
 local function test_special_characters()
   -- Dot matches any character
-  local result = re.match("abc", "a.c")
-  assert(result == "abc", "expected 'abc', got '" .. tostring(result) .. "'")
+  local m = check.must(re.match("abc", "a.c"))
+  assert(m.text == "abc", "expected 'abc', got '" .. tostring(m.text) .. "'")
 end
 test_special_characters()
 
 local function test_escaped_special_characters()
   -- Escaped dot matches literal dot
-  local result = re.match("a.c", "a\\.c")
-  assert(result == "a.c", "expected 'a.c', got '" .. tostring(result) .. "'")
+  local m = check.must(re.match("a.c", "a\\.c"))
+  assert(m.text == "a.c", "expected 'a.c', got '" .. tostring(m.text) .. "'")
 end
 test_escaped_special_characters()
 


### PR DESCRIPTION
Fixes the module-level surface of #978; the `Regex:search` → `:match` rename moves upstream (below).

- **`CompileOptions {basic, ignore_case, newline, no_sub}` replaces the integer compile flags.** All six constants shared one `integer` namespace, so `re.match(text, pat, re.NOTBOL)` type-checked and the search flag was *silently ignored* (disjoint bits) — the D3 failure mode, warned about only in a non-doc comment. Two namespaces are now unmixable by type. Only `NOTBOL`/`NOTEOL` survive, scoped to the raw `Regex` layer.
- **`match` returns `Match {text, caps} | nil, string`** — the old `string|nil, {string}|nil, string|nil` tri-state was hand-decoded at every call site (the module's own doc taught the decoding recipe). Two slots, three honest outcomes: a Match, bare nil on no-match, `nil, err` on failure.
- **`test` → `is_match: boolean | nil, string`** — the old shape returned `false` both for "no match" and "your pattern is invalid". Rule 3 naming, and `~= nil` narrows the boolean union exactly (the carried patch's case).
- **`gmatch` is sound**: declared `MatchIterator, string`, it returned `nil, err` on a bad pattern — `for m in re.gmatch(t, p) do` type-checked and crashed. Now `MatchIterator | nil, string`.
- Stale doc deleted: `gmatch`'s "the engine reports no offsets, so lazy stepping buys nothing" contradicted the offsets rework documented two sections up in the same file.

**Scope note, correcting the audit:** the review claimed `Regex:search` could be renamed because `compile()` casts into a cosmic-owned record — but a Teal record only *types* what the binding's userdata metatable provides; the method names live in C (`tool/net/lre.c`). The module header's "a userdata metatable is the C layer's to name" was right. `:search`/`:find` keep their names here; a `:match` metatable alias goes to whilp/cosmopolitan#237 (upstream-first, D5), and `re.tl`'s header now states the boundary precisely.

Migrations: `re_ops_test`'s helper and the two flag call sites, `re_bench`'s log-scan scenario. `re` has no gen-0 tooling callers, so no transition aliases (the #1013 rule, checked).

Part of the api-review backlog (#1007), phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_