### PR TITLE
skills: fix what ships — phantom cast ratchet, Stat contradiction, gotcha tombstones (#1004)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,38 +141,9 @@ return { greet = greet }
 
 ### Error Handling Patterns
 
-most functions return `value, string` — nil + error message on failure:
-
-```teal
-local function decode(str: string): any, string
-  local result, err = cosmo.DecodeJson(str)
-  return result, err as string
-end
-```
-
-boolean success/fail:
-
-```teal
-function db:exec(sql: string): boolean, string
-  local rc = raw_db:exec(sql)
-  if rc ~= sqlite3.OK then
-    return false, raw_db:errmsg()
-  end
-  return true
-end
-```
-
-use Result records for complex operations with multiple error states:
-
-```teal
-local record Result
-  ok: boolean
-  status: number
-  headers: {string:string}
-  body: string
-  error: string
-end
-```
+the pattern table and worked snippets ship in the binary
+(`cosmic --docs guide.modules`, `cosmic --examples errors`); the
+doctrine prose is [docs/stdlib.md](docs/stdlib.md). the shape rules:
 
 **honest nil — the type must admit failure:**
 - **Fallible value**: `T | nil, string` — the checker forces callers to narrow.
@@ -219,16 +190,11 @@ won't fit it. Write the actual reason (`from any`, `userdata boundary`,
 `tuple element`, `record union after guard`, ...) — a cast you cannot
 justify is one to remove, via `is`, `check.must`, or a precise type.
 
-**`find` says whether it means a pattern.** `s:find(x)` treats x as a Lua
-pattern, so a `-`, `.`, `(` or `%` in it silently changes what matches —
-and the failure is invisible, because the call still returns, just about
-the wrong thing. A test that writes under `/tmp/a-b/` and greps for that
-path passes everywhere except where the path has a dash. When the needle
-is not a string literal the linter (`find-needle`) asks which you meant:
-`, 1, true` for a substring, `, 1, false` for a real pattern. Literals
-are exempt — `s:find("%d+")` reads as a pattern already. There is no
-`plain` flag on `match`/`gmatch`/`gsub`, so a variable needle there is a
-pattern by construction; escape it if it isn't one.
+**`find` says whether it means a pattern.** A variable needle in
+`s:find(x)` needs `, 1, true` (substring) or `, 1, false` (real
+pattern) — the `find-needle` lint asks which you meant, and
+`cosmic --docs guide.lint` (its shipped home) has the full rule,
+including the `match`/`gmatch`/`gsub` corollary.
 
 rules:
 - never throw from library code — `cosmic.check` alone is exempt ([D23](docs/decisions/d23-check-throws.md)); D22's CSPRNG throws are the only others

--- a/_cli/lint_test.tl
+++ b/_cli/lint_test.tl
@@ -285,7 +285,7 @@ test_find_needle_wants_the_intent_stated()
 local function test_gsub_replacement_wants_the_intent_stated()
 
   -- nil-declaration: `local x = nil` with no annotation is the type nil
-  -- forever (gotcha 13); the rule fires at the declaration, where the fix
+  -- forever; the rule fires at the declaration, where the fix
   -- is. The trap spelled inside a string fixture must never count.
   local function test_nil_declaration_flags_the_bare_form()
     local diags = lint.check_nil_declaration("m.tl", "local earliest = nil\n")

--- a/_make/init.tl
+++ b/_make/init.tl
@@ -270,7 +270,7 @@ local VERBS < const >: {Verb} = {
   -- first-class kind with the same scope semantics, a gate this repo
   -- runs today -- and the verb set was the one place the symmetry
   -- broke. `lint` is the other half of that gate (the 500-line cap,
-  -- the cast ratchet, both already public in `_tool.lint`), and it
+  -- the cast reasons, both already public in `_tool.lint`), and it
   -- gets a verb rather than folding into `check` because its file set
   -- is the whole tree, not the compiled closure. Naming them is what
   -- lets `ci` below be a list of verb names: its pipeline is

--- a/docs/agent-usability.md
+++ b/docs/agent-usability.md
@@ -1,5 +1,12 @@
 # Agent Usability Study — June 2026
 
+> **As of June 2026, build `8c7e138`.** This is a dated study log, not
+> live guidance: module names, guide entry numbers, and error messages
+> cited below are the ones that binary shipped, and several have since
+> been renamed or retired (`cosmic.io`, `cosmic.fs_walk`,
+> `cosmic.assert`; gotcha entries are now cited by slug). Read it for
+> the methodology and the findings' direction, not the identifiers.
+
 Four Sonnet agents were given a clean directory containing only the `cosmic`
 binary (build `8c7e138`) and a coding task. No repo access, no web, no other
 runtimes. Tasks covered four surface areas:
