### PR TITLE
--docs: a page may omit a function, it may not invent one, and one renderer says so

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -74,9 +74,10 @@ _tool/coverage/baseline.tl 151 161
 _tool/coverage/lines.tl 65 71
 _tool/coverage/report.tl 203 224
 _tool/doc/comments.tl 53 53
+_tool/doc/dtl.tl 8 84
+_tool/doc/exports.tl 52 53
 _tool/doc/index.tl 119 126
 _tool/doc/init.tl 225 251
-_tool/doc/render.tl 114 192
 _tool/doc/scan.tl 67 67
 _tool/example.tl 134 167
 _tool/lint.tl 16 17
@@ -204,4 +205,4 @@ cosmic/user.tl 48 61
 cosmic/uuid.tl 9 9
 cosmic/zip.tl 72 85
 tlconfig.lua 7 7
-total 14876 19509
+total 14822 19454

--- a/_tool/doc/dtl.tl
+++ b/_tool/doc/dtl.tl
@@ -1,5 +1,7 @@
---- Rendering and .d.tl parsing for the doc module.
---- Contains the markdown renderer and the type declaration file parser.
+--- Parsing for `.d.tl` type declaration files.
+---
+--- The rendering that used to sit beside this is gone: pages come
+--- from `cosmic.doc.render_module`, the one renderer.
 
 local doc_types = require("cosmic.doc")
 local type FunctionDoc = doc_types.FunctionDoc
@@ -8,137 +10,6 @@ local type ModuleDoc = doc_types.ModuleDoc
 local doc_comments = require("_tool.doc.comments")
 local extract_doc_comment = doc_comments.extract_doc_comment
 local parse_annotations = doc_comments.parse_annotations
-
---- Render documentation as markdown.
-local function render(doc: ModuleDoc): string
-  local lines: {string} = {}
-  local module_name = doc.file:match("([^/]+)%.d%.tl$") or doc.file:match("([^/]+)%.tl$") or doc.file
-  if module_name == "init" then
-    -- A directory module's init shard is the module: title the page by
-    -- the directory name (fs/init.tl -> fs), not the shard filename.
-    module_name = doc.file:match("([^/]+)/init%.tl$") or module_name
-  end
-  table.insert(lines, "# " .. module_name)
-  table.insert(lines, "")
-  if doc.module_doc then
-    table.insert(lines, doc.module_doc)
-    table.insert(lines, "")
-  end
-  if #doc.records > 0 then
-    table.insert(lines, "## Types")
-    table.insert(lines, "")
-    for _, rec in ipairs(doc.records) do
-      table.insert(lines, "### " .. rec.name)
-      table.insert(lines, "")
-      if rec.description then
-        table.insert(lines, rec.description)
-        table.insert(lines, "")
-      end
-      if #rec.fields > 0 then
-        table.insert(lines, "```teal")
-        table.insert(lines, "local record " .. rec.name)
-        for _, field in ipairs(rec.fields) do
-          local field_name, field_type, field_desc = field[1], field[2], field[3]
-          if field_desc and field_desc ~= "" then
-            for desc_line in field_desc:gmatch("[^\n]+") do
-              table.insert(lines, "  -- " .. desc_line)
-            end
-          end
-          table.insert(lines, "  " .. field_name .. ": " .. field_type)
-        end
-        table.insert(lines, "end")
-        table.insert(lines, "```")
-        table.insert(lines, "")
-      end
-    end
-  end
-  -- Functions
-  local exported_names: {string: boolean} = {}
-  for _, rec in ipairs(doc.records) do
-    if rec.name:match("Module$") then
-      for _, field in ipairs(rec.fields) do
-        if field[2]:match("^function") then
-          exported_names[field[1]] = true
-        end
-      end
-    end
-  end
-  local exported_functions: {FunctionDoc} = {}
-  for _, func in ipairs(doc.functions) do
-    if not func.is_local or exported_names[func.name] then
-      table.insert(exported_functions, func)
-    end
-  end
-  if #exported_functions > 0 then
-    table.insert(lines, "## Functions")
-    table.insert(lines, "")
-    for _, func in ipairs(exported_functions) do
-      table.insert(lines, "### " .. func.name)
-      table.insert(lines, "")
-      if func.signature then
-        table.insert(lines, "```teal")
-        table.insert(lines, "function " .. func.name .. func.signature)
-        table.insert(lines, "```")
-        table.insert(lines, "")
-      end
-      if func.description then
-        table.insert(lines, func.description)
-        table.insert(lines, "")
-      end
-      if #func.params > 0 then
-        table.insert(lines, "**Parameters:**")
-        table.insert(lines, "")
-        for _, param in ipairs(func.params) do
-          local param_line = "- `" .. param.name .. "` (" .. param.param_type .. ")"
-          if param.description then param_line = param_line .. " - " .. param.description end
-          table.insert(lines, param_line)
-        end
-        table.insert(lines, "")
-      end
-      if #func.returns > 0 then
-        table.insert(lines, "**Returns:**")
-        table.insert(lines, "")
-        for _, ret in ipairs(func.returns) do
-          local ret_line = "- " .. ret.return_type
-          if ret.description then ret_line = ret_line .. " - " .. ret.description end
-          table.insert(lines, ret_line)
-        end
-        table.insert(lines, "")
-      end
-    end
-  end
-  -- Examples
-  if #doc.examples > 0 then
-    table.insert(lines, "## Examples")
-    table.insert(lines, "")
-    for _, example in ipairs(doc.examples) do
-      local title = example.name:gsub("^Example_?", ""):gsub("_", " ")
-      if title == "" then title = "Basic usage" end
-      table.insert(lines, "### " .. title)
-      table.insert(lines, "")
-      if example.description then
-        table.insert(lines, example.description)
-        table.insert(lines, "")
-      end
-      table.insert(lines, "```teal")
-      local body = example.body
-      local output_start = body:find("%-%-%s*Output:")
-      if output_start then body = body:sub(1, output_start - 1) end
-      body = body:gsub("^%s*\n", ""):gsub("\n%s*$", "")
-      table.insert(lines, body)
-      table.insert(lines, "```")
-      table.insert(lines, "")
-      if example.expected_output then
-        table.insert(lines, "Output:")
-        table.insert(lines, "```")
-        table.insert(lines, example.expected_output)
-        table.insert(lines, "```")
-        table.insert(lines, "")
-      end
-    end
-  end
-  return table.concat(lines, "\n")
-end
 
 --- Parse a .d.tl type declaration file and extract documentation.
 local function parse_dtl(source: string, file_path: string): ModuleDoc
