### PR TITLE
say that warnings are errors, on the line that fails for one

### DIFF
--- a/_cli/main_handlers.tl
+++ b/_cli/main_handlers.tl
@@ -220,7 +220,7 @@ local function handle_check_types(file: string, include_dirs?: {string}): intege
   local result = tealc.check_file(file, {include_dirs = include_dirs})
 
   if #result.warnings > 0 then
-    io.stderr:write(tealc.format_issues(result.warnings, nil) .. "\n")
+    io.stderr:write(tealc.format_issues(result.warnings, {hints = true}) .. "\n")
   end
   if #result.errors > 0 then
     io.stderr:write(tealc.format_issues(result.errors, {hints = true}) .. "\n")

--- a/_make/check.tl
+++ b/_make/check.tl
@@ -148,7 +148,7 @@ local function check_files(files: {File}): integer
   for _, f in ipairs(files) do
     local result = teal.check_file(f.path, {include_dirs = include_dirs})
     if #result.warnings > 0 then
-      io.stderr:write(teal.format_issues(result.warnings) .. "\n")
+      io.stderr:write(teal.format_issues(result.warnings, {hints = true}) .. "\n")
     end
     if #result.errors > 0 then
       io.stderr:write(teal.format_issues(result.errors, {hints = true}) .. "\n")

--- a/cosmic/_teal_hints.tl
+++ b/cosmic/_teal_hints.tl
@@ -21,6 +21,23 @@
 --- @param msg string The error message to match
 --- @return string|nil A short hint string, or nil if no hint applies
 local function hint_for_message(msg: string): string | nil
+  -- Pattern 0: the WARNINGS, which are errors here. The word "warning"
+  -- reads as survivable right up until the exit code disagrees, so the
+  -- hint says the policy before it says the fix. Shadowing a Lua
+  -- builtin (`local function load`) is the common way in: nothing in
+  -- the message mentions that `load` was already something.
+  local shadowed = msg:match("shadows previous declaration of '([%w_]+)'")
+  if shadowed then
+    return "  hint: warnings are errors here — rename `" .. shadowed ..
+    "`, which already names something in scope (a Lua builtin such as " ..
+    "`load`, `type` or `error` when you did not declare one yourself) " ..
+    "— see `cosmic --docs guide.gotchas`"
+  end
+  if msg:find("^unused ") then
+    return "  hint: warnings are errors here — remove it, or prefix the " ..
+    "name with `_` to mark it deliberately unused (`local _out`, " ..
+    "`_self: Poller`) — see `cosmic --docs guide.gotchas`"
+  end
   -- Pattern 1: number/integer mismatch
   if msg:find("got number, expected integer") then
     return "  hint: annotate the variable `: number`, or convert with math.tointeger; integer is required for string indices/lengths"


### PR DESCRIPTION
Warnings are errors here, and nothing in the output says so. An agent in the 2026-08-09 clean-room round named a local `load`, got

```
w.tl:1:1: warning: function shadows previous declaration of 'load'
```

and read it as survivable — which it looks like, right up until the exit code disagrees two lines later. It cost that agent its first build, and it ranked the confusion as its top friction point.

## Change

The rounds' own lesson is that a hint on the failing line beats a gotcha entry, so both warning classes carry one:

```
w.tl:1:1: warning: function shadows previous declaration of 'load'
  hint: warnings are errors here — rename `load`, which already names something in
  scope (a Lua builtin such as `load`, `type` or `error` when you did not declare one
  yourself) — see `cosmic --docs guide.gotchas`
w.tl:4:7: warning: unused variable unusedvar: integer
  hint: warnings are errors here — remove it, or prefix the name with `_` to mark it
  deliberately unused (`local _out`, `_self: Poller`) — see `cosmic --docs guide.gotchas`
```

Each says the policy first, then the fix. Warnings now reach the hint renderer on the two paths that print them (`--check types` and `--make check`) — before, only errors did.

`--make ci` on this branch: `ci: PASS (5 stages)`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhxzHF8xve3kCKJot6bBAx)_