@@ -221,9 +228,10 @@ clean-room run.
    cosmic --docs cosmic.fs_types.WalkStat"), and symbol-not-found lists the
    module's available symbols inline instead of telling the agent to go
    look. Lookup helpers moved to a new `docs_lookup.tl` (500-line cap).
-2. **`arg` layout documented** in `cosmic.proc` docs and `guide.gotchas`
-   entry 7 (`arg[-1]` = interpreter path, `arg[0]` = `/zip/main.lua`,
-   `rawget(arg, -1) as string` for strict mode).
+2. **`arg` layout documented** in `cosmic.proc` docs and the
+   `guide.gotchas` `arg[0]` entry, since retired (`arg[-1]` =
+   interpreter path, `arg[0]` = `/zip/main.lua`; `proc.interpreter()`
+   is today's answer).
 3. **`--fix <file>` formats in place**; the `--check fmt` hint now says
    `run 'cosmic --fix <file>' to fix in place`. The formatting guide's
    previous in-place recipe documented a flag order that did not work; it
@@ -270,7 +278,8 @@ in the wild:
   invocation, exactly as the new hint instructed.
 - `--docs cosmic.fs_types.WalkStat` resolved; the fs.walk "do not join"
   warning and the new sqlite `LIKE` example were both consumed directly.
-- The child+TCP agent used `rawget(arg, -1)` from gotchas entry 7 and
+- The child+TCP agent used `rawget(arg, -1)` from the gotchas guide's
+  `arg[0]` entry (since retired — `proc.interpreter()` is the answer now) and
   explicitly noted it would otherwise have burned time on a silently
   broken `arg[0]` spawn; it also used `listen_tcp` with port 0 and
   pipe-based readiness.

--- a/docs/design/make/verbs.md
+++ b/docs/design/make/verbs.md
@@ -15,7 +15,7 @@ clean           remove o/                                            [now]
 run   <path>    build, then run that source against the tree         [now]
 benchmark [paths…]  run every *_benchmark.tl against the stage       [now]
 example [paths…] run Example_* against the staged tree               [now]
-lint  [paths…]  style gate: file length, cast ratchet, test order  [now]
+lint  [paths…]  style gate: file length, cast reasons, test order  [now]
 ```
 
 `run` takes **paths, never binary names**: a built `o/bin/<name>` is

--- a/skills/cosmic/checking.md
+++ b/skills/cosmic/checking.md
@@ -108,26 +108,24 @@ end
 
 a record whose runtime values are userdata needs Teal's `userdata` member
 in its own source (see `re.tl`'s Regex) — then `is` compiles to a
-`type() == "userdata"` test everywhere. caveats: `is` narrowing does not
+`type() == "userdata"` test everywhere; `fs.Stat` declares it, so
+`st is fs.Stat` narrows. caveats: `is` narrowing does not
 survive an early-exit guard (`if not (x is Rec) then return end` does not
-narrow below it — unlike the plain truthiness guard, which does); do not
-use `is` with a required `cosmo.*` class — the
-runtime tl loader can lax-recompile a module where the required `.d.tl`
-marker doesn't resolve, silently degrading `is` to a table test — keep
-casts at those boundaries; and `is` is wrong for mixed-representation
-records like `fs.Stat` (usually the raw userdata, sometimes a wrapper
-table). in linear code, use `as` to cast when you know more than the
-type checker:
+narrow below it — unlike the plain truthiness guard, which does), and
+`is` with a required `cosmo.*` class relies on the cosmic searcher
+resolving the `.d.tl` marker — the one unsupported path is user code
+calling `require("tl").loader()`, which shadows the cosmic searcher
+with tl's silent one. in linear code, use `as` to cast when you know
+more than the type checker:
 
 ```teal
 local result = json.decode(input) as {string: any}
 local count = value as integer
 ```
 
-per-file `as` counts are pinned by the cast ratchet (`_build/casts.txt`,
-enforced by `--make lint`). every cast carries its own `-- cast: <reason>`
-on the line or the line above, so there is no baseline to raise: a cast
-you cannot justify is one to remove.
+every cast carries its own `-- cast: <reason>` on the line or the line
+above (enforced by `--make lint`): a cast you cannot justify is one to
+remove.
 
 ### Record Types
 

--- a/skills/cosmic/gotchas.md
+++ b/skills/cosmic/gotchas.md
@@ -1,8 +1,16 @@
 # Teal Gotchas for Newcomers
 
-common errors that trip up agents and developers new to Teal. each entry shows the wrong pattern, the error it produces, and the fix.
+common errors that trip up agents and developers new to Teal. each
+entry shows the wrong pattern, the error it produces, and the fix.
 
-## 1. integer vs number
+entries are named by their heading slug — cite one as "the
+`record-fields-dont-narrow` gotcha", never by position — so entries
+can retire without a renumbering breaking references. an entry whose
+trap became unreachable (a checker error, a lint at the declaration)
+is deleted, not tombstoned: the checker's own message now carries the
+fix.
+
+## integer-vs-number
 
 Teal distinguishes `integer` from `number`: string indices
 (`string.sub`, `string.byte`, table lookups) require `integer`, and
@@ -21,7 +29,7 @@ local m = ("hello"):sub(math.tointeger(x) or 1, 5)
 sizes — are annotated `integer` at the source of truth, so no
 conversion dance is needed on that side.)
 
-## 2. traversing `any` from json.decode
+## any-from-json-decode
 
 for the two common top-level shapes, skip `any` entirely:
 `json.decode_object` returns `{string: any} | nil, string` and
@@ -44,9 +52,10 @@ end
 cannot index or iterate `any` directly — narrow with `is` where the
 shape is uncertain (as with the nested values above), or cast
 (`local obj = json.decode(input) as {string: any}`) when the shape is
-trusted. new casts count against the cast ratchet (`_build/casts.txt`).
+trusted. a new cast needs its `-- cast: <reason>` justification (the
+lint enforces it).
 
-## 3. `arg` elements are `string | nil`
+## nilable-arg
 
 the global `arg` table has type `{string | nil}`: accessing `arg[1]`
 without a guard may give you `nil`, a type error where a `string` is
@@ -78,7 +87,7 @@ cosmic.main(function(args: {string}, env: cosmic.Env): number, string
   end)
 ```
 
-## 4. multi-return capture
+## multi-return-capture
 
 the checker's `excess return values` error carries the fix as a hint:
 capture multiple returns first — `local v, err = f(...)`. wrapping a
@@ -94,40 +103,7 @@ for row in rows do
 end
 ```
 
-## 5. retired — moved to guide.modules
-
-how `require` resolves local module paths is information, not a trap;
-it now lives in `cosmic --docs guide.modules`.
-
-## 6. retired — the checker prevents it
-
-binding a module to a local that shadows a Lua builtin
-(`local io = require("cosmic.fd")`) is a `--check types` error today
-(`variable shadows previous declaration of 'io'`, warnings are errors),
-so the runtime surprise this entry described is unreachable. rename the
-local (`fd`, `fs`, ...); Lua's `io.stderr` stays available.
-
-## 7. retired — `proc.interpreter()` is the one-call answer
-
-`arg[0]` is the script path as the runtime sees it (`/zip/main.lua` in
-a packed binary), not the interpreter. to re-invoke cosmic, call
-`require("cosmic.proc").interpreter()` — typed, resolved, cached; the
-self-reinvocation recipe in `cosmic --docs guide.recipes` shows the
-whole shape.
-
-## 8. retired — the checker flags discarded errors
-
-most cosmic functions return `(value, error)`, and the strict checker
-(`--check types`, and the build's strict compile) now flags both ways
-the error used to vanish: a fallible call standing as a bare statement
-(`fs.write(path, data)` on its own line), and a fallible call as the
-final argument of `print` and friends (which rendered the error as a
-literal `nil`). capture the returns — `local v, err = f(...)`, or
-`local _ok, _err = f(...)` for deliberate fire-and-forget — or wrap in
-`assert`/`check.must` in tests and examples. the details are in
-`cosmic --docs guide.checking`.
-
-## 9. record fields don't narrow — copy the field to a local
+## record-fields-dont-narrow
 
 a guard on a plain variable narrows it: truthiness (`if r then`, `if
 not r then return end`), `assert(r, "msg")`, and `== nil` / `~= nil`
@@ -164,7 +140,7 @@ un-narrowed type but not the cause: `cannot index key 'x' in ... of
 type Inner | nil`. the full pattern set is in
 `cosmic --docs guide.checking`.
 
-## 10. a record other files use must be nested in the module's interface record
+## exported-record-types
 
 a standalone top-level `local record` is visible only inside its own
 file. another file writing `store.Task` gets `unknown type store.Task` —
@@ -198,14 +174,7 @@ end
 works when the record must stay standalone for internal reasons — see
 how `cosmic.fs` re-exports `Stat`.)
 
-## 11. retired — the checker prevents it
-
-shadowing any declaration, including Lua builtins (`local function
-load(...)`, `local type = ...`), is a `--check types` error today
-(warnings are errors). the error names the shadowed declaration; rename
-yours (`load_data`, `kind`, ...).
-
-## 12. colon-call only works on the value's own record type
+## colon-call
 
 the checker's `invalid key 'add' in record 'db'` error carries the fix
 as a hint: a function on your MODULE's record is dot-called with the
@@ -218,25 +187,7 @@ db:add("alice") -- error: invalid key 'add' in record 'db' of type sqlite.Databa
 store.add(db, "alice") -- right: module function, dot-called, value first
 ```
 
-## 13. retired — the lint catches it at the declaration
-
-a local initialized with `= nil` and no type annotation is inferred as
-the type `nil` — forever. the `nil-declaration` lint now flags the
-declaration itself with the fix (`local x: integer | nil = nil`), so
-the far-away assignment errors this entry used to explain are never
-reached. with the annotation, the running-min/max idiom compiles as
-written — scalars narrow through the `not earliest or ...` guard fine.
-
-## 14. retired — the taught path never calls `os.exit`
-
-`cosmic.main(fn)` (the entry-point shape the quickstart teaches) does
-the exit itself and accepts any numeric return, so this trap no longer
-appears on the taught path. if you call `os.exit` yourself, it requires
-`integer | boolean`, not `number` — convert at the call site
-(`os.exit(math.tointeger(code) or 1)`); the error-site hint names the
-same fix.
-
-## 15. `gsub`'s replacement string interprets `%` — use `str.replace` for literal text
+## gsub-replacement
 
 `string.gsub`'s replacement is not plain text (`%1` splices a capture,
 a lone `%` is a runtime error), so templating an untrusted value in
