### PR TITLE
agent eval round 4: the map literal, the per-line cast, and what `--test` runs

### DIFF
--- a/cosmic/_teal_hints.tl
+++ b/cosmic/_teal_hints.tl
@@ -15,7 +15,9 @@
 ---      3p/tl/tl_patch.tl), but record FIELDS never narrow, and
 ---      nothing else tells the author
 ---   3. excess return values (multiple returns captured incorrectly)
----   4. <any type> operations (ipairs, index, concat on any)
+---   4. <any type> operations (ipairs, index, concat on any), and the
+---      `{Key = value}` literal that inferred a closed record where a
+---      `{string: T}` map was meant
 
 --- Return a fix-hint line for a known error message, or nil.
 --- @param msg string The error message to match
@@ -121,6 +123,16 @@ local function hint_for_message(msg: string): string | nil
   -- Pattern 4c: index on any type
   if msg:find("cannot index") and msg:find("<any type>") then
     return "  hint: cast first, e.g. `local obj = val as {string: any}`"
+  end
+  -- Pattern 4d: a `{Key = value}` literal indexed with a computed
+  -- string. tl infers a closed record from the literal and ends its
+  -- message with "consider using an enum", which is the fix for a
+  -- fixed key SET and the wrong turn for a lookup TABLE — the common
+  -- case (a month-name or status-code map). Nothing else says the
+  -- annotation is what was missing.
+  if msg:find("cannot index object of type record", 1, true)
+  and msg:find("with a string", 1, true) then
+    return "  hint: a `{Key = value}` literal infers a closed record, not a map — annotate it as one (`local months: {string: integer} = {Jan = 1}`); an enum fits a fixed key SET, not a lookup table — see `cosmic --docs guide.gotchas`"
   end
   return nil
 end

--- a/cosmic/teal_test.tl
+++ b/cosmic/teal_test.tl
@@ -363,6 +363,23 @@ f({})
 end
 test_hint_index_any()
 
