### PR TITLE
gentype: a module's VALUES belong in the generated types, not only its functions

### DIFF
--- a/_types/gentype_extract.tl
+++ b/_types/gentype_extract.tl
@@ -42,6 +42,14 @@ local function extract_module_content(source: string, module_name: string): stri
   local fn_pattern = "^function%s+" .. module_name .. "%."
   local class_pattern = "^%-%-%-@class%s+" .. module_name .. "%."
   local alias_pattern = "^%-%-%-@alias%s+" .. module_name .. "%."
+  -- A module's surface is not only functions: `cosmo.null = {}` declares
+  -- a VALUE, annotated `---@type`, written qualified and OUTSIDE the
+  -- module table. Such a line used to be dropped here as neither a
+  -- function nor a class, so the parser never saw it and the value was
+  -- absent from the generated types. Keep it with its annotations, and
+  -- emit it in the bare `name = …` form the module table uses, so the
+  -- parser's existing `---@type` field rule reads it unchanged.
+  local value_pattern = "^" .. module_name .. "%.([%w_]+%s*=.*)$"
   local pending: {string} = {}
   local function flush_standalone_class()
     local is_class = false
@@ -68,6 +76,10 @@ local function extract_module_content(source: string, module_name: string): stri
       elseif line:match(fn_pattern) then
         for _, a in ipairs(pending) do table.insert(out, a) end
         table.insert(out, line)
+        pending = {}
+      elseif line:match(value_pattern) then
+        for _, a in ipairs(pending) do table.insert(out, a) end
+        table.insert(out, "  " .. line:match(value_pattern))
         pending = {}
       else
         flush_standalone_class()

--- a/_types/gentype_test.tl
+++ b/_types/gentype_test.tl
@@ -258,6 +258,31 @@ re = {
 end
 test_constant_docs_and_comment_braces()
 
+-- A module's surface includes VALUES, not only functions, and the
+-- definitions write those qualified: `cosmo.null = {}` under a
+-- `---@type` block, outside the module table. Both halves used to miss
+-- it — the extractor dropped the line as neither a function nor a
+-- class, so the parser never saw it — and the value was absent from
+-- the generated types, forcing callers through an erasure cast.
+local function test_qualified_value_field_is_generated()
+  local source = [==[
+cosmo = {
+}
+
+--- The null sentinel.
+---@type JsonValue
+cosmo.null = {}
+]==]
+  local dtl = gentype.generate_dtl(gentype.parse_module(source, "cosmo"))
+  assert(dtl:match("null: any"),
+    "a qualified `<module>.name = …` value field belongs on the module " ..
+    "record:\n" .. dtl)
+  assert(dtl:match("%-%-%- The null sentinel%.\n%s*null:"),
+    "and it carries its doc comment:\n" .. dtl)
+  print("test_qualified_value_field_is_generated: PASS")
+end
+test_qualified_value_field_is_generated()
+
 -- A standalone data class (`---@class mod.Name` + `---@field ...`) renders as
 -- a record even when empty (opaque userdata handles), and every class type is
 -- exported on the module record unless a function shares its name.

--- a/cosmic/json.tl
+++ b/cosmic/json.tl
@@ -192,16 +192,8 @@ local record JsonModule
   array: function(t?: {any}): {any}
 end
 
--- The binding's null sentinel is a VALUE, not a function, and gentype
--- only lifts `<module>.<name> = ...` value fields it can see as such —
--- a dotted `cosmo.null = {}` is not one — so the generated cosmo types
--- carry no `null` field. Read it through erasure; the identity is what
--- matters (the encoder recognizes the table by its metatable).
--- cast: binding value absent from the generated types
-local null_sentinel = (cosmo as {string: any})["null"]
-
 local M: JsonModule = {
-  null = null_sentinel,
+  null = cosmo.null,
   decode = decode,
   decode_object = decode_object,
   decode_array = decode_array,


### PR DESCRIPTION
Closes the generator gap found while landing #1047: `cosmo.null` — the sentinel that makes JSON null round-trips lossless — was absent from the generated cosmo types, so `cosmic.json` reached it through an erasure cast.

## Why it was missing

The value is declared **qualified and outside the module table**:

```lua
--- Sentinel value that `EncodeJson` serializes as JSON `null` …
---@type JsonValue
cosmo.null = {}
```

`gentype.tl` already has a rule for `---@type` value fields — but it never saw this one. `gentype_extract.tl` keeps a module's annotation blocks only when they precede a `function <module>.…` declaration or a class block, and discards everything else. The line and its annotations were dropped one stage *earlier* than the rule that would have handled them, so the two halves each looked correct in isolation.

## The fix

The extractor now keeps a qualified `<module>.name = …` declaration with its annotations, and emits it in the bare `name = …` form the module table already uses. The parser's existing `---@type` rule then reads it unchanged — **`gentype.tl` needs no edit at all**, which is why the diff is small and why the seam lands where the responsibility does (the extractor decides what belongs to a module).

Result: `cosmo.null` generates as `null: any`, and `cosmic/json.tl` drops its cast.

The test drives the whole path (extract → parse → render) rather than either half, since the two halves failing to meet is exactly what hid this.

## Verification

- warm `bin/cosmic --make ci` → `ci: PASS (5 stages)`
- cold gate `rm -rf o && bin/cosmic --make fetch && bin/cosmic --make ci` → `ci: PASS (5 stages)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_