### PR TITLE
json: charter option spellings and an honest decode doc (#998, cosmic half)

### DIFF
--- a/cosmic/json.tl
+++ b/cosmic/json.tl
@@ -7,8 +7,8 @@
 --- - `{"a":null,"b":1}` decodes with `a` absent and re-encodes as `{"b":1}`.
 --- - `[1,null,2]` decodes with a hole at index 2; re-encoding sees a table
 ---   of length 1 and truncates to `[1]`.
---- - NaN and +/-Inf fail encode() with an error unless `nan="null"` is
----   given, which serializes them as `null` (the v8 behavior).
+--- - NaN and +/-Inf fail encode() with an error unless `nan_as_null=true`
+---   is given, which serializes them as `null` (the v8 behavior).
 --- If null-preserving round-trips matter, restructure the data (e.g. encode
 --- explicit sentinel values) rather than relying on this module.
 ---
@@ -27,19 +27,23 @@ local record Options
   --- Indentation string used when pretty is true (default " ").
   indent: string
   --- Maximum serializer recursion depth (default 64, max 32767).
-  maxdepth: integer
-  --- The only accepted value is "null": encode NaN and Infinity as
-  --- `null` (the v8 behavior) instead of failing with nil, error.
-  nan: string
+  max_depth: integer
+  --- Encode NaN and +/-Inf as `null` (the v8 behavior) instead of
+  --- failing with nil, error (default false).
+  nan_as_null: boolean
 end
 
 --- Decode a JSON string into a Lua value.
 --- Converts JSON strings, numbers, booleans, arrays, and objects into their Lua equivalents.
---- JSON `null` becomes nil, so null-valued object keys vanish and arrays
---- containing null are truncated at the first null when re-encoded (see the
---- module-level null policy above).
+--- A successful decode of JSON `null` returns `nil, nil` — success the
+--- house `if not v then` guard cannot tell from failure — so when the
+--- input may be `null`, test the ERROR, not the value. Better, when
+--- the top-level shape is known, use decode_object/decode_array: their
+--- nil always means failure. JSON `null` becomes Lua nil, so
+--- null-valued object keys vanish and arrays containing null decode
+--- with holes (see the module-level null policy above).
 --- @param str string The JSON string to decode
---- @return any The decoded Lua value (table, string, number, boolean, or nil)
+--- @return any The decoded Lua value (table, string, number, boolean, or nil — and nil for JSON null)
 --- @return string? Error message if decoding failed
 local function decode(str: string): any, string
   local result, err = cosmo.DecodeJson(str)
@@ -48,11 +52,11 @@ end
 
 --- Encode a Lua value as a JSON string.
 --- Converts Lua tables, strings, numbers, booleans, and nil into JSON format.
---- NaN and +/-Inf fail with an error unless `nan="null"` is given;
---- nil-valued table entries are absent (see the module-level null policy
---- above).
+--- NaN and +/-Inf fail with an error unless `nan_as_null=true` is
+--- given; nil-valued table entries are absent (see the module-level
+--- null policy above).
 --- @param value any The Lua value to encode
---- @param opts Options? pretty, sorted, indent, maxdepth, nan
+--- @param opts Options? pretty, sorted, indent, max_depth, nan_as_null
 --- @return string | nil The JSON string representation
 --- @return string? Error message if encoding failed
 local function encode(value: any, opts?: Options): string | nil, string
@@ -60,13 +64,14 @@ local function encode(value: any, opts?: Options): string | nil, string
   local err: string | nil
   if opts then
     -- Build a plain table to avoid a nominal type conflict with
-    -- cosmo's EncoderOptions record.
+    -- cosmo's EncoderOptions record; the charter spellings map to the
+    -- binding's own (maxdepth, nan="null") here.
     result, err = cosmo.EncodeJson(value, {
         pretty = opts.pretty,
         sorted = opts.sorted,
         indent = opts.indent,
-        maxdepth = opts.maxdepth,
-        nan = opts.nan,
+        maxdepth = opts.max_depth,
+        nan = opts.nan_as_null and "null" or nil,
       })
   else
     result, err = cosmo.EncodeJson(value)

--- a/cosmic/json_test.tl
+++ b/cosmic/json_test.tl
@@ -160,12 +160,12 @@ local function test_encode_default_stays_compact()
 end
 test_encode_default_stays_compact()
 
-local function test_encode_maxdepth()
-  local result, err = json.encode({a = {b = {c = 1}}}, {maxdepth = 2})
-  assert(result == nil, "encode past maxdepth should fail")
-  assert(err ~= nil, "maxdepth failure should carry an error message")
+local function test_encode_max_depth()
+  local result, err = json.encode({a = {b = {c = 1}}}, {max_depth = 2})
+  assert(result == nil, "encode past max_depth should fail")
+  assert(err ~= nil, "max_depth failure should carry an error message")
 end
-test_encode_maxdepth()
+test_encode_max_depth()
 
 -- Null policy: these pin the documented (lossy) behavior so a change in the
 -- C encoder/decoder shows up as a test failure, not a silent contract drift.
@@ -198,11 +198,11 @@ local function test_nan_inf_encoding()
   local inf_json, inf_err = json.encode({math.huge})
   assert(inf_json == nil, "Inf is documented to fail encode, got: " .. tostring(inf_json))
   assert(inf_err ~= nil, "Inf encode failure should carry an error message")
-  -- nan="null" opts into the v8 behavior for both NaN and Infinity.
-  local nan_null = json.encode({0 / 0}, {nan = "null"})
-  assert(nan_null == "[null]", "NaN with nan='null' should encode, got: " .. tostring(nan_null))
-  local inf_null = json.encode({math.huge, -math.huge}, {nan = "null"})
-  assert(inf_null == "[null,null]", "Inf with nan='null' should encode, got: " .. tostring(inf_null))
+  -- nan_as_null opts into the v8 behavior for both NaN and Infinity.
+  local nan_null = json.encode({0 / 0}, {nan_as_null = true})
+  assert(nan_null == "[null]", "NaN with nan_as_null should encode, got: " .. tostring(nan_null))
+  local inf_null = json.encode({math.huge, -math.huge}, {nan_as_null = true})
+  assert(inf_null == "[null,null]", "Inf with nan_as_null should encode, got: " .. tostring(inf_null))
 end
 test_nan_inf_encoding()
 
@@ -269,7 +269,7 @@ end
 test_decode_depth_limit()
 
 local function test_encode_default_depth_limit()
-  -- Without an explicit maxdepth, a very deep table still fails cleanly.
+  -- Without an explicit max_depth, a very deep table still fails cleanly.
   local t: {any} = {1}
   local root = t
   for _ = 1, 200 do


### PR DESCRIPTION
The unblocked cosmic side of #998 (does NOT close it — the binding half stays tracked there).

## Option renames

- `Options.maxdepth` → `max_depth` (rule 1)
- `nan: string` → `nan_as_null: boolean` — the old field accepted exactly one string value (`"null"`), so a typo silently changed behavior; a boolean cannot. `encode()` maps the charter spellings to the binding's own (`maxdepth`, `nan="null"`), so the C boundary is untouched.

## Honest decode doc

`decode`'s doc now states the trap instead of hiding it: a successful decode of JSON `null` returns `nil, nil` — success the house `if not v then` guard cannot tell from failure — so test the error when the input may be `null`, or better, use `decode_object`/`decode_array`, whose nil always means failure.

## Deliberately not here

The binding-exposure half — sparse-array encode errors by default, `EncodeOptions` opt-in to emit `null` for holes (lossless `[1,null,2]` round-trip without a sentinel), `DecodeOptions.nullval` — is blocked on the whilp/cosmopolitan companion issue. The NULL POLICY block keeps describing today's truncation behavior until that lands; shrinking it now would make the docs dishonest.

## Verification

- warm `bin/cosmic --make ci` → `ci: PASS (5 stages)`
- cold gate `rm -rf o && bin/cosmic --make fetch && bin/cosmic --make ci` → `ci: PASS (5 stages)`

Part of #998.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_