### PR TITLE
bootstrap pin 2026-08-08-8abaf1f: retire the gen-0 compatibility layer

### DIFF
--- a/_cli/args.tl
+++ b/_cli/args.tl
@@ -1,36 +1,14 @@
 --- CLI flag definitions for cosmic, as one flags.Spec (#991).
 --- Shared by the dispatcher and tests to keep the flag list in sync.
---- The getopt-shaped tables below are DERIVED from the spec for the
---- pinned engine's dispatcher, which still parses with them at cold
---- start; they are deleted at the pin advance.
 
---- The spec's shape, declared LOCALLY rather than as flags.Spec: at
---- cold start the pinned engine requires this file at its own boot and
---- type-checks it against ITS embedded flags records, which predate
---- the #991 Flag/Spec.flags vocabulary. A local structural twin keeps
---- this file compilable under both generations; the dispatcher casts
---- it to flags.Spec at the parse call. Retype as flags.Spec at the
---- pin advance.
-local record CliFlag
-  long: string
-  short: string
-  arg: string
-  arg_optional: boolean
-  repeated: boolean
-  help: string
-end
-
-local record CliSpec
-  name: string
-  flags: {CliFlag}
-end
+local flags = require("cosmic.flags")
 
 --- The dispatcher's interface. `-c` is make's shell contract:
 --- `$(SHELL) $(.SHELLFLAGS) '<line>'` with `.SHELLFLAGS` defaulting to
 --- `-c`, so `SHELL := cosmic` works with no further configuration.
 --- The long names for the Lua-compatible shorts (-e/-l/-i/-E/-W) are
 --- new with the flags port; the shorts remain the documented spelling.
-local spec: CliSpec = {
+local spec: flags.Spec = {
   name = "cosmic-lua",
   flags = {
     {long = "recipe", short = "c", arg = "LINE",
@@ -78,26 +56,6 @@ local spec: CliSpec = {
     {long = "modules", arg = "MANIFEST", help = "module resolution manifest"},
   },
 }
-
--- DERIVED getopt tables (#991): the pinned engine's dispatcher still
--- parses with these at cold start. One source of truth — the spec
--- above — and these projections of it; deleted at the pin advance.
-
-local shortopts = ""
-local longopts: {{string: string}} = {}
-for _, f in ipairs(spec.flags) do
-  local has_arg = "none"
-  if f.arg then
-    has_arg = f.arg_optional and "optional" or "required"
-  end
-  if f.short then
-    shortopts = shortopts .. f.short
-    if f.arg then
-      shortopts = shortopts .. (f.arg_optional and "::" or ":")
-    end
-  end
-  longopts[#longopts + 1] = {name = f.long, has_arg = has_arg, short = f.short}
-end
 
 --- Options requiring an argument, derived from the spec and shared so
 --- the dispatcher's pre-scan stays in sync with it.
@@ -162,14 +120,10 @@ local function renamed_check(argv: {string}): string | nil
 end
 
 return {
-  --- The dispatcher's flags.Spec (typed as its structural twin; see
-  --- CliSpec above).
   spec = spec,
   renamed_check = renamed_check,
   resolve_optional_arg = resolve_optional_arg,
-  -- DERIVED for the pinned dispatcher (#991); deleted at pin advance.
-  shortopts = shortopts,
-  longopts = longopts,
+  -- Derived from the spec, for the dispatcher's pre-scan (main.tl).
   short_needs_arg = short_needs_arg,
   long_needs_arg = long_needs_arg,
 }

--- a/_cli/args_test.tl
+++ b/_cli/args_test.tl
@@ -383,21 +383,14 @@ local function test_help_includes_all_options()
   assert(ok, "cosmic --help should succeed")
   local help_text = out
 
-  -- Extract short option characters from shortopts (skip ':' modifiers)
+  -- Every flag the spec declares, in both spellings.
   local short_options: {string} = {}
-  local i = 1
-  while i <= #cli.shortopts do
-    local c = cli.shortopts:sub(i, i)
-    if c ~= ":" then
-      table.insert(short_options, "-" .. c)
-    end
-    i = i + 1
-  end
-
-  -- Extract long option names from longopts table
   local long_options: {string} = {}
-  for _, opt in ipairs(cli.longopts) do
-    table.insert(long_options, "--" .. opt.name)
+  for _, f in ipairs(cli.spec.flags) do
+    if f.short then
+      table.insert(short_options, "-" .. f.short)
+    end
+    table.insert(long_options, "--" .. f.long)
   end
 
   -- Check that every short option appears in help text

--- a/_cli/build/steps.tl
+++ b/_cli/build/steps.tl
@@ -215,7 +215,7 @@ local function do_copy(args: {string}): integer
   end
   local mode = st:mode() % 512 -- permission bits (0777)
   local _ok, _err = fs.make_dirs(fs.dirname(dst))
-  local ok, werr = fs.write(dst, content, mode)
+  local ok, werr = fs.write(dst, content, {mode = mode})
   if not ok then
     return fail("write " .. dst .. " failed: " .. (werr or "unknown error"))
   end

--- a/_cli/build/work.tl
+++ b/_cli/build/work.tl
@@ -117,18 +117,10 @@ end
 --- output's mtime. (Moved verbatim from steps.tl; see the restamp
 --- comment there for why an unchanged result still touches the mtime.)
 local function run_into(argv: {string}, out: string): integer
-  -- TRANSITIONAL dual-shape dispatch (delete at the next pin advance,
-  -- #981-class): the pinned binary's child.run returns a Result with
-  -- spawn_error folded in; the tree's returns Result | nil, string.
-  -- cast: transitional dual-shape call
-  local run_dual = child.run as function({string}, child.Options): (any, any)
-  local r_any, rerr = run_dual(argv, nil)
-  -- cast: transitional dual-shape probe
-  local spawn_err = r_any ~= nil and (r_any as {string: any}).spawn_error or rerr
-  if r_any == nil or spawn_err ~= nil then
-    return fail("start " .. argv[1] .. " failed: " .. tostring(spawn_err or "start failed"))
+  local r, rerr = child.run(argv, nil)
+  if r == nil then
+    return fail("start " .. argv[1] .. " failed: " .. tostring(rerr or "start failed"))
   end
-  local r = r_any as child.Result -- cast: transitional dual-shape result
   if r.stderr and r.stderr ~= "" then
     io.stderr:write(r.stderr)
   end

--- a/_cli/driver.tl
+++ b/_cli/driver.tl
@@ -135,15 +135,8 @@ local function fence(verb: string, args: {string}): string | nil
   -- restricting — the right default when nobody knows whether the dump
   -- will still work — and every fenced recipe then reports only the
   -- lines it ran before the fence landed. (#989: the mark replaced the
-  -- keep_coverage policy flag.) The probe guards the gen-0 cold start,
-  -- where the pinned engine's coverage module predates the mark; the
-  -- seal there loses nothing because gen-0 collects no coverage.
-  -- Delete the guard at pin advance.
-  local coverage = require("cosmic.coverage") as {string: any} -- cast: transitional probe
-  local keep = coverage["keep_on_restrict"]
-  if type(keep) == "function" then
-    (keep as function())() -- cast: from any
-  end
+  -- keep_coverage policy flag.)
+  require("cosmic.coverage").keep_on_restrict()
   local enforced, err = sandbox.apply({
       fs = fs_policy,
       best_effort = true,

--- a/_cli/grants.tl
+++ b/_cli/grants.tl
@@ -240,9 +240,9 @@ local function plan(verb: string, args: {string}): sandbox.Fs | nil, string | ni
   -- asserts the refusal saw a sandbox error instead.
   --
   -- Dropping the rule costs nothing: the program is not there, so
-  -- granting exec on it protects no one, and whatever the verb does
-  -- next it does with an honest error of its own.
-  -- Predates sandbox.Fs.optional (#989); keep until the pin advance.
+  -- granting exec on it protects no one, and the verb still errors.
+  -- Filtered here, not via sandbox.Fs.optional (#989): the planned
+  -- policy must equal the enforced one (`_cli/driver_test.tl`).
   local ex: {string} = {}
   for _, p in ipairs(ex_raw) do
     if fs.is_present(p) then

--- a/_cli/help_test.tl
+++ b/_cli/help_test.tl
@@ -21,9 +21,9 @@ local function test_generate_contains_all_longopts()
   local result = help.generate()
   assert(result:find("Cosmic options:"), "help text should contain 'Cosmic options:'")
 
-  for _, opt in ipairs(cli_args.longopts) do
-    local pattern = "%-%-" .. opt.name:gsub("%-", "%%-")
-    assert(result:find(pattern, 1, false), "help text missing long option: --" .. opt.name)
+  for _, f in ipairs(cli_args.spec.flags) do
+    local pattern = "%-%-" .. f.long:gsub("%-", "%%-")
+    assert(result:find(pattern, 1, false), "help text missing long option: --" .. f.long)
   end
 end
 test_generate_contains_all_longopts()
@@ -33,10 +33,12 @@ local function test_generate_contains_all_shortopts()
   assert(result:find("Standard lua options:") or result:find("Cosmic options:"),
     "help text should contain option sections")
 
-  -- parse shortopts string, skipping ':' modifiers
-  for c in cli_args.shortopts:gmatch("[^:]") do
-    local pattern = "%-" .. c
-    assert(result:find(pattern, 1, false), "help text missing short option: -" .. c)
+  for _, f in ipairs(cli_args.spec.flags) do
+    if f.short then
+      local pattern = "%-" .. f.short
+      assert(result:find(pattern, 1, false),
+        "help text missing short option: -" .. f.short)
+    end
   end
 end
 test_generate_contains_all_shortopts()

--- a/_docs/publish.tl
+++ b/_docs/publish.tl
@@ -185,18 +185,10 @@ local function make_readme(docs_dir: string): string
 end
 
 local function run(argv: {string}): boolean, string
-  -- TRANSITIONAL dual-shape dispatch (delete at the next pin advance,
-  -- #981-class): the pinned binary's child.run returns a Result with
-  -- spawn_error folded in; the tree's returns Result | nil, string.
-  -- cast: transitional dual-shape call
-  local run_dual = child.run as function({string}, child.Options): (any, any)
-  local r_any, rerr = run_dual(argv, nil)
-  -- cast: transitional dual-shape probe
-  local spawn_err = r_any ~= nil and (r_any as {string: any}).spawn_error or rerr
-  if r_any == nil or spawn_err ~= nil then
-    return nil, tostring(spawn_err or "start failed")
+  local r, rerr = child.run(argv, nil)
+  if r == nil then
+    return nil, tostring(rerr or "start failed")
   end
-  local r = r_any as child.Result -- cast: transitional dual-shape result
   if not r.ok then
     return nil, table.concat(argv, " ") .. " failed with exit code " .. tostring(r.code)
   end

--- a/_make/converge.tl
+++ b/_make/converge.tl
@@ -205,19 +205,14 @@ local function to_the_tree(proj: Project, argv: {string},
 
   local was_us = fs.is_file(built) and same_file(built, self)
   local before = stamp_of(built)
-  -- TRANSITIONAL dual-shape dispatch (delete at the next pin advance,
-  -- #981-class): the pinned binary's child.run returns a Result with
-  -- spawn_error folded in; the tree's returns Result | nil, string.
-  -- cast: transitional dual-shape call
-  local run_dual = child.run as function({string}, child.Options): (any, any)
-  local r_any, rerr = run_dual({self, "--make", "build"},
+  local r, rerr = child.run({self, "--make", "build"},
     {stdout = "inherit", stderr = "inherit"})
-  local r = r_any as child.Result -- cast: transitional dual-shape result
-  if r_any == nil or not r.ok then
-    -- cast: transitional dual-shape probe
-    local spawn_err = r_any ~= nil and (r_any as {string: any}).spawn_error or rerr
-    return false, "make: " ..
-    tostring(spawn_err or "the converging build failed"), "build failed"
+  if r == nil then
+    return false, "make: " .. tostring(rerr or "the converging build failed"),
+    "build failed"
+  end
+  if not r.ok then
+    return false, "make: the converging build failed", "build failed"
   end
   if not fs.is_file(built) then
     return false, "make: " .. built .. ": the build produced no artifact",

--- a/_make/fetch.tl
+++ b/_make/fetch.tl
@@ -216,34 +216,17 @@ local function one(p: Pin): boolean, string
   -- pinning is for, and the guard would block it. The threat the guard
   -- addresses is absent here by construction; the case it breaks is
   -- real.
-  -- TRANSITIONAL SHAPE DISPATCH — delete at the next pin advance
-  -- (alongside errno's #981 aliases). This file executes under the
-  -- PINNED binary at cold start, where cosmic.fetch's record still
-  -- says fetch returns the old Result (ok/status/body and the
-  -- maxresponse option), while the tree's fetch returns
-  -- Response | nil, err (and reads max_response_bytes). The casts
-  -- erase the signature so both generations type-check; the options
-  -- table carries both size keys so each implementation honors its
-  -- own; the result dispatch reads whichever shape arrived.
-  local fetch_opts: {string: any} = {
-    allow_private = true, max_attempts = ATTEMPTS,
-    maxresponse = MAX_BODY, max_response_bytes = MAX_BODY,
-  }
-  -- cast: transitional dual-shape call (pin Result vs tree Response)
-  local do_fetch = cfetch.fetch as function(string, any): (any, any)
-  local r1, r2 = do_fetch(p.url, fetch_opts)
-  if r1 == nil then
+  local response, ferr = cfetch.fetch(p.url, {
+      allow_private = true,
+      max_attempts = ATTEMPTS,
+      max_response_bytes = MAX_BODY,
+    })
+  if response == nil then
     return false, "make: " .. p.source .. ": " .. p.url .. ": " ..
-    tostring(r2 or "fetch failed")
+    tostring(ferr or "fetch failed")
   end
-  local result = r1 as {string: any} -- cast: transitional dual-shape result
-  if result.ok == false then
-    -- Pinned-era Result carrying a transport failure.
-    return false, "make: " .. p.source .. ": " .. p.url .. ": " ..
-    tostring(result.error or "fetch failed")
-  end
-  local status = result.status as integer -- cast: transitional dual-shape field
-  local body = result.body as string -- cast: transitional dual-shape field
+  local status = response.status
+  local body = response.body
   -- An HTTP error page is a response, not a transport failure, so the
   -- status is checked before hashing. Without that, the commonest
   -- failure -- a typo'd version in the url -- reports itself as a

--- a/_make/generate.tl
+++ b/_make/generate.tl
@@ -250,19 +250,11 @@ local function run_generator(proj: Project, gen: string, dest: string,
   end
   argv[#argv + 1] = gen
   argv[#argv + 1] = dest
-  -- TRANSITIONAL dual-shape dispatch (delete at the next pin advance,
-  -- #981-class): the pinned binary's child.run returns a Result with
-  -- spawn_error folded in; the tree's returns Result | nil, string.
-  -- cast: transitional dual-shape call
-  local run_dual = child.run as function({string}, child.Options): (any, any)
-  local r_any, rerr = run_dual(argv,
+  local r, rerr = child.run(argv,
     {stdout = "inherit", stderr = "inherit"})
-  -- cast: transitional dual-shape probe
-  local spawn_err = r_any ~= nil and (r_any as {string: any}).spawn_error or rerr
-  if r_any == nil or spawn_err ~= nil then
-    return false, "make: " .. gen .. ": " .. tostring(spawn_err or "start failed")
+  if r == nil then
+    return false, "make: " .. gen .. ": " .. tostring(rerr or "start failed")
   end
-  local r = r_any as child.Result -- cast: transitional dual-shape result
   if not r.ok then
     return false, "make: " .. gen .. " failed"
   end

--- a/_make/graph_test.tl
+++ b/_make/graph_test.tl
@@ -190,7 +190,7 @@ local function test_find_make_never_searches_path()
   assert(fs.remove_all(box))
   assert(fs.make_dirs(fs.join(box, "bin")))
   assert(fs.write(fs.join(box, "bin", "make"), "#!/bin/sh\nexit 0\n",
-      tonumber("755", 8) as integer)) -- cast: octal is integral
+      {mode = tonumber("755", 8) as integer})) -- cast: octal is integral
   local saved_path = cenv.get("PATH")
   local saved_make = cenv.get("COSMIC_MAKE")
   assert(cenv.unset("COSMIC_MAKE"))

--- a/_make/runverb.tl
+++ b/_make/runverb.tl
@@ -178,20 +178,12 @@ local function run(proj: Project, path: string, cosmic: string,
     return stage.verdict("run", false, "dup stdin: " .. tostring(derr))
   end
   local stdin0 = fd.wrap(dup0)
-  -- TRANSITIONAL dual-shape dispatch (delete at the next pin advance,
-  -- #981-class): the pinned binary's child.run returns a Result with
-  -- spawn_error folded in; the tree's returns Result | nil, string.
-  -- cast: transitional dual-shape call
-  local run_dual = child.run as function({string}, child.Options): (any, any)
-  local res_any, rerr = run_dual(child_argv,
+  local res, rerr = child.run(child_argv,
     {cwd = proj.root, stdout = "inherit", stderr = "inherit", stdin = stdin0})
   local _ok, _err = stdin0:close()
-  -- cast: transitional dual-shape probe
-  local spawn_err = res_any ~= nil and (res_any as {string: any}).spawn_error or rerr
-  if res_any == nil or spawn_err ~= nil then
-    return stage.verdict("run", false, tostring(spawn_err or "start failed"))
+  if res == nil then
+    return stage.verdict("run", false, tostring(rerr or "start failed"))
   end
-  local res = res_any as child.Result -- cast: transitional dual-shape result
   if not res.ok then
     -- The TARGET's exit code, not a verdict's: `run` is a passthrough,
     -- and a caller that branches on it is asking about the program.

--- a/_tool/testrun.tl
+++ b/_tool/testrun.tl
@@ -82,29 +82,25 @@ local function run(argv: {string}, output_base: string): integer, string
   -- other one (`.got`, `.out`, `.err`, `.tests`) instead of scraped
   -- back out of prose.
   local started_ms = time.monotonic_ms()
-  -- TRANSITIONAL dual-shape dispatch (delete at the next pin advance,
-  -- #981-class): the pinned binary's child.run returns a Result with
-  -- spawn_error folded in; the tree's returns Result | nil, string.
-  -- cast: transitional dual-shape call
-  local run_dual = child.run as function({string}, child.Options): (any, any)
-  local r_any, rerr = run_dual(argv, {env = child_env})
+  local r, rerr = child.run(argv, {env = child_env})
   local wall_ms = time.monotonic_ms() - started_ms
-  -- cast: transitional dual-shape probe
-  local spawn_err = r_any ~= nil and (r_any as {string: any}).spawn_error or rerr
-  local r = (r_any or {}) as child.Result -- cast: transitional dual-shape result
-  local stdout_content = r.stdout or ""
-  local stderr_content = r.stderr or ""
+  local stdout_content = ""
+  local stderr_content = ""
   local exit_code: integer = 1
-  if r_any == nil or spawn_err ~= nil then
+  if r == nil then
     -- The executable could not be started (e.g. a missing binary): report the
     -- conventional 127 "command not found" code and surface the error.
     exit_code = 127
-    stderr_content = tostring(spawn_err or "start failed")
-  elseif r.code ~= nil then
-    exit_code = r.code
-  elseif r.signal ~= nil then
-    -- Signal death is reported as the conventional 128+signal exit code.
-    exit_code = (128 + r.signal) as integer -- cast: number to integer
+    stderr_content = tostring(rerr or "start failed")
+  else
+    stdout_content = r.stdout or ""
+    stderr_content = r.stderr or ""
+    if r.code ~= nil then
+      exit_code = r.code
+    elseif r.signal ~= nil then
+      -- Signal death is reported as the conventional 128+signal exit code.
+      exit_code = (128 + r.signal) as integer -- cast: number to integer
+    end
   end
 
   -- Clean up temp directory

--- a/bin/cosmic.pin
+++ b/bin/cosmic.pin
@@ -4,5 +4,5 @@
 # `*_pin.tl` — those are resolved by `cosmic --make fetch`, which needs a
 # cosmic to run, which is the thing this pin provides. Bump both fields
 # together; the sha is what is verified before anything is executed.
-url = https://github.com/whilp/cosmic/releases/download/2026-08-08-0e17f3b/cosmic-lua
-sha256 = 0919620f8a849888722b88f772ade9eb1e49504fe4c3507cb28a5f65020c0f6e
+url = https://github.com/whilp/cosmic/releases/download/2026-08-08-8abaf1f/cosmic-lua
+sha256 = 15230db4b257d31c3cf07435c869a1c4b292a380d3f17ba4ac27c92fcc431137

--- a/cmd/cosmic/embed_gen.tl
+++ b/cmd/cosmic/embed_gen.tl
@@ -32,11 +32,7 @@ local artifact = require("_make.artifact")
 local cosmo = require("cosmo")
 local env = require("cosmic.env")
 local fs = require("cosmic.fs")
--- TRANSITIONAL dual require (#992, delete at the pin advance): the pin
--- predates `_tool/`; its path is computed so the checker never sees it.
--- cast: transitional dual-shape probe (pcall returns retyped loosely)
-local idx_ok, index_m = pcall(require, "_tool.doc.index") as (boolean, any)
-if not idx_ok then idx_ok, index_m = pcall(require, "cosmic.doc" .. ".index") end
+local index_m = require("_tool.doc.index")
 local literal = require("cosmic.literal")
 local project = require("_make.project")
 local types = require("_make.types")
@@ -285,13 +281,7 @@ local function write_index(proj: Project, dest: string): boolean, string
   -- The `cosmic.doc.index` that resolves here is the RUNNING cosmic's,
   -- not this tree's: a build produced by the pin sees the pin's
   -- signature, the way `cosmo.Slurp` above is chosen to survive both.
-  -- The names argument is newer than some pins, and an older one
-  -- ignores it and falls back to naming by path — which is why the
-  -- release, and the gate, build twice.
-  -- cast: dual-shape module (#992); the signature may predate names
-  local generate_index = (assert(idx_ok and index_m, "no doc index generator") as {string: any}).generate as
-  function(files: {string}, names: {string: string}): string | nil, string
-  local body, err = generate_index(documented(proj), declared_names())
+  local body, err = index_m.generate(documented(proj), declared_names())
   if not body then
     return false, "doc index: " .. (err or "unknown error")
   end

--- a/cmd/cosmic/main.tl
+++ b/cmd/cosmic/main.tl
@@ -191,8 +191,7 @@ local function parse_args(): Options
     return opts
   end
 
-  -- cast: args.tl types the spec as a structural twin (pin-safe; #991)
-  local p0, perr = flags.parse(cli_args.spec as flags.Spec, cosmic_args)
+  local p0, perr = flags.parse(cli_args.spec, cosmic_args)
   if not p0 then
     -- flags errors arrive unprefixed (#991); this program adds its
     -- name, plus a targeted usage hint for the multi-argument flags.

--- a/cosmic/errno_test.tl
+++ b/cosmic/errno_test.tl
@@ -115,17 +115,13 @@ end
 test_constants_excludes_termios()
 
 -- The canonical names (D20 rename, #981): same functions, one grammar.
--- The old names are transition aliases until the pin advance.
-local function test_canonical_names_and_aliases()
+-- The pre-#981 aliases (wrap/is/code/name_of/constants) are gone; what
+-- is left to check is that the names that replaced them work.
+local function test_canonical_names()
   assert(errno.format("mkdir: EACCES: denied", "mkdir: /x")
     == "mkdir: /x: EACCES: denied")
   assert(errno.is_code(errno.code_of("ENOENT"), "ENOENT"))
   assert(errno.name_in("open: ENOENT: No such file or directory") == "ENOENT")
   assert(errno.codes.ENOENT == errno.code_of("ENOENT"))
-  assert(errno.format == errno.format, "wrap aliases format")
-  assert(errno.is_code == errno.is_code, "is aliases is_code")
-  assert(errno.code_of == errno.code_of, "code aliases code_of")
-  assert(errno.name_in == errno.name_in, "name_of aliases name_in")
-  assert(errno.codes == errno.codes, "constants aliases codes")
 end
-test_canonical_names_and_aliases()
+test_canonical_names()

--- a/cosmic/flags/getopt.tl
+++ b/cosmic/flags/getopt.tl
@@ -5,19 +5,6 @@
 --- optional/required arguments.
 local cosmo_getopt = require("cosmo.getopt")
 
--- The underlying cosmo.getopt binding changed shape across cosmos releases:
--- newer builds expose the single-shot `parse` the generated declarations
--- describe, while older ones (including the pinned build bootstrap) expose
--- only a stateful `new`/parser iterator that the generated declarations no
--- longer carry. This record is that legacy surface, kept for runtime
--- feature detection; either field may be nil depending on the cosmos
--- version.
-local record LegacyGetopt
-  parse: function(args: {string}, optstring: string, longopts: {table}): any, any
-  new: function(args: {string}, optstring: string, longopts: {table}): any
-end
-local legacy = cosmo_getopt as LegacyGetopt -- cast: legacy binding surface
-
 --- Whether an option takes an argument (#991: a real enum — the
 --- stringly field let any typo through as "none").
 local enum HasArg
@@ -52,15 +39,6 @@ local type Option = cosmo_getopt.Option
 --- @field unknown {string} Unrecognized options, each including its dashes
 --- @field missing {string} Options that required an argument but got none
 local type Result = cosmo_getopt.Result
-
--- The minimal iterator surface of the legacy binding, used only by
--- the bootstrap-runtime emulation of parse() below. (#991: the public
--- Parser/new shim is deleted; this record and the LegacyGetopt fork go
--- with the next pin advance.)
-local record LegacyParser
-  next: function(self: LegacyParser): string, string
-  remaining: function(self: LegacyParser): {string}
-end
 
 -- Convert typed LongOpt records to the positional table form the C binding
 -- expects: {name, has_arg, short}.
@@ -110,35 +88,11 @@ end
 ---     end
 local function parse(args: {string}, optstring: string, longopts?: {LongOpt}): Result | nil, string
   local raw_longopts = to_raw_longopts(longopts)
-
-  if legacy.parse then
-    -- Newer cosmos: native single-shot parse via the generated surface.
-    local res, err = cosmo_getopt.parse(args, optstring, raw_longopts)
-    if not res then
-      return nil, err
-    end
-    return res
+  local res, err = cosmo_getopt.parse(args, optstring, raw_longopts)
+  if not res then
+    return nil, err
   end
-
-  -- Older cosmos (build bootstrap): emulate parse via the iterator. The
-  -- old binding conflates unknown and missing as "?", so both land in
-  -- `unknown` here; the accurate split is only available on the native path,
-  -- which is what the shipped binary uses.
-  local result: Result = {opts = {}, args = {}, unknown = {}, missing = {}}
-  local p = legacy.new(args, optstring, raw_longopts) as LegacyParser -- cast: from any
-  while true do
-    local opt, optarg = p:next()
-    if not opt then
-      break
-    end
-    if opt == "?" then
-      table.insert(result.unknown, optarg)
-    else
-      table.insert(result.opts, {opt = opt, arg = optarg})
-    end
-  end
-  result.args = p:remaining()
-  return result
+  return res
 end
 
 local record GetoptModule

--- a/cosmic/fs/file.tl
+++ b/cosmic/fs/file.tl
@@ -42,18 +42,13 @@ local write_atomic: function(path: string, data: string, mode?: integer): boolea
 --- fsync and rename (#988: was the separate write_atomic).
 --- @param path string Path to the file
 --- @param data string Data to write
---- @param opts WriteOptions|integer Options — a bare integer is the
----   pre-#988 mode form, still accepted because the PINNED bootstrap's
----   own _script_cache calls it that way against this (tree) module;
----   deleted one pin advance after every in-tree caller moved
+--- @param opts WriteOptions Options carrying mode and atomic
 --- @return boolean True on success
 --- @return string Error message if failed
-local function write(path: string, data: string, opts?: WriteOptions | integer): boolean, string
+local function write(path: string, data: string, opts?: WriteOptions): boolean, string
   local mode: integer
   local atomic = false
-  if opts is integer then
-    mode = opts
-  elseif opts then
+  if opts then
     mode = opts.mode
     atomic = opts.atomic or false
   end

--- a/cosmic/fs/init.tl
+++ b/cosmic/fs/init.tl
@@ -123,8 +123,8 @@ local record FsModule
   -- Whole-file operations
   read: function(path: string): string | nil, string
   --- Write a file; opts carries mode and atomic (#988: write_atomic
-  --- folded in; a bare-integer mode still works until pin advance).
-  write: function(path: string, data: string, opts?: fs_file.WriteOptions | integer): boolean, string
+  --- folded in).
+  write: function(path: string, data: string, opts?: fs_file.WriteOptions): boolean, string
   truncate: function(path: string, length?: integer): boolean, string
 
   -- File operations

--- a/cosmic/fs/traps_test.tl
+++ b/cosmic/fs/traps_test.tl
@@ -10,7 +10,7 @@ local TEST_TMPDIR = os.getenv("TEST_TMPDIR")
 local fsa = fs as {string: any} -- cast: signature transition
 
 local function write_file(path: string, content: string, mode?: integer)
-  assert(fs.write(path, content, mode))
+  assert(fs.write(path, content, {mode = mode}))
 end
 
 -- 1. copy_tree: nested dirs, exec-bit file, symlinks recreated (never

--- a/cosmic/tar.tl
+++ b/cosmic/tar.tl
@@ -161,7 +161,7 @@ local function write_entry(hdr: Header, name: string, payload: string,
     end
     local mode = hdr.mode % 512 -- permission bits only (0777 mask)
     if mode == 0 then mode = tonumber("644", 8) as integer end -- cast: octal is integral
-    local ok, err = fs.write(dest, payload, mode)
+    local ok, err = fs.write(dest, payload, {mode = mode})
     if not ok then
       return false, "write " .. dest .. " failed: " .. (err or "unknown error")
     end

--- a/cosmic/zip.tl
+++ b/cosmic/zip.tl
@@ -287,7 +287,7 @@ local function extract_entries(archive: Archive, destdir: string,
         file_mode = mode
       end
 
-      local write_ok, write_err = fs.write(filepath, content, file_mode)
+      local write_ok, write_err = fs.write(filepath, content, {mode = file_mode})
       if not write_ok then
         return false, "cannot write '" .. filepath .. "': " .. (write_err or "unknown error")
       end


### PR DESCRIPTION
Advances `bin/cosmic.pin` — the trust root's one pin, the cosmic that builds cosmic — from `2026-08-08-0e17f3b` to the release cut from the #1051 merge, and deletes the compatibility layer that pin was the last caller of.

The pinned binary boot-executes tree files and resolves `cosmic.*` to the **tree's** copies, so every signature the old pin called had to survive here. That is what these shims were. 24 files, **+88 / −270**.

## Three commits

1. **The pin.** sha256 computed locally and cross-checked against the release's published `SHA256SUMS`.
2. **The dual-shape dispatches.** Seven `child.run` sites carried a cast erasing the signature so one source type-checked under two generations (the old pin folded `spawn_error` into `Result`; the tree returns `Result | nil, string`). Each is now an ordinary call with a plain nil guard, which narrows — no cast needed. `_make/fetch.tl` was the same story a layer up: it passed **both** option spellings and read whichever result shape arrived. 18 casts gone.
3. **The deprecated forms.** `fs.write`'s bare-integer mode, `_cli/args.tl`'s structural twin for `flags.Spec`, the derived getopt projections, `getopt.tl`'s legacy iterator fork, the coverage probe, and `embed_gen.tl`'s dual require.

## Two markers were wrong, and the gates caught both

**`fs.write`'s integer mode** was marked deletable at the *cosmos* pin advance. It wasn't — the caller keeping it alive was the pinned bootstrap's own `_script_cache`, so it needed *this* advance. Worse, a grep said there were no in-tree callers; there were four. The type checker named them one build at a time (`cosmic/zip.tl`, `cosmic/tar.tl`, `_cli/build/steps.tl`, two tests). The checker got the last word.

**`_cli/grants.tl`'s `is_present` filter is NOT deleted.** Its comment called it a stand-in for `sandbox.Fs.optional`, but they are not equivalent: `optional` drops rules at *apply* time, leaving `plan()` returning a policy containing rules the facade silently discards, while the filter keeps the planned policy equal to the enforced one. `_cli/driver_test.tl` asserts exactly that and failed when I swapped the filter for the flag. I reverted rather than weaken the test; the comment now explains why it stays instead of promising its own removal.

Similarly, `short_needs_arg`/`long_needs_arg` **stay** — the marker lumped them in with the pinned-dispatcher projections, but `cmd/cosmic/main.tl`'s pre-scan reads them. Only `shortopts`/`longopts` went, and the two tests that read them now read `spec.flags` — the source of truth rather than a projection of it.

## One unrelated fix

`errno_test`'s alias assertions had degenerated into tautologies (`errno.format == errno.format`) when #1049 deleted the aliases they were written to check — five assertions that could not fail. Removed.

## Verification

- `bin/cosmic --make ci` → `ci: PASS (5 stages)`
- cold build — `rm -rf o && bin/cosmic --make fetch && bin/cosmic --make ci` → `ci: PASS (5 stages)`

The cold build is the one that matters for a bootstrap advance: it is the only run where the new pin builds the shim-free tree. Every failure above was found by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn

---
_Generated by [Claude Code](https://claude.ai/code/session_017wczGjptmCN6VVrRqfKbdn)_