### PR TITLE
docs: derive the module tables; shrink stdlib.md to what only it can say (#1003)

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -11,6 +11,7 @@ _cli/check.tl 24 31
 _cli/doc_compat.tl 16 26
 _cli/driver.tl 21 34
 _cli/embed_compat.tl 15 25
+_cli/env_vars.tl 68 68
 _cli/grants.tl 158 168
 _cli/help.tl 46 48
 _cli/lint.tl 190 215
@@ -206,4 +207,4 @@ cosmic/user.tl 48 61
 cosmic/uuid.tl 9 9
 cosmic/zip.tl 72 85
 tlconfig.lua 7 7
-total 14834 19494
+total 14902 19562

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,53 +356,55 @@ all modules are under `cosmic/` and imported as `cosmic.*`:
 
 | module | description |
 |--------|-------------|
-| ansi | ANSI terminal styling: colors, attributes, strip, NO_COLOR-aware gating |
-| check | assertion helpers for tests/examples (`equal`, `truthy`, `must`) plus environment-gating helpers (`needs`, `enforce_skip`, `enforcing`) |
-| child | child process spawning with I/O control |
-| codec | hex/base64/base32/Latin-1 encoding and CRC-32 checksums |
-| compress | zlib compression/decompression |
-| coverage | line coverage collection for cosmic programs (`--make coverage`) |
-| deep | deep copy/merge/structural equality for nested tables |
-| doc | query the embedded documentation index |
-| embed | create custom executables with embedded files |
-| env | environment variables: get (nil when unset), get_or, set/unset/list, dotenv parse/format and env.d loading |
-| errno | canonical errno formatting (`wrap`) and lookup helpers (`is`, `code`, `constants`) for `cosmo.unix` failures |
-| fetch | HTTP client with retry support |
-| flags | declarative command-line flag parsing with generated --help |
-| format | Teal/Lua code formatter |
-| fs | filesystem: paths, stat, walk, read/write, mkdir, symlink, tmp |
-| fuzzy | fuzzy string matching (edit distance) |
-| hash | SHA-256 digest and Argon2 password hashing |
-| html | HTML escaping |
-| instrument | timing/resource spans: emit `key=value` lines, and parse them back |
-| fd | file descriptor I/O: open/wrap handles, pipes |
-| ip | IP address parsing, formatting, classification |
-| json | JSON encode/decode |
-| log | leveled logging with key=value fields, to stderr or a custom sink (syslog included) |
-| net | TCP/UDP/Unix sockets |
-| poll | poll(2) wrapper for I/O multiplexing |
-| proc | current process: pid, exec, resource usage |
-| rand | cryptographic random bytes |
-| re | POSIX extended regular expressions |
-| sandbox | the in-process containment door: one fail-closed fs + sys policy (landlock/unveil/pledge are its internal shards) |
-| searcher | the runtime `.tl` package searcher every artifact installs at boot |
-| literal | read/write a Teal/Lua file as data: `return { … }` of literals, never executed |
-| quicksand | out-of-process containment: Linux namespace + allowlist-proxy boxes via quicksand.new |
-| shm | shared memory with atomic ops and futexes |
-| signal | signal handling, timers, sigsets |
-| sqlite | SQLite with ergonomic query/exec/transaction API |
-| sse | Server-Sent Events parser |
-| stream | the byte-stream Reader/Writer contract every producer and consumer composes over |
-| string | trim, split, capitalize, starts_with, etc. |
-| sys | OS/architecture detection, sysconf (nproc, page size), uname |
-| tar | extract a tarball (.tar.gz or plain .tar), in process |
-| teal | Teal compilation and type checking |
-| time | timestamps, sleep, clock, datetime |
-| tty | terminal detection, window size, termios |
-| url | URL encoding, parsing, escaping |
-| user | user/group identity |
-| uuid | UUIDv4 and UUIDv7 generation |
-| zip | ZIP archive reading and writing |
+| ansi | ANSI terminal styling. |
+| check | Assertion helpers for tests with auto-formatted failure messages. |
+| child | Child process management. |
+| codec | Encoding and decoding utilities: bytes in, bytes out. |
+| compress | Compression and decompression utilities. |
+| coverage | Line coverage collection for cosmic programs. |
+| deep | Deep table operations. |
+| deploy | Examples for deploying cosmic scripts. |
+| doc | Query the documentation index embedded in the binary. |
+| embed | Embed files and directories into a cosmic executable. |
+| env | Environment variables: get/set/unset/list, dotenv, and env.d loading. |
+| errno | Error information from system calls. |
+| errors | Examples for the error-handling doctrine every cosmic.* module follows. |
+| fd | File descriptor I/O operations. |
+| fetch | Structured HTTP fetch with retry, streaming, and honest error channels. |
+| flags | Declarative command-line flag parsing with a generated --help. |
+| format | Code formatter for Teal and Lua files. |
+| fs | Unified filesystem module. |
+| fuzzy | Fuzzy string matching utilities. |
+| hash | Cryptographic digests, HMAC, and Argon2 password hashing. |
+| html | HTML utilities. |
+| instrument | Timing and resource-usage spans, one `key=value` line each. |
+| ip | IP address parsing, formatting, and classification utilities. |
+| json | JSON encoding and decoding utilities. |
+| literal | Teal source read and written as data: one `return { … }` of literals. |
+| log | Leveled logging. |
+| net | Networking and socket utilities. |
+| poll | Typed interface for polling file descriptors. |
+| proc | Current process management. |
+| quicksand | Network + filesystem process isolation primitives. |
+| rand | Random bytes, integers, floats, choice, shuffle, and tokens. |
+| re | Regular expression matching using POSIX extended regex syntax. |
+| sandbox | One-call, fail-closed in-process sandbox: the one door (#989). |
+| searcher | The cosmic-owned runtime `.tl` package searcher, replacing tl.loader(). |
+| shm | Shared memory for inter-process communication. |
+| signal | Signal handling utilities. |
+| sqlite | Ergonomic SQLite wrapper with automatic cleanup and 1-indexed columns. |
+| sse | Server-Sent Events: parse a stream of them, format one for the wire. |
+| stream | The stream contract: byte-stream Reader/Writer interfaces. |
+| string | String utilities. |
+| sys | System information utilities. |
+| tar | In-process tarball extraction, without a host `tar`. |
+| teal | Teal compilation and type-checking. |
+| time | Time and clock utilities. |
+| tty | Terminal (TTY) utilities. |
+| url | URL encoding, decoding, parsing, formatting, and escaping utilities. |
+| user | User and group identity operations. |
+| uuid | UUID generation utilities. |
+| zip | ZIP archive reading and writing. |
 
 ## `--make` fixtures
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ hello.tl` checks without running. `./cosmic-lua -i` starts a REPL, and
   handling conventions
 - [docs/architecture.md](docs/architecture.md) — how the binary is put
   together
-- [docs/build.md](docs/build.md) — building custom executables with
-  embedded files
+- [docs/build.md](docs/build.md) — `cosmic --make`: how the build
+  system sees a project
 - [docs/contributing.md](docs/contributing.md) and
   [AGENTS.md](AGENTS.md) — developing cosmic itself
 - [whilp/cosmopolitan](https://github.com/whilp/cosmopolitan) — the

--- a/_build/docs_test.tl
+++ b/_build/docs_test.tl
@@ -37,4 +37,21 @@ local function test_the_decisions_index_matches_the_records()
 end
 test_the_decisions_index_matches_the_records()
 
+-- The module table says exactly what the doc index says — the same
+-- index `--help` renders its module list from, so AGENTS.md cannot
+-- describe a module differently than the binary does (#1003). A row's
+-- text is its module's H1 first line; fix a row at the module header.
+local function test_the_module_table_matches_the_doc_index()
+  local rendered = derive.modules_table()
+  local text = check.must(fs.read(derive.AGENTS))
+  local committed = derive.committed_table(text, derive.MODULES_HEAD)
+  assert(committed ~= "",
+    derive.AGENTS .. " has no `" .. derive.MODULES_HEAD .. "` table")
+  assert(committed == rendered,
+    derive.AGENTS .. " no longer matches the doc index.\n" ..
+    "Run `bin/cosmic _docs/derive.tl` to rewrite it.\n\ncommitted:\n" ..
+    committed .. "\n\nfrom the index:\n" .. rendered)
+end
+test_the_module_table_matches_the_doc_index()
+
 print("all derived-document tests passed")

--- a/_build/env_vars_test.tl
+++ b/_build/env_vars_test.tl
@@ -1,0 +1,101 @@
+#!/usr/bin/env cosmic
+--- reads: _cli _make _build _tool _docs _perf _types cosmic cmd embed bin
+-- Ratchet over the COSMIC_* environment variable registry (#1003).
+--
+-- The public/internal split used to be prose in sys/help.md
+-- ("everything else is INTERNAL"), and prose drifts: variables were
+-- read by code and named in neither list. Now the registry
+-- (_cli/env_vars.tl) declares every variable with a role, --help
+-- renders the public rows, and this gate holds the two directions: a
+-- variable code reads must be declared, and a declared row must be
+-- read by something.
+
+local check = require("cosmic.check")
+local env_vars = require("_cli.env_vars")
+local fs = require("cosmic.fs")
+
+local TREES < const >: {string} = {"_cli", "_make", "_build", "_tool",
+  "_docs", "_perf", "_types", "cosmic", "cmd"}
+
+--- Whether a source file participates in the scan. Tests and examples
+--- invent fixture variables (COSMIC_TEST_*, COSMIC_ENVD_*) that are
+--- not configuration; the registry itself declares names in quotes.
+--- @param path string A source path
+--- @return boolean
+local function is_scanned(path: string): boolean
+  if path:find("/testdata/", 1, true) then
+    return false
+  end
+  if path:match("_test%.tl$") or path:match("_example%.tl$") then
+    return false
+  end
+  if path:find("env_vars.tl", 1, true) then
+    return false
+  end
+  return true
+end
+
+--- Every COSMIC_* name the tree reads, with one place it does.
+--- Quoted occurrences in Teal (the shape of an env.get/os.getenv
+--- argument) plus $-references in the shell trust root and the make
+--- rules; comments mention names unquoted and stay out.
+--- @return {string: string} Variable name -> a path that reads it
+local function scan(): {string: string}
+  local found: {string: string} = {}
+  for _, tree in ipairs(TREES) do
+    local files = check.must(fs.find(tree, {glob = "*.tl"}))
+    for _, path in ipairs(files) do
+      if is_scanned(path) then
+        local text = fs.read(path)
+        if text then
+          for name in text:gmatch("[\"'](COSMIC_[A-Z_]+)[\"']") do
+            found[name] = found[name] or path
+          end
+        end
+      end
+    end
+  end
+  for _, path in ipairs({"bin/cosmic", "embed/cosmic.mk"}) do
+    local text = fs.read(path)
+    if text then
+      for name in text:gmatch("%$[{(]?(COSMIC_[A-Z_]+)") do
+        found[name] = found[name] or path
+      end
+    end
+  end
+  return found
+end
+
+local function test_every_read_variable_is_declared()
+  local found = scan()
+  local declared = env_vars.names()
+  local missing: {string} = {}
+  for name, where in pairs(found) do
+    if not declared[name] then
+      missing[#missing + 1] = name .. " (" .. where .. ")"
+    end
+  end
+  table.sort(missing)
+  assert(#missing == 0,
+    "COSMIC_* variable(s) read by code but missing from " ..
+    "_cli/env_vars.tl — declare each with a role:\n  " ..
+    table.concat(missing, "\n  "))
+end
+test_every_read_variable_is_declared()
+
+local function test_every_declared_variable_is_read()
+  local found = scan()
+  local stale: {string} = {}
+  for _, v in ipairs(env_vars.rows) do
+    if not found[v.name] then
+      stale[#stale + 1] = v.name
+    end
+  end
+  table.sort(stale)
+  assert(#stale == 0,
+    "registry row(s) nothing reads — delete them from " ..
+    "_cli/env_vars.tl:\n  " .. table.concat(stale, "\n  "))
+end
+test_every_declared_variable_is_read()
+
+print("all env-var registry tests passed")

--- a/_cli/env_vars.tl
+++ b/_cli/env_vars.tl
@@ -1,0 +1,109 @@
+--- The COSMIC_* environment variable registry (#1003).
+--- One table, two roles. A PUBLIC row is a knob a person sets, and
+--- `--help` renders exactly these rows; an INTERNAL row is set by the
+--- build or the toolchain for its own children, declared here so the
+--- split is a checkable fact instead of a prose claim. The ratchet
+--- (`_build/env_vars_test.tl`) scans the tree both ways: a variable
+--- code reads that this table does not carry fails the gate, and so
+--- does a row nothing reads — the two ways the old hand-typed help
+--- section drifted.
+
+--- One variable: its name, what setting it does, and whether a person
+--- is meant to set it.
+local record Var
+  name: string
+  desc: string
+  public: boolean
+end
+
+local VARS < const >: {Var} = {
+  -- Public: knobs a person sets.
+  {name = "COSMIC_FENCE", public = true,
+    desc = "0 opts out of the derived build sandbox (on by default)"},
+  {name = "COSMIC_JOBS", public = true,
+    desc = "build parallelism (default: one job per cpu)"},
+  {name = "COSMIC_MAKE_ROOT", public = true,
+    desc = "name the project root instead of using the cwd"},
+  {name = "COSMIC_VERSION", public = true,
+    desc = "the --version stamp, when no .version is committed"},
+  {name = "COSMIC_COVERAGE", public = true,
+    desc = "directory to dump line-coverage .cov files into"},
+  {name = "COSMIC_INSTRUMENTATION", public = true,
+    desc = "1 emits timing spans to stderr"},
+  {name = "COSMIC_LOG_LEVEL", public = true,
+    desc = "cosmic.log's threshold"},
+  {name = "COSMIC_NO_REQUIRE_HINTS", public = true,
+    desc = "disable helpful module-not-found suggestions"},
+  {name = "COSMIC_NO_WELCOME", public = true,
+    desc = "suppress welcome message on first run"},
+  {name = "COSMIC_FULL_TRACEBACK", public = true,
+    desc = "show full stack traceback including internal frames"},
+  {name = "COSMIC_DEBUG", public = true,
+    desc = "1 traces env.d loading on stderr (names only, never values)"},
+  {name = "COSMIC_ENFORCE", public = true,
+    desc = "1 fails sandbox tests that would otherwise skip"},
+  {name = "COSMIC_FIXPOINT", public = true,
+    desc = "1 runs the gated two-build fixpoint test"},
+  {name = "COSMIC_BENCHMARK_MIN_MS", public = true,
+    desc = "--benchmark's per-run timing floor, in milliseconds"},
+  {name = "COSMIC_TL_CACHE_DIR", public = true,
+    desc = "where compiled-script caches live"},
+  {name = "COSMIC_EMBED", public = true,
+    desc = "env fallback for --embed (colon-separated paths)"},
+  {name = "COSMIC_OUTPUT", public = true,
+    desc = "env fallback for --output"},
+  {name = "COSMIC_EXTRACT", public = true,
+    desc = "env fallback for --extract"},
+  -- Internal: the build sets these for its own children.
+  {name = "COSMIC_MAKE", public = false,
+    desc = "the engine a recipe line runs under"},
+  {name = "COSMIC_MAKE_GEN", public = false,
+    desc = "the converge generation counter"},
+  {name = "COSMIC_EXEC_ROOT", public = false,
+    desc = "the root an exec step may write beneath"},
+}
+
+--- Every declared name, as a set, for the ratchet's membership check.
+--- @return {string: boolean} Declared names, public and internal alike
+local function names(): {string: boolean}
+  local out: {string: boolean} = {}
+  for _, v in ipairs(VARS) do
+    out[v.name] = true
+  end
+  return out
+end
+
+--- The public rows rendered as help lines, aligned like the module
+--- list: two leading spaces, names padded to the longest.
+--- @return {string} One line per public variable
+local function help_lines(): {string}
+  local max_len = 0
+  for _, v in ipairs(VARS) do
+    if v.public and #v.name > max_len then
+      max_len = #v.name
+    end
+  end
+  local out: {string} = {}
+  for _, v in ipairs(VARS) do
+    if v.public then
+      out[#out + 1] = "  " .. v.name ..
+      string.rep(" ", max_len - #v.name + 2) .. v.desc
+    end
+  end
+  return out
+end
+
+local record EnvVarsModule
+  type Var = Var
+  rows: {Var}
+  names: function(): {string: boolean}
+  help_lines: function(): {string}
+end
+
+local M: EnvVarsModule = {
+  rows = VARS,
+  names = names,
+  help_lines = help_lines,
+}
+
+return M

--- a/_cli/help.tl
+++ b/_cli/help.tl
@@ -1,8 +1,55 @@
 --- Help text generation for cosmic CLI.
---- Produces the complete --help output including static option descriptions
---- and dynamic module list from embedded docs.
+--- Produces the complete --help output: static option descriptions from
+--- sys/help.md with its derived lists filled in from the registries
+--- that own them (#1003 — a hand-typed copy of a registry drifts), and
+--- the dynamic module list from the embedded docs.
 
 local fs = require("cosmic.fs")
+local str = require("cosmic.string")
+
+--- Greedy-wrap a name list into help-width lines.
+--- @param names_list {string} The names, in the order they should read
+--- @param first string The first line's prefix (indentation included)
+--- @param indent string Every continuation line's prefix
+--- @param suffix string Appended to the last name (e.g. a closing paren)
+--- @return string The wrapped lines, newline-joined
+local function wrap_names(names_list: {string}, first: string,
+    indent: string, suffix: string): string
+  local lines: {string} = {}
+  local line = first
+  for i, name in ipairs(names_list) do
+    local piece = name .. (i < #names_list and "," or suffix)
+    if line == first or line == indent then
+      line = line .. piece
+    elseif #line + 1 + #piece <= 78 then
+      line = line .. " " .. piece
+    else
+      lines[#lines + 1] = line
+      line = indent .. piece
+    end
+  end
+  lines[#lines + 1] = line
+  return table.concat(lines, "\n")
+end
+
+--- The `-c` vocabulary, from the step registry itself.
+--- @return {string} The verb names, sorted
+local function recipe_verbs(): {string}
+  local modes = require("_cli.build.steps")
+  local out: {string} = {}
+  for name in pairs(modes) do
+    out[#out + 1] = name
+  end
+  table.sort(out)
+  return out
+end
+
+--- The `--make` verbs, from the verb registry, in registry order.
+--- @return {string} The active (unplanned) verb names
+local function make_verbs(): {string}
+  require("_make.init")
+  return require("_make.help").names(false)
+end
 
 --- Generate help text for cosmic CLI.
 --- @return string The complete help text
@@ -12,6 +59,18 @@ local function generate(): string
   -- Load static help text from embedded file
   local static_help, err = fs.read("/zip/sys/help.md")
   assert(static_help, "failed to load embedded help: " .. (err or "unknown error"))
+
+  -- Fill the derived lists in. The tokens sit on their own lines in
+  -- help.md; each renders from the registry that owns the names, so
+  -- adding a verb or a public variable updates --help by itself.
+  local pad33 = string.rep(" ", 33)
+  static_help = str.replace(static_help, "{{recipe_verbs}}",
+    wrap_names(recipe_verbs(), pad33 .. "vocabulary: ", pad33, ")"), 1)
+  static_help = str.replace(static_help, "{{make_verbs}}",
+    wrap_names(make_verbs(), string.rep(" ", 32) .. "(", pad33,
+      "; `--make help` lists them)"), 1)
+  static_help = str.replace(static_help, "{{env_vars}}",
+    table.concat(require("_cli.env_vars").help_lines(), "\n"), 1)
   table.insert(lines, static_help)
 
   -- Show module list with descriptions (only cosmic.* modules, not cosmo.* bindings)

--- a/_cli/help_test.tl
+++ b/_cli/help_test.tl
@@ -56,6 +56,18 @@ local function test_generate_contains_env_vars()
 end
 test_generate_contains_env_vars()
 
+local function test_generate_renders_derived_lists()
+  local result = help.generate()
+  assert(not result:find("{{", 1, true), "an unrendered {{token}} survived")
+  assert(result:find("write-list", 1, true),
+    "the -c vocabulary renders from the step registry")
+  assert(result:find("`--make help` lists them", 1, true),
+    "the --make verbs render from the verb registry")
+  assert(result:find("COSMIC_FENCE", 1, true),
+    "the public env vars render from the registry")
+end
+test_generate_renders_derived_lists()
+
 local function test_generate_contains_documentation_section()
   local result = help.generate()
   assert(result:find("Documentation:"), "help text should contain 'Documentation:'")

--- a/_docs/derive.tl
+++ b/_docs/derive.tl
@@ -20,6 +20,7 @@
 --- prose: it says why the records exist and how to add one, which no
 --- generator can know.
 
+local docs = require("cosmic.doc")
 local fs = require("cosmic.fs")
 local proc = require("cosmic.proc")
 
@@ -28,6 +29,10 @@ local INDEX < const > = DECISIONS .. "/README.md"
 
 --- The header row the decisions table starts at.
 local DECISIONS_HEAD < const > = "| # | decision | |"
+
+--- The document holding the derived module table, and its header row.
+local AGENTS < const > = "AGENTS.md"
+local MODULES_HEAD < const > = "| module | description |"
 
 --- One decision record: its number, its title, and its file.
 local record Record
@@ -89,6 +94,30 @@ local function decisions_table(): string, {string}
   return table.concat(out, "\n"), bad
 end
 
+--- The module table, rendered from the embedded doc index — the same
+--- source `--help` renders its module list from at runtime (#1003), so
+--- the committed table cannot describe a module differently than the
+--- binary does. A row's text is its module's own H1 first line; a bad
+--- row is fixed at the module header, and the fix propagates here.
+--- @return string The header and rows, newline-joined
+local function modules_table(): string
+  local rows: {{string, string}} = {}
+  for _, t in ipairs(docs.topics()) do
+    local name = t[1]
+    if name:sub(1, 7) == "cosmic." then
+      rows[#rows + 1] = {name:sub(8), (t[2] or ""):gsub("%s+$", "")}
+    end
+  end
+  table.sort(rows, function(a: {string}, b: {string}): boolean
+      return a[1] < b[1]
+    end)
+  local out: {string} = {MODULES_HEAD, "|--------|-------------|"}
+  for _, r in ipairs(rows) do
+    out[#out + 1] = "| " .. r[1] .. " | " .. r[2] .. " |"
+  end
+  return table.concat(out, "\n")
+end
+
 --- The table currently committed in a document.
 --- @param text string The document
 --- @param head string The table's header row
@@ -142,14 +171,20 @@ end
 local record DeriveModule
   DECISIONS_HEAD: string
   INDEX: string
+  AGENTS: string
+  MODULES_HEAD: string
   decisions_table: function(): string, {string}
+  modules_table: function(): string
   committed_table: function(text: string, head: string): string
 end
 
 local M: DeriveModule = {
   DECISIONS_HEAD = DECISIONS_HEAD,
   INDEX = INDEX,
+  AGENTS = AGENTS,
+  MODULES_HEAD = MODULES_HEAD,
   decisions_table = decisions_table,
+  modules_table = modules_table,
   committed_table = committed_table,
 }
 
@@ -159,13 +194,23 @@ if proc.is_main() then
     io.stderr:write("derive: " .. path ..
       ": no `# D<n> — <title>` heading; it is not in the index\n")
   end
-  local changed, err = rewrite(INDEX, DECISIONS_HEAD, rendered)
-  if err then
-    io.stderr:write("derive: " .. err .. "\n")
+  local failed = false
+  for _, job in ipairs({
+      {INDEX, DECISIONS_HEAD, rendered},
+      {AGENTS, MODULES_HEAD, modules_table()},
+    }) do
+    local changed, err = rewrite(job[1], job[2], job[3])
+    if err then
+      io.stderr:write("derive: " .. err .. "\n")
+      failed = true
+    else
+      print(changed and ("derive: rewrote " .. job[1])
+        or ("derive: " .. job[1] .. " already matches its source"))
+    end
+  end
+  if failed then
     os.exit(1)
   end
-  print(changed and ("derive: rewrote " .. INDEX)
-    or ("derive: " .. INDEX .. " already matches the records"))
 end
 
 return M

--- a/cosmic/doc/init.tl
+++ b/cosmic/doc/init.tl
@@ -1,8 +1,8 @@
---- Query the documentation index embedded in the binary: the `--docs`
---- CLI's engine, and the shared doc-type vocabulary both halves of the
---- doc family type themselves with (#992: the extraction half — parse
---- Teal source, render markdown — is `_tool.doc` now; only the
---- toolchain parses source, so the public module is the query half).
+--- Query the documentation index embedded in the binary.
+--- The `--docs` CLI's engine, and the shared doc-type vocabulary both
+--- halves of the doc family type themselves with (#992: the extraction
+--- half — parse Teal source, render markdown — is `_tool.doc` now; only
+--- the toolchain parses source, so the public module is the query half).
 local types = require("cosmic.doc.types")
 
 -- The query half of the converged `doc`/`docs` family: lookup and

--- a/cosmic/env.tl
+++ b/cosmic/env.tl
@@ -1,4 +1,4 @@
---- Environment variable utilities.
+--- Environment variables: get/set/unset/list, dotenv, and env.d loading.
 --- Reading, setting, and listing environment variables — env.get()
 --- returns nil when the variable is not set, so the caller narrows;
 --- env.get_or() takes a fallback and cannot fail — plus the dotenv

--- a/cosmic/errors_example.tl
+++ b/cosmic/errors_example.tl
@@ -1,0 +1,52 @@
+--- Examples for the error-handling doctrine every cosmic.* module follows.
+--- The doctrine itself is short — the type must admit failure — and
+--- these are its three shapes, runnable: a fallible VALUE returns
+--- `value | nil, string`; a fallible EFFECT returns `boolean, string`;
+--- an infallible function returns a bare value. Library code never
+--- throws (cosmic.check is the one exemption, D23).
+
+-- Example_value_error demonstrates the primary pattern: a fallible
+-- value comes back as `value | nil, string`, and the checker forces
+-- the caller to narrow before using it.
+local function Example_value_error()
+  local json = require("cosmic.json")
+  local data, err = json.decode("{ not json")
+  if not data then
+    print("parse failed: " .. err)
+  end
+  -- Output:
+  -- parse failed: object key must be string
+end
+
+-- Example_boolean_error demonstrates the fallible-effect pattern: an
+-- operation with nothing to return succeeds `true` or fails
+-- `false, message`.
+local function Example_boolean_error()
+  local fs = require("cosmic.fs")
+  local ok, err = fs.write("/no/such/dir/out.txt", "data")
+  if not ok then
+    print("write failed: " .. (err and "yes" or "no message"))
+  end
+  -- Output:
+  -- write failed: yes
+end
+
+-- Example_infallible demonstrates the third shape: encoding,
+-- compression, and escaping cannot fail on any input, so they return a
+-- bare value with no error channel to check.
+local function Example_infallible()
+  local codec = require("cosmic.codec")
+  local uuid = require("cosmic.uuid")
+  print(codec.encode_hex("hi"))
+  print(#uuid.v4())
+  -- Output:
+  -- 6869
+  -- 36
+end
+
+-- Suppress unused warnings for examples
+local _ = {
+  Example_value_error,
+  Example_boolean_error,
+  Example_infallible,
+}

--- a/cosmic/flags/init.tl
+++ b/cosmic/flags/init.tl
@@ -1,7 +1,7 @@
---- Declarative command-line flag parsing: the one public parser
---- (#991 — cosmic.getopt is an internal shard of this module now).
---- Describe a program's flags once as data — names, value
---- placeholders, defaults, help text — and get parsing, validation,
+--- Declarative command-line flag parsing with a generated --help.
+--- The one public parser (#991 — cosmic.getopt is an internal shard of
+--- this module now). Describe a program's flags once as data — names,
+--- value placeholders, defaults, help text — and get parsing, validation,
 --- and rendered --help from the one spec.
 ---
 --- Example usage:

--- a/cosmic/hash.tl
+++ b/cosmic/hash.tl
@@ -1,6 +1,5 @@
---- Hash utilities.
---- Wraps cosmo.GetCryptoHash and cosmo.argon2 for digest, HMAC, and
---- password hashing.
+--- Cryptographic digests, HMAC, and Argon2 password hashing.
+--- Wraps cosmo.GetCryptoHash and cosmo.argon2.
 ---
 --- Example usage:
 ---   local hash = require("cosmic.hash")

--- a/cosmic/instrument.tl
+++ b/cosmic/instrument.tl
@@ -1,6 +1,7 @@
---- Instrumentation for timing and resource usage: wrap an operation in
---- a span, and get one structured `key=value` line per span on stderr
---- when `COSMIC_INSTRUMENTATION` is `1` or `true`.
+--- Timing and resource-usage spans, one `key=value` line each.
+--- Wrap an operation in a span, and get one structured `key=value`
+--- line per span on stderr when `COSMIC_INSTRUMENTATION` is `1` or
+--- `true`.
 ---
 --- Both halves are here on purpose. A span EMITS (`begin`/`finish`,
 --- with `format_line` as the pure writer), and `parse_line`/

--- a/cosmic/literal.tl
+++ b/cosmic/literal.tl
@@ -1,6 +1,6 @@
---- Teal source read as **data**: one `return { … }` of literals, lexed
---- and matched, never loaded and never called.
----
+--- Teal source read and written as data: one `return { … }` of literals.
+--- Lexed and matched, never loaded and never called; format/format_file
+--- write the same shape parse reads.
 --- This is the reader behind `*_pin.tl` (`cosmic --make fetch`), and it
 --- is public because it has callers outside `cosmic/` — this repo's own
 --- build tooling reads its dependency pins with it, and any project

--- a/cosmic/rand.tl
+++ b/cosmic/rand.tl
@@ -1,4 +1,4 @@
---- Random number generation.
+--- Random bytes, integers, floats, choice, shuffle, and tokens.
 --- Wraps cosmo.GetRandomBytes for cryptographically secure randomness, and
 --- cosmo.Rand64 for fast non-cryptographic use cases.
 ---

--- a/cosmic/searcher.tl
+++ b/cosmic/searcher.tl
@@ -1,5 +1,4 @@
---- cosmic-owned runtime .tl package searcher, replacing
---- tl.loader().
+--- The cosmic-owned runtime `.tl` package searcher, replacing tl.loader().
 ---
 --- Public, and the caller set is what settled it: the generated
 --- embed wrapper runs `require("cosmic.searcher").install()` before the

--- a/cosmic/stream.tl
+++ b/cosmic/stream.tl
@@ -1,5 +1,6 @@
---- The stream contract: the byte-stream interfaces every producer and
---- consumer in the standard library composes over (api-review-2).
+--- The stream contract: byte-stream Reader/Writer interfaces.
+--- Every producer and consumer in the standard library composes over
+--- them (api-review-2).
 ---
 --- Reader is the one EOF convention: read() returns a non-empty chunk,
 --- or bare nil (no error) at end of stream, or nil plus an error message

--- a/cosmic/tar.tl
+++ b/cosmic/tar.tl
@@ -1,6 +1,6 @@
-#!/usr/bin/env lua
---- In-process tarball extraction: unpack a `.tar.gz` (or plain `.tar`;
---- gzip is detected from the header) without a host `tar`.
+--- In-process tarball extraction, without a host `tar`.
+--- Unpacks a `.tar.gz` or plain `.tar` (gzip is detected from the
+--- header).
 ---
 --- It began as the stage pipeline's replacement for `tar -xzmf`
 --- and moved here when `--make` needed it too: `_make` unpacks pinned

--- a/docs/build.md
+++ b/docs/build.md
@@ -102,14 +102,16 @@ into different tree *paths* and comparing.
 
 ## CI
 
-Three lanes in `.github/workflows/pr.yml`:
+Four lanes in `.github/workflows/pr.yml`:
 
 - **`ci`** — fetch with a network, then build and run the whole gate
   inside a loopback-only network namespace, so a stray download fails
   loudly.
 - **`build`** — everything needing a real network or a real kernel:
-  double-build reproducibility, `--make fetch` against the real pins, and
+  the fixpoint assertion, `--make fetch` against the real pins, and
   the sandbox-enforcement lane.
+- **`repro`** — a fresh container refetches the real pins, rebuilds at
+  another path, and byte-compares against `build`'s artifact.
 - **`smoke`** — the built binary on real macOS and Windows runners.
 
 ## Selection

--- a/docs/design/make/README.md
+++ b/docs/design/make/README.md
@@ -38,10 +38,10 @@ what ships. Dropped whole in 2a; the fuller account is in
 1. **conventions** — a project is a directory tree. filenames and
    directory positions declare intent. no spec file, no `rules.tl`, no
    `cook.mk`.
-2. **a constant rules file plus generated facts** — `o/cosmic.mk` ships
-   inside the binary, byte-identical for every project. `o/project.mk`
-   is generated and holds *only variable assignments*. no rule is ever
-   generated.
+2. **a constant rules file plus generated facts** — `/zip/cosmic.mk`
+   ships inside the binary, byte-identical for every project.
+   `o/project.mk` is generated and holds *only variable assignments*.
+   no rule is ever generated.
 3. **cosmic as `SHELL`** — make invokes `cosmic -c '<line>'` for every
    recipe line. lines are whitespace-split argv whose `argv[0]` must be
    a cosmic verb, or `exec` — which resolves **only to pinned bytes**.

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -1,315 +1,24 @@
 # Standard Library
 
-the `cosmic.*` modules provide a typed, ergonomic layer over Cosmopolitan Libc bindings. import them as:
+the `cosmic.*` modules provide a typed, ergonomic layer over
+Cosmopolitan Libc bindings:
 
 ```teal
 local json = require("cosmic.json")
-local fs = require("cosmic.fs")
-local sqlite = require("cosmic.sqlite")
 ```
 
-## Module Index
-
-### Core
-
-| module | description |
-|--------|-------------|
-| `cosmic.json` | JSON encode/decode |
-| `cosmic.fd` | file descriptor I/O: open/wrap handles, pipes |
-| `cosmic.stream` | the stream contract: Reader/Writer interfaces |
-| `cosmic.fs` | filesystem paths, stat, walk, mkdir, temp files |
-| `cosmic.string` | trim, split, replace, contains, fields, lines, pad, dedent, truncate, shell_quote |
-| `cosmic.env` | environment variable get/set/unset/list, dotenv parsing and env.d loading |
-| `cosmic.errno` | errno names, numbers, and error-string helpers |
-| `cosmic.check` | assertion helpers for tests with auto-formatted failure messages |
-| `cosmic.sys` | OS and architecture detection |
-| `cosmic.time` | timestamps, sleep, clock, datetime breakdown |
-| `cosmic.uuid` | UUIDv4 (random) and UUIDv7 (time-ordered) |
-| `cosmic.deep` | deep copy/merge/structural equality for nested tables |
-| `cosmic.searcher` | the runtime `.tl` package searcher every artifact installs at boot |
-
-### Networking
-
-| module | description |
-|--------|-------------|
-| `cosmic.fetch` | HTTP client with retry and structured results |
-| `cosmic.net` | TCP/UDP/Unix domain sockets |
-| `cosmic.ip` | IP address parsing, formatting, classification |
-| `cosmic.url` | URL encoding, parsing, escaping |
-| `cosmic.sse` | Server-Sent Events stream parser |
-| `cosmic.poll` | poll(2) for I/O multiplexing |
-
-### Data
-
-| module | description |
-|--------|-------------|
-| `cosmic.sqlite` | SQLite with query/exec/transaction API |
-| `cosmic.codec` | hex/base64/base32/Latin-1 encoding and CRC-32 checksums |
-| `cosmic.compress` | zlib/gzip/raw compress/decompress |
-| `cosmic.html` | HTML entity escaping |
-| `cosmic.zip` | ZIP archive reading and writing |
-| `cosmic.tar` | extract a gzipped tarball, in process |
-
-### Security
-
-| module | description |
-|--------|-------------|
-| `cosmic.hash` | SHA-256 and Argon2 password hashing |
-| `cosmic.rand` | cryptographic random bytes |
-| `cosmic.sandbox` | one-call fail-closed facade over pledge, unveil, and landlock |
-| `cosmic.pledge` | restrict system calls on OpenBSD and Linux |
-| `cosmic.unveil` | restrict filesystem visibility on OpenBSD, or Linux via landlock |
-| `cosmic.landlock` | Linux >=5.13 self-restricting filesystem sandbox |
-| `cosmic.quicksand` | Linux namespace + allowlist proxy box primitives and declarative `Box` builder |
-
-### Process
-
-| module | description |
-|--------|-------------|
-| `cosmic.child` | spawn child processes with I/O control |
-| `cosmic.proc` | current process: pid, exec, resource usage |
-| `cosmic.signal` | signal handling, timers, sigsets |
-| `cosmic.user` | user/group identity operations |
-| `cosmic.shm` | shared memory with atomics and futexes |
-
-### Terminal & Logging
-
-| module | description |
-|--------|-------------|
-| `cosmic.tty` | terminal detection, window size, termios |
-| `cosmic.flags` | declarative command-line flag parsing with generated `--help` |
-| `cosmic.ansi` | ANSI terminal styling: colors, attributes, strip, NO_COLOR-aware gating |
-| `cosmic.log` | leveled logging with key=value fields, to stderr or a custom sink (syslog included) |
-
-### Text
-
-| module | description |
-|--------|-------------|
-| `cosmic.re` | POSIX extended regular expressions |
-| `cosmic.fuzzy` | fuzzy string matching (edit distance) |
-| `cosmic.format` | Teal/Lua code formatter |
-
-### Tooling
-
-| module | description |
-|--------|-------------|
-| `cosmic.teal` | Teal compilation and type checking |
-| `cosmic.doc` | query the embedded documentation index |
-| `cosmic.embed` | create custom executables |
-| `cosmic.coverage` | line coverage collection for cosmic programs (the ratchet is toolchain-internal) |
-| `cosmic.instrument` | timing/resource spans: emit key=value lines to stderr, and parse them back |
-| `cosmic.literal` | read/write a Teal/Lua file as data: one `return { … }` of literals, never executed |
-
-## Error Handling Patterns
-
-### Value + Error String (Primary)
-
-most functions return `value, string` where the second return is an error message on failure:
-
-```teal
-local data, err = json.decode(input)
-if not data then
-  print("parse failed: " .. err)
-  return
-end
-```
-
-### Boolean + Error String
-
-operations that succeed or fail:
-
-```teal
-local ok, err = db:exec("CREATE TABLE t (id INTEGER)")
-if not ok then
-  print("exec failed: " .. err)
-end
-```
-
-### Result Records
-
-complex operations return a record:
-
-```teal
-local result = fetch.fetch("https://example.com")
-if result.ok then
-  print(result.status, result.body)
-else
-  print(result.error)
-end
-```
-
-### Infallible Functions
-
-some functions cannot fail:
-
-```teal
-local hex = codec.encode_hex(data)        -- always succeeds
-local compressed = compress.compress(data) -- always succeeds
-local id = uuid.v4()                       -- always succeeds
-```
-
-## Common Patterns
-
-### File I/O
-
-```teal
-local fs = require("cosmic.fs")
-local fd = require("cosmic.fd")
-
--- read entire file
-local content, err = fs.read("config.json")
-
--- write entire file
-local ok, err = fs.write("output.txt", content)
-
--- low-level handle operations
-local h, err = fd.open("file.dat", fd.O_RDONLY)
-local data = h:read()
-h:close()
-```
-
-### Filesystem
-
-```teal
-local fs = require("cosmic.fs")
-
-fs.exists("/tmp/test")              -- true/false
-fs.is_dir("/tmp")                    -- true/false
-fs.join("/usr", "local", "bin")     -- "/usr/local/bin"
-fs.basename("/usr/local/bin")       -- "bin"
-fs.dirname("/usr/local/bin")        -- "/usr/local"
-fs.make_dirs("/tmp/a/b/c")          -- create parents
-fs.remove_all("/tmp/test")          -- recursive delete
-
--- walk directory tree
-for path in fs.find_iter("src", {glob = "*.tl"}) do
-  print(path)
-end
-```
-
-### SQLite
-
-```teal
-local sqlite = require("cosmic.sqlite")
-
-local db, err = sqlite.open(":memory:")
-db:exec("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
-db:exec("INSERT INTO users (name) VALUES (?)", "alice")
-
-for row in db:query("SELECT * FROM users WHERE name = ?", "alice") do
-  print(row.id, row.name)
-end
-
-db:transaction(function(tx)
-  tx:exec("INSERT INTO users (name) VALUES (?)", "bob")
-  tx:exec("INSERT INTO users (name) VALUES (?)", "carol")
-end)
-
-db:close()
-```
-
-### HTTP
-
-```teal
-local fetch = require("cosmic.fetch")
-
-local result = fetch.fetch("https://api.example.com/data")
-if result.ok then
-  local json = require("cosmic.json")
-  local data = json.decode(result.body)
-end
-```
-
-### Child Processes
-
-```teal
-local child = require("cosmic.child")
-
-local result, err = child.run({"ls", "-la"})
-if result then
-  print(result.stdout)
-  print(result.ok, result.code)
-end
-```
-
-### Networking
-
-```teal
-local net = require("cosmic.net")
-
-local sock, err = net.connect_tcp("127.0.0.1", 8080)
-sock:send("GET / HTTP/1.0\r\n\r\n")
-local response = sock:recv(4096)  -- bare nil (no error) = peer closed
-sock:close()
-```
-
-### Sandboxing
-
-`cosmic.sandbox` is the one to reach for in-process: a single
-declarative policy over filesystem (`fs`) and system-call (`sys`)
-restriction, fail-closed, mechanism picked per OS (landlock on Linux,
-unveil on OpenBSD, pledge for `sys`). The `fs` groups mean three
-things: `ro` is read-only (no execute), `exec` is read + execute, `rw`
-is read + write (never execute). A successful `apply` returns a report
-of what was actually enforced:
-
-```teal
-local sandbox = require("cosmic.sandbox")
-assert(sandbox.apply{
-  fs = { exec = {"/usr"}, ro = {"/etc"}, rw = {"/tmp"} },
-  sys = { promises = "stdio rpath wpath" },
-})
-```
-
-`cosmic.quicksand.Box` composes the Linux namespace primitives, the
-same sandbox policy, and an allowlist HTTP proxy into a declarative
-policy + `run(argv)` call for a *child* workload. Policy is a plain
-table, composable with `Box.merge(base, over)`; the `fs` and `sys`
-sections are cosmic.sandbox's own schemas:
-
-```teal
-local quicksand = require("cosmic.quicksand")
-
-local box = assert(quicksand.new({
-  fs   = { exec = {"/usr"}, ro = {"/etc/ssl/certs"}, rw = {"/tmp"} },
-  sys  = { promises = "stdio rpath wpath cpath proc exec" },
-  net  = { allow = { ["api.example.com:443"] = {} } },
-  proc = { no_new_privs = true, uid = 1000 },
-  env  = { keep = {"PATH", "HOME"}, set = { CI = "1" } },
-  cwd  = "/tmp",
-}))
-os.exit(assert(box:run({ "/usr/bin/bash", "-c", "make test" })))
-```
-
-`quicksand.new` validates shape (including `sys` promise tokens, via
-cosmic.sandbox's validator); `run` performs the capability preflight,
-then forks a supervisor that unshares `USER|NET|NS` (+`UTS` if
-`hostname` is set), writes uid/gid maps, brings up loopback,
-optionally starts the allowlist proxy (injecting `HTTP(S)_PROXY` into
-the workload env unless `net.proxy_env == false`), then forks the
-workload which applies chdir, the fs policy, no_new_privs, capability
-drops, drop_privs, the sys policy, and `execvpe(argv, env)`. The
-returned integer is the workload's exit code (or `128+signo` on
-signal).
-
-Containment is two public modules (#989): `cosmic.sandbox` for
-in-process self-restriction — its `Options` carries the mechanism
-tuning (`no_new_privs`, `handled`) that used to require reaching for
-the mechanism modules — and `cosmic.quicksand` for out-of-process
-boxes. The mechanisms behind them (landlock, pledge, unveil, netns,
-proxy, proc) are internal shards, not API.
-
-## Documentation
-
-use the built-in docs system:
+the module list is not maintained here — the binary renders it from its
+own documentation index, so the list can never disagree with what ships:
 
 ```bash
-cosmic --docs json            # show cosmic.json docs
-cosmic --docs sqlite.open     # show specific function
-cosmic --docs "parse url"     # search docs
-cosmic --examples json        # show examples
-cosmic --help                 # list all modules
+cosmic --help                 # every module, one line each
+cosmic --docs json            # one module's full docs
+cosmic --docs sqlite.open     # one function
+cosmic --examples json        # runnable examples for a module
 ```
+
+(the same index drives the derived module table in
+[AGENTS.md](../AGENTS.md); `bin/cosmic _docs/derive.tl` rewrites it.)
 
 from the REPL:
 
@@ -317,4 +26,29 @@ from the REPL:
 $ cosmic -i
 > help("json")
 > help("fs.walk")
+```
+
+## Error Handling
+
+what this page alone says is the doctrine — the type must admit
+failure, and library code never throws:
+
+- **fallible value**: `value | nil, string` — the primary pattern; the
+  checker forces callers to narrow before use
+- **fallible effect**: `boolean, string` — operations with nothing to
+  return succeed `true` or fail `false, message`
+- **result records**: complex operations with multiple error states
+  return a record (`fetch.fetch`'s `ok`/`status`/`body`/`error`)
+- **infallible**: encoding, compression, escaping return a bare value —
+  no error channel to check
+
+failed `cosmo.unix` calls carry a formatted message plus the numeric
+errno; wrappers add context with `errno.wrap` and branch with
+`errno.is`. the one throwing module is `cosmic.check` (tests and
+examples only; D23).
+
+each shape is runnable, and gated in CI:
+
+```bash
+cosmic --examples errors
 ```

--- a/sys/help.md
+++ b/sys/help.md
@@ -13,7 +13,7 @@ Cosmic options:
   --check <kind> <file>         run one gate check on one file. kinds:
                                   types     type-check, strict
                                   fmt       formatting (diff on stderr)
-                                  lint      file length, casts, test order
+                                  lint      every lint rule (--docs guide.lint)
                                   example   run Example_* and check output
                                 a kind IS its verb: the whole project is
                                 `--make check|fmt|lint|example`
@@ -32,13 +32,9 @@ Cosmic options:
                                 e.g. cosmic --coverage-report o/.coverage cosmic
   -c, --recipe <line>           run one recipe line as argv, not shell
                                 (for make: SHELL := cosmic. the closed
-                                 vocabulary: assert-elf, assert-marker,
-                                 capture, compile, copy, exec, link,
-                                 record, remove, tee, verdict, write-list)
+{{recipe_verbs}}
   --make <verb> [paths]...      build this project
-                                (build, check, test, fmt, lint, example,
-                                 benchmark, docs, coverage, run, ci, fetch,
-                                 clean; `--make help` lists them)
+{{make_verbs}}
   --skill <dir>                 write agent skill file (SKILL.md) to directory
   --welcome                     show welcome message
   -h, --help                    show this help message
@@ -52,21 +48,12 @@ Standard lua options (each also has a long spelling, #991):
   -W, --warn                  turn warnings into errors
 
 Environment variables:
-  COSMIC_FENCE               0 opts out of the derived build sandbox (on by default)
-  COSMIC_JOBS                build parallelism (default: one job per cpu)
-  COSMIC_MAKE_ROOT           name the project root instead of using the cwd
-  COSMIC_VERSION             the --version stamp, when no .version is committed
-  COSMIC_COVERAGE            directory to dump line-coverage .cov files into
-  COSMIC_INSTRUMENTATION     1 emits timing spans to stderr
-  COSMIC_LOG_LEVEL           cosmic.log's threshold
-  COSMIC_NO_REQUIRE_HINTS    disable helpful module-not-found suggestions
-  COSMIC_NO_WELCOME          suppress welcome message on first run
-  COSMIC_FULL_TRACEBACK      show full stack traceback including internal frames
+{{env_vars}}
 
   Every other COSMIC_-prefixed variable is INTERNAL: the build sets it
-  for its own children (which engine, what a step may exec, the
-  converge budget, a test's scratch directory). Setting one by hand
-  confuses a build rather than configuring it.
+  for its own children, and the registry (`_cli/env_vars.tl`) declares
+  each one — a gate fails when code and registry disagree. Setting an
+  internal one by hand confuses a build rather than configuring it.
 
   NO_COLOR, TERM, TMPDIR, HOME, PATH, XDG_*, SOURCE_DATE_EPOCH and CI
   are third-party conventions cosmic honours rather than invents.


### PR DESCRIPTION
Implements #1003. The two hand-maintained 58-row module tables restated what `--help` already renders from the doc index, and they had drifted (`codec`, `hash`, `rand`, `env` all said less than they ship). Now there is one source: a module's own H1 first line.

## Derived module table

- `_docs/derive.tl` grows `modules_table()`: AGENTS.md's module table is now a derived region, rewritten by `bin/cosmic _docs/derive.tl` and gated by `_build/docs_test.tl` alongside the decisions index. A bad row is fixed at the module header, and the fix propagates to the table AND `--help` at once.
- Module H1 first lines were rewritten to stand alone — `doc`, `flags`, `instrument`, `literal`, `searcher`, `stream` had truncated first lines, `tar`'s shebang hid its header entirely, and `hash`/`rand`/`env` undersold their surface.

## stdlib.md shrinks ~320 → ~60 lines

What remains is a pointer at `--help`/`--docs` (which cannot drift) plus the error-handling doctrine — the one part no generator can know. Its code blocks now live gated in `cosmic/errors_example.tl` (`cosmic --examples errors`), per goals.md's "a doc statement that is not CI-verified is a bug".

## help.md renders from the registries

The hand-typed `-c` vocabulary and `--make` verb list are now `{{tokens}}` the help generator fills from the registries that own the names (`_cli/build/steps.tl`, `_make/help.tl` via the verb registry). The lint line no longer claims three rules where eight exist.

## COSMIC_* registry + ratchet

The public/internal split is a table in code (`_cli/env_vars.tl`): `--help` renders the public rows, and `_build/env_vars_test.tl` scans the tree both ways — a variable code reads must be declared, and a declared row must be read by something. Eight real variables the old prose split named in neither list are now declared: `COSMIC_DEBUG`, `COSMIC_ENFORCE`, `COSMIC_FIXPOINT`, `COSMIC_BENCHMARK_MIN_MS`, `COSMIC_TL_CACHE_DIR`, `COSMIC_EMBED`, `COSMIC_OUTPUT`, `COSMIC_EXTRACT`.

## Regardless-fixes

- `docs/build.md` counts four CI lanes (`repro` was missing)
- `README.md` describes build.md as the `--make` manual, not "building custom executables"
- `docs/design/make/README.md` says `/zip/cosmic.mk` ships, not `o/cosmic.mk`

## Verification

- warm `bin/cosmic --make ci` → `ci: PASS (5 stages)`
- cold gate `rm -rf o && bin/cosmic --make fetch && bin/cosmic --make ci` → `ci: PASS (5 stages)`
- baseline: one new row (`_cli/env_vars.tl 68 68`), nothing lowered

Closes #1003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_