### PR TITLE
doc comments: sweep the archaeology out of the shipped API docs (#1005)

### DIFF
--- a/_tool/benchmark.tl
+++ b/_tool/benchmark.tl
@@ -83,9 +83,7 @@ local DEFAULT_MIN_SECONDS = 1.0
 --- honors `filter` with the same substring contract).
 local record RunOptions
   --- Run only benchmarks whose name contains this SUBSTRING, matched
-  --- plainly (e.g. "concat" matches Benchmark_string_concat). Folded in
-  --- from the old positional between the path and the options
-  --- (api-review-6).
+  --- plainly (e.g. "concat" matches Benchmark_string_concat).
   filter: string
   --- Minimum calibrated duration per benchmark, in integer
   --- milliseconds. Defaults to 1000 (Go's 1s convention) when unset. A

--- a/_tool/doc/init.tl
+++ b/_tool/doc/init.tl
@@ -261,7 +261,7 @@ local function parse(source: string, file_path: string): ModuleDoc
       })
   end
   -- Type aliases: `local type Name = target`. The alias IS the public
-  -- name (api-review-8: zip's Archive aliases the generated
+  -- name (zip's Archive aliases the generated
   -- cosmo.zip.Reader) while the target holds the field/method table, so
   -- without an entry the public name is invisible in the rendered Types
   -- section and unresolvable per-symbol. The alias renders as its own

--- a/_tool/lint_test.tl
+++ b/_tool/lint_test.tl
@@ -39,7 +39,7 @@ test_style_valid()
 -- here is its own change with its own multi-hundred-line diff.
 local function test_style_long_line_is_not_enforced()
   -- Column width is house style (90), not a gate: the dead
-  -- check_column_length export is gone (api-review-7), and the unused
+  -- check_column_length export is gone, and the unused
   -- DEFAULT_COLUMN_WIDTH constant followed it (#993).
   local long_line = string.rep("x", 91)
   local input = write_temp("style_long.tl", long_line .. "\n")

--- a/_tool/testrun.tl
+++ b/_tool/testrun.tl
@@ -8,8 +8,7 @@ local records = require("_tool.records")
 local time = require("cosmic.time")
 
 --- The output grammar lives in `_tool.records`, which is where every
---- printer and every asserting test reads it from (api-review: the
---- STATUS_ICONS/status_of re-exports are gone; require _tool.records).
+--- printer and every asserting test reads it from.
 
 --- Run a test executable and capture output.
 --- Creates a temporary directory (TEST_TMPDIR) for the test and cleans up after.
@@ -319,44 +318,6 @@ local function report(paths: {string}): integer
 
   return failed > 0 and 1 or 0
 end
-
---- Example showing a minimal Makefile-based test harness.
---- Demonstrates pattern rules for running tests and collecting results.
----
---- ```makefile
---- # Pattern rule: for each test_*.lua, run it and capture output
---- o/test/%.got: test_%.lua $(COSMIC)
---- 	$(COSMIC) --test $@ $< $<
----
---- # Collect all test targets
---- tests := $(patsubst test_%.lua,o/test/%.got,$(wildcard test_*.lua))
----
---- # Run all tests and report
---- test: $(tests)
---- 	$(COSMIC) --report $(tests)
---- ```
-local function Example_makefile()
-  local testrun = require("_tool.testrun")
-  local tmpdir = fs.temp_dir("/tmp/testrun_example_XXXXXX")
-  if not tmpdir then return end
-
-  -- Run /bin/true and capture output
-  local exit_code = testrun.run({"/bin/true"}, fs.join(tmpdir, "test1"))
-  print("exit_code:", exit_code)
-
-  -- Report on the result
-  testrun.report({fs.join(tmpdir, "test1")})
-
-  local _ok, _err = fs.remove_all(tmpdir)
-  -- Output:
-  -- exit_code:	0
-  -- ✓ test1
-  --
-  -- 1 checks: 1 passed
-end
-
--- Suppress unused warning
-local _ = Example_makefile
 
 local record TestrunModule
   run: function(argv: {string}, output_base: string): integer, string

--- a/cosmic/check.tl
+++ b/cosmic/check.tl
@@ -109,9 +109,7 @@ local function truthy(value: any, label?: string)
   error(msg, 2)
 end
 
---- Assert that a (value, err) pair represents failure (api-review-8
---- renamed it from `err`, which read as a noun and shadowed every
---- local error; #1000 spelled `fails` out to `failed`).
+--- Assert that a (value, err) pair represents failure.
 --- Expects value to be nil and err to be a non-nil, non-empty string,
 --- matching the standard cosmic error-return convention.
 --- @param value any The first return value (expected to be nil)
@@ -188,8 +186,8 @@ end
 --- mechanism was probed *available* yet the operation was still blocked,
 --- which on the unsandboxed lane can only mean an outer sandbox is present.
 --- Callers still `return` after calling this; it does not exit the
---- process (api-review-8: was `skip`, a name that promised the exit
---- `needs` performs — this only RECORDS the enforcement gap).
+--- process — it only RECORDS the enforcement gap (`needs` is the one
+--- that exits).
 --- @param reason string Why enforcement could not run
 --- @param strict boolean? Escalate to failure under COSMIC_ENFORCE=1
 local function enforce_skip(reason: string, strict?: boolean)
@@ -212,12 +210,10 @@ end
 --- is always provisioned and its absence means the provisioning broke,
 --- not that the developer is mid-setup.
 ---
---- Say so by EXITING — which this function now does itself
---- (api-review-8): when the precondition is missing it prints the skip
---- and exits EXIT_SKIP, so a caller cannot forget the exit and turn a
---- skip into a silent pass (the old `if not needs(...) then
---- os.exit(...) end` dance, and the lint rule that policed it, are
---- both gone). When it returns at all, the precondition held.
+--- Say so by EXITING — which this function does itself: when the
+--- precondition is missing it prints the skip and exits EXIT_SKIP, so
+--- a caller cannot forget the exit and turn a skip into a silent
+--- pass. When it returns at all, the precondition held.
 ---
 ---     check.needs("the make engine", fs.is_file(make_bin))
 ---

--- a/cosmic/check_test.tl
+++ b/cosmic/check_test.tl
@@ -338,9 +338,9 @@ local function test_needs_skips_locally_and_fails_in_ci()
   local had = os.getenv("CI")
   assert(env.unset("CI"))
 
-  -- A met precondition simply returns (api-review-8: needs EXITS the
-  -- process itself when the precondition is missing, so the exit path
-  -- is exercised in a child below, not in this process).
+  -- A met precondition simply returns (needs EXITS the process itself
+  -- when the precondition is missing, so the exit path is exercised
+  -- in a child below, not in this process).
   check.needs("a satisfied precondition", true)
 
   -- The missing-locally path: the child must exit EXIT_SKIP, not 0.

--- a/cosmic/child/init.tl
+++ b/cosmic/child/init.tl
@@ -184,7 +184,7 @@ local function make_handle(pid: integer, st: childio.PumpState): Handle
       return nil, errno.wrap(err, "read")
     end
     if chunk == "" then
-      return nil -- end of file (api-review-2, #589)
+      return nil -- end of file (#589)
     end
     return chunk
   end

--- a/cosmic/child/init_test.tl
+++ b/cosmic/child/init_test.tl
@@ -390,7 +390,7 @@ local function test_spawn_overlap_no_stdin_leak()
 end
 test_spawn_overlap_no_stdin_leak()
 
--- === honest option types: fd.Handle in Options (/ api-review-2 B5) ===
+-- === honest option types: fd.Handle in Options ===
 
 -- stdout as a Handle: the child writes into a pipe we own; run()'s own
 -- capture is then empty for that stream.

--- a/cosmic/child/io.tl
+++ b/cosmic/child/io.tl
@@ -51,8 +51,8 @@ local record PumpState
 end
 
 --- Raw descriptors resolved from the public spawn Options. The public
---- surface speaks fd.Handle (api-review-2); everything below this
---- boundary speaks raw descriptors.
+--- surface speaks fd.Handle; everything below this boundary speaks
+--- raw descriptors.
 local record Stdio
   stdin_data: string
   stdin_fd: integer

--- a/cosmic/child/types.tl
+++ b/cosmic/child/types.tl
@@ -35,8 +35,8 @@ end
 --- else. stdout/stderr Handles (cosmic.fd) become the child's fd 1/2
 --- (the matching Result field is then ""); start does not take
 --- ownership — the child gets its own copy, so close your end when done
---- (see Example_run_pipe). Raw integer fds are not part of this surface
---- (api-review-2); wrap one with fd.wrap() first. "inherit" writes to
+--- (see Example_run_pipe). Raw integer fds are not part of this
+--- surface; wrap one with fd.wrap() first. "inherit" writes to
 --- THIS process's fd 1/2 so output streams as it runs; Result stays "".
 local record Options
   stdin: string | cfd.Handle -- string piped to stdin, or Handle -> fd 0

--- a/cosmic/compress.tl
+++ b/cosmic/compress.tl
@@ -16,8 +16,8 @@ end
 
 --- Framings decompress() can consume: the three producible ones plus
 --- "auto", header detection for zlib or gzip input. The split enums
---- are what make "auto" decompress-only by TYPE (api-review #996: one
---- shared enum meant compress() rejected it at runtime instead). A
+--- are what make "auto" decompress-only by TYPE (one shared enum
+--- would leave compress() to reject it at runtime instead). A
 --- held CompressFormat value crosses with a widening cast (Teal enums
 --- are nominal even when the word sets nest); a string literal needs
 --- none.
@@ -39,7 +39,6 @@ local record DecompressOptions
   --- input framing; defaults to "zlib"
   format: DecompressFormat
   --- cap on the decompressed size in bytes, default 64 MiB
-  --- (api-review #996: was `max_output`; rule 2 puts the unit in the name)
   max_output_bytes: integer
 end
 

--- a/cosmic/embed/extract.tl
+++ b/cosmic/embed/extract.tl
@@ -1,9 +1,8 @@
 --- Extracting an executable's zip contents.
 ---
 --- Split out of cosmic.embed for the 500-line cap. The extraction
---- itself is czip.extract (api-review: embed no longer reimplements
---- the loop or re-declares zip's records) — the zip-slip guard, the
---- upfront validation, and the mode masking all live there, once.
+--- itself is czip.extract — the zip-slip guard, the upfront
+--- validation, and the mode masking all live there, once.
 
 local czip = require("cosmic.zip")
 local fs = require("cosmic.fs")

--- a/cosmic/embed/init.tl
+++ b/cosmic/embed/init.tl
@@ -339,8 +339,7 @@ local function write(paths: {string}, opts?: Options): integer | nil, string
   unix.chmod(tmp_path, tonumber("755", 8))
 
   -- Open the copy in append mode to modify its zip in-place
-  -- (api-review: cosmic.zip's own Archive — embed no longer keeps a
-  -- structural twin of it)
+  -- (cosmic.zip's own Archive)
   local appender_maybe, appender_err = czip.open(tmp_path, {mode = "append"})
   if not appender_maybe then
     local _ok, _err = fs.remove(tmp_path)

--- a/cosmic/fetch/init.tl
+++ b/cosmic/fetch/init.tl
@@ -99,14 +99,13 @@ local record Options
   allow_private: boolean
   --- HTTP proxy URL.
   proxy: string
-  --- Maximum response body size in bytes (api-review: was
-  --- `maxresponse`, the binding's spelling).
+  --- Maximum response body size in bytes.
   max_response_bytes: integer
   --- Per-socket-operation timeout in milliseconds (connect, each
   --- read/write, TLS handshake) — NOT a whole-request deadline. 0 or nil
   --- keeps the 60-second default; there is no "infinite" option.
-  --- (api-review-6: was `timeout`, in seconds — durations are integer
-  --- milliseconds with the unit in the name, house-wide.)
+  --- (Durations are integer milliseconds with the unit in the name,
+  --- house-wide.)
   timeout_ms: integer
   --- Total number of attempts (1 = no retry, default 1). Clamped to >= 1:
   --- 0 or negative would otherwise skip the fetch loop and return nothing.

--- a/cosmic/format/init.tl
+++ b/cosmic/format/init.tl
@@ -10,7 +10,7 @@ local rules = require("cosmic.format.rules")
 --- A formatting issue (syntax error preventing formatting).
 -- One Issue record and one renderer for the whole toolchain: the
 -- checker's (cosmic.teal), which this module reuses instead of keeping
--- a nominally-incompatible twin (api-review-7).
+-- a nominally-incompatible twin.
 local teal = require("cosmic.teal")
 
 local type Issue = teal.Issue

--- a/cosmic/fs/types.tl
+++ b/cosmic/fs/types.tl
@@ -64,7 +64,7 @@ local record fs_types
 
   --- File or directory metadata.
   --- Use the is_dir()/is_file()/is_link()/... methods to check file type.
-  --- ONE representation (api-review, fs.Stat unification): always the
+  --- ONE representation: always the
   --- raw cosmo.unix stat userdata, with the is_* predicates installed
   --- once on the binding's shared metatable — so `st is fs.Stat`
   --- narrows correctly and no wrapper table is ever allocated.
@@ -282,7 +282,7 @@ end
 
 -- "unknown" until the first wrap probes; then "direct" or
 -- "unsupported". There is no wrapper-table fallback any more
--- (api-review, fs.Stat unification): two representations made `is`
+-- (the Stat unification): two representations made `is`
 -- unusable and put a justified cast at every Stat use site, to cover a
 -- runtime shape the pinned cosmos has never had. A sealed metatable is
 -- now an honest error from stat/lstat/fstat instead of a silent switch

--- a/cosmic/ip.tl
+++ b/cosmic/ip.tl
@@ -1,6 +1,6 @@
 --- IP address parsing, formatting, and classification utilities.
---- The typed Addr is the only address currency in public signatures
---- (api-review-2): parse and resolve return Addr, sockets accept
+--- The typed Addr is the only address currency in public signatures:
+--- parse and resolve return Addr, sockets accept
 --- and return Addr, and classification lives on Addr methods. The
 --- implementation is IPv4-only — IPv6 strings are rejected with an
 --- explicit error — but the shape is ready for IPv6 as a value

--- a/cosmic/ip_test.tl
+++ b/cosmic/ip_test.tl
@@ -7,7 +7,7 @@ local function p(s: string): ip.Addr
   return (check.must(ip.parse(s)))
 end
 
--- parse tests: parse returns a typed Addr (api-review-2)
+-- parse tests: parse returns a typed Addr
 
 local function test_parse_ipv4_basic()
   local a = p("192.168.1.1")

--- a/cosmic/literal.tl
+++ b/cosmic/literal.tl
@@ -418,12 +418,10 @@ local function parse_table(toks: {Token}, i: integer, where: string,
 end
 
 --- Options for parse/parse_file: how errors talk about the file.
---- (api-review-6: these were two message-wording positionals. The
---- field is `file`, not `where`: `where` opens a record invariant
---- clause in Teal and cannot name a field.)
+--- (The field is `file`, not `where`, which Teal reserves.)
 local record Options
-  --- File name to prefix messages with (parse only — parse_file
-  --- always uses the path it read). Default "literal".
+  --- File name to prefix messages with. Default "literal" for parse;
+  --- parse_file defaults it to the path it read.
   file: string
   --- What to call the file in errors — `cosmic --make` reads pins with
   --- noun "pin", so the same grammar complains about "a pin". Default
@@ -433,7 +431,7 @@ end
 
 --- Read the literal a file returns, without running it.
 --- @param source string The file's contents
---- @param opts Options? where: file name for messages; noun: file kind in errors
+--- @param opts Options? file: name for messages; noun: file kind in errors
 --- @return {string: any}|nil The declared table
 --- @return string The error message when the file is not a literal
 local function parse(source: string, opts?: Options): {string: any} | nil, string
@@ -468,7 +466,8 @@ end
 
 --- Read a file as a literal table, without running it.
 --- @param path string Path to the file
---- @param opts Options? noun: file kind in errors (where is always the path)
+--- @param opts Options? noun: file kind in errors; file: message label
+--- (defaults to the path)
 --- @return {string: any}|nil The declared table
 --- @return string The error message when unreadable or not a literal
 local function parse_file(path: string, opts?: Options): {string: any} | nil, string
@@ -477,7 +476,8 @@ local function parse_file(path: string, opts?: Options): {string: any} | nil, st
     return nil, "cannot read " .. path .. ": " .. (rerr or "unknown error")
   end
   local noun = opts and opts.noun
-  return parse(source, {file = path, noun = noun})
+  local label = (opts and opts.file) or path
+  return parse(source, {file = label, noun = noun})
 end
 
 local record LiteralModule

--- a/cosmic/net/connect_test.tl
+++ b/cosmic/net/connect_test.tl
@@ -138,8 +138,8 @@ end
 test_listen_unix_connect_unix()
 
 local function test_connect_with_timeout_loopback()
-  -- The old nb_connect surface, now ConnectOptions.timeout_ms
-  -- (api-review-8): connect with a bound, get back a BLOCKING socket.
+  -- ConnectOptions.timeout_ms: connect with a bound, get back a
+  -- BLOCKING socket.
   local server = check.must(net.listen_tcp("127.0.0.1", 0))
   local server_port = check.must(server:getsockname()).port
 

--- a/cosmic/net/init.tl
+++ b/cosmic/net/init.tl
@@ -1,10 +1,10 @@
 --- Networking and socket utilities.
 --- Wraps cosmo.unix socket functions for TCP/UDP and Unix domain sockets.
---- Addresses are typed (api-review-2): every public signature
---- takes a dotted-quad string or an ip.Addr and returns ip.Addr — bare
---- integers are not addresses. IPv4 only: IPv6 strings are rejected
---- with an explicit "IPv6 not supported" error, and lands later as a
---- new Addr family, not a new API.
+--- Addresses are typed: every public signature takes a dotted-quad
+--- string or an ip.Addr and returns ip.Addr — bare integers are not
+--- addresses. IPv4 only: IPv6 strings are rejected with an explicit
+--- "IPv6 not supported" error, and lands later as a new Addr family,
+--- not a new API.
 local unix = require("cosmo.unix")
 local ip = require("cosmic.ip")
 local net_socket = require("cosmic.net.socket")
@@ -20,8 +20,7 @@ local type Address = net_socket.Address
 
 local make_socket = net_socket.make_socket
 
---- Options for socket() and socketpair(): named fields replace the old
---- three positional magic ints (api-review-6).
+--- Options for socket() and socketpair().
 local record SocketOptions
   --- AF_INET (socket default), AF_UNIX (socketpair default).
   family: integer
@@ -122,9 +121,7 @@ local connect_with_timeout = require("cosmic.net.connect").with_timeout
 local record ConnectOptions
   --- Bound the connect attempt: fail with an error after this many
   --- milliseconds instead of waiting on the kernel's own (much longer)
-  --- timeout. The returned socket is BLOCKING either way (api-review-8:
-  --- this option absorbs the old nb_connect, whose manually-managed
-  --- socket + non-blocking aftermath was the module's sharpest edge).
+  --- timeout. The returned socket is BLOCKING either way.
   timeout_ms: integer
 end
 
@@ -165,11 +162,10 @@ local function connect_tcp(addr: Address, port: integer, opts?: ConnectOptions):
 end
 
 --- Open a TCP connection to host:port. This name and shape are the
---- stable dial contract (api-review-2, and reserved since): host
---- is a dotted-quad literal or a DNS name — resolution happens inside —
---- and the result is a connected Socket. Future address families and
---- richer endpoint forms extend the values dial accepts, never the
---- signature.
+--- stable dial contract: host is a dotted-quad literal or a DNS name —
+--- resolution happens inside — and the result is a connected Socket.
+--- Future address families and richer endpoint forms extend the values
+--- dial accepts, never the signature.
 --- @param host string Host to connect to: dotted-quad literal or DNS name
 --- @param port integer Remote TCP port
 --- @param opts ConnectOptions? timeout_ms bounds the connect attempt
@@ -192,8 +188,7 @@ end
 
 --- Options for listen_tcp.
 local record ListenOptions
-  --- Maximum pending connections (default 128); the old positional
-  --- between port and the options record, folded in (api-review-6).
+  --- Maximum pending connections (default 128).
   backlog: integer
   --- Set SO_REUSEADDR on the listener (default true: rebinding a
   --- just-closed address must not fail with EADDRINUSE).
@@ -215,18 +210,11 @@ end
 ---   local port = assert(srv:getsockname()).port
 ---   local client = net.connect_tcp("127.0.0.1", port)
 ---
---- Amends the api-review-2 recorded decision: the (Socket, port, err)
---- triple's slot-3 error was invisible to `check.must` and to
---- `local s, err = ...` — every misuse type-checked and crashed at
---- runtime. Error-in-slot-2 wins over the port convenience.
----
 --- @param addr Address Local IPv4 address to bind ("127.0.0.1", "0.0.0.0" for all)
 --- @param port integer Local port to bind; use 0 for an OS-assigned ephemeral port
 --- @param opts ListenOptions? backlog (default 128), reuseaddr (default true), reuseport (default false)
 --- @return Socket | nil Listening socket ready to accept; when port 0
---- was requested, read the OS-assigned port with
---- `s:getsockname().port` (the old (Socket, port, err) triple put the
---- error in slot 3, where `check.must` and `local s, err = ...` lost it)
+--- was requested, read the OS-assigned port with `s:getsockname().port`
 --- @return string Error message on failure
 local function listen_tcp(addr: Address, port: integer, opts?: ListenOptions): Socket | nil, string
   opts = opts or {}

--- a/cosmic/net/io_test.tl
+++ b/cosmic/net/io_test.tl
@@ -281,7 +281,7 @@ end
 test_send_offset()
 
 -- recv(0) reads "" from the kernel on a stream socket, which is
--- indistinguishable from "peer closed" (api-review-2, #589) unless
+-- indistinguishable from "peer closed" (#589) unless
 -- bufsiz is rejected outright: an honest error, not a throw.
 local function test_recv_zero_bufsiz_is_error()
   local a, b = pair()

--- a/cosmic/net/socket.tl
+++ b/cosmic/net/socket.tl
@@ -1,6 +1,6 @@
 --- Socket implementation for the networking module.
 --- Contains the Socket constructor and all Socket method implementations.
---- Addresses are typed (api-review-2): methods accept a dotted-quad
+--- Addresses are typed: methods accept a dotted-quad
 --- string or an ip.Addr, and return ip.Addr — bare integers are not part
 --- of the public surface (wrap C-boundary integers with ip.from_int()).
 local unix = require("cosmo.unix")
@@ -231,15 +231,15 @@ local function make_socket(fd: integer): Socket
         dgram = self:getsockopt(unix.SOL_SOCKET, unix.SO_TYPE) == unix.SOCK_DGRAM
       end
       if not dgram then
-        return nil -- peer closed: end of stream (api-review-2, #589)
+        return nil -- peer closed: end of stream (#589)
       end
     end
     return data
   end
 
   -- The stream.Reader/Writer contract is exactly recv/send's: recv
-  -- returns bare nil at end of stream (api-review-2) and send
-  -- returns bytes written. Alias rather than wrap.
+  -- returns bare nil at end of stream and send returns bytes
+  -- written. Alias rather than wrap.
   sock.read = sock.recv
   sock.write = sock.send
 

--- a/cosmic/shm.tl
+++ b/cosmic/shm.tl
@@ -66,8 +66,7 @@ local record ShmModule
     --- Wait until the word no longer holds `expect`. Returns 0 when
     --- woken; nil plus an error naming EAGAIN (value already differed)
     --- or ETIMEDOUT (timeout expired). `timeout_ms` is a RELATIVE
-    --- timeout in integer milliseconds (api-review-6: was an absolute
-    --- s+ns deadline pair); omit it to wait forever. A wait interrupted
+    --- timeout in integer milliseconds; omit it to wait forever. A wait interrupted
     --- by a signal is retried automatically — the deadline is computed
     --- once, up front, so retries keep the timeout exact.
     wait: function(self: Memory, word_index: integer, expect: integer, timeout_ms?: integer): integer | nil, string

--- a/cosmic/signal.tl
+++ b/cosmic/signal.tl
@@ -5,8 +5,8 @@ local errstr = require("cosmic.errno").wrap
 local errno_is = require("cosmic.errno").is
 
 --- Options for setitimer: which timer, initial fire time, repeat interval.
---- Durations are integer milliseconds (api-review-6: was four s+ns
---- fields); 0 value_ms disarms the timer, 0 interval_ms means one-shot.
+--- Durations are integer milliseconds; 0 value_ms disarms the timer,
+--- 0 interval_ms means one-shot.
 local record SetitimerOptions
   which: integer
   value_ms: integer

--- a/cosmic/stream.tl
+++ b/cosmic/stream.tl
@@ -1,6 +1,6 @@
 --- The stream contract: byte-stream Reader/Writer interfaces.
 --- Every producer and consumer in the standard library composes over
---- them (api-review-2).
+--- them.
 ---
 --- Reader is the one EOF convention: read() returns a non-empty chunk,
 --- or bare nil (no error) at end of stream, or nil plus an error message
@@ -52,8 +52,7 @@ local record stream
 
   --- What lines() returns: each call yields the next line without its
   --- trailing newline, then nil + the error once on a read failure,
-  --- then plain nil forever (api-review #996: the type was inline at
-  --- every signature; exported so consumers can name it).
+  --- then plain nil forever (exported so consumers can name it).
   type LineIter = function(): string | nil, string
 
   --- Optional capability: a Reader that can scan for a delimiter
@@ -157,8 +156,7 @@ end
 --- hand-rolled adapter. read(n?) returns successive chunks (at most n
 --- bytes when n is given, the whole remainder otherwise), then bare
 --- nil at end of stream, per the Reader contract; n must be positive
---- when given. (api-review #996: was `from_string`; rule 5 names
---- constructors `new_*`, pairing it with new_buffer.)
+--- when given.
 --- @param data string The bytes to serve
 --- @return Reader A reader over the bytes
 function stream.new_reader(data: string): stream.Reader
@@ -187,7 +185,6 @@ end
 --- appends and reports the chunk fully written; contents() returns
 --- everything written so far. Point stream.copy (or any Writer taker)
 --- at one to materialize a pipeline's output as a string.
---- (api-review #996: was `buffer`; rule 5 names constructors `new_*`.)
 --- @return Buffer The in-memory writer
 function stream.new_buffer(): stream.Buffer
   local parts: {string} = {}

--- a/cosmic/stream_test.tl
+++ b/cosmic/stream_test.tl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cosmic
---- Stream-contract conformance suite (api-review-2): every byte
+--- Stream-contract conformance suite: every byte
 --- producer honors the one EOF convention — read returns a chunk, bare
 --- nil (no error) at end of stream, and keeps returning bare nil after
 --- EOF; failures return nil plus an error message. Run against

--- a/cosmic/tar.tl
+++ b/cosmic/tar.tl
@@ -46,8 +46,7 @@ local MAX_TAR = 512 * 1024 * 1024
 local record ExtractOptions
   --- Cap on the unpacked archive size in bytes (default 512 MiB): the
   --- bound the gunzip step enforces, so a corrupt or malicious archive
-  --- cannot balloon memory (api-review #996: was a private constant
-  --- while zip's cap was an option).
+  --- cannot balloon memory.
   max_archive_bytes: integer
 end
 
@@ -186,8 +185,7 @@ end
 
 --- Extract a tarball into destdir. Gzip compression is detected from
 --- the file's magic bytes, so `.tar.gz` and plain `.tar` both extract
---- with the same call (api-review #996: this used to gunzip
---- unconditionally, so an uncompressed tarball was unreadable).
+--- with the same call.
 --- @param archive string Path to the .tar.gz or .tar file
 --- @param destdir string Directory to extract into (created if needed)
 --- @param opts ExtractOptions? max_archive_bytes: unpacked size cap

--- a/cosmic/time.tl
+++ b/cosmic/time.tl
@@ -1,7 +1,7 @@
 --- Time and clock utilities.
 --- Wraps cosmo.unix time functions for timestamps, sleeping, and time breakdown.
 ---
---- Recorded decision (api-review-2): the formatting surface stays the
+--- Recorded decision: the formatting surface stays the
 --- curated trio — format_http/parse_http (RFC 7231), format_date/parse_date
 --- (YYYY-MM-DD), format_iso8601/parse_iso8601 — plus timegm. A general
 --- strftime passthrough (time.format(fmt, ts)) is deferred to post-stable

--- a/cosmic/tty.tl
+++ b/cosmic/tty.tl
@@ -104,8 +104,7 @@ local function login_tty(fd: integer): boolean, string
   return true
 end
 
---- Checks if a file descriptor refers to a terminal (api-review-8:
---- one is_tty(fd?) replaces isatty plus the three per-stream wrappers).
+--- Checks if a file descriptor refers to a terminal.
 --- @param fd integer? File descriptor to check: 0=stdin, 1=stdout
 --- (the default — "is my output a terminal" is the common question),
 --- 2=stderr

--- a/cosmic/url.tl
+++ b/cosmic/url.tl
@@ -2,8 +2,8 @@
 local cosmo = require("cosmo")
 
 --- Percent-encode a string for use as a URL query parameter value
---- (api-review-8: was `encode` — escape/unescape is the syntax-safety
---- verb pair, D20). Spaces become %20, specials become %XX.
+--- (escape/unescape is the syntax-safety verb pair, D20).
+--- Spaces become %20, specials become %XX.
 --- Use this when building query strings manually:
 --- `"q=" .. url.escape_param(term)` — or format_query() for whole maps.
 ---
@@ -20,8 +20,8 @@ local function escape_param(str: string): string
   return cosmo.EscapeParam(str)
 end
 
---- Decode a percent-encoded query parameter (api-review-8: was
---- `decode`). Handles %XX sequences and + as space — the param rules.
+--- Decode a percent-encoded query parameter.
+--- Handles %XX sequences and + as space — the param rules.
 --- For other components (paths, hosts, fragments), where + is a
 --- literal plus, use unescape().
 --- @param str string The percent-encoded string

--- a/cosmic/zip.tl
+++ b/cosmic/zip.tl
@@ -18,8 +18,7 @@ local fs = require("cosmic.fs")
 local type AddOptions = zip.AddOptions
 
 --- File metadata within a ZIP archive: size, compressed_size, crc32,
---- mtime, method (0=stored, 8=deflated), and mode (api-review #996:
---- was `Stat`, which collided with fs.Stat at call sites).
+--- mtime, method (0=stored, 8=deflated), and mode.
 local type EntryStat = zip.Stat
 
 --- Directory entry returned by Archive:list(): name, size, and mode. The
@@ -41,7 +40,7 @@ local record OpenOptions
   --- Compression level 0-9, for write/append.
   level: integer
   --- Refuse any member whose declared uncompressed size exceeds this
-  --- many bytes (api-review #996: was the binding's `max_file_size`).
+  --- many bytes.
   max_file_size_bytes: integer
 end
 
@@ -203,8 +202,8 @@ local function open(path: string | integer, opts?: OpenOptions): Archive | nil, 
 end
 
 --- Open a ZIP archive from in-memory data, always in read mode
---- (api-review #996: was `open_bytes` — rule 2 reserves `_bytes` for
---- counts; `_string` is the bytes-not-path sibling spelling).
+--- (`_string` is the bytes-not-path sibling spelling; `_bytes` is
+--- reserved for counts).
 --- @param data string The ZIP archive data
 --- @param opts OpenOptions? max_file_size_bytes (mode is always read)
 --- @return Archive | nil The archive, or nil on error


### PR DESCRIPTION
Implements #1005. `--docs` renders these comments; ~50 of them cited `api-review-N` review IDs a user cannot look up, or narrated renames of names that no longer exist.

## The sweep

Every shipped doc comment now describes the current contract only. Where a parenthetical carried real semantics it keeps them — `dial`'s stability promise, the BLOCKING socket after `timeout_ms`, compress's enum-split rationale, the `where`-is-reserved note in literal, GitHub-issue `#589` citations (those are lookupable) — and the pure was-called-X rename history is gone. 32 files, −150/+81 lines.

**Acceptance holds**: `grep -rn "api-review" cosmic/ --include="*.tl"` returns nothing; `_tool/` is swept too.

## Docs contradicted by adjacent code

- **literal**: `parse`'s `@param` no longer names a `where` option (the field is `file`), and `parse_file` now **honors `opts.file`** as the message label instead of silently discarding it — it still defaults to the path, so no caller changes.
- **_tool/testrun**: the never-run `Example_makefile` — an `Example_` function in a non-example file, documenting recipes `cosmic.mk` no longer generates — is deleted (~40 lines).
- zip.tl's header, re.tl, shm.tl, and walk_example were flagged in the issue but had already been fixed by their own issues; verified current rather than re-edited.

## Verification

- warm `bin/cosmic --make ci` → `ci: PASS (5 stages)`
- cold gate `rm -rf o && bin/cosmic --make fetch && bin/cosmic --make ci` → `ci: PASS (5 stages)`

Closes #1005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_