### PR TITLE
url/sse/ip: complete the pairs, one shape per parser

### DIFF
--- a/cosmic/fetch/extras.tl
+++ b/cosmic/fetch/extras.tl
@@ -106,24 +106,12 @@ local function unix_proxy(path: string): string | nil, string
   return "unix://" .. path
 end
 
---- Percent-encode params as k=v pairs joined with "&", keys sorted so
---- the encoding is deterministic. Spaces become %20 (not "+").
-local function encode_pairs(params: {string: string}): string
-  local keys: {string} = {}
-  for k in pairs(params) do
-    table.insert(keys, k)
-  end
-  table.sort(keys)
-  local out: {string} = {}
-  for _, k in ipairs(keys) do
-    table.insert(out, url_mod.escape_param(k) .. "=" .. url_mod.escape_param(params[k]))
-  end
-  return table.concat(out, "&")
-end
-
 --- Append query params to a URL, honoring an existing query string.
 local function append_query(url: string, params: {string: string}): string
-  local qs = encode_pairs(params)
+  -- url.format_query is the one percent-encoder for query maps; it
+  -- accepts plain-string values, so fetch's one-value map feeds it
+  -- directly (sorted keys, %20 spaces).
+  local qs = url_mod.format_query(params)
   if qs == "" then
     return url
   end
@@ -263,7 +251,7 @@ local function prepare<T>(url: string, opts_in: T): string, T, string
     set_default_content_type(prepared, "application/json")
   elseif opts.form then
     prepared.form = nil
-    prepared.body = encode_pairs(opts.form)
+    prepared.body = url_mod.format_query(opts.form)
     set_default_content_type(prepared, "application/x-www-form-urlencoded")
   elseif opts.multipart then
     local body, ctype_or_err = encode_multipart(opts.multipart)

--- a/cosmic/fetch/init.tl
+++ b/cosmic/fetch/init.tl
@@ -253,7 +253,9 @@ end
 
 local function backoff(attempt: integer, base_delay_ms: integer, max_delay_ms: integer)
   -- Full jitter: uniform in [0, min(max_delay_ms, base_delay_ms * 2^(attempt-1))].
-  local _ok, _err = time.sleep_ms(math.random() * math.min(max_delay_ms, base_delay_ms * 2 ^ (attempt - 1)))
+  -- Durations are integer milliseconds (D20 rule 2); floor the jitter.
+  local _ok, _err = time.sleep_ms(math.floor(
+    math.random() * math.min(max_delay_ms, base_delay_ms * 2 ^ (attempt - 1))))
 end
 
 --- Fetch a URL and return a structured result.

--- a/cosmic/fetch/init.tl
+++ b/cosmic/fetch/init.tl
@@ -255,7 +255,7 @@ local function backoff(attempt: integer, base_delay_ms: integer, max_delay_ms: i
   -- Full jitter: uniform in [0, min(max_delay_ms, base_delay_ms * 2^(attempt-1))].
   -- Durations are integer milliseconds (D20 rule 2); floor the jitter.
   local _ok, _err = time.sleep_ms(math.floor(
-    math.random() * math.min(max_delay_ms, base_delay_ms * 2 ^ (attempt - 1))))
+      math.random() * math.min(max_delay_ms, base_delay_ms * 2 ^ (attempt - 1))))
 end
 
 --- Fetch a URL and return a structured result.

--- a/cosmic/ip.tl
+++ b/cosmic/ip.tl
@@ -1,11 +1,13 @@
 --- IP address parsing, formatting, and classification utilities.
 --- The typed Addr is the only address currency in public signatures
---- (api-review-2): parse and lookup return Addr, sockets accept
+--- (api-review-2): parse and resolve return Addr, sockets accept
 --- and return Addr, and classification lives on Addr methods. The
 --- implementation is IPv4-only — IPv6 strings are rejected with an
 --- explicit error — but the shape is ready for IPv6 as a value
 --- extension: a later "inet6" family is a new Addr value, not a new
 --- API. Addr:int() exposes the raw v4 integer for the C boundary.
+--- The format halves are method-form: Addr:format() and Cidr:format()
+--- (or tostring()) invert parse and parse_cidr.
 local cosmo = require("cosmo")
 
 --- Category of an IPv4 address, as reported by categorize().
@@ -101,7 +103,7 @@ end
 --- hold an Addr.
 --- @param n integer The IP address as an integer
 --- @return Addr The typed IP address
-local function addr(n: integer): Addr
+local function from_int(n: integer): Addr
   return make_addr(n)
 end
 
@@ -143,7 +145,7 @@ end
 --- @param hostname string The hostname to look up
 --- @return Addr? The resolved IP address, or nil on error
 --- @return string? Error message on failure
-local function lookup(hostname: string): Addr | nil, string
+local function resolve(hostname: string): Addr | nil, string
   local raw, err = cosmo.ResolveIp(hostname)
   if not raw then
     return nil, "dns: lookup failed for " .. hostname .. ": " .. tostring(err)
@@ -152,7 +154,7 @@ local function lookup(hostname: string): Addr | nil, string
 end
 
 --- A parsed IPv4 CIDR block (e.g. "10.0.0.0/8"). Compares by value
---- and formats with tostring(). Construct with cidr().
+--- and formats with tostring(). Construct with parse_cidr().
 local record Cidr
   _n: integer
   _bits: integer
