### PR TITLE
doc's query half sheds DocsResult and takes its noun names (#1001, slice 3)

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -1,5 +1,5 @@
-# columns: path covered-lines total-lines
 # coverage ratchet baseline: `cosmic --make coverage --baseline` rewrites this file.
+# columns: path covered-lines total-lines
 3p/tl/tl_patch.tl 0 1
 _build/ratchet.tl 36 36
 _cli/args.tl 0 35
@@ -8,6 +8,7 @@ _cli/build/modules.tl 46 49
 _cli/build/steps.tl 183 239
 _cli/build/work.tl 148 169
 _cli/check.tl 24 31
+_cli/doc_compat.tl 16 26
 _cli/driver.tl 21 34
 _cli/grants.tl 158 168
 _cli/help.tl 46 48
@@ -203,4 +204,4 @@ cosmic/user.tl 48 61
 cosmic/uuid.tl 9 9
 cosmic/zip.tl 72 85
 tlconfig.lua 7 7
-total 14809 19435
+total 14825 19461

--- a/_cli/doc_compat.tl
+++ b/_cli/doc_compat.tl
@@ -37,19 +37,27 @@ local function paired(fn: any): function(q?: string): (string | nil, string)
   end
 end
 
+-- The casts sit in statement position: the pin's parser rejects an
+-- anonymous function type after `as` inside a table constructor.
+-- cast: transitional dual-shape call
+local compat_is_available = (docs_any["is_available"] or docs_any["has_docs"]) as
+function(): boolean
+
+-- cast: transitional dual-shape call
+local compat_topics = (docs_any["topics"] or docs_any["list_topics"]) as
+function(boolean): {{string, string}}
+
+-- cast: transitional dual-shape call
+local compat_guides = (docs_any["guides"] or docs_any["list_guides"]) as
+function(): {{string, string}}
+
 local M: DocCompat = {
   query = paired(docs_any["query"]),
   module_examples = paired(docs_any["module_examples"]
     or docs_any["show_module_examples"]),
-  -- cast: transitional dual-shape call
-  is_available = (docs_any["is_available"] or docs_any["has_docs"]) as
-  function(): boolean,
-  -- cast: transitional dual-shape call
-  topics = (docs_any["topics"] or docs_any["list_topics"]) as
-  function(include_cosmo?: boolean): {{string, string}},
-  -- cast: transitional dual-shape call
-  guides = (docs_any["guides"] or docs_any["list_guides"]) as
-  function(): {{string, string}},
+  is_available = compat_is_available,
+  topics = compat_topics,
+  guides = compat_guides,
 }
 
 return M

--- a/_cli/doc_compat.tl
+++ b/_cli/doc_compat.tl
@@ -1,0 +1,55 @@
+--- TRANSITIONAL doc compatibility (#1001; DELETE this module at the
+--- pin advance): the pin boot-checks `_cli` against ITS embedded
+--- cosmic.doc — DocsResult{ok, output} returns, `has_docs`/`list_*`
+--- spellings — while the tree's record returns `string | nil, string`
+--- pairs under noun names. These wrappers reach the members through
+--- erasure with a runtime fallback to the pin's spellings, and
+--- normalize a pin-shaped DocsResult into the pair, so the dispatcher
+--- compiles and runs under both generations.
+local docs = require("cosmic.doc")
+
+local record DocCompat
+  query: function(q?: string): string | nil, string
+  module_examples: function(q: string): string | nil, string
+  is_available: function(): boolean
+  topics: function(include_cosmo?: boolean): {{string, string}}
+  guides: function(): {{string, string}}
+end
+
+local docs_any = docs as {string: any} -- cast: transitional dual-shape module
+
+--- Wrap a lookup so a pin-shaped DocsResult return reads as the pair.
+local function paired(fn: any): function(q?: string): (string | nil, string)
+  local call = fn as function(any): (any, any) -- cast: transitional dual-shape call
+  return function(q?: string): string | nil, string
+    local r, err = call(q)
+    if r is string then
+      return r
+    end
+    if r == nil then
+      return nil, err as string -- cast: transitional dual-shape result
+    end
+    local rec = r as {string: any} -- cast: transitional dual-shape result
+    if rec["ok"] then
+      return rec["output"] as string -- cast: transitional dual-shape result
+    end
+    return nil, rec["output"] as string -- cast: transitional dual-shape result
+  end
+end
+
+local M: DocCompat = {
+  query = paired(docs_any["query"]),
+  module_examples = paired(docs_any["module_examples"]
+    or docs_any["show_module_examples"]),
+  -- cast: transitional dual-shape call
+  is_available = (docs_any["is_available"] or docs_any["has_docs"]) as
+  function(): boolean,
+  -- cast: transitional dual-shape call
+  topics = (docs_any["topics"] or docs_any["list_topics"]) as
+  function(include_cosmo?: boolean): {{string, string}},
+  -- cast: transitional dual-shape call
+  guides = (docs_any["guides"] or docs_any["list_guides"]) as
+  function(): {{string, string}},
+}
+
+return M

--- a/_cli/help.tl
+++ b/_cli/help.tl
@@ -15,9 +15,9 @@ local function generate(): string
   table.insert(lines, static_help)
 
   -- Show module list with descriptions (only cosmic.* modules, not cosmo.* bindings)
-  local docs = require("cosmic.doc")
-  if docs.has_docs() then
-    local topics = docs.list_topics() -- excludes cosmo.* by default
+  local docs = require("_cli.doc_compat")
+  if docs.is_available() then
+    local topics = docs.topics() -- excludes cosmo.* by default
     if #topics > 0 then
       local cosmic_topics: {{string, string}} = {}
 
