### PR TITLE
perf: extract and embed stream archive bytes in C (cosmos 2026.08.08-23abf0799)

### DIFF
--- a/3p/cosmos/cosmos_pin.tl
+++ b/3p/cosmos/cosmos_pin.tl
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "d3e7b4f5ded80f3854a44d49313287d1f108a910b5c31f8c2bf7219ed3afc145"}},
+  platforms = {["*"] = {sha = "a1eb637b8f8fd5e5cc4b05fc4da4123d56c81fd1e644d78c711f5aa575789ce7"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.08.07-b922daeb1"
+  version = "2026.08.08-23abf0799"
 }

--- a/_cli/require_hints.tl
+++ b/_cli/require_hints.tl
@@ -2,7 +2,6 @@
 --- Intercepts module-not-found errors and suggests similar modules.
 
 local original_require = require
-local fuzzy = original_require("cosmic.fuzzy")
 
 --- Cached module mapping, built lazily on first use.
 local module_map: {string: string} = nil
@@ -105,6 +104,10 @@ local function find_similar(name: string, max_distance?: integer): {string}
   -- Compare against both the short name and the full qualified name.
   -- This catches typos in either the prefix (e.g. "cosm.json") or the
   -- suffix (e.g. "cosmic.jsn" -> "cosmic.json", distance 1).
+  -- cosmic.fuzzy is required lazily, like cosmic.string above: this
+  -- only runs on the require-failure path, and a boot-time require
+  -- would put the module on every invocation's boot surface (#973).
+  local fuzzy = original_require("cosmic.fuzzy")
   for _, pair in ipairs(candidates) do
     local full = pair[1]
     local short = pair[2]

--- a/cmd/cosmic/main.tl
+++ b/cmd/cosmic/main.tl
@@ -35,7 +35,6 @@ end
 
 local getopt = require("cosmic.getopt")
 local cli_args = require("_cli.args")
-local help = require("_cli.help")
 local handlers = require("_cli.main_handlers")
 
 -- Parsed options record
@@ -358,15 +357,23 @@ local function main(): integer, string
     opts.extract = extract_env
   end
   if opts.version then return handlers.handle_version() end
-  if opts.help then io.write(help.generate() .. "\n"); return 0 end
+  -- _cli.help is required here, not at the top: --help is a
+  -- human-paced branch, and a boot-time require would put the module
+  -- on every invocation's boot surface (#973)
+  if opts.help then io.write(require("_cli.help").generate() .. "\n"); return 0 end
   if opts.welcome then io.write(handlers.generate_welcome()); return 0 end
 
   -- Show welcome on first invocation (skip when --help/--version/--welcome handled above)
+  -- The tty gate runs first: the banner only ever prints to a
+  -- terminal, so headless boots (CI, builds, scripts) skip the
+  -- was-shown lookup and never load _cli.welcome at all (#973).
+  -- Behavior is unchanged: the banner still prints exactly once, on
+  -- the first invocation whose stderr is a tty.
   if not os.getenv("COSMIC_NO_WELCOME") then
-    local welcome = require("_cli.welcome")
-    if not welcome.was_shown() then
-      local tty = require("cosmic.tty")
-      if tty.is_tty(2) then
+    local tty = require("cosmic.tty")
+    if tty.is_tty(2) then
+      local welcome = require("_cli.welcome")
+      if not welcome.was_shown() then
         io.stderr:write(handlers.generate_welcome())
         welcome.mark_shown()
       end

--- a/cmd/cosmic/main.tl
+++ b/cmd/cosmic/main.tl
@@ -357,18 +357,11 @@ local function main(): integer, string
     opts.extract = extract_env
   end
   if opts.version then return handlers.handle_version() end
-  -- _cli.help is required here, not at the top: --help is a
-  -- human-paced branch, and a boot-time require would put the module
-  -- on every invocation's boot surface (#973)
   if opts.help then io.write(require("_cli.help").generate() .. "\n"); return 0 end
   if opts.welcome then io.write(handlers.generate_welcome()); return 0 end
 
-  -- Show welcome on first invocation (skip when --help/--version/--welcome handled above)
-  -- The tty gate runs first: the banner only ever prints to a
-  -- terminal, so headless boots (CI, builds, scripts) skip the
-  -- was-shown lookup and never load _cli.welcome at all (#973).
-  -- Behavior is unchanged: the banner still prints exactly once, on
-  -- the first invocation whose stderr is a tty.
+  -- First-run welcome, tty gate first: the banner only ever prints to a terminal,
+  -- so headless boots never load _cli.welcome (#973). Still once, on the first tty.
   if not os.getenv("COSMIC_NO_WELCOME") then
     local tty = require("cosmic.tty")
     if tty.is_tty(2) then

--- a/cosmic/embed/init.tl
+++ b/cosmic/embed/init.tl
@@ -84,7 +84,11 @@ local record DirEntry
   kind: integer
 end
 
--- Internal record for files staged for embedding.
+-- Internal record for files staged for embedding. Files collected from
+-- the tree carry only their path — the appender streams them from disk
+-- (add_file, whilp/cosmopolitan#238) so a tree's bytes never exist as
+-- Lua strings. content is set only on synthetic entries (the wrapper
+-- main), which have no file behind them.
 local record FileToEmbed
   path: string
   content: string
@@ -148,15 +152,12 @@ local function collect_dir(dir: string): {FileToEmbed} | nil, string
             if walk_err then return walk_err end
           elseif unix.S_ISREG(sst:mode()) then
             -- Only embed regular files; skip symlinks (S_ISLNK) entirely.
-            local content, read_err = fs.read(full_path)
-            if not content then
-              return "cannot open file '" .. full_path .. "': " .. (read_err or "unknown error")
-            end
+            -- No read here: the add loop streams the file by path, and
+            -- an unreadable file fails there naming its stored_name.
             -- Extract permission bits (lower 9 bits)
             local file_mode = sst:mode() & tonumber("777", 8)
             collected[#collected + 1] = {
               path = full_path,
-              content = content,
               stored_name = rel,
               mode = file_mode,
             }
@@ -225,7 +226,18 @@ local function wrap_user_main(files_to_embed: {FileToEmbed}, exe_path: string): 
   if not main_entry then
     return nil
   end
-  if main_entry.content:sub(1, #WRAP_SENTINEL) == WRAP_SENTINEL then
+  -- Collected entries carry no content (they stream by path); the wrap
+  -- decision needs main's bytes, so this one file is read here.
+  local main_bytes = main_entry.content
+  if not main_bytes then
+    local read_bytes, read_err = fs.read(main_entry.path)
+    if not read_bytes then
+      return "error: cannot open file '" .. main_entry.path .. "': " ..
+      (read_err or "unknown error")
+    end
+    main_bytes = read_bytes
+  end
+  if main_bytes:sub(1, #WRAP_SENTINEL) == WRAP_SENTINEL then
     return nil -- already wrapped (extract/embed roundtrip)
   end
   local exe_reader = czip.open(exe_path)
@@ -233,7 +245,7 @@ local function wrap_user_main(files_to_embed: {FileToEmbed}, exe_path: string): 
     local rd = exe_reader
     local exe_main = rd:read("main.lua")
     rd:close()
-    if exe_main == main_entry.content then
+    if exe_main == main_bytes then
       return nil -- unmodified dispatcher entry: keep the roundtrip exact
     end
   end
@@ -284,23 +296,19 @@ local function embed(paths: {string}, opts?: Options): EmbedResult
         files_to_embed[#files_to_embed + 1] = f
       end
     else
-      local content, open_err = fs.read(p)
-      if not content then
-        return {ok = false, message = "error: cannot open file '" .. p .. "': " .. (open_err or "unknown error"), file_count = 0}
+      -- No read here: stat answers existence and mode, and the add
+      -- loop streams the bytes by path (add_file). A vanished or
+      -- unreadable path still fails, naming the file.
+      local st, stat_err = fs.stat(p)
+      if not st then
+        return {ok = false, message = "error: cannot open file '" .. p .. "': " .. (stat_err or "unknown error"), file_count = 0}
       end
 
       local stored_name = p:gsub("^/+", "")
-
-      -- Get file mode
-      local st = fs.stat(p)
-      local file_mode = tonumber("644", 8) -- default
-      if st then
-        file_mode = (st as Stat):mode() & tonumber("777", 8) -- cast: mixed-rep Stat
-      end
+      local file_mode = (st as Stat):mode() & tonumber("777", 8) -- cast: mixed-rep Stat
 
       files_to_embed[#files_to_embed + 1] = {
         path = p,
-        content = content,
         stored_name = stored_name,
         mode = file_mode,
       }
@@ -389,7 +397,17 @@ local function embed(paths: {string}, opts?: Options): EmbedResult
       -- live mtimes now has to ask for them.
       mtime = opts.mtime or floor.epoch(),
     }
-    local add_ok, add_err = appender:add(file_info.stored_name, file_info.content, add)
+    -- Tree files stream from disk in C (add_file); only synthetic
+    -- entries (the wrapper main) carry content and go through add.
+    -- Explicit mode and mtime above override add_file's source-derived
+    -- defaults, so artifacts stay byte-reproducible.
+    local add_ok: boolean
+    local add_err: string
+    if file_info.content then
+      add_ok, add_err = appender:add(file_info.stored_name, file_info.content, add)
+    else
+      add_ok, add_err = appender:add_file(file_info.stored_name, file_info.path, add)
+    end
     if not add_ok then
       appender:close()
       local _ok, _err = fs.unlink(tmp_path)

--- a/cosmic/zip.tl
+++ b/cosmic/zip.tl
@@ -198,10 +198,6 @@ local function extract(r: Archive, destdir: string, opts?: ExtractOptions): bool
       ok, err = ensure_dir(fs.join(destdir, name))
       if not ok then return false, err end
     else
-      local content, read_err = r:read(name)
-      if not content then
-        return false, "cannot read '" .. name .. "' from archive: " .. (read_err or "unknown error")
-      end
       local filepath = fs.join(destdir, name)
       ok, err = ensure_dir(fs.dirname(filepath))
       if not ok then return false, err end
@@ -213,11 +209,23 @@ local function extract(r: Archive, destdir: string, opts?: ExtractOptions): bool
         file_mode = mode
       end
 
-      local write_ok, write_err = fs.write(filepath, content, file_mode)
-      if not write_ok then
-        return false, "cannot write '" .. filepath .. "': " .. (write_err or "unknown error")
+      -- save() decompresses and CRC-checks in C and writes straight to
+      -- the file — the entry's bytes never exist as a Lua string
+      -- (whilp/cosmopolitan#238). Dot-form through a cast rather than
+      -- r:save(...): cosmic.zip sits in the type generator's import
+      -- closure (gentype reads the runtime archive through it), so this
+      -- file must compile against the DRIVING binary's bundled types,
+      -- which always predate a zip surface it is adding.
+      -- cast: zip surface newer than the bootstrap types
+      local save_fn = (r as {string: any})["save"] as
+      function(Archive, string, string): (boolean, string)
+      local save_ok, save_err = save_fn(r, name, filepath)
+      if not save_ok then
+        return false, "cannot extract '" .. name .. "' to '" .. filepath ..
+        "': " .. (save_err or "unknown error")
       end
-      -- barf's mode only applies on create; force it for overwrites.
+      -- save creates with 0644; force the entry's mode, as the write
+      -- path always did for overwrites.
       local _ok, _err = fs.chmod(filepath, file_mode)
     end
   end


### PR DESCRIPTION
Completes whilp/cosmopolitan#238 (C side merged as whilp/cosmopolitan#239, shipped in `2026.08.08-23abf0799`).

## What changed

- **Pin bump** to `2026.08.08-23abf0799`, carrying `zip.Reader:save` and `zip.Appender:add_file`.
- **`cosmic/zip.tl`**: `extract`'s file branch calls `save` — the entry is decompressed and CRC-checked in C and written straight to the destination; the entry's bytes never exist as a Lua string. Mode handling unchanged (chmod after, as the write path always did). One structural note: the call is dot-form through a justified cast, because `cosmic.zip` sits inside the type generator's import closure and must compile against the driving binary's bundled types, which always predate a zip surface it is adding.
- **`cosmic/embed/init.tl`**: collected tree files carry only their path; the add loop streams them with `add_file`. Explicit `mode`/`mtime` options override `add_file`'s source-derived defaults, so artifacts stay byte-reproducible. Only the synthetic wrapper-main entry still goes through `add`, and the wrap-detection reads main's bytes on demand.

## Numbers, honestly

Measured during the C round (cosmic wired against the same build, full loop):

```
embed_extract_tree  alloc 7218.5 KB -> 521.3 KB/op  (-93%)   wall -3.0% (inside noise)
embed_run_tree      alloc flat (fs.copy of the base binary — filed as whilp/cosmopolitan#240)
39 scenarios: 0 real regressions; ci PASS
```

**Wall is neutral** — extract is inflate+write bound, and the projection that string churn was wall cost is withdrawn on the issue. The delivered value: −93% alloc/GC pressure on every extract, and embed peak memory no longer scaling with tree size (a large tree currently lives wholly in RAM during pack).

## Gates

- `ci: PASS (5 stages)` under the real new pin, no overrides
- perf-compare: no regression above any noise bar
- `test_zip.lua`/`test_zip_append.lua` upstream pin the byte-identity and default semantics of both new methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQZgh4AsGFiQdzcXi4aeD1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQZgh4AsGFiQdzcXi4aeD1)_