@@ -243,11 +245,11 @@ end
 --- The address part follows parse()'s strict dotted-quad rules; the
 --- prefix must be a decimal 0-32 without leading zeros. Host bits set
 --- below the prefix are masked away (like Go's ParseCIDR):
---- cidr("10.1.2.3/8") is the 10.0.0.0/8 block.
+--- parse_cidr("10.1.2.3/8") is the 10.0.0.0/8 block.
 --- @param str string The CIDR string to parse
 --- @return Cidr | nil The parsed block, or nil on error
 --- @return string Error message if parsing failed
-local function cidr(str: string): Cidr | nil, string
+local function parse_cidr(str: string): Cidr | nil, string
   local addr_part, bits_part = str:match("^([^/]*)/(%d+)$")
   if not addr_part then
     return nil, "invalid CIDR (want addr/prefix): " .. str
@@ -274,17 +276,17 @@ local record IpModule
   type Category = Category
   type Family = Family
   type Cidr = Cidr
-  addr: function(n: integer): Addr
+  from_int: function(n: integer): Addr
   parse: function(str: string): Addr | nil, string
-  cidr: function(str: string): Cidr | nil, string
-  lookup: function(hostname: string): Addr | nil, string
+  parse_cidr: function(str: string): Cidr | nil, string
+  resolve: function(hostname: string): Addr | nil, string
 end
 
 local M: IpModule = {
-  addr = addr,
+  from_int = from_int,
   parse = parse,
-  cidr = cidr,
-  lookup = lookup,
+  parse_cidr = parse_cidr,
+  resolve = resolve,
 }
 
 return M

--- a/cosmic/ip_test.tl
+++ b/cosmic/ip_test.tl
@@ -95,14 +95,14 @@ local function test_addr_equality()
   -- they were produced.
   assert(p("10.0.0.1") == p("10.0.0.1"), "equal addresses must be ==")
   assert(p("10.0.0.1") ~= p("10.0.0.2"), "different addresses must be ~=")
-  assert(p("127.0.0.1") == ip.addr(2130706433), "parse and addr agree")
+  assert(p("127.0.0.1") == ip.from_int(2130706433), "parse and addr agree")
 end
 test_addr_equality()
 
 local function test_addr_family()
   local a = p("8.8.8.8")
   assert(a.family == "inet", "family is 'inet' for IPv4")
-  local b = ip.addr(0)
+  local b = ip.from_int(0)
   assert(b.family == "inet", "constructed Addr carries family too")
 end
 test_addr_family()
@@ -187,7 +187,7 @@ test_is_public()
 -- lookup tests
 
 local function test_lookup_localhost()
-  local a, err = ip.lookup("localhost")
+  local a, err = ip.resolve("localhost")
   assert(a, "expected Addr for localhost, got nil: " .. tostring(err))
   assert(err == nil, "expected nil error, got " .. tostring(err))
   local aa = check.must(a)
@@ -197,7 +197,7 @@ end
 test_lookup_localhost()
 
 local function test_lookup_invalid_returns_nil()
-  local a, err = ip.lookup("this.host.does.not.exist.invalid")
+  local a, err = ip.resolve("this.host.does.not.exist.invalid")
   assert(a == nil, "expected nil for invalid hostname")
   assert(err ~= nil, "expected error message for invalid hostname")
   assert(err:find("lookup failed"), "expected 'lookup failed' in error: " .. tostring(err))
@@ -207,13 +207,13 @@ test_lookup_invalid_returns_nil()
 -- addr constructor (the int-to-Addr escape hatch for the C boundary)
 
 local function test_addr_int()
-  local a = ip.addr(2130706433)
+  local a = ip.from_int(2130706433)
   assert(a:int() == 2130706433, "expected 2130706433, got " .. tostring(a:int()))
 end
 test_addr_int()
 
 local function test_addr_methods()
-  local a = ip.addr(p("127.0.0.1"):int())
+  local a = ip.from_int(p("127.0.0.1"):int())
   assert(a:format() == "127.0.0.1", "expected '127.0.0.1', got '" .. a:format() .. "'")
   assert(a:categorize() == "LOOPBACK", "expected 'LOOPBACK', got '" .. a:categorize() .. "'")
   assert(a:is_loopback() == true, "expected loopback")
@@ -222,7 +222,7 @@ end
 test_addr_methods()
 
 local function test_lookup_returns_addr_with_methods()
-  local aa = check.must(ip.lookup("localhost"))
+  local aa = check.must(ip.resolve("localhost"))
   assert(aa:format() == "127.0.0.1", "expected '127.0.0.1', got '" .. aa:format() .. "'")
   assert(aa:is_loopback() == true, "expected loopback")
   assert(tostring(aa) == "127.0.0.1", "expected tostring '127.0.0.1'")
@@ -232,7 +232,7 @@ test_lookup_returns_addr_with_methods()
 -- CIDR tests
 
 local function test_cidr_parse()
-  local c = check.must(ip.cidr("192.168.0.0/16"))
+  local c = check.must(ip.parse_cidr("192.168.0.0/16"))
   assert(c:bits() == 16, "expected 16 bits")
   assert(tostring(c:network()) == "192.168.0.0", "expected network 192.168.0.0")
   assert(tostring(c) == "192.168.0.0/16", "expected tostring 192.168.0.0/16")
@@ -241,24 +241,24 @@ end
 test_cidr_parse()
 
 local function test_cidr_masks_host_bits()
-  local c = check.must(ip.cidr("10.1.2.3/8"))
+  local c = check.must(ip.parse_cidr("10.1.2.3/8"))
   assert(tostring(c:network()) == "10.0.0.0", "expected host bits masked away")
   assert(tostring(c) == "10.0.0.0/8", "expected canonical form")
 end
 test_cidr_masks_host_bits()
 
 local function test_cidr_netmask_broadcast_size()
-  local c = check.must(ip.cidr("192.168.1.0/24"))
+  local c = check.must(ip.parse_cidr("192.168.1.0/24"))
   assert(tostring(c:netmask()) == "255.255.255.0", "expected /24 netmask")
   assert(tostring(c:broadcast()) == "192.168.1.255", "expected broadcast")
   assert(c:size() == 256, "expected 256 addresses, got " .. tostring(c:size()))
 
-  local host = check.must(ip.cidr("1.2.3.4/32"))
+  local host = check.must(ip.parse_cidr("1.2.3.4/32"))
   assert(tostring(host:netmask()) == "255.255.255.255", "expected /32 netmask")
   assert(tostring(host:broadcast()) == "1.2.3.4", "expected /32 broadcast = itself")
   assert(host:size() == 1, "expected single address")
 
-  local all = check.must(ip.cidr("0.0.0.0/0"))
+  local all = check.must(ip.parse_cidr("0.0.0.0/0"))
   assert(tostring(all:netmask()) == "0.0.0.0", "expected /0 netmask")
   assert(tostring(all:broadcast()) == "255.255.255.255", "expected /0 broadcast")
   assert(all:size() == 4294967296, "expected 2^32 addresses")
@@ -270,7 +270,7 @@ test_cidr_netmask_broadcast_size()
 -- for an allowlist check. Callers parse first, so the parse error has
 -- somewhere to go.
 local function test_cidr_contains()
-  local c = check.must(ip.cidr("192.168.1.0/24"))
+  local c = check.must(ip.parse_cidr("192.168.1.0/24"))
   local function member(s: string): boolean
     local a = check.must(ip.parse(s))
     return c:contains(a)
@@ -281,11 +281,11 @@ local function test_cidr_contains()
   assert(not member("192.168.2.1"), "expected non-member")
   assert(not member("10.0.0.1"), "expected non-member")
 
-  local all = check.must(ip.cidr("0.0.0.0/0"))
+  local all = check.must(ip.parse_cidr("0.0.0.0/0"))
   local everyone = check.must(ip.parse("8.8.8.8"))
   assert(all:contains(everyone), "expected /0 to contain everything")
 
-  local host = check.must(ip.cidr("1.2.3.4/32"))
+  local host = check.must(ip.parse_cidr("1.2.3.4/32"))
   local self_addr = check.must(ip.parse("1.2.3.4"))
   local neighbor = check.must(ip.parse("1.2.3.5"))
   assert(host:contains(self_addr), "expected /32 to contain itself")
@@ -294,9 +294,9 @@ end
 test_cidr_contains()
 
 local function test_cidr_equality()
-  local a = check.must(ip.cidr("10.0.0.0/8"))
-  local b = check.must(ip.cidr("10.9.9.9/8"))
-  local c = check.must(ip.cidr("10.0.0.0/9"))
+  local a = check.must(ip.parse_cidr("10.0.0.0/8"))
+  local b = check.must(ip.parse_cidr("10.9.9.9/8"))
+  local c = check.must(ip.parse_cidr("10.0.0.0/9"))
   assert(a == b, "expected same masked block to compare equal")
   assert(a ~= c, "expected different prefix to differ")
 end
@@ -316,7 +316,7 @@ local function test_cidr_invalid()
     "", -- empty
   }
   for _, s in ipairs(cases) do
