### PR TITLE
string/fuzzy: empty-needle consistency; distance over levenshtein

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,7 +368,7 @@ all modules are under `cosmic/` and imported as `cosmic.*`:
 | flags | declarative command-line flag parsing with generated --help |
 | format | Teal/Lua code formatter |
 | fs | filesystem: paths, stat, walk, read/write, mkdir, symlink, tmp |
-| fuzzy | fuzzy string matching (Levenshtein distance) |
+| fuzzy | fuzzy string matching (edit distance) |
 | getopt | command-line option parsing (short + long opts) |
 | hash | SHA-256 digest and Argon2 password hashing |
 | html | HTML escaping |

--- a/_perf/bench/fuzzy_bench.tl
+++ b/_perf/bench/fuzzy_bench.tl
@@ -37,13 +37,16 @@ local function scenarios(): {pt.Scenario}, string
         return fuzzy.find_similar(QUERY, CANDIDATES)
       end,
       check = function(_: any, res: any): boolean, string
-        local names = res as {string} -- cast: from any
-        if names == nil or #names ~= 1 then
+        local matches = res as {fuzzy.Match} -- cast: from any
+        if matches == nil or #matches ~= 1 then
           return false, "expected exactly one match, got " ..
-          tostring(names and #names)
+          tostring(matches and #matches)
         end
-        if names[1] ~= "install" then
-          return false, "wrong match: " .. tostring(names[1])
+        if matches[1].value ~= "install" then
+          return false, "wrong match: " .. tostring(matches[1].value)
+        end
+        if matches[1].distance ~= 1 then
+          return false, "wrong distance: " .. tostring(matches[1].distance)
         end
         return true
       end,

--- a/cosmic/doc/show.tl
+++ b/cosmic/doc/show.tl
@@ -405,11 +405,11 @@ local function find_suggestions(query: string, index: DocIndex): {string}
       end
     end
   end
-  local similar = fuzzy.find_similar(query, candidates, 3)
+  local similar = fuzzy.find_similar(query, candidates, {max_distance = 3})
   local results: {string} = {}
   local seen: {string: boolean} = {}
-  for _, simple in ipairs(similar) do
-    local fulls = name_to_full[simple]
+  for _, m in ipairs(similar) do
+    local fulls = name_to_full[m.value]
     if fulls then
       for _, full in ipairs(fulls) do
         if not seen[full] then
@@ -435,10 +435,10 @@ local function find_example_suggestions(query: string, index: DocIndex): {string
       end
     end
   end
-  local similar = fuzzy.find_similar(query, candidates, 3)
+  local similar = fuzzy.find_similar(query, candidates, {max_distance = 3})
   local results: {string} = {}
-  for _, simple in ipairs(similar) do
-    if name_to_full[simple] then table.insert(results, name_to_full[simple]) end
+  for _, m in ipairs(similar) do
+    if name_to_full[m.value] then table.insert(results, name_to_full[m.value]) end
   end
   return results
 end

--- a/cosmic/fuzzy.tl
+++ b/cosmic/fuzzy.tl
@@ -1,12 +1,14 @@
 --- Fuzzy string matching utilities.
+--- Approximate (edit-distance) matching. For exact plain-text search
+--- see cosmic.string; for pattern-based matching see cosmic.re.
 
---- Compute Levenshtein distance between two strings.
+--- Compute the edit distance between two strings (Levenshtein).
 --- Uses a two-row algorithm with O(min(n,m)) memory and string.byte
 --- for fast character comparison.
 --- @param a string First string
 --- @param b string Second string
 --- @return integer Edit distance
-local function levenshtein(a: string, b: string): integer
+local function distance(a: string, b: string): integer
   local la = #a
   local lb = #b
   if la == 0 then return lb end
@@ -47,14 +49,36 @@ local function levenshtein(a: string, b: string): integer
   return prev[lb]
 end
 
---- Find similar strings from a list using Levenshtein distance.
+--- One similar candidate: the value and the edit distance the search
+--- already computed for it (previously thrown away, which forced the
+--- one caller wanting a ranked score to re-run the DP itself).
+local record Match
+  value: string
+  distance: integer
+end
+
+--- Options for find_similar.
+local record Options
+  --- Maximum edit distance to consider (default 3).
+  max_distance: integer
+  --- Keep at most this many matches (default all).
+  limit: integer
+end
+
+--- Find similar strings from a list by edit distance (case-insensitive,
+--- deduplicated on the lowercased form).
 --- @param query string The search query
 --- @param candidates {string} List of strings to match against
---- @param max_distance integer Maximum edit distance to consider (default 3)
---- @return {string} List of similar values, sorted by distance then alphabetically
-local function find_similar(query: string, candidates: {string}, max_distance?: integer): {string}
-  max_distance = max_distance or 3
-  local results: {{string, integer}} = {} -- {value, distance}
+--- @param opts Options? max_distance (default 3), limit (default all)
+--- @return {Match} Matches with their distances, sorted by distance then value
+local function find_similar(query: string, candidates: {string}, opts?: Options): {Match}
+  local max_distance = 3
+  local limit: integer = nil
+  if opts then
+    if opts.max_distance then max_distance = opts.max_distance end
+    limit = opts.limit
+  end
+  local results: {Match} = {}
   local seen: {string: boolean} = {}
 
   local query_lower = query:lower()
@@ -68,40 +92,48 @@ local function find_similar(query: string, candidates: {string}, max_distance?: 
       -- differs from the query by more than max_distance can never qualify.
       -- Skipping it avoids the O(n*m) DP with no change to the result set.
       if math.abs(#query_lower - #candidate_lower) <= max_distance then
-        local dist = levenshtein(query_lower, candidate_lower)
+        local dist = distance(query_lower, candidate_lower)
         if dist <= max_distance then
           seen[candidate_lower] = true
-          table.insert(results, {candidate, dist})
+          table.insert(results, {value = candidate, distance = dist})
         end
       end
     end
   end
 
-  -- Sort by distance, then alphabetically
-  table.sort(results, function(a: {string, integer}, b: {string, integer}): boolean
-      if a[2] ~= b[2] then
-        return a[2] < b[2]
+  -- Sort by distance, then by value
+  table.sort(results, function(a: Match, b: Match): boolean
+      if a.distance ~= b.distance then
+        return a.distance < b.distance
       end
-      return a[1] < b[1]
+      return a.value < b.value
     end)
 
-  -- Extract just the names
-  local names: {string} = {}
-  for _, r in ipairs(results) do
-    table.insert(names, r[1])
+  if limit and #results > limit then
+    local trimmed: {Match} = {}
+    for i = 1, limit do
+      trimmed[i] = results[i]
+    end
+    return trimmed
   end
-
-  return names
+  return results
 end
 
 local record FuzzyModule
+  type Match = Match
+  type Options = Options
+  distance: function(a: string, b: string): integer
+  find_similar: function(query: string, candidates: {string}, opts?: Options): {Match}
+  --- DEPRECATED (D20 transition, #1002): alias of distance, kept while
+  --- the pinned bootstrap's require_hints still calls it; deleted at
+  --- the next pin advance alongside errno's aliases (#981).
   levenshtein: function(a: string, b: string): integer
-  find_similar: function(query: string, candidates: {string}, max_distance?: integer): {string}
 end
 
 local M: FuzzyModule = {
-  levenshtein = levenshtein,
+  distance = distance,
   find_similar = find_similar,
+  levenshtein = distance,
 }
 
 return M

--- a/cosmic/fuzzy_test.tl
+++ b/cosmic/fuzzy_test.tl
@@ -3,45 +3,45 @@
 
 local fuzzy = require("cosmic.fuzzy")
 
--- levenshtein tests
+-- distance tests
 
-local function test_levenshtein_identical()
-  assert(fuzzy.levenshtein("hello", "hello") == 0, "identical strings should have distance 0")
-  assert(fuzzy.levenshtein("", "") == 0, "empty strings should have distance 0")
+local function test_distance_identical()
+  assert(fuzzy.distance("hello", "hello") == 0, "identical strings should have distance 0")
+  assert(fuzzy.distance("", "") == 0, "empty strings should have distance 0")
 end
-test_levenshtein_identical()
+test_distance_identical()
 
-local function test_levenshtein_empty()
-  assert(fuzzy.levenshtein("", "abc") == 3, "empty to 'abc' should be 3")
-  assert(fuzzy.levenshtein("abc", "") == 3, "'abc' to empty should be 3")
+local function test_distance_empty()
+  assert(fuzzy.distance("", "abc") == 3, "empty to 'abc' should be 3")
+  assert(fuzzy.distance("abc", "") == 3, "'abc' to empty should be 3")
 end
-test_levenshtein_empty()
+test_distance_empty()
 
-local function test_levenshtein_single_edit()
+local function test_distance_single_edit()
   -- insertion
-  assert(fuzzy.levenshtein("abc", "abcd") == 1, "insertion should be distance 1")
+  assert(fuzzy.distance("abc", "abcd") == 1, "insertion should be distance 1")
   -- deletion
-  assert(fuzzy.levenshtein("abcd", "abc") == 1, "deletion should be distance 1")
+  assert(fuzzy.distance("abcd", "abc") == 1, "deletion should be distance 1")
   -- substitution
-  assert(fuzzy.levenshtein("abc", "aXc") == 1, "substitution should be distance 1")
+  assert(fuzzy.distance("abc", "aXc") == 1, "substitution should be distance 1")
 end
-test_levenshtein_single_edit()
+test_distance_single_edit()
 
-local function test_levenshtein_common_typos()
-  assert(fuzzy.levenshtein("Database", "Databse") == 1, "transposition-like typo")
-  assert(fuzzy.levenshtein("spawn", "spwan") == 2, "adjacent swap")
-  assert(fuzzy.levenshtein("sqlite", "sqlit") == 1, "missing letter")
-  assert(fuzzy.levenshtein("argon2", "argonn2") == 1, "extra letter")
+local function test_distance_common_typos()
+  assert(fuzzy.distance("Database", "Databse") == 1, "transposition-like typo")
+  assert(fuzzy.distance("spawn", "spwan") == 2, "adjacent swap")
+  assert(fuzzy.distance("sqlite", "sqlit") == 1, "missing letter")
+  assert(fuzzy.distance("argon2", "argonn2") == 1, "extra letter")
 end
-test_levenshtein_common_typos()
+test_distance_common_typos()
 
-local function test_levenshtein_case_sensitive()
-  -- levenshtein is case-sensitive by default
-  assert(fuzzy.levenshtein("ABC", "abc") == 3, "case differences count as substitutions")
+local function test_distance_case_sensitive()
+  -- distance is case-sensitive by default
+  assert(fuzzy.distance("ABC", "abc") == 3, "case differences count as substitutions")
 end
-test_levenshtein_case_sensitive()
+test_distance_case_sensitive()
 
-local function test_levenshtein_symmetry()
+local function test_distance_symmetry()
   -- distance(a,b) must equal distance(b,a) for all cases
   local cases: {{string, string}} = {
     {"kitten", "sitting"},
@@ -50,114 +50,137 @@ local function test_levenshtein_symmetry()
     {"xyz", ""},
   }
   for _, p in ipairs(cases) do
-    local d1 = fuzzy.levenshtein(p[1], p[2])
-    local d2 = fuzzy.levenshtein(p[2], p[1])
-    assert(d1 == d2, "levenshtein should be symmetric: '" .. p[1] .. "' <-> '" .. p[2] .. "': " .. tostring(d1) .. " vs " .. tostring(d2))
+    local d1 = fuzzy.distance(p[1], p[2])
+    local d2 = fuzzy.distance(p[2], p[1])
+    assert(d1 == d2, "distance should be symmetric: '" .. p[1] .. "' <-> '" .. p[2] .. "': " .. tostring(d1) .. " vs " .. tostring(d2))
   end
 end
-test_levenshtein_symmetry()
+test_distance_symmetry()
 
-local function test_levenshtein_single_char()
-  assert(fuzzy.levenshtein("a", "b") == 1, "single char substitution")
-  assert(fuzzy.levenshtein("a", "a") == 0, "single char identical")
-  assert(fuzzy.levenshtein("a", "") == 1, "single char to empty")
-  assert(fuzzy.levenshtein("", "z") == 1, "empty to single char")
+local function test_distance_single_char()
+  assert(fuzzy.distance("a", "b") == 1, "single char substitution")
+  assert(fuzzy.distance("a", "a") == 0, "single char identical")
+  assert(fuzzy.distance("a", "") == 1, "single char to empty")
+  assert(fuzzy.distance("", "z") == 1, "empty to single char")
 end
-test_levenshtein_single_char()
+test_distance_single_char()
 
-local function test_levenshtein_asymmetric_lengths()
+local function test_distance_asymmetric_lengths()
   -- when #a >> #b, the two-row optimization should swap to use less memory
-  assert(fuzzy.levenshtein("ab", "abcdefghij") == 8, "short vs long")
-  assert(fuzzy.levenshtein("abcdefghij", "ab") == 8, "long vs short")
-  assert(fuzzy.levenshtein("kitten", "sitting") == 3, "classic example")
-  assert(fuzzy.levenshtein("saturday", "sunday") == 3, "classic example 2")
+  assert(fuzzy.distance("ab", "abcdefghij") == 8, "short vs long")
+  assert(fuzzy.distance("abcdefghij", "ab") == 8, "long vs short")
+  assert(fuzzy.distance("kitten", "sitting") == 3, "classic example")
+  assert(fuzzy.distance("saturday", "sunday") == 3, "classic example 2")
 end
-test_levenshtein_asymmetric_lengths()
+test_distance_asymmetric_lengths()
 
-local function test_levenshtein_longer_strings()
+local function test_distance_longer_strings()
   local a = string.rep("abc", 20) -- 60 chars
   local b = string.rep("abc", 20) -- identical
-  assert(fuzzy.levenshtein(a, b) == 0, "long identical strings")
+  assert(fuzzy.distance(a, b) == 0, "long identical strings")
   -- change one char in the middle
   local c = a:sub(1, 30) .. "X" .. a:sub(32)
-  assert(fuzzy.levenshtein(a, c) == 1, "long strings with one substitution")
+  assert(fuzzy.distance(a, c) == 1, "long strings with one substitution")
 end
-test_levenshtein_longer_strings()
+test_distance_longer_strings()
+
+local function test_levenshtein_alias()
+  -- DEPRECATED alias, kept for the pinned bootstrap until the next pin
+  -- advance (#1002); it must stay the same function as distance.
+  assert(fuzzy.levenshtein == fuzzy.distance, "levenshtein should alias distance")
+end
+test_levenshtein_alias()
 
 -- find_similar tests
 
 local function test_find_similar_exact_match()
   local candidates = {"foo", "bar", "baz"}
-  local results = fuzzy.find_similar("foo", candidates, 0)
+  local results = fuzzy.find_similar("foo", candidates, {max_distance = 0})
   assert(#results == 1, "should find exact match")
-  assert(results[1] == "foo", "should return foo")
+  assert(results[1].value == "foo", "should return foo")
+  assert(results[1].distance == 0, "exact match should have distance 0")
 end
 test_find_similar_exact_match()
 
 local function test_find_similar_typo()
   local candidates = {"Database", "Statement", "Connection"}
-  local results = fuzzy.find_similar("Databse", candidates, 2)
+  local results = fuzzy.find_similar("Databse", candidates, {max_distance = 2})
   assert(#results == 1, "should find one match")
-  assert(results[1] == "Database", "should find Database for Databse")
+  assert(results[1].value == "Database", "should find Database for Databse")
+  assert(results[1].distance == 1, "Databse -> Database is one edit")
 end
 test_find_similar_typo()
 
 local function test_find_similar_case_insensitive()
   local candidates = {"Database", "Statement"}
-  local results = fuzzy.find_similar("database", candidates, 0)
+  local results = fuzzy.find_similar("database", candidates, {max_distance = 0})
   assert(#results == 1, "should find case-insensitive match")
-  assert(results[1] == "Database", "should preserve original case in result")
+  assert(results[1].value == "Database", "should preserve original case in result")
 end
 test_find_similar_case_insensitive()
 
 local function test_find_similar_sorted_by_distance()
   local candidates = {"abc", "abcd", "abcde", "xyz"}
-  local results = fuzzy.find_similar("abc", candidates, 3)
-  assert(results[1] == "abc", "exact match should be first")
-  assert(results[2] == "abcd", "distance 1 should be second")
-  assert(results[3] == "abcde", "distance 2 should be third")
+  local results = fuzzy.find_similar("abc", candidates, {max_distance = 3})
+  assert(results[1].value == "abc", "exact match should be first")
+  assert(results[2].value == "abcd", "distance 1 should be second")
+  assert(results[3].value == "abcde", "distance 2 should be third")
+  assert(results[2].distance == 1, "abcd should carry its distance")
+  assert(results[3].distance == 2, "abcde should carry its distance")
 end
 test_find_similar_sorted_by_distance()
 
 local function test_find_similar_alphabetical_tiebreaker()
   local candidates = {"cat", "bat", "rat"}
-  local results = fuzzy.find_similar("hat", candidates, 1)
+  local results = fuzzy.find_similar("hat", candidates, {max_distance = 1})
   -- all have distance 1, should be sorted alphabetically
-  assert(results[1] == "bat", "alphabetically first should be first, got: " .. (results[1] or "nil"))
-  assert(results[2] == "cat", "alphabetically second should be second")
-  assert(results[3] == "rat", "alphabetically third should be third")
+  local first = results[1] and results[1].value or "nil"
+  assert(results[1].value == "bat", "alphabetically first should be first, got: " .. first)
+  assert(results[2].value == "cat", "alphabetically second should be second")
+  assert(results[3].value == "rat", "alphabetically third should be third")
 end
 test_find_similar_alphabetical_tiebreaker()
 
 local function test_find_similar_no_matches()
   local candidates = {"apple", "banana", "cherry"}
-  local results = fuzzy.find_similar("xyz", candidates, 2)
+  local results = fuzzy.find_similar("xyz", candidates, {max_distance = 2})
   assert(#results == 0, "should find no matches for distant query")
 end
 test_find_similar_no_matches()
 
 local function test_find_similar_deduplicates()
   local candidates = {"foo", "foo", "bar", "foo"}
-  local results = fuzzy.find_similar("foo", candidates, 0)
+  local results = fuzzy.find_similar("foo", candidates, {max_distance = 0})
   assert(#results == 1, "should deduplicate results")
 end
 test_find_similar_deduplicates()
 
 local function test_find_similar_default_max_distance()
   local candidates = {"abcdef"}
-  -- default max_distance is 3
+  -- default max_distance is 3, with or without an opts table
   local results = fuzzy.find_similar("abc", candidates)
   assert(#results == 1, "should use default max_distance of 3")
+  local results2 = fuzzy.find_similar("abc", candidates, {})
+  assert(#results2 == 1, "empty opts should also default max_distance to 3")
 end
 test_find_similar_default_max_distance()
 
--- FIX 5: dedup must be case-insensitive — {"Foo","foo"} should produce 1 result.
 local function test_find_similar_dedup_case_insensitive()
+  -- dedup must be case-insensitive: {"Foo","foo"} produces 1 result
   local candidates = {"Foo", "foo"}
-  local results = fuzzy.find_similar("foo", candidates, 0)
+  local results = fuzzy.find_similar("foo", candidates, {max_distance = 0})
   assert(#results == 1,
     "case-insensitive dedup: expected 1 result for {Foo, foo}, got " .. #results)
 end
 test_find_similar_dedup_case_insensitive()
+
+local function test_find_similar_limit()
+  local candidates = {"abc", "abcd", "abcde", "abx"}
+  local results = fuzzy.find_similar("abc", candidates, {max_distance = 3, limit = 2})
+  assert(#results == 2, "limit should trim the result list, got " .. #results)
+  assert(results[1].value == "abc", "limit keeps the closest matches")
+  assert(results[2].value == "abcd", "distance 1 ties break alphabetically")
+end
+test_find_similar_limit()
 
 print("All fuzzy tests passed")

--- a/cosmic/re.tl
+++ b/cosmic/re.tl
@@ -6,7 +6,9 @@
 --- integer namespace silently ignored it. The compiled Regex keeps the
 --- binding's own :search/:find method names and integer search flags
 --- (NOTBOL/NOTEOL) — a userdata metatable is the C layer's to name, so
---- renaming them is an upstream change, not a record edit.
+--- renaming them is an upstream change, not a record edit. For exact
+--- plain-text search see cosmic.string; for approximate (edit-distance)
+--- matching see cosmic.fuzzy.
 ---
 --- For best performance, compile patterns once and reuse them.
 --- The convenience functions (match, is_match, find, find_all, gmatch,

--- a/cosmic/string.tl
+++ b/cosmic/string.tl
@@ -1,7 +1,9 @@
 --- String utilities.
 --- Common string manipulation functions for trimming, splitting, searching,
 --- padding, and quoting. All functions are infallible and treat their
---- arguments as plain text (no Lua patterns).
+--- arguments as plain text (no Lua patterns). For pattern-based search
+--- and splitting see cosmic.re; for approximate (edit-distance)
+--- matching see cosmic.fuzzy.
 ---
 --- Example usage:
 ---   local str = require("cosmic.string")
@@ -48,6 +50,8 @@ end
 --- Split a string by a separator.
 --- If separator is empty string, splits into individual characters.
 --- Trailing empty fields (from a trailing separator) are preserved.
+--- The empty string yields one empty field, {""} — the same answer
+--- re.split gives, so the two splits agree on the empty subject.
 --- @param s string The string to split
 --- @param sep string The separator to split on
 --- @return {string} Array of substrings
@@ -62,7 +66,7 @@ local function split(s: string, sep: string): {string}
     return result
   end
   if s == "" then
-    return result
+    return {""}
   end
   local pos = 1
   local sep_len = #sep
@@ -111,13 +115,15 @@ end
 
 --- Count non-overlapping occurrences of a substring.
 --- Plain-text search; the substring is not a Lua pattern.
---- The empty substring counts as zero occurrences.
+--- The empty substring matches before every character and at the end,
+--- so it counts #s + 1 occurrences — agreeing with contains, which
+--- says the empty substring is contained in every string.
 --- @param s string The string to search
 --- @param sub string The substring to count
 --- @return integer Number of non-overlapping occurrences
 local function count(s: string, sub: string): integer
   if sub == "" then
-    return 0
+    return #s + 1
   end
   local n = 0
   local pos = 1
@@ -134,20 +140,38 @@ end
 --- Replace occurrences of a substring with plain text.
 --- Both old and new are treated literally (no Lua patterns, unlike
 --- string.gsub). Replaces all occurrences unless max is given.
---- An empty old string returns s unchanged.
+--- An empty old string matches before every character and at the end,
+--- so new is inserted at each of the #s + 1 boundaries — the same
+--- positions count counts, and what Python and Go do.
 --- @param s string The string to operate on
 --- @param old string The substring to replace
 --- @param new string The replacement text
 --- @param max integer? Maximum number of replacements (default unlimited)
 --- @return string The string with replacements applied
 local function replace(s: string, old: string, new: string, max?: integer): string
-  if old == "" or max == 0 then
+  if max == 0 then
     return s
   end
   local parts: {string} = {}
   local n = 0
   local done = 0
   local pos = 1
+  if old == "" then
+    for i = 1, #s do
+      if not max or done < max then
+        n = n + 1
+        parts[n] = new
+        done = done + 1
+      end
+      n = n + 1
+      parts[n] = s:sub(i, i)
+    end
+    if not max or done < max then
+      n = n + 1
+      parts[n] = new
+    end
+    return table.concat(parts)
+  end
   while true do
     local found = s:find(old, pos, true)
     if not found or (max and done >= max) then

--- a/cosmic/string_search_test.tl
+++ b/cosmic/string_search_test.tl
@@ -45,7 +45,9 @@ end
 test_count_plain_text()
 
 local function test_count_empty()
-  assert(str.count("hello", "") == 0, "expected 0 for empty substring")
+  -- the empty substring is contained everywhere: #s + 1 boundaries
+  assert(str.count("hello", "") == 6, "expected #s + 1 for empty substring")
+  assert(str.count("", "") == 1, "expected 1 for empty in empty")
   assert(str.count("", "a") == 0, "expected 0 for empty string")
 end
 test_count_empty()
@@ -81,7 +83,10 @@ end
 test_replace_multichar_and_growth()
 
 local function test_replace_empty_old()
-  assert(str.replace("abc", "", "x") == "abc", "expected empty old to be a no-op")
+  -- empty old inserts new at every boundary, like Python and Go
+  assert(str.replace("abc", "", "x") == "xaxbxcx", "expected insertion at boundaries")
+  assert(str.replace("", "", "x") == "x", "expected one insertion in empty string")
+  assert(str.replace("abc", "", "x", 2) == "xaxbc", "expected max to cap insertions")
 end
 test_replace_empty_old()
 

--- a/cosmic/string_test.tl
+++ b/cosmic/string_test.tl
@@ -118,8 +118,10 @@ end
 test_split_no_separator()
 
 local function test_split_empty_string()
+  -- one empty field, agreeing with re.split (and Go/Python)
   local parts = str.split("", ",")
-  assert(#parts == 0, "expected 0 parts, got " .. #parts)
+  assert(#parts == 1, "expected 1 part, got " .. #parts)
+  assert(parts[1] == "", "expected the one part to be empty")
 end
 test_split_empty_string()
 

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -89,7 +89,7 @@ local sqlite = require("cosmic.sqlite")
 | module | description |
 |--------|-------------|
 | `cosmic.re` | POSIX extended regular expressions |
-| `cosmic.fuzzy` | fuzzy string matching (Levenshtein) |
+| `cosmic.fuzzy` | fuzzy string matching (edit distance) |
 | `cosmic.format` | Teal/Lua code formatter |
 
 ### Tooling


### PR DESCRIPTION
Fixes #1002. From the 2026-08 API review (F2, data-group audit §1.11-1.12, §4.1-4.2).

## cosmic.string: one answer for the empty needle

The module's empty-needle answers contradicted each other: `contains(s, "")` was true, but `count(s, "")` was 0 and `replace(s, "", new)` was a no-op — and `str.split("", sep)` yielded zero fields while `re.split("", p)` yielded one, two splits in one stdlib disagreeing on the empty subject.

Now the empty substring is contained everywhere, and every function answers accordingly:

- `count(s, "")` → `#s + 1` (one occurrence at each boundary)
- `replace(s, "", new)` → inserts `new` at each of the `#s + 1` boundaries, honoring `max` (Python/Go semantics: `"abc" → "xaxbxcx"`)
- `split("", sep)` → `{""}`, agreeing with `re.split`, Go, and Python
- `split("", "")` stays `{}` (char-split of nothing), matching Go's `strings.Split("", "")`

In-tree, only tests and benches call `str.split`, so the `{""}` change has no downstream callers to migrate.

## cosmic.fuzzy: distance, and matches that keep their distances

- `levenshtein` → `distance` — named for the capability, not the algorithm.
- `find_similar(query, candidates, max_distance?)` returning `{string}` → `find_similar(query, candidates, opts?: Options {max_distance, limit})` returning `{Match {value, distance}}`. The distances were already computed and thrown away, which is exactly what the one internal `levenshtein` caller reached around the API to recover.
- `levenshtein` remains as a DEPRECATED alias of `distance`: `_cli/require_hints.tl` is gen-0-loaded (the pinned binary type-checks it against its embedded fuzzy record), so the alias is deleted at the next pin advance, alongside errno's (#981).

Callers migrated: both `cosmic/doc/show.tl` suggestion sites (`{max_distance = 3}`, iterate `m.value`), and `_perf/bench/fuzzy_bench.tl` — whose check now pins the match's `value` *and* `distance`, so a matcher that returns the right name with a wrong score fails.

## Cross-references

The three matching surfaces now each point at the other two: `string` (exact plain-text) ↔ `re` (patterns) ↔ `fuzzy` (edit distance). The `re.tl` line landed after merging main with #1018's header rewrite, so this PR carries the complete triangle.

## Tests

- `fuzzy_test.tl` rewritten for `distance`/`Match`, plus new coverage: `limit` trimming, distances carried in results, default `max_distance` with and without an opts table, and an alias identity check (`levenshtein == distance`).
- `string_test.tl` / `string_search_test.tl` updated for the new empty-needle answers, including `max`-capped empty-old replacement.

Verified locally with the full gate (`bin/cosmic --make ci`): the pre-merge head passed `ci: PASS (5 stages)`; the merged head (main + re.tl cross-ref) gate run is noted in the PR thread if it differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn