### PR TITLE
system modules finish the charter: shm, tty, signal, time, proc (#999)

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -155,7 +155,7 @@ cosmic/net/connect.tl 31 37
 cosmic/net/init.tl 0 120
 cosmic/net/socket.tl 228 256
 cosmic/poll.tl 82 96
-cosmic/proc/init.tl 31 74
+cosmic/proc/init.tl 24 72
 cosmic/proc/rusage.tl 20 28
 cosmic/quicksand/box/env.tl 27 27
 cosmic/quicksand/box/init.tl 0 70
@@ -201,4 +201,4 @@ cosmic/user.tl 48 61
 cosmic/uuid.tl 9 9
 cosmic/zip.tl 72 85
 tlconfig.lua 7 7
-total 14786 19393
+total 14779 19391

--- a/cosmic/child/init_example.tl
+++ b/cosmic/child/init_example.tl
@@ -156,7 +156,7 @@ local function Example_supervisor()
         done = done + 1
       end
     end
-    assert(time.sleep(0, 5 * 1000 * 1000)) -- 5ms between polls: reap, don't spin
+    assert(time.sleep_ms(5)) -- 5ms between polls: reap, don't spin
   end
 
   for index, status in ipairs(statuses) do

--- a/cosmic/child/init_test.tl
+++ b/cosmic/child/init_test.tl
@@ -130,7 +130,7 @@ local function test_try_wait()
       res = t.result
       break
     end
-    assert(time.sleep(0, 10000000)) -- 10ms
+    assert(time.sleep_ms(10)) -- 10ms
   end
   assert(res ~= nil, "try_wait should eventually reap the stopped child")
   assert(res.signal == signal.SIGKILL, "expected SIGKILL, got signal=" .. tostring(res.signal))
@@ -159,7 +159,7 @@ local function test_abandoned_handle_reaped()
   end
   collectgarbage("collect")
   collectgarbage("collect")
-  assert(time.sleep(0, 100000000)) -- 100ms for the kernel to finish teardown
+  assert(time.sleep_ms(100)) -- 100ms for the kernel to finish teardown
   assert(not signal.kill(pid, 0), "abandoned child should be killed and reaped, not left alive/zombie")
 end
 test_abandoned_handle_reaped()

--- a/cosmic/embed_advanced_test.tl
+++ b/cosmic/embed_advanced_test.tl
@@ -244,7 +244,7 @@ local function test_embed_does_not_corrupt_running_process()
   assert(fs.write(fs.join(appdir, "main.lua"), [[
 local time = require("cosmic.time")
 -- Sleep to give the test time to overwrite the binary
-time.sleep(1)
+time.sleep_ms(1000)
 -- Exercise code paths that touch mmapped pages (string ops, table ops, format)
 local t = {}
 for i = 1, 100 do t[i] = string.format("item_%04d", i) end
@@ -262,7 +262,7 @@ io.write("OK:" .. #result)
   local handle = check.must(child.start({binary}))
 
   -- Wait briefly for the process to start and mmap its pages
-  assert(time.sleep(0, 100000000)) -- 100ms
+  assert(time.sleep_ms(100)) -- 100ms
 
   -- Re-embed over the same path while the process is running.
   -- Without atomic write, this would corrupt the running process.

--- a/cosmic/instrument_test.tl
+++ b/cosmic/instrument_test.tl
@@ -35,7 +35,7 @@ test_finish_measures_when_disabled()
 
 local function test_finish_and_format_line()
   local span = instrument.begin("check-types", "cosmic/fs.tl")
-  assert(time.sleep(0, 1000000)) -- sleep 1ms to get measurable time
+  assert(time.sleep_ms(1)) -- sleep 1ms to get measurable time
   local data = instrument.finish(span, 0)
   local line = instrument.format_line(data)
   assert(line:match("^cosmic:"), "expected 'cosmic:' prefix, got: " .. line)
@@ -88,7 +88,7 @@ test_is_enabled()
 
 local function test_round_trip()
   local span = instrument.begin("test", "cosmic/sqlite_test.tl")
-  assert(time.sleep(0, 1000000))
+  assert(time.sleep_ms(1))
   local data = instrument.finish(span, 0)
   local line = instrument.format_line(data)
   local parsed = check.must(instrument.parse_line(line), "expected parsed result")

--- a/cosmic/proc/init.tl
+++ b/cosmic/proc/init.tl
@@ -114,9 +114,15 @@ end
 --- Terminates the current process immediately.
 --- Memory is freed, file descriptors are closed, connections are reset.
 --- This function never returns.
---- @param exitcode integer? Exit code (defaults to 0)
-local exit: function(exitcode?: integer) = unix.exit
+--- @param exit_code integer? Exit code (defaults to 0)
+local exit: function(exit_code?: integer) = unix.exit
 
+-- Beyond POSIX (#999): the three members below are cosmic
+-- conveniences, not syscall wrappers — the rest of this module keeps
+-- POSIX names under rule 4's syscall-shaped exemption.
+--   which()        $PATH lookup
+--   interpreter()  the running cosmic binary's resolved path
+--   is_main()      script-vs-module detection
 -- Exec (replace current process) --
 
 --- Performs $PATH lookup of executable (which(1)).
@@ -133,39 +139,44 @@ local function which(prog: string): string | nil, string
   return p
 end
 
---- Resolved-interpreter cache: argv0 is resolved against the cwd (and
---- $PATH) of the FIRST call, so a program that chdirs should call
---- interpreter() before doing so when it was started via a relative path.
+-- Resolved at LOAD (#999): argv0 is resolved against the cwd and
+-- $PATH of require time, so a program that chdirs later still gets
+-- the right answer — the old lazy cache documented a call-order
+-- requirement ("call interpreter() before chdir") instead of meeting it.
 local interpreter_path: string | nil = nil
+local interpreter_err: string | nil = nil
+do
+  local argv0 = rawget(arg, -1)
+  if argv0 == nil or argv0 == "" then
+    interpreter_err = "interpreter: arg[-1] is not set"
+  else
+    local abs = fs_path.absolute_path(argv0)
+    if fs_path.is_file(abs) then
+      interpreter_path = abs
+    else
+      -- A bare name found on $PATH (which() reports the errno when not).
+      local found, err = which(argv0)
+      if found then
+        interpreter_path = found
+      else
+        interpreter_err = "interpreter: cannot resolve '" .. argv0
+        .. "': " .. tostring(err)
+      end
+    end
+  end
+end
 
 --- Absolute path of the running cosmic interpreter — for re-invoking it
 --- to run another script as a child: `child.start({proc.interpreter(),
 --- "worker.tl"})`. This is `arg[-1]` resolved, NOT `arg[0]` (the script
 --- path as the runtime sees it, `/zip/main.lua` in a packed binary). A
 --- bare PATH-invoked argv0 (`cosmic`, the shebang shape) is resolved
---- with a real $PATH search. The result is cached across calls.
+--- with a real $PATH search — at module load (#999), so a later chdir
+--- cannot change the answer.
 --- @return string | nil The interpreter's absolute path
 --- @return string? Error message when argv0 is missing or unresolvable
 local function interpreter(): string | nil, string
-  if interpreter_path then
-    return interpreter_path
-  end
-  local argv0 = rawget(arg, -1)
-  if argv0 == nil or argv0 == "" then
-    return nil, "interpreter: arg[-1] is not set"
-  end
-  local abs = fs_path.absolute_path(argv0)
-  if fs_path.is_file(abs) then
-    interpreter_path = abs
-    return abs
-  end
-  -- A bare name found on $PATH (which() reports the errno when not).
-  local found, err = which(argv0)
-  if not found then
-    return nil, "interpreter: cannot resolve '" .. argv0 .. "': " .. tostring(err)
-  end
-  interpreter_path = found
-  return found
+  return interpreter_path, interpreter_err
 end
 
 --- Replaces current process with new program; never returns on success.
@@ -223,7 +234,7 @@ end
 --- Waits for a child process to change state.
 --- A raw passthrough: EINTR surfaces here, unlike child.Handle:wait.
 --- @param pid integer? Child pid to wait for (-1 or nil for any child)
---- @param options integer? Wait options (e.g. WNOHANG)
+--- @param wait_flags integer? Wait flags (e.g. WNOHANG; #999: rule 7 reserves `options`)
 --- @return integer | nil The pid that changed state (0 with WNOHANG if none), or nil on failure
 --- @return integer Status word (interpret with WIFEXITED/WEXITSTATUS/...)
 --- @return Rusage Resource usage for the reaped child
@@ -238,8 +249,8 @@ local record WaitResult
   rusage: Rusage
 end
 
-local function wait(pid?: integer, options?: integer): WaitResult | nil, string
-  local wpid, status, rusage = unix.wait(pid, options)
+local function wait(pid?: integer, wait_flags?: integer): WaitResult | nil, string
+  local wpid, status, rusage = unix.wait(pid, wait_flags)
   if wpid == nil then
     -- On failure the binding returns (nil, err, errno): the error string
     -- arrives in the second slot, where the status word would have been.
@@ -299,7 +310,7 @@ local record ProcModule
   daemon: function(nochdir?: boolean, noclose?: boolean): boolean, string
 
   -- Termination
-  exit: function(exitcode?: integer)
+  exit: function(exit_code?: integer)
 
   -- Exec
   interpreter: function(): string | nil, string
@@ -312,7 +323,7 @@ local record ProcModule
   -- Process control (children)
   fork: function(): integer | nil, string
   type WaitResult = WaitResult
-  wait: function(pid?: integer, options?: integer): WaitResult | nil, string
+  wait: function(pid?: integer, wait_flags?: integer): WaitResult | nil, string
   WIFEXITED: function(status: integer): boolean
   WEXITSTATUS: function(status: integer): integer
   WIFSIGNALED: function(status: integer): boolean
@@ -356,7 +367,7 @@ local record ProcModule
   PRIO_PGRP: integer
   PRIO_USER: integer
 
-  -- Wait options
+  -- Wait flags
   WNOHANG: integer
   WUNTRACED: integer
   WCONTINUED: integer
@@ -432,7 +443,7 @@ local M: ProcModule = {
   PRIO_PGRP = unix.PRIO_PGRP,
   PRIO_USER = unix.PRIO_USER,
 
-  -- Wait options
+  -- Wait flags
   WNOHANG = unix.WNOHANG,
   WUNTRACED = unix.WUNTRACED,
   WCONTINUED = unix.WCONTINUED,

--- a/cosmic/proc_test.tl
+++ b/cosmic/proc_test.tl
@@ -332,7 +332,7 @@ test_wexitstatus_values()
 local function test_wifsignaled_on_kill()
   local pid = check.must(proc.fork())
   if pid == 0 then
-    assert(time.sleep(10))
+    assert(time.sleep_ms(10000))
     proc.exit(0)
   else
     assert(signal.kill(pid, signal.SIGKILL), "expected kill to succeed")
@@ -347,7 +347,7 @@ test_wifsignaled_on_kill()
 local function test_wnohang_returns_zero_for_running_process()
   local pid = check.must(proc.fork())
   if pid == 0 then
-    assert(time.sleep(0, 100000000)) -- 100ms
+    assert(time.sleep_ms(100)) -- 100ms
     proc.exit(0)
   else
     local wr = check.must(proc.wait(pid, proc.WNOHANG))

--- a/cosmic/quicksand/proc_test.tl
+++ b/cosmic/quicksand/proc_test.tl
@@ -184,9 +184,9 @@ if not pid then
 end
 if pid == 0 then
   b:drop_read()
-  time.sleep(0, 50000000) -- 50ms: let the parent block in b:wait() first
+  time.sleep_ms(50) -- 50ms: let the parent block in b:wait() first
   unix.kill(unix.getppid(), unix.SIGUSR1) -- interrupt the parent's read
-  time.sleep(0, 200000000) -- 200ms "still finishing setup"
+  time.sleep_ms(200) -- 200ms "still finishing setup"
   b:signal()
   os.exit(0)
 end
@@ -289,7 +289,7 @@ test_become_init_returns_child_exit_status()
 local function test_become_init_maps_signal_death_to_128_plus_signum()
   local out = run_init("init_signaled", [[
 local pid = forked()
-if pid == 0 then time.sleep(60) os.exit(0) end
+if pid == 0 then time.sleep_ms(60000) os.exit(0) end
 unix.kill(pid, unix.SIGKILL)
 io.write("code=" .. tostring(qproc.become_init(pid)) .. "\n")
 ]])
@@ -315,11 +315,11 @@ test_become_init_maps_signal_death_to_128_plus_signum()
 local function test_become_init_forwards_signals_to_main()
   local out = run_init("init_forward", [[
 local main = forked()
-if main == 0 then time.sleep(60) os.exit(0) end
+if main == 0 then time.sleep_ms(60000) os.exit(0) end
 local supervisor = unix.getpid()
 local killer = forked()
 if killer == 0 then
-  time.sleep(1)
+  time.sleep_ms(1000)
   unix.kill(supervisor, unix.SIGTERM)
   os.exit(0)
 end
@@ -343,7 +343,7 @@ test_become_init_forwards_signals_to_main()
 local function test_become_init_sidecar_exit_kills_main()
   local out = run_init("init_sidecar", [[
 local main = forked()
-if main == 0 then time.sleep(60) os.exit(0) end
+if main == 0 then time.sleep_ms(60000) os.exit(0) end
 local side = forked()
 if side == 0 then os.exit(0) end
 local fired = -1

--- a/cosmic/quicksand/proxy/http_test.tl
+++ b/cosmic/quicksand/proxy/http_test.tl
@@ -170,7 +170,7 @@ local function test_pump_relays_data_across_eintr()
 
   assert(c2:close())
   assert(u2:close())
-  assert(time.sleep(0, 150000000))
+  assert(time.sleep_ms(150))
   local payload = "hello-through-pump"
   local sent = c1:send(payload)
   assert(sent == #payload, "send failed: " .. tostring(sent))

--- a/cosmic/shm.tl
+++ b/cosmic/shm.tl
@@ -1,11 +1,12 @@
 --- Shared memory for inter-process communication.
---- Provides atomic operations and wait/wake primitives for synchronization.
---- Memory created with mapshared is shared across fork() and provides
---- fundamental synchronization primitives including futexes.
+--- Provides atomic operations and wait/wake primitives for
+--- synchronization. Memory created with shm.open (#999: was
+--- `mapshared`) is shared across fork() and provides fundamental
+--- synchronization primitives including futexes.
 ---
 --- This is a real wrapper over unix.mapshared, not a passthrough: sizes
 --- and offsets are validated in Lua (the region size is known at
---- mapshared time) so failures return nil, err per the stdlib error
+--- open time) so failures return nil, err per the stdlib error
 --- convention instead of throwing, and residual binding throws are
 --- pcall-translated.
 local unix = require("cosmo.unix")
@@ -21,7 +22,7 @@ local record ShmModule
   --- word's actual value at the time (the old value on success). A
   --- record rather than (swapped, actual, err) returns — the error is
   --- in slot 2 where `local r, err = ...` can see it.
-  record Cmpxchg
+  record Exchange
     swapped: boolean
     value: integer
   end
@@ -29,6 +30,14 @@ local record ShmModule
   --- Words are 64-bit; word_index is 0-based. Futex words (wait/wake)
   --- only inspect the low 32 bits — store only int32 values in words
   --- you wait on.
+  ---
+  --- Memory ordering (#999, stated because a sync-primitives surface
+  --- without one is a guess): every atomic word operation is
+  --- sequentially consistent (the binding's C11 atomics use the
+  --- default memory_order_seq_cst), so a store or exchange published
+  --- before a wake is visible to the waiter it wakes; plain read/write
+  --- byte access carries NO ordering — publish through the atomics.
+  ---
   --- Not a mirror of the generated unix.Memory: this is a deliberately
   --- narrowed surface whose methods validate bounds in Lua, return
   --- nil, err instead of throwing, and add size().
@@ -43,9 +52,9 @@ local record ShmModule
     --- Atomic store to a word.
     store: function(self: Memory, word_index: integer, value: integer): boolean, string
     --- Atomic exchange; returns the old value.
-    xchg: function(self: Memory, word_index: integer, value: integer): integer | nil, string
+    exchange: function(self: Memory, word_index: integer, value: integer): integer | nil, string
     --- Compare-and-exchange; returns success plus the actual old value.
-    cmpxchg: function(self: Memory, word_index: integer, old: integer, new: integer): Cmpxchg | nil, string
+    compare_exchange: function(self: Memory, word_index: integer, old: integer, new: integer): Exchange | nil, string
     --- Atomic add; returns the old value.
     fetch_add: function(self: Memory, word_index: integer, value: integer): integer | nil, string
     --- Atomic AND; returns the old value.
@@ -66,18 +75,19 @@ local record ShmModule
     --- Wakes nothing once the region has been unmapped.
     wake: function(self: Memory, word_index: integer, count?: integer): integer | nil, string
     --- Release the mapping now instead of waiting for the garbage
-    --- collector. Idempotent: true when this call released the mapping,
-    --- false when it was already unmapped. Afterwards every fallible
-    --- method returns an error naming the unmapped state.
-    unmap: function(self: Memory): boolean
+    --- collector. Idempotent and returns nothing (#999: it used to
+    --- return false for "already released", so asserting the second,
+    --- correct call failed). Afterwards every fallible method returns
+    --- an error naming the unmapped state.
+    close: function(self: Memory)
     --- The mapped region size in bytes.
     size: function(self: Memory): integer
   end
-  mapshared: function(size: integer): Memory | nil, string
+  open: function(size_bytes: integer): Memory | nil, string
 end
 
 local type Memory = ShmModule.Memory
-local type Cmpxchg = ShmModule.Cmpxchg
+local type Exchange = ShmModule.Exchange
 
 --- Validate a 0-based word index against the region size.
 local function check_word(word_index: integer, size: integer, op: string): string
@@ -186,8 +196,8 @@ local function wrap(raw: unix.Memory, size: integer): Memory
     return res
   end
 
-  function mem:xchg(word_index: integer, value: integer): integer | nil, string
-    return atomic("xchg", raw.xchg, word_index, value)
+  function mem:exchange(word_index: integer, value: integer): integer | nil, string
+    return atomic("exchange", raw.xchg, word_index, value)
   end
 
   function mem:fetch_add(word_index: integer, value: integer): integer | nil, string
@@ -206,14 +216,14 @@ local function wrap(raw: unix.Memory, size: integer): Memory
     return atomic("fetch_xor", raw.fetch_xor, word_index, value)
   end
 
-  function mem:cmpxchg(word_index: integer, old: integer, new: integer): Cmpxchg | nil, string
-    local range_err = check_word(word_index, size, "cmpxchg")
+  function mem:compare_exchange(word_index: integer, old: integer, new: integer): Exchange | nil, string
+    local range_err = check_word(word_index, size, "compare_exchange")
     if range_err then
       return nil, range_err
     end
     local ok, success, actual = pcall(raw.cmpxchg, raw, word_index, old, new)
     if not ok then
-      return nil, errstr(success, "cmpxchg")
+      return nil, errstr(success, "compare_exchange")
     end
     -- cast: from any (pcall widens the binding's returns)
     return {swapped = success as boolean, value = actual as integer}
@@ -256,9 +266,6 @@ local function wrap(raw: unix.Memory, size: integer): Memory
     return rc
   end
 
-  -- wake is declared infallible, so it cannot grow an error slot for the
-  -- unmapped state; mirror the out-of-range posture (wake nothing) and
-  -- keep the raw call — which throws once unmapped — behind the flag.
   local unmapped = false
 
   function mem:wake(word_index: integer, count?: integer): integer | nil, string
@@ -274,9 +281,9 @@ local function wrap(raw: unix.Memory, size: integer): Memory
     return raw:wake(word_index, count)
   end
 
-  function mem:unmap(): boolean
+  function mem:close()
     unmapped = true
-    return (raw:unmap())
+    raw:unmap()
   end
 
   return mem
@@ -289,11 +296,11 @@ end
 --- Example usage for a simple mutex:
 --- ```lua
 --- local shm = require("cosmic.shm")
---- local mem = assert(shm.mapshared(8000 * 8))
+--- local mem = assert(shm.open(8000 * 8))
 --- local LOCK = 0  -- word index for lock
 ---
 --- -- Lock acquisition
---- while mem:xchg(LOCK, 1) == 1 do
+--- while mem:exchange(LOCK, 1) == 1 do
 ---   mem:wait(LOCK, 1)
 --- end
 ---
@@ -304,27 +311,27 @@ end
 --- mem:wake(LOCK, 1)
 --- ```
 ---
---- @param size integer Size in bytes: positive, a multiple of the 8-byte word size
+--- @param size_bytes integer Size in bytes: positive, a multiple of the 8-byte word size
 --- @return Memory | nil Shared memory object, or nil on failure
 --- @return string? Error message on failure
-local function mapshared(size: integer): Memory | nil, string
-  if size == nil or size <= 0 then
-    return nil, "mapshared: size must be a positive number of bytes: " .. tostring(size)
+local function open(size_bytes: integer): Memory | nil, string
+  if size_bytes == nil or size_bytes <= 0 then
+    return nil, "open: size must be a positive number of bytes: " .. tostring(size_bytes)
   end
-  if size % WORD ~= 0 then
-    return nil, "mapshared: size must be a multiple of the " .. tostring(WORD)
-    .. "-byte word size: " .. tostring(size)
+  if size_bytes % WORD ~= 0 then
+    return nil, "open: size must be a multiple of the " .. tostring(WORD)
+    .. "-byte word size: " .. tostring(size_bytes)
   end
   -- Residual throws (e.g. out of memory, size cap) become nil, err.
-  local ok, raw = pcall(unix.mapshared, size)
+  local ok, raw = pcall(unix.mapshared, size_bytes)
   if not ok then
-    return nil, errstr(raw, "mapshared")
+    return nil, errstr(raw, "open")
   end
-  return wrap(raw, size)
+  return wrap(raw, size_bytes)
 end
 
 local M: ShmModule = {
-  mapshared = mapshared,
+  open = open,
 }
 
 return M

--- a/cosmic/shm_example.tl
+++ b/cosmic/shm_example.tl
@@ -1,6 +1,6 @@
 --- Examples for the cosmic.shm module.
 --- Demonstrates shared-memory string I/O and the atomic word
---- operations. Memory from mapshared() is inherited across fork(),
+--- operations. Memory from open() is inherited across fork(),
 --- which is what makes the atomics useful; the examples stay in one
 --- process so their output is deterministic.
 
@@ -10,7 +10,7 @@
 local function Example_string_io()
   local check = require("cosmic.check")
   local shm = require("cosmic.shm")
-  local mem = check.must(shm.mapshared(4096))
+  local mem = check.must(shm.open(4096))
   assert(mem:write("hello"))
   print(check.must(mem:read()))
   print(mem:size())
@@ -25,7 +25,7 @@ end
 local function Example_atomic_counter()
   local check = require("cosmic.check")
   local shm = require("cosmic.shm")
-  local mem = check.must(shm.mapshared(4096))
+  local mem = check.must(shm.open(4096))
   assert(mem:store(0, 41))
   local before = mem:fetch_add(0, 1)
   print(before, check.must(mem:load(0)))
@@ -33,17 +33,17 @@ local function Example_atomic_counter()
   -- 41	42
 end
 
--- Example_cmpxchg demonstrates compare-and-exchange: the swap only
+-- Example_compare_exchange demonstrates compare-and-exchange: the swap only
 -- happens when the word still holds the expected old value, and the
 -- actual old value comes back either way.
-local function Example_cmpxchg()
+local function Example_compare_exchange()
   local check = require("cosmic.check")
   local shm = require("cosmic.shm")
-  local mem = check.must(shm.mapshared(4096))
+  local mem = check.must(shm.open(4096))
   assert(mem:store(0, 7))
-  local r = check.must(mem:cmpxchg(0, 7, 8))
+  local r = check.must(mem:compare_exchange(0, 7, 8))
   print(r.swapped, r.value, check.must(mem:load(0)))
-  local r2 = check.must(mem:cmpxchg(0, 7, 9)) -- stale expectation: no swap
+  local r2 = check.must(mem:compare_exchange(0, 7, 9)) -- stale expectation: no swap
   print(r2.swapped, r2.value, check.must(mem:load(0)))
   -- Output:
   -- true	7	8
@@ -51,4 +51,4 @@ local function Example_cmpxchg()
 end
 
 -- Suppress unused warnings for examples
-local _ = {Example_string_io, Example_atomic_counter, Example_cmpxchg}
+local _ = {Example_string_io, Example_atomic_counter, Example_compare_exchange}

--- a/cosmic/shm_test.tl
+++ b/cosmic/shm_test.tl
@@ -5,24 +5,24 @@ local check = require("cosmic.check")
 -- Test module exports
 
 local function test_module_exports()
-  assert(shm.mapshared ~= nil, "mapshared function should be exported")
-  assert(type(shm.mapshared) == "function", "mapshared should be a function")
+  assert(shm.open ~= nil, "open function should be exported")
+  assert(type(shm.open) == "function", "open should be a function")
 end
 test_module_exports()
 
 -- Test basic shared memory creation
 
-local function test_mapshared_creates_memory()
-  local mem = check.must(shm.mapshared(4096))
-  assert(mem ~= nil, "mapshared should return a memory object")
+local function test_open_creates_memory()
+  local mem = check.must(shm.open(4096))
+  assert(mem ~= nil, "open should return a memory object")
 end
-test_mapshared_creates_memory()
+test_open_creates_memory()
 
 -- Test memory read/write operations
 -- Note: write/read with no arguments uses null-terminated string semantics
 
 local function test_memory_write_read()
-  local mem = check.must(shm.mapshared(4096))
+  local mem = check.must(shm.open(4096))
   assert(mem:write("hello")) -- writes "hello\0"
   local data = mem:read() -- reads until null terminator
   assert(data == "hello", "expected 'hello', got '" .. tostring(data) .. "'")
@@ -30,7 +30,7 @@ end
 test_memory_write_read()
 
 local function test_memory_write_read_with_offset()
-  local mem = check.must(shm.mapshared(4096))
+  local mem = check.must(shm.open(4096))
   assert(mem:write("hello")) -- writes at offset 0
   assert(mem:write("world")) -- overwrites
   local data = mem:read()
@@ -41,7 +41,7 @@ test_memory_write_read_with_offset()
 -- Test atomic word operations
 
 local function test_memory_store_load()
-  local mem = check.must(shm.mapshared(4096))
+  local mem = check.must(shm.open(4096))
   assert(mem:store(0, 42))
   local value = mem:load(0)
   assert(value == 42, "expected 42, got " .. tostring(value))
@@ -49,7 +49,7 @@ end
 test_memory_store_load()
 
 local function test_memory_store_load_different_index()
-  local mem = check.must(shm.mapshared(4096))
+  local mem = check.must(shm.open(4096))
   assert(mem:store(0, 100))
   assert(mem:store(1, 200))
   local v0 = mem:load(0)
@@ -61,44 +61,44 @@ test_memory_store_load_different_index()
 
 -- Test atomic exchange
 
-local function test_memory_xchg()
-  local mem = check.must(shm.mapshared(4096))
+local function test_memory_exchange()
+  local mem = check.must(shm.open(4096))
   assert(mem:store(0, 10))
-  local old = mem:xchg(0, 20)
-  assert(old == 10, "xchg should return old value 10, got " .. tostring(old))
+  local old = mem:exchange(0, 20)
+  assert(old == 10, "exchange should return old value 10, got " .. tostring(old))
   local current = mem:load(0)
-  assert(current == 20, "after xchg, value should be 20, got " .. tostring(current))
+  assert(current == 20, "after exchange, value should be 20, got " .. tostring(current))
 end
-test_memory_xchg()
+test_memory_exchange()
 
 -- Test compare-and-exchange
 
-local function test_memory_cmpxchg_success()
-  local mem = check.must(shm.mapshared(4096))
+local function test_memory_compare_exchange_success()
+  local mem = check.must(shm.open(4096))
   assert(mem:store(0, 100))
-  local r = check.must(mem:cmpxchg(0, 100, 200))
-  assert(r.swapped == true, "cmpxchg should succeed when old matches")
-  assert(r.value == 100, "cmpxchg should return old value 100, got " .. tostring(r.value))
+  local r = check.must(mem:compare_exchange(0, 100, 200))
+  assert(r.swapped == true, "compare_exchange should succeed when old matches")
+  assert(r.value == 100, "compare_exchange should return old value 100, got " .. tostring(r.value))
   local current = mem:load(0)
-  assert(current == 200, "after successful cmpxchg, value should be 200, got " .. tostring(current))
+  assert(current == 200, "after successful compare_exchange, value should be 200, got " .. tostring(current))
 end
-test_memory_cmpxchg_success()
+test_memory_compare_exchange_success()
 
-local function test_memory_cmpxchg_failure()
-  local mem = check.must(shm.mapshared(4096))
+local function test_memory_compare_exchange_failure()
+  local mem = check.must(shm.open(4096))
   assert(mem:store(0, 100))
-  local r = check.must(mem:cmpxchg(0, 50, 200))
-  assert(r.swapped == false, "cmpxchg should fail when old doesn't match")
-  assert(r.value == 100, "cmpxchg should return actual value 100, got " .. tostring(r.value))
+  local r = check.must(mem:compare_exchange(0, 50, 200))
+  assert(r.swapped == false, "compare_exchange should fail when old doesn't match")
+  assert(r.value == 100, "compare_exchange should return actual value 100, got " .. tostring(r.value))
   local current = mem:load(0)
-  assert(current == 100, "after failed cmpxchg, value should still be 100, got " .. tostring(current))
+  assert(current == 100, "after failed compare_exchange, value should still be 100, got " .. tostring(current))
 end
-test_memory_cmpxchg_failure()
+test_memory_compare_exchange_failure()
 
 -- Test fetch_add
 
 local function test_memory_fetch_add()
-  local mem = check.must(shm.mapshared(4096))
+  local mem = check.must(shm.open(4096))
   assert(mem:store(0, 10))
   local old = mem:fetch_add(0, 5)
   assert(old == 10, "fetch_add should return old value 10, got " .. tostring(old))
@@ -110,7 +110,7 @@ test_memory_fetch_add()
 -- Test fetch_and
 
 local function test_memory_fetch_and()
-  local mem = check.must(shm.mapshared(4096))
+  local mem = check.must(shm.open(4096))
   assert(mem:store(0, 0xFF))
   local old = mem:fetch_and(0, 0x0F)
   assert(old == 0xFF, "fetch_and should return old value 255, got " .. tostring(old))
@@ -122,7 +122,7 @@ test_memory_fetch_and()
 -- Test fetch_or
 
 local function test_memory_fetch_or()
-  local mem = check.must(shm.mapshared(4096))
+  local mem = check.must(shm.open(4096))
   assert(mem:store(0, 0x0F))
   local old = mem:fetch_or(0, 0xF0)
   assert(old == 0x0F, "fetch_or should return old value 15, got " .. tostring(old))
@@ -134,7 +134,7 @@ test_memory_fetch_or()
 -- Test fetch_xor
 
 local function test_memory_fetch_xor()
-  local mem = check.must(shm.mapshared(4096))
+  local mem = check.must(shm.open(4096))
   assert(mem:store(0, 0xFF))
   local old = mem:fetch_xor(0, 0x0F)
   assert(old == 0xFF, "fetch_xor should return old value 255, got " .. tostring(old))
@@ -146,7 +146,7 @@ test_memory_fetch_xor()
 -- Test wake (basic call, no waiters)
 
 local function test_memory_wake_no_waiters()
-  local mem = check.must(shm.mapshared(4096))
+  local mem = check.must(shm.open(4096))
   assert(mem:store(0, 0))
   local woken = mem:wake(0, 1)
   -- With no waiters, wake should return 0
@@ -157,30 +157,30 @@ test_memory_wake_no_waiters()
 -- Real wrapper with error slots (review item 25): invalid
 -- sizes and out-of-range accesses return nil, err instead of throwing.
 
-local function test_mapshared_size_not_multiple_of_word()
-  local mem, err = shm.mapshared(100)
-  assert(mem == nil, "mapshared(100) should fail (not a multiple of 8)")
+local function test_open_size_not_multiple_of_word()
+  local mem, err = shm.open(100)
+  assert(mem == nil, "open(100) should fail (not a multiple of 8)")
   assert(type(err) == "string" and err:find("multiple"),
     "error should mention the word-size multiple, got: " .. tostring(err))
 end
-test_mapshared_size_not_multiple_of_word()
+test_open_size_not_multiple_of_word()
 
-local function test_mapshared_rejects_nonpositive_size()
-  local mem, err = shm.mapshared(0)
-  assert(mem == nil and type(err) == "string", "mapshared(0) should fail with an error")
-  local mem2, err2 = shm.mapshared(-8)
-  assert(mem2 == nil and type(err2) == "string", "mapshared(-8) should fail with an error")
+local function test_open_rejects_nonpositive_size()
+  local mem, err = shm.open(0)
+  assert(mem == nil and type(err) == "string", "open(0) should fail with an error")
+  local mem2, err2 = shm.open(-8)
+  assert(mem2 == nil and type(err2) == "string", "open(-8) should fail with an error")
 end
-test_mapshared_rejects_nonpositive_size()
+test_open_rejects_nonpositive_size()
 
 local function test_memory_size()
-  local mem = check.must(shm.mapshared(4096))
+  local mem = check.must(shm.open(4096))
   assert(mem:size() == 4096, "size() should return the mapped size, got " .. tostring(mem:size()))
 end
 test_memory_size()
 
 local function test_memory_read_out_of_range()
-  local mem = check.must(shm.mapshared(64))
+  local mem = check.must(shm.open(64))
   local data, err = mem:read(9999, 8)
   assert(data == nil, "read past the region should fail")
   assert(type(err) == "string" and err:find("range"),
@@ -189,7 +189,7 @@ end
 test_memory_read_out_of_range()
 
 local function test_memory_write_out_of_range()
-  local mem = check.must(shm.mapshared(8))
+  local mem = check.must(shm.open(8))
   local ok, err = mem:write("far too long for eight bytes", 0)
   assert(ok == false, "write past the region should fail")
   assert(type(err) == "string" and err:find("range"),
@@ -201,7 +201,7 @@ test_memory_write_out_of_range()
 -- order is (offset, data, bytes), not (data, offset, bytes), so this
 -- once silently discarded the offset (treating it as a bytes count).
 local function test_memory_write_at_explicit_offset()
-  local mem = check.must(shm.mapshared(4096))
+  local mem = check.must(shm.open(4096))
   local ok1, err1 = mem:write("XXXXXXXXXX", 0)
   assert(ok1, "setup write failed: " .. tostring(err1))
   local ok2, err2 = mem:write("world", 3)
@@ -217,7 +217,7 @@ test_memory_write_at_explicit_offset()
 -- the validated min(bytes, #data) either wrote nothing (offset 0
 -- collides with "no count") or threw "bytes is more than what's in data".
 local function test_memory_write_clamps_bytes_to_data_length()
-  local mem = check.must(shm.mapshared(4096))
+  local mem = check.must(shm.open(4096))
   local ok, err = mem:write("hi", 0, 100)
   assert(ok == true, "write with bytes > #data should still succeed: " .. tostring(err))
   local data = check.must(mem:read(0, 2))
@@ -226,7 +226,7 @@ end
 test_memory_write_clamps_bytes_to_data_length()
 
 local function test_memory_word_index_out_of_range()
-  local mem = check.must(shm.mapshared(64))
+  local mem = check.must(shm.open(64))
   local v, err = mem:load(9999)
   assert(v == nil, "load of out-of-range word should fail")
   assert(type(err) == "string" and err:find("range"),
@@ -239,7 +239,7 @@ end
 test_memory_word_index_out_of_range()
 
 local function test_memory_wait_wrong_expect_returns_eagain()
-  local mem = check.must(shm.mapshared(64))
+  local mem = check.must(shm.open(64))
   assert(mem:store(0, 5))
   local rc, err = mem:wait(0, 3)
   assert(rc == nil, "wait with mismatched expect should fail immediately")
@@ -253,7 +253,7 @@ test_memory_wait_wrong_expect_returns_eagain()
 -- retries, so the wait ends in ETIMEDOUT, never EINTR.
 local function test_memory_wait_retries_eintr_until_deadline()
   local signal = require("cosmic.signal")
-  local mem = check.must(shm.mapshared(64))
+  local mem = check.must(shm.open(64))
   assert(mem:store(0, 0))
   local prev = check.must(signal.sigaction(signal.SIGALRM, function(_: number) end))
   -- Interval timer: interrupts the wait several times before the deadline.
@@ -278,15 +278,17 @@ local function test_memory_wait_retries_eintr_until_deadline()
 end
 test_memory_wait_retries_eintr_until_deadline()
 
--- unmap releases the mapping deterministically instead of waiting
--- for the garbage collector. Idempotent and observable; afterwards every
--- fallible method returns an error instead of touching freed memory, and
--- wake wakes nothing.
-local function test_memory_unmap()
-  local mem = assert(shm.mapshared(64)) as shm.Memory -- cast: record union after guard
+-- close releases the mapping deterministically instead of waiting
+-- for the garbage collector. Idempotent and returns NOTHING (#999:
+-- it used to return false for "already released", so asserting the
+-- second, correct call failed); afterwards every fallible method
+-- returns an error instead of touching freed memory, and wake wakes
+-- nothing.
+local function test_memory_close()
+  local mem = assert(shm.open(64)) as shm.Memory -- cast: record union after guard
   assert(mem:store(0, 7))
-  assert(mem:unmap() == true, "first unmap should release and say so")
-  assert(mem:unmap() == false, "second unmap should be a no-op")
+  mem:close()
+  mem:close() -- the second, correct call is a quiet no-op, not a false
   local v, err = mem:load(0)
   assert(v == nil, "load after unmap should fail")
   assert(type(err) == "string" and err:find("unmapped"),
@@ -299,4 +301,4 @@ local function test_memory_unmap()
   assert(woken == nil and wake_err and wake_err:find("unmapped", 1, true),
     "wake after unmap is a caller bug and must say so, got: " .. tostring(wake_err))
 end
-test_memory_unmap()
+test_memory_close()

--- a/cosmic/signal.tl
+++ b/cosmic/signal.tl
@@ -2,6 +2,7 @@
 --- Wraps cosmo.unix signal functions for process signaling, handlers, and timers.
 local unix = require("cosmo.unix")
 local errstr = require("cosmic.errno").wrap
+local errno_is = require("cosmic.errno").is
 
 --- Options for setitimer: which timer, initial fire time, repeat interval.
 --- Durations are integer milliseconds (api-review-6: was four s+ns
@@ -12,13 +13,10 @@ local record SetitimerOptions
   interval_ms: integer
 end
 
---- Result from setitimer: the previous timer, in the same shape.
---- Sub-millisecond remainders round UP, so a still-armed timer never
---- reads as the 0 that would disarm it when passed back.
-local record SetitimerResult
-  value_ms: integer
-  interval_ms: integer
-end
+--- setitimer's return is this SAME record (#999): the previous timer,
+--- `which` included, so a restore is `signal.setitimer(prev)` with no
+--- reassembly. Sub-millisecond remainders round UP, so a still-armed
+--- timer never reads as the 0 that would disarm it when passed back.
 
 --- Signal set for blocking, unblocking, and waiting on signals.
 --- Wraps unix.Sigset for use with sigprocmask, sigaction, and sigsuspend.
@@ -135,18 +133,22 @@ local record SignalModule
 
   --- Suspend the process until a signal is delivered.
   --- Temporarily replaces the signal mask with the provided mask.
-  --- Always returns nil plus an error message: EINTR once a signal
-  --- was delivered and handled, or another errno on failure.
+  --- True once a signal was delivered and handled (the EINTR that IS
+  --- this call's success — #999: success used to be an error string,
+  --- so asserting it always threw); false, err on any other errno.
   --- A deliberate exception to the automatic EINTR retry policy
   --- (cosmic.stream): waiting for the interruption is the call's
   --- entire purpose.
-  sigsuspend: function(mask?: Sigset): nil, string
+  sigsuspend: function(mask?: Sigset): boolean, string
+
+  --- Options for setitimer, and its result: the previous timer in the
+  --- same shape, so a restore round-trips (#999; rule 10 exports).
+  type SetitimerOptions = SetitimerOptions
 
   --- Schedule SIGALRM signals at intervals.
-  --- Accepts a SetitimerOptions record with named fields for clarity.
-  --- Returns a SetitimerResult with the previous timer values, or
-  --- nil plus an error message.
-  setitimer: function(opts: SetitimerOptions): SetitimerResult | nil, string
+  --- Returns the previous timer as a SetitimerOptions, or nil plus an
+  --- error message.
+  setitimer: function(opts: SetitimerOptions): SetitimerOptions | nil, string
 
   --- Send a signal to a process.
   --- pid > 0 signals one process by id; 0 signals current group; -1 signals all.
@@ -209,10 +211,9 @@ local function strsignal(sig: integer): string
 end
 
 --- Set an interval timer with opts record for clarity.
---- Calls raw unix.setitimer which expects C-order (interval first, value second).
---- Returns a SetitimerResult with previous timer values, or nil plus
---- an error message on failure.
-local function setitimer(opts: SetitimerOptions): SetitimerResult | nil, string
+--- Returns the previous timer as a SetitimerOptions (same shape as the
+--- input, `which` included), or nil plus an error message on failure.
+local function setitimer(opts: SetitimerOptions): SetitimerOptions | nil, string
   local value_ms = opts.value_ms or 0
   local interval_ms = opts.interval_ms or 0
   local old_isec, old_ins, old_vsec, old_vns = unix.setitimer(
@@ -228,6 +229,7 @@ local function setitimer(opts: SetitimerOptions): SetitimerResult | nil, string
     return nil, errstr(old_ins, "setitimer")
   end
   return {
+    which = opts.which,
     value_ms = old_vsec * 1000 + math.ceil(old_vns / 1000000),
     interval_ms = old_isec * 1000 + math.ceil(old_ins / 1000000),
   }
@@ -241,7 +243,7 @@ local raw_sigaction = unix.sigaction as function(sig: integer, handler?: any, fl
 -- cast: function shape for nominal Sigset
 local raw_sigprocmask = unix.sigprocmask as function(integer, Sigset): (Sigset, any)
 -- cast: function shape for nominal Sigset
-local raw_sigsuspend = unix.sigsuspend as function(Sigset): (any, any)
+local raw_sigsuspend = unix.sigsuspend as function(Sigset): (any, any, any)
 
 --- Register a signal handler for the specified signal.
 --- Lua handlers run deferred in ordinary VM context (see the
@@ -301,11 +303,15 @@ end
 
 --- Suspend the process until a signal is delivered.
 --- @param mask Sigset? Temporary signal mask while suspended
---- @return nil Always nil (sigsuspend only returns after a signal)
+--- @return boolean True once a signal was delivered and handled
+--- @return string? Error message on any errno other than EINTR
 --- @return string Error message: EINTR after a signal was handled
-local function sigsuspend(mask?: Sigset): nil, string
-  local _, err = raw_sigsuspend(mask)
-  return nil, errstr(err, "sigsuspend")
+local function sigsuspend(mask?: Sigset): boolean, string
+  local _, err, eno = raw_sigsuspend(mask)
+  if errno_is(eno, "EINTR") then
+    return true
+  end
+  return false, errstr(err, "sigsuspend")
 end
 
 local M = {} as SignalModule -- cast: record built incrementally

--- a/cosmic/signal_example.tl
+++ b/cosmic/signal_example.tl
@@ -22,7 +22,7 @@ local function Example_handler()
 
   assert(signal.raise(signal.SIGUSR1)) -- pending: SIGUSR1 is blocked
   assert(signal.sigprocmask(signal.SIG_SETMASK, oldmask))
-  assert(time.sleep(0, 1000000)) -- give delivery a moment
+  assert(time.sleep_ms(1)) -- give delivery a moment
 
   print(received == signal.SIGUSR1)
   assert(signal.sigaction(signal.SIGUSR1, prev.handler, prev.flags, prev.mask))

--- a/cosmic/signal_test.tl
+++ b/cosmic/signal_test.tl
@@ -107,7 +107,7 @@ local function test_sigaction_handler()
   assert(signal.sigprocmask(signal.SIG_SETMASK, oldmask))
 
   -- Allow time for signal delivery
-  assert(time.sleep(0, 1000000)) -- 1ms
+  assert(time.sleep_ms(1)) -- 1ms
 
   assert(received_signal == signal.SIGUSR1,
     "handler should have received SIGUSR1, got " .. tostring(received_signal))
@@ -146,7 +146,7 @@ local function test_raise()
   assert(signal.raise(signal.SIGUSR2))
 
   -- Small delay to ensure signal is delivered
-  assert(time.sleep(0, 1000000)) -- 1ms
+  assert(time.sleep_ms(1)) -- 1ms
 
   assert(received, "should have received SIGUSR2")
 
@@ -180,7 +180,7 @@ local function test_setitimer()
   assert(signal.sigprocmask(signal.SIG_SETMASK, oldmask))
 
   -- Wait 200ms for signal delivery
-  assert(time.sleep(0, 200000000))
+  assert(time.sleep_ms(200))
 
   assert(received, "SIGALRM handler should have been called")
 
@@ -226,24 +226,22 @@ local function test_sigprocmask_error_names_errno()
 end
 test_sigprocmask_error_names_errno()
 
-local function test_sigsuspend_returns_eintr()
-  -- sigsuspend never succeeds: it returns nil plus EINTR once a signal
-  -- is delivered. Arm a short one-shot timer to provide that signal.
+local function test_sigsuspend_succeeds_on_delivery()
+  -- The EINTR that ends a sigsuspend IS its success (#999: success
+  -- used to be an error string, so asserting it always threw). Arm a
+  -- short one-shot timer to provide the delivering signal, and restore
+  -- the previous timer by passing setitimer's result straight back —
+  -- the round-trip the shared record shape exists for.
   local prev = check.must(signal.sigaction(signal.SIGALRM, function(_: number) end))
-  assert(signal.setitimer({
+  local prev_timer = check.must(signal.setitimer({
         which = signal.ITIMER_REAL,
         value_ms = 50,
         interval_ms = 0,
       }))
   local mask = signal.sigset(signal.SIGUSR2)
-  local _, err = signal.sigsuspend(mask)
-  assert(type(err) == "string" and err:match("EINTR"),
-    "sigsuspend should return an EINTR error, got: " .. tostring(err))
-  assert(signal.setitimer({
-        which = signal.ITIMER_REAL,
-        value_ms = 0,
-        interval_ms = 0,
-      }))
+  local ok, err = signal.sigsuspend(mask)
+  assert(ok == true, "signal delivery is sigsuspend's success, got: " .. tostring(err))
+  assert(signal.setitimer(prev_timer))
   assert(signal.sigaction(signal.SIGALRM, prev.handler, prev.flags, prev.mask))
 end
-test_sigsuspend_returns_eintr()
+test_sigsuspend_succeeds_on_delivery()

--- a/cosmic/time.tl
+++ b/cosmic/time.tl
@@ -71,19 +71,9 @@ local function monotonic_ns(): integer
   return secs * 1000000000 + nanos
 end
 
---- Sleep for the specified duration.
---- Returns 0, 0 after an uninterrupted sleep. When a signal interrupts
---- the sleep, returns the remaining seconds and nanoseconds plus an
---- error string naming EINTR. Invalid input (e.g. a negative duration)
---- returns nil, nil, and an error naming EINVAL.
---- sleep is a deliberate exception to the automatic EINTR retry policy
---- (cosmic.stream): the interruption IS the result, and the
---- remainder lets callers resume or bail as they choose.
---- @param seconds integer Seconds to sleep
---- @param nanos integer? Additional nanoseconds to sleep (default: 0)
---- @return integer | nil Remaining seconds (0 on success), or nil on invalid input
---- @return integer Remaining nanoseconds (0 on success)
---- @return string? Error message when interrupted (EINTR) or invalid (EINVAL)
+-- The (seconds, nanos) engine under sleep_ms — internal since #999:
+-- rule 2 makes integer milliseconds THE duration, and this was the
+-- tree's only three-return function.
 local function sleep(seconds: integer, nanos?: integer): integer | nil, integer, string
   local ns = nanos or 0
   local t0s, t0n = unix.clock_gettime(unix.CLOCK_MONOTONIC)
@@ -382,7 +372,6 @@ local record TimeModule
   now_ms: function(): integer
   monotonic_ms: function(): integer
   monotonic_ns: function(): integer
-  sleep: function(seconds: integer, nanos?: integer): integer | nil, integer, string
   sleep_ms: function(ms: number): integer | nil, string
   gmtime: function(unixts: integer): DateTime
   localtime: function(unixts: integer): DateTime
@@ -404,7 +393,6 @@ local M: TimeModule = {
   now_ms = now_ms,
   monotonic_ms = monotonic_ms,
   monotonic_ns = monotonic_ns,
-  sleep = sleep,
   sleep_ms = sleep_ms,
   gmtime = gmtime,
   localtime = localtime,

--- a/cosmic/time_test.tl
+++ b/cosmic/time_test.tl
@@ -25,42 +25,24 @@ test_monotonic()
 
 -- sleep tests
 
-local function test_sleep()
+-- sleep_ms is THE sleep (#999): integer milliseconds in, a single
+-- milliseconds remainder out.
+local function test_sleep_ms_passes_time()
   local before_secs, before_nanos = time.monotonic()
-  assert(time.sleep(0, 1000000)) -- sleep 1ms
+  assert(time.sleep_ms(1))
   local after_secs, after_nanos = time.monotonic()
   local before = before_secs + before_nanos / 1000000000
   local after = after_secs + after_nanos / 1000000000
-  assert(after > before, "time should have passed after sleep")
+  assert(after > before, "time should have passed after sleep_ms")
 end
-test_sleep()
+test_sleep_ms_passes_time()
 
-local function test_sleep_zero()
-  -- sleep(0) should return immediately
-  local secs, nanos = time.sleep(0)
-  assert(secs ~= nil, "expected seconds to be non-nil")
-  assert(nanos ~= nil, "expected nanos to be non-nil")
-end
-test_sleep_zero()
-
--- Honest sleep signature: 0,0 on an uninterrupted sleep;
--- nil, nil, err naming EINVAL on invalid input, rather than a string in
--- the nanos slot with no declared error return.
-local function test_sleep_success_returns_zero_remainder()
-  local secs, nanos, err = time.sleep(0, 1000)
-  assert(secs == 0, "expected 0 remaining seconds, got " .. tostring(secs))
-  assert(nanos == 0, "expected 0 remaining nanos, got " .. tostring(nanos))
+local function test_sleep_ms_zero_returns_immediately()
+  local rem, err = time.sleep_ms(0)
+  assert(rem == 0, "expected 0 remaining ms, got " .. tostring(rem))
   assert(err == nil, "expected no error, got " .. tostring(err))
 end
-test_sleep_success_returns_zero_remainder()
-
-local function test_sleep_invalid_names_errno()
-  local secs, nanos, err = time.sleep(-1)
-  assert(secs == nil and nanos == nil, "invalid sleep should return nil remainders")
-  assert(type(err) == "string" and err:match("EINVAL"),
-    "sleep error should name EINVAL, got: " .. tostring(err))
-end
-test_sleep_invalid_names_errno()
+test_sleep_ms_zero_returns_immediately()
 
 local function test_sleep_ms_invalid_names_errno()
   local rem, err = time.sleep_ms(-1000)

--- a/cosmic/tty.tl
+++ b/cosmic/tty.tl
@@ -3,13 +3,18 @@
 local unix = require("cosmo.unix")
 local errstr = require("cosmic.errno").wrap
 
+-- 1-based Lua indices into Termios.cc (#999): C's 0-based VMIN/VTIME
+-- shifted once, here, so neither this module nor any caller writes +1.
+local VMIN < const > = unix.VMIN + 1
+local VTIME < const > = unix.VTIME + 1
+
 --- Terminal I/O settings (the generated unix.Termios record).
 local type Termios = unix.Termios
 
 --- Module type for TTY operations.
 local record TtyModule
   --- Window size information.
-  record WinSize
+  record WindowSize
     rows: integer
     cols: integer
   end
@@ -17,7 +22,7 @@ local record TtyModule
   --- Terminal I/O settings.
   type Termios = Termios
 
-  --- An open pseudoterminal pair (see openpty).
+  --- An open pseudoterminal pair (see open_pty).
   record Pty
     manager: integer -- controlling side; write here to feed the terminal
     subordinate: integer -- the terminal itself, what a program's stdio sees
@@ -25,7 +30,7 @@ local record TtyModule
   end
 
   --- Options for raw()/make_raw().
-  record RawOptions
+  record Options
     --- Keep ISIG set so Ctrl-C/Ctrl-Z still generate signals.
     keep_signals: boolean
   end
@@ -47,31 +52,33 @@ local record TtyModule
   BRKINT: integer
   OPOST: integer
 
-  --- cc indices (C-style; the Lua cc array is 1-based, so cc[VMIN + 1]).
+  --- 1-BASED cc indices (#999): `t.cc[tty.VMIN]` is C's c_cc[VMIN].
+  --- The generated unix constants are C's 0-based values; these are
+  --- pre-shifted for Lua's 1-based cc array so no caller writes `+ 1`.
   VMIN: integer
   VTIME: integer
 
   is_tty: function(fd?: integer): boolean
-  winsize: function(fd: integer): WinSize | nil, string
-  getattr: function(fd: integer): Termios | nil, string
-  setattr: function(fd: integer, action: integer, termios: Termios): boolean, string
-  make_raw: function(termios: Termios, opts?: RawOptions): Termios
-  raw: function(fd: integer, opts?: RawOptions): Termios | nil, string
-  noecho: function(fd: integer): Termios | nil, string
+  window_size: function(fd: integer): WindowSize | nil, string
+  attributes: function(fd: integer): Termios | nil, string
+  apply_attributes: function(fd: integer, action: integer, termios: Termios): boolean, string
+  make_raw: function(termios: Termios, opts?: Options): Termios
+  raw: function(fd: integer, opts?: Options): Termios | nil, string
+  disable_echo: function(fd: integer): Termios | nil, string
   restore: function(fd: integer, termios: Termios, action?: integer): boolean, string
-  getpass: function(prompt: string): string | nil, string
-  openpty: function(): Pty | nil, string
+  read_password: function(prompt: string): string | nil, string
+  open_pty: function(): Pty | nil, string
   login_tty: function(fd: integer): boolean, string
 end
 
 --- Opens a new pseudoterminal pair.
---- The subordinate fd IS a terminal: isatty, getattr, raw, noecho and
+--- The subordinate fd IS a terminal: is_tty, attributes, raw, disable_echo and
 --- the rest operate on it. That is what makes terminal code testable
 --- where no terminal exists -- a CI container, or any process whose
 --- stdio is a pipe. Both descriptors belong to the caller; close them.
 --- @return TtyModule.Pty | nil The open pair
 --- @return string? Error message on failure
-local function openpty(): TtyModule.Pty | nil, string
+local function open_pty(): TtyModule.Pty | nil, string
   local mfd, sfd, name = unix.openpty()
   if not mfd then
     -- on failure the binding returns (nil, err, errno), so the second
@@ -109,9 +116,9 @@ end
 
 --- Gets the terminal window size for a file descriptor.
 --- @param fd integer File descriptor (typically 0, 1, or 2)
---- @return WinSize|nil Window size record with rows and cols, or nil on error
+--- @return WindowSize|nil Window size record with rows and cols, or nil on error
 --- @return string|nil Error message if not a terminal
-local function winsize(fd: integer): TtyModule.WinSize | nil, string
+local function window_size(fd: integer): TtyModule.WindowSize | nil, string
   local rows, cols = unix.tiocgwinsz(fd)
   if rows == nil then
     -- On failure the binding returns (nil, err, errno): the error string
@@ -125,7 +132,7 @@ end
 --- @param fd integer File descriptor (typically 0 for stdin)
 --- @return Termios | nil Terminal attributes
 --- @return string? Error message if not a terminal
-local function getattr(fd: integer): Termios | nil, string
+local function attributes(fd: integer): Termios | nil, string
   local termios, err = unix.tcgetattr(fd)
   if not termios then
     return nil, errstr(err, "tcgetattr")
@@ -139,7 +146,7 @@ end
 --- @param termios Termios Terminal attributes to set
 --- @return boolean True on success
 --- @return string? Error message on failure
-local function setattr(fd: integer, action: integer, termios: Termios): boolean, string
+local function apply_attributes(fd: integer, action: integer, termios: Termios): boolean, string
   local ok, err = unix.tcsetattr(fd, action, termios)
   if not ok then
     return false, errstr(err, "tcsetattr")
@@ -176,9 +183,9 @@ end
 --- (unless opts.keep_signals), selects 8-bit characters, and sets
 --- VMIN=1/VTIME=0 so reads deliver one byte at a time without timeout.
 --- @param termios Termios Current terminal attributes
---- @param opts RawOptions? keep_signals: keep Ctrl-C/Ctrl-Z generating signals
---- @return Termios New attributes to pass to setattr()
-local function make_raw(termios: Termios, opts?: TtyModule.RawOptions): Termios
+--- @param opts Options? keep_signals: keep Ctrl-C/Ctrl-Z generating signals
+--- @return Termios New attributes to pass to apply_attributes()
+local function make_raw(termios: Termios, opts?: TtyModule.Options): Termios
   local t = copy_termios(termios)
   t.iflag = t.iflag & ~ (unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP
     | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON)
@@ -189,9 +196,8 @@ local function make_raw(termios: Termios, opts?: TtyModule.RawOptions): Termios
   end
   t.lflag = t.lflag & ~ lclear
   t.cflag = (t.cflag & ~ (unix.CSIZE | unix.PARENB)) | unix.CS8
-  -- The Lua cc array is 1-based: cc[i + 1] holds C's c_cc[i].
-  t.cc[unix.VMIN + 1] = 1
-  t.cc[unix.VTIME + 1] = 0
+  t.cc[VMIN] = 1
+  t.cc[VTIME] = 0
   return t
 end
 
@@ -200,17 +206,17 @@ end
 --- control, no output post-processing (see make_raw).
 --- Returns the original termios for later restoration.
 --- @param fd integer File descriptor (typically 0 for stdin)
---- @param opts RawOptions? keep_signals: keep Ctrl-C/Ctrl-Z generating signals
+--- @param opts Options? keep_signals: keep Ctrl-C/Ctrl-Z generating signals
 --- @return Termios | nil Original terminal attributes for restore()
 --- @return string? Error message if not a terminal
-local function raw(fd: integer, opts?: TtyModule.RawOptions): Termios | nil, string
-  local termios, err = getattr(fd)
+local function raw(fd: integer, opts?: TtyModule.Options): Termios | nil, string
+  local termios, err = attributes(fd)
   if not termios then
     return nil, err
   end
   local t = termios
   local original = copy_termios(t)
-  local ok, set_err = setattr(fd, unix.TCSANOW, make_raw(t, opts))
+  local ok, set_err = apply_attributes(fd, unix.TCSANOW, make_raw(t, opts))
   if not ok then
     return nil, set_err
   end
@@ -222,15 +228,15 @@ end
 --- @param fd integer File descriptor (typically 0 for stdin)
 --- @return Termios | nil Original terminal attributes for restore()
 --- @return string? Error message if not a terminal
-local function noecho(fd: integer): Termios | nil, string
-  local termios, err = getattr(fd)
+local function disable_echo(fd: integer): Termios | nil, string
+  local termios, err = attributes(fd)
   if not termios then
     return nil, err
   end
   local t = termios
   local original = copy_termios(t)
   t.lflag = t.lflag & ~ unix.ECHO
-  local ok, set_err = setattr(fd, unix.TCSANOW, t)
+  local ok, set_err = apply_attributes(fd, unix.TCSANOW, t)
   if not ok then
     return nil, set_err
   end
@@ -239,13 +245,13 @@ end
 
 --- Restores terminal attributes.
 --- @param fd integer File descriptor
---- @param termios Termios Terminal attributes from raw() or noecho()
+--- @param termios Termios Terminal attributes from raw() or disable_echo()
 --- @param action integer? When to apply: NOW (default), DRAIN (after
 --- pending output is written), or FLUSH (DRAIN + discard pending input)
 --- @return boolean True on success
 --- @return string? Error message on failure
 local function restore(fd: integer, termios: Termios, action?: integer): boolean, string
-  return setattr(fd, action or unix.TCSANOW, termios)
+  return apply_attributes(fd, action or unix.TCSANOW, termios)
 end
 
 --- Reads a password from the terminal without echoing.
@@ -255,10 +261,10 @@ end
 --- @param prompt string Text to display before reading
 --- @return string|nil The password (without trailing newline), or nil on error
 --- @return string? Error message on failure
-local function getpass(prompt: string): string | nil, string
+local function read_password(prompt: string): string | nil, string
   io.stderr:write(prompt)
   -- If stdin is not a tty, read without echo manipulation
-  if not unix.isatty(0) then
+  if not is_tty(0) then
     local line = io.stdin:read("l")
     if line == nil then
       return nil, "EOF"
@@ -266,7 +272,7 @@ local function getpass(prompt: string): string | nil, string
     return line
   end
   -- Disable echo on stdin (fd 0)
-  local original, err = noecho(0)
+  local original, err = disable_echo(0)
   if not original then
     return nil, err
   end
@@ -291,15 +297,15 @@ end
 
 local M: TtyModule = {
   is_tty = is_tty,
-  winsize = winsize,
-  getattr = getattr,
-  setattr = setattr,
+  window_size = window_size,
+  attributes = attributes,
+  apply_attributes = apply_attributes,
   make_raw = make_raw,
   raw = raw,
-  noecho = noecho,
+  disable_echo = disable_echo,
   restore = restore,
-  getpass = getpass,
-  openpty = openpty,
+  read_password = read_password,
+  open_pty = open_pty,
   login_tty = login_tty,
 
   -- Constants
@@ -314,8 +320,8 @@ local M: TtyModule = {
   ICRNL = unix.ICRNL,
   BRKINT = unix.BRKINT,
   OPOST = unix.OPOST,
-  VMIN = unix.VMIN,
-  VTIME = unix.VTIME,
+  VMIN = VMIN,
+  VTIME = VTIME,
 }
 
 return M

--- a/cosmic/tty_pty_test.tl
+++ b/cosmic/tty_pty_test.tl
@@ -3,12 +3,12 @@
 ---
 --- tty_test.tl covers the not-a-terminal paths and the module surface.
 --- This file covers what needs a real tty: a CI container has no
---- controlling terminal, so tty.openpty() supplies one and the mode
+--- controlling terminal, so tty.open_pty() supplies one and the mode
 --- changes are checked where they actually take effect, rather than
 --- asserted as `tty.raw ~= nil`.
 ---
 --- Two levels of evidence here, and the second is the point:
----   * settings are read back with getattr, so the assertion is that the
+---   * settings are read back with attributes, so the assertion is that the
 ---     KERNEL accepted them -- not merely that we computed some bits;
 ---   * echo is observed end to end, by writing to the manager side and
 ---     seeing whether the line discipline sends it back. That is what
@@ -36,9 +36,9 @@ local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
 --- discipline `check.needs` documents and every other gated precondition
 --- in this repo uses (see e.g. `_make/build_test.tl`).
 local function with_pty(): tty.Pty
-  local pty, err = tty.openpty()
+  local pty, err = tty.open_pty()
   if not pty then
-    check.needs("a real pty (tty.openpty failed: " .. tostring(err) .. ")", false)
+    check.needs("a real pty (tty.open_pty failed: " .. tostring(err) .. ")", false)
     return nil
   end
   return pty
@@ -59,19 +59,19 @@ local function test_openpty_yields_a_real_terminal()
   assert(tty.is_tty(pty.manager), "the manager fd must be a terminal")
   assert(pty.name:match("^/dev/"),
     "expected a device path, got: " .. tostring(pty.name))
-  local ws = check.must(tty.winsize(pty.subordinate))
-  assert(ws.rows ~= nil and ws.cols ~= nil, "winsize should report a size")
+  local ws = check.must(tty.window_size(pty.subordinate))
+  assert(ws.rows ~= nil and ws.cols ~= nil, "window_size should report a size")
   close_pty(pty)
 end
 test_openpty_yields_a_real_terminal()
 
---- getattr on a terminal returns settings, and a fresh pty starts in
+--- attributes on a terminal returns settings, and a fresh pty starts in
 --- the cooked state -- ECHO and ICANON on. Asserted explicitly because
 --- every later test is "these bits get cleared": if they were already
 --- clear, those tests would pass without doing anything.
 local function test_getattr_on_a_terminal_starts_cooked()
   local pty = with_pty()
-  local t = check.must(tty.getattr(pty.subordinate))
+  local t = check.must(tty.attributes(pty.subordinate))
   assert(t.lflag & tty.ECHO ~= 0, "a fresh pty should start with ECHO on")
   assert(t.lflag & tty.ICANON ~= 0, "a fresh pty should start canonical")
   close_pty(pty)
@@ -83,13 +83,13 @@ test_getattr_on_a_terminal_starts_cooked()
 --- kernel actually hands back.
 local function test_make_raw_is_pure()
   local pty = with_pty()
-  local before = check.must(tty.getattr(pty.subordinate))
+  local before = check.must(tty.attributes(pty.subordinate))
   local lflag, oflag = before.lflag, before.oflag
-  local vmin = before.cc[tty.VMIN + 1]
+  local vmin = before.cc[tty.VMIN]
   local rawt = tty.make_raw(before)
   assert(before.lflag == lflag and before.oflag == oflag,
     "make_raw must not mutate its input")
-  assert(before.cc[tty.VMIN + 1] == vmin,
+  assert(before.cc[tty.VMIN] == vmin,
     "make_raw must not mutate the input's cc table")
   assert(rawt.lflag ~= lflag, "the returned attrs should differ")
   close_pty(pty)
@@ -101,23 +101,23 @@ test_make_raw_is_pure()
 local function test_raw_then_restore_round_trips()
   local pty = with_pty()
   local sfd = pty.subordinate
-  local before = check.must(tty.getattr(sfd))
+  local before = check.must(tty.attributes(sfd))
 
   local original = check.must(tty.raw(sfd))
-  local now = check.must(tty.getattr(sfd))
+  local now = check.must(tty.attributes(sfd))
   assert(now.lflag & tty.ECHO == 0, "raw must clear ECHO")
   assert(now.lflag & tty.ICANON == 0, "raw must clear ICANON")
   assert(now.lflag & tty.ISIG == 0, "raw must clear ISIG by default")
   assert(now.oflag & tty.OPOST == 0, "raw must clear OPOST")
-  assert(now.cc[tty.VMIN + 1] == 1, "raw must set VMIN=1")
-  assert(now.cc[tty.VTIME + 1] == 0, "raw must set VTIME=0")
+  assert(now.cc[tty.VMIN] == 1, "raw must set VMIN=1")
+  assert(now.cc[tty.VTIME] == 0, "raw must set VTIME=0")
 
   assert(tty.restore(sfd, original))
-  local after = check.must(tty.getattr(sfd))
+  local after = check.must(tty.attributes(sfd))
   assert(after.lflag == before.lflag, "restore must put lflag back")
   assert(after.oflag == before.oflag, "restore must put oflag back")
   assert(after.cflag == before.cflag, "restore must put cflag back")
-  assert(after.cc[tty.VMIN + 1] == before.cc[tty.VMIN + 1],
+  assert(after.cc[tty.VMIN] == before.cc[tty.VMIN],
     "restore must put the cc table back")
   close_pty(pty)
 end
@@ -128,7 +128,7 @@ test_raw_then_restore_round_trips()
 local function test_raw_keep_signals_leaves_isig()
   local pty = with_pty()
   check.must(tty.raw(pty.subordinate, {keep_signals = true}))
-  local now = check.must(tty.getattr(pty.subordinate))
+  local now = check.must(tty.attributes(pty.subordinate))
   assert(now.lflag & tty.ISIG ~= 0,
     "keep_signals should leave ISIG set so Ctrl-C still signals")
   assert(now.lflag & tty.ICANON == 0,
@@ -137,17 +137,17 @@ local function test_raw_keep_signals_leaves_isig()
 end
 test_raw_keep_signals_leaves_isig()
 
---- noecho is narrower than raw: echo off, line editing untouched.
+--- disable_echo is narrower than raw: echo off, line editing untouched.
 local function test_noecho_clears_only_echo()
   local pty = with_pty()
-  local before = check.must(tty.getattr(pty.subordinate))
-  check.must(tty.noecho(pty.subordinate))
-  local now = check.must(tty.getattr(pty.subordinate))
-  assert(now.lflag & tty.ECHO == 0, "noecho must clear ECHO")
+  local before = check.must(tty.attributes(pty.subordinate))
+  check.must(tty.disable_echo(pty.subordinate))
+  local now = check.must(tty.attributes(pty.subordinate))
+  assert(now.lflag & tty.ECHO == 0, "disable_echo must clear ECHO")
   assert(now.lflag & tty.ICANON ~= 0,
-    "noecho must leave canonical mode alone -- that is raw()'s job")
+    "disable_echo must leave canonical mode alone -- that is raw()'s job")
   assert(now.lflag & tty.ISIG == before.lflag & tty.ISIG,
-    "noecho must not touch signal generation")
+    "disable_echo must not touch signal generation")
   close_pty(pty)
 end
 test_noecho_clears_only_echo()
@@ -176,9 +176,9 @@ local function test_noecho_actually_stops_echo()
   assert(echo_observed(pty),
     "a cooked terminal should echo what is written to it -- if this "
     .. "fails the test below proves nothing")
-  check.must(tty.noecho(pty.subordinate))
+  check.must(tty.disable_echo(pty.subordinate))
   assert(not echo_observed(pty),
-    "after noecho the terminal must not echo")
+    "after disable_echo the terminal must not echo")
   close_pty(pty)
 end
 test_noecho_actually_stops_echo()
@@ -195,7 +195,7 @@ local function test_raw_stops_echo_and_restore_revives_it()
 end
 test_raw_stops_echo_and_restore_revives_it()
 
--- getpass, the last path listed. It reads fd 0 specifically and
+-- read_password, the last path listed. It reads fd 0 specifically and
 -- only suppresses echo when fd 0 is a terminal, so covering it needs a
 -- process whose stdin IS a pty -- login_tty in a forked child, which
 -- replaces that child's session. Hence the fork: it must not happen in
@@ -205,9 +205,9 @@ test_raw_stops_echo_and_restore_revives_it()
 -- login_tty its stdout IS the terminal under observation; mixing the
 -- two would make "what did the terminal echo?" unanswerable.
 
---- Wait until getpass has actually turned echo off.
+--- Wait until read_password has actually turned echo off.
 ---
---- getpass writes its prompt BEFORE calling noecho, so a parent that
+--- read_password writes its prompt BEFORE calling disable_echo, so a parent that
 --- writes as soon as it sees the prompt can have its input echoed by a
 --- still-cooked terminal. That is a race, and it would show up as a
 --- flaky failure rather than a wrong answer. The ECHO bit is the real
@@ -215,7 +215,7 @@ test_raw_stops_echo_and_restore_revives_it()
 --- reports the same terminal state the child is changing.
 local function await_echo_off(pty: tty.Pty): boolean
   for _ = 1, 500 do
-    local t = tty.getattr(pty.subordinate)
+    local t = tty.attributes(pty.subordinate)
     if t is tty.Termios and t.lflag & tty.ECHO == 0 then
       return true
     end
@@ -226,18 +226,18 @@ end
 
 local function test_getpass_reads_without_echoing()
   local pty = with_pty()
-  local result = fs.join(TEST_TMPDIR, "getpass.out")
+  local result = fs.join(TEST_TMPDIR, "read_password.out")
 
   local pid = proc.fork()
   if pid == 0 then
     -- Child: adopt the pty as our controlling terminal, so fd 0 is a
-    -- tty and getpass takes the echo-suppressing branch.
+    -- tty and read_password takes the echo-suppressing branch.
     local ok, lerr = tty.login_tty(pty.subordinate)
     if not ok then
       assert(fs.write(result, "LOGIN_TTY_FAILED:" .. tostring(lerr)))
       os.exit(0)
     end
-    local pw, err = tty.getpass("Password: ")
+    local pw, err = tty.read_password("Password: ")
     assert(fs.write(result, pw or ("ERR:" .. tostring(err))))
     os.exit(0)
   end
@@ -250,7 +250,7 @@ local function test_getpass_reads_without_echoing()
     -- Same discipline as `with_pty`: a timed-out race is a SKIP, and a
     -- skip must exit EXIT_SKIP, not `return` and leave the file to exit
     -- 0 (a PASS by `records.status_of`'s reading).
-    check.needs("getpass disabling echo before the race timeout", false)
+    check.needs("read_password disabling echo before the race timeout", false)
   end
   assert(mgr:write("hunter2\n"))
   assert(proc.wait(pid))
@@ -270,17 +270,17 @@ local function test_getpass_reads_without_echoing()
 
   local got = check.must(fs.read(result))
   assert(got == "hunter2",
-    "getpass should return the typed line, got: " .. got)
+    "read_password should return the typed line, got: " .. got)
   assert(seen:find("Password: ", 1, true),
-    "getpass should write its prompt to the terminal, saw: " .. seen)
-  -- The whole point of getpass: the secret must not come back.
+    "read_password should write its prompt to the terminal, saw: " .. seen)
+  -- The whole point of read_password: the secret must not come back.
   assert(not seen:find("hunter2", 1, true),
-    "getpass must not echo what was typed, but the terminal returned: "
+    "read_password must not echo what was typed, but the terminal returned: "
     .. seen)
 end
 test_getpass_reads_without_echoing()
 
---- getpass restores the terminal when it is done, so a caller that
+--- read_password restores the terminal when it is done, so a caller that
 --- prompts for a password does not leave the user's terminal mute.
 local function test_getpass_restores_echo_afterwards()
   local pty = with_pty()
@@ -289,7 +289,7 @@ local function test_getpass_restores_echo_afterwards()
   local pid = proc.fork()
   if pid == 0 then
     if not tty.login_tty(pty.subordinate) then os.exit(1) end
-    local pw = tty.getpass("pw: ")
+    local pw = tty.read_password("pw: ")
     assert(fs.write(result, pw or ""))
     os.exit(0)
   end
@@ -302,16 +302,16 @@ local function test_getpass_restores_echo_afterwards()
     -- Same discipline as `with_pty`: a timed-out race is a SKIP, and a
     -- skip must exit EXIT_SKIP, not `return` and leave the file to exit
     -- 0 (a PASS by `records.status_of`'s reading).
-    check.needs("getpass disabling echo before the race timeout", false)
+    check.needs("read_password disabling echo before the race timeout", false)
   end
   assert(mgr:write("secret\n"))
   assert(proc.wait(pid))
 
-  local after = check.must(tty.getattr(pty.subordinate))
+  local after = check.must(tty.attributes(pty.subordinate))
   assert(after.lflag & tty.ECHO ~= 0,
-    "getpass must restore echo before returning")
+    "read_password must restore echo before returning")
   assert(after.lflag & tty.ICANON ~= 0,
-    "getpass must leave canonical mode as it found it")
+    "read_password must leave canonical mode as it found it")
   close_pty(pty)
 end
 test_getpass_restores_echo_afterwards()

--- a/cosmic/tty_test.tl
+++ b/cosmic/tty_test.tl
@@ -9,7 +9,7 @@ local tty = require("cosmic.tty")
 
 local function test_module_exports()
   assert(tty.is_tty ~= nil, "is_tty function should be exported")
-  assert(tty.winsize ~= nil, "winsize function should be exported")
+  assert(tty.window_size ~= nil, "window_size function should be exported")
 end
 test_module_exports()
 
@@ -47,39 +47,39 @@ local function test_is_tty_defaults_to_stdout()
 end
 test_is_tty_defaults_to_stdout()
 
--- Test winsize function
+-- Test window_size function
 
 local function test_winsize_non_tty()
-  -- When not a tty, winsize should return nil with error message
+  -- When not a tty, window_size should return nil with error message
   -- Open a regular file to get a non-tty fd
   local f = io.open("/dev/null", "r")
   if f then
-    -- /dev/null is not a tty, so winsize should fail
+    -- /dev/null is not a tty, so window_size should fail
     -- But we're testing with fd numbers, so test with what we have
     f:close()
   end
   -- In test environment, fd 0 is likely not a tty
   if not tty.is_tty(0) then
-    local ws, err = tty.winsize(0)
-    -- Should return nil or a valid winsize
+    local ws, err = tty.window_size(0)
+    -- Should return nil or a valid window_size
     if ws == nil then
-      assert(err ~= nil, "winsize should return error message when not a tty")
+      assert(err ~= nil, "window_size should return error message when not a tty")
     end
   end
 end
 test_winsize_non_tty()
 
 local function test_winsize_structure()
-  -- If stdout is a tty, verify winsize returns proper structure
+  -- If stdout is a tty, verify window_size returns proper structure
   if not tty.is_tty(1) then
     io.stderr:write("SKIP: test_winsize_structure (stdout is not a tty)\n")
     return
   end
-  local ws, _err = tty.winsize(1)
+  local ws, _err = tty.window_size(1)
   if ws then
     local w = ws
-    assert(w.rows ~= nil, "winsize should have rows field")
-    assert(w.cols ~= nil, "winsize should have cols field")
+    assert(w.rows ~= nil, "window_size should have rows field")
+    assert(w.cols ~= nil, "window_size should have cols field")
     assert(type(w.rows) == "number", "rows should be a number")
     assert(type(w.cols) == "number", "cols should be a number")
     assert(w.rows > 0, "rows should be positive")
@@ -91,10 +91,10 @@ test_winsize_structure()
 -- Test termios function exports
 
 local function test_termios_exports()
-  assert(tty.getattr ~= nil, "getattr function should be exported")
-  assert(tty.setattr ~= nil, "setattr function should be exported")
+  assert(tty.attributes ~= nil, "attributes function should be exported")
+  assert(tty.apply_attributes ~= nil, "apply_attributes function should be exported")
   assert(tty.raw ~= nil, "raw function should be exported")
-  assert(tty.noecho ~= nil, "noecho function should be exported")
+  assert(tty.disable_echo ~= nil, "disable_echo function should be exported")
   assert(tty.restore ~= nil, "restore function should be exported")
 end
 test_termios_exports()
@@ -111,22 +111,22 @@ end
 test_termios_constants()
 
 local function test_getattr_non_tty()
-  -- When not a tty, getattr should fail with error
+  -- When not a tty, attributes should fail with error
   if not tty.is_tty(0) then
-    local termios, err = tty.getattr(0)
-    assert(termios == nil, "getattr should return nil for non-tty")
-    assert(err ~= nil, "getattr should return error message for non-tty")
+    local termios, err = tty.attributes(0)
+    assert(termios == nil, "attributes should return nil for non-tty")
+    assert(err ~= nil, "attributes should return error message for non-tty")
   end
 end
 test_getattr_non_tty()
 
 local function test_getattr_structure()
-  -- If stdin is a tty, verify getattr returns proper structure
+  -- If stdin is a tty, verify attributes returns proper structure
   if not tty.is_tty(0) then
     io.stderr:write("SKIP: test_getattr_structure (stdin is not a tty)\n")
     return
   end
-  local termios, _err = tty.getattr(0)
+  local termios, _err = tty.attributes(0)
   if termios then
     local t = termios
     assert(t.iflag ~= nil, "termios should have iflag")
@@ -151,22 +151,22 @@ end
 test_raw_non_tty()
 
 local function test_noecho_non_tty()
-  -- When not a tty, noecho should fail with error
+  -- When not a tty, disable_echo should fail with error
   if not tty.is_tty(0) then
-    local original, err = tty.noecho(0)
-    assert(original == nil, "noecho should return nil for non-tty")
-    assert(err ~= nil, "noecho should return error message for non-tty")
+    local original, err = tty.disable_echo(0)
+    assert(original == nil, "disable_echo should return nil for non-tty")
+    assert(err ~= nil, "disable_echo should return error message for non-tty")
   end
 end
 test_noecho_non_tty()
 
--- getpass: exercised end-to-end in a subprocess with a
+-- read_password: exercised end-to-end in a subprocess with a
 -- piped (non-tty) stdin, instead of only checking the export exists.
 
 local getpass_script = fs.join(check.must(os.getenv("TEST_TMPDIR")), "getpass_child.lua")
 assert(fs.write(getpass_script, [[
 local tty = require("cosmic.tty")
-local line, err = tty.getpass("pw: ")
+local line, err = tty.read_password("pw: ")
 if line == nil then
   io.write("ERR:" .. tostring(err))
 else
@@ -177,11 +177,11 @@ local cosmic_bin = fs.join(check.must(os.getenv("TEST_BIN")), "cosmic")
 
 local function test_getpass_non_tty_reads_one_line()
   local h = check.must(child.start({cosmic_bin, getpass_script}, {stdin = "sekrit\nsecond\n"}),
-    "getpass child should spawn")
+    "read_password child should spawn")
   local r = check.must(h:wait())
-  assert(r.ok, "getpass child should exit 0: " .. tostring(r.stderr))
+  assert(r.ok, "read_password child should exit 0: " .. tostring(r.stderr))
   assert(r.stdout == "GOT:sekrit",
-    "getpass should return exactly the first stdin line, got: " .. tostring(r.stdout))
+    "read_password should return exactly the first stdin line, got: " .. tostring(r.stdout))
   assert(r.stderr:match("^pw: "),
     "the prompt must go to stderr, got: " .. tostring(r.stderr))
 end
@@ -189,11 +189,11 @@ test_getpass_non_tty_reads_one_line()
 
 local function test_getpass_non_tty_eof()
   local h = check.must(child.start({cosmic_bin, getpass_script}, {stdin = ""}),
-    "getpass child should spawn")
+    "read_password child should spawn")
   local r = check.must(h:wait())
-  assert(r.ok, "getpass child should exit 0: " .. tostring(r.stderr))
+  assert(r.ok, "read_password child should exit 0: " .. tostring(r.stderr))
   assert(r.stdout == "ERR:EOF",
-    "getpass at stdin EOF should return nil, 'EOF', got: " .. tostring(r.stdout))
+    "read_password at stdin EOF should return nil, 'EOF', got: " .. tostring(r.stdout))
 end
 test_getpass_non_tty_eof()
 
@@ -233,8 +233,8 @@ test_make_raw_clears_input_and_output_flags()
 local function test_make_raw_sets_vmin_vtime()
   local t = fixture_termios()
   local raw = tty.make_raw(t)
-  local vmin = tty.VMIN + 1
-  local vtime = tty.VTIME + 1
+  local vmin = tty.VMIN
+  local vtime = tty.VTIME
   assert(raw.cc[vmin] == 1, "raw mode must set VMIN=1")
   assert(raw.cc[vtime] == 0, "raw mode must set VTIME=0")
 end
@@ -251,8 +251,8 @@ test_make_raw_keep_signals()
 local function test_make_raw_does_not_alias_or_mutate_input()
   local t = fixture_termios()
   local raw = tty.make_raw(t)
-  local vmin = tty.VMIN + 1
-  local vtime = tty.VTIME + 1
+  local vmin = tty.VMIN
+  local vtime = tty.VTIME
   assert(raw.cc ~= t.cc, "make_raw must deep-copy cc, not alias it")
   assert(t.iflag & tty.IXON ~= 0, "make_raw must not mutate its input")
   assert(t.cc[vmin] ~= raw.cc[vmin] or t.cc[vtime] ~= raw.cc[vtime],
@@ -263,10 +263,10 @@ end
 test_make_raw_does_not_alias_or_mutate_input()
 
 local function test_winsize_error_names_errno()
-  local ws, err = tty.winsize(999)
-  assert(ws == nil, "winsize on a bad fd should fail")
+  local ws, err = tty.window_size(999)
+  assert(ws == nil, "window_size on a bad fd should fail")
   assert(type(err) == "string" and err:match("E%u+"),
-    "winsize error should name the errno, got: " .. tostring(err))
+    "window_size error should name the errno, got: " .. tostring(err))
 end
 test_winsize_error_names_errno()
 


### PR DESCRIPTION
Implements #999's charter work across the five system modules. One PR, as the issue asked.

## shm

- `open(size_bytes)` / `close()` replace `mapshared` / `unmap` (rules 5 and 2), and `close` gets the shape fix: it is idempotent and returns **nothing** — the old `false` for "already unmapped" meant `assert(mem:unmap())` failed on the second, correct call.
- `exchange` / `compare_exchange` replace `xchg` / `cmpxchg`, with the `Cmpxchg` record renamed `Exchange`.
- The memory-ordering semantics are stated on `Memory` (sequentially consistent atomics — the binding's C11 default — with plain byte read/write explicitly carrying no ordering), and the stale wake comment arguing against its own current signature is gone.

## tty

- `attributes` / `apply_attributes` / `window_size` / `disable_echo` / `read_password` / `open_pty` replace the POSIX/C spellings; `WinSize` → `WindowSize`, `RawOptions` → `Options` (rule 7 — it is the module's only options record).
- `VMIN` / `VTIME` are exported **pre-shifted to Lua's 1-based cc array**: `t.cc[tty.VMIN]` is C's `c_cc[VMIN]`, and the off-by-one note that used to be repeated twice is one `+ 1` in one place.
- `read_password` routes its stdin probe through `is_tty` instead of raw `unix.isatty(0)`.

## signal

- `setitimer` now returns its own `SetitimerOptions` shape (`which` included), so a restore is `signal.setitimer(prev)` with no reassembly — the round-trip `PrevAction` already had; the record is exported per rule 10 and `SetitimerResult` is gone.
- `sigsuspend` returns `boolean, string`: the EINTR that ends it **is** its success, so it returns `true` then — the old shape made success an error string, and asserting it always threw. Its test now asserts the success and exercises the setitimer round-trip in the same breath.
- The C-argument-order implementation note is out of the public doc.

## time

- `sleep_ms(ms: integer)` is THE sleep (rule 2). The `(seconds, nanos)` three-return variant — kept "for symmetry with clock_gettime", which #993 deleted — is internal now, the engine under `sleep_ms`. All twenty callers of the `sleep(0, N*1000*1000)` incantations became `sleep_ms(N)`.

## proc

- `exit(exit_code?)` and `wait(pid?, wait_flags?)` parameter renames (rule 7 reserves `options`).
- `interpreter()` resolves at module **load** instead of first call — the lazy cache documented a call-order requirement ("call before chdir") instead of meeting it. The coverage floor for `proc/init.tl` follows honestly: load-time lines run before collection arms.
- The three non-syscall members (`which`, `interpreter`, `is_main`) sit behind a section header naming the POSIX boundary.

## Deferred, deliberately

The issue's last item — migrate the `proc.fork`+`proc.wait` sites to `child.start`, then reconsider `wait`+`W*` — is left for its own change: the two remaining fork sites are `_perf` bench scenarios (they fork an in-process server loop; replacing that with a spawned interpreter changes what the scenario measures, which belongs under the optimize loop's compare gate, not inside a rename PR), and `check.reap` exists to serve forked tests. The "reconsider" is gated on those migrations by the issue's own phrasing.

## Verification

- `bin/cosmic --make ci` → `ci: PASS (5 stages)`, run from a cold `o/` (`rm -rf o && fetch && ci`), so the pin-boot path is exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_