### PR TITLE
--check, --fix and --format act on every path, not just the first

### DIFF
--- a/_cli/args.tl
+++ b/_cli/args.tl
@@ -24,13 +24,13 @@ local spec: flags.Spec = {
     {long = "help", short = "h", help = "show help"},
     {long = "compile", arg = "FILE", help = "compile a Teal file"},
     {long = "compile-strict", arg = "FILE", help = "compile, warnings fatal"},
-    {long = "format", arg = "FILE", help = "print a file formatted"},
-    {long = "fix", arg = "FILE", help = "format a file in place"},
+    {long = "format", arg = "FILE", help = "print files formatted"},
+    {long = "fix", arg = "FILE", help = "format files in place"},
     -- One flag, a KIND, then the file: `--check types foo.tl`. It
     -- mirrors `--make <verb> [paths]` — a word, then what to apply it
     -- to — so the per-file spelling and the project-wide one are one
     -- vocabulary instead of four flags beside four verbs.
-    {long = "check", arg = "KIND", help = "run one check kind on a file"},
+    {long = "check", arg = "KIND", help = "run one check kind on files"},
     {long = "embed", arg = "PATH", repeated = true,
       help = "embed a file into the output executable"},
     {long = "output", arg = "FILE", help = "where to write"},
@@ -118,10 +118,47 @@ local function renamed_check(argv: {string}): string | nil
   return nil
 end
 
+--- The path list behind a file-taking flag: the flag's own argument
+--- first, then the positionals that followed it. `first` is nil for
+--- `--check`, whose argument is the KIND rather than a path.
+--- @param first string The flag's own argument, when it names a file
+--- @param rest {string} The positionals the parser left over
+--- @return {string} Every path named, in the order given
+local function with_extra_paths(first: string, rest: {string}): {string}
+  local paths: {string} = {}
+  if first then
+    paths[#paths + 1] = first
+  end
+  for _, path in ipairs(rest) do
+    paths[#paths + 1] = path
+  end
+  return paths
+end
+
+--- Run one per-file action over every path and return the WORST exit
+--- code, so one bad file among many still fails the run. One fan-out,
+--- shared by every flag that takes a path list.
+--- @param paths {string} The files to act on
+--- @param action function What to do with one path
+--- @return integer The worst exit code any path produced
+local function over_paths(paths: {string},
+    action: function(string): integer): integer
+  local worst = 0
+  for _, path in ipairs(paths) do
+    local code = action(path)
+    if code > worst then
+      worst = code
+    end
+  end
+  return worst
+end
+
 return {
   spec = spec,
   renamed_check = renamed_check,
   resolve_optional_arg = resolve_optional_arg,
+  with_extra_paths = with_extra_paths,
+  over_paths = over_paths,
   -- Derived from the spec, for the dispatcher's pre-scan (main.tl).
   short_needs_arg = short_needs_arg,
   long_needs_arg = long_needs_arg,

--- a/_cli/check.tl
+++ b/_cli/check.tl
@@ -41,7 +41,7 @@ local RETIRED < const >: {string: string} = {
 --- @param file string The file to check
 --- @param include_dirs {string} Include path, for the type check
 --- @return integer Exit code
-local function run(kind: string, file: string,
+local function run_one(kind: string, file: string,
     include_dirs: {string}): integer
   if RETIRED[kind] then
     io.stderr:write("cosmic-lua: --check " .. kind .. " is now `--check " ..
@@ -73,10 +73,35 @@ local function run(kind: string, file: string,
   return handlers.handle_check_examples(file)
 end
 
+--- Run one check over every file named, and fail if ANY of them fails.
+---
+--- Every path is checked, every failure is printed, and the exit code
+--- is the worst of them. A gate that reports PASS over a file it never
+--- read is worse than no gate, which is why the fan-out lives here
+--- rather than in each caller.
+--- @param kind string Which check: types, fmt, lint or example
+--- @param files {string} The files to check, in order
+--- @param include_dirs {string} Include path, for the type check
+--- @return integer Exit code
+local function run(kind: string, files: {string},
+    include_dirs: {string}): integer
+  if #files == 0 then
+    return run_one(kind, "", include_dirs)
+  end
+  local worst = 0
+  for _, file in ipairs(files) do
+    local code = run_one(kind, file, include_dirs)
+    if code > worst then
+      worst = code
+    end
+  end
+  return worst
+end
+
 local record CheckModule
   KINDS: {string: string}
   RETIRED: {string: string}
-  run: function(kind: string, file: string, include_dirs: {string}): integer
+  run: function(kind: string, files: {string}, include_dirs: {string}): integer
 end
 
 local M: CheckModule = {

--- a/_cli/lint_test.tl
+++ b/_cli/lint_test.tl
@@ -367,10 +367,10 @@ local function test_check_kinds_are_named_when_wrong()
   for old, now in pairs(chk.RETIRED) do
     assert(chk.KINDS[now], old .. " points at " .. now .. ", which is not a kind")
     assert(not chk.KINDS[old], old .. " must not still be a kind")
-    assert(chk.run(old, "x.tl", {}) == 1, old .. " must be refused")
+    assert(chk.run(old, {"x.tl"}, {}) == 1, old .. " must be refused")
   end
-  assert(chk.run("bogus", "x.tl", {}) == 1, "an unknown kind fails")
-  assert(chk.run("types", "", {}) == 1, "a missing file fails")
+  assert(chk.run("bogus", {"x.tl"}, {}) == 1, "an unknown kind fails")
+  assert(chk.run("types", {}, {}) == 1, "a missing file fails")
 end
 test_check_kinds_are_named_when_wrong()
 

--- a/_cli/main_handlers.tl
+++ b/_cli/main_handlers.tl
@@ -172,7 +172,7 @@ local function handle_check_format(file: string): integer
   end
 
   if original == result.code then
-    io.write("Format check passed\n")
+    io.write("Format check passed: " .. file .. "\n")
     instrument.finish(span, 0)
     return 0
   end
@@ -227,7 +227,7 @@ local function handle_check_types(file: string, include_dirs?: {string}): intege
   end
 
   if result.ok then
-    io.write("Type check passed\n")
+    io.write("Type check passed: " .. file .. "\n")
     instrument.finish(span, 0)
     return 0
   else
@@ -348,7 +348,7 @@ local function handle_check_style(file: string): integer
   end
   local diagnostics = found
   if #diagnostics == 0 then
-    io.write("Style check passed\n")
+    io.write("Style check passed: " .. file .. "\n")
     instrument.finish(span, 0)
     return 0
   end

--- a/cmd/cosmic/main.tl
+++ b/cmd/cosmic/main.tl
@@ -54,11 +54,13 @@ local record Options
   script_args: {integer: string}
   compile: string
   compile_strict: string
-  format: string
-  fix: string
-  --- The kind named by `--check <kind>`, and the file it applies to.
+  --- The file-taking flags all take a LIST. A path the tool accepted
+  --- and then ignored is the one outcome a gate must not have.
+  format: {string}
+  fix: {string}
+  --- The kind named by `--check <kind>`, and the files it applies to.
   check_kind: string
-  check_file: string
+  check_files: {string}
   embed: {string}
   output: string
   extract: string
@@ -92,6 +94,9 @@ local function parse_args(): Options
     help = false,
     script_args = {},
     embed = {},
+    format = {},
+    fix = {},
+    check_files = {},
     welcome = false,
     write_if_changed = false,
     include_dirs = {},
@@ -100,17 +105,17 @@ local function parse_args(): Options
   local short_needs_arg = cli_args.short_needs_arg
   local long_needs_arg = cli_args.long_needs_arg
 
-  -- Options that consume all remaining arguments (no script after them)
+  -- Options that consume all remaining arguments (no script after them).
+  -- The file-taking flags belong here because they take a path LIST:
+  -- anything else stops this scan at the first positional past a flag's
+  -- declared arity and reads the rest as a script name, so the parser
+  -- never sees those paths. Greedy, they arrive as the list they are.
   local long_greedy: {string: boolean} = {
     ["report"] = true,
     ["coverage-report"] = true,
-  }
-
-  -- Options that take their own argument AND one positional after it:
-  -- `--check <kind> <file>`. Without this the file reads as a script
-  -- name and parsing stops before it.
-  local long_extra_arg: {string: boolean} = {
     ["check"] = true,
+    ["fix"] = true,
+    ["format"] = true,
   }
 
   -- Find first non-option argument (script name) to know where to stop parsing
@@ -146,11 +151,9 @@ local function parse_args(): Options
         payload_parse_end = eq and i or i + 1
         script_idx = nil
         break
-      elseif long_greedy[opt_name] then
+      elseif long_greedy[opt_name:match("^([^=]+)=") or opt_name] then
         script_idx = nil
         break
-      elseif long_extra_arg[opt_name:match("^([^=]+)=") or opt_name] then
-        i = i + (opt_name:find("=", 1, true) and 2 or 3)
       elseif not opt_name:find("=") and long_needs_arg[opt_name] then
         i = i + 2
       else
@@ -234,13 +237,22 @@ local function parse_args(): Options
   opts.help = p.help
   opts.compile = p.values["compile"]
   opts.compile_strict = p.values["compile-strict"]
-  opts.format = p.values["format"]
-  opts.fix = p.values["fix"]
+  -- The flag's own argument is the first path; the rest are the
+  -- positionals the parser left in p.args, so `--fix a.tl b.tl` names
+  -- both files. The list stays empty unless the flag itself was given:
+  -- the positionals belong to whichever flag claimed them, not to
+  -- every flag.
+  if p.values["format"] then
+    opts.format = cli_args.with_extra_paths(p.values["format"], p.args)
+  end
+  if p.values["fix"] then
+    opts.fix = cli_args.with_extra_paths(p.values["fix"], p.args)
+  end
   if p.values["check"] then
-    -- The kind is the flag's argument; the file is the next
-    -- positional, which the parser has left in p.args.
+    -- The kind is the flag's argument; the files are the positionals,
+    -- which the parser has left in p.args.
     opts.check_kind = p.values["check"]
-    opts.check_file = p.args[1]
+    opts.check_files = cli_args.with_extra_paths(nil, p.args)
   end
   for _, path in ipairs(p.lists["embed"]) do
     opts.embed[#opts.embed + 1] = path
@@ -269,7 +281,7 @@ local function parse_args(): Options
   -- A command flag ends the run before any script dispatch, matching
   -- the old parse loop's early returns.
   if opts.recipe or opts.help or opts.compile or opts.compile_strict
-  or opts.format or opts.fix or opts.check_kind or opts.extract
+  or #opts.format > 0 or #opts.fix > 0 or opts.check_kind or opts.extract
   or opts.examples or opts.benchmark or opts.docs or opts.test_output
   or opts.report_paths or opts.coverage_report_paths or opts.make_verb then
     return opts
@@ -337,10 +349,25 @@ local function main(): integer, string
   end
   if opts.compile then return handlers.handle_compile(opts.compile, opts.output, opts.write_if_changed, opts.include_dirs) end
   if opts.compile_strict then return handlers.handle_compile(opts.compile_strict, opts.output, opts.write_if_changed, opts.include_dirs, true) end
-  if opts.format then return handlers.handle_format(opts.format, opts.output, opts.write_if_changed) end
-  if opts.fix then return handlers.handle_format(opts.fix, opts.fix, true) end
+  if #opts.format > 0 then
+    if #opts.format > 1 and opts.output then
+      io.stderr:write("cosmic-lua: --output takes one file; " ..
+        "--format printed several\n")
+      return 1
+    end
+    return cli_args.over_paths(opts.format, function(path: string): integer
+        -- Parenthesized: handle_format returns (code, err) and this
+        -- wants the code alone.
+        return (handlers.handle_format(path, opts.output, opts.write_if_changed))
+      end)
+  end
+  if #opts.fix > 0 then
+    return cli_args.over_paths(opts.fix, function(path: string): integer
+        return (handlers.handle_format(path, path, true))
+      end)
+  end
   if opts.check_kind then
-    return require("_cli.check").run(opts.check_kind, opts.check_file,
+    return require("_cli.check").run(opts.check_kind, opts.check_files,
       opts.include_dirs)
   end
   if #opts.embed > 0 then return handlers.handle_embed(opts.embed, opts.output, opts.exe) end


### PR DESCRIPTION
`--check`, `--fix` and `--format` take a path LIST. Each runs its action over every path and returns the worst exit code, so one bad file among ten fails the run, and each per-file success line names its file.

## Why greedy

The dispatcher's pre-scan walks argv to find where cosmic's own options stop and a script begins, advancing past each flag by its declared arity. Anything less than greedy stops at the second path and reads it as a script name, so the parser never sees it — and a check then reports PASS over a file it never opened:

```
$ cosmic --check types clean.tl broken.tl
Type check passed
exit=0
```

The `=` form is stripped to its flag name before the greedy lookup, so `--check=fmt` behaves as `--check fmt`; `_cli/main_handlers_test.tl` covers that path.

One fan-out serves all three (`_cli.args.over_paths`) rather than a loop per call site.

## Verification

```
$ cosmic --check types clean.tl broken.tl   # exit 1, names broken.tl
$ cosmic --fix a.tl b.tl                    # both rewritten
$ cosmic --check=fmt a.tl                   # exit 0
```

`--make ci`: `ci: PASS (5 stages)`.