### PR TITLE
cosmos 2026.08.08-2bbc6e5ff: spend the bindings the pin just landed

### DIFF
--- a/3p/cosmos/cosmos_pin.tl
+++ b/3p/cosmos/cosmos_pin.tl
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "d3e7b4f5ded80f3854a44d49313287d1f108a910b5c31f8c2bf7219ed3afc145"}},
+  platforms = {["*"] = {sha = "961d406b5cb66a79eaa3e41aa0648e4bafa000e82e46918fc8d7276d0ae0bfa4"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.08.07-b922daeb1"
+  version = "2026.08.08-2bbc6e5ff"
 }

--- a/_perf/bench/re_bench.tl
+++ b/_perf/bench/re_bench.tl
@@ -67,7 +67,7 @@ local function scenarios(): {pt.Scenario}, string
       -- per-call compile cost.
       name = "re_search_compiled",
       fn = function(_: any): any
-        local _m, caps = (compiled as re.Regex):search(LOG_LINE) -- cast: record union after guard
+        local _m, caps = (compiled as re.Regex):match(LOG_LINE) -- cast: record union after guard
         return caps
       end,
       check = function(_: any, res: any): boolean, string

--- a/cosmic/json.tl
+++ b/cosmic/json.tl
@@ -1,16 +1,18 @@
 --- JSON encoding and decoding utilities.
 --- Wraps cosmo.EncodeJson and cosmo.DecodeJson with convenient Teal-typed interface.
 ---
---- NULL POLICY (lossy — read before round-tripping):
---- Lua tables cannot hold nil values, so JSON `null` does not survive a
---- decode/encode round-trip:
---- - `{"a":null,"b":1}` decodes with `a` absent and re-encodes as `{"b":1}`.
---- - `[1,null,2]` decodes with a hole at index 2; re-encoding sees a table
----   of length 1 and truncates to `[1]`.
+--- NULL POLICY: Lua tables cannot hold nil values, so by default JSON
+--- `null` decodes to nil and a null-valued object key simply vanishes —
+--- `{"a":null,"b":1}` re-encodes as `{"b":1}`. That is the one lossy
+--- case left, and both escape hatches are opt-in:
+--- - `decode(s, {null_value = json.null})` substitutes a sentinel for
+---   every `null`, so keys and array slots survive; `json.null`
+---   re-encodes as `null`, closing the round trip.
+--- - an array with holes is an ERROR on encode, never a silent
+---   truncation; `sparse_as_null = true` encodes each hole as `null`,
+---   which round-trips `[1,null,2]` losslessly with no sentinel at all.
 --- - NaN and +/-Inf fail encode() with an error unless `nan_as_null=true`
 ---   is given, which serializes them as `null` (the v8 behavior).
---- If null-preserving round-trips matter, restructure the data (e.g. encode
---- explicit sentinel values) rather than relying on this module.
 ---
 --- Decoded arrays carry a shared marker metatable so an empty `[]`
 --- re-encodes as `[]` instead of `{}`; use array() to mark empty tables
@@ -31,6 +33,19 @@ local record Options
   --- Encode NaN and +/-Inf as `null` (the v8 behavior) instead of
   --- failing with nil, error (default false).
   nan_as_null: boolean
+  --- Encode array holes as `null` instead of failing with nil, error
+  --- (default false). With it, an array that decoded from JSON
+  --- containing `null` re-encodes losslessly.
+  sparse_as_null: boolean
+end
+
+--- Options accepted by decode(). All fields are optional.
+local record DecodeOptions
+  --- A value to stand in for JSON `null`, so nulls survive the decode
+  --- as something a Lua table can hold. Pass `json.null` to make the
+  --- round trip lossless: it re-encodes as `null`. Without it, `null`
+  --- decodes to nil (null-valued keys vanish, arrays get holes).
+  null_value: any
 end
 
 --- Decode a JSON string into a Lua value.
@@ -39,13 +54,19 @@ end
 --- house `if not v then` guard cannot tell from failure — so when the
 --- input may be `null`, test the ERROR, not the value. Better, when
 --- the top-level shape is known, use decode_object/decode_array: their
---- nil always means failure. JSON `null` becomes Lua nil, so
+--- nil always means failure. JSON `null` becomes Lua nil by default, so
 --- null-valued object keys vanish and arrays containing null decode
---- with holes (see the module-level null policy above).
+--- with holes; `opts.null_value` (typically `json.null`) substitutes a
+--- sentinel instead, which also makes the value non-nil and so tells
+--- success from failure by itself.
 --- @param str string The JSON string to decode
+--- @param opts DecodeOptions? null_value: stand-in for JSON null
 --- @return any The decoded Lua value (table, string, number, boolean, or nil — and nil for JSON null)
 --- @return string? Error message if decoding failed
-local function decode(str: string): any, string
+local function decode(str: string, opts?: DecodeOptions): any, string
+  if opts and opts.null_value ~= nil then
+    return cosmo.DecodeJson(str, {nullval = opts.null_value})
+  end
   local result, err = cosmo.DecodeJson(str)
   return result, err
 end
@@ -53,10 +74,11 @@ end
 --- Encode a Lua value as a JSON string.
 --- Converts Lua tables, strings, numbers, booleans, and nil into JSON format.
 --- NaN and +/-Inf fail with an error unless `nan_as_null=true` is
---- given; nil-valued table entries are absent (see the module-level
---- null policy above).
+--- given, and an array with holes fails unless `sparse_as_null=true`
+--- is; nil-valued table entries are absent (see the module-level null
+--- policy above).
 --- @param value any The Lua value to encode
---- @param opts Options? pretty, sorted, indent, max_depth, nan_as_null
+--- @param opts Options? pretty, sorted, indent, max_depth, nan_as_null, sparse_as_null
 --- @return string | nil The JSON string representation
 --- @return string? Error message if encoding failed
 local function encode(value: any, opts?: Options): string | nil, string
@@ -65,13 +87,14 @@ local function encode(value: any, opts?: Options): string | nil, string
   if opts then
     -- Build a plain table to avoid a nominal type conflict with
     -- cosmo's EncoderOptions record; the charter spellings map to the
-    -- binding's own (maxdepth, nan="null") here.
+    -- binding's own (maxdepth, nan="null", sparsenull) here.
     result, err = cosmo.EncodeJson(value, {
         pretty = opts.pretty,
         sorted = opts.sorted,
         indent = opts.indent,
         maxdepth = opts.max_depth,
         nan = opts.nan_as_null and "null" or nil,
+        sparsenull = opts.sparse_as_null,
       })
   else
     result, err = cosmo.EncodeJson(value)
@@ -155,15 +178,30 @@ end
 
 local record JsonModule
   type Options = Options
+  type DecodeOptions = DecodeOptions
 
-  decode: function(str: string): any, string
+  --- The null sentinel: pass it as decode's `null_value` to keep JSON
+  --- nulls, and it encodes back as `null`. An empty marked table, so
+  --- `v == json.null` is the test.
+  null: any
+
+  decode: function(str: string, opts?: DecodeOptions): any, string
   decode_object: function(str: string): {string: any} | nil, string
   decode_array: function(str: string): {any} | nil, string
   encode: function(value: any, opts?: Options): string | nil, string
   array: function(t?: {any}): {any}
 end
 
+-- The binding's null sentinel is a VALUE, not a function, and gentype
+-- only lifts `<module>.<name> = ...` value fields it can see as such —
+-- a dotted `cosmo.null = {}` is not one — so the generated cosmo types
+-- carry no `null` field. Read it through erasure; the identity is what
+-- matters (the encoder recognizes the table by its metatable).
+-- cast: binding value absent from the generated types
+local null_sentinel = (cosmo as {string: any})["null"]
+
 local M: JsonModule = {
+  null = null_sentinel,
   decode = decode,
   decode_object = decode_object,
   decode_array = decode_array,

--- a/cosmic/json_test.tl
+++ b/cosmic/json_test.tl
@@ -179,15 +179,41 @@ local function test_null_object_key_dropped()
 end
 test_null_object_key_dropped()
 
-local function test_null_array_element_truncates()
+-- A null array element still decodes to a hole by default, but the
+-- hole is now LOUD on re-encode rather than a silent truncation, and
+-- two opt-ins make the round trip lossless (#998).
+local function test_null_array_element_is_a_loud_hole()
   local decoded = json.decode("[1,null,2]") as {any} -- cast: from any
   assert(decoded[1] == 1, "first element should survive")
   assert(decoded[2] == nil, "null element should decode to nil (hole)")
   assert(decoded[3] == 2, "element after null should still be reachable")
-  local reencoded = json.encode(decoded)
-  assert(reencoded == "[1]", "array with hole is documented to truncate on re-encode, got: " .. tostring(reencoded))
+  local reencoded, err = json.encode(decoded)
+  assert(reencoded == nil, "a hole must not silently truncate, got: " .. tostring(reencoded))
+  assert(err and err:find("sparse", 1, true),
+    "the refusal names the condition, got: " .. tostring(err))
 end
-test_null_array_element_truncates()
+test_null_array_element_is_a_loud_hole()
+
+local function test_sparse_as_null_round_trips_an_array()
+  local decoded = json.decode("[1,null,2]") as {any} -- cast: from any
+  assert(json.encode(decoded, {sparse_as_null = true}) == "[1,null,2]",
+    "sparse_as_null re-encodes the hole as null, losslessly")
+end
+test_sparse_as_null_round_trips_an_array()
+
+local function test_null_value_sentinel_survives_the_round_trip()
+  local arr = json.decode("[1,null,2]", {null_value = json.null}) as {any} -- cast: from any
+  assert(arr[2] == json.null, "the sentinel fills the slot")
+  assert(json.encode(arr) == "[1,null,2]", "and re-encodes as null")
+  local obj = json.decode('{"a":null,"b":1}', {null_value = json.null}) as {string: any} -- cast: from any
+  assert(obj.a == json.null, "a null-valued key survives instead of vanishing")
+  assert(json.encode(obj) == '{"a":null,"b":1}', "and round-trips")
+  -- The sentinel also makes a top-level null non-nil, so success is
+  -- distinguishable from failure without inspecting the error.
+  local top, terr = json.decode("null", {null_value = json.null})
+  assert(top == json.null and terr == nil, "top-level null decodes to the sentinel")
+end
+test_null_value_sentinel_survives_the_round_trip()
 
 local function test_nan_inf_encoding()
   -- Non-finite numbers are rejected by default: encoding them silently

--- a/cosmic/re.tl
+++ b/cosmic/re.tl
@@ -3,10 +3,10 @@
 --- functions are SUBJECT-FIRST D20: match(text, pattern), like
 --- string.match. Compile behavior is a CompileOptions record — a search
 --- flag in a compile slot cannot type-check, where the old shared
---- integer namespace silently ignored it. The compiled Regex keeps the
---- binding's own :search/:find method names and integer search flags
---- (NOTBOL/NOTEOL) — a userdata metatable is the C layer's to name, so
---- renaming them is an upstream change, not a record edit. For exact
+--- integer namespace silently ignored it. The compiled Regex speaks
+--- :match/:find with integer search flags (NOTBOL/NOTEOL) — a userdata
+--- metatable is the C layer's to name, so `match` arriving on the
+--- charter verb took an upstream change (cosmopolitan#237). For exact
 --- plain-text search see cosmic.string; for approximate (edit-distance)
 --- matching see cosmic.fuzzy.
 ---
@@ -19,26 +19,28 @@
 local re = require("cosmo.re")
 
 --- A compiled regular expression pattern.
---- Use compile() to create, then call :search() for O(n) matching.
+--- Use compile() to create, then call :match() for O(n) matching.
 local record Regex
   -- Runtime values are cosmo.re's compiled-regex userdata (compile()
   -- casts them in), so `x is Regex` must test for userdata.
   userdata
-  --- Search for pattern match in text.
+  --- Match the pattern against text (D20 rule 9's reserved verb; the
+  --- binding's metatable carries `match` since cosmopolitan#237, so
+  --- this is the method itself and not a wrapper).
   --- On a match, returns the matched substring plus a table of the
   --- parenthesized capture groups (an empty table when the pattern has
   --- no groups, "" for groups that did not participate). A no-match is
   --- not an error: it returns a single bare nil. A genuine engine
   --- failure (e.g. out of memory) returns nil, err — the error string
   --- arrives in the second position, mirroring the cosmo.re binding.
-  --- @param text string The text to search
+  --- @param text string The text to match against
   --- @param flags integer? Optional flags: NOTBOL, NOTEOL
   --- @return string | nil The matched substring, or nil if no match
   --- @return {string} | nil Capture groups on match (error string on engine failure)
   --- @return string | nil Error message on engine failure
-  search: function(self: Regex, text: string, flags?: integer): string | nil, {string} | nil, string | nil
+  match: function(self: Regex, text: string, flags?: integer): string | nil, {string} | nil, string | nil
 
-  --- Like search, but reports WHERE: absolute 1-based inclusive start
+  --- Like match, but reports WHERE: absolute 1-based inclusive start
   --- and end offsets into text, plus the capture table. init starts
   --- the search at that offset while keeping the returned offsets
   --- absolute, which is what lets iteration advance in O(n) instead of
@@ -176,7 +178,7 @@ local function match(text: string, pattern: string, opts?: CompileOptions): Matc
   local entry = cache_entry(pattern, opts)
   local regex, cerr = entry.rx, entry.err
   if regex is Regex then
-    local m, caps = regex:search(text)
+    local m, caps = regex:match(text)
     if not m then
       if caps then
         -- Engine failure: the binding reports nil, err.
@@ -234,7 +236,7 @@ local function compile_for_iter(pattern: string, opts?: CompileOptions): Regex |
     return nil, entry.iter_err
   end
   if not entry.iter_ok then
-    local em = entry.rx:search("")
+    local em = entry.rx:match("")
     if em then
       entry.iter_err = "pattern matches the empty string unsupported: " .. pattern
       return nil, entry.iter_err

--- a/cosmic/re_test.tl
+++ b/cosmic/re_test.tl
@@ -37,49 +37,49 @@ test_compile_invalid_unbalanced_parens()
 
 local function test_regex_search_match()
   local regex = check.must(re.compile("world"), "compile failed")
-  local result = regex:search("hello world")
+  local result = regex:match("hello world")
   assert(result == "world", "expected 'world', got '" .. tostring(result) .. "'")
 end
 test_regex_search_match()
 
 local function test_regex_search_no_match()
   local regex = check.must(re.compile("xyz"), "compile failed")
-  local result = regex:search("hello world")
+  local result = regex:match("hello world")
   assert(result == nil, "expected nil for no match")
 end
 test_regex_search_no_match()
 
 local function test_regex_search_beginning()
   local regex = check.must(re.compile("^hello"), "compile failed")
-  local result = regex:search("hello world")
+  local result = regex:match("hello world")
   assert(result == "hello", "expected 'hello', got '" .. tostring(result) .. "'")
 end
 test_regex_search_beginning()
 
 local function test_regex_search_end()
   local regex = check.must(re.compile("world$"), "compile failed")
-  local result = regex:search("hello world")
+  local result = regex:match("hello world")
   assert(result == "world", "expected 'world', got '" .. tostring(result) .. "'")
 end
 test_regex_search_end()
 
 local function test_regex_search_character_class()
   local regex = check.must(re.compile("[0-9]+"), "compile failed")
-  local result = regex:search("abc123def")
+  local result = regex:match("abc123def")
   assert(result == "123", "expected '123', got '" .. tostring(result) .. "'")
 end
 test_regex_search_character_class()
 
 local function test_regex_search_alternation()
   local regex = check.must(re.compile("cat|dog"), "compile failed")
-  local result = regex:search("I have a dog")
+  local result = regex:match("I have a dog")
   assert(result == "dog", "expected 'dog', got '" .. tostring(result) .. "'")
 end
 test_regex_search_alternation()
 
 local function test_regex_search_captures()
   local regex = check.must(re.compile("([a-z]+)([0-9]+)"), "compile failed")
-  local result, raw_caps = regex:search("abc123")
+  local result, raw_caps = regex:match("abc123")
   assert(result == "abc123", "expected 'abc123', got '" .. tostring(result) .. "'")
   local caps = check.must(raw_caps, "expected captures table on match")
   assert(#caps == 2, "expected 2 captures, got " .. tostring(#caps))
@@ -91,7 +91,7 @@ test_regex_search_captures()
 local function test_regex_search_no_match_no_error()
   -- A no-match from a compiled regex is a single bare nil, not an error.
   local regex = check.must(re.compile("cat"), "compile failed")
-  local result, caps = regex:search("dog only")
+  local result, caps = regex:match("dog only")
   assert(result == nil, "expected nil for no match")
   assert(caps == nil, "expected no second value for no match")
 end
@@ -205,7 +205,7 @@ test_ignore_case_option()
 
 local function test_compile_ignore_case_option()
   local regex = check.must(re.compile("WORLD", {ignore_case = true}))
-  local result = regex:search("hello world")
+  local result = regex:match("hello world")
   assert(result == "world", "expected 'world' with ignore_case")
 end
 test_compile_ignore_case_option()
@@ -256,13 +256,13 @@ test_escaped_special_characters()
 local function test_reuse_compiled_regex()
   local regex = check.must(re.compile("[a-z]+"), "compile failed")
 
-  local r1 = regex:search("123abc456")
+  local r1 = regex:match("123abc456")
   assert(r1 == "abc", "first search failed")
 
-  local r2 = regex:search("xyz789")
+  local r2 = regex:match("xyz789")
   assert(r2 == "xyz", "second search failed")
 
-  local r3 = regex:search("12345")
+  local r3 = regex:match("12345")
   assert(r3 == nil, "expected nil for no match")
 end
 test_reuse_compiled_regex()

--- a/cosmic/signal.tl
+++ b/cosmic/signal.tl
@@ -261,20 +261,10 @@ local raw_sigsuspend = unix.sigsuspend as function(Sigset): (any, any, any)
 -- cannot parse a bare `function | integer` union in a function statement;
 -- the SignalModule record above carries the precise public type.
 local function sigaction(sig: integer, handler?: any, flags?: integer, mask?: Sigset): PrevAction | nil, string
-  -- Never pass explicit trailing nils: the binding leaves nil-valued
-  -- stack slots 3/4 in place, which shifts the stack index it later uses
-  -- to store a Lua handler in its registry table — the handler would be
-  -- registered as nil and never dispatched.
-  local prev, prev_flags, prev_mask: any, any, any
-  if mask ~= nil then
-    prev, prev_flags, prev_mask = raw_sigaction(sig, handler, flags or 0, mask)
-  elseif flags ~= nil then
-    prev, prev_flags, prev_mask = raw_sigaction(sig, handler, flags)
-  elseif handler ~= nil then
-    prev, prev_flags, prev_mask = raw_sigaction(sig, handler)
-  else
-    prev, prev_flags, prev_mask = raw_sigaction(sig)
-  end
+  -- One call with whatever the caller gave: the binding tolerates
+  -- explicit trailing nils now (cosmopolitan#237), so the four-branch
+  -- ladder that existed to never produce them is gone.
+  local prev, prev_flags, prev_mask = raw_sigaction(sig, handler, flags, mask)
   if prev == nil then
     -- On failure the binding returns (nil, err, errno): the error string
     -- arrives in the second slot.

--- a/cosmic/time.tl
+++ b/cosmic/time.tl
@@ -76,27 +76,15 @@ end
 -- tree's only three-return function.
 local function sleep(seconds: integer, nanos?: integer): integer | nil, integer, string
   local ns = nanos or 0
-  local t0s, t0n = unix.clock_gettime(unix.CLOCK_MONOTONIC)
-  -- On failure the binding returns (nil, err, errno): the error string
-  -- arrives in the second slot, the numeric errno in the third.
-  local rem_s, rem_ns, eno = unix.nanosleep(seconds, ns)
+  -- The binding reports its own remainder now (cosmopolitan#237): zero
+  -- when the sleep completed, and on EINTR the kernel's own remainder
+  -- after the errno. Both used to need a pair of clock reads here.
+  local rem_s, rem_ns, eno, eintr_s, eintr_ns = unix.nanosleep(seconds, ns)
   if rem_s ~= nil then
-    -- The binding's success-path remainder is unreliable (nanosleep only
-    -- fills it on EINTR); an uninterrupted sleep's remainder is zero.
-    return 0, 0
+    return rem_s, rem_ns
   end
   if errno.is(eno, "EINTR") then
-    -- The binding discards the kernel's remainder on the error path;
-    -- recover it from the monotonic clock instead.
-    local t1s, t1n = unix.clock_gettime(unix.CLOCK_MONOTONIC)
-    local elapsed = (t1s - t0s) * 1000000000 + (t1n - t0n)
-    local remaining = seconds * 1000000000 + ns - elapsed
-    if remaining < 0 then
-      remaining = 0
-    end
-    return math.floor(remaining / 1000000000),
-    remaining % 1000000000,
-    errno.wrap(rem_ns, "sleep")
+    return eintr_s or 0, eintr_ns or 0, errno.wrap(rem_ns, "sleep")
   end
   return nil, nil, errno.wrap(rem_ns, "sleep")
 end


### PR DESCRIPTION
Bumps `3p/cosmos/cosmos_pin.tl` to the release carrying whilp/cosmopolitan#236 and #237, then deletes the four workarounds those fixes existed to retire.

## What the pin buys

- **`signal.sigaction` is one call again.** The binding tolerates explicit trailing nils now, so the four-branch ladder that existed purely to never produce them is gone.
- **`time.sleep` reads no clocks.** `nanosleep` reports a zero remainder on success and the kernel's own remainder after the errno on EINTR, so the two `clock_gettime` calls that reconstructed it are gone — every sleep in the tree pays two fewer syscalls.
- **`re.Regex:search` → `re.Regex:match`** (D20 rule 9's reserved verb). The binding's metatable carries `match` now, so this is the method itself and not a wrapper; `re.tl`, `re_test.tl` and the re bench move with it.
- **json spends both new options** (#998's remaining half): `sparse_as_null` encodes array holes as `null`; `decode(s, {null_value = json.null})` keeps nulls as a sentinel that re-encodes as `null`; `json.null` is exported. The NULL POLICY block shrinks to the one inherent case — a null-valued key vanishing by default — with both escape hatches named. `test_null_array_element_truncates` becomes `test_null_array_element_is_a_loud_hole`, plus two round-trip tests.

## Not retired, and why

`signal.tl`'s hand-mirrored `Sigset` record and its casts stay. #237 added `unix.sigset` **beside** `unix.Sigset` rather than renaming, so the capitalized constructor field still shadows the record type in the generated declarations (`o/_types/types_gen/cosmo/unix.d.tl` keeps `Sigset` file-local) and cosmic still cannot re-export it. Freeing the name needs the capitalized spelling *removed* upstream — a contract change deserving its own decision, so I did not sneak it in.

One incidental gap found: `cosmo.null` is a value field spelled `cosmo.null = {}`, which gentype's `<module>.<name> = ...` rule does not lift, so the generated types carry no `null`. `json.null` reads it through one justified erasure cast; growing the generator is a separate change.

## Perf, stated honestly

An A/B of `json_bench` across the two pins showed `json_encode_large` at **+8.5%** (1.42 → 1.54 ms/op) — a plausible cost for #236's new sparse-array key walk. But a rematch on the new pin *alone* moved the **decode** scenarios, which this change barely touches, by **+16%** (1.35 → 1.60 µs on `json_decode_small`). The host's drift exceeds the effect size, so the measurement neither confirms nor rules out a real cost. It wants a quiet host and interleaved runs — the trap cosmopolitan#242 documented. Not claiming "no regression"; flagging it for a proper measurement.

## Verification

- warm `bin/cosmic --make ci` → `ci: PASS (5 stages)`
- cold gate `rm -rf o && bin/cosmic --make fetch && bin/cosmic --make ci` → `ci: PASS (5 stages)`

Finishes #998.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_