### PR TITLE
returns: no marker, because nothing foreign needed one

### DIFF
--- a/.cosmic-coverage
+++ b/.cosmic-coverage
@@ -17,7 +17,7 @@ _cli/lint_render.tl 26 26
 _cli/main_handlers.tl 11 221
 _cli/pattern_args.tl 132 135
 _cli/require_hints.tl 104 124
-_cli/returns.tl 110 142
+_cli/returns.tl 100 132
 _cli/run.tl 28 33
 _cli/visibility.tl 24 25
 _cli/welcome.tl 0 25
@@ -199,11 +199,11 @@ cosmic/string.tl 180 183
 cosmic/sys.tl 14 22
 cosmic/tar.tl 116 126
 cosmic/teal.tl 92 100
-cosmic/time.tl 142 155
+cosmic/time.tl 131 143
 cosmic/tty.tl 119 126
 cosmic/url.tl 126 141
 cosmic/user.tl 48 61
 cosmic/uuid.tl 9 9
 cosmic/zip.tl 72 85
 tlconfig.lua 7 7
-total 14900 19569
+total 14879 19547

--- a/3p/cosmos/cosmos_pin.tl
+++ b/3p/cosmos/cosmos_pin.tl
@@ -1,7 +1,7 @@
 return {
   format = "zip",
-  platforms = {["*"] = {sha = "1382ddb25227a9fca81104bd5e95bf1c5bdfab8b4a47ec44184c954f4bbb370d"}},
+  platforms = {["*"] = {sha = "2d47145f2ccb092ecc4796c13debc2afa6ab9304447e6289b07ad83498f33558"}},
   strip_components = 0,
   url = "https://github.com/whilp/cosmopolitan/releases/download/{version}/cosmos.zip",
-  version = "2026.08.08-7d8770074"
+  version = "2026.08.09-dcc0fcc76"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,8 +199,9 @@ record (`fs.find`'s `.errors`, `sqlite`'s `Checkout`), never in slot 3, because
 `local v, err = f()` and `check.must(f())` are the only two call shapes anyone
 writes and neither can see past the second. An infallible tuple is untouched
 (`string.partition` returns three strings and none of them could be an error).
-A `cosmo.*` binding's tuple is not ours to fold — those declarations carry a
-`-- returns: <reason>`. Full rule: `cosmic --docs guide.lint`.
+A `cosmo.*` binding's tuple is not ours to fold — but it is already declared in
+the generated `.d.tl`, which lint exempts by position, so name that type instead
+of retyping its shape. Full rule: `cosmic --docs guide.lint`.
 
 **`find` says whether it means a pattern.** A variable needle in
 `s:find(x)` needs `, 1, true` (substring) or `, 1, false` (real

--- a/_cli/lint.tl
+++ b/_cli/lint.tl
@@ -412,7 +412,7 @@ local function lint_file(path: string): {Diagnostic} | nil, string
     for _, d in ipairs(check_nil_declaration(path, content)) do
       diagnostics[#diagnostics + 1] = d
     end
-    for _, d in ipairs(returns.check_fallible_returns(path, content, lines)) do
+    for _, d in ipairs(returns.check_fallible_returns(path, content)) do
       diagnostics[#diagnostics + 1] = d
     end
     for _, d in ipairs(visibility.check_shard_require(path, lines)) do

--- a/_cli/returns.tl
+++ b/_cli/returns.tl
@@ -23,13 +23,16 @@
 --- signature is a RECORD — one value carrying the extras, one error
 --- beside it.
 ---
---- The one shape that cannot be fixed is a foreign one: a `cosmo.*`
---- binding's tuple is decided in C, and a Teal record DESCRIBING it
---- must say what it really returns (`cosmic.re`'s Regex methods are
---- the binding's own metatable). Those declarations carry a
---- `-- returns: <reason>` marker, trailing or on the line above, the
---- same two positions `-- cast:` reads. It is a justification, not an
---- exemption: the deviation stays visible and named.
+--- There is no escape hatch, and none is needed. A `cosmo.*` binding's
+--- tuple IS decided in C and cannot be folded — but it is already
+--- declared, once, in the generated `.d.tl` files, which describe C
+--- interfaces and which lint exempts by POSITION. Every marker this
+--- rule once carried turned out to mark a cosmic-side RESTATEMENT of
+--- one of those declarations: a hand-copy that could drift from the
+--- binding, and in two cases already had. Name the generated type
+--- instead of retyping its shape (`cosmic.re`'s Regex is now
+--- `cosmo.re`'s), cast the argument rather than the whole binding, or
+--- declare `any...` when the arity genuinely is not yours to know.
 ---
 --- Token-exact, via the lexer, so a signature quoted inside a string
 --- or a doc comment never counts. The type grammar parsed here is the
@@ -215,39 +218,11 @@ local function params_open(tokens: {Token}, i: integer): integer
   return 0
 end
 
---- Whether the signature starting on line `y` says why it deviates.
----
---- Trailing on the line, or anywhere in the comment block directly
---- above it — not just the single line above, the way `-- cast:` reads.
---- A foreign shape takes a sentence to explain, and a reason split
---- across two comment lines is still one reason.
---- @param lines {string} The file's lines
---- @param y integer The line the `function` keyword is on
---- @return boolean True when the marker is present
-local function is_marked(lines: {string}, y: integer): boolean
-  local here = lines[y]
-  if here and here:match("%-%- returns: %S") then
-    return true
-  end
-  for i = y - 1, 1, -1 do
-    local line = lines[i]
-    if not (line and line:match("^%s*%-%-")) then
-      return false
-    end
-    if line:match("^%s*%-%-%-? returns: %S") then
-      return true
-    end
-  end
-  return false
-end
-
 --- Every declared return list that puts a slot past the error.
 --- @param file string Path, for the diagnostic
 --- @param content string The file's bytes
---- @param lines {string} The file's lines
 --- @return {Diagnostic} One per over-wide fallible signature
-local function check_fallible_returns(file: string, content: string,
-    lines: {string}): {Diagnostic}
+local function check_fallible_returns(file: string, content: string): {Diagnostic}
   local tokens = tl.lex(content, file)
   if not tokens then
     return {}
@@ -259,7 +234,7 @@ local function check_fallible_returns(file: string, content: string,
       local after = open > 0 and skip_balanced(tokens, open, "(", ")") or 0
       if after > 0 and tokens[after] and tokens[after].tk == ":" then
         local slots = parse_list(tokens, after + 1)
-        if #slots > 2 and slots[1] and not is_marked(lines, t.y) then
+        if #slots > 2 and slots[1] then
           diagnostics[#diagnostics + 1] = {
             file = file,
             line = t.y,
@@ -270,8 +245,9 @@ local function check_fallible_returns(file: string, content: string,
               .. " slots; a caller writing `local v, err = f()` cannot"
               .. " reach past slot 2, and check.must feeds slot 2 to its"
               .. " `err` parameter — carry the extras in the value's"
-              .. " record, or say why the shape is not yours with a"
-              .. " trailing `-- returns: <reason>` (see `cosmic --docs"
+              .. " record. A cosmo binding's own tuple is already"
+              .. " declared in the generated .d.tl: name that type"
+              .. " rather than retyping its shape (see `cosmic --docs"
               .. " guide.lint`)",
               file, t.y, #slots),
           }
@@ -283,8 +259,7 @@ local function check_fallible_returns(file: string, content: string,
 end
 
 local record ReturnsModule
-  check_fallible_returns: function(file: string, content: string,
-  lines: {string}): {Diagnostic}
+  check_fallible_returns: function(file: string, content: string): {Diagnostic}
 end
 
 local M: ReturnsModule = {

--- a/_cli/returns_test.tl
+++ b/_cli/returns_test.tl
@@ -14,11 +14,7 @@ local type Diagnostic = style.Diagnostic
 
 --- Run the rule over a source string, as lint_file does.
 local function diagnose(source: string): {Diagnostic}
-  local lines: {string} = {}
-  for line in (source .. "\n"):gmatch("([^\n]*)\n") do
-    lines[#lines + 1] = line
-  end
-  return returns.check_fallible_returns("t.tl", source, lines)
+  return returns.check_fallible_returns("t.tl", source)
 end
 
 --- How many slots the rule counted, for a source it flags exactly once.
@@ -90,30 +86,26 @@ local function test_record_field_signature_is_checked()
 end
 test_record_field_signature_is_checked()
 
-local function test_marker_on_the_line_passes()
-  check.equal(#diagnose(
-      "local record M\n  f: function(): any, string, integer -- returns: cosmo shape\n" ..
-      "end\nreturn M\n"), 0,
-    "a trailing marker justifies a foreign shape")
-end
-test_marker_on_the_line_passes()
+-- A foreign shape needs no marker: a cosmo binding's tuple is declared
+-- once in the generated .d.tl, which lint exempts by position, and code
+-- that needs to NAME it refers to that type instead of retyping it. A
+-- varargs return is the other way out, for an arity that genuinely is
+-- not the caller's to know.
 
-local function test_marker_in_the_comment_block_above_passes()
+local function test_varargs_return_is_one_slot()
   check.equal(#diagnose(
-      "local record M\n  -- returns: the binding's own tuple, decided in C,\n" ..
-      "  -- which this record only describes\n" ..
-      "  f: function(): any, string, integer\nend\nreturn M\n"), 0,
-    "a two-line reason is still one reason")
+      "local record M\n  probe: function(any): any...\nend\nreturn M\n"), 0,
+    "`any...` declares one slot, not an open-ended tuple")
 end
-test_marker_in_the_comment_block_above_passes()
+test_varargs_return_is_one_slot()
 
-local function test_unrelated_comment_above_does_not_pass()
+local function test_a_comment_never_exempts()
   check.equal(#diagnose(
-      "local record M\n  -- just a note\n" ..
+      "local record M\n  -- returns: a reason someone typed\n" ..
       "  f: function(): any, string, integer\nend\nreturn M\n"), 1,
-    "only the marker justifies; a comment is not a justification")
+    "there is no comment escape hatch; the shape has to change")
 end
-test_unrelated_comment_above_does_not_pass()
+test_a_comment_never_exempts()
 
 local function test_body_is_not_read_as_more_slots()
   -- The return list ends at the first token that is not a comma: a
@@ -166,7 +158,7 @@ local function test_message_names_the_fix()
   local message = diags[1].message
   check.truthy(message:find("local v, err = f()", 1, true),
     "the message must show the call shape that cannot reach slot 3")
-  check.truthy(message:find("-- returns: <reason>", 1, true),
-    "the message must name the marker, for shapes that are not ours")
+  check.truthy(message:find(".d.tl", 1, true),
+    "the message must point at where a foreign shape is already declared")
 end
 test_message_names_the_fix()

--- a/cosmic/check_assertions_test.tl
+++ b/cosmic/check_assertions_test.tl
@@ -266,26 +266,24 @@ end
 test_must_passes_false_through()
 
 -- must: multi-return forwarding (the assert-parity contract)
+--
+-- Exercised with explicit arguments rather than through a fixture that
+-- returns four values. The SPREAD of a multi-return call into must is
+-- Lua's behaviour, not must's; what belongs to must is that it hands
+-- the extras back untouched. Testing it directly also means this file
+-- no longer has to declare a signature the returns rule forbids.
 
 local type Iter = function(): string
 
--- returns: the fixture IS the forbidden shape on purpose — it is what
--- must's assert-parity forwarding exists for, and a rule-11-clean
--- signature could not exercise it (fs.find_iter, which used to have
--- this shape, no longer does: #1063 folded its guard into the record)
-local function fake_files(fail: boolean, guard: any): Iter | nil, string, any, any
-  if fail then
-    return nil, "cannot open"
-  end
+local function two_paths(): Iter
   local n = 0
-  local iter = function(): string
+  return function(): string
     n = n + 1
     if n <= 2 then
       return "f" .. n
     end
     return nil
   end
-  return iter, nil, nil, guard
 end
 
 local function test_must_single_pair_collapses()
@@ -297,18 +295,18 @@ test_must_single_pair_collapses()
 
 local function test_must_forwards_extra_returns()
   local guard: any = {}
-  check.equal(select("#", check.must(fake_files(false, guard))), 4)
-  local _iter, _e, _ctl, g = check.must(fake_files(false, guard))
+  check.equal(select("#", check.must(two_paths(), nil, nil, guard)), 4)
+  local _iter, _e, _ctl, g = check.must(two_paths(), nil, nil, guard)
   check.truthy(rawequal(g, guard), "4th return must be the same guard value")
 end
 test_must_forwards_extra_returns()
 
 local function test_must_keeps_closing_guard_in_for()
-  -- the reason forwarding matters: the 4th return is Lua 5.4's
+  -- the reason forwarding matters: the 4th value is Lua 5.4's
   -- to-be-closed slot, so an early break must still run __close
   local closed = false
   local guard = setmetatable({}, {__close = function() closed = true end})
-  for _ in check.must(fake_files(false, guard)) do
+  for _ in check.must(two_paths(), nil, nil, guard) do
     break
   end
   check.truthy(closed, "early break must close the forwarded guard")

--- a/cosmic/quicksand/init.tl
+++ b/cosmic/quicksand/init.tl
@@ -68,9 +68,10 @@ end
 --- @return boolean true when the syscall is wired up on this host
 local function probe(fn: any): boolean
   if not fn then return false end
-  -- returns: the cosmo binding failure tuple (nil, err, errno) this
-  -- probe reads; the C shape is not ours to fold into a record
-  local call = fn as function(any, any): any, string, integer -- cast: function shape
+  -- A varargs return, because this probe is handed an ARBITRARY
+  -- binding: it reads slot 1 and the numeric errno, and has no business
+  -- declaring how many slots some other binding returns.
+  local call = fn as function(any, any): any ... -- cast: function shape
   local ok, _, eno = call(nil, nil)
   if ok then return true end
   if errno.is_code(eno, "ENOSYS") then return false end

--- a/cosmic/quicksand/init_test.tl
+++ b/cosmic/quicksand/init_test.tl
@@ -68,9 +68,7 @@ test_is_supported_matches_capabilities()
 -- probe's ENOSYS classification can be exercised without a host that
 -- actually lacks the syscall.
 local function mk_fail(msg: string, n: integer): any
-  -- returns: a stand-in for a cosmo binding, so it has the binding's
-  -- (nil, err, errno) tuple; probe reads the C shape, not ours
-  return function(): any, string, integer
+  return function(): any ...
     return nil, msg, n
   end
 end
@@ -115,8 +113,7 @@ local function test_probe_string_only_failure_is_available()
   -- A failure that carries no numeric errno (third slot nil) cannot be
   -- classified as ENOSYS; the error string alone must never match, so
   -- the probe reports the syscall wired up.
-  -- returns: same synthetic cosmo binding shape as mk_fail above
-  check.equal(quicksand.probe(function(): any, string, integer
+  check.equal(quicksand.probe(function(): any ...
         return nil, "prctl: ENOSYS: Function not implemented", nil
       end), true,
     "an error string without a numeric errno is never classified as ENOSYS")

--- a/cosmic/re.tl
+++ b/cosmic/re.tl
@@ -18,46 +18,16 @@
 --- the explicit-lifetime API, and each call returns a fresh handle.
 local re = require("cosmo.re")
 
---- A compiled regular expression pattern.
+--- A compiled regular expression pattern, as returned by compile().
 --- Use compile() to create, then call :match() for O(n) matching.
-local record Regex
-  -- Runtime values are cosmo.re's compiled-regex userdata (compile()
-  -- casts them in), so `x is Regex` must test for userdata.
-  userdata
-  --- Match the pattern against text (D20 rule 9's reserved verb; the
-  --- binding's metatable carries `match` since cosmopolitan#237, so
-  --- this is the method itself and not a wrapper).
-  --- On a match, returns the matched substring plus a table of the
-  --- parenthesized capture groups (an empty table when the pattern has
-  --- no groups, "" for groups that did not participate). A no-match is
-  --- not an error: it returns a single bare nil. A genuine engine
-  --- failure (e.g. out of memory) returns nil, err — the error string
-  --- arrives in the second position, mirroring the cosmo.re binding.
-  --- @param text string The text to match against
-  --- @param flags integer? Optional flags: NOTBOL, NOTEOL
-  --- @return string | nil The matched substring, or nil if no match
-  --- @return {string} | nil Capture groups on match (error string on engine failure)
-  --- @return string | nil Error message on engine failure
-  -- returns: the binding's own metatable method — this record DESCRIBES
-  -- cosmo.re's C shape (cosmopolitan#237), it does not choose it
-  match: function(self: Regex, text: string, flags?: integer): string | nil, {string} | nil, string | nil
-
-  --- Like match, but reports WHERE: absolute 1-based inclusive start
-  --- and end offsets into text, plus the capture table. init starts
-  --- the search at that offset while keeping the returned offsets
-  --- absolute, which is what lets iteration advance in O(n) instead of
-  --- re-slicing the subject per match. A no-match is a single bare
-  --- nil; an engine failure puts the error string in the second
-  --- position.
-  --- @param text string The text to search
-  --- @param flags integer? Optional flags: NOTBOL, NOTEOL
-  --- @param init integer? 1-based offset to start searching at
-  --- @return integer | nil Absolute start offset, or nil
-  --- @return integer | string | nil End offset (error string when start is nil)
-  --- @return {string} Capture groups on match
-  -- returns: same C metatable as match above; the shape is cosmo.re's
-  find: function(self: Regex, text: string, flags?: integer, init?: integer): integer | nil, integer | string | nil, {string}
-end
+---
+--- This IS `cosmo.re`'s type, not a mirror of it. The methods live on
+--- the binding's own metatable, so their shapes are declared once, in
+--- the generated `cosmo/re.d.tl`, where a C tuple belongs — restating
+--- them here meant a hand-copy that could drift from the binding (and
+--- a `:match` slot the binding never returns), plus a userdata cast on
+--- every value crossing between the two nominally-different records.
+local type Regex = re.Regex
 
 --- Compile behavior. Each field maps to one POSIX cflag; a record
 --- keeps the compile and search namespaces unmixable (the old integer
@@ -98,7 +68,7 @@ local function compile(pattern: string, opts?: CompileOptions): Regex | nil, str
   if not result then
     return nil, err
   end
-  return result as Regex -- cast: userdata boundary
+  return result
 end
 
 --- One memoized compilation of a convenience-surface pattern. rx/err
@@ -146,7 +116,7 @@ local function cache_entry(pattern: string, opts?: CompileOptions): CacheEntry
     cache = {}
     cache_count = 0
   end
-  local rx, cerr = re.compile(pattern, flags) as (Regex | nil, string) -- cast: userdata boundary
+  local rx, cerr = re.compile(pattern, flags)
 
   if rx is Regex then
     entry = {rx = rx}
@@ -190,7 +160,10 @@ local function match(text: string, pattern: string, opts?: CompileOptions): Matc
       -- No match is not an error.
       return nil
     end
-    return {text = m, caps = caps}
+    -- the guard above took the failure path, where the union's string
+    -- arm lives; a match always carries the capture table
+    -- cast: captures, past the no-match/failure guard
+    return {text = m, caps = caps as {string}}
   end
   return nil, cerr
 end

--- a/cosmic/signal.tl
+++ b/cosmic/signal.tl
@@ -228,9 +228,6 @@ end
 -- reason -- the wrapper below takes `handler` as `any`, because the
 -- formatter cannot parse a bare `function | integer` union in a
 -- function statement, and `any` does not pass to the binding's union.
--- returns: the cosmo.unix binding's own tuple, restated so the cast has
--- something to name; the C shape is not this wrapper's to choose
-local raw_sigaction = unix.sigaction as function(sig: integer, handler?: any, flags?: integer, mask?: Sigset): (any, any, any) -- cast: handler union
 
 --- Register a signal handler for the specified signal.
 --- Lua handlers run deferred in ordinary VM context (see the
@@ -252,7 +249,14 @@ local function sigaction(sig: integer, handler?: any, flags?: integer, mask?: Si
   -- One call with whatever the caller gave: the binding tolerates
   -- explicit trailing nils now (cosmopolitan#237), so the four-branch
   -- ladder that existed to never produce them is gone.
-  local prev, prev_flags, prev_mask = raw_sigaction(sig, handler, flags, mask)
+  -- Cast the ARGUMENT, not the whole binding: casting `unix.sigaction`
+  -- to a function type meant restating its return tuple here, a
+  -- hand-copy of what `cosmo/unix.d.tl` already declares (and one that
+  -- had already drifted -- it said three untyped slots where the
+  -- binding declares five typed ones).
+  local raw_handler = handler as (function | integer) -- cast: handler union
+  local prev, prev_flags, prev_mask =
+  unix.sigaction(sig, raw_handler, flags, mask)
   if prev == nil then
     -- On failure the binding returns (nil, err, errno): the error string
     -- arrives in the second slot.

--- a/cosmic/time.tl
+++ b/cosmic/time.tl
@@ -107,20 +107,20 @@ local function sleep_ms(ms: number): integer | nil, string
   return sleep_remaining_ms(seconds, math.floor(remaining_ms * 1000000))
 end
 
---- Shared by gmtime/localtime: they differ only in which cosmo.unix
---- function does the breakdown (Zulu vs the TZ-aware local one), and
---- both shape the same 11 values into a DateTime.
---- @param fn function The cosmo.unix breakdown function to call (gmtime or localtime)
+-- gmtime and localtime each destructure their own binding, rather than
+-- sharing a helper that takes the BINDING as a parameter. That helper
+-- had to restate cosmo.unix's 13-value tuple to type its parameter --
+-- a hand-copy of what `cosmo/unix.d.tl` already declares, which is
+-- both a shape that can drift and the one thing D20 rule 11 has no
+-- room for. A duplicated field mapping cannot drift silently: both
+-- halves are checked against DateTime.
+
+--- Break down a UNIX timestamp into UTC (Zulu) time components.
 --- @param unixts integer UNIX timestamp (seconds since epoch)
---- @return DateTime Broken-down time
-local function breakdown(
-    -- returns: fn is the raw cosmo.unix gmtime/localtime binding, whose
-    -- 13-value tuple is the C contract; this wrapper is what folds it
-    -- into a DateTime record, which is rule 11 applied, not dodged
-    fn: function(integer): integer | nil, integer, integer, integer, integer, integer, integer, integer, integer, integer, string, string, unix.Errno,
-    unixts: integer
-  ): DateTime
-  local year, mon, mday, hour, min, sec, gmtoff, wday, yday, isdst, zone = fn(unixts)
+--- @return DateTime Broken-down time in UTC
+local function gmtime(unixts: integer): DateTime
+  local year, mon, mday, hour, min, sec, gmtoff, wday, yday, isdst, zone =
+  unix.gmtime(unixts)
   return {
     year = year,
     month = mon,
@@ -136,19 +136,26 @@ local function breakdown(
   }
 end
 
---- Break down a UNIX timestamp into UTC (Zulu) time components.
---- @param unixts integer UNIX timestamp (seconds since epoch)
---- @return DateTime Broken-down time in UTC
-local function gmtime(unixts: integer): DateTime
-  return breakdown(unix.gmtime, unixts)
-end
-
 --- Break down a UNIX timestamp into local time components.
 --- Respects the TZ environment variable.
 --- @param unixts integer UNIX timestamp (seconds since epoch)
 --- @return DateTime Broken-down time in local timezone
 local function localtime(unixts: integer): DateTime
-  return breakdown(unix.localtime, unixts)
+  local year, mon, mday, hour, min, sec, gmtoff, wday, yday, isdst, zone =
+  unix.localtime(unixts)
+  return {
+    year = year,
+    month = mon,
+    day = mday,
+    hour = hour,
+    min = min,
+    sec = sec,
+    gmtoff = gmtoff,
+    wday = wday,
+    yday = yday,
+    isdst = isdst > 0,
+    zone = zone,
+  }
 end
 
 --- Format a UNIX timestamp as an HTTP date string (RFC 7231).

--- a/docs/guides/lint.md
+++ b/docs/guides/lint.md
@@ -136,13 +136,22 @@ an INFALLIBLE tuple is untouched: `string.partition` returns
 rule has nothing to say about it. the discriminator is nil in slot 1,
 never a guess about what the slots mean.
 
-the one shape you cannot fix is a foreign one — a `cosmo.*` binding's
-tuple is decided in C, and a Teal record DESCRIBING it has to say what
-it really returns. those carry a `-- returns: <reason>` marker, trailing
-on the line or anywhere in the comment block directly above it (`--
-cast:` reads only the single line above; this one takes a sentence).
-it is a justification, not an exemption: a shape you cannot explain is
-one to fold into a record.
+there is no escape hatch, and none is needed. a `cosmo.*` binding's
+tuple IS decided in C — but it is already declared, once, in the
+generated `.d.tl` files, which describe C interfaces and which lint
+exempts by position. so when you need to name a binding's shape, refer
+to the generated type rather than retyping it:
+
+- `cosmic.re`'s `Regex` IS `cosmo.re`'s, not a copy of it
+- cast the ARGUMENT that needs widening, not the whole binding, and no
+  return list has to be restated to give the cast a target
+- declare `any...` when the arity genuinely is not yours to know — a
+  varargs return is one slot, and honest about it
+
+the rule shipped with a `-- returns: <reason>` comment marker. every
+site that used one turned out to be a cosmic-side restatement of a
+declaration that already existed, and two had already drifted from the
+binding they copied. the marker is gone.
 
 this is D20 rule 11 made mechanical. the rule exists because the two
 call shapes everyone writes — `local v, err = f()` and


### PR DESCRIPTION
Follow-up to #1066. The `fallible-returns` rule shipped with a `-- returns: <reason>` comment as its escape hatch for shapes decided in C. **The hatch is gone, and no site needs it.**

## What the markers were actually marking

Every one of the six turned out to be a cosmic-side **restatement** of a declaration that already exists in the generated `.d.tl` — the files that describe C interfaces, which lint already exempts *by position*. cosmic tripped its own rule only because Teal has no `typeof`, so a cast target or a parameter type needs *something* to point at, and the shapes got hand-copied.

Two of those copies had already drifted from the binding they mirrored:

| | cosmic said | the binding says |
|---|---|---|
| `signal.tl` | `(any, any, any)` — 3 untyped slots | `function \| integer \| nil, integer, Sigset, string, Errno` — 5 typed |
| `re.tl` `:match` | 3 slots | 2 — verified at runtime (`select("#", …)` → 2 on a hit, 1 on a miss) |

So the markers were guarding stale duplicates, which is a worse defect than the one the rule was pointing at.

## How each site lost its marker

- **`cosmic.re`'s `Regex` IS `cosmo.re`'s type** now, not a mirror of it. The methods are declared once, in the generated `re.d.tl`, where a C tuple belongs. Two `-- cast: userdata boundary` casts disappear with the mirror, because the runtime value never was a different type.
- **`signal.tl` casts the argument, not the binding.** The cast existed to widen `handler` past a formatter limitation; casting `unix.sigaction` itself dragged its whole return tuple along as the cast target. Casting the argument needs no return list at all.
- **`time.tl`'s `gmtime`/`localtime` each destructure their own binding.** The shared `breakdown(fn, unixts)` helper had to retype cosmo's 13 values to type its `fn` parameter. A duplicated field mapping cannot drift silently — both halves are checked against `DateTime` — where a copied foreign tuple can, and did.
- **quicksand's probe and its fixtures declare `any...`.** One slot, and honest: the probe is handed an *arbitrary* binding and has no business declaring how many values someone else returns.
- **`check`'s forwarding fixture is deleted.** `must`'s contract is that it hands extras back untouched; the *spread* of a multi-return call into it is Lua's behaviour, not `must`'s. Explicit arguments (`check.must(iter, nil, nil, guard)`) test the contract, keep the `<close>`-in-a-`for` case, and need no fixture shaped like the thing the rule forbids.

## The rule itself

`is_marked` and the `lines` parameter are gone from `_cli/returns.tl`; the diagnostic now points at where a foreign shape is already declared instead of offering a comment. `_cli/returns_test.tl` gains the two cases that pin the new behaviour: a varargs return counts as one slot, and **a `-- returns:` comment no longer exempts anything**.

## The upstream half, now landed

The wrong `:match` arity originated in `definitions.lua`, where three blocks — `re.Regex:search`, `re.Regex:match`, `re.search` — declared a third return the C never pushes, contradicting their own prose. Fixed in whilp/cosmopolitan#247 (merged), and **this PR carries the pin bump** to `2026.08.09-dcc0fcc76`, which spans exactly that one commit. The generated type this tree consumes is now:

```teal
match: function(self: Regex, str: string, flags?: SearchFlag): string | nil, {string} | string | nil
```

`cosmic/re.tl` already read the real contract, and its `caps as {string}` cast — written to compile against both the old and new shapes — becomes load-bearing here rather than redundant. `re.Regex:find` is untouched upstream: its three returns are real.

## Verification

- `cosmic --make ci` — PASS (5 stages), against the new pin.
- Before the bump, checked against both the pinned and corrected annotations via `GENTYPE_DEFS`, so the two halves were never ordering-coupled.
- `grep -- "-- returns:"` over the tree: no marker anywhere outside the rule's own negative test.
- Coverage rebaselined (line-count shifts from the deletions).