### PR TITLE
D20 amendments: rule 11 (record-not-tuple), carve-outs, and the verb discriminator (#1006)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ not yet carry is in [docs/design/make/](docs/design/make/).
 - **source language**: Teal (`.tl` files) — typed Lua that compiles to Lua 5.4
 - **error handling**: return `value, string` (nil + error message on failure). never throw from library code.
 - **doc comments**: `---` prefix with `@param` and `@return` tags
-- **naming**: the ten-rule charter is [D20](docs/decisions/d20-naming-charter.md); a
+- **naming**: the charter is [D20](docs/decisions/d20-naming-charter.md); a
   deviation in new code is a bug. Headlines: `snake_case` spelled out, units in the
   identifier (`_ms`), `is_*` predicates, `Options`/`opts`, lowercase constructors.
 - **formatting**: 2-space indent, LF line endings, enforced by `cosmic --check fmt`

--- a/cosmic/proc/init.tl
+++ b/cosmic/proc/init.tl
@@ -239,9 +239,8 @@ end
 --- @return integer Status word (interpret with WIFEXITED/WEXITSTATUS/...)
 --- @return Rusage Resource usage for the reaped child
 --- @return string? Error message on failure
---- What wait(2) reaped. A record rather than (pid, status, rusage,
---- err) returns: the old shape put the error in slot 4, unreachable
---- from `local pid, err = ...` and from check.must.
+--- What wait(2) reaped; a record per D20 rule 11 (the error stays
+--- reachable in slot 2).
 local record WaitResult
   pid: integer
   --- Raw status word; decode with WIFEXITED/WEXITSTATUS/WIFSIGNALED/WTERMSIG.

--- a/cosmic/proc/rusage.tl
+++ b/cosmic/proc/rusage.tl
@@ -7,9 +7,8 @@ local errstr = require("cosmic.errno").wrap
 
 local type Rusage = unix.Rusage
 
---- A resource limit pair. A record rather than (soft, hard, err)
---- returns: the old shape put the error in slot 3, where
---- `local soft, hard = ...` silently lost it.
+--- A resource limit pair; a record per D20 rule 11 (the error stays
+--- reachable in slot 2).
 local record Rlimit
   --- Soft limit (can be exceeded, may generate a signal).
   soft: integer

--- a/cosmic/shm.tl
+++ b/cosmic/shm.tl
@@ -20,8 +20,7 @@ local record ShmModule
   --- Shared memory region with atomic word operations and futexes.
   --- One compare-exchange outcome: whether the swap happened, and the
   --- word's actual value at the time (the old value on success). A
-  --- record rather than (swapped, actual, err) returns — the error is
-  --- in slot 2 where `local r, err = ...` can see it.
+  --- record per D20 rule 11 (the error stays reachable in slot 2).
   record Exchange
     swapped: boolean
     value: integer

--- a/cosmic/signal.tl
+++ b/cosmic/signal.tl
@@ -41,9 +41,8 @@ end
 
 --- Signal handling module.
 --- Provides signal constants, sigaction, sigprocmask, sigsuspend, and delivery functions.
---- The disposition sigaction replaced. A record rather than
---- (handler, flags, mask, err) returns: the old shape put the error in
---- slot 4, unreachable from `local prev, err = ...`. Restore with
+--- The disposition sigaction replaced; a record per D20 rule 11 (the
+--- error stays reachable in slot 2). Restore with
 --- `signal.sigaction(sig, prev.handler, prev.flags, prev.mask)`.
 local record PrevAction
   --- The previous handler: a Lua function, or SIG_DFL/SIG_IGN.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -31,7 +31,7 @@ than editing the record it replaces.
 | D17 | a graph rule's tool prerequisite is a per-tool stamp, not the binary | [→](d17-tool-stamps.md) |
 | D18 | expensive recipe steps skip on input bytes, not just on mtime | [→](d18-step-skip.md) |
 | D19 | what "public" means for toolchain modules, and the visibility lint | [→](d19-toolchain-visibility.md) |
-| D20 | the naming charter: ten rules, and the renames that applied them | [→](d20-naming-charter.md) |
+| D20 | the naming charter, and the renames that applied it | [→](d20-naming-charter.md) |
 | D21 | carried patches: the middle path between pin and fork | [→](d21-carried-tl-patch.md) |
 | D22 | the CSPRNG surface is infallible; a broken one crashes | [→](d22-infallible-csprng.md) |
 | D23 | cosmic.check throws by design; needs/reap may exit | [→](d23-check-throws.md) |

--- a/docs/decisions/d20-naming-charter.md
+++ b/docs/decisions/d20-naming-charter.md
@@ -1,4 +1,4 @@
-# D20 — the naming charter: ten rules, and the renames that applied them
+# D20 — the naming charter, and the renames that applied it
 
 - **date:** 2026-08
 - **context:** the API review found five or six *competing
@@ -9,7 +9,8 @@
   exports. Each was locally defensible; together they made every call
   site a guess. The pre-1.0 window (D10) is the one time renames are
   cheap.
-- **decision:** ten rules. New code follows them; a deviation is a bug.
+- **decision:** the rules below (ten at first writing; rule 11 added
+  2026-08, #1006). New code follows them; a deviation is a bug.
   1. `snake_case`, words spelled out; no new abbreviations.
      `PascalCase` is for record TYPES only — no PascalCase functions;
      constructors are lowercase (`signal.sigset()`; `Sigset()` is
@@ -17,17 +18,34 @@
   2. Units live in the identifier: `_ms`, `_kb`, `_bytes`. Durations
      are integer milliseconds.
   3. Predicates are `is_*` (`fs.is_file`, `poll:is_empty`);
-     object-state getters are bare participles (`h:closed()`).
+     object-state getters are bare participles (`h:closed()`). Named
+     carve-out (#1006): `starts_with`/`ends_with`/`contains` on
+     `cosmic.string` keep their cross-language spellings — every
+     mainstream string API spells them so — and predicates are `is_*`
+     everywhere else, which is why `re.is_match` and
+     `hash.is_equal_constant_time` sit correctly beside them.
   4. Getters are bare nouns (`sys.nproc()`, `fs.cwd()`); `get*/set*`
      prefixes survive only in syscall-shaped modules (`proc`, `user`,
      `signal`), which keep POSIX names wholesale. Battery modules use
      English: `fs.make_dirs`, `fs.remove_all`, `fs.temp_dir`.
+     Additions (#1006): a syscall-shaped module marks its non-syscall
+     members with a section header (`proc.which`/`interpreter`/
+     `is_main` sit under one), so the wholesale-POSIX license visibly
+     stops where the battery half starts; `net` is declared NOT
+     syscall-shaped — its verbs follow the battery rules. The fs
+     kept-POSIX set is the amended section below.
   5. Constructors: `open` = acquires a closeable resource; `new` =
      pure in-memory object; `wrap` = adopts an existing raw resource.
   6. `parse`/`format` for text↔value; `encode`/`decode` for
      representation change; `escape`/`unescape` for syntax safety.
      Every pair ships both halves or documents why not. The file
      variant is `<verb>_file` (`literal.parse`/`parse_file`).
+     The discriminator (#1006): `encode`/`decode` when the target is a
+     named wire format the world already calls encoding — JSON,
+     base64, hex — so `json.encode`/`json.decode` are sanctioned;
+     `parse`/`format` when reading a structure out of text — URL,
+     time, literal, IP. `re.gmatch`/`re.gsub` are deliberate Lua
+     mirrors, recorded as such, not rule-9 verbs.
   7. Options records are named `Options` (or `<Thing>Options` when a
      module has several); the argument is named `opts`. Named
      exemption (#991): `flags.Spec` — a CLI interface declaration is
@@ -40,6 +58,13 @@
      (`child.start`), `begin`/`finish` for spans (`instrument`).
   10. Every type in a public signature is exported (`type X = X`);
       `Reader`/`Writer` are reserved for the `cosmic.stream` contract.
+  11. (added 2026-08, #1006) A multi-value return whose last slot
+      would be an error returns a RECORD instead: the error must be
+      reachable from `local v, err = ...` and from `check.must`, so a
+      tuple never carries it in slot 3 or beyond. `proc.WaitResult`,
+      `proc.Rlimit`, `signal.PrevAction`, and `shm`'s `Exchange` are
+      the shape; this rule replaces the four per-site justifications
+      they carried.
 - **the transition:** the pinned cosmic that cold-starts a build
   EXECUTES tree tooling (`_cli`/`_make`/…) against its own embedded,
   pre-rename `cosmic.*` modules, so a rename cannot be atomic: renamed
@@ -54,7 +79,13 @@
   `Reader`/`Writer` type aliases, `child.spawn`, `embed.run`,
   `doc.run`, `literal.of_source/of_file`, `proc.commandv` — is gone,
   and tooling calls the charter names everywhere. The protocol above
-  remains the template for any future public rename.
+  remains the template for any future public rename, with one
+  amendment (#1006): a rename wave's PR lists, explicitly, the family
+  members it does NOT rename. Every wave so far missed a sibling the
+  next review had to catch — `listen_unix` beside `listen_tcp`, zip's
+  reader beside `fetch.Reader`, `maxresponse` beside `timeout_ms` —
+  and the omission was invisible precisely because nothing required
+  naming it.
 - **the kept-POSIX set (amended 2026-08, #988):** operations are named
   in English, and the POSIX names that survive are the
   effectively-English concepts — a closed, recorded carve-out, not a
@@ -73,4 +104,8 @@
   family, zip `Archive`/`Builder`, url escape family, syslog `Level`
   enum, tty `is_tty` consolidation, net dial options, fs find/find_iter)
   following separately. Renames not yet applied are tracked there, not
-  relitigated per-file.
+  relitigated per-file. Two error-shape carve-outs recorded in their
+  own files bound rule 11 and the never-throw doctrine:
+  [D22](d22-infallible-csprng.md) (the CSPRNG's deliberate
+  crash-on-failure) and [D23](d23-check-throws.md) (`cosmic.check`
+  alone may throw).


### PR DESCRIPTION
Implements #1006 — one decisions PR recording what the 2026-08 review decided, so none of it is relitigated per-file.

## The amendments

- **Rule 11 (new):** a multi-value return whose last slot would be an error returns a RECORD — the error must be reachable from `local v, err = ...` and from `check.must`, so a tuple never carries it in slot 3+. `proc.WaitResult`, `proc.Rlimit`, `signal.PrevAction`, and `shm`'s `Exchange` are named as the shape, and their four per-site doc-comment justifications shrink to rule-11 citations — one rule replaces four archaeologies.
- **Rule 3 carve-out:** `starts_with`/`ends_with`/`contains` on `cosmic.string` keep their cross-language spellings; predicates are `is_*` everywhere else, which is why `re.is_match` and `hash.is_equal_constant_time` sit correctly beside them.
- **Rule 6 discriminator:** `encode`/`decode` when the target is a named wire format the world already calls encoding (JSON, base64, hex — `json.encode`/`decode` sanctioned explicitly); `parse`/`format` when reading a structure out of text (URL, time, literal, IP). The cover the old text cited (`codec.encode_lua`) is already gone (#1001). `re.gmatch`/`gsub` recorded as deliberate Lua mirrors.
- **Rule 4 additions:** syscall-shaped modules mark non-syscall members with a section header — `proc`'s Beyond-POSIX block (#999) is the shape; `net` is declared NOT syscall-shaped (its renames land with the net issue); the fs kept-POSIX set remains the existing #988 amended section.
- **Rule 7:** `flags.Spec` exemption was already recorded (#991) — verified, not re-added.
- **Transition protocol amendment:** a rename wave's PR lists, explicitly, the family members it does NOT rename — every wave so far missed a sibling (`listen_unix` beside `listen_tcp`, zip's reader beside `fetch.Reader`, `maxresponse` beside `timeout_ms`), invisibly, because nothing required naming it.
- **Cross-references:** consequences now point at [D22](../blob/main/docs/decisions/d22-infallible-csprng.md) (CSPRNG crash carve-out) and [D23](../blob/main/docs/decisions/d23-check-throws.md) (check throws) as the recorded bounds on the error-shape rules.

The H1 sheds its "ten rules" count (rule 11 exists now); the derived decisions index row follows via `bin/cosmic _docs/derive.tl`, and AGENTS.md cites "the charter" without a number to go stale.

## Verification

- warm `bin/cosmic --make ci` → `ci: PASS (5 stages)`
- cold gate `rm -rf o && bin/cosmic --make fetch && bin/cosmic --make ci` → `ci: PASS (5 stages)`

Closes #1006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_