### PR TITLE
signal: call unix.sigset, the constructor that will survive the next pin

### DIFF
--- a/cosmic/signal.tl
+++ b/cosmic/signal.tl
@@ -19,13 +19,13 @@ end
 --- timer never reads as the 0 that would disarm it when passed back.
 
 --- Signal set for blocking, unblocking, and waiting on signals.
---- Wraps unix.Sigset for use with sigprocmask, sigaction, and sigsuspend.
---- This mirror is deliberate: the generated unix record cannot re-export
---- the Sigset record type because its `Sigset` name is taken by the
---- constructor function field there. Here the constructor is
---- `sigset(...)` (lowercase), so the TYPE name Sigset stays free to
---- export — a Teal record cannot hold a value field and a type alias
---- under one name.
+--- Wraps unix.sigset for use with sigprocmask, sigaction, and sigsuspend.
+--- This mirror is transitional: the generated unix record cannot yet
+--- re-export the Sigset record type, because the pinned cosmos still
+--- carries `Sigset` as a constructor FIELD and a Teal record cannot
+--- hold a value field and a type alias under one name.
+--- whilp/cosmopolitan#246 removed that field, so the mirror and the
+--- casts below go at the cosmos pin bump that carries it.
 local record Sigset
   --- Adds signal to bitset.
   add: function(self: Sigset, sig: integer)
@@ -306,7 +306,7 @@ end
 local M = {} as SignalModule -- cast: record built incrementally
 
 -- cast: function shape for nominal Sigset
-M.sigset = unix.Sigset as function(...: integer): Sigset
+M.sigset = unix.sigset as function(...: integer): Sigset
 M.sigaction = sigaction
 M.sigprocmask = sigprocmask
 M.sigsuspend = sigsuspend


### PR DESCRIPTION
whilp/cosmopolitan#246 (merged) removes `unix.Sigset` as a **constructor field**, so the next cosmos release deletes the name `cosmic/signal.tl` currently calls. This switches to `unix.sigset` now, ahead of that.

Free to do today: the lowercase spelling has existed since whilp/cosmopolitan#244, which the **current** pin (`2026.08.08-2bbc6e5ff`) already carries. So this works against the pin we have and means the next cosmos pin bump finds nothing to break here — instead of discovering it as a build failure partway through a bump.

## What stays, and why

The hand-mirrored `Sigset` record and its three casts remain. The generated `unix` record still cannot re-export the **type**, because the pinned cosmos still spends that name on the constructor function, and a Teal record cannot hold a value field and a type alias under one name. Its comment now says exactly that and names the change that ends it, rather than describing the collision as permanent — which is what it said before, and what turned out to be wrong.

Deleting the mirror is the last item on the pin-advance ledger, and it lands with the cosmos pin bump that carries #246.

## Verification

`bin/cosmic --make ci` → `ci: PASS (5 stages)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_