### PR TITLE
check.must: declare one return, so it composes where `assert` does

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,8 +168,9 @@ local) and `is` early-exit guards (`if not (x is Rec) then return end`). The oth
   check.must(sqlite.open(path))` yields a plain `Database` — no cast, no assert. Lua
   passes multiple returns through, so a failing call reports the callee's own error
   string. `must` narrows nil only (`false` passes through), and it throws, so it is for
-  tests/examples, never library code. Like `assert`, must forwards extra returns past
-  the second; a plain `value, err` pair still collapses to the value alone. Never write
+  tests/examples, never library code. Like `assert`, it declares ONE return, so it
+  composes anywhere a value goes — `return check.must(f())`, `g(x, check.must(f()))`,
+  `for row in check.must(db:query(sql))` — with no parenthesis-truncation. Never write
   `assert(x) as T` in a test; that pattern is retired.
 - **Use `is` for dispatch past nil**: `if sock is net.Socket then sock:send(...)
   end` narrows inside the positive branch (one `type(x) == "table"` check); also

--- a/_build/guides_test.tl
+++ b/_build/guides_test.tl
@@ -234,7 +234,7 @@ test_the_verb_table_is_the_registry()
 -- `o/`") is not a teaching row and stays free.
 local function test_no_table_row_teaches_asset_outside_pins()
   for _, path in ipairs(guide_files()) do
-    for _, row in ipairs((check.must(ratchet.rows(path)))) do
+    for _, row in ipairs(check.must(ratchet.rows(path))) do
       local lower = row.line:lower()
       if lower:find("asset", 1, true) then
         assert(lower:find("pin", 1, true), row.where .. ": a table row " ..
@@ -254,7 +254,7 @@ test_no_table_row_teaches_asset_outside_pins()
 local function test_everything_else_teaches_never_embedded()
   local seen = 0
   for _, path in ipairs(guide_files()) do
-    for _, row in ipairs((check.must(ratchet.rows(path)))) do
+    for _, row in ipairs(check.must(ratchet.rows(path))) do
       if row.cell == "everything else" then
         seen = seen + 1
         assert(row.line:find("never embedded", 1, true), row.where ..

--- a/_build/ratchet_test.tl
+++ b/_build/ratchet_test.tl
@@ -56,7 +56,7 @@ end
 -- would report a cell of dashes as something the document teaches.
 local function test_a_heading_confines_the_scan()
   local path = doc()
-  local got = cells((check.must(ratchet.rows(path, "Verbs", "verb"))))
+  local got = cells(check.must(ratchet.rows(path, "Verbs", "verb")))
   assert(#got == 2, "expected the two verb rows, got " .. #got ..
     ": " .. table.concat(got, " / "))
   assert(got[1] == "`build`", "got: " .. got[1])
@@ -73,7 +73,7 @@ test_a_heading_confines_the_scan()
 -- sweep a whole document for a retired word use, and a reader that
 -- quietly scoped itself to the first table would let the rest through.
 local function test_no_heading_reads_every_table()
-  local got = cells((check.must(ratchet.rows(doc()))))
+  local got = cells(check.must(ratchet.rows(doc())))
   assert(#got == 6, "expected every row of both tables plus the two " ..
     "unfiltered headers, got " .. #got .. ": " .. table.concat(got, " / "))
 end

--- a/_build/snippets_test.tl
+++ b/_build/snippets_test.tl
@@ -50,7 +50,7 @@ local teal = require("cosmic.teal")
 --- path that does not exist.
 local function declared_files(): {string}
   local imports = require("_make.imports")
-  return (check.must(imports.reads_of_file(".", "_build/snippets_test.tl")))
+  return check.must(imports.reads_of_file(".", "_build/snippets_test.tl"))
 end
 
 --- The example project the guides describe — `greet.text` in the

--- a/_make/artifact_test.tl
+++ b/_make/artifact_test.tl
@@ -255,7 +255,7 @@ local function test_stripped_to_the_floor()
   -- outside the floor is extractable either.
   local reader = check.must(zip.open(bin))
   local bytes: {string: integer} = {}
-  for _, e in ipairs((check.must(reader:list()))) do
+  for _, e in ipairs(check.must(reader:list())) do
     local top = e.name:match("^(%.lua/[^/]+)") or e.name:match("^([^/]+)")
     bytes[top] = (bytes[top] or 0) + e.size
   end
@@ -302,7 +302,7 @@ local function test_provided_namespace_supersedes_the_floor()
   -- and must be absent here, while the project's own entry stays.
   local reader = check.must(zip.open(bin))
   local own, base_leftover = false, false
-  for _, e in ipairs((check.must(reader:list()))) do
+  for _, e in ipairs(check.must(reader:list())) do
     if e.name == "cosmic/mine.lua" then
       own = true
     end

--- a/_make/fixtures_test.tl
+++ b/_make/fixtures_test.tl
@@ -120,7 +120,7 @@ local function test_lua_markers_are_first_class()
   local zip = require("cosmic.zip")
   local reader = check.must(zip.open(fs.join(luaonly_root, "o/bin/luaonly")))
   local shipped = false
-  for _, e in ipairs((check.must(reader:list()))) do
+  for _, e in ipairs(check.must(reader:list())) do
     if e.name:find("main_test", 1, true) then shipped = true end
   end
   reader:close()
@@ -151,7 +151,7 @@ local function test_only_declared_payload_ships()
   local zip = require("cosmic.zip")
   local reader = check.must(zip.open(fs.join(assets_root, "o/bin/assets")))
   local saw: {string: boolean} = {}
-  for _, e in ipairs((check.must(reader:list()))) do
+  for _, e in ipairs(check.must(reader:list())) do
     saw[e.name] = true
     assert(not e.name:find("testdata", 1, true),
       "testdata/ must never reach an artifact: " .. e.name)

--- a/_make/testrun_test.tl
+++ b/_make/testrun_test.tl
@@ -54,7 +54,7 @@ local function test_runner_carries_root_payload()
   assert(fs.is_file(runner), "runner exists at " .. testrun.PATH)
   local reader = check.must(zip.open(runner))
   local saw: {string: boolean} = {}
-  for _, e in ipairs((check.must(reader:list()))) do
+  for _, e in ipairs(check.must(reader:list())) do
     saw[e.name] = true
   end
   reader:close()

--- a/_tool/coverage/lines_test.tl
+++ b/_tool/coverage/lines_test.tl
@@ -5,7 +5,7 @@ local cov_lines = require("_tool.coverage.lines")
 
 --- Compute lines for Lua source, asserting the parse succeeded.
 local function lines_of(source: string, name: string): {integer: boolean}
-  return (check.must(cov_lines.executable_lines(source, name)))
+  return check.must(cov_lines.executable_lines(source, name))
 end
 
 local function test_marks_basic_statements()

--- a/cosmic/_teal_hints.tl
+++ b/cosmic/_teal_hints.tl
@@ -103,7 +103,7 @@ local function hint_for_message(msg: string): string | nil
       if arity and arity > max_arity then max_arity = arity end
     end
     if given and given > max_arity and max_arity > 0 then
-      return "  hint: if the last argument is a multi-return call it spreads all its declared returns — parenthesize to pass just the value: `f(x, (check.must(g())))` — see `cosmic --docs guide.gotchas`"
+      return "  hint: if the last argument is a multi-return call it spreads all its declared returns — parenthesize to pass just the first: `f(x, (str.partition(s, \"=\")))` — see `cosmic --docs guide.gotchas`"
     end
   end
   -- Pattern 4a: ipairs on a nil union or on any — different fixes: a

--- a/cosmic/check.tl
+++ b/cosmic/check.tl
@@ -136,30 +136,22 @@ end
 --- every fallible call site needs its own `assert(x) as T`. `must`
 --- centralizes that unsoundness behind a runtime nil check. Lua passes multiple returns through, so
 --- `must(fs.read(path))` fails with fs.read's own error string.
---- Like `assert`, must forwards extra returns past the second, so
---- `for p in check.must(fs.find_iter(d)) do` keeps the 4th return — the
---- to-be-closed guard that releases directory handles on early break.
---- A plain `value, err` pair still collapses to the value alone, so
---- `print(check.must(fs.read(p)))` prints no trailing nil. The checker,
---- though, sees the declared three-value tuple: when must is the LAST
---- argument to another call, parenthesize to truncate it —
---- `table.insert(parts, (check.must(chunk)))`. The type checker's
---- `wrong number of arguments` error at such a site carries this fix
---- as a hint; `cosmic --docs guide.gotchas` has the entry.
+--- Declares ONE return (#1064), so it composes exactly where `assert`
+--- does: `return check.must(sqlite.open(":memory:"))` and
+--- `table.insert(parts, check.must(chunk))` both type-check, with no
+--- parenthesis-truncation anywhere. There is nothing to forward past
+--- slot 2, because a fallible return has two slots and no more (D20
+--- rule 11, enforced by the `fallible-returns` lint) — a resource that
+--- must be released rides on the returned record's `__close`, the way
+--- `fs.find_iter` and `sqlite.Rows` do.
 --- @param value T? The fallible value (nil on failure)
 --- @param err string? Failure message; a `nil, err` pair fills this in
---- @param ... any Extra returns (iterator state, closing guard, ...)
 --- @return T The value, known non-nil
---- @return string The second argument, forwarded when extras exist
---- @return any... The extra returns, forwarded unchanged
-local function must<T>(value: T | nil, err?: string, ...: any): T, string, any ...
+local function must<T>(value: T | nil, err?: string): T
   if value == nil then
     error(err or "must failed: expected value, got nil", 2)
   end
-  if select("#", ...) == 0 then
-    return value
-  end
-  return value, err, ...
+  return value
 end
 
 --- Report whether the enforcement lane is active.
@@ -290,7 +282,7 @@ local record CheckModule
   equal: function<T>(actual: T, expected: T, label?: string)
   not_equal: function<T>(actual: T, expected: T, label?: string)
   truthy: function(value: any, label?: string)
-  must: function<T>(value: T | nil, err?: string, ...: any): T, string, any ...
+  must: function<T>(value: T | nil, err?: string): T
   failed: function(value: any, err: string, label?: string)
   enforcing: function(): boolean
   enforce_skip: function(reason: string, strict?: boolean)

--- a/cosmic/check_assertions_test.tl
+++ b/cosmic/check_assertions_test.tl
@@ -265,17 +265,16 @@ local function test_must_passes_false_through()
 end
 test_must_passes_false_through()
 
--- must: multi-return forwarding (the assert-parity contract)
+-- must: one declared return (the assert-parity contract, #1064)
 --
--- Exercised with explicit arguments rather than through a fixture that
--- returns four values. The SPREAD of a multi-return call into must is
--- Lua's behaviour, not must's; what belongs to must is that it hands
--- the extras back untouched. Testing it directly also means this file
--- no longer has to declare a signature the returns rule forbids.
+-- must forwards nothing past the value, because a fallible return has
+-- two slots and no more (D20 rule 11). What that buys is composition:
+-- must appears in return position, in last-argument position, and as a
+-- for-in iterator without a single parenthesis-truncation.
 
 local type Iter = function(): string
 
-local function two_paths(): Iter
+local function two_paths(): Iter | nil, string
   local n = 0
   return function(): string
     n = n + 1
@@ -286,32 +285,43 @@ local function two_paths(): Iter
   end
 end
 
-local function test_must_single_pair_collapses()
-  -- a plain value, err pair yields exactly one value: no trailing nil
-  -- in print()/varargs contexts
+local function test_must_returns_exactly_one_value()
+  -- a value, err pair yields exactly one value: no trailing nil in
+  -- print()/varargs contexts, and none for the checker either
   check.equal(select("#", check.must(make_widget(false))), 1)
 end
-test_must_single_pair_collapses()
+test_must_returns_exactly_one_value()
 
-local function test_must_forwards_extra_returns()
-  local guard: any = {}
-  check.equal(select("#", check.must(two_paths(), nil, nil, guard)), 4)
-  local _iter, _e, _ctl, g = check.must(two_paths(), nil, nil, guard)
-  check.truthy(rawequal(g, guard), "4th return must be the same guard value")
+local function widget_or_throw(): Widget
+  -- return position: `assert` type-checks here and so does must
+  return check.must(make_widget(false))
 end
-test_must_forwards_extra_returns()
 
-local function test_must_keeps_closing_guard_in_for()
-  -- the reason forwarding matters: the 4th value is Lua 5.4's
-  -- to-be-closed slot, so an early break must still run __close
-  local closed = false
-  local guard = setmetatable({}, {__close = function() closed = true end})
-  for _ in check.must(two_paths(), nil, nil, guard) do
-    break
+local function test_must_composes_in_return_position()
+  check.equal(widget_or_throw().name, "gear")
+end
+test_must_composes_in_return_position()
+
+local function test_must_composes_as_last_argument()
+  -- no parenthesis-truncation: must contributes one argument, not three
+  local chunk: string | nil = "x"
+  local parts: {string} = {}
+  table.insert(parts, check.must(chunk))
+  check.equal(#parts, 1)
+  check.equal(parts[1], "x")
+end
+test_must_composes_as_last_argument()
+
+local function test_must_drives_a_for_in_loop()
+  -- a two-slot fallible iterator needs the value alone; anything the
+  -- loop must release rides on the value's own __close (fs.find_iter)
+  local seen = 0
+  for _ in check.must(two_paths()) do
+    seen = seen + 1
   end
-  check.truthy(closed, "early break must close the forwarded guard")
+  check.equal(seen, 2)
 end
-test_must_keeps_closing_guard_in_for()
+test_must_drives_a_for_in_loop()
 
 -- must: failing cases
 

--- a/cosmic/child/stdio_test.tl
+++ b/cosmic/child/stdio_test.tl
@@ -31,9 +31,7 @@ local function run_capturing(name: string, src: string): child.Result, string
       {stdout = out_h}))
   local r = check.must(h:wait())
   assert(out_h:close())
-  -- parenthesised: must forwards extra returns, which would overflow
-  -- this function's declared two
-  return r, (check.must(fs.read(outfile)))
+  return r, check.must(fs.read(outfile))
 end
 
 --- The core claim: an inherited stream reaches the real descriptor, and

--- a/cosmic/embed_advanced_test.tl
+++ b/cosmic/embed_advanced_test.tl
@@ -104,7 +104,7 @@ local function test_embed_overwrites_cleanly()
   local orig_data = fs.read(cosmic)
   local orig_reader = check.must(zip.open_string(orig_data))
   local orig_files: {string: boolean} = {}
-  for _, entry in ipairs((check.must(orig_reader:list()))) do
+  for _, entry in ipairs(check.must(orig_reader:list())) do
     -- Skip directory entries
     if entry.name:sub(-1) ~= "/" then
       orig_files[entry.name] = true

--- a/cosmic/env_dotenv_test.tl
+++ b/cosmic/env_dotenv_test.tl
@@ -394,7 +394,7 @@ local function load_dotenv_capturing_stderr(dir: string): env.LoadResult, string
   local result = env.load_dotenv(dir)
   io.stderr:close()
   io.stderr = real_stderr
-  return result, (check.must(fs.read(capture_path)))
+  return result, check.must(fs.read(capture_path))
 end
 
 local function test_cosmic_debug_empty_not_enabled()

--- a/cosmic/flags_test.tl
+++ b/cosmic/flags_test.tl
@@ -16,7 +16,7 @@ local spec: flags.Spec = {
 
 -- Parse a command line that must succeed.
 local function must(s: flags.Spec, argv: {string}): flags.Parsed
-  return (check.must(flags.parse(s, argv)))
+  return check.must(flags.parse(s, argv))
 end
 
 local function test_short_and_long_forms()
@@ -287,14 +287,14 @@ local function test_repeated_flag_collects_lists()
       {long = "count", arg = "N"},
     },
   }
-  local p = (check.must(flags.parse(rspec, {"-D", "a=1", "--define", "b=2", "--count", "9"})))
+  local p = check.must(flags.parse(rspec, {"-D", "a=1", "--define", "b=2", "--count", "9"}))
   assert(#p.lists["define"] == 2, "both occurrences collect")
   assert(p.lists["define"][1] == "a=1" and p.lists["define"][2] == "b=2",
     "in argv order")
   assert(p.values["define"] == "b=2", "values keeps the last occurrence")
   assert(p.lists["count"] == nil, "non-repeated flags have no list")
 
-  local empty = (check.must(flags.parse(rspec, {})))
+  local empty = check.must(flags.parse(rspec, {}))
   assert(empty.lists["define"] ~= nil and #empty.lists["define"] == 0,
     "declared repeated flag always has a (possibly empty) list")
 end
@@ -305,11 +305,11 @@ local function test_arg_optional_flag()
     name = "doc",
     flags = {{long = "docs", arg = "QUERY", arg_optional = true}},
   }
-  local bare = (check.must(flags.parse(ospec, {"--docs"})))
+  local bare = check.must(flags.parse(ospec, {"--docs"}))
   assert(bare.values["docs"] == "", "bare optional-arg flag reads as empty string")
-  local given = (check.must(flags.parse(ospec, {"--docs=fs.read"})))
+  local given = check.must(flags.parse(ospec, {"--docs=fs.read"}))
   assert(given.values["docs"] == "fs.read", "attached value comes through")
-  local absent = (check.must(flags.parse(ospec, {})))
+  local absent = check.must(flags.parse(ospec, {}))
   assert(absent.values["docs"] == nil, "absent flag stays nil")
 end
 test_arg_optional_flag()

--- a/cosmic/fs/glob_test.tl
+++ b/cosmic/fs/glob_test.tl
@@ -61,8 +61,8 @@ end
 test_glob_literal_component()
 
 local function test_glob_no_match_and_missing_dirs()
-  assert(#(check.must(fs.glob(root, "*.nope"))) == 0, "expected no matches")
-  assert(#(check.must(fs.glob(root, "missing/*.lua"))) == 0,
+  assert(#check.must(fs.glob(root, "*.nope")) == 0, "expected no matches")
+  assert(#check.must(fs.glob(root, "missing/*.lua")) == 0,
     "expected no matches through a missing directory")
 end
 test_glob_no_match_and_missing_dirs()

--- a/cosmic/ip_test.tl
+++ b/cosmic/ip_test.tl
@@ -4,7 +4,7 @@ local ip = require("cosmic.ip")
 
 --- Parse an address the test knows is valid, asserting success.
 local function p(s: string): ip.Addr
-  return (check.must(ip.parse(s)))
+  return check.must(ip.parse(s))
 end
 
 -- parse tests: parse returns a typed Addr

--- a/cosmic/json_test.tl
+++ b/cosmic/json_test.tl
@@ -250,7 +250,7 @@ test_integer_precision_roundtrip()
 
 local function test_float_precision_roundtrip()
   for _, f in ipairs({0.1, 3.141592653589793, 1e308, -2.5e-10}) do
-    local decoded = json.decode((check.must(json.encode(f))))
+    local decoded = json.decode(check.must(json.encode(f)))
     assert(decoded == f,
       "float should round-trip bit-exactly: " .. tostring(f)
       .. " -> " .. tostring(decoded))
@@ -276,7 +276,7 @@ local function test_nul_byte_roundtrip()
   local encoded = json.encode("\0")
   assert(encoded == '"\\u0000"',
     "an embedded NUL should encode as \\u0000, got: " .. tostring(encoded))
-  local rt = json.decode((check.must(json.encode("a\0b"))))
+  local rt = json.decode(check.must(json.encode("a\0b")))
   assert(rt == "a\0b" and #rt == 3, "NUL inside a string must round-trip")
 end
 test_nul_byte_roundtrip()

--- a/cosmic/quicksand/proxy/serve_test.tl
+++ b/cosmic/quicksand/proxy/serve_test.tl
@@ -48,7 +48,7 @@ local function roundtrip(srv: serve.Server, request: string): string
   while true do
     local chunk = sock:recv(4096)
     if not chunk then break end
-    table.insert(parts, (check.must(chunk)))
+    table.insert(parts, check.must(chunk))
   end
   assert(sock:close())
   return table.concat(parts)

--- a/cosmic/tar_example.tl
+++ b/cosmic/tar_example.tl
@@ -33,7 +33,7 @@ local function Example_extract()
   local archive = fs.join(dir, "release.tar.gz")
   local tarball = block("notes.txt", "hello from a tarball\n")
   .. string.rep("\0", 1024)
-  assert(fs.write(archive, (check.must(compress.compress(tarball, {format = "gzip"})))))
+  assert(fs.write(archive, check.must(compress.compress(tarball, {format = "gzip"}))))
 
   assert(tar.extract(archive, fs.join(dir, "out")))
   print(check.must(fs.read(fs.join(dir, "out/notes.txt"))))

--- a/cosmic/tar_test.tl
+++ b/cosmic/tar_test.tl
@@ -217,7 +217,7 @@ local function test_truncated_archive_is_refused()
   -- without one, which is what a boundary-aligned truncation leaves.
   local body = tar_entry("a.txt", "one\n", oct("644"), "0", "") ..
   tar_entry("b.txt", "two\n", oct("644"), "0", "")
-  assert(fs.write(path, (check.must(compress.compress(body, {format = "gzip"})))))
+  assert(fs.write(path, check.must(compress.compress(body, {format = "gzip"}))))
 
   assert(fs.remove_all(dest))
   local ok, err = untar.extract(path, dest)

--- a/docs/guides/gotchas.md
+++ b/docs/guides/gotchas.md
@@ -235,19 +235,26 @@ print(page)
 
 Lua spreads every return of a call in the LAST argument position into
 the argument list, and the checker counts the declared tuple — so
-`table.insert(parts, check.must(chunk))` presents three arguments
-(`check.must` declares three returns) and fails with `wrong number of
+`table.insert(parts, str.partition(line, "="))` presents four arguments
+(`partition` declares three returns) and fails with `wrong number of
 arguments`. the error-site hint names the fix: parenthesize to
 truncate to one value.
 
 ```teal
-local check = require("cosmic.check")
+local str = require("cosmic.string")
 
 local parts: {string} = {}
-local chunk: string | nil = "x"
-table.insert(parts, (check.must(chunk)))
+local line = "key=value"
+table.insert(parts, (str.partition(line, "=")))
 ```
 
-runtime behavior differs from the checker here (a plain `value, err`
-pair collapses to the value alone at runtime), which is why the site
-looks correct until `--check types` runs.
+runtime behavior differs from the checker only when the extra returns
+are `nil` (they collapse away), which is why such a site can look
+correct until `--check types` runs.
+
+`check.must` is NOT in this family: it declares one return (#1064), so
+`table.insert(parts, check.must(chunk))` and
+`return check.must(sqlite.open(":memory:"))` both check clean with no
+parentheses. Only a genuinely multi-value function — an infallible
+tuple like `partition`, or a `cosmo.*` binding — spreads here, because
+a fallible cosmic return has two slots and no more.


### PR DESCRIPTION
Fixes #1064. (#1063 landed in #1066/#1068 — `query_value` is retired and `fs.find_iter` returns `FileIter | nil, string` with the close guard folded into `__close`, so forwarding had zero consumers left.)

## The change

```diff
-must: function<T>(value: T | nil, err?: string, ...: any): T, string, any ...
+must: function<T>(value: T | nil, err?: string): T
```

and the forwarding branch goes with it — `must` is now a nil check and a return.

## What that buys

`must` narrowed but composed nowhere: three declared returns meant it spread in every value position, so `return check.must(sqlite.open(":memory:"))` failed with `excess return values, expected 1, got 3`, and a last-argument site needed parenthesis-truncation. Both type-check now, and every `(check.must(...))` in the tree loses its truncating parentheses — 20 sites across `cosmic/`, `_make/`, `_build/` and `_tool/`.

## Regression coverage

The forwarding tests in `check_assertions_test.tl` become composition tests, each of which fails `--check types` if the extra returns ever come back:

- return position (`local function widget_or_throw(): Widget return check.must(...) end`)
- last-argument position (`table.insert(parts, check.must(chunk))`, unparenthesized)
- for-in over a two-slot fallible iterator
- `select("#", check.must(pair())) == 1`

## Docs

The `tuple-spread` gotcha keeps its real half — an infallible tuple like `string.partition` still spreads in last-argument position — and now says plainly that `check.must` is not in that family. The error-site hint in `_teal_hints.tl` teaches the same example, and `AGENTS.md` records the one-return contract.

## Gate

`o/bin/cosmic --make ci` → `ci: PASS (5 stages)`, 195 files, 194 passed / 1 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGnvLWBroNRX1eCEyymjPE)_