-    local c, err = ip.cidr(s)
+    local c, err = ip.parse_cidr(s)
     assert(c == nil, "expected failure for '" .. s .. "'")
     assert(err ~= nil, "expected error message for '" .. s .. "'")
   end

--- a/cosmic/net/connect_test.tl
+++ b/cosmic/net/connect_test.tl
@@ -27,7 +27,7 @@ local function test_interfaces()
     if iface.name == "lo" then
       has_loopback = true
       -- Loopback should be 127.0.0.1; Addr compares by value (__eq)
-      assert(iface.ip == ip.addr(0x7f000001),
+      assert(iface.ip == ip.from_int(0x7f000001),
         "loopback should have 127.0.0.1, got " .. iface.ip:format())
     end
   end
@@ -263,7 +263,7 @@ local function test_connect_tcp_accepts_string_and_addr()
   assert(a1:close())
 
   -- connect by typed ip.Addr
-  local addr = ip.addr(0x7f000001)
+  local addr = ip.from_int(0x7f000001)
   local c2 = check.must(net.connect_tcp(addr, port))
   local a2 = check.must(server:accept())
   assert(c2:close())

--- a/cosmic/net/init.tl
+++ b/cosmic/net/init.tl
@@ -15,7 +15,7 @@ local errstr = require("cosmic.errno").wrap
 local type Socket = net_socket.Socket
 
 --- An address a helper accepts: a dotted-quad string ("127.0.0.1") or a
---- typed ip.Addr. Wrap C-boundary integers with ip.addr().
+--- typed ip.Addr. Wrap C-boundary integers with ip.from_int().
 local type Address = net_socket.Address
 
 local make_socket = net_socket.make_socket
@@ -181,7 +181,7 @@ local function dial(host: string, port: integer, opts?: ConnectOptions): Socket 
   if parsed then
     a = parsed
   else
-    local looked, lerr = ip.lookup(host)
+    local looked, lerr = ip.resolve(host)
     if not looked then
       return nil, "dial " .. host .. ": " .. tostring(lerr)
     end
@@ -293,7 +293,7 @@ local function interfaces(): {Interface} | nil, string
   for i, entry in ipairs(raw as {{string: any}}) do -- cast: from any
     list[i] = {
       name = entry["name"] as string, -- cast: from any
-      ip = ip.addr(entry["ip"] as integer), -- cast: from any
+      ip = ip.from_int(entry["ip"] as integer), -- cast: from any
     }
   end
   return list

--- a/cosmic/net/socket.tl
+++ b/cosmic/net/socket.tl
@@ -2,7 +2,7 @@
 --- Contains the Socket constructor and all Socket method implementations.
 --- Addresses are typed (api-review-2): methods accept a dotted-quad
 --- string or an ip.Addr, and return ip.Addr — bare integers are not part
---- of the public surface (wrap C-boundary integers with ip.addr()).
+--- of the public surface (wrap C-boundary integers with ip.from_int()).
 local unix = require("cosmo.unix")
 local errstr = require("cosmic.errno").wrap
 local errno_is = require("cosmic.errno").is
@@ -326,7 +326,7 @@ local function make_socket(fd: integer): Socket
       -- arrives in the second slot, where the sender ip would have been.
       return nil, errstr(sender, "recvfrom")
     end
-    return {data = data, addr = ip.addr(sender), port = port}
+    return {data = data, addr = ip.from_int(sender), port = port}
   end
 
   function sock:getsockname(): Endpoint | nil, string
@@ -337,7 +337,7 @@ local function make_socket(fd: integer): Socket
       -- arrives in the second slot, where the port would have been.
       return nil, errstr(port, "getsockname")
     end
-    return {addr = ip.addr(raw), port = port}
+    return {addr = ip.from_int(raw), port = port}
   end
 
   function sock:getpeername(): Endpoint | nil, string
@@ -348,7 +348,7 @@ local function make_socket(fd: integer): Socket
       -- arrives in the second slot, where the port would have been.
       return nil, errstr(port, "getpeername")
     end
-    return {addr = ip.addr(raw), port = port}
+    return {addr = ip.from_int(raw), port = port}
   end
 
   function sock:bind(addr?: Address, port?: integer): boolean, string

--- a/cosmic/sse.tl
+++ b/cosmic/sse.tl
@@ -1,10 +1,12 @@
---- Server-Sent Events parser for streaming HTTP responses.
---- Parses SSE format from any stream.Reader (a fetch.Reader, an fd
+--- Server-Sent Events: parse a stream of them, format one for the wire.
+--- parse() reads SSE from any stream.Reader (a fetch.Reader, an fd
 --- Handle wrapping a socket, a child's stdout) and yields complete
 --- events, following the WHATWG event stream processing model:
 --- unterminated events at EOF are discarded, empty-data dispatches
 --- reset the event type buffer, the last event ID updates as soon as
 --- an `id:` line is seen, and `retry:` accepts only ASCII digits.
+--- format() is the serializing half, so a cosmic program can serve SSE
+--- without hand-writing the wire framing.
 
 local stream = require("cosmic.stream")
 
@@ -13,24 +15,25 @@ local record Event
   data: string -- concatenated data: lines (required)
   event: string -- event type, defaults to "message"
   id: string -- last event ID
-  retry: number -- reconnection time in milliseconds
+  retry_ms: integer -- reconnection time in milliseconds
 end
 
 --- An open SSE event stream.
-local record Stream
-  --- Iterator over parsed events: yields Event values; on a mid-stream
-  --- transport failure yields nil plus the error message once, then
-  --- plain nil — so truncation is distinguishable from a graceful close.
-  --- Event is a record, so narrow each yield in a positive branch:
+local record EventStream
+  --- Next parsed event: an Event, or bare nil on a graceful close. On
+  --- a mid-stream transport failure it yields nil plus the error
+  --- message once, then plain nil — so truncation is distinguishable
+  --- from a graceful close. The positive branch narrows the yield
+  --- (a guard before a break does not):
   ---   while true do
-  ---     local ev = s.next()
-  ---     if ev is sse.Event then handle(ev) else break end
+  ---     local ev = s:next()
+  ---     if ev then handle(ev) else break end
   ---   end
-  next: function(): Event | nil, string
+  next: function(self: EventStream): Event | nil, string
   --- The last seen event ID (nil until an id: line is seen), for
   --- reconnecting with a Last-Event-ID request header. Updates as soon
   --- as an id: line is parsed, even when no event is dispatched.
-  last_event_id: function(): string | nil
+  last_event_id: function(self: EventStream): string | nil
 end
 
 --- Parse a single field line into name and value.
@@ -65,30 +68,22 @@ end
 local line_iter = stream.lines
 
 --- Parse SSE events from a streaming reader.
---- Returns a Stream whose next() yields Event values. Event is a
---- record, so `for ev in s.next do` leaves ev un-narrowed (`Event |
---- nil`) — iterate with a positive `is` branch instead:
----   while true do
----     local ev = s.next()
----     if ev is sse.Event then handle(ev) else break end
----   end
---- When the underlying reader fails mid-body (reset, truncation, TLS
---- error) next() yields nil plus the error message once, then nil — so
---- a truncated stream is distinguishable from a graceful close. A
+--- Returns an EventStream whose :next() yields Event values (see the
+--- record for the loop shape and the truncation-vs-close contract). A
 --- partially accumulated event at end-of-stream is discarded per the
---- SSE spec, not dispatched. stream.last_event_id() exposes the id for
+--- SSE spec, not dispatched. :last_event_id() exposes the id for
 --- reconnects.
 --- @param reader stream.Reader the reader to parse events from
---- @return Stream the open event stream
-local function events(reader: stream.Reader): Stream
+--- @return EventStream the open event stream
+local function parse(reader: stream.Reader): EventStream
   local current_data: {string} = {}
   local current_event: string = nil
-  local current_retry: number = nil
+  local current_retry_ms: integer = nil
   local last_id: string = nil
   local lines_iter = line_iter(reader)
   local done = false
 
-  local function next_event(): Event | nil, string
+  local function next_event(_self: EventStream): Event | nil, string
     if done then
       return nil
     end
@@ -119,16 +114,16 @@ local function events(reader: stream.Reader): Stream
           -- dispatch nothing. Otherwise a retry: from this discarded
           -- block would leak into the next dispatched event.
           current_event = nil
-          current_retry = nil
+          current_retry_ms = nil
         else
           local ev: Event = {
             data = data,
             event = current_event or "message",
             id = last_id,
-            retry = current_retry,
+            retry_ms = current_retry_ms,
           }
           current_event = nil
-          current_retry = nil
+          current_retry_ms = nil
           return ev
         end
       else
@@ -147,7 +142,7 @@ local function events(reader: stream.Reader): Stream
           elseif name == "retry" then
             -- digits-only per spec; anything else is ignored
             if value:match("^%d+$") then
-              current_retry = tonumber(value)
+              current_retry_ms = math.tointeger(tonumber(value))
             end
           end
           -- ignore unknown field names per spec
@@ -157,7 +152,7 @@ local function events(reader: stream.Reader): Stream
     end
   end
 
-  local function last_event_id(): string | nil
+  local function last_event_id(_self: EventStream): string | nil
     return last_id
   end
 
@@ -167,14 +162,52 @@ local function events(reader: stream.Reader): Stream
   }
 end
 
-local record sse
-  type Event = Event
-  type Stream = Stream
-  events: function(reader: stream.Reader): Stream
+--- Serialize one Event to its wire form: `event:`/`id:`/`retry:`
+--- fields when present, one `data:` line per newline-separated data
+--- segment, and the dispatching blank line. The inverse of parse for a
+--- dispatchable event (data ~= ""): parse(format(ev)) yields ev back.
+--- Infallible.
+--- @param ev Event the event to serialize
+--- @return string the wire bytes, terminator included
+local function format(ev: Event): string
+  local out: {string} = {}
+  if ev.event and ev.event ~= "message" then
+    out[#out + 1] = "event: " .. ev.event
+  end
+  if ev.id then
+    out[#out + 1] = "id: " .. ev.id
+  end
+  if ev.retry_ms then
+    out[#out + 1] = "retry: " .. tostring(ev.retry_ms)
+  end
+  -- One data: line per segment; a lone trailing newline in data would
+  -- otherwise be silently lost on the round trip.
+  local data = ev.data or ""
+  local pos = 1
+  while true do
+    local nl = data:find("\n", pos, true)
+    if nl then
+      out[#out + 1] = "data: " .. data:sub(pos, nl - 1)
+      pos = nl + 1
+    else
+      out[#out + 1] = "data: " .. data:sub(pos)
+      break
+    end
+  end
+  out[#out + 1] = "\n"
+  return table.concat(out, "\n")
 end
 
-local M: sse = {
-  events = events,
+local record SseModule
+  type Event = Event
+  type EventStream = EventStream
+  parse: function(reader: stream.Reader): EventStream
+  format: function(ev: Event): string
+end
+
+local M: SseModule = {
+  parse = parse,
+  format = format,
 }
 
 return M

--- a/cosmic/sse_test.tl
+++ b/cosmic/sse_test.tl
@@ -81,23 +81,24 @@ end
 --- Collect every event; return the events, the terminal error (if any),
 --- and the stream's final last_event_id.
 local function collect(content: string, fail_with?: string): {sse.Event}, string, string | nil
-  local stream = sse.events(mock_reader(content, fail_with))
+  local stream = sse.parse(mock_reader(content, fail_with))
   local events_list: {sse.Event} = {}
   local terminal_err: string
   while true do
-    local event, err = stream.next()
+    local event, err = stream:next()
     if not event then
       terminal_err = err
       break
     end
     table.insert(events_list, event)
   end
-  return events_list, terminal_err, stream.last_event_id()
+  return events_list, terminal_err, stream:last_event_id()
 end
 
 local function test_module_loads()
   assert(sse ~= nil, "sse module should not be nil")
-  assert(type(sse.events) == "function", "sse.events should be a function")
+  assert(type(sse.parse) == "function", "sse.parse should be a function")
+  assert(type(sse.format) == "function", "sse.format should be a function")
 end
 test_module_loads()
 
@@ -137,7 +138,7 @@ test_event_id()
 local function test_retry_field()
   local events_list = collect("retry: 5000\ndata: test\n\n")
   assert(#events_list == 1, "should have 1 event")
-  assert(events_list[1].retry == 5000, "retry should be 5000, got: " .. tostring(events_list[1].retry))
+  assert(events_list[1].retry_ms == 5000, "retry should be 5000, got: " .. tostring(events_list[1].retry_ms))
 end
 test_retry_field()
 
@@ -210,8 +211,8 @@ local function test_empty_data_dispatch_resets_retry()
   -- whole block, undispatched) must not leak into the next event
   local events_list = collect("retry: 5000\n\ndata: hi\n\n")
   assert(#events_list == 1, "should have 1 event")
-  assert(events_list[1].retry == nil,
-    "retry must reset on empty-data dispatch, got: " .. tostring(events_list[1].retry))
+  assert(events_list[1].retry_ms == nil,
+    "retry must reset on empty-data dispatch, got: " .. tostring(events_list[1].retry_ms))
 end
 test_empty_data_dispatch_resets_retry()
 
@@ -225,7 +226,7 @@ test_unknown_fields_ignored()
 local function test_invalid_retry_ignored()
   local events_list = collect("retry: not-a-number\ndata: test\n\n")
   assert(#events_list == 1, "should have 1 event")
-  assert(events_list[1].retry == nil, "invalid retry should be nil")
+  assert(events_list[1].retry_ms == nil, "invalid retry should be nil")
 end
 test_invalid_retry_ignored()
 
@@ -233,8 +234,8 @@ local function test_retry_digits_only()
   -- "3000ms" is not digits-only; tonumber-style prefixes must not pass
   local events_list = collect("retry: 3000ms\ndata: a\n\nretry: 0x10\ndata: b\n\n")
   assert(#events_list == 2, "should have 2 events")
-  assert(events_list[1].retry == nil, "'3000ms' must be ignored")
-  assert(events_list[2].retry == nil, "'0x10' must be ignored")
+  assert(events_list[1].retry_ms == nil, "'3000ms' must be ignored")
+  assert(events_list[2].retry_ms == nil, "'0x10' must be ignored")
 end
 test_retry_digits_only()
 
@@ -292,7 +293,7 @@ local function test_complete_event_with_all_fields()
   assert(#events_list == 1, "should have 1 event")
   assert(events_list[1].event == "update", "event type should be 'update'")
   assert(events_list[1].id == "42", "id should be '42'")
-  assert(events_list[1].retry == 3000, "retry should be 3000")
+  assert(events_list[1].retry_ms == 3000, "retry should be 3000")
   assert(events_list[1].data == "line 1\nline 2", "data should be multiline")
 end
 test_complete_event_with_all_fields()
@@ -329,26 +330,33 @@ end
 test_read_error_propagates()
 
 local function test_read_error_then_iterator_exhausted()
-  local stream = sse.events(mock_reader("data: one\n\n", "boom"))
-  local first = check.must(stream.next())
+  local stream = sse.parse(mock_reader("data: one\n\n", "boom"))
+  local first = check.must(stream:next())
   assert(first.data == "one", "first event expected")
-  local second, err = stream.next()
+  local second, err = stream:next()
   assert(second == nil and err == "boom", "error must be yielded once")
-  local third, err3 = stream.next()
+  local third, err3 = stream:next()
   assert(third == nil and err3 == nil, "after the error the iterator returns plain nil")
 end
 test_read_error_then_iterator_exhausted()
 
-local function test_stream_iterates_with_for_in()
-  local stream = sse.events(mock_reader("data: a\n\ndata: b\n\n"))
+local function test_stream_loops_with_positive_branch()
+  -- The documented loop shape: the POSITIVE branch narrows the yield
+  -- past nil (a guard before a break does not survive the flow join).
+  local stream = sse.parse(mock_reader("data: a\n\ndata: b\n\n"))
   local seen: {string} = {}
-  for event in stream.next do
-    table.insert(seen, check.must(event).data)
+  while true do
+    local event = stream:next()
+    if event then
+      table.insert(seen, event.data)
+    else
+      break
+    end
   end
   assert(#seen == 2 and seen[1] == "a" and seen[2] == "b",
-    "stream.next must work for-in iterator")
+    "the positive-branch loop must see both events")
 end
-test_stream_iterates_with_for_in()
+test_stream_loops_with_positive_branch()
 
 local function test_error_discards_partial_event()
   -- data buffered before the failure belongs to an unterminated event;
@@ -372,15 +380,33 @@ local function test_events_from_socket_backed_reader()
   assert(a:send("data: from a socket\n\nevent: ping\ndata: second\n\n"))
   assert(a:close())
 
-  local stream_events = sse.events(fd.wrap(b.fd))
-  local ev1 = check.must(stream_events.next())
+  local stream_events = sse.parse(fd.wrap(b.fd))
+  local ev1 = check.must(stream_events:next())
   assert(ev1.data == "from a socket", "first event data: " .. tostring(ev1.data))
   assert(ev1.event == "message", "default event type")
-  local ev2 = check.must(stream_events.next())
+  local ev2 = check.must(stream_events:next())
   assert(ev2.data == "second", "second event data: " .. tostring(ev2.data))
   assert(ev2.event == "ping", "explicit event type")
-  local done, derr = stream_events.next()
+  local done, derr = stream_events:next()
   assert(done == nil and derr == nil, "clean close ends the stream")
   assert(b:close())
 end
 test_events_from_socket_backed_reader()
+
+-- format: the serializing half (D20 rule 6 — a pair ships both halves).
+local function test_format_roundtrip()
+  local ev: sse.Event = {data = "line1\nline2", event = "update", id = "7", retry_ms = 250}
+  local wire = sse.format(ev)
+  local back = check.must(sse.parse(mock_reader(wire)):next())
+  assert(back.data == ev.data, "data round-trips, got: " .. back.data)
+  assert(back.event == "update", "event type round-trips")
+  assert(back.id == "7", "id round-trips")
+  assert(back.retry_ms == 250, "retry_ms round-trips")
+end
+test_format_roundtrip()
+
+local function test_format_minimal_event()
+  local wire = sse.format({data = "hi"} as sse.Event) -- cast: partial literal
+  assert(wire == "data: hi\n\n", "minimal event is one data line + blank, got: " .. wire)
+end
+test_format_minimal_event()

--- a/cosmic/stream.tl
+++ b/cosmic/stream.tl
@@ -144,7 +144,7 @@ end
 
 --- Wrap bytes already in hand as a Reader, so in-memory data (a file
 --- read whole, a decompressed buffer, a test fixture) feeds any stream
---- consumer — stream.lines, sse.events, stream.copy — without a
+--- consumer — stream.lines, sse.parse, stream.copy — without a
 --- hand-rolled adapter. read(n?) returns successive chunks (at most n
 --- bytes when n is given, the whole remainder otherwise), then bare
 --- nil at end of stream, per the Reader contract; n must be positive

--- a/cosmic/url.tl
+++ b/cosmic/url.tl
@@ -78,10 +78,13 @@ end
 --- Format a query map back into a query string: the inverse of
 --- parse_query. Keys are sorted (deterministic output) and each of a
 --- key's values becomes its own k=v pair, in order; both halves are
---- percent-encoded with the param rules (spaces become %20).
---- @param params {string:{string}} Keys, each with all its values in order
+--- percent-encoded with the param rules (spaces become %20). A value
+--- may be a plain string as well as a list — so a parsed query feeds
+--- back in unchanged, and the common one-value-per-key map (e.g.
+--- fetch's query option) needs no wrapping.
+--- @param params {string:{string} | string} Keys with one value or all values in order
 --- @return string The query string (no leading ?)
-local function format_query(params: {string: {string}}): string
+local function format_query(params: {string: {string} | string}): string
   local keys: {string} = {}
   for k in pairs(params) do
     keys[#keys + 1] = k
@@ -89,8 +92,13 @@ local function format_query(params: {string: {string}}): string
   table.sort(keys)
   local out: {string} = {}
   for _, k in ipairs(keys) do
-    for _, v in ipairs(params[k]) do
+    local v = params[k]
+    if v is string then
       out[#out + 1] = escape_param(k) .. "=" .. escape_param(v)
+    else
+      for _, item in ipairs(v) do
+        out[#out + 1] = escape_param(k) .. "=" .. escape_param(item)
+      end
     end
   end
   return table.concat(out, "&")
@@ -276,32 +284,21 @@ local function escape_fragment(str: string): string
   return cosmo.EscapeFragment(str)
 end
 
---- Escape a string for literal URL matching.
---- @param str string The string to escape
---- @return string The escaped string
-local function escape_literal(str: string): string
-  return cosmo.EscapeLiteral(str)
-end
-
---- Escape a username for use in a URL.
---- @param str string The username to escape
---- @return string The escaped username
-local function escape_user(str: string): string
-  return cosmo.EscapeUser(str)
-end
-
---- Escape a password for use in a URL.
---- @param str string The password to escape
---- @return string The escaped password
-local function escape_pass(str: string): string
-  return cosmo.EscapePass(str)
-end
-
---- Escape an IP address for use in a URL.
---- @param str string The IP address to escape
---- @return string The escaped IP address
-local function escape_ip(str: string): string
-  return cosmo.EscapeIp(str)
+--- Format a HostPort back into a host:port string: the inverse of
+--- parse_host. An IPv6 host (any host carrying a colon) is bracketed,
+--- which is exactly the rule parse_host knows and callers were left to
+--- rediscover; a nil port yields the bare host.
+--- @param hp HostPort The host (port optional)
+--- @return string The host:port string
+local function format_host(hp: HostPort): string
+  local host = hp.host
+  if host:find(":", 1, true) then
+    host = "[" .. host .. "]"
+  end
+  if hp.port then
+    return host .. ":" .. tostring(hp.port)
+  end
+  return host
 end
 
 local record UrlModule
@@ -314,16 +311,13 @@ local record UrlModule
   parse: function(url: string): Url | nil, string
   format: function(u: Url): string
   parse_query: function(query: string): {string: {string}}
-  format_query: function(params: {string: {string}}): string
+  format_query: function(params: {string: {string} | string}): string
   parse_host: function(hostport: string): HostPort | nil, string
   escape_host: function(str: string): string
   escape_path: function(str: string): string
   escape_segment: function(str: string): string
   escape_fragment: function(str: string): string
-  escape_literal: function(str: string): string
-  escape_user: function(str: string): string
-  escape_pass: function(str: string): string
-  escape_ip: function(str: string): string
+  format_host: function(hp: HostPort): string
 end
 
 local M: UrlModule = {
@@ -339,10 +333,7 @@ local M: UrlModule = {
   escape_path = escape_path,
   escape_segment = escape_segment,
   escape_fragment = escape_fragment,
-  escape_literal = escape_literal,
-  escape_user = escape_user,
-  escape_pass = escape_pass,
-  escape_ip = escape_ip,
+  format_host = format_host,
 }
 
 return M

--- a/cosmic/url_test.tl
+++ b/cosmic/url_test.tl
@@ -403,36 +403,6 @@ local function test_escape_fragment_with_spaces()
 end
 test_escape_fragment_with_spaces()
 
-local function test_escape_literal_basic()
-  local result = url.escape_literal("test")
-  assert(result == "test", "expected 'test', got '" .. result .. "'")
-end
-test_escape_literal_basic()
-
-local function test_escape_user_with_special_chars()
-  local result = url.escape_user("user@domain")
-  assert(result:match("%%40") or result:match("%%2540"), "expected @ to be encoded")
-end
-test_escape_user_with_special_chars()
-
-local function test_escape_pass_with_special_chars()
-  local result = url.escape_pass("p@ss:word")
-  assert(result:match("%%"), "expected special chars to be encoded")
-end
-test_escape_pass_with_special_chars()
-
-local function test_escape_ip_ipv4()
-  local result = url.escape_ip("192.168.1.1")
-  assert(result == "192.168.1.1", "expected '192.168.1.1', got '" .. result .. "'")
-end
-test_escape_ip_ipv4()
-
-local function test_escape_ip_ipv6()
-  local result = url.escape_ip("::1")
-  assert(result:match("::1") or result:match("%%3A"), "expected ipv6 to be handled, got '" .. result .. "'")
-end
-test_escape_ip_ipv6()
-
 -- parse must preserve percent-encoding in the query field: ?a=x%26y has
 -- ONE param (key=a, value=x&y); the reconstructed query must not turn %26
 -- into a literal & (which would look like two params).
@@ -456,3 +426,23 @@ local function test_parse_query_field_flag_param()
   assert(not result.query:match("flag=$"), "query must not end with 'flag='")
 end
 test_parse_query_field_flag_param()
+
+-- format_host: the inverse parse_host was missing — reassembling
+-- host:port requires the IPv6 bracketing rule only parse_host knew.
+local function test_format_host_roundtrip()
+  local hp = check.must(url.parse_host("example.com:8080"))
+  assert(url.format_host(hp) == "example.com:8080")
+  local v6 = check.must(url.parse_host("[::1]:443"))
+  assert(url.format_host(v6) == "[::1]:443", "IPv6 hosts re-bracket")
+  local bare = check.must(url.parse_host("example.com"))
+  assert(url.format_host(bare) == "example.com", "nil port yields bare host")
+end
+test_format_host_roundtrip()
+
+-- format_query accepts plain-string values beside lists, so a parsed
+-- query and fetch's one-value map both feed it without wrapping.
+local function test_format_query_string_values()
+  assert(url.format_query({b = "2", a = "1"}) == "a=1&b=2")
+  assert(url.format_query({k = {"1", "2"}, s = "x"}) == "k=1&k=2&s=x")
+end
+test_format_query_string_values()


### PR DESCRIPTION
Fixes #997.

**sse** — the biggest half:
- `events()` → `parse(r): EventStream` (rule 6 verb; the record renamed from `Stream`, which sat one letter from `stream.Reader` in its own file), with **colon methods** — the closure-field object was the stdlib's only dot-called surface.
- `Event.retry: number` → `retry_ms: integer` (rule 2 — the unit lived in a comment).
- **`format(ev)` lands** — the missing serializing half, so a cosmic program can serve SSE without hand-writing the wire framing (D09). `parse(format(ev))` round-trips a dispatchable event, including multi-line data; tested both ways.
- The module doc now teaches the loop shape that actually narrows (positive branch — a guard before a `break` does not survive the flow join), replacing the six-line `is`-dispatch recipe that was printed twice.

**url:**
- `format_host(hp)` — the inverse `parse_host` was missing; reassembling `host:port` requires the IPv6 bracketing rule only `parse_host` knew.
- `format_query` accepts `{string: {string} | string}`, so a parsed query round-trips *and* fetch's one-value-per-key map feeds it unwrapped.
- The four inverse-less, zero-caller escapes (`escape_literal`/`escape_user`/`escape_pass`/`escape_ip`) are deleted — the escape family goes 9 → 5 and "`unescape()` as their shared inverse" now covers all of it.

**ip:** `addr(n)` → `from_int(n)` (rule 5), `cidr(str)` → `parse_cidr(str)` (a bare noun doing a parse, one line below `parse` in the module record), `lookup` → `resolve`; the header notes the method-form `format` inverses the way url's does.

**fetch riders:** `extras.encode_pairs` dies in favor of `url.format_query` (byte-identical algorithm, one percent-encoder in the binary); the retry jitter floors to integer ms (rule 2). The `deadline_ms` whole-request option noted in the issue belongs with #975's Result reshape, not here.

Gen-0 check (the #1013 rule): no `_cli`/`_make`/`cmd` file requires `cosmic.net`, `cosmic.ip`, or `cosmic.sse`, so clean renames, no transition aliases.

Part of the api-review backlog (#1007), phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_