+-- tl's own message for this one ends "consider using an enum", which
+-- is the fix for a fixed key set and the wrong turn for a lookup
+-- table; the hint has to name the annotation instead.
+local function test_hint_record_literal_indexed_with_string()
+  local msg, hint = first_hinted_error("h_map.tl", [[
+local months = {Jan = 1, Feb = 2}
+local function num(name: string): integer
+  return months[name]
+end
+print(num("Jan"))
+]])
+  assert(msg:find("cannot index object of type record", 1, true)
+    and msg:find("with a string", 1, true), "wrong error: " .. msg)
+  assert(hint:find("{string: integer}", 1, true), "wrong hint: " .. hint)
+end
+test_hint_record_literal_indexed_with_string()
+
 -- The lax/strict contract, asserted rather than only documented:
 -- --compile (default) is the permissive gradual-typing on-ramp; strict
 -- compile refuses everything --check types refuses (type errors AND

--- a/docs/agent-usability-2026-08.md
+++ b/docs/agent-usability-2026-08.md
@@ -1,0 +1,177 @@
+# Agent Usability Study — August 2026, round 4
+
+> **As of August 2026, main `26bb9bf`.** A dated study log, not live
+> guidance: the module names, guide slugs and error messages quoted
+> below are the ones that build shipped. Read it for the findings and
+> the fixes they motivated, not the identifiers. The method is
+> `skills/agent-eval/SKILL.md`; the predecessor study is
+> [agent-usability.md](agent-usability.md).
+
+Four Sonnet agents, four fresh briefs, one file each: the `cosmic`
+binary built from `26bb9bf` (`ci: PASS (5 stages)` before staging).
+No repo access, no web, no skill roster, a throwaway `HOME` per agent
+and the session env scrubbed. The isolation probe returned `NONE`, so
+these numbers are not lower bounds the way round 1's were — all four
+self-reports confirm the prompt was first contact with cosmic.
+
+## Results
+
+| agent | brief | surfaces | first build | green ci | verified |
+|-------|-------|----------|-------------|----------|----------|
+| 1 | `todo` — JSON-backed task CLI, subcommands, `--json` | flags, fs, json | 1 | 2 | yes |
+| 2 | `logstat` — access-log parser, percentiles, histogram | string, time, testdata | 2 | 3 | yes |
+| 3 | `notes` — SQLite CRUD, tags, transactions, search | sqlite, flags, time | 2 | 2 | yes |
+| 4 | `mkproj` — spec-driven scaffolder, ≥4 modules | imports, project model | 1 | 1 | yes |
+
+4/4 built, tested and green. "verified" means checked here, not
+self-reported: each project's `o/bin/<name>` was run by hand
+(`todo stats --json`, `logstat sample.log`, `notes new|list|search`,
+`mkproj --dry-run` and a real scaffold plus its clobber refusal), and
+`--make ci` was re-run in each tree from this session — all four
+reported `ci: PASS (4 stages)` (`example` skipped: no `*_example.tl`).
+
+Nobody hit a dead end. Every failure any agent reported was resolved
+in the same session from the tool's own output; no agent had to guess
+at undocumented behaviour, and none reported a wrong answer from the
+docs.
+
+## What the journals agree on
+
+Two frictions showed up in more than one journal. Those are the
+findings worth spending on; a single agent's stumble is noise.
+
+**1. `cast-justify` reads as per-statement, and is per-line.**
+(agents 2 and 3, one lost `ci` cycle each.) Both wrote a multi-line
+table literal widening a `{string: any}` row into a typed record, put
+one `-- cast:` comment above the whole constructor, and were surprised
+that lint wanted one per field. Both had *read* the rule first; both
+misparsed "the whole line" as "the whole statement". Agent 3: "I read
+'the pattern' rather than 'the line' the first time through." Agent 2
+asked for the same fix independently: a worked multi-line example.
+
+**2. multi-return values spread where you did not mean them to.**
+(agent 3 three times, agent 4 among the constructs that fired.) Agent
+3 hit `time.format_iso8601(time.now())` (two returns into a one-arg
+call), then `return check.must(child.run(...))`, then
+`check.must(db:query_value(...))` — where `query_value`'s third return
+shape (`value, found, err`) puts a boolean into `must`'s `err?: string`
+slot. The existing hints caught all three at the exact line, so each
+cost one edit rather than a debugging session — but the trap fires
+often enough that agent 3 ranked it #1 despite having read the
+`tuple-spread` gotcha up front. This is the round-3 lesson again: the
+hint converts a stall into an edit; it does not prevent the write.
+
+Single-agent findings worth acting on:
+
+**3. `{Key = value}` infers a closed record, and tl's message points
+the wrong way.** (agent 2, ranked #3, "the one gap I'd most want
+added".) A month-name lookup table produced:
+
+```text
+error: cannot index object of type record (Jan: integer; Feb: integer)
+with a string, consider using an enum
+```
+
+The suggestion fits a fixed key *set*; for a lookup *table* the fix is
+`local months: {string: integer} = ...`. No hint fired, and the
+message's own advice sends you to an enum.
+
+**4. `--test <output> <cmd>...` reads as "the binary under test".**
+(agent 4, ranked #2, and the only real dead end in the round.) Agent 4
+ran `cosmic --test o/foo o/bin/mkproj spec_test.tl`, which cheerfully
+ran *its own CLI* against the test file as if it were a spec and
+reported invalid JSON. `guide.testing` spells the argument out as
+`<cosmic_binary>`; `--help` did not.
+
+## Fixed in this change
+
+Following the skill's priority — hint at the error site first, gotcha
+entry second, guide prose third:
+
+- **finding 3 → a hint at the error site.** `cosmic/_teal_hints.tl`
+  gains pattern 4d for `cannot index object of type record ... with a
+  string`, naming the map annotation and saying what an enum is
+  actually for. A canary test in `cosmic/teal_test.tl` provokes the
+  real message through the real check path, so a tl bump that rewords
+  it fails there instead of silently killing the hint.
+- **finding 3 → a `record-vs-map` gotcha entry**, next to
+  `integer-vs-number` where agent 2 asked for it.
+- **finding 1 → `guide.lint`** says "one PHYSICAL line ... never a
+  whole statement" and carries the multi-line worked example both
+  agents wanted — the `{string: any}`-row-into-record shape they each
+  wrote.
+- **finding 4 → `sys/help.md`** says `<cmd>` is the cosmic binary that
+  runs the test file, not the program under test.
+
+Finding 2 is left where it is on purpose: the hints already fire on
+every instance, name the fix, and cost one edit. The remaining cost is
+that the trap is *writable*, which no error-site change reaches.
+
+## Backlog (not fixed here)
+
+- **`flags` has no cross-cutting flag.** (agent 1, ranked #1, and the
+  largest chunk of non-obvious code in that project.) A `--json` or
+  `--file` meant to apply to every subcommand has no home in a
+  `CommandSpec`, so agent 1 hand-rolled an argv pre-scanner and had to
+  reason about `--file=path` vs `--file path`, bare `--file`, and
+  flags before *or* after the verb. The `flags` doc's own example is a
+  todo CLI, so it stops one step short of the case a todo CLI needs.
+- **`json.array` returns `{any}`.** (agent 1, ranked #2.) Marking a
+  genuinely-empty table for round-trip-safe encoding costs the element
+  type, and the obvious repair (`as {Task}` at each call site) is
+  exactly what `cast-justify` then nags about; the good repair (one
+  generic wrapper) is not suggested anywhere.
+- **`check.must` meets a three-value return.** `query_value` returns
+  `value, found, err`; `must`'s second parameter is `err?: string`.
+  The collision is legible only after the checker points at it.
+- **`cosmic.string`'s "no Lua patterns" reads as a prohibition.**
+  (agent 2, minor.) It means "this module does not take them", not
+  "cosmic programs do not have them" — one clarifying clause.
+- **`--help` says `cosmic-lua`, everything else says `cosmic`.**
+  (agent 1, minor.) A moment of "did I get the right binary".
+
+Not actionable, recorded for the next reader: `file(1)` calls the APE
+binary a DOS/MBR boot sector (agents 3 and 4 both paused on it), and
+the `example` stage reporting "nothing to do" for a project with no
+examples surprised nobody but does mean a green project prints
+`ci: PASS (4 stages)`, not 5.
+
+## What stayed easy
+
+All four journals converge here, and it is the same list as round 3 —
+worth keeping intact:
+
+- **`--docs` is sufficient.** Every agent said outright that the
+  no-web constraint never bound, and that they never had to read
+  source or guess a signature. `guide.quickstart` was named by three
+  of the four as the thing that produced a correct layout with zero
+  guessing.
+- **Error messages that name their own fix.** Every agent listed this.
+  Agent 3: "I never had to guess at a fix; I just followed what the
+  tool printed."
+- **`cosmic --fix <file>`** — named by all four; the fmt failure
+  message prints the literal command, and copy-pasting it is the whole
+  repair.
+- **`cosmic.flags`** — named by all four as the best batteries-included
+  moment: one spec table yields parsing, dispatch and an aligned
+  `--help`. (The gap in finding-5 above is a gap *in* something all
+  four agents liked.)
+- **The position-declares-meaning project model.** Agent 4:
+  "`cmd/mkproj/main.tl` just *became* `o/bin/mkproj` the moment it
+  existed in the right place."
+- **One command for the gate.** `--make ci` ending in one verdict line
+  meant nobody had to remember a chain of invocations.
+- **The spawn-your-own-binary test pattern** from `guide.testing`
+  mapped onto "test the subcommand dispatch" with no harness design
+  needed (agents 1, 2, 3).
+
+## Reading these numbers against round 3
+
+Round 3's fully-isolated fleet converged to 1/1/1/1 on first build.
+This round is 1/2/2/1 — but on harder briefs (round 3's did not
+require a spec-driven multi-module generator or transactional SQLite),
+and both 2s were single type errors caught by hinted messages, not
+stalls. The comparable claim is the one this round supports directly:
+**every failure was a one-edit fix from the tool's own output**, and
+the two that repeated across agents are both now fixed at the error
+site or in the guide they misread.

--- a/docs/guides/gotchas.md
+++ b/docs/guides/gotchas.md
@@ -32,6 +32,29 @@ print(s, m)
 sizes — are annotated `integer` at the source of truth, so no
 conversion dance is needed on that side.)
 
+## record-vs-map
+
+a `{Key = value, ...}` literal infers a CLOSED record type — a type
+with exactly those field names — not a map. indexing it with a
+computed string then fails with `cannot index object of type record
+(...) with a string, consider using an enum`. that trailing suggestion
+fits a fixed key SET; for a lookup table the fix is to annotate the
+map type at the declaration.
+
+```teal
+local months: {string: integer} = {Jan = 1, Feb = 2, Mar = 3}
+
+local function month_number(name: string): integer | nil
+  return months[name]
+end
+print(month_number("Feb"))
+```
+
+without the annotation, `months.Jan` still works (it is a record
+field) and only the computed lookup fails — so the trap surfaces at
+the call site, not at the table. the error carries the annotation as a
+hint.
+
 ## any-from-json-decode
 
 for the two common top-level shapes, skip `any` entirely:

--- a/docs/guides/lint.md
+++ b/docs/guides/lint.md
@@ -32,7 +32,9 @@ the fix is `.cosmicignore`, not splitting the file.
 every `as` cast is an unchecked hole in the type system, so each one
 must say why: a trailing `-- cast: <reason>` on the same line, or on the
 line directly above when 90 columns will not fit it. one comment covers
-the whole line, however many casts the line holds.
+one PHYSICAL line, however many casts that line holds — never a whole
+statement: a call spread over five lines with a cast on each needs five
+comments, not one above the call.
 
 ```teal
 local check = require("cosmic.check")
@@ -47,6 +49,24 @@ local d = db as sqlite.Database -- cast: record union after guard
 -- cast: from any (json.decode result)
 local obj = json.decode(input) as {string: any}
 print(d, obj)
+```
+
+the multi-line shape is where the per-line rule bites, and it is the
+common one — a `{string: any}` row widened field by field into a typed
+record:
+
+```teal
+local record Note
+  id: integer
+  title: string
+end
+
+local row: {string: any} = {id = 1, title = "first"}
+local note: Note = {
+  id = row.id as integer, -- cast: from any (sqlite row)
+  title = row.title as string, -- cast: from any (sqlite row)
+}
+print(note.id, note.title)
 ```
 
 write the actual reason (`from any`, `userdata boundary`, `record union

--- a/skills/agent-eval/SKILL.md
+++ b/skills/agent-eval/SKILL.md
@@ -152,3 +152,10 @@ forces the whole `--make` surface, not just scripting.
   it: narrowing hints on every error path, the `.cosmicignore` hint,
   `guide.lint`, `guide.quickstart`, doc-index shard flattening,
   `flags.command`, and lint source-line snippets.
+- August 2026, round 4: four new briefs against main `26bb9bf` — a
+  JSON CLI, a log analyzer, a SQLite CRUD tool and a multi-module
+  scaffolder — 4/4 green, no dead ends, write-up in
+  `docs/agent-usability-2026-08.md`. It produced the `record-vs-map`
+  hint and gotcha, the per-line `cast-justify` example, and the
+  `--test <cmd>` help wording; it left `flags`' missing cross-cutting
+  flag and `json.array`'s `{any}` return on the backlog.

--- a/sys/help.md
+++ b/sys/help.md
@@ -25,6 +25,8 @@ Cosmic options:
   --benchmark <file.tl[:pat]>   run Benchmark_* functions, report timing
   --docs [query]                show documentation for module, symbol, or guide
   --test <output> <cmd>...      run test, write <output>.{got,out,err}
+                                <cmd> is the cosmic binary that RUNS the
+                                test file, not the program under test
                                 e.g. cosmic --test o/foo ./cosmic foo_test.tl
   --report <paths>...           report on .got files written by --test
                                 e.g. cosmic --report o/foo.got


### PR DESCRIPTION
A clean-room round per `skills/agent-eval/SKILL.md`, plus the fixes it earned.

## The round

Four Sonnet agents, four fresh briefs, one file each — the `cosmic` binary built from `26bb9bf` (`ci: PASS (5 stages)` before staging). No repo access, no web, `--disallowedTools "Skill"` to drop the roster, a throwaway `HOME` per agent, session env scrubbed. The isolation probe returned `NONE`, and all four self-reports confirm the prompt was first contact.

| agent | brief | surfaces | first build | green ci |
|-------|-------|----------|-------------|----------|
| 1 | `todo` — JSON-backed task CLI, subcommands, `--json` | flags, fs, json | 1 | 2 |
| 2 | `logstat` — access-log parser, percentiles, histogram | string, time, testdata | 2 | 3 |
| 3 | `notes` — SQLite CRUD, tags, transactions, search | sqlite, flags, time | 2 | 2 |
| 4 | `mkproj` — spec-driven scaffolder, ≥4 modules | imports, project model | 1 | 1 |

4/4 green, no dead ends but one. Not taken on self-report: each `o/bin/<name>` was run by hand here and `--make ci` re-run in every tree (all four `ci: PASS (4 stages)`).

## What changed, and why

Two frictions repeated across journals — those are the ones spent on; a single agent's stumble is noise.

- **`{Key = value}` infers a closed record, and tl's message points the wrong way.** `cannot index object of type record (...) with a string, consider using an enum` — the enum fits a fixed key SET, not a lookup table. New hint pattern 4d in `cosmic/_teal_hints.tl` names the annotation (`local months: {string: integer} = ...`) and says what an enum is actually for, with a canary test in `cosmic/teal_test.tl` provoking the real message through the real check path, so a tl reword fails there instead of silently killing the hint. Plus a `record-vs-map` gotcha entry beside `integer-vs-number`, where the agent asked for it.
- **`cast-justify` reads as per-statement and is per-line.** Two agents put one `-- cast:` comment above a multi-line constructor and each lost a ci cycle; both had read the rule first. `guide.lint` now says one PHYSICAL line, never a whole statement, and carries the multi-line worked example (the `{string: any}`-row-into-record shape they both wrote).
- **`--test <output> <cmd>...` read as "the binary under test"** — the round's one real dead end. `--help` now says `<cmd>` is the cosmic binary that runs the test file.

The multi-return tuple-spread trap fired four times across two agents and is deliberately left alone: the existing hints catch every instance at the exact line and cost one edit. What remains is that the trap is *writable*, which no error-site change reaches.

## Left on the backlog, with the evidence recorded

`flags` has no cross-cutting flag (agent 1's top friction and the largest chunk of non-obvious code in that project); `json.array` returns `{any}`, losing the element type; `check.must` meets `query_value`'s three-value return; `cosmic.string`'s "no Lua patterns" reads as a prohibition; `--help` says `cosmic-lua` where everything else says `cosmic`.

## Gate

`o/bin/cosmic --make ci` → `ci: PASS (5 stages)`. The three fixes were re-verified against the rebuilt binary: the hint fires on a live repro, the help text ships, the gotcha renders under `--docs guide.gotchas`.

Full write-up: `docs/agent-usability-2026-08.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4Espks9AWAn6mTUVrWGuS)_