### PR TITLE
fs: visit with an Entry record; one find family

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -129,12 +129,13 @@ cosmic/format/init.tl 185 224
 cosmic/format/rules.tl 208 220
 cosmic/format/types.tl 98 113
 cosmic/fs/file.tl 28 46
+cosmic/fs/find.tl 111 134
 cosmic/fs/init.tl 61 91
 cosmic/fs/ops.tl 97 138
 cosmic/fs/path.tl 151 162
 cosmic/fs/tree.tl 37 64
 cosmic/fs/types.tl 16 51
-cosmic/fs/walk.tl 149 183
+cosmic/fs/walk.tl 41 55
 cosmic/fuzzy.tl 48 50
 cosmic/getopt.tl 36 56
 cosmic/hash.tl 71 74
@@ -199,4 +200,4 @@ cosmic/user.tl 48 61
 cosmic/uuid.tl 9 9
 cosmic/zip.tl 72 85
 tlconfig.lua 7 7
-total 14546 19202
+total 14549 19208

--- a/_make/generate.tl
+++ b/_make/generate.tl
@@ -305,9 +305,11 @@ local function digest_of(dir: string): string
   if not next(found) then
     return "empty"
   end
+  -- find_info keys are full paths (#987); the digest wants names
+  -- relative to dir so the hash never moves with the tree's location.
   local names: {string} = {}
-  for rel in pairs(found) do
-    names[#names + 1] = rel
+  for full in pairs(found) do
+    names[#names + 1] = full:sub(#dir + 2)
   end
   table.sort(names)
   local parts: {string} = {}

--- a/_make/stamp.tl
+++ b/_make/stamp.tl
@@ -59,7 +59,7 @@ local BOOT_MODULES < const >: {string} = {
   "_cli.args", "_cli.help", "_cli.main_handlers", "_cli.require_hints",
   "_cli.run", "_cli.welcome",
   "cosmic._fields", "cosmic.env", "cosmic.errno", "cosmic.fd", "cosmic.fs",
-  "cosmic.fs.file", "cosmic.fs.ops", "cosmic.fs.path", "cosmic.fs.tree",
+  "cosmic.fs.file", "cosmic.fs.find", "cosmic.fs.ops", "cosmic.fs.path", "cosmic.fs.tree",
   "cosmic.fs.types", "cosmic.fs.walk", "cosmic.fuzzy", "cosmic.getopt",
   "cosmic.instrument", "cosmic.searcher", "cosmic.stream", "cosmic.sys",
   "cosmic.tty",

--- a/cosmic/fs/find.tl
+++ b/cosmic/fs/find.tl
@@ -1,0 +1,344 @@
+--- File collection: one find family over cosmic.fs.walk's visitor.
+--- find/find_iter/find_info share FindOptions and one error contract —
+--- slot 2 means the root failed, period; subtree failures ride in an
+--- explicit later slot as a list, so `if err then return nil, err end`
+--- is correct at every call site. glob stays the component-path
+--- expander (a different capability: its pattern spans "/" components
+--- and it never recurses) with the same error contract.
+local unix = require("cosmo.unix")
+local cosmo_path = require("cosmo.path")
+local types = require("cosmic.fs.types")
+local fs_walk = require("cosmic.fs.walk")
+local errstr = require("cosmic.errno").wrap
+local FileInfo = types.FileInfo
+local type Entry = types.Entry
+local type WalkDirHandle = types.DirHandle
+
+--- Convert a glob pattern to a Lua pattern.
+--- Supports * (any run) and ? (one char); every other character —
+--- including [ ] brackets and Lua-pattern magic like % — is literal.
+--- @param glob string The glob pattern
+--- @return string The equivalent Lua pattern
+local function glob_to_pattern(glob: string): string
+  -- Escape every Lua pattern magic character, including [ ] and + - which are
+  -- meaningful inside Lua character classes. Otherwise a glob like "*[a-z]*"
+  -- would smuggle a Lua character class through and match the wrong files.
+  local pattern = glob
+  :gsub("([%.%^%$%(%)%[%]%+%-%%])", "%%%1") -- escape special chars (except * ?)
+  :gsub("%*", ".*") -- * -> .*
+  :gsub("%?", ".") -- ? -> .
+  return "^" .. pattern .. "$"
+end
+
+--- Options for the find family: how entries are selected and how far
+--- the search descends.
+local record FindOptions
+  --- glob matched against each basename (`*` any run, `?` one char;
+  --- everything else — including `%` and brackets — literal)
+  glob: string
+  --- Lua pattern matched against each basename, for callers who mean
+  --- one (the explicit sibling; never guessed from the string)
+  pattern: string
+  --- Maximum depth to visit (entries directly in dir are depth 1);
+  --- nil or 0 means unlimited.
+  max_depth: integer
+  --- false searches only the top level (same as max_depth = 1);
+  --- default true.
+  recursive: boolean
+  --- Also return directories whose basename matches (default: files
+  --- and every other non-directory entry type only).
+  include_dirs: boolean
+  --- Sort the returned list (find only; find_iter yields discovery
+  --- order — an iterator cannot sort without materializing).
+  sorted: boolean
+end
+
+--- Resolve FindOptions to the Lua pattern the walkers share.
+local function find_pattern(opts?: FindOptions): string
+  if opts and opts.pattern then
+    return opts.pattern
+  end
+  return glob_to_pattern((opts and opts.glob) or "*")
+end
+
+--- Resolve FindOptions to walk's max_depth (recursive=false wins).
+local function find_depth(opts?: FindOptions): integer
+  if opts and opts.recursive == false then
+    return 1
+  end
+  return (opts and opts.max_depth) or 0
+end
+
+--- Recursively collect paths under dir whose basename matches.
+--- Slot 2 means the root failed; subtree failures land in slot 3 as a
+--- list (nil when the search was clean), never beside a non-nil result.
+--- @param dir string The directory to search
+--- @param opts FindOptions? Selection and depth options (default: all files)
+--- @return {string} | nil Matching paths, or nil if the root failed
+--- @return string The root-open error when slot 1 is nil
+--- @return {string} Subtree errors, in encounter order (nil when none)
+local function find(dir: string, opts?: FindOptions): {string} | nil, string, {string}
+  local lua_pattern = find_pattern(opts)
+  local include_dirs = opts and opts.include_dirs
+  local results: {string} = {}
+  local ctx, fatal, errs = fs_walk.visit(dir, function(e: Entry, acc: {string})
+      if (include_dirs or not e.stat:is_dir()) and e.name:match(lua_pattern) then
+        table.insert(acc, e.path)
+      end
+    end, results, {max_depth = find_depth(opts)})
+  if not ctx then
+    return nil, fatal
+  end
+  if opts and opts.sorted then
+    table.sort(results)
+  end
+  return results, nil, errs
+end
+
+--- Recursively collect matching files with their FileInfo, keyed by
+--- FULL path like every sibling (#987: was relative). Directories are
+--- never included (FileInfo describes regular files); selection and
+--- depth follow FindOptions.
+--- @param dir string The directory to search
+--- @param opts FindOptions? Selection and depth options (default: all files)
+--- @return {string:FileInfo} | nil Map of full paths, or nil if the root failed
+--- @return string The root-open error when slot 1 is nil
+--- @return {string} Subtree errors, in encounter order (nil when none)
+local function find_info(dir: string, opts?: FindOptions): {string: FileInfo} | nil, string, {string}
+  local lua_pattern = find_pattern(opts)
+  local files: {string: FileInfo} = {}
+  local ctx, fatal, errs = fs_walk.visit(dir, function(e: Entry, acc: {string: FileInfo})
+      if e.stat:is_file() and e.name:match(lua_pattern) then
+        acc[e.path] = {mode = e.stat:mode() & 0x1ff}
+      end
+    end, files, {max_depth = find_depth(opts)})
+  if not ctx then
+    return nil, fatal
+  end
+  return files, nil, errs
+end
+
+--- Iterator over file paths, as returned by find_iter(). The second
+--- return is nil while paths remain; once the tree is exhausted every
+--- further call returns `nil, errs` — the subtree-error list, nil when
+--- the walk was clean.
+local type FileIter = function(): string | nil, {string}
+
+--- Iterate over matching paths lazily; same selection as find(),
+--- except `sorted` (an iterator yields discovery order).
+--- The fourth return value is a to-be-closed guard: a plain
+--- `for f in fs.find_iter(dir) do ... end` loop adopts it as the
+--- loop's closing value (Lua 5.4), so directory handles are closed
+--- even when the loop exits early via break/error.
+--- If the root directory cannot be opened, returns nil plus the error.
+--- Failures below the root do NOT stop iteration; they accumulate and,
+--- once the iterator is exhausted, come back as its second value
+--- (a list) from then on. A plain `for` loop never sees them — call
+--- the iterator once more after the loop:
+---
+---     local iter = check.must(fs.find_iter(dir))
+---     for f in iter do ... end
+---     local _, errs = iter() -- subtree errors, nil when clean
+---
+--- In tests/examples iterate with `for f in check.must(fs.find_iter(dir)) do`
+--- (must, like assert, forwards all four returns, keeping the guard).
+--- @param dir string The directory to search
+--- @param opts FindOptions? Selection and depth options (default: all files)
+--- @return function | nil Iterator yielding paths, or nil if the root failed
+--- @return string The root-open error when slot 1 is nil
+--- @return nil Unused (generic-for control slot)
+--- @return any Closing guard that releases open directory handles
+local function find_iter(dir: string, opts?: FindOptions): FileIter | nil, string, any, any
+  local lua_pattern = find_pattern(opts)
+  local include_dirs = opts and opts.include_dirs
+  local max_depth = find_depth(opts)
+
+  -- Stack of (dir, handle, depth) for depth-first traversal; entries
+  -- read from a stack top at depth d are themselves at depth d.
+  local stack: {{string, WalkDirHandle, integer}} = {}
+  local handle, oerr = unix.opendir(dir)
+  if not handle then
+    return nil, errstr(oerr, "opendir: " .. dir)
+  end
+  table.insert(stack, {dir, handle as WalkDirHandle, 1}) -- cast: userdata boundary
+
+  local function close_all()
+    for i = #stack, 1, -1 do
+      stack[i][2]:close()
+      stack[i] = nil
+    end
+  end
+  local guard = setmetatable({}, {__close = close_all, __gc = close_all})
+
+  -- Subtree errors, in encounter order; the exhausted iterator's
+  -- second return (nil while any path remains).
+  local errs: {string} = {}
+
+  -- Shared by both places a subdirectory gets opened below (the DT_DIR
+  -- fast path and the stat() fallback for DT_UNKNOWN): push it onto
+  -- the traversal stack — unless the depth limit says stop — or record
+  -- the opendir failure.
+  local function push_subdir(path: string, child_depth: integer)
+    if max_depth ~= 0 and child_depth > max_depth then
+      return
+    end
+    local subhandle, serr = unix.opendir(path)
+    if subhandle then
+      -- cast: userdata boundary
+      table.insert(stack, {path, subhandle as WalkDirHandle, child_depth})
+    else
+      errs[#errs + 1] = errstr(serr, "opendir: " .. path)
+    end
+  end
+
+  local iter = function(): string, {string}
+    -- anchor the guard as an upvalue: a caller that keeps only the
+    -- iterator (dropping the fourth return) must not let the guard's
+    -- __gc close these handles while the iterator is still running
+    local _ = guard
+    while #stack > 0 do
+      local current = stack[#stack]
+      local current_dir = current[1]
+      local current_handle = current[2]
+      local current_depth = current[3]
+
+      local entry, kind = current_handle:read()
+      if not entry then
+        current_handle:close()
+        table.remove(stack)
+      elseif entry ~= "." and entry ~= ".." then
+        local full_path = cosmo_path.join(current_dir, entry)
+        if kind == unix.DT_DIR then
+          -- d_type never follows symlinks, so this is a real directory
+          -- (a symlinked dir reports DT_LNK), and skips a stat(2) call.
+          push_subdir(full_path, current_depth + 1)
+          if include_dirs and string.match(entry, lua_pattern) then
+            return full_path
+          end
+        elseif kind ~= unix.DT_UNKNOWN then
+          -- Definitely not a directory: find_iter() never needs stat data,
+          -- only the path, so just check the pattern without stat(2).
+          if string.match(entry, lua_pattern) then
+            return full_path
+          end
+        else
+          -- Filesystem doesn't expose d_type; fall back to a real stat,
+          -- using AT_SYMLINK_NOFOLLOW so a symlinked dir reports
+          -- S_ISLNK, not S_ISDIR, preserving the same cycle prevention.
+          local st, serr = unix.stat(full_path, unix.AT_SYMLINK_NOFOLLOW)
+          if st then
+            if unix.S_ISDIR(st:mode()) then
+              push_subdir(full_path, current_depth + 1)
+              if include_dirs and string.match(entry, lua_pattern) then
+                return full_path
+              end
+            elseif string.match(entry, lua_pattern) then
+              return full_path
+            end
+          else
+            errs[#errs + 1] = errstr(serr, "stat: " .. full_path)
+          end
+        end
+      end
+    end
+    if #errs == 0 then
+      return nil
+    end
+    return nil, errs
+  end
+  return iter, nil, nil, guard
+end
+
+--- List entries in one directory whose name matches a glob component.
+--- Appends matching paths (any entry type) to out; returns an error
+--- string on opendir failure, nil otherwise.
+local function glob_level(dir: string, lua_pattern: string, out: {string}): string
+  local handle, oerr = unix.opendir(dir)
+  if not handle then
+    return errstr(oerr, "opendir: " .. dir)
+  end
+  local h = handle as WalkDirHandle -- cast: userdata boundary
+  while true do
+    local entry = h:read()
+    if not entry then break end
+    if entry ~= "." and entry ~= ".." and string.match(entry, lua_pattern) then
+      table.insert(out, cosmo_path.join(dir, entry))
+    end
+  end
+  h:close()
+end
+
+--- Expand a glob pattern against a directory, WITHOUT recursing — the
+--- component-path expander, a different capability from find's
+--- recursive basename selection: the pattern may span path components
+--- ("src/*.lua", "*/init.tl"); each component is a glob (`*` any run,
+--- `?` one char, both never crossing a "/"), other characters match
+--- literally, and there is no `**`. Unlike a shell, `*` also matches
+--- names starting with a dot. Matches of every entry type are
+--- returned, sorted. Slot 2 means dir itself failed to open; an
+--- unreadable directory at a deeper level does not stop expansion, and
+--- those errors ride in slot 3 as a list (nil when clean).
+--- @param dir string The directory the pattern is relative to
+--- @param pattern string Glob pattern, optionally with "/" components
+--- @return {string} | nil Sorted matching paths, or nil if dir failed
+--- @return string The root-open error when slot 1 is nil
+--- @return {string} Deeper-level errors, in encounter order (nil when none)
+local function glob(dir: string, pattern: string): {string} | nil, string, {string}
+  if pattern:sub(1, 1) == "/" then
+    return nil, "glob: pattern must be relative to dir: " .. pattern
+  end
+  local comps: {string} = {}
+  for comp in pattern:gmatch("[^/]+") do
+    table.insert(comps, comp)
+  end
+  if #comps == 0 then
+    return nil, "glob: empty pattern"
+  end
+  local current: {string} = {dir}
+  local errs: {string} = {}
+  for i, comp in ipairs(comps) do
+    local lua_pattern = glob_to_pattern(comp)
+    local next_level: {string} = {}
+    for j, d in ipairs(current) do
+      -- Below the first level only descend through directories; a file
+      -- matching an intermediate component cannot contain entries.
+      if i == 1 or cosmo_path.isdir(d) then
+        local gerr = glob_level(d, lua_pattern, next_level)
+        if gerr then
+          -- The root directory failing is fatal; deeper failures are
+          -- recorded and expansion continues.
+          if i == 1 and j == 1 then
+            return nil, gerr
+          end
+          errs[#errs + 1] = gerr
+        end
+      end
+    end
+    current = next_level
+  end
+  table.sort(current)
+  if #errs == 0 then
+    return current
+  end
+  return current, nil, errs
+end
+
+local record FsFindModule
+  --- Iterator over paths, as returned by find_iter().
+  type FileIter = FileIter
+  type FindOptions = FindOptions
+
+  find: function(dir: string, opts?: FindOptions): {string} | nil, string, {string}
+  find_iter: function(dir: string, opts?: FindOptions): FileIter | nil, string, any, any
+  find_info: function(dir: string, opts?: FindOptions): {string: FileInfo} | nil, string, {string}
+  glob: function(dir: string, pattern: string): {string} | nil, string, {string}
+end
+
+local M: FsFindModule = {
+  find = find,
+  find_iter = find_iter,
+  find_info = find_info,
+  glob = glob,
+}
+
+return M

--- a/cosmic/fs/init.tl
+++ b/cosmic/fs/init.tl
@@ -328,26 +328,34 @@ local record FsModule
   major: function(dev: integer): integer
   minor: function(dev: integer): integer
 
-  --- Walk a directory tree depth-first, calling the visitor per entry.
-  --- Visitor signature: visitor(path, name, st, ctx): nil | "skip" | "stop"
-  ---   path = full path to the entry (e.g. "dir/sub/file.txt") — do NOT join with name.
-  ---   name = basename of the entry (e.g. "file.txt").
-  ---   st   = WalkStat (import: local types = require("cosmic.fs.types"); types.WalkStat).
-  --- Returning "skip" does not descend into the entry (dirs only); "stop"
-  --- ends the walk now; returning nothing continues.
-  --- Root open failure returns nil, err; subtree failures return the first
-  --- error alongside the results.
+  --- DEPRECATED positional walker (#987): visitor(path, name, st, ctx)
+  --- with the first subtree error beside a non-nil result. Use visit().
+  --- Deleted at the next pin advance.
   walk: function<T>(dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string
+
+  --- One visited entry: path (full — never join with name), name,
+  --- stat, depth (entries directly in dir are depth 1).
+  type Entry = Entry
+  --- Walk dir depth-first with an Entry visitor: visitor(e: fs.Entry,
+  --- ctx) may return "skip" (don't descend) or "stop" (end now).
+  --- Slot 2 is the root-open failure; subtree errors come back in
+  --- slot 3 as a list (nil when the walk was clean).
+  visit: function<T>(dir: string, visitor: function(Entry, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string, {string}
+
   --- Expand a glob pattern without recursing; components ("src/*.lua")
-  --- are each globs, and matches of every entry type are returned sorted.
-  glob: function(dir: string, pattern: string): {string} | nil, string
-  type FindOptions = fs_walk.FindOptions
-  --- Recursively collect files under dir; opts selects basenames by
-  --- glob or Lua pattern (default: all files).
-  find: function(dir: string, opts?: fs_walk.FindOptions): {string} | nil, string
-  --- Iterate files under dir lazily; same selection as find().
-  find_iter: function(dir: string, opts?: fs_walk.FindOptions): FileIter | nil, string, any, any
-  --- Recursively collect files under dir with their FileInfo (mode).
+  --- are each globs, and matches of every entry type are returned
+  --- sorted. Slot 2 is the root failure; deeper errors in slot 3.
+  glob: function(dir: string, pattern: string): {string} | nil, string, {string}
+  type FindOptions = fs_find.FindOptions
+  --- Collect paths under dir; FindOptions selects basenames (glob or
+  --- Lua pattern) and bounds the search (max_depth, recursive,
+  --- include_dirs, sorted). Slot 2 is the root failure; subtree errors
+  --- in slot 3.
+  find: function(dir: string, opts?: fs_find.FindOptions): {string} | nil, string, {string}
+  --- Iterate paths under dir lazily; same selection as find() except
+  --- sorted. The exhausted iterator returns nil plus the subtree-error
+  --- list.
+  find_iter: function(dir: string, opts?: fs_find.FindOptions): FileIter | nil, string, any, any
   --- Matching files with their FileInfo, keyed by FULL path (#987:
   --- was relative); same options and slots as find.
   find_info: function(dir: string, opts?: fs_find.FindOptions): {string: FileInfo} | nil, string, {string}

--- a/cosmic/fs/init.tl
+++ b/cosmic/fs/init.tl
@@ -199,20 +199,26 @@ local function fdopendir(fd: integer): Dir | nil, string
   return nil, errstr(err, "fdopendir")
 end
 
--- Re-export walk functions from fs_walk submodule
+-- Re-export the walker (fs_walk) and the find family (fs_find)
 local fs_walk = require("cosmic.fs.walk")
+local fs_find = require("cosmic.fs.find")
 
 -- Recursive tree operations
 local fs_tree = require("cosmic.fs.tree")
 
 --- Iterator over file paths, as returned by files().
-local type FileIter = fs_walk.FileIter
+local type FileIter = fs_find.FileIter
 
---- Visitor verdict for walk(): nil continues, "skip" prunes, "stop" ends the walk.
+--- Visitor verdict for visit()/walk(): nil continues, "skip" prunes,
+--- "stop" ends the walk.
 local type WalkAction = fs_walk.WalkAction
 
---- Options for walk() (max_depth).
+--- Options for visit()/walk() (max_depth).
 local type WalkOptions = fs_walk.WalkOptions
+
+--- One visited entry (path/name/stat/depth), as visit() hands to its
+--- visitor.
+local type Entry = types.Entry
 
 --- Module interface
 local record FsModule
@@ -342,7 +348,9 @@ local record FsModule
   --- Iterate files under dir lazily; same selection as find().
   find_iter: function(dir: string, opts?: fs_walk.FindOptions): FileIter | nil, string, any, any
   --- Recursively collect files under dir with their FileInfo (mode).
-  find_info: function(dir: string): {string: FileInfo} | nil, string
+  --- Matching files with their FileInfo, keyed by FULL path (#987:
+  --- was relative); same options and slots as find.
+  find_info: function(dir: string, opts?: fs_find.FindOptions): {string: FileInfo} | nil, string, {string}
 
   -- Access mode constants
   F_OK: integer
@@ -436,12 +444,13 @@ local M: FsModule = {
   major = fs_ops.major,
   minor = fs_ops.minor,
 
-  -- Directory walking
+  -- Directory walking and the find family
   walk = fs_walk.walk,
-  glob = fs_walk.glob,
-  find = fs_walk.find,
-  find_iter = fs_walk.find_iter,
-  find_info = fs_walk.find_info,
+  visit = fs_walk.visit,
+  glob = fs_find.glob,
+  find = fs_find.find,
+  find_iter = fs_find.find_iter,
+  find_info = fs_find.find_info,
 
   -- Access mode constants (re-exported from fs_ops)
   F_OK = fs_ops.F_OK,

--- a/cosmic/fs/path_test.tl
+++ b/cosmic/fs/path_test.tl
@@ -202,11 +202,14 @@ local function test_find_info()
   assert(collected, "find_info should succeed")
   local found = collected
 
-  assert(found["file1.lua"] ~= nil, "expected file1.lua")
-  assert(found["file2.txt"] ~= nil, "expected file2.txt")
-  assert(found["subdir/file3.lua"] ~= nil, "expected subdir/file3.lua")
-  assert(found["subdir/nested/file4.lua"] ~= nil, "expected subdir/nested/file4.lua")
-  assert(found["file1.lua"].mode ~= nil, "expected mode property")
+  -- Keys are FULL paths (#987), like every find sibling.
+  assert(found[fs.join(walk_dir, "file1.lua")] ~= nil, "expected file1.lua")
+  assert(found[fs.join(walk_dir, "file2.txt")] ~= nil, "expected file2.txt")
+  assert(found[fs.join(walk_dir, "subdir/file3.lua")] ~= nil,
+    "expected subdir/file3.lua")
+  assert(found[fs.join(walk_dir, "subdir/nested/file4.lua")] ~= nil,
+    "expected subdir/nested/file4.lua")
+  assert(found[fs.join(walk_dir, "file1.lua")].mode ~= nil, "expected mode property")
   teardown(walk_dir)
 end
 test_find_info()

--- a/cosmic/fs/types.tl
+++ b/cosmic/fs/types.tl
@@ -123,6 +123,17 @@ local record fs_types
     mode: integer
   end
 
+  --- One visited entry, as cosmic.fs.visit hands to its visitor: the
+  --- full path (already complete — never join it with name), the
+  --- basename, the entry's Stat, and its depth (entries directly under
+  --- the walk root are depth 1).
+  record Entry
+    path: string
+    name: string
+    stat: Stat
+    depth: integer
+  end
+
   --- Wrap a raw cosmo.unix Stat so it carries the type predicates.
   --- Fallible only in the one way the unification allows: a runtime
   --- whose stat metatable cannot take the predicates is refused, not

--- a/cosmic/fs/walk.tl
+++ b/cosmic/fs/walk.tl
@@ -1,23 +1,26 @@
---- Directory walking and file collection utilities.
---- Provides recursive directory traversal, pattern-based file collection,
---- and file iteration.
+--- Directory tree walking: `visit` hands an Entry record to its
+--- visitor; `walk` is the DEPRECATED positional form (#987), kept
+--- because the pinned build engine still calls it — deleted at the
+--- next pin advance alongside errno's aliases (#981). File collection
+--- (find/find_iter/find_info/glob) lives in cosmic.fs.find, built on
+--- this walker.
 local unix = require("cosmo.unix")
 local cosmo_path = require("cosmo.path")
 local types = require("cosmic.fs.types")
 local errstr = require("cosmic.errno").wrap
 local type WalkStat = types.WalkStat
-local FileInfo = types.FileInfo
+local type Entry = types.Entry
 local type WalkDirHandle = types.DirHandle
 
---- Visitor verdict for walk(): returning nothing continues as before,
---- "skip" does not descend into the entry (dirs only; no-op for files),
+--- Visitor verdict: returning nothing continues as before, "skip"
+--- does not descend into the entry (dirs only; no-op for files),
 --- "stop" ends the walk immediately.
 local enum WalkAction
   "skip"
   "stop"
 end
 
---- Options for walk().
+--- Options for visit()/walk().
 local record WalkOptions
   --- Maximum directory depth to visit: entries directly in dir are at
   --- depth 1, entries one level down at depth 2, and so on. The walk
@@ -27,15 +30,15 @@ local record WalkOptions
 end
 
 local walk_tree: function<T>(string,
-function(string, string, WalkStat, T): (WalkAction ...), T, {string}, integer, integer): boolean
+function(Entry, T): (WalkAction ...), T, {string}, integer, integer): boolean
 
 --- Shared per-directory loop. Consumes (and closes) an already-open
---- handle, records the first subtree error in errbox[1], and returns
---- true when a visitor asked to stop the walk. Entries visited here are
---- at depth; max_depth of 0 means unlimited.
+--- handle, appends subtree errors to errs, and returns true when a
+--- visitor asked to stop the walk. Entries visited here are at depth;
+--- max_depth of 0 means unlimited.
 local function walk_entries<T>(dir: string, h: WalkDirHandle,
-    visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx: T,
-    errbox: {string}, depth: integer, max_depth: integer): boolean
+    visitor: function(Entry, T): (WalkAction ...), ctx: T,
+    errs: {string}, depth: integer, max_depth: integer): boolean
   while true do
     local entry = h:read()
     if not entry then break end
@@ -50,7 +53,8 @@ local function walk_entries<T>(dir: string, h: WalkDirHandle,
         wst, werr = types.wrap(st)
       end
       if wst is WalkStat then
-        local action = visitor(full_path, entry, wst, ctx)
+        local e: Entry = {path = full_path, name = entry, stat = wst, depth = depth}
+        local action = visitor(e, ctx)
         if action == "stop" then
           h:close()
           return true
@@ -58,13 +62,13 @@ local function walk_entries<T>(dir: string, h: WalkDirHandle,
         -- cast: record union after guard
         if action ~= "skip" and unix.S_ISDIR((st as unix.Stat):mode())
         and (max_depth == 0 or depth < max_depth) then
-          if walk_tree(full_path, visitor, ctx, errbox, depth + 1, max_depth) then
+          if walk_tree(full_path, visitor, ctx, errs, depth + 1, max_depth) then
             h:close()
             return true
           end
         end
-      elseif not errbox[1] then
-        errbox[1] = werr or errstr(serr, "stat: " .. full_path)
+      else
+        errs[#errs + 1] = werr or errstr(serr, "stat: " .. full_path)
       end
     end
   end
@@ -72,58 +76,47 @@ local function walk_entries<T>(dir: string, h: WalkDirHandle,
   return false
 end
 
---- Recursive walk helper. An opendir failure below the root is recorded
---- in errbox[1] rather than swallowed or fatal.
+--- Recursive walk helper. An opendir failure below the root is
+--- appended to errs rather than swallowed or fatal.
 walk_tree = function<T>(dir: string,
-    visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx: T,
-    errbox: {string}, depth: integer, max_depth: integer): boolean
+    visitor: function(Entry, T): (WalkAction ...), ctx: T,
+    errs: {string}, depth: integer, max_depth: integer): boolean
   local handle, oerr = unix.opendir(dir)
   if not handle then
-    if not errbox[1] then
-      errbox[1] = errstr(oerr, "opendir: " .. dir)
-    end
+    errs[#errs + 1] = errstr(oerr, "opendir: " .. dir)
     return false
   end
   -- cast: userdata boundary
-  return walk_entries(dir, handle as WalkDirHandle, visitor, ctx, errbox, depth, max_depth)
+  return walk_entries(dir, handle as WalkDirHandle, visitor, ctx, errs, depth, max_depth)
 end
 
---- Walk a directory tree, calling visitor for each entry.
---- Recursively traverses all subdirectories.
---- Does NOT recurse into symlinked directories to prevent symlink cycles.
+--- Walk a directory tree, calling visitor with an Entry per entry.
+--- Recursively traverses all subdirectories; does NOT recurse into
+--- symlinked directories, preventing symlink cycles.
 ---
---- The visitor receives four arguments:
----   path  (string)  — the full path to the entry (e.g. "dir/sub/file.txt").
----   name  (string)  — the basename of the entry (e.g. "file.txt").
----   st    (WalkStat) — stat result for the entry.
----   ctx   (T)       — the context value passed to walk().
+--- The visitor receives (fs.Entry, ctx): Entry carries `path` (the
+--- FULL path — never join it with name), `name` (the basename),
+--- `stat` (fs.Stat) and `depth` (entries directly in dir are depth 1).
+--- Its return controls traversal: nil continues, "skip" does not
+--- descend into the entry (dirs only), "stop" ends the walk now.
 ---
---- The visitor's return value controls the traversal:
----   nil    — continue (a visitor that returns nothing keeps today's behavior)
----   "skip" — do not descend into this entry (dirs only; no-op for files)
----   "stop" — end the walk now; walk returns ctx plus any first error
+---   fs.visit(dir, function(e: fs.Entry, acc: {string})
+---     if e.stat:is_file() then table.insert(acc, e.path) end
+---   end, {})
 ---
---- IMPORTANT: do NOT join path and name — path is already the full path.
---- Joining them produces doubled paths like "dir/sub/file.txt/file.txt".
----
---- WalkStat is exported on the public fs module — annotate the visitor's
---- third parameter as fs.WalkStat:
----   local fs = require("cosmic.fs")
----   fs.walk(dir, function(path: string, name: string, st: fs.WalkStat, ctx: any) ... end)
---- (cosmic.fs.types is an internal shard; requiring it from outside
---- cosmic/ fails the lint visibility rule.)
----
---- If the root directory cannot be opened, returns nil plus the error.
---- Failures below the root (unreadable subdirectory, vanished entry) do
---- not stop the walk; the first such error is returned alongside the
---- context so callers never mistake a partial walk for a complete one.
+--- Slot 2 means failure, period: if the root cannot be opened, visit
+--- returns nil plus the error. Failures below the root (an unreadable
+--- subdirectory, a vanished entry) do not stop the walk; they are
+--- returned as a list in slot 3 — nil when the walk was clean — so a
+--- partial walk is never mistaken for a complete one.
 --- @param dir string The directory to walk
---- @param visitor function Called for each entry: function(path, name, st, ctx): nil|"skip"|"stop"
+--- @param visitor function Called per entry: function(e: Entry, ctx): nil|"skip"|"stop"
 --- @param ctx T Optional context passed to every visitor call
 --- @param opts WalkOptions? max_depth limits how deep the walk descends
 --- @return T | nil The context object, or nil if the root could not be opened
---- @return string First error encountered, if any
-local function walk<T>(dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string
+--- @return string The root-open error when slot 1 is nil
+--- @return {string} Subtree errors, in encounter order (nil when none)
+local function visit<T>(dir: string, visitor: function(Entry, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string, {string}
   ctx = ctx or {} as T -- cast: fresh table as generic T
   local max_depth = 0
   if opts and opts.max_depth then
@@ -133,363 +126,55 @@ local function walk<T>(dir: string, visitor: function(string, string, WalkStat, 
   if not handle then
     return nil, errstr(oerr, "opendir: " .. dir)
   end
-  local errbox: {string} = {}
+  local errs: {string} = {}
   -- cast: userdata boundary
-  walk_entries(dir, handle as WalkDirHandle, visitor, ctx, errbox, 1, max_depth)
-  return ctx, errbox[1]
+  walk_entries(dir, handle as WalkDirHandle, visitor, ctx, errs, 1, max_depth)
+  if #errs == 0 then
+    return ctx
+  end
+  return ctx, nil, errs
 end
 
---- Convert a glob pattern to a Lua pattern.
---- Supports * (any run) and ? (one char); every other character —
---- including [ ] brackets and Lua-pattern magic like % — is literal.
---- @param glob string The glob pattern
---- @return string The equivalent Lua pattern
-local function glob_to_pattern(glob: string): string
-  -- Escape every Lua pattern magic character, including [ ] and + - which are
-  -- meaningful inside Lua character classes. Otherwise a glob like "*[a-z]*"
-  -- would smuggle a Lua character class through and match the wrong files.
-  local pattern = glob
-  :gsub("([%.%^%$%(%)%[%]%+%-%%])", "%%%1") -- escape special chars (except * ?)
-  :gsub("%*", ".*") -- * -> .*
-  :gsub("%?", ".") -- ? -> .
-  return "^" .. pattern .. "$"
-end
-
---- Shared body of collect/collect_matching: walk the tree gathering
---- files whose basename matches the given Lua pattern.
-local function collect_by_pattern(dir: string, lua_pattern: string): {string} | nil, string
-  local results: {string} = {}
-  local ctx, err = walk(dir, function(full_path: string, entry: string, st: WalkStat, acc: {string})
-      if not st:is_dir() and entry:match(lua_pattern) then
-        table.insert(acc, full_path)
-      end
-    end, results)
-  if not ctx then
-    return nil, err
-  end
-  return results, err
-end
-
---- Options for find/find_iter: how a file's BASENAME is selected.
---- At most one of glob/pattern; neither selects every file.
-local record FindOptions
-  --- glob matched against each basename (`*` any run, `?` one char;
-  --- everything else — including `%` and brackets — literal)
-  glob: string
-  --- Lua pattern matched against each basename, for callers who mean
-  --- one (the explicit sibling; never guessed from the string)
-  pattern: string
-end
-
---- Resolve FindOptions to the Lua pattern the walkers share.
-local function find_pattern(opts?: FindOptions): string
-  if opts and opts.pattern then
-    return opts.pattern
-  end
-  return glob_to_pattern((opts and opts.glob) or "*")
-end
-
---- Recursively collect file paths under dir (api-review-8: find/
---- find_iter replace collect/collect_matching/files).
---- If the root directory cannot be opened, returns nil plus the error.
---- Failures below the root do not stop the collection; the first such
---- error is returned alongside the results.
---- @param dir string The directory to search
---- @param opts FindOptions? glob or pattern over basenames (default: all files)
---- @return {string} | nil List of matching paths, or nil if the root failed
---- @return string First error encountered, if any
-local function find(dir: string, opts?: FindOptions): {string} | nil, string
-  return collect_by_pattern(dir, find_pattern(opts))
-end
-
---- List entries in one directory whose name matches a glob component.
---- Appends matching paths (any entry type) to out; returns an error
---- string on opendir failure, nil otherwise.
-local function glob_level(dir: string, lua_pattern: string, out: {string}): string
-  local handle, oerr = unix.opendir(dir)
-  if not handle then
-    return errstr(oerr, "opendir: " .. dir)
-  end
-  local h = handle as WalkDirHandle -- cast: userdata boundary
-  while true do
-    local entry = h:read()
-    if not entry then break end
-    if entry ~= "." and entry ~= ".." and string.match(entry, lua_pattern) then
-      table.insert(out, cosmo_path.join(dir, entry))
-    end
-  end
-  h:close()
-end
-
---- Expand a glob pattern against a directory, WITHOUT recursing:
---- unlike collect(), only the levels named by the pattern are read.
---- The pattern may span path components ("src/*.lua", "*/init.tl");
---- each component is a glob (`*` any run, `?` one char, both never
---- crossing a "/"), other characters match literally, and there is no
---- `**`. Unlike a shell, `*` also matches names starting with a dot.
---- Matches of every entry type (files, dirs, symlinks) are returned,
---- sorted. If dir itself cannot be opened, returns nil plus the error;
---- an unreadable directory at a deeper level does not stop expansion,
---- and the first such error is returned alongside the results.
---- @param dir string The directory the pattern is relative to
---- @param pattern string Glob pattern, optionally with "/" components
---- @return {string} | nil Sorted matching paths, or nil if dir failed
---- @return string First error encountered, if any
-local function glob(dir: string, pattern: string): {string} | nil, string
-  if pattern:sub(1, 1) == "/" then
-    return nil, "glob: pattern must be relative to dir: " .. pattern
-  end
-  local comps: {string} = {}
-  for comp in pattern:gmatch("[^/]+") do
-    table.insert(comps, comp)
-  end
-  if #comps == 0 then
-    return nil, "glob: empty pattern"
-  end
-  local current: {string} = {dir}
-  local first_err: string = nil
-  for i, comp in ipairs(comps) do
-    local lua_pattern = glob_to_pattern(comp)
-    local next_level: {string} = {}
-    for j, d in ipairs(current) do
-      -- Below the first level only descend through directories; a file
-      -- matching an intermediate component cannot contain entries.
-      if i == 1 or cosmo_path.isdir(d) then
-        local gerr = glob_level(d, lua_pattern, next_level)
-        if gerr then
-          -- The root directory failing is fatal; deeper failures are
-          -- recorded (first one wins) and expansion continues.
-          if i == 1 and j == 1 then
-            return nil, gerr
-          end
-          if not first_err then
-            first_err = gerr
-          end
-        end
-      end
-    end
-    current = next_level
-  end
-  table.sort(current)
-  return current, first_err
-end
-
---- Recursively collect all files with their Unix permissions
---- (api-review-8: was collect_all — find's sibling whose result carries
---- FileInfo rather than bare paths).
---- Returns a map of relative paths to file information.
---- If the root directory cannot be opened, returns nil plus the error.
---- Failures below the root do not stop the collection; the first such
---- error is returned alongside the results.
+--- DEPRECATED positional walker (#987): visitor(path, name, st, ctx)
+--- with the first subtree error folded into slot 2 beside a non-nil
+--- result. Use visit() — the Entry record deletes the "do NOT join
+--- path and name" trap and exposes depth, and its slot 2 means
+--- failure. Kept because the pinned build engine still calls this
+--- form; deleted at the next pin advance (#981-class).
 --- @param dir string The directory to walk
---- @return {string:FileInfo} | nil Map of relative paths to file information
+--- @param visitor function Called per entry: function(path, name, st, ctx): nil|"skip"|"stop"
+--- @param ctx T Optional context passed to every visitor call
+--- @param opts WalkOptions? max_depth limits how deep the walk descends
+--- @return T | nil The context object, or nil if the root could not be opened
 --- @return string First error encountered, if any
-local function find_info(dir: string): {string: FileInfo} | nil, string
-  local files: {string: FileInfo} = {}
-  local errbox: {string} = {}
-
-  local function do_walk(base_dir: string, rel_base: string): boolean
-    local handle, oerr = unix.opendir(base_dir)
-    if not handle then
-      if not errbox[1] then
-        errbox[1] = errstr(oerr, "opendir: " .. base_dir)
-      end
-      return false
-    end
-    local h = handle as WalkDirHandle -- cast: userdata boundary
-
-    while true do
-      local entry, kind = h:read()
-      if not entry then break end
-      if entry ~= "." and entry ~= ".." then
-        local full_path = cosmo_path.join(base_dir, entry)
-        local rel_path = rel_base == "" and entry or cosmo_path.join(rel_base, entry)
-
-        if kind == unix.DT_DIR then
-          -- d_type never follows symlinks, so a real directory (as opposed
-          -- to a symlink to one) is enough to recurse without a stat(2)
-          -- call. This is what prevents infinite recursion through
-          -- symlink cycles below too: a symlinked dir reports DT_LNK.
-          do_walk(full_path, rel_path)
-        elseif kind ~= unix.DT_REG and kind ~= unix.DT_UNKNOWN then
-          -- Definitely neither a directory nor a regular file (symlink,
-          -- fifo, socket, ...): matches neither branch below, so skip
-          -- without paying for a stat(2) call.
-        else
-          -- kind is DT_REG (need the mode bits) or DT_UNKNOWN (filesystem
-          -- doesn't expose d_type; fall back to a real stat). Use
-          -- AT_SYMLINK_NOFOLLOW so a symlinked dir reports S_ISLNK, not
-          -- S_ISDIR, preserving the same cycle prevention as above.
-          local st, serr = unix.stat(full_path, unix.AT_SYMLINK_NOFOLLOW)
-          if st then
-            if unix.S_ISDIR(st:mode()) then
-              do_walk(full_path, rel_path)
-            elseif unix.S_ISREG(st:mode()) then
-              local mode = st:mode() & 0x1ff
-              files[rel_path] = {mode = mode}
-            end
-          elseif not errbox[1] then
-            errbox[1] = errstr(serr, "stat: " .. full_path)
-          end
-        end
-      end
-    end
-    h:close()
-    return true
+local function walk<T>(dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string
+  local rctx, fatal, errs = visit(dir, function(e: Entry, c: T): (WalkAction ...)
+      return visitor(e.path, e.name, e.stat, c)
+    end, ctx, opts)
+  if rctx == nil then
+    return nil, fatal
   end
-
-  if not do_walk(dir, "") then
-    return nil, errbox[1]
-  end
-  return files, errbox[1]
-end
-
---- Iterator over file paths, as returned by find_iter(). The second return
---- is nil while paths remain; once the tree is exhausted every further
---- call returns `nil, first_error` (nil when the walk was clean) — the
---- same (result, first-subtree-error) pairing walk()/collect() return,
---- just delayed until the iterator itself is spent rather than bundled
---- with a single return value up front.
-local type FileIter = function(): string | nil, string
-
---- Iterate over files matching a pattern.
---- Returns an iterator that yields file paths. The fourth return value
---- is a to-be-closed guard: a plain `for f in fs.find_iter(dir) do ... end`
---- loop adopts it as the loop's closing value (Lua 5.4), so directory
---- handles are closed even when the loop exits early via break/error.
---- If the root directory cannot be opened, returns nil plus the error.
---- Failures below the root (an unreadable subdirectory, a vanished
---- entry) do NOT stop iteration, matching walk()/collect() — the first
---- such error is captured and, once the iterator is exhausted, returned
---- as its second value from then on. A plain `for f in fs.find_iter(dir) do`
---- never sees it (the loop ends on the first nil without inspecting
---- further returns); call the iterator again after the loop to read it:
----
----     local iter = check.must(fs.find_iter(dir))
----     for f in iter do ... end
----     local _, suberr = iter() -- first subtree error, if any
----
---- in tests/examples iterate the checked value with
---- `for f in check.must(fs.find_iter(dir)) do` (must, like assert, forwards
---- all four returns, keeping the closing guard); in library code use
---- `assert(fs.find_iter(dir)) as fs.FileIter`, which also forwards them.
---- @param dir string The directory to search
---- @param opts FindOptions? glob or pattern over basenames (default: all files)
---- @return function | nil Iterator yielding file paths, or nil if the root could not be opened
---- @return string Error if the root directory could not be opened
---- @return nil Unused (generic-for control slot)
---- @return any Closing guard that releases open directory handles
-local function find_iter(dir: string, opts?: FindOptions): FileIter | nil, string, any, any
-  local lua_pattern = find_pattern(opts)
-
-  -- Stack of (dir, handle) for depth-first traversal
-  local stack: {{string, WalkDirHandle}} = {}
-  local handle, oerr = unix.opendir(dir)
-  if not handle then
-    return nil, errstr(oerr, "opendir: " .. dir)
-  end
-  table.insert(stack, {dir, handle as WalkDirHandle}) -- cast: userdata boundary
-
-  local function close_all()
-    for i = #stack, 1, -1 do
-      stack[i][2]:close()
-      stack[i] = nil
-    end
-  end
-  local guard = setmetatable({}, {__close = close_all, __gc = close_all})
-
-  -- First error found below the root, same role as walk_entries' errbox.
-  local errbox: {string} = {}
-
-  -- Shared by both places a subdirectory gets opened below (the DT_DIR
-  -- fast path and the stat() fallback for DT_UNKNOWN): push it onto the
-  -- traversal stack, or record the first opendir failure below the
-  -- root, matching walk_entries' error-channel contract.
-  local function push_subdir(path: string)
-    local subhandle, serr = unix.opendir(path)
-    if subhandle then
-      -- cast: userdata boundary
-      table.insert(stack, {path, subhandle as WalkDirHandle})
-    elseif not errbox[1] then
-      errbox[1] = errstr(serr, "opendir: " .. path)
-    end
-  end
-
-  local iter = function(): string, string
-    -- anchor the guard as an upvalue: a caller that keeps only the
-    -- iterator (dropping the fourth return) must not let the guard's
-    -- __gc close these handles while the iterator is still running
-    local _ = guard
-    while #stack > 0 do
-      local current = stack[#stack]
-      local current_dir = current[1]
-      local current_handle = current[2]
-
-      local entry, kind = current_handle:read()
-      if not entry then
-        current_handle:close()
-        table.remove(stack)
-      elseif entry ~= "." and entry ~= ".." then
-        local full_path = cosmo_path.join(current_dir, entry)
-        if kind == unix.DT_DIR then
-          -- d_type never follows symlinks, so this is a real directory
-          -- (a symlinked dir reports DT_LNK), and skips a stat(2) call.
-          push_subdir(full_path)
-        elseif kind ~= unix.DT_UNKNOWN then
-          -- Definitely not a directory: find_iter() never needs stat data,
-          -- only the path, so just check the pattern without stat(2).
-          if string.match(entry, lua_pattern) then
-            return full_path
-          end
-        else
-          -- Filesystem doesn't expose d_type; fall back to a real stat,
-          -- using AT_SYMLINK_NOFOLLOW so a symlinked dir reports
-          -- S_ISLNK, not S_ISDIR, preserving the same cycle prevention.
-          local st, serr = unix.stat(full_path, unix.AT_SYMLINK_NOFOLLOW)
-          if st then
-            if unix.S_ISDIR(st:mode()) then
-              push_subdir(full_path)
-            elseif string.match(entry, lua_pattern) then
-              return full_path
-            end
-          elseif not errbox[1] then
-            errbox[1] = errstr(serr, "stat: " .. full_path)
-          end
-        end
-      end
-    end
-    return nil, errbox[1]
-  end
-  return iter, nil, nil, guard
+  return rctx, errs and errs[1] or nil
 end
 
 local record FsWalkModule
-  --- Iterator over file paths, as returned by find_iter().
-  type FileIter = FileIter
-
   --- Visitor verdict: nil continues, "skip" prunes, "stop" ends the walk.
   type WalkAction = WalkAction
 
-  --- Options for walk() max_depth.
+  --- Options for visit()/walk() max_depth.
   type WalkOptions = WalkOptions
 
-  --- Walk dir tree. visitor(path, name, st, ctx): path is the FULL path; name is the basename.
-  --- Do NOT join path and name — path is already complete.
-  --- The visitor may return "skip" (don't descend) or "stop" (end the walk).
+  --- Walk dir tree with an Entry-record visitor; slot 2 is the root
+  --- failure, slot 3 the subtree-error list.
+  visit: function<T>(dir: string, visitor: function(Entry, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string, {string}
+
+  --- DEPRECATED positional walker; use visit(). Deleted at pin advance.
   walk: function<T>(dir: string, visitor: function(string, string, WalkStat, T): (WalkAction ...), ctx?: T, opts?: WalkOptions): T | nil, string
-  glob: function(dir: string, pattern: string): {string} | nil, string
-  type FindOptions = FindOptions
-  find: function(dir: string, opts?: FindOptions): {string} | nil, string
-  find_iter: function(dir: string, opts?: FindOptions): FileIter | nil, string, any, any
-  find_info: function(dir: string): {string: FileInfo} | nil, string
 end
 
 local M: FsWalkModule = {
+  visit = visit,
   walk = walk,
-  glob = glob,
-  find = find,
-  find_iter = find_iter,
-  find_info = find_info,
 }
 
 return M

--- a/cosmic/fs/walk_example.tl
+++ b/cosmic/fs/walk_example.tl
@@ -1,12 +1,11 @@
---- Examples for the cosmic.fs.walk module.
---- Demonstrates walk(), collect(), and files() for directory traversal.
+--- Examples for directory traversal: visit() with its Entry record,
+--- find() for collection, find_iter() for streaming.
 
--- Example_walk demonstrates walking a directory tree.
--- The visitor receives the FULL path as the first argument and the basename
--- as the second. Do not join them — path is already complete.
-local function Example_walk()
+-- Example_visit demonstrates walking a directory tree. The visitor
+-- receives an fs.Entry: e.path is the FULL path (already complete),
+-- e.name the basename, e.stat the entry's Stat, e.depth the depth.
+local function Example_visit()
   local fs = require("cosmic.fs")
-  local types = require("cosmic.fs.types")
 
   -- Build a small tree under a temp directory.
   local base = os.getenv("TEST_TMPDIR") or "/tmp"
@@ -20,11 +19,9 @@ local function Example_walk()
 
   -- Collect entries and sort for deterministic output.
   local entries: {string} = {}
-  assert(fs.walk(tmpdir, function(_path: string, name: string, st: types.WalkStat, ctx: {string})
-        -- path is the full path; name is just the basename.
-        -- Never do fs.join(path, name) — that would double the path.
-        local kind = st:is_dir() and "dir" or "file"
-        table.insert(ctx, kind .. " " .. name)
+  assert(fs.visit(tmpdir, function(e: fs.Entry, ctx: {string})
+        local kind = e.stat:is_dir() and "dir" or "file"
+        table.insert(ctx, kind .. " " .. e.name .. " depth=" .. e.depth)
       end, entries))
 
   table.sort(entries)
@@ -34,13 +31,13 @@ local function Example_walk()
 
   assert(fs.remove_all(tmpdir))
   -- Output:
-  -- dir conf
-  -- file README
-  -- file app.ini
+  -- dir conf depth=1
+  -- file README depth=1
+  -- file app.ini depth=2
 end
 
--- Example_collect demonstrates collecting files matching a glob pattern.
-local function Example_collect()
+-- Example_find demonstrates collecting files matching a glob pattern.
+local function Example_find()
   local check = require("cosmic.check")
   local fs = require("cosmic.fs")
 
@@ -54,10 +51,9 @@ local function Example_collect()
   assert(fs.write(fs.join(subdir, "util.lua"), "-- util\n"))
   assert(fs.write(fs.join(tmpdir, "README.txt"), "readme\n"))
 
-  -- collect returns full paths (or nil if the root could not be opened);
-  -- sort for deterministic output.
-  local luafiles = check.must(fs.find(tmpdir, {glob = "*.lua"}))
-  table.sort(luafiles)
+  -- find returns full paths, or nil plus the error if the root could
+  -- not be opened; sorted = true makes the output deterministic.
+  local luafiles = check.must(fs.find(tmpdir, {glob = "*.lua", sorted = true}))
   for _, p in ipairs(luafiles) do
     -- print only the basename so output is not path-dependent.
     print(fs.basename(p))
@@ -69,8 +65,8 @@ local function Example_collect()
   -- util.lua
 end
 
--- Example_files demonstrates the files() iterator for streaming traversal.
-local function Example_files()
+-- Example_find_iter demonstrates the streaming iterator.
+local function Example_find_iter()
   local check = require("cosmic.check")
   local fs = require("cosmic.fs")
 
@@ -82,8 +78,8 @@ local function Example_files()
   assert(fs.write(fs.join(tmpdir, "b.txt"), "b\n"))
 
   local names: {string} = {}
-  -- files() returns nil, err if the root cannot be opened; must passes
-  -- the iterator and its closing guard through on success.
+  -- find_iter returns nil, err if the root cannot be opened; must
+  -- passes the iterator and its closing guard through on success.
   for p in check.must(fs.find_iter(tmpdir, {glob = "*.txt"})) do
     table.insert(names, fs.basename(p))
   end
@@ -98,4 +94,4 @@ local function Example_files()
   -- b.txt
 end
 
-local _ = {Example_walk, Example_collect, Example_files}
+local _ = {Example_visit, Example_find, Example_find_iter}

--- a/cosmic/fs/walk_test.tl
+++ b/cosmic/fs/walk_test.tl
@@ -1,7 +1,9 @@
 #!/usr/bin/env cosmic
---- Tests for fs_walk module (symlink cycle safety)
+--- Tests for the walker (cosmic.fs.walk) and the find family
+--- (cosmic.fs.find): symlink cycle safety, error slots, options.
 local check = require("cosmic.check")
 local fs_walk = require("cosmic.fs.walk")
+local fs_find = require("cosmic.fs.find")
 local fs = require("cosmic.fs")
 local user = require("cosmic.user")
 local type WalkAction = fs_walk.WalkAction
@@ -65,15 +67,15 @@ local function test_find_all_symlink_cycle_terminates()
   write_file(fs.join(subdir, "real.txt"), "data")
   assert(fs.symlink("..", fs.join(subdir, "loop")))
 
-  local collected = fs_walk.find_info(base)
+  local collected = fs_find.find_info(base)
   assert(collected, "find_info should succeed")
   local files = collected
-  -- Should contain sub/real.txt but NOT any path with loop/ in it
-  for rel_path in pairs(files) do
-    assert(not rel_path:match("loop"),
-      "find_info should not recurse into symlink loop, found: " .. rel_path)
+  -- Keys are FULL paths (#987); none may contain loop/
+  for full_path in pairs(files) do
+    assert(not full_path:match("loop"),
+      "find_info should not recurse into symlink loop, found: " .. full_path)
   end
-  assert(files["sub/real.txt"] ~= nil, "real.txt should be found")
+  assert(files[fs.join(base, "sub/real.txt")] ~= nil, "real.txt should be found")
 end
 test_find_all_symlink_cycle_terminates()
 
@@ -86,7 +88,7 @@ local function test_find_iter_symlink_cycle_terminates()
   assert(fs.symlink("..", fs.join(subdir, "loop")))
 
   local collected: {string} = {}
-  for p in check.must(fs_walk.find_iter(base, {glob = "*.lua"})) do
+  for p in check.must(fs_find.find_iter(base, {glob = "*.lua"})) do
     collected[#collected + 1] = p
     -- Safety: abort if we find more than a small number
     assert(#collected <= 10,
@@ -132,7 +134,7 @@ test_walk_missing_root_errors()
 
 local function test_find_missing_root_errors()
   local missing = fs.join(tmpdir, "no", "such", "dir")
-  local results, err = fs_walk.find(missing, {glob = "*.lua"})
+  local results, err = fs_find.find(missing, {glob = "*.lua"})
   assert(results == nil, "collect of a missing root should return nil")
   assert(err and err:match("ENOENT"),
     "collect error should name ENOENT: " .. tostring(err))
@@ -141,7 +143,7 @@ test_find_missing_root_errors()
 
 local function test_find_all_missing_root_errors()
   local missing = fs.join(tmpdir, "no", "such", "dir")
-  local results, err = fs_walk.find_info(missing)
+  local results, err = fs_find.find_info(missing)
   assert(results == nil, "find_info of a missing root should return nil")
   assert(err and err:match("ENOENT"),
     "find_info error should name ENOENT: " .. tostring(err))
@@ -152,7 +154,7 @@ local function test_find_iter_missing_root_errors()
   -- #558a: strict, like collect — a typo'd directory must be an error,
   -- not an iterator that silently yields zero files.
   local missing = fs.join(tmpdir, "no", "such", "dir")
-  local iter, err = fs_walk.find_iter(missing)
+  local iter, err = fs_find.find_iter(missing)
   assert(iter == nil, "files() on a missing root should return nil")
   assert(err and err:match("ENOENT"),
     "files error should name ENOENT: " .. tostring(err))
@@ -206,7 +208,7 @@ local function test_find_iter_permission_denied_subdir_reports_error()
   write_file(fs.join(locked, "hidden.txt"), "x")
   assert(fs.chmod(locked, 0))
 
-  local iter = check.must(fs_walk.find_iter(base))
+  local iter = check.must(fs_find.find_iter(base))
   local seen: {string: boolean} = {}
   local f = iter()
   while f do
@@ -216,12 +218,12 @@ local function test_find_iter_permission_denied_subdir_reports_error()
   assert(fs.chmod(locked, tonumber("755", 8)))
 
   assert(seen["seen.txt"], "readable entries must still be yielded")
-  -- The loop above already ran the terminating (nil, err) call; the
-  -- iterator stays exhausted, so calling it again just reports the
-  -- same first error rather than resuming anything.
-  local _, suberr = iter()
-  assert(suberr and suberr:match("EACCES"),
-    "files() must surface the denied subdir once exhausted: " .. tostring(suberr))
+  -- The exhausted iterator reports the subtree-error LIST from then
+  -- on; calling it again re-reports rather than resuming anything.
+  local _, suberrs = iter()
+  assert(suberrs and suberrs[1] and suberrs[1]:match("EACCES"),
+    "find_iter must surface the denied subdir once exhausted: "
+    .. tostring(suberrs and suberrs[1]))
 end
 test_find_iter_permission_denied_subdir_reports_error()
 
@@ -334,9 +336,10 @@ test_walk_skip_with_symlink_cycle_terminates()
 local function test_find_success_has_no_error()
   local base = mksubdir("collect_ok")
   write_file(fs.join(base, "one.lua"), "-- 1")
-  local results, err = fs_walk.find(base, {glob = "*.lua"})
-  assert(results, "collect should succeed")
-  assert(err == nil, "no error expected on a clean walk, got " .. tostring(err))
+  local results, err, suberrs = fs_find.find(base, {glob = "*.lua"})
+  assert(results, "find should succeed")
+  assert(err == nil, "slot 2 is nil unless the root failed, got " .. tostring(err))
+  assert(suberrs == nil, "slot 3 is nil on a clean walk")
   assert(#(results) == 1, "expected exactly one match")
 end
 test_find_success_has_no_error()
@@ -347,7 +350,7 @@ test_find_success_has_no_error()
 local function count_open_fds(): integer
   -- Exhausting the iterator closes its own handle as it goes.
   local n = 0
-  local iter = check.must(fs_walk.find_iter("/proc/self/fd"))
+  local iter = check.must(fs_find.find_iter("/proc/self/fd"))
   for _ in iter do n = n + 1 end
   return n
 end
@@ -364,7 +367,7 @@ local function test_find_iter_early_break_closes_handles()
   end
 
   local before = count_open_fds()
-  for p in check.must(fs_walk.find_iter(base, {glob = "*.txt"})) do
+  for p in check.must(fs_find.find_iter(base, {glob = "*.txt"})) do
     assert(p, "expected a path")
     break -- abandon the iterator with directories still open
   end
@@ -374,3 +377,95 @@ local function test_find_iter_early_break_closes_handles()
       before, after))
 end
 test_find_iter_early_break_closes_handles()
+
+-- visit(): the Entry record carries path/name/stat/depth, and the
+-- subtree-error list rides slot 3 — never beside the result in slot 2.
+
+local function test_visit_entry_and_depth()
+  local base = mksubdir("visit_entry")
+  local sub = fs.join(base, "sub")
+  assert(fs.make_dirs(sub))
+  write_file(fs.join(sub, "deep.txt"), "x")
+  write_file(fs.join(base, "top.txt"), "x")
+
+  local depths: {string: integer} = {}
+  local ctx, err, suberrs = fs.visit(base, function(e: fs.Entry, c: {string: integer})
+      assert(e.path:sub(1, #base) == base, "Entry.path is the full path")
+      c[e.name] = e.depth
+    end, depths)
+  assert(ctx ~= nil, "visit should succeed: " .. tostring(err))
+  assert(suberrs == nil, "clean walk carries no subtree errors")
+  assert(depths["top.txt"] == 1, "top-level entries are depth 1")
+  assert(depths["sub"] == 1, "the subdir itself is depth 1")
+  assert(depths["deep.txt"] == 2, "entries one level down are depth 2")
+end
+test_visit_entry_and_depth()
+
+local function test_visit_denied_subdir_lands_in_slot_three()
+  if user.geteuid() == 0 then
+    return -- root bypasses permission checks; nothing to observe
+  end
+  local base = mksubdir("visit_denied")
+  local locked = fs.join(base, "locked")
+  assert(fs.make_dirs(locked))
+  assert(fs.chmod(locked, 0))
+  local ctx, err, suberrs = fs.visit(base, function(_e: fs.Entry, _c: {string}) end, {})
+  assert(fs.chmod(locked, tonumber("755", 8)))
+  assert(ctx ~= nil, "a denied subdir must not abort the walk")
+  assert(err == nil, "slot 2 means the ROOT failed, and it did not")
+  assert(suberrs and suberrs[1] and suberrs[1]:match("EACCES"),
+    "the denied subdir must land in slot 3: " .. tostring(suberrs and suberrs[1]))
+end
+test_visit_denied_subdir_lands_in_slot_three()
+
+-- FindOptions: depth bounds, directory inclusion, sorting.
+
+local function setup_depth_tree(): string
+  local base = mksubdir("find_opts")
+  local sub = fs.join(base, "bdir")
+  assert(fs.make_dirs(sub))
+  write_file(fs.join(base, "a.txt"), "x")
+  write_file(fs.join(sub, "c.txt"), "x")
+  return base
+end
+
+local function test_find_max_depth_and_recursive()
+  local base = setup_depth_tree()
+  local all = check.must(fs.find(base, {glob = "*.txt"}))
+  assert(#all == 2, "unbounded find sees both files")
+  local top = check.must(fs.find(base, {glob = "*.txt", max_depth = 1}))
+  assert(#top == 1 and top[1]:match("a%.txt$"), "max_depth = 1 stays at the top")
+  local flat = check.must(fs.find(base, {glob = "*.txt", recursive = false}))
+  assert(#flat == 1, "recursive = false equals max_depth = 1")
+end
+test_find_max_depth_and_recursive()
+
+local function test_find_include_dirs_and_sorted()
+  local base = setup_depth_tree()
+  local everything = check.must(fs.find(base, {include_dirs = true, sorted = true}))
+  assert(#everything == 3, "include_dirs adds the directory itself")
+  assert(everything[1]:match("a%.txt$"), "sorted: a.txt first")
+  assert(everything[2]:match("bdir$"), "sorted: bdir second")
+  assert(everything[3]:match("c%.txt$"), "sorted: c.txt last")
+end
+test_find_include_dirs_and_sorted()
+
+local function test_find_iter_honors_depth_and_dirs()
+  local base = setup_depth_tree()
+  local names: {string: boolean} = {}
+  for p in check.must(fs_find.find_iter(base, {include_dirs = true, max_depth = 1})) do
+    names[fs.basename(p)] = true
+  end
+  assert(names["a.txt"] and names["bdir"], "top level yielded, dirs included")
+  assert(not names["c.txt"], "max_depth = 1 must not descend")
+end
+test_find_iter_honors_depth_and_dirs()
+
+local function test_find_info_full_paths_and_options()
+  local base = setup_depth_tree()
+  local info = check.must(fs.find_info(base, {glob = "*.txt", max_depth = 1}))
+  assert(info[fs.join(base, "a.txt")], "keys are full paths")
+  assert(info[fs.join(base, "bdir/c.txt")] == nil, "max_depth bounds find_info too")
+  assert(info[fs.join(base, "a.txt")].mode ~= nil, "FileInfo carries mode")
+end
+test_find_info_full_paths_and_options()


### PR DESCRIPTION
Fixes #987. From the 2026-08 API review (F2, fs-group audit §3.1-3.2, §3.7).

## visit: the walker gets an Entry record

```teal
fs.visit(dir, function(e: fs.Entry, ctx)  -- Entry {path, name, stat, depth}
  ...                                     -- return "skip" | "stop" | nothing
end, ctx?, opts?)                         -- : T | nil, string, {string}
```

The `Entry` record deletes the "do NOT join path and name" warning that appeared four times across docs and examples, and exposes `depth` — which the walker already tracked. `visit` is the permanent name; **`walk` becomes a deprecated wrapper** with its exact old contract (positional visitor, first subtree error folded beside the result), kept because the pinned build engine calls it at cold start — deleted at the next pin advance (#981-class). A visitor-callback signature can't be dual-shaped, which is why this is a new name rather than a transition on `walk` itself.

## One find family, one error contract

The find functions move to `cosmic/fs/find.tl` and unify on:

```teal
FindOptions {glob, pattern, max_depth, recursive, include_dirs, sorted}
find(dir, opts?)      : {string} | nil, string, {string}
find_iter(dir, opts?) : FileIter | nil, string, nil, guard
find_info(dir, opts?) : {string: FileInfo} | nil, string, {string}
```

**Slot 2 means failure, period.** The "partial error beside a non-nil result" convention — which made `if err then return nil, err end` wrong for four functions — is gone: subtree errors ride slot 3 as a list (nil when clean), and `visit` follows the same contract. `find_info` now returns **full paths** like its siblings and takes the same options (its two callers relativize where they need to — `_make/generate.tl`'s digest, one test). `find_iter` honors `max_depth`/`recursive`/`include_dirs`, and its exhausted iterator returns the error *list*; `sorted` is find-only (documented — an iterator can't sort without materializing).

`glob` keeps its name and capability — its patterns span `/` components and it never recurses, which `find`'s recursive basename selection can't express — but adopts the same slot contract and its doc now positions it as the component-path expander rather than a fifth spelling of find.

## Example and boot surface

`walk_example.tl` is rewritten around `visit`/`find`/`find_iter` (it still demonstrated functions retired two reviews ago); `BOOT_MODULES` gains `cosmic.fs.find`; `walk_test` gains coverage for Entry/depth, the slot-3 contract on both `visit` and `find`, and every new FindOption.

Verified: full gate `ci: PASS (5 stages)`, plus a cold build from the pin (`rm -rf o && fetch && build` → `build: PASS`) — the pinned engine walks the entire tree through the deprecated `walk` wrapper and boot-loads the new `fs.find` module, which is exactly the compatibility this PR must keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_