@@ -257,13 +128,11 @@ local function parse_dtl(source: string, file_path: string): ModuleDoc
   return doc
 end
 
-local record DocRenderModule
-  render: function(doc: ModuleDoc): string
+local record DtlModule
   parse_dtl: function(source: string, file_path: string): ModuleDoc
 end
 
-local M: DocRenderModule = {
-  render = render,
+local M: DtlModule = {
   parse_dtl = parse_dtl,
 }
 

--- a/_tool/doc/exports.tl
+++ b/_tool/doc/exports.tl
@@ -1,0 +1,120 @@
+--- What a module publishes, read from the module itself.
+---
+--- Two views, unioned: the table literal a module assigns, and its
+--- interface record's function-typed fields. Kept apart from the
+--- parser because both the publishable view and the shard merge in
+--- `index.tl` ask the same question, and one answer serves them.
+
+--- The names a module states in a table literal it assigns to its
+--- module table: `local M: FsModule = { read = ..., }`, the bare
+--- `M = { ... }` a step after `local M: EnvModule`, and the inline
+--- `return {attach = attach}`. One of several views of a module's
+--- export surface; `export_surface` below is what callers want.
+local function scan_exports(source: string): {string: boolean} | nil
+  local names: {string: boolean} = nil
+  local in_table = false
+  for line in (source .. "\n"):gmatch("([^\n]*)\n") do
+    if in_table then
+      if line:match("^}") then
+        in_table = false
+      else
+        local key = line:match("^%s*([%w_]+)%s*=")
+        if key then
+          names = names or {}
+          names[key] = true
+        end
+      end
+    elseif line:match("^local%s+[%w_]+%s*:%s*[%w_%.]+%s*=%s*{")
+    or line:match("^[%w_]+%s*=%s*{")
+    or line:match("^return%s*{") then
+      local inline = line:match("{(.*)}%s*$")
+      local rest = inline or line:match("{(.*)$")
+      if rest then
+        for key in rest:gmatch("([%w_]+)%s*=") do
+          names = names or {}
+          names[key] = true
+        end
+      end
+      in_table = inline == nil
+    end
+  end
+  return names
+end
+
+--- The function-typed fields of a module's INTERFACE RECORD — the
+--- other view, and the one that does not depend on how the module
+--- happens to build its table. A module states its API as a record
+--- (`EnvModule`, `SignalModule`, the `stream` record a module returns
+--- directly), and `render.tl` has always read exports that way.
+--- Whichever record it is, its function fields are exported names.
+--- @param source string The module source
+--- @param records {{string:any}} The records the parser found
+--- @param into {string:boolean} The surface being accumulated
+--- @return boolean Whether any record contributed a name
+local function record_exports(source: string, records: {{string: any}},
+    into: {string: boolean}): boolean
+  if not records then
+    return false
+  end
+  local returned = source:match("\nreturn%s+([%w_]+)%s*\n?$")
+  local found = false
+  for _, rec in ipairs(records) do
+    local name = rec.name as string -- cast: from any
+    if name == returned or name:match("Module$") then
+      local fields = rec.fields as {{string}} -- cast: from any
+      for _, field in ipairs(fields or {}) do
+        if field[2] and field[2]:match("^function") then
+          into[field[1]] = true
+          found = true
+        end
+      end
+    end
+  end
+  return found
+end
+
+--- Every name a module publishes, by every view that can be read: the
+--- literal it assigns, and its interface record's function fields.
+---
+--- Always a set, never "unknown": a module whose shape no view
+--- recognizes yields an EMPTY surface, and an empty surface publishes
+--- no locals at all. The rule is the one the doc itself states — a
+--- page may omit a function, it may not invent one. Omission is
+--- visible and harmless; a documented function nobody can call costs
+--- the reader a build.
+--- @param source string The module source
+--- @param records {{string:any}} The records the parser found
+--- @return {string:boolean} The exported names, possibly empty
+local function export_surface(source: string,
+    records: {{string: any}}): {string: boolean}
+  local names: {string: boolean} = {}
+  local literal = scan_exports(source)
+  if literal then
+    for name in pairs(literal) do
+      names[name] = true
+    end
+  end
+  local _found = record_exports(source, records, names)
+  return names
+end
+
+--- Drop a module's private helpers from its own page.
+---
+--- A local is published only where the module's export surface names
+--- it, so a page never advertises a function the module does not have.
+--- `render.tl` holds the markdown it renders to the same rule; this is
+--- the same rule for the index the binary ships, which is the only doc
+--- surface a reader without the repo has. A page that names a function
+--- nobody can call is worse than one that omits it: the reader writes
+--- the call, and the build fails.
+---
+local record ExportsModule
+  export_surface: function(source: string,
+  records: {{string: any}}): {string: boolean}
+end
+
+local M: ExportsModule = {
+  export_surface = export_surface,
+}
+
+return M

--- a/_tool/doc/index.tl
+++ b/_tool/doc/index.tl
@@ -2,6 +2,7 @@
 --- Run directly as a script with source files as arguments.
 
 local doc = require("_tool.doc")
+local doc_exports = require("_tool.doc.exports")
 -- This script is compiled and run by the pinned BOOTSTRAP cosmic, whose
 -- embedded types predate the current tree; use the signature-stable
 -- cosmo.Slurp instead of cosmic.fs.read so it works under both, and
@@ -56,44 +57,6 @@ local function merge_entries(dst: {string: any}, src: {string: any},
       table.insert(into, entry)
     end
   end
-end
-
---- The export list a module states in its top-level typed table
---- literal (`local M: FsModule = { read = fs_file.read, ... }`): the
---- keys. That literal is the convention every module follows (the
---- module's API is its returned interface record), so its keys are the
---- authoritative "what this module exports" — the interface record's
---- own fields would serve too, but the parser does not extract
---- function-typed record fields today. nil when the file builds its
---- module table some other way; callers treat that as "unknown", not
---- "empty".
-local function scan_exports(source: string): {string: boolean} | nil
-  local names: {string: boolean} = nil
-  local in_table = false
-  for line in (source .. "\n"):gmatch("([^\n]*)\n") do
-    if in_table then
-      if line:match("^}") then
-        in_table = false
-      else
-        local key = line:match("^%s*([%w_]+)%s*=")
-        if key then
-          names = names or {}
-          names[key] = true
-        end
-      end
-    elseif line:match("^local%s+[%w_]+%s*:%s*[%w_%.]+%s*=%s*{") then
-      local inline = line:match("{(.*)}%s*$")
-      local rest = inline or line:match("{(.*)$")
-      if rest then
-        for key in rest:gmatch("([%w_]+)%s*=") do
-          names = names or {}
-          names[key] = true
-        end
-      end
-      in_table = inline == nil
-    end
-  end
-  return names
 end
 
 --- Fold directory-module shards into the parent users require.
@@ -205,7 +168,15 @@ local function generate(files: {string},
       if not file_path:match("%.d%.tl$") then
         -- The export list rides along for flatten_shards below, and is
         -- stripped again before the index is encoded.
-        (module_doc as {string: any}).exports = scan_exports(source) -- cast: from any
+        -- The same publishable view the markdown page is rendered
+        -- from, so a page and a symbol lookup answer alike. The surface
+        -- rides along for flatten_shards below, which filters a SHARD's
+        -- exports against the parent that re-exports them — a different
+        -- question from what one module publishes.
+        local records = (module_doc as {string: any}).records -- cast: from any
+        doc.publishable(module_doc as doc.ModuleDoc, source); -- cast: parsed above
+        (module_doc as {string: any}).exports = -- cast: from any
+        doc_exports.export_surface(source, records as {{string: any}}) -- cast: from any
       end
       modules[name] = module_doc
     end

--- a/_tool/doc/index_test.tl
+++ b/_tool/doc/index_test.tl
@@ -290,3 +290,131 @@ return {}
     "the init example lands on the directory module's page")
 end
 test_init_example_lands_on_directory_module()
+
+-- A private helper stays OFF the module's own page: a doc comment is
+-- not an export, and a page that names a helper a caller cannot reach
+-- is a page that lies. The exported neighbour beside it is the
+-- control — filtering may not cost a real function.
+local function test_private_helpers_stay_off_the_page()
+  local path = write_temp("gizmo.tl", [[
+--- Gizmo module.
+--- Reachable.
+local function spin(): number
+  return 1
+end
+--- A helper nobody outside this file can call.
+local function grind(): number
+  return 2
+end
+local record GizmoModule
+  spin: function(): number
+end
+local M: GizmoModule = {
+  spin = spin,
+}
+return M
+]])
+  local mod = find_module(generate_modules({path}), "gizmo")
+  assert(mod, "gizmo module should be indexed")
+  local names: {string: boolean} = {}
+  for _, f in ipairs(mod.functions as {any}) do -- cast: from any
+    names[(f as {string: any}).name as string] = true -- cast: from any
+  end
+  assert(names["spin"], "an exported function must stay documented")
+  assert(not names["grind"],
+    "a private helper must not be documented as public API")
+end
+test_private_helpers_stay_off_the_page()
+
+-- A module that IS its record (`return stream`) states its exports as
+-- that record's function fields, and defines them dot-qualified. Both
+-- halves are read: the dotted definition is documented under its own
+-- bare name, and the private helper beside it is still dropped.
+local function test_record_module_exports_and_dotted_names()
+  local path = write_temp("sprocket.tl", [[
+--- Sprocket module.
+local record sprocket
+  --- Turn it.
+  turn: function(n: number): number
+end
+--- A helper nobody outside this file can call.
+local function grind(n: number): number
+  return n
+end
+--- Turn it.
+function sprocket.turn(n: number): number
+  return grind(n)
+end
+return sprocket
+]])
+  local mod = find_module(generate_modules({path}), "sprocket")
+  assert(mod, "sprocket module should be indexed")
+  local names: {string: boolean} = {}
+  for _, f in ipairs(mod.functions as {any}) do -- cast: from any
+    names[(f as {string: any}).name as string] = true -- cast: from any
+  end
+  assert(names["turn"],
+    "`function sprocket.turn` must be documented as `turn`, not `sprocket`")
+  assert(not names["sprocket"],
+    "the table's own name is not a function anyone can call")
+  assert(not names["grind"], "the private helper must stay off the page")
+end
+test_record_module_exports_and_dotted_names()
+
+-- A `function` word inside a doc comment must not swallow the real
+-- definition on the next line: a scan that ran past the newline to the
+-- next `(` would consume the very function the comment documents, and
+-- the module's page would be missing it.
+local function test_doc_comment_does_not_eat_the_next_function()
+  local path = write_temp("ratchet.tl", [[
+--- Ratchet module.
+--- @return function Iterator yielding each click
+local function clicks(): function
+  return function() end
+end
+return { clicks = clicks }
+]])
+  local mod = find_module(generate_modules({path}), "ratchet")
+  assert(mod, "ratchet module should be indexed")
+  local names: {string: boolean} = {}
+  for _, f in ipairs(mod.functions as {any}) do -- cast: from any
+    names[(f as {string: any}).name as string] = true -- cast: from any
+  end
+  assert(names["clicks"],
+    "a `function` word in the doc comment must not hide the function")
+end
+test_doc_comment_does_not_eat_the_next_function()
+
+-- The word `function` inside a string literal is not a definition.
+-- Only a line that BEGINS with the definition is one, which is why
+-- prose like "a function on your MODULE's record" stopped putting a
+-- phantom `on` on cosmic._teal_hints' page. The record field in the
+-- same fixture is the other half of the rule: `spin: function(): number`
+-- names a field, not a definition to document twice.
+local function test_a_function_word_in_a_string_is_not_a_definition()
+  local path = write_temp("lathe.tl", [[
+--- Lathe module.
+local record LatheModule
+  spin: function(): number
+end
+--- Turn it.
+local function spin(): number
+  local _advice = "a function on your MODULE's record is dot-called"
+  return 1
+end
+local M: LatheModule = {
+  spin = spin,
+}
+return M
+]])
+  local mod = find_module(generate_modules({path}), "lathe")
+  assert(mod, "lathe module should be indexed")
+  local names: {string: boolean} = {}
+  for _, f in ipairs(mod.functions as {any}) do -- cast: from any
+    names[(f as {string: any}).name as string] = true -- cast: from any
+  end
+  assert(names["spin"], "the real definition must be documented")
+  assert(not names["on"],
+    "`function on` inside a string literal is prose, not an export")
+end
+test_a_function_word_in_a_string_is_not_a_definition()

--- a/_tool/doc/init.tl
+++ b/_tool/doc/init.tl
@@ -6,9 +6,11 @@
 --- Parses doc comments, records, functions, and examples from .tl files.
 
 local doc_types = require("cosmic.doc")
+local type FunctionDoc = doc_types.FunctionDoc
 local type ModuleDoc = doc_types.ModuleDoc
 
-local doc_render = require("_tool.doc.render")
+local doc_dtl = require("_tool.doc.dtl")
+local doc_exports = require("_tool.doc.exports")
 local scan = require("_tool.doc.scan")
 local doc_comments = require("_tool.doc.comments")
 local extract_doc_comment = doc_comments.extract_doc_comment
@@ -173,14 +175,19 @@ local function parse(source: string, file_path: string): ModuleDoc
     last_pos = new_pos
   end
   -- Local functions
-  for func_start, is_local, func_name in source:gmatch("()(local%s+)function%s+([%w_:]+)<?[^>%(]*>?%s*%(") do
+  for func_start, is_local, func_name in source:gmatch("()(local%s+)function%s+([%w_:]+)<?[^>%(\n]*>?%s*%(") do
     update_line_num(func_start)
     local line_start = func_start
     while line_start > 1 and source:byte(line_start - 1) ~= BYTE_NEWLINE do
       line_start = line_start - 1
     end
     local line_prefix = source:sub(line_start, (func_start) - 1)
-    if line_prefix:match("^%s*%-%-") then goto continue_local end
+    -- A definition starts its own line. Anything with code before it on
+    -- the line is a `function` WORD, not a definition: a record field
+    -- (`read: function(self)`), a comment, or -- the case that put a
+    -- phantom `on` on a page -- prose inside a string literal ("a
+    -- function on your MODULE's record is dot-called...").
+    if not line_prefix:match("^%s*$") then goto continue_local end
     if not (func_name):match("^Example") then
       local signature = extract_signature(source, func_start)
       local func_doc = extract_doc_comment(source, func_start)
@@ -196,15 +203,26 @@ local function parse(source: string, file_path: string): ModuleDoc
   -- Non-local functions
   line_num = 1
   last_pos = 1
-  for func_start, func_name in source:gmatch("()function%s+([%w_:]+)<?[^>%(]*>?%s*%(") do
+  -- The name pattern spans dots so `function stream.write_all(...)`
+  -- reads as one name. Stopping at the dot would file every
+  -- dot-defined function under the TABLE's name — entries nobody can
+  -- call, and the real functions documented nowhere.
+  for func_start, dotted_name in source:gmatch("()function%s+([%w_:%.]+)<?[^>%(\n]*>?%s*%(") do
+    -- `stream.write_all` is `write_all` on the page: a reader has the
+    -- module under whatever local name they chose, and every other
+    -- module's page lists the bare name.
+    local func_name = dotted_name:match("^[%w_]+%.([%w_:]+)$") or dotted_name
     local line_start = func_start
     while line_start > 1 and source:byte(line_start - 1) ~= BYTE_NEWLINE do
       line_start = line_start - 1
     end
     local line_prefix = source:sub(line_start, (func_start) - 1)
-    if line_prefix:match("^%s*%-%-") then goto continue_nonlocal end
+    -- Same rule as the local branch above: only a line that begins with
+    -- the definition is one. It subsumes the old record-field guard,
+    -- since `read: function(self)` has its name before the keyword.
+    if not line_prefix:match("^%s*$") then goto continue_nonlocal end
     local before = source:sub(math.max(1, (func_start) - 20), (func_start) - 1)
-    if not before:match("local%s*$") and not before:match(":%s*$") then
+    if not before:match("local%s*$") then
       update_line_num(func_start)
       if not (func_name):match("^Example") then
         local signature = extract_signature(source, func_start)
@@ -332,6 +350,35 @@ local function parse(source: string, file_path: string): ModuleDoc
   return doc
 end
 
+--- The publishable view of a parsed module: the same doc with the
+--- private helpers dropped.
+---
+--- `parse` reports what a FILE contains, which is what a parser is
+--- for; this decides what a READER is shown, which is a different
+--- question with one answer. Both outputs ask it here — the markdown
+--- page and the index the binary ships — so a page and a symbol
+--- lookup cannot disagree about what a module exports.
+---
+--- A `local function` survives only where the module's surface names
+--- it. A method (`Handle:read`) belongs to the record that owns it,
+--- not the module table, so the surface cannot speak to it and it is
+--- kept.
+--- @param doc ModuleDoc The parsed module, edited in place
+--- @param source string The module source the doc was parsed from
+--- @return ModuleDoc That same doc
+local function publishable(doc: ModuleDoc, source: string): ModuleDoc
+  local surface = doc_exports.export_surface(source, doc.records as {{string: any}}) -- cast: from any
+  local kept: {FunctionDoc} = {}
+  for _, func in ipairs(doc.functions) do
+    if not func.is_local or surface[func.name]
+    or func.name:find(":", 1, true) then
+      kept[#kept + 1] = func
+    end
+  end
+  doc.functions = kept
+  return doc
+end
+
 --- Parse a file and return structured documentation.
 local function parse_file(file_path: string): ModuleDoc | nil, string
   local f, err = io.open(file_path, "r")
@@ -339,7 +386,7 @@ local function parse_file(file_path: string): ModuleDoc | nil, string
   local source = f:read("*a")
   f:close()
   if file_path:match("%.d%.tl$") then
-    return doc_render.parse_dtl(source, file_path), nil
+    return doc_dtl.parse_dtl(source, file_path), nil
   else
     return parse(source, file_path), nil
   end
@@ -356,28 +403,37 @@ local function render_file(file_path: string): string | nil, string
   f:close()
   local doc: ModuleDoc
   if file_path:match("%.d%.tl$") then
-    doc = doc_render.parse_dtl(source, file_path)
+    doc = doc_dtl.parse_dtl(source, file_path)
   else
     doc = parse(source, file_path)
   end
-  return doc_render.render(doc)
+  local name = file_path:match("([^/]+)%.d%.tl$") or file_path:match("([^/]+)%.tl$")
+  or file_path
+  if name == "init" then
+    -- A directory module's init shard IS the module: title the page by
+    -- the directory name (fs/init.tl -> fs), not the shard filename.
+    name = file_path:match("([^/]+)/init%.tl$") or name
+  end
+  return doc_types.render_module(name, publishable(doc, source))
 end
 
 local record DocExtractModule
   type ModuleDoc = ModuleDoc
 
+  export_surface: function(source: string,
+  records: {{string: any}}): {string: boolean}
+  publishable: function(doc: ModuleDoc, source: string): ModuleDoc
   parse: function(source: string, file_path: string): ModuleDoc
   parse_dtl: function(source: string, file_path: string): ModuleDoc
   parse_file: function(file_path: string): ModuleDoc | nil, string
-  render: function(doc: ModuleDoc): string
   render_file: function(file_path: string): string | nil, string
 end
 
 local M: DocExtractModule = {
+  publishable = publishable,
   parse = parse,
-  parse_dtl = doc_render.parse_dtl,
+  parse_dtl = doc_dtl.parse_dtl,
   parse_file = parse_file,
-  render = doc_render.render,
   render_file = render_file,
 }
 

--- a/_tool/doc/init_test.tl
+++ b/_tool/doc/init_test.tl
@@ -3,6 +3,7 @@
 
 local fs = require("cosmic.fs")
 local doc = require("_tool.doc")
+local docs = require("cosmic.doc")
 local check = require("cosmic.check")
 
 local tmpdir = os.getenv("TEST_TMPDIR")
@@ -346,7 +347,8 @@ end
 ]]
 
   local result = doc.parse(source, "mymodule.tl")
-  local md = doc.render(result)
+  -- One renderer: the page a reader gets from `--docs` is this page.
+  local md = docs.render_module("mymodule", result)
   assert(md:find("# mymodule"), "should have module header")
   assert(md:find("Test module"), "should have module description")
   assert(md:find("## Types"), "should have Types section")
@@ -423,7 +425,7 @@ end
 ]]
 
   local result = doc.parse(source, "test.tl")
-  local md = doc.render(result)
+  local md = docs.render_module("test", result)
   assert(md:find("### foo bar baz"), "should convert underscores to spaces in title")
 end
 test_example_title()


### PR DESCRIPTION
A `local function` is published only where the module's export surface names it, so a page never advertises a function the module does not have.

## One renderer

`_tool/doc/render.tl` emitted the same headings, fences and bullet lists as `cosmic.doc`'s renderer — two copies of the same page, which is how the export rule came to be written into one of them and not the other. Pages now come from `cosmic.doc.render_module` alone:

- the `.d.tl` parser that shared that file moves to `_tool/doc/dtl.tl`;
- the surface helpers move to `_tool/doc/exports.tl`;
- `render.tl` is deleted.

`--docs <module>` and `--make docs` now emit the same page from the same code. The one remaining difference is data, not rendering: the index merges `*_example.tl` files into a module's doc, so `--docs` hoists a quick example that a single-file parse cannot know about.

## One rule, asked where output is produced

The surface unions the two views a module offers: the table literal it assigns — in all four shapes the tree uses — and its interface record's function-typed fields. It is always a set, never "unknown": a module whose shape no view recognizes yields an empty surface, and an empty surface publishes no locals. Omission is visible and harmless; a documented function nobody can call costs the reader a build.

`publishable` asks it once, and both outputs ask it there — the markdown page and the index the binary ships — so a page and a symbol lookup cannot disagree. `parse` is left alone: it reports what a *file* contains, which is what a parser is for. (I tried putting the rule in `parse` first; 17 of 20 parser fixtures are bare snippets with no module table, and they were right to object.)

## Two extraction rules

- A function's name spans dots, so `function stream.write_all(...)` is documented as `write_all` rather than filed under the table's name.
- A definition begins its own line. Anything with code before it is the word `function`, not a definition — a record field, a comment, or prose inside a string literal — which also stops a doc comment from swallowing the definition it documents.

## Effect

Zero bare-name phantoms on any page (33 entries remain, all record methods like `handle:read`, documented under the record that owns them). Exported-but-undocumented unchanged at 11.

Splitting the file shows what the aggregate was hiding: the `.d.tl` parser enters the ratchet at **8/84 covered**, having been averaged in with a well-covered renderer. That is a floor, not an endorsement — worth its own follow-up.

The coverage baseline moves by exactly three rows (drop `render.tl`, add `dtl.tl` and `exports.tl`) rather than a full rebaseline, which would have lowered unrelated floors.

`--make ci`: `ci: PASS (5 stages)`.