@@ -250,7 +201,7 @@ local str = require("cosmic.string")
 local page = str.replace(template, "{{name}}", user_name)
 ```
 
-## 16. a multi-return call as the last argument spreads its whole tuple
+## tuple-spread
 
 Lua spreads every return of a call in the LAST argument position into
 the argument list, and the checker counts the declared tuple — so


### PR DESCRIPTION
Implements #1004. These guides ship in the binary and are what a bare-sandbox agent reads; staleness here is worse than in repo docs.

## Phantom mechanism

`checking.md`, `gotchas.md`, and `docs/design/make/verbs.md` cited a cast ratchet at `_build/casts.txt` — a file that exists nowhere in the tree, in a sentence that refuted itself ("counts are pinned … so there is no baseline"). The real mechanism is the per-site `-- cast: <reason>` lint; all three now say that. (One code comment in `_make/init.tl` said "cast ratchet" too — now "cast reasons".)

## Stat contradiction

`checking.md` said `is` is wrong for `fs.Stat` ("mixed-representation"); `fs/types.tl` declares Teal's `userdata` member, so `st is fs.Stat` narrows — AGENTS.md was right. The passage now matches. The adjacent `cosmo.*` caveat was also stale (it warned against `is` on required `cosmo.*` classes wholesale); it now states the searcher rule: the one unsupported path is user code calling `require("tl").loader()`.

## Gotcha tombstones

Entries are now named by heading slug (`integer-vs-number`, `record-fields-dont-narrow`, `gsub-replacement`, …), never by position — the intro states the citation rule — so the 7 "retired —" tombstones that existed only to hold their numbers are deleted (~60 of 251 lines). The two numeric cross-references (`agent-usability.md`'s "entry 7", a `lint_test.tl` comment) are rewritten.

## As-of banner

`docs/agent-usability.md` opens with a banner naming it a dated study log (June 2026, build `8c7e138`) — every module name in it is retired, and it is linked as live guidance from goals.md and the agent-eval skill.

## Dedup

- **find-needle**: full text lives in `guide.lint` (it ships); AGENTS.md keeps one pointer sentence with the two-suffix rule.
- **error-handling table**: AGENTS.md's three worked snippets become a pointer at `guide.modules` / `cosmic --examples errors` / docs/stdlib.md; the honest-nil shape rules and the narrowing doctrine (unique to AGENTS.md) stay. `guide.modules` keeps its table (it ships), contributing.md was already a link.

## Verification

- warm `bin/cosmic --make ci` → `ci: PASS (5 stages)`
- cold gate `rm -rf o && bin/cosmic --make fetch && bin/cosmic --make ci` → `ci: PASS (5 stages)`

Closes #1004.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_