@@ -55,7 +55,7 @@ local function generate(): string
   end
 
   -- Show guides list
-  local guides = docs.list_guides()
+  local guides = docs.guides()
   if #guides > 0 then
     local max_len = 0
     for _, g in ipairs(guides) do

--- a/_cli/main_handlers.tl
+++ b/_cli/main_handlers.tl
@@ -30,11 +30,11 @@ local function run_repl()
 
   require("cosmo")
 
-  -- Inject help() into REPL
-  local docs = require("cosmic.doc")
+  -- Inject help() into REPL (via the pin-compat shim, #1001)
+  local docs = require("_cli.doc_compat")
   rawset(_G, "help", function(query: string)
-      local result = docs.query(query or "")
-      print(result.output)
+      local out, qerr = docs.query(query or "")
+      print(out or qerr)
     end)
 
   require("cosmo.repl").start()
@@ -64,10 +64,10 @@ end
 --- @return DocsRunResult Result with ok status and output text
 local function run_docs(query: string): DocsRunResult
   local docs = require("cosmic.doc")
-
-  local result = docs.query(query)
-  if result.ok then
-    return {ok = true, output = result.output}
+  local doc_compat = require("_cli.doc_compat")
+  local out, qerr = doc_compat.query(query)
+  if out then
+    return {ok = true, output = out}
   end
 
   local results = docs.search(query)
@@ -75,7 +75,7 @@ local function run_docs(query: string): DocsRunResult
     return {ok = true, output = docs.render_search_results(results, query)}
   end
 
-  return {ok = false, output = result.output}
+  return {ok = false, output = qerr}
 end
 
 --- Handle --version flag.
@@ -289,16 +289,16 @@ end
 
 --- Handle --examples flag.
 local function handle_examples(module_name: string): integer
-  local docs = require("cosmic.doc")
+  local docs = require("_cli.doc_compat")
 
   if module_name == "" then
-    local result = docs.query("examples")
-    io.write(result.output .. "\n")
-    return result.ok and 0 or 1
+    local out, qerr = docs.query("examples")
+    io.write((out or qerr) .. "\n")
+    return out and 0 or 1
   else
-    local result = docs.show_module_examples(module_name)
-    io.write(result.output .. "\n")
-    return result.ok and 0 or 1
+    local out, qerr = docs.module_examples(module_name)
+    io.write((out or qerr) .. "\n")
+    return out and 0 or 1
   end
 end
 
@@ -324,10 +324,10 @@ end
 --- Handle --docs flag.
 local function handle_docs(query: string): integer
   if query == "" then
-    local docs = require("cosmic.doc")
-    local result = docs.query("")
-    io.write(result.output .. "\n")
-    return result.ok and 0 or 1
+    local docs = require("_cli.doc_compat")
+    local out, qerr = docs.query("")
+    io.write((out or qerr) .. "\n")
+    return out and 0 or 1
   else
     local result = run_docs(query)
     if result.ok then

--- a/cosmic/doc/examples_query_test.tl
+++ b/cosmic/doc/examples_query_test.tl
@@ -9,7 +9,7 @@ local check = require("cosmic.check")
 
 -- Test show_module_examples with function-level filter
 local function test_show_module_examples_function_filter()
-  if not docs.has_docs() then
+  if not docs.is_available() then
     io.stderr:write("SKIP: test_show_module_examples_function_filter (no docs available)\n")
     print("test_show_module_examples_function_filter: PASS (skipped)")
     return
@@ -48,11 +48,10 @@ local function test_show_module_examples_function_filter()
   end
 
   if test_mod and test_func then
-    local result = docs.show_module_examples(test_mod .. "." .. test_func)
-    assert(result, "show_module_examples should return a result")
-    assert(result.ok, "function filter should find matching examples for " .. test_mod .. "." .. test_func)
-    assert(result.output:match(test_func), "output should contain function name")
-    assert(result.output:match("examples"), "output should contain 'examples' header")
+    local output, qerr = docs.module_examples(test_mod .. "." .. test_func)
+    assert(output ~= nil, "function filter should find matching examples for " .. test_mod .. "." .. test_func)
+    assert((output or qerr):match(test_func), "output should contain function name")
+    assert((output or qerr):match("examples"), "output should contain 'examples' header")
     print("test_show_module_examples_function_filter: PASS (tested " .. test_mod .. "." .. test_func .. ")")
   else
     print("test_show_module_examples_function_filter: PASS (no suitable module+function found)")
@@ -62,7 +61,7 @@ test_show_module_examples_function_filter()
 
 -- Test show_module_examples with nonexistent function returns error
 local function test_show_module_examples_no_match()
-  if not docs.has_docs() then
+  if not docs.is_available() then
     io.stderr:write("SKIP: test_show_module_examples_no_match (no docs available)\n")
     print("test_show_module_examples_no_match: PASS (skipped)")
     return
@@ -79,10 +78,9 @@ local function test_show_module_examples_no_match()
   end
 
   if test_mod then
-    local result = docs.show_module_examples(test_mod .. ".nonexistent_function_xyz")
-    assert(result, "show_module_examples should return a result")
-    assert(not result.ok, "nonexistent function should return ok=false")
-    assert(result.output:match("No examples"), "output should say no examples found")
+    local output, qerr = docs.module_examples(test_mod .. ".nonexistent_function_xyz")
+    assert(not output, "nonexistent function should be a miss")
+    assert((output or qerr):match("No examples"), "output should say no examples found")
     print("test_show_module_examples_no_match: PASS")
   else
     print("test_show_module_examples_no_match: PASS (no module with examples found)")
@@ -92,7 +90,7 @@ test_show_module_examples_no_match()
 
 -- Test show_module_examples still works with plain module name
 local function test_show_module_examples_module_only()
-  if not docs.has_docs() then
+  if not docs.is_available() then
     io.stderr:write("SKIP: test_show_module_examples_module_only (no docs available)\n")
     print("test_show_module_examples_module_only: PASS (skipped)")
     return
@@ -109,10 +107,9 @@ local function test_show_module_examples_module_only()
   end
 
   if test_mod then
-    local result = docs.show_module_examples(test_mod)
-    assert(result, "show_module_examples should return a result")
-    assert(result.ok, "module-only query should succeed for " .. test_mod)
-    assert(result.output:match("examples"), "output should contain 'examples' header")
+    local output, qerr = docs.module_examples(test_mod)
+    assert(output ~= nil, "module-only query should succeed for " .. test_mod)
+    assert((output or qerr):match("examples"), "output should contain 'examples' header")
     print("test_show_module_examples_module_only: PASS (tested " .. test_mod .. ")")
   else
     print("test_show_module_examples_module_only: PASS (no module with examples found)")
@@ -122,15 +119,14 @@ test_show_module_examples_module_only()
 
 -- Test that bare module name resolves in show_module_examples (bug 4)
 local function test_show_module_examples_bare_name()
-  if not docs.has_docs() then
+  if not docs.is_available() then
     io.stderr:write("SKIP: test_show_module_examples_bare_name\n")
     print("test_show_module_examples_bare_name: PASS (skipped)")
     return
   end
-  local r = docs.show_module_examples("child")
-  assert(r, "should return result")
-  assert(not (not r.ok and r.output:match("module not found: child")),
-    "bare 'child' should not fail with module not found: " .. r.output)
+  local r, rerr = docs.module_examples("child")
+  assert(not (r == nil and rerr:match("module not found: child")),
+    "bare 'child' should not fail with module not found: " .. tostring(rerr))
   print("test_show_module_examples_bare_name: PASS")
 end
 test_show_module_examples_bare_name()
@@ -140,7 +136,7 @@ test_show_module_examples_bare_name()
 -- module (box's run(), matched by Example_run_return_shape) must fall back
 -- to the function-filter reading instead of failing with "No examples".
 local function test_show_module_examples_module_function_collision()
-  if not docs.has_docs() then
+  if not docs.is_available() then
     io.stderr:write("SKIP: test_show_module_examples_module_function_collision\n")
     print("test_show_module_examples_module_function_collision: PASS (skipped)")
     return
@@ -150,10 +146,9 @@ local function test_show_module_examples_module_function_collision()
     print("test_show_module_examples_module_function_collision: PASS (fixture modules absent)")
     return
   end
-  local result = docs.show_module_examples("cosmic.quicksand.box.run")
-  assert(result, "should return a result")
-  assert(result.ok, "collision query must resolve via the function filter: " .. result.output)
-  assert(result.output:match("run"), "output should mention run")
+  local output, qerr = docs.module_examples("cosmic.quicksand.box.run")
+  assert(output ~= nil, "collision query must resolve via the function filter: " .. (output or qerr))
+  assert((output or qerr):match("run"), "output should mention run")
   print("test_show_module_examples_module_function_collision: PASS")
 end
 test_show_module_examples_module_function_collision()

--- a/cosmic/doc/init.tl
+++ b/cosmic/doc/init.tl
@@ -23,36 +23,38 @@ local record DocModule
   type Param = types.Param
   type Return = types.Return
   type DocIndex = types.DocIndex
-  type DocsResult = types.DocsResult
   type SearchResult = types.SearchResult
 
-  -- Query: the index embedded in the binary (`--docs`).
-  query: function(q?: string): DocsResult
-  has_docs: function(): boolean
-  list_topics: function(include_cosmo?: boolean): {{string, string}}
+  -- Query: the index embedded in the binary (`--docs`). The fallible
+  -- lookups return `string | nil, string` (#1001: DocsResult{ok, output}
+  -- was the success-text-or-error-text-by-flag anti-pattern this very
+  -- file documents render_file shedding).
+  query: function(q?: string): string | nil, string
+  is_available: function(): boolean
+  topics: function(include_cosmo?: boolean): {{string, string}}
   embedded_index: function(): DocIndex | nil, string
   render_module: function(name: string, doc: ModuleDoc): string
   search: function(query: string, include_cosmo?: boolean): {SearchResult}
   render_search_results: function(results: {SearchResult}, query: string): string
-  show_module_examples: function(query: string): DocsResult
-  show_guide: function(topic: string): DocsResult
-  list_guide_topics: function(): {string}
-  list_guides: function(): {{string, string}}
+  module_examples: function(query: string): string | nil, string
+  guide: function(topic: string): string | nil, string
+  guide_topics: function(): {string}
+  guides: function(): {{string, string}}
   strip_frontmatter: function(content: string): string
 end
 
 local M: DocModule = {
   query = query.run,
-  has_docs = query.has_docs,
-  list_topics = query.list_topics,
+  is_available = query.is_available,
+  topics = query.topics,
   embedded_index = query.embedded_index,
   render_module = query.render_module,
   search = query.search,
   render_search_results = query.render_search_results,
-  show_module_examples = query.show_module_examples,
-  show_guide = query.show_guide,
-  list_guide_topics = query.list_guide_topics,
-  list_guides = query.list_guides,
+  module_examples = query.module_examples,
+  guide = query.guide,
+  guide_topics = query.guide_topics,
+  guides = query.guides,
   strip_frontmatter = query.strip_frontmatter,
 }
 

--- a/cosmic/doc/public_test.tl
+++ b/cosmic/doc/public_test.tl
@@ -27,7 +27,7 @@ local INTERNAL_SAMPLES = {
 
 local function topic_names(): {string: boolean}
   local names: {string: boolean} = {}
-  for _, topic in ipairs(docs.list_topics()) do
+  for _, topic in ipairs(docs.topics()) do
     names[topic[1]] = true
   end
   return names
@@ -67,8 +67,7 @@ local function test_directory_modules_indexed_under_their_name()
     "directory module must be indexed, not cosmic.fs.init")
   assert(not idx.modules["cosmic.fs.init"],
     "init shard must not appear own module")
-  local result = docs.query("fs")
-  assert(result.ok, "--docs fs must resolve to the fs module page")
+  assert(docs.query("fs"), "--docs fs must resolve to the fs module page")
   print("test_directory_modules_indexed_under_their_name: PASS")
 end
 test_directory_modules_indexed_under_their_name()
@@ -91,13 +90,11 @@ end
 test_internal_modules_stay_searchable_with_badge()
 
 local function test_internal_doc_page_carries_header()
-  local result = docs.query("cosmic.child.io")
-  assert(result.ok, "--docs cosmic.child.io must still render a page")
-  assert(result.output:find("internal module — not API, may change without notice", 1, true),
+  local page = check.must(docs.query("cosmic.child.io"))
+  assert(page:find("internal module — not API, may change without notice", 1, true),
     "internal module page must carry the internal-module header")
-  local public_page = docs.query("cosmic.json")
-  assert(public_page.ok, "--docs cosmic.json must render")
-  assert(not public_page.output:find("internal module — not API", 1, true),
+  local public_page = check.must(docs.query("cosmic.json"))
+  assert(not public_page:find("internal module — not API", 1, true),
     "public module page must not carry the internal-module header")
   print("test_internal_doc_page_carries_header: PASS")
 end

--- a/cosmic/doc/query.tl
+++ b/cosmic/doc/query.tl
@@ -80,18 +80,18 @@ end
 
 --- List guides with descriptions from each file's heading.
 local function guides(): {{string, string}}
-  local topics = guide_topics()
-  local guides: {{string, string}} = {}
-  for _, name in ipairs(topics) do
+  local names = guide_topics()
+  local out: {{string, string}} = {}
+  for _, name in ipairs(names) do
     local content = require("cosmic.fs").read(GUIDES_DIR .. "/" .. name .. ".md")
     local desc = name
     if content then
       local heading = string.match(content, "^#%s+(.-)%s*\n")
       if heading then desc = heading end
     end
-    table.insert(guides, {name, desc})
+    table.insert(out, {name, desc})
   end
-  return guides
+  return out
 end
 
 --- Show a guide topic or list all guides.
@@ -143,19 +143,19 @@ local function topics(include_cosmo?: boolean): {{string, string}}
   if not index then return {} end
   local idx = index
 
-  local topics: {{string, string}} = {}
+  local out: {{string, string}} = {}
   for name, doc in pairs(idx.modules) do
     if not doc.internal and (include_cosmo or not is_cosmo_module(name)) then
       local desc = docs_render.first_paragraph(doc.module_doc)
-      table.insert(topics, {name, desc})
+      table.insert(out, {name, desc})
     end
   end
 
-  table.sort(topics, function(a: {string, string}, b: {string, string}): boolean
+  table.sort(out, function(a: {string, string}, b: {string, string}): boolean
       return a[1] < b[1]
     end)
 
-  return topics
+  return out
 end
 
 local calc_score = docs_lookup.calc_score

--- a/cosmic/doc/query.tl
+++ b/cosmic/doc/query.tl
@@ -5,7 +5,6 @@ local docs_lookup = require("cosmic.doc.lookup")
 local types = require("cosmic.doc.types")
 local ModuleDoc = types.ModuleDoc
 local DocIndex = types.DocIndex
-local DocsResult = types.DocsResult
 local SearchResult = types.SearchResult
 local ExampleEntry = types.ExampleEntry
 
@@ -43,7 +42,7 @@ end
 
 --- Check if embedded docs are available.
 --- @return boolean True if docs are embedded
-local function has_docs(): boolean
+local function is_available(): boolean
   local index, _ = embedded_index()
   return index ~= nil
 end
@@ -60,7 +59,7 @@ local function strip_frontmatter(content: string): string
 end
 
 --- List available guide topics from the embedded skills directory.
-local function list_guide_topics(): {string}
+local function guide_topics(): {string}
   local fs = require("cosmic.fs")
   local fs_types = require("cosmic.fs.types")
   local dir = fs.open_dir(GUIDES_DIR)
@@ -80,8 +79,8 @@ local function list_guide_topics(): {string}
 end
 
 --- List guides with descriptions from each file's heading.
-local function list_guides(): {{string, string}}
-  local topics = list_guide_topics()
+local function guides(): {{string, string}}
+  local topics = guide_topics()
   local guides: {{string, string}} = {}
   for _, name in ipairs(topics) do
     local content = require("cosmic.fs").read(GUIDES_DIR .. "/" .. name .. ".md")
@@ -96,16 +95,16 @@ local function list_guides(): {{string, string}}
 end
 
 --- Show a guide topic or list all guides.
-local function show_guide(topic: string): DocsResult
+local function guide(topic: string): string | nil, string
   local fs = require("cosmic.fs")
   if topic == "" then
     local content, err = fs.read(GUIDES_DIR .. "/SKILL.md")
     if not content then
-      return {ok = false, output = "error: " .. (err or "no guides available")}
+      return nil, "error: " .. (err or "no guides available")
     end
-    return {ok = true, output = strip_frontmatter(content)}
+    return strip_frontmatter(content)
   end
-  local topics = list_guide_topics()
+  local topics = guide_topics()
   local valid = false
   for _, t in ipairs(topics) do
     if t == topic then valid = true; break end
@@ -116,14 +115,14 @@ local function show_guide(topic: string): DocsResult
     for _, t in ipairs(topics) do
       table.insert(lines, "  " .. t)
     end
-    return {ok = false, output = table.concat(lines, "\n")}
+    return nil, table.concat(lines, "\n")
   end
   local path = GUIDES_DIR .. "/" .. topic .. ".md"
   local content, err = fs.read(path)
   if not content then
-    return {ok = false, output = "error: " .. (err or "failed to load " .. path)}
+    return nil, "error: " .. (err or "failed to load " .. path)
   end
-  return {ok = true, output = content}
+  return content
 end
 
 --- Check if a module name is a low-level cosmo module.
@@ -139,7 +138,7 @@ end
 --- searchable and directly addressable by name.
 --- @param include_cosmo boolean Include low-level cosmo.* modules (default: false)
 --- @return {{string, string}} List of {name, description} pairs, sorted by name
-local function list_topics(include_cosmo?: boolean): {{string, string}}
+local function topics(include_cosmo?: boolean): {{string, string}}
   local index, _ = embedded_index()
   if not index then return {} end
   local idx = index
@@ -294,11 +293,12 @@ end
 
 --- Show examples for a specific module, optionally filtered by function name.
 --- @param query string Module name (full, bare, or module.function)
---- @return DocsResult Result with examples content
-local function show_module_examples(query: string): DocsResult
+--- @return string | nil The rendered examples, or nil when not found
+--- @return string? The not-found message
+local function module_examples(query: string): string | nil, string
   local index, err = embedded_index()
   if not index then
-    return {ok = false, output = "error: " .. (err or "no documentation embedded")}
+    return nil, "error: " .. (err or "no documentation embedded")
   end
   local idx = index
   -- Resolve bare name (e.g. "child" -> "cosmic.child")
@@ -311,7 +311,7 @@ local function show_module_examples(query: string): DocsResult
       for _, example in ipairs(doc.examples) do
         table.insert(lines, docs_render.render_example(example))
       end
-      return {ok = true, output = table.concat(lines, "\n")}
+      return table.concat(lines, "\n")
     end
     -- The resolved module has no examples, but the query may also read as
     -- module.function — cosmic.quicksand.box.run is both the (example-less)
@@ -343,67 +343,65 @@ local function show_module_examples(query: string): DocsResult
         for _, example in ipairs(matching) do
           table.insert(lines, docs_render.render_example(example))
         end
-        return {ok = true, output = table.concat(lines, "\n")}
+        return table.concat(lines, "\n")
       end
     end
-    return {ok = false, output = "No examples for " .. query}
+    return nil, "No examples for " .. query
   end
 
   if resolved then
-    return {ok = false, output = "No examples for " .. resolved}
+    return nil, "No examples for " .. resolved
   end
 
   local suggestions = docs_render.find_example_suggestions(query, idx)
   if #suggestions > 0 then
     local lines: {string} = {"error: module not found: " .. query, "", "Did you mean?"}
     for i = 1, math.min(3, #suggestions) do table.insert(lines, "  " .. suggestions[i]) end
-    return {ok = false, output = table.concat(lines, "\n")}
+    return nil, table.concat(lines, "\n")
   end
-  return {ok = false, output = "error: module not found: " .. query}
+  return nil, "error: module not found: " .. query
 end
 
 --- Main entry point for the docs command.
 --- @param query string Optional query string (module or module.symbol)
---- @return DocsResult Result with documentation content
-local function run(query?: string): DocsResult
+--- @return string | nil The rendered documentation, or nil when not found
+--- @return string? The not-found message
+local function run(query?: string): string | nil, string
   local index, err = embedded_index()
   if not index then
-    return {
-      ok = false,
-      output = "error: " .. (err or "no documentation embedded") .. "\n" ..
-      "Build with 'make cosmic' to include documentation.",
-    }
+    return nil, "error: " .. (err or "no documentation embedded") .. "\n"
+    .. "Build with 'make cosmic' to include documentation."
   end
   local idx = index
 
   if not query or query == "" then
-    local topics = list_topics()
-    if #topics == 0 then
-      return {ok = false, output = "error: no documentation found"}
+    local topic_list = topics()
+    if #topic_list == 0 then
+      return nil, "error: no documentation found"
     end
-    return {ok = true, output = docs_render.render_topic_list(topics)}
+    return docs_render.render_topic_list(topic_list)
   end
 
   if query == "examples" then
     local examples = list_all_examples()
-    return {ok = true, output = docs_render.render_examples_list(examples)}
+    return docs_render.render_examples_list(examples)
   end
 
   if query == "guide" then
-    return show_guide("")
+    return guide("")
   end
   if query:sub(1, 6) == "guide." then
-    return show_guide(query:sub(7))
+    return guide(query:sub(7))
   end
 
   if idx.modules[query] then
-    return {ok = true, output = docs_render.render_module(query, idx.modules[query])}
+    return docs_render.render_module(query, idx.modules[query])
   end
 
   -- Bare module names short-circuit to their cosmic.* page, not fuzzy search
   if idx.modules["cosmic." .. query] then
     local full = "cosmic." .. query
-    return {ok = true, output = docs_render.render_module(full, idx.modules[full])}
+    return docs_render.render_module(full, idx.modules[full])
   end
 
   -- Try splitting query into module + remainder by iterating splits longest-to-shortest
@@ -434,16 +432,15 @@ local function run(query?: string): DocsResult
     local method = remainder[2]
     local rendered = docs_render.find_symbol(doc, symbol, method)
     if rendered then
-      return {ok = true, output = rendered}
+      return rendered
     else
       if method then
-        return {
-          ok = false,
-          output = "error: method '" .. method .. "' not found in '" .. matched_mod .. "." .. symbol .. "'\n" ..
-          "Use 'cosmic --docs " .. matched_mod .. "." .. symbol .. "' to see available methods.",
-        }
+        return nil, "error: method '" .. method .. "' not found in '"
+        .. matched_mod .. "." .. symbol .. "'\n"
+        .. "Use 'cosmic --docs " .. matched_mod .. "." .. symbol
+        .. "' to see available methods."
       else
-        return {ok = false, output = docs_lookup.symbol_not_found(symbol, matched_mod, idx)}
+        return nil, docs_lookup.symbol_not_found(symbol, matched_mod, idx)
       end
     end
   end
@@ -457,43 +454,40 @@ local function run(query?: string): DocsResult
     end
     table.insert(lines, "")
     table.insert(lines, "Try: cosmic --docs " .. suggestions[1])
-    return {ok = false, output = table.concat(lines, "\n")}
+    return nil, table.concat(lines, "\n")
   end
 
-  return {
-    ok = false,
-    output = "error: documentation not found for '" .. query .. "'\n" ..
-    "Use 'cosmic --docs' to see available modules.",
-  }
+  return nil, "error: documentation not found for '" .. query .. "'\n"
+  .. "Use 'cosmic --docs' to see available modules."
 end
 
 local record DocsModule
-  run: function(query?: string): DocsResult
-  has_docs: function(): boolean
-  list_topics: function(include_cosmo?: boolean): {{string, string}}
+  run: function(query?: string): string | nil, string
+  is_available: function(): boolean
+  topics: function(include_cosmo?: boolean): {{string, string}}
   embedded_index: function(): DocIndex | nil, string
   render_module: function(name: string, doc: ModuleDoc): string
   search: function(query: string, include_cosmo?: boolean): {SearchResult}
   render_search_results: function(results: {SearchResult}, query: string): string
-  show_module_examples: function(query: string): DocsResult
-  show_guide: function(topic: string): DocsResult
-  list_guide_topics: function(): {string}
-  list_guides: function(): {{string, string}}
+  module_examples: function(query: string): string | nil, string
+  guide: function(topic: string): string | nil, string
+  guide_topics: function(): {string}
+  guides: function(): {{string, string}}
   strip_frontmatter: function(content: string): string
 end
 
 local M: DocsModule = {
   run = run,
-  has_docs = has_docs,
-  list_topics = list_topics,
+  is_available = is_available,
+  topics = topics,
   embedded_index = embedded_index,
   render_module = docs_render.render_module,
   search = search,
   render_search_results = docs_render.render_search_results,
-  show_module_examples = show_module_examples,
-  show_guide = show_guide,
-  list_guide_topics = list_guide_topics,
-  list_guides = list_guides,
+  module_examples = module_examples,
+  guide = guide,
+  guide_topics = guide_topics,
+  guides = guides,
   strip_frontmatter = strip_frontmatter,
 }
 

--- a/cosmic/doc/query_test.tl
+++ b/cosmic/doc/query_test.tl
@@ -9,8 +9,8 @@ local doc_types = require("cosmic.doc.types")
 local function test_module_loads()
   assert(docs, "docs module should load")
   assert(docs.query, "docs.query should exist")
-  assert(docs.has_docs, "docs.has_docs should exist")
-  assert(docs.list_topics, "docs.list_topics should exist")
+  assert(docs.is_available, "docs.is_available should exist")
+  assert(docs.topics, "docs.topics should exist")
   assert(docs.embedded_index, "docs.embedded_index should exist")
   assert(docs.render_module, "docs.render_module should exist")
   assert(docs.search, "docs.search should exist")
@@ -20,7 +20,7 @@ end
 test_module_loads()
 
 local function test_has_docs()
-  local result = docs.has_docs()
+  local result = docs.is_available()
   assert(type(result) == "boolean", "has_docs should return a boolean")
   print("test_has_docs: PASS")
 end
@@ -42,12 +42,12 @@ end
 test_load_index()
 
 local function test_run_list()
-  local result = docs.query()
-  assert(result, "run should return a result")
-  assert(type(result.ok) == "boolean", "result.ok should be a boolean")
-  assert(type(result.output) == "string", "result.output should be a string")
-  if result.ok then
-    assert(result.output:match("cosmic documentation") or result.output:match("Modules"),
+  local output, qerr = docs.query()
+  assert(output ~= nil or qerr ~= nil, "run should return output or a message")
+  assert(type(output ~= nil) == "boolean", "output ~= nil should be a boolean")
+  assert(type((output or qerr)) == "string", "(output or qerr) should be a string")
+  if output ~= nil then
+    assert((output or qerr):match("cosmic documentation") or (output or qerr):match("Modules"),
       "list output should mention documentation or modules")
   end
   print("test_run_list: PASS")
@@ -56,13 +56,13 @@ test_run_list()
 
 -- Test run with a module query
 local function test_run_module()
-  local result = docs.query("cosmic.doc")
-  assert(result, "run should return a result")
-  assert(type(result.ok) == "boolean", "result.ok should be a boolean")
-  assert(type(result.output) == "string", "result.output should be a string")
+  local output, qerr = docs.query("cosmic.doc")
+  assert(output ~= nil or qerr ~= nil, "run should return output or a message")
+  assert(type(output ~= nil) == "boolean", "output ~= nil should be a boolean")
+  assert(type((output or qerr)) == "string", "(output or qerr) should be a string")
   -- If docs are available, this should work; otherwise it returns an error
-  if result.ok then
-    assert(result.output:match("doc") or result.output:match("documentation"),
+  if output ~= nil then
+    assert((output or qerr):match("doc") or (output or qerr):match("documentation"),
       "module output should contain relevant content")
   end
   print("test_run_module: PASS")
@@ -70,12 +70,12 @@ end
 test_run_module()
 
 local function test_run_symbol()
-  local result = docs.query("cosmic.doc.parse")
-  assert(result, "run should return a result")
-  assert(type(result.ok) == "boolean", "result.ok should be a boolean")
-  assert(type(result.output) == "string", "result.output should be a string")
-  if result.ok then
-    assert(result.output:match("parse") or result.output:match("function"),
+  local output, qerr = docs.query("cosmic.doc.parse")
+  assert(output ~= nil or qerr ~= nil, "run should return output or a message")
+  assert(type(output ~= nil) == "boolean", "output ~= nil should be a boolean")
+  assert(type((output or qerr)) == "string", "(output or qerr) should be a string")
+  if output ~= nil then
+    assert((output or qerr):match("parse") or (output or qerr):match("function"),
       "symbol output should contain relevant content")
   end
   print("test_run_symbol: PASS")
@@ -84,12 +84,12 @@ test_run_symbol()
 
 -- Test run with invalid query
 local function test_run_invalid()
-  local result = docs.query("nonexistent.module.that.does.not.exist")
-  assert(result, "run should return a result")
-  assert(type(result.output) == "string", "result.output should be a string")
+  local output, qerr = docs.query("nonexistent.module.that.does.not.exist")
+  assert(output ~= nil or qerr ~= nil, "run should return output or a message")
+  assert(type((output or qerr)) == "string", "(output or qerr) should be a string")
   -- Should return an error for nonexistent module
-  if not result.ok then
-    assert(result.output:match("not found") or result.output:match("error"),
+  if not output then
+    assert((output or qerr):match("not found") or (output or qerr):match("error"),
       "error output should mention not found or error")
   end
   print("test_run_invalid: PASS")
@@ -97,7 +97,7 @@ end
 test_run_invalid()
 
 local function test_list_topics()
-  local topics = docs.list_topics()
+  local topics = docs.topics()
   assert(type(topics) == "table", "list_topics should return a table")
   -- Each topic should be a {name, description} pair
   for _, topic in ipairs(topics) do
@@ -157,7 +157,7 @@ local function test_search_methods()
     end
   end
   -- If docs are available and lsqlite3 is indexed, we should find Database.exec
-  if docs.has_docs() then
+  if docs.is_available() then
     print("test_search_methods: PASS (found " .. #results .. " results, methods=" .. tostring(found_method) .. ")")
   else
     io.stderr:write("SKIP: test_search_methods content assertions (no docs available)\n")
@@ -167,12 +167,12 @@ test_search_methods()
 
 -- Test run with method lookup (module.Record.method pattern)
 local function test_run_method()
-  local result = docs.query("cosmo.lsqlite3.Database.exec")
-  assert(result, "run should return a result")
-  assert(type(result.ok) == "boolean", "result.ok should be a boolean")
-  assert(type(result.output) == "string", "result.output should be a string")
-  if result.ok then
-    assert(result.output:match("exec") or result.output:match("Database"),
+  local output, qerr = docs.query("cosmo.lsqlite3.Database.exec")
+  assert(output ~= nil or qerr ~= nil, "run should return output or a message")
+  assert(type(output ~= nil) == "boolean", "output ~= nil should be a boolean")
+  assert(type((output or qerr)) == "string", "(output or qerr) should be a string")
+  if output ~= nil then
+    assert((output or qerr):match("exec") or (output or qerr):match("Database"),
       "method output should contain relevant content")
   end
   print("test_run_method: PASS")
@@ -181,12 +181,12 @@ test_run_method()
 
 -- Test cosmo module shows tip about cosmic equivalent
 local function test_cosmic_equivalent_tip()
-  local result = docs.query("cosmo.lsqlite3")
-  assert(result, "run should return a result")
-  if result.ok then
-    assert(result.output:find("cosmic.sqlite", 1, true),
+  local output, qerr = docs.query("cosmo.lsqlite3")
+  assert(output ~= nil or qerr ~= nil, "run should return output or a message")
+  if output ~= nil then
+    assert((output or qerr):find("cosmic.sqlite", 1, true),
       "cosmo.lsqlite3 docs should mention cosmic.sqlite equivalent")
-    assert(result.output:find("Tip:", 1, true),
+    assert((output or qerr):find("Tip:", 1, true),
       "cosmo.lsqlite3 docs should show tip")
   end
   print("test_cosmic_equivalent_tip: PASS")
@@ -265,7 +265,7 @@ test_module_path_boost()
 
 -- Test that list_topics excludes cosmo.* modules by default
 local function test_list_topics_excludes_cosmo()
-  local topics = docs.list_topics()
+  local topics = docs.topics()
   local found_cosmo = false
   for _, topic in ipairs(topics) do
     if topic[1]:match("^cosmo%.") then
@@ -280,7 +280,7 @@ test_list_topics_excludes_cosmo()
 
 -- Test that list_topics(true) includes cosmo.* modules
 local function test_list_topics_includes_cosmo_when_requested()
-  local topics = docs.list_topics(true)
+  local topics = docs.topics(true)
   local found_cosmo = false
   local found_cosmic = false
   for _, topic in ipairs(topics) do
@@ -291,7 +291,7 @@ local function test_list_topics_includes_cosmo_when_requested()
       found_cosmic = true
     end
   end
-  if docs.has_docs() then
+  if docs.is_available() then
     assert(found_cosmo, "list_topics(true) should include cosmo.* modules")
     assert(found_cosmic, "list_topics(true) should include cosmic.* modules")
   else
@@ -327,7 +327,7 @@ local function test_search_includes_cosmo_when_requested()
       break
     end
   end
-  if docs.has_docs() then
+  if docs.is_available() then
     assert(found_cosmo, "search(query, true) should include cosmo.* modules")
   else
     io.stderr:write("SKIP: test_search_includes_cosmo_when_requested content assertions (no docs available)\n")
@@ -338,11 +338,11 @@ test_search_includes_cosmo_when_requested()
 
 -- Test that explicit cosmo module lookup still works
 local function test_explicit_cosmo_access()
-  local result = docs.query("cosmo.unix")
-  assert(result, "run should return a result")
-  if docs.has_docs() then
-    assert(result.ok, "explicit cosmo.unix lookup should succeed")
-    assert(result.output:match("unix"), "output should contain unix content")
+  local output, qerr = docs.query("cosmo.unix")
+  assert(output ~= nil or qerr ~= nil, "run should return output or a message")
+  if docs.is_available() then
+    assert(output ~= nil, "explicit cosmo.unix lookup should succeed")
+    assert((output or qerr):match("unix"), "output should contain unix content")
   else
     io.stderr:write("SKIP: test_explicit_cosmo_access content assertions (no docs available)\n")
   end
@@ -352,19 +352,17 @@ test_explicit_cosmo_access()
 
 -- Test symbol lookup finds re-exported record methods (bug 1) and quick example (bug 3)
 local function test_run_reexported_and_quick_example()
-  if not docs.has_docs() then print("test_run_reexported_and_quick_example: PASS (skipped)"); return end
+  if not docs.is_available() then print("test_run_reexported_and_quick_example: PASS (skipped)"); return end
   local r = docs.query("cosmic.sqlite.query")
-  assert(r, "run should return result")
-  if r.ok then assert(r.output:match("query"), "should find query method") end
+  if r then assert(r:match("query"), "should find query method") end
   local idx = check.must(docs.embedded_index())
   local test_mod: string = nil
   for mod_name, mod_doc in pairs(idx.modules) do
     if mod_doc.examples and #mod_doc.examples > 0 then test_mod = mod_name; break end
   end
   if test_mod then
-    local mr = docs.query(test_mod)
-    assert(mr and mr.ok, "module lookup should succeed")
-    assert(mr.output:match("Quick example"), "should have Quick example section")
+    local mr = check.must(docs.query(test_mod))
+    assert(mr:match("Quick example"), "should have Quick example section")
   end
   print("test_run_reexported_and_quick_example: PASS")
 end

--- a/cosmic/doc/types.tl
+++ b/cosmic/doc/types.tl
@@ -80,12 +80,6 @@ local record doc_types
     description: string
   end
 
-  --- Result from a docs operation.
-  record DocsResult
-    ok: boolean
-    output: string
-  end
-
 end
 
 return doc_types


### PR DESCRIPTION
Third #1001 slice: the doc item. (Slices 1–2 merged as #1036 and #1038; embed and literal/codec remain.)

## The surface

- **`DocsResult {ok, output}` is gone** — the exact success-text-or-error-text-by-flag anti-pattern the same file documents `render_file` shedding. `query`, `guide` (was `show_guide`), and `module_examples` (was `show_module_examples`) return `string | nil, string`: the rendered page, or nil plus the not-found message.
- **Noun names**: `has_docs` → `is_available` (rule 3); `list_topics`/`list_guides`/`list_guide_topics` → `topics`/`guides`/`guide_topics`; the `show_*` verbs → their nouns.
- The rule-10 type exports this issue asks for were already landed by #1034's split; the record's comment now names the retired shape so the shape decision doesn't re-open.

## The pin seam

The dispatcher (`--docs`, `--examples`, the REPL's `help()`) and `--help` are boot-checked by the pin against its embedded `DocsResult`-shaped record, so they reach doc through a transitional `_cli/doc_compat.tl` shim: erasure with runtime fallbacks to the pin's spellings, plus a `paired()` normalizer that converts a pin-shaped `DocsResult` into the pair at gen-0. One file, deleted whole at the pin advance — the same pattern as `_cli/teal_compat.tl`, including its relearned lesson that the pin's parser rejects an anonymous function type after `as` inside a table constructor (and `?` inside a cast's function type), so the casts sit in statement position.

## Verification

- `bin/cosmic --make ci` → `ci: PASS (5 stages)`; the branch's first gate ran from a cold `o/`, exercising the pin-boot compile of the shim and both converted `_cli` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_