### PR TITLE
the snippet gate declares what it reads

### DIFF
--- a/_build/snippets_test.tl
+++ b/_build/snippets_test.tl
@@ -1,4 +1,18 @@
 #!/usr/bin/env cosmic
+--- reads: README.md
+--- reads: AGENTS.md
+--- reads: docs
+--- reads: skills
+--- reads: sys
+--- reads: cmd
+--- reads: cosmic
+--- reads: _build
+--- reads: _cli
+--- reads: _docs
+--- reads: _make
+--- reads: _perf
+--- reads: _tool
+--- reads: _types
 -- Every code snippet this repository shows a reader is real code.
 --
 -- "Shows a reader" is the whole surface, not one directory: the guides
@@ -27,10 +41,17 @@ local env = require("cosmic.env")
 local fs = require("cosmic.fs")
 local teal = require("cosmic.teal")
 
---- Trees whose markdown is not this repository talking to a reader:
---- build output, vendored source, and the fixture projects that exist
---- to be built rather than read.
-local SKIP < const >: {string} = {"o/", "3p/", "_make/testdata/"}
+--- The files this test reads, from its own `--- reads:` declarations
+--- above. One list, two consumers: make takes it as the prerequisite
+--- set and the content key — so editing a guide re-runs this test
+--- rather than replaying its verdict — and the scan below takes it as
+--- the population. Deriving the second from the first is what keeps
+--- them from drifting, and the model refuses a declaration naming a
+--- path that does not exist.
+local function declared_files(): {string}
+  local imports = require("_make.imports")
+  return (check.must(imports.reads_of_file(".", "_build/snippets_test.tl")))
+end
 
 --- The example project the guides describe — `greet.text` in the
 --- quickstart, `mymod` in the module guide, `cosmic.mymod` in the
@@ -164,21 +185,10 @@ end
 --- Every fence this repository shows a reader.
 local function all_fences(): {Fence}
   local out: {Fence} = {}
-  local function wanted(path: string): boolean
-    for _, prefix in ipairs(SKIP) do
-      if path:sub(1, #prefix) == prefix or path:sub(1, #prefix + 2) == "./" .. prefix then
-        return false
-      end
-    end
-    return true
-  end
-  for _, path in ipairs(check.must(fs.find(".", {glob = "*.md"})) as {string}) do -- cast: find returns paths
-    if wanted(path) then
+  for _, path in ipairs(declared_files()) do
+    if path:sub(-3) == ".md" then
       markdown_fences(path, out)
-    end
-  end
-  for _, path in ipairs(check.must(fs.find(".", {glob = "*.tl"})) as {string}) do -- cast: find returns paths
-    if wanted(path) then
+    elseif path:sub(-3) == ".tl" then
       doc_comment_fences(path, out)
     end
   end


### PR DESCRIPTION
A test's prerequisites are its import closure plus whatever it declares with `--- reads:`. The snippet gate added in #1059 declared nothing, and it reads markdown and doc comments it never imports — so make had no reason to re-run it. Editing a guide left `o/test-summary.txt` up to date and the previous verdict was replayed: a stale PASS over an edited file, which is the failure D18 exists to prevent.

## The declarations are also the scan set

`reads_of_file` expands each declared directory to its files, so the test walks exactly what make hashes — one list, two consumers, no way for the population and the prerequisites to disagree. The `SKIP` list is gone along with the tree walk that needed it: what is not declared is not read, and the model refuses a declaration naming a path that does not exist.

## Verification

Appending a broken fence to `docs/stdlib.md` and re-running:

```
docs/stdlib.md:57: unknown variable: nope
test: FAIL (1 of 1 file)
```

Reverting it passes again. Before this change the same edit reported PASS from cache.

`--make ci`: `ci: PASS (5 stages)`.

## Note

I reported this behaviour as a gap in the build model when I hit it. That was wrong — the mechanism exists and is documented in D18; the new test simply failed to use it. `_build/skills_test.tl` has declared `reads:` all along.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhxzHF8xve3kCKJot6bBAx)_