### PR TITLE
embed sheds EmbedResult and the module-name stutter (#1001, slice 4)

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -10,11 +10,12 @@ _cli/build/work.tl 148 169
 _cli/check.tl 24 31
 _cli/doc_compat.tl 16 26
 _cli/driver.tl 21 34
+_cli/embed_compat.tl 15 25
 _cli/grants.tl 158 168
 _cli/help.tl 46 48
 _cli/lint.tl 190 215
 _cli/lint_render.tl 26 26
-_cli/main_handlers.tl 11 220
+_cli/main_handlers.tl 11 221
 _cli/pattern_args.tl 132 135
 _cli/require_hints.tl 104 124
 _cli/run.tl 28 33
@@ -120,7 +121,7 @@ cosmic/doc/types.tl 2 2
 cosmic/doc/visibility.tl 17 17
 cosmic/embed/extract.tl 31 59
 cosmic/embed/floor.tl 33 38
-cosmic/embed/init.tl 149 187
+cosmic/embed/init.tl 143 180
 cosmic/env.tl 24 34
 cosmic/errno.tl 17 26
 cosmic/fd.tl 95 118
@@ -204,4 +205,4 @@ cosmic/user.tl 48 61
 cosmic/uuid.tl 9 9
 cosmic/zip.tl 72 85
 tlconfig.lua 7 7
-total 14825 19461
+total 14834 19480

--- a/_cli/embed_compat.tl
+++ b/_cli/embed_compat.tl
@@ -1,0 +1,63 @@
+--- TRANSITIONAL embed compatibility (#1001; DELETE this module at the
+--- pin advance): the pin boot-executes `_make`'s artifact staging and
+--- `_cli`'s --embed/--extract handlers against ITS embedded
+--- cosmic.embed — `embed`/EmbedResult{ok, message, file_count},
+--- positional extract exe_path, `EPOCH` — while the tree's record has
+--- `write`/`extract` returning `integer | nil, string`, an
+--- ExtractOptions record, and `EPOCH_SECONDS`. These wrappers detect
+--- the generation at runtime and normalize both the arguments and the
+--- result, so one caller shape runs under both.
+local embed = require("cosmic.embed")
+
+local record EmbedCompat
+  write: function(paths: {string}, opts?: embed.Options): integer | nil, string
+  extract: function(output_dir: string, exe_path?: string): integer | nil, string
+  EPOCH_SECONDS: integer
+end
+
+local embed_any = embed as {string: any} -- cast: transitional dual-shape module
+
+--- Normalize a pin-shaped EmbedResult (or a tree-shaped pair) into
+--- the pair.
+local function counted(r: any, err: any): integer | nil, string
+  if r == nil then
+    return nil, err as string -- cast: transitional dual-shape result
+  end
+  if r is number then
+    return math.tointeger(r)
+  end
+  local rec = r as {string: any} -- cast: transitional dual-shape result
+  if rec["ok"] then
+    return rec["file_count"] as integer -- cast: transitional dual-shape result
+  end
+  return nil, rec["message"] as string -- cast: transitional dual-shape result
+end
+
+local function compat_write(paths: {string}, opts?: embed.Options): integer | nil, string
+  -- cast: transitional dual-shape call
+  local call = (embed_any["write"] or embed_any["embed"]) as
+  function({string}, embed.Options): (any, any)
+  return counted(call(paths, opts))
+end
+
+local function compat_extract(output_dir: string, exe_path?: string): integer | nil, string
+  if embed_any["write"] then
+    -- The tree generation: extract takes an options record.
+    -- cast: transitional dual-shape call
+    local call = embed_any["extract"] as
+    function(string, {string: string}): (any, any)
+    return counted(call(output_dir, exe_path and {exe_path = exe_path} or nil))
+  end
+  -- cast: transitional dual-shape call
+  local call = embed_any["extract"] as function(string, string): (any, any)
+  return counted(call(output_dir, exe_path))
+end
+
+local M: EmbedCompat = {
+  write = compat_write,
+  extract = compat_extract,
+  -- cast: transitional dual-shape member
+  EPOCH_SECONDS = (embed_any["EPOCH_SECONDS"] or embed_any["EPOCH"]) as integer,
+}
+
+return M

--- a/_cli/main_handlers.tl
+++ b/_cli/main_handlers.tl
@@ -2,12 +2,6 @@
 --- Each handler implements one CLI command flag.
 local instrument = require("cosmic.instrument")
 
---- Result from running docs command.
-local record DocsRunResult
-  ok: boolean
-  output: string
-end
-
 --- Generate welcome message for first-run experience.
 --- @return string The welcome message text
 local function generate_welcome(): string
@@ -57,25 +51,6 @@ local function load_script_file(script_path: string): function(...: any): any ..
   else
     return loadfile(script_path)
   end
-end
-
---- Run docs command with smart matching.
---- @param query string The query string
---- @return DocsRunResult Result with ok status and output text
-local function run_docs(query: string): DocsRunResult
-  local docs = require("cosmic.doc")
-  local doc_compat = require("_cli.doc_compat")
-  local out, qerr = doc_compat.query(query)
-  if out then
-    return {ok = true, output = out}
-  end
-
-  local results = docs.search(query)
-  if #results > 0 then
-    return {ok = true, output = docs.render_search_results(results, query)}
-  end
-
-  return {ok = false, output = qerr}
 end
 
 --- Handle --version flag.
@@ -263,18 +238,26 @@ end
 
 --- Handle --embed flag.
 local function handle_embed(paths: {string}, output: string, exe?: string): integer
-  local embed = require("cosmic.embed")
-  local result = embed.embed(paths, {output = output, exe_path = exe})
-  io.write(result.message .. "\n")
-  return result.ok and 0 or 1
+  local embed = require("_cli.embed_compat")
+  local n, werr = embed.write(paths, {output = output, exe_path = exe})
+  if not n then
+    io.write((werr or "error: embed failed") .. "\n")
+    return 1
+  end
+  io.write("embedded " .. n .. " file(s) into " .. (output or "cosmic") .. "\n")
+  return 0
 end
 
 --- Handle --extract flag.
 local function handle_extract(dir: string, exe?: string): integer
-  local embed = require("cosmic.embed")
-  local result = embed.extract(dir, exe)
-  io.write(result.message .. "\n")
-  return result.ok and 0 or 1
+  local embed = require("_cli.embed_compat")
+  local n, xerr = embed.extract(dir, exe)
+  if not n then
+    io.write((xerr or "error: extract failed") .. "\n")
+    return 1
+  end
+  io.write("extracted " .. n .. " file(s) to " .. dir .. "\n")
+  return 0
 end
 
 --- Handle --check example flag.
@@ -321,22 +304,26 @@ local function handle_benchmark(spec: string): integer
   return result.exit_code
 end
 
---- Handle --docs flag.
+--- Handle --docs flag: exact lookup first, then search fallback.
 local function handle_docs(query: string): integer
-  if query == "" then
-    local docs = require("_cli.doc_compat")
-    local out, qerr = docs.query("")
-    io.write((out or qerr) .. "\n")
-    return out and 0 or 1
-  else
-    local result = run_docs(query)
-    if result.ok then
-      io.write(result.output .. "\n")
-      return 0
-    else
-      io.stderr:write(result.output .. "\n")
-      return 1
+  local doc_compat = require("_cli.doc_compat")
+  local out, qerr = doc_compat.query(query)
+  if not out and query ~= "" then
+    local docs = require("cosmic.doc")
+    local results = docs.search(query)
+    if #results > 0 then
+      out = docs.render_search_results(results, query)
     end
+  end
+  if out then
+    io.write(out .. "\n")
+    return 0
+  elseif query == "" then
+    io.write((qerr or "error: no documentation found") .. "\n")
+    return 1
+  else
+    io.stderr:write((qerr or "error: no documentation found") .. "\n")
+    return 1
   end
 end
 
@@ -459,7 +446,6 @@ local record HandlersModule
   generate_welcome: function(): string
   run_repl: function()
   load_script_file: function(script_path: string): function(...: any): any ... | nil, string
-  run_docs: function(query: string): DocsRunResult
   handle_version: function(): integer
   handle_compile: function(file: string, output?: string, write_if_changed?: boolean, include_dirs?: {string}, strict?: boolean): integer, string
   handle_format: function(file: string, output?: string, write_if_changed?: boolean): integer, string
@@ -480,7 +466,6 @@ local M: HandlersModule = {
   generate_welcome = generate_welcome,
   run_repl = run_repl,
   load_script_file = load_script_file,
-  run_docs = run_docs,
   handle_version = handle_version,
   handle_compile = handle_compile,
   handle_format = handle_format,

--- a/_make/artifact.tl
+++ b/_make/artifact.tl
@@ -21,7 +21,8 @@
 --- (`_make.generate` runs once per project, before any binary stages).
 
 local bytecode = require("_make.bytecode")
-local embed = require("cosmic.embed")
+-- Through the transitional pin-compat shim (#1001; see _cli/embed_compat).
+local embedc = require("_cli.embed_compat")
 local fs = require("cosmic.fs")
 local project = require("_make.project")
 local types = require("_make.types")
@@ -309,7 +310,7 @@ end
 --- Copy the plan into a staging directory under `o/`.
 ---
 --- Staging to disk rather than handing `embed` a list of (content,
---- name) pairs keeps one code path: `embed.embed` on a directory stores
+--- name) pairs keeps one code path: `embed.write` on a directory stores
 --- everything relative to that directory's root, which is exactly the
 --- artifact layout once the plan has named it.
 --- @param proj Project The scanned project
@@ -463,12 +464,12 @@ local function build(proj: Project, binary: Binary, cosmic: string): string | ni
     -- base's copy as well would ship two standard libraries, with the
     -- project's winning on package.path and the base's riding along.
     local staged_out = out .. ".new"
-    local result = embed.embed({dir},
+    local count, aerr = embedc.write({dir},
       {output = staged_out, exe_path = pair[2], strip = true,
-        provides = validate.claims(proj), mtime = embed.EPOCH})
-    if not result.ok then
+        provides = validate.claims(proj), mtime = embedc.EPOCH_SECONDS})
+    if not count then
       local _ok, _err = fs.unlink(staged_out)
-      return nil, "make: " .. binary.name .. pair[1] .. ": " .. result.message
+      return nil, "make: " .. binary.name .. pair[1] .. ": " .. (aerr or "embed failed")
     end
     local rerr = replace_if_changed(staged_out, out)
     if rerr then

--- a/_make/artifact.tl
+++ b/_make/artifact.tl
@@ -21,8 +21,7 @@
 --- (`_make.generate` runs once per project, before any binary stages).
 
 local bytecode = require("_make.bytecode")
--- Through the transitional pin-compat shim (#1001; see _cli/embed_compat).
-local embedc = require("_cli.embed_compat")
+local embedc = require("_cli.embed_compat") -- pin-compat shim (#1001)
 local fs = require("cosmic.fs")
 local project = require("_make.project")
 local types = require("_make.types")

--- a/_make/testrun.tl
+++ b/_make/testrun.tl
@@ -13,7 +13,8 @@
 --- without lying about the other. Spawning `o/bin/<name>` covers
 --- those, and stays the way to exercise a binary's CLI surface.
 
-local embed = require("cosmic.embed")
+-- Through the transitional pin-compat shim (#1001; see _cli/embed_compat).
+local embedc = require("_cli.embed_compat")
 local fs = require("cosmic.fs")
 local artifact = require("_make.artifact")
 local project = require("_make.project")
@@ -105,11 +106,11 @@ local function build(proj: Project, cosmic: string): boolean, string
     end
   end
   local staged_out = PATH .. ".new"
-  local result = embed.embed({dir},
-    {output = staged_out, exe_path = cosmic, mtime = embed.EPOCH})
-  if not result.ok then
+  local count, terr = embedc.write({dir},
+    {output = staged_out, exe_path = cosmic, mtime = embedc.EPOCH_SECONDS})
+  if not count then
     local _ok, _err = fs.unlink(staged_out)
-    return false, "make: test runner: " .. result.message
+    return false, "make: test runner: " .. (terr or "embed failed")
   end
   local rerr = artifact.replace_if_changed(staged_out, PATH)
   if rerr then

--- a/_make/testrun.tl
+++ b/_make/testrun.tl
@@ -13,8 +13,7 @@
 --- without lying about the other. Spawning `o/bin/<name>` covers
 --- those, and stays the way to exercise a binary's CLI surface.
 
--- Through the transitional pin-compat shim (#1001; see _cli/embed_compat).
-local embedc = require("_cli.embed_compat")
+local embedc = require("_cli.embed_compat") -- pin-compat shim (#1001)
 local fs = require("cosmic.fs")
 local artifact = require("_make.artifact")
 local project = require("_make.project")

--- a/_perf/bench/embed_bench.tl
+++ b/_perf/bench/embed_bench.tl
@@ -18,13 +18,6 @@ local pt = require("_perf.perf_types")
 local DIRS = 120
 local FILES_PER_DIR = 5
 
--- Mirrors cosmic.embed's EmbedResult shape (not exported by that module).
-local record EmbedResult
-  ok: boolean
-  message: string
-  file_count: integer
-end
-
 local tmpdir: string
 local srcdir: string
 local packed_exe: string
@@ -140,16 +133,17 @@ local function scenarios(): {pt.Scenario}, string
       -- per-file slurp/embed cost.
       name = "embed_run_tree",
       fn = function(_: any): any
-        return embed.embed({srcdir}, {output = packed_exe, exe_path = bin})
+        -- Parenthesized: the pair collapses to the count the check reads.
+        return (embed.write({srcdir}, {output = packed_exe, exe_path = bin}))
       end,
       check = function(_: any, res: any): boolean, string
-        local r = res as EmbedResult -- cast: from any
-        if not r.ok then
-          return false, "embed.embed failed"
+        local count = res as integer -- cast: from any
+        if not count then
+          return false, "embed.write failed"
         end
-        if r.file_count ~= total_files then
+        if count ~= total_files then
           return false, string.format("embedded %d files, want %d",
-            r.file_count, total_files)
+            count, total_files)
         end
         return true
       end,
@@ -161,9 +155,9 @@ local function scenarios(): {pt.Scenario}, string
       -- from the archive read/write cost.
       name = "embed_extract_tree",
       setup = function(): any, string
-        local result = embed.embed({srcdir}, {output = packed_exe, exe_path = bin})
-        if not result.ok then
-          return nil, "embed.embed: " .. tostring(result.message)
+        local count, werr = embed.write({srcdir}, {output = packed_exe, exe_path = bin})
+        if not count then
+          return nil, "embed.write: " .. tostring(werr)
         end
         local expected, cerr = count_zip_files(packed_exe)
         if not expected then
@@ -172,17 +166,18 @@ local function scenarios(): {pt.Scenario}, string
         return expected
       end,
       fn = function(_: any): any
-        return embed.extract(extract_dir, packed_exe)
+        -- Parenthesized: the pair collapses to the count the check reads.
+        return (embed.extract(extract_dir, {exe_path = packed_exe}))
       end,
       check = function(ctx: any, res: any): boolean, string
-        local r = res as EmbedResult -- cast: from any
+        local count = res as integer -- cast: from any
         local expected = ctx as integer -- cast: from any
-        if not r.ok then
+        if not count then
           return false, "embed.extract failed"
         end
-        if r.file_count ~= expected then
+        if count ~= expected then
           return false, string.format("extracted %d files, want %d",
-            r.file_count, expected)
+            count, expected)
         end
         return true
       end,

--- a/_perf/bench/embed_startup_bench.tl
+++ b/_perf/bench/embed_startup_bench.tl
@@ -1,6 +1,6 @@
---- Startup of an embed.embed()-produced executable.
+--- Startup of an embed.write()-produced executable.
 ---
---- embed.embed() bundles a user app into a copy of the cosmic binary; the
+--- embed.write() bundles a user app into a copy of the cosmic binary; the
 --- produced executable boots into the embedded main.lua, which loads the
 --- app's other embedded .lua modules. Whatever compression those modules
 --- carry is paid back as inflate() calls on every launch of the app — the
@@ -126,9 +126,9 @@ local function scenarios(): {pt.Scenario}, string
   -- Build the embedded executable once: the per-op cost is its startup,
   -- not the (fixed, megabyte-scale) embed operation.
   packed_exe = fs.join(tmpdir, "packed")
-  local res = embed.embed({appdir}, {output = packed_exe, exe_path = bin})
-  if not res.ok then
-    return nil, "embed.embed: " .. tostring(res.message)
+  local count, werr = embed.write({appdir}, {output = packed_exe, exe_path = bin})
+  if not count then
+    return nil, "embed.write: " .. tostring(werr)
   end
 
   local want = SENTINEL .. ":" .. tostring(expected_sum)

--- a/_tool/doc/init_test.tl
+++ b/_tool/doc/init_test.tl
@@ -438,10 +438,10 @@ end
 test_embed_has_module_doc()
 
 local function test_embed_has_type_descriptions()
-  -- EmbedResult is declared in the extraction half; init.tl aliases it.
+  -- ExtractOptions is declared in the extraction half; init.tl aliases it.
   local md = check.must(doc.render_file("cosmic/embed/extract.tl"), "should read embed/extract.tl")
-  -- EmbedResult should have a description, not just a bare header
-  assert(md:find("### EmbedResult\n\n[^#]"), "EmbedResult should have description")
+  -- ExtractOptions should have a description, not just a bare header
+  assert(md:find("### ExtractOptions\n\n[^#]"), "ExtractOptions should have description")
 end
 test_embed_has_type_descriptions()
 

--- a/cosmic/embed/extract.tl
+++ b/cosmic/embed/extract.tl
@@ -8,23 +8,26 @@
 local czip = require("cosmic.zip")
 local fs = require("cosmic.fs")
 
---- Result returned from embed and extract operations.
-local record EmbedResult
-  ok: boolean
-  message: string
-  file_count: integer
+--- Options for extract (#1001: was a bare positional exe_path).
+local record ExtractOptions
+  --- Path to the executable to extract (default arg[-1], the running
+  --- binary).
+  exe_path: string
 end
 
 --- Extract the zip contents of a cosmic executable to a directory.
---- Creates the output directory if needed. Existing files are overwritten.
+--- Creates the output directory if needed. Existing files are
+--- overwritten. Returns the extracted file count (#1001: EmbedResult's
+--- success-or-error-text-by-flag record is gone).
 --- @param output_dir string Directory to extract into
---- @param exe_path string Path to the executable to extract (defaults to arg[-1])
---- @return EmbedResult Result with ok status, message, and file count
-local function extract(output_dir: string, exe_path?: string): EmbedResult
-  exe_path = exe_path or arg[-1]
+--- @param opts ExtractOptions? exe_path: the executable to extract
+--- @return integer | nil The extracted file count, or nil on failure
+--- @return string? Error message on failure
+local function extract(output_dir: string, opts?: ExtractOptions): integer | nil, string
+  local exe_path = (opts and opts.exe_path) or arg[-1]
 
   if not exe_path then
-    return {ok = false, message = "error: could not determine executable path", file_count = 0}
+    return nil, "error: could not determine executable path"
   end
 
   -- Open straight from the path: reading the whole executable into a
@@ -36,9 +39,9 @@ local function extract(output_dir: string, exe_path?: string): EmbedResult
   local archive_maybe = czip.open(exe_path)
   if not archive_maybe then
     if not fs.read(exe_path) then
-      return {ok = false, message = "error: cannot read executable '" .. exe_path .. "'", file_count = 0}
+      return nil, "error: cannot read executable '" .. exe_path .. "'"
     end
-    return {ok = false, message = "error: no zip archive found in '" .. exe_path .. "'", file_count = 0}
+    return nil, "error: no zip archive found in '" .. exe_path .. "'"
   end
   local archive = archive_maybe
 
@@ -47,8 +50,8 @@ local function extract(output_dir: string, exe_path?: string): EmbedResult
   local entries, lerr = archive:list()
   if not entries then
     archive:close()
-    return {ok = false, message = "error: cannot list '" .. exe_path .. "': " ..
-      (lerr or "unknown error"), file_count = 0}
+    return nil, "error: cannot list '" .. exe_path .. "': " ..
+      (lerr or "unknown error")
   end
   local count = 0
   for _, entry in ipairs(entries) do
@@ -60,19 +63,15 @@ local function extract(output_dir: string, exe_path?: string): EmbedResult
   local ok, err = czip.extract(archive, output_dir)
   archive:close()
   if not ok then
-    return {ok = false, message = "error: " .. (err or "extract failed"), file_count = 0}
+    return nil, "error: " .. (err or "extract failed")
   end
 
-  return {
-    ok = true,
-    message = "extracted " .. count .. " file(s) to " .. output_dir,
-    file_count = count,
-  }
+  return count
 end
 
 local record ExtractModule
-  type EmbedResult = EmbedResult
-  extract: function(output_dir: string, exe_path?: string): EmbedResult
+  type ExtractOptions = ExtractOptions
+  extract: function(output_dir: string, opts?: ExtractOptions): integer | nil, string
 end
 
 local M: ExtractModule = {

--- a/cosmic/embed/extract.tl
+++ b/cosmic/embed/extract.tl
@@ -51,7 +51,7 @@ local function extract(output_dir: string, opts?: ExtractOptions): integer | nil
   if not entries then
     archive:close()
     return nil, "error: cannot list '" .. exe_path .. "': " ..
-      (lerr or "unknown error")
+    (lerr or "unknown error")
   end
   local count = 0
   for _, entry in ipairs(entries) do

--- a/cosmic/embed/init.tl
+++ b/cosmic/embed/init.tl
@@ -48,7 +48,7 @@ local Stat = fs_types.Stat
 local floor = require("cosmic.embed.floor")
 local extract_mod = require("cosmic.embed.extract")
 
---- Options for run().
+--- Options for write().
 local record Options
   --- Output path for the new executable (default "cosmic").
   output: string
@@ -69,11 +69,6 @@ local record Options
   --- one tree agree byte-for-byte.
   mtime: integer
 end
-
---- Result returned from embed and extract operations. The extraction
---- half declares the same shape; this is the one the module surface
---- publishes.
-local type EmbedResult = extract_mod.EmbedResult
 
 local type EmbedDirHandle = fs_types.DirHandle
 
@@ -264,18 +259,21 @@ end
 --- with their given path (leading / stripped).
 --- @param paths {string} List of file or directory paths to embed
 --- @param opts Options? output, exe_path, stripping, reproducibility
---- @return EmbedResult Result with ok status, message, and file count
-local function embed(paths: {string}, opts?: Options): EmbedResult
+--- @return integer | nil The embedded file count, or nil on failure (#1001:
+--- was `embed` returning EmbedResult — the module-name stutter and the
+--- success-or-error-text-by-flag record leave together)
+--- @return string? Error message on failure
+local function write(paths: {string}, opts?: Options): integer | nil, string
   opts = opts or {}
   local output = opts.output or "cosmic"
   local exe_path = opts.exe_path or arg[-1]
 
   if not exe_path then
-    return {ok = false, message = "error: could not determine executable path", file_count = 0}
+    return nil, "error: could not determine executable path"
   end
 
   if #paths == 0 then
-    return {ok = false, message = "error: no files specified", file_count = 0}
+    return nil, "error: no files specified"
   end
 
   -- Collect all files to embed, resolving directories recursively
@@ -285,7 +283,7 @@ local function embed(paths: {string}, opts?: Options): EmbedResult
     if fs.is_dir(p) then
       local dir_files, err = collect_dir(p)
       if not dir_files then
-        return {ok = false, message = "error: " .. (err or "unknown error"), file_count = 0}
+        return nil, "error: " .. (err or "unknown error")
       end
       for _, f in ipairs(dir_files) do
         files_to_embed[#files_to_embed + 1] = f
@@ -293,7 +291,7 @@ local function embed(paths: {string}, opts?: Options): EmbedResult
     else
       local content, open_err = fs.read(p)
       if not content then
-        return {ok = false, message = "error: cannot open file '" .. p .. "': " .. (open_err or "unknown error"), file_count = 0}
+        return nil, "error: cannot open file '" .. p .. "': " .. (open_err or "unknown error")
       end
 
       local stored_name = p:gsub("^/+", "")
@@ -315,12 +313,12 @@ local function embed(paths: {string}, opts?: Options): EmbedResult
   end
 
   if #files_to_embed == 0 then
-    return {ok = false, message = "error: no files found to embed", file_count = 0}
+    return nil, "error: no files found to embed"
   end
 
   local wrap_err = wrap_user_main(files_to_embed, exe_path)
   if wrap_err then
-    return {ok = false, message = wrap_err, file_count = 0}
+    return nil, wrap_err
   end
 
   -- Build in a temp file, then atomically rename into place.
@@ -329,14 +327,14 @@ local function embed(paths: {string}, opts?: Options): EmbedResult
   -- mappings for code pages; overwriting the file invalidates those pages).
   local tmp_fd, tmp_path = unix.mkstemp(output .. ".XXXXXX")
   if not tmp_fd then
-    return {ok = false, message = "error: cannot create temp file near '" .. output .. "'", file_count = 0}
+    return nil, "error: cannot create temp file near '" .. output .. "'"
   end
   unix.close(tmp_fd)
 
   local copy_ok, copy_err = fs.copy(exe_path, tmp_path)
   if not copy_ok then
     local _ok, _err = fs.remove(tmp_path)
-    return {ok = false, message = "error: cannot copy '" .. exe_path .. "' to '" .. tmp_path .. "': " .. (copy_err or "unknown error"), file_count = 0}
+    return nil, "error: cannot copy '" .. exe_path .. "' to '" .. tmp_path .. "': " .. (copy_err or "unknown error")
   end
   unix.chmod(tmp_path, tonumber("755", 8))
 
@@ -346,7 +344,7 @@ local function embed(paths: {string}, opts?: Options): EmbedResult
   local appender_maybe, appender_err = czip.open(tmp_path, {mode = "append"})
   if not appender_maybe then
     local _ok, _err = fs.remove(tmp_path)
-    return {ok = false, message = "error: failed to open zip for appending: " .. tostring(appender_err or "unknown error"), file_count = 0}
+    return nil, "error: failed to open zip for appending: " .. tostring(appender_err or "unknown error")
   end
   local appender = appender_maybe
 
@@ -400,7 +398,7 @@ local function embed(paths: {string}, opts?: Options): EmbedResult
     if not add_ok then
       appender:close()
       local _ok, _err = fs.remove(tmp_path)
-      return {ok = false, message = "error: failed to add '" .. file_info.stored_name .. "' to zip: " .. tostring(add_err or "unknown error"), file_count = 0}
+      return nil, "error: failed to add '" .. file_info.stored_name .. "' to zip: " .. tostring(add_err or "unknown error")
     end
   end
 
@@ -411,30 +409,26 @@ local function embed(paths: {string}, opts?: Options): EmbedResult
   local rename_ok, rename_err = fs.move(tmp_path, output)
   if not rename_ok then
     local _ok, _err = fs.remove(tmp_path)
-    return {ok = false, message = "error: cannot rename temp file to '" .. output .. "': " .. tostring(rename_err or "unknown"), file_count = 0}
+    return nil, "error: cannot rename temp file to '" .. output .. "': " .. tostring(rename_err or "unknown")
   end
 
-  return {
-    ok = true,
-    message = "embedded " .. #files_to_embed .. " file(s) into " .. output,
-    file_count = #files_to_embed,
-  }
+  return #files_to_embed
 end
 
 local record EmbedModule
   --- Exported so callers can name options and results; type aliases,
   --- not runtime values.
   type Options = Options
-  type EmbedResult = EmbedResult
+  type ExtractOptions = extract_mod.ExtractOptions
 
-  EPOCH: integer
-  embed: function(paths: {string}, opts?: Options): EmbedResult
-  extract: function(output_dir: string, exe_path?: string): EmbedResult
+  EPOCH_SECONDS: integer
+  write: function(paths: {string}, opts?: Options): integer | nil, string
+  extract: function(output_dir: string, opts?: extract_mod.ExtractOptions): integer | nil, string
 end
 
 local M: EmbedModule = {
-  EPOCH = floor.epoch(),
-  embed = embed,
+  EPOCH_SECONDS = floor.epoch(),
+  write = write,
   extract = extract_mod.extract,
 }
 

--- a/cosmic/embed_advanced_test.tl
+++ b/cosmic/embed_advanced_test.tl
@@ -298,9 +298,9 @@ local function test_extract_rejects_path_traversal()
   assert(fs.write(malicious, patched))
 
   local outdir = fs.join(tmpdir, "extract-target")
-  local result = embed.extract(outdir, malicious)
-  assert(not result.ok, "extract should reject path traversal entry")
-  assert(result.message:match("unsafe path"), "expected unsafe path error, got: " .. result.message)
+  local count, xerr = embed.extract(outdir, {exe_path = malicious})
+  assert(not count, "extract should reject path traversal entry")
+  assert(xerr:match("unsafe path"), "expected unsafe path error, got: " .. xerr)
 
   -- The escaping file must not have been written next to the target dir.
   local escaped = fs.join(tmpdir, "escaped.txt")
@@ -316,17 +316,17 @@ local function test_extract_failure_messages_distinguish_causes()
   local outdir = fs.join(tmpdir, "extract-fail-target")
 
   local missing = fs.join(tmpdir, "does-not-exist.bin")
-  local result = embed.extract(outdir, missing)
-  assert(not result.ok, "extract of a missing path must fail")
-  assert(result.message:find("cannot read executable", 1, true),
-    "missing file reports the read error, got: " .. result.message)
+  local count, xerr = embed.extract(outdir, {exe_path = missing})
+  assert(not count, "extract of a missing path must fail")
+  assert(xerr:find("cannot read executable", 1, true),
+    "missing file reports the read error, got: " .. xerr)
 
   local notzip = fs.join(tmpdir, "not-an-archive.bin")
   assert(fs.write(notzip, "just some bytes, no zip here"))
-  local result2 = embed.extract(outdir, notzip)
-  assert(not result2.ok, "extract of a non-archive must fail")
-  assert(result2.message:find("no zip archive found", 1, true),
-    "readable non-archive reports the archive error, got: " .. result2.message)
+  local count2, xerr2 = embed.extract(outdir, {exe_path = notzip})
+  assert(not count2, "extract of a non-archive must fail")
+  assert(xerr2:find("no zip archive found", 1, true),
+    "readable non-archive reports the archive error, got: " .. xerr2)
 end
 test_extract_failure_messages_distinguish_causes()
 
@@ -340,8 +340,8 @@ local function test_embed_symlink_loop_terminates()
   assert(fs.symlink("..", fs.join(appdir, "sub", "loop")))
 
   -- embed.collect_dir is called internally; run via the module directly
-  local result = embed.embed({appdir}, {output = fs.join(tmpdir, "cosmic-symlinkloop"), exe_path = cosmic})
-  assert(result.ok, "embed of dir with symlink loop should succeed: " .. (result.message or ""))
+  local count, werr = embed.write({appdir}, {output = fs.join(tmpdir, "cosmic-symlinkloop"), exe_path = cosmic})
+  assert(count, "embed of dir with symlink loop should succeed: " .. (werr or ""))
   -- Only real.txt should be embedded, not any path through the loop
   local data = fs.read(fs.join(tmpdir, "cosmic-symlinkloop"))
   local reader = check.must(zip.open_string(data))
@@ -365,8 +365,8 @@ local function test_embed_symlink_to_outside_file_skipped()
   -- Symlink inside the embed dir pointing outside
   assert(fs.symlink(outside, fs.join(appdir, "leaked.txt")))
 
-  local result = embed.embed({appdir}, {output = fs.join(tmpdir, "cosmic-symlinkoutside"), exe_path = cosmic})
-  assert(result.ok, "embed should succeed even with outside symlink: " .. (result.message or ""))
+  local count, werr = embed.write({appdir}, {output = fs.join(tmpdir, "cosmic-symlinkoutside"), exe_path = cosmic})
+  assert(count, "embed should succeed even with outside symlink: " .. (werr or ""))
   -- "leaked.txt" (the symlink) must not appear in the zip
   local data = fs.read(fs.join(tmpdir, "cosmic-symlinkoutside"))
   local reader = check.must(zip.open_string(data))


### PR DESCRIPTION
Fourth #1001 slice: the embed item. (Slices 1–3 merged as #1036, #1038, #1039; literal/codec remains.)

## The surface

- **`embed.embed` → `embed.write`** — the module-name stutter goes, and with it `EmbedResult {ok, message, file_count}`, one record meaning success-text or error-text by flag. `write(paths, opts?)` and `extract(output_dir, opts?)` return `integer | nil, string`: the file count, or nil plus the message.
- **`extract`'s bare positional `exe_path` → `ExtractOptions`** (rule 7), declared in the extraction shard and re-exported.
- **`EPOCH` → `EPOCH_SECONDS`** (rule 2).
- The success sentences ("embedded N file(s) into X") move to the one place that prints them — the dispatcher's handlers — instead of riding inside the library's return value.
- The missing `Appender:has(name)` the issue notes stays with the zip issue's `Archive`, per the issue.

## The pin seam

`_make`'s artifact staging and test-runner staging execute under the pin at gen-0 against the pin's embed record, as do the `--embed`/`--extract` handlers — so all four routes go through a transitional `_cli/embed_compat.tl` shim that detects the generation, adapts extract's argument shape (options record vs. positional path), normalizes a pin-shaped `EmbedResult` into the pair, and carries `EPOCH_SECONDS` over the pin's `EPOCH`. One file, deleted whole at the pin advance, joining `teal_compat` and `doc_compat`.

## Also

- The two `_perf` bench scenarios read the returned count instead of the record — the measured work is unchanged.
- `main_handlers` came out 15 lines lighter: the `DocsRunResult`/`run_docs` indirection from the doc slice folded into `handle_docs`, paying for the embed handlers' growth under the 500-line cap.

## Verification

- `bin/cosmic --make ci` → `ci: PASS (5 stages)`; the branch's first gate ran from a cold `o/`, exercising the gen-0 staging path through the shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_