### PR TITLE
narrowing: `assert` strips nil, so the primitive newcomers reach for works

### DIFF
--- a/3p/tl/tl_patch.tl
+++ b/3p/tl/tl_patch.tl
@@ -15,8 +15,16 @@
 --   when absent. cosmic generates the cache in _types/tlast_gen.tl and
 --   thaws it in cosmic/_teal_ast.tl.
 --
--- Three edits teach the checker that a plain variable's nil
--- union narrows through the guards Lua programmers actually write:
+-- Four edits teach the checker that a nil union narrows through the
+-- guards Lua programmers actually write:
+--
+-- - narrow-assert-decl (+ its -tl-tl twin): `assert` DECLARES that it
+--   strips nil (`function<A, B>(A | nil, ? B, ...: any): A`), so it
+--   narrows in expression position — `local db = assert(open(p))` —
+--   and not only as a statement. tl's own declaration hands the union
+--   straight back, `| nil` included, which is the trap a Lua
+--   programmer hits before ever meeting `check.must`
+--   (whilp/cosmic#1065).
 --
 -- - narrow-truthiness: `if r then` / `if not r then return end`. Lua
 --   has no falsy tables, so for a union of nil with non-boolean
@@ -184,6 +192,34 @@ tl.ast_hooks = { type_mt = type_mt, new_typeid = new_typeid }
          local result = tl.check(program, "@stdlib", {}, env)
          assert_no_errors(result.type_errors, "standard library contains type errors")
       end
+]=====],
+  },
+  ["narrow-assert-decl"] = {
+    file = "tl.lua",
+    note = "whilp/cosmic#1065: assert strips nil, so it narrows in expression position",
+    find = [=====[      assert: function<A, B>(A, ? B, ...: any): A --[[special_function]]
+]=====],
+    replace = [=====[      -- cosmic carried patch (whilp/cosmic#1065): assert's declared
+      -- argument strips the nil, so `local db = assert(open(p))` and
+      -- `local d2 = assert(d)` yield A rather than handing `A | nil`
+      -- straight back. The statement form already narrowed (see
+      -- narrow-assert below); this is the expression form, which is
+      -- what a Lua programmer writes first.
+      assert: function<A, B>(A | nil, ? B, ...: any): A --[[special_function]]
+]=====],
+  },
+  ["narrow-assert-decl-tl-tl"] = {
+    file = "tl.tl",
+    note = "whilp/cosmic#1065: assert strips nil (Teal ground truth)",
+    find = [=====[      assert: function<A, B>(A, ? B, ...: any): A --[[special_function]]
+]=====],
+    replace = [=====[      -- cosmic carried patch (whilp/cosmic#1065): assert's declared
+      -- argument strips the nil, so `local db = assert(open(p))` and
+      -- `local d2 = assert(d)` yield A rather than handing `A | nil`
+      -- straight back. The statement form already narrowed (see
+      -- narrow-assert below); this is the expression form, which is
+      -- what a Lua programmer writes first.
+      assert: function<A, B>(A | nil, ? B, ...: any): A --[[special_function]]
 ]=====],
   },
   ["narrow-assert"] = {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,10 @@ formatted string plus the numeric errno), wrappers add context with
 **Narrowing nil unions.** A guard on a plain variable narrows `T | nil` for every
 `T`: truthiness (`if not r then return end`), `assert(r)`, and `== nil`/`~= nil` —
 which is exact, so it narrows boolean unions the other two deliberately skip — via
-the carried tl patch (`3p/tl/tl_patch.tl`; mechanism in `_make/patch.tl`). What
+the carried tl patch (`3p/tl/tl_patch.tl`; mechanism in `_make/patch.tl`). The same
+patch makes `assert` narrow as an EXPRESSION, so `local db =
+assert(sqlite.open(p))` is a plain `Database` — the primitive a Lua programmer
+reaches for works, with no cosmic-specific combinator in the way. What
 still does NOT narrow: record FIELDS (copy the field to a local and guard the
 local) and `is` early-exit guards (`if not (x is Rec) then return end`). The other tools:
 

--- a/_make/fixpoint_test.tl
+++ b/_make/fixpoint_test.tl
@@ -52,9 +52,14 @@ end
 --- Copy the working tree into `dest`, minus everything generated.
 ---
 --- `git ls-files` would be the precise answer and is not available: the
---- test lane grants no host executables. Pruning `o/` and dotfiles gets
+--- test lane grants no host executables. Pruning `o/` and `.git` gets
 --- the same set for this repo, and a stray untracked file only makes
 --- the copy larger, never the assertion weaker.
+---
+--- Dot-directories are COPIED, `.git` excepted: `.github/workflows` is
+--- a declared read (`_build/workflows_test.tl`), and the model
+--- validates that every declared read exists, so a copy that pruned
+--- dotfiles wholesale failed the build it was meant to measure.
 --- @param dest string Directory to populate
 local function copy_tree(dest: string)
   assert(fs.make_dirs(dest))
@@ -62,7 +67,7 @@ local function copy_tree(dest: string)
   assert(fs.visit(repo, function(e: fs.Entry): fs.WalkAction
         local path, entry, st = e.path, e.name, e.stat
         local rel = path:sub(#repo + 2)
-        if entry:sub(1, 1) == "." or rel == "o" then
+        if entry == ".git" or rel == "o" then
           return "skip"
         end
         if not st:is_file() then
@@ -166,8 +171,8 @@ local function generation(label: string, with: string): string
   local dir = fs.join(tmpdir, "fixpoint-" .. label)
   assert(fs.remove_all(dir))
   copy_tree(dir)
-  -- The version as a tree input. `copy_tree` skips dotfiles, so this is
-  -- the copy's own declaration and never the developer's.
+  -- The version as a tree input, written after the copy so it is the
+  -- copy's own declaration and never the developer's.
   assert(fs.write(fs.join(dir, ".version"),
       'return { cosmic = "fixpoint" }\n'))
   assert(seed_pins(dir), "seeding should succeed once the guard has passed")

--- a/cosmic/_teal_hints.tl
+++ b/cosmic/_teal_hints.tl
@@ -11,9 +11,10 @@
 ---   1. got number, expected integer (string index/length requires integer)
 ---   2. X | nil used un-narrowed: passed where X is expected, indexed,
 ---      or looped over — truthiness, `assert(x)` and `== nil` all
----      narrow a plain variable (the carried tl patch,
----      3p/tl/tl_patch.tl), but record FIELDS never narrow, and
----      nothing else tells the author
+---      narrow a plain variable, and `assert` narrows composed with a
+---      fallible call too (the carried tl patch, 3p/tl/tl_patch.tl),
+---      but record FIELDS never narrow, and nothing else tells the
+---      author
 ---   3. excess return values (multiple returns captured incorrectly)
 ---   4. <any type> operations (ipairs, index, concat on any)
 
@@ -61,9 +62,10 @@ local function hint_for_message(msg: string): string | nil
   end
   -- Pattern 2b: indexing through an un-narrowed nil union. A guard on
   -- a plain variable — truthiness, `assert(x)`, `== nil` — narrows it
-  -- since the carried tl patch (3p/tl/tl_patch.tl), so what lands here
-  -- is a record FIELD (guarding `o.sub` never narrows `o.sub`) or a
-  -- value that was never guarded at all.
+  -- since the carried tl patch (3p/tl/tl_patch.tl), and so does
+  -- `assert(f())` in expression position, so what lands here is a
+  -- record FIELD (guarding `o.sub` never narrows `o.sub`) or a value
+  -- that was never guarded at all.
   if msg:find("cannot index") and msg:find("| nil", 1, true) then
     return "  hint: record fields do not narrow — copy the field to a local and guard the local (`local v = o.sub; if v then ... end`); an unguarded `T | nil` needs its guard first — see `cosmic --docs guide.checking`"
   end

--- a/cosmic/check.tl
+++ b/cosmic/check.tl
@@ -131,11 +131,13 @@ local function failed(value: any, err: string, label?: string)
 end
 
 --- Assert a fallible return and narrow away nil.
---- The one sanctioned narrowing hole for tests and examples: tl 0.24.8
---- does not flow-narrow record unions through `assert`, so without this
---- every fallible call site needs its own `assert(x) as T`. `must`
---- centralizes that unsoundness behind a runtime nil check. Lua passes multiple returns through, so
---- `must(fs.read(path))` fails with fs.read's own error string.
+--- Since #1065 plain `assert` narrows here too — the carried tl patch
+--- declares that it strips nil — so this is no longer the only way to
+--- get past a `T | nil` in a test. What it still buys: Lua passes
+--- multiple returns through, so `must(fs.read(path))` fails with
+--- fs.read's own error string rather than a message the call site had
+--- to write; and it narrows nil ONLY, so a `false` value passes
+--- through where `assert` would throw on it.
 --- Declares ONE return (#1064), so it composes exactly where `assert`
 --- does: `return check.must(sqlite.open(":memory:"))` and
 --- `table.insert(parts, check.must(chunk))` both type-check, with no

--- a/cosmic/teal_test.tl
+++ b/cosmic/teal_test.tl
@@ -67,9 +67,10 @@ test_hint_nil_union_not_narrowed()
 -- nil union narrows through truthiness (positive branch and negated
 -- early-return alike), through `assert(x)`, and through `== nil` /
 -- `~= nil` — which is exact, so it narrows boolean unions truthiness
--- cannot touch. A tl pin bump that lands without the patch — or a
--- patch whose anchor drifted — fails HERE, not as a hundred downstream
--- type errors.
+-- cannot touch. `assert` narrows in EXPRESSION position too, since it
+-- declares that it strips nil. A tl pin bump that lands without the
+-- patch — or a patch whose anchor drifted — fails HERE, not as a
+-- hundred downstream type errors.
 local function test_narrowing_canary()
   local path = fs.join(tmpdir, "narrow_ok.tl")
   assert(fs.write(path, [[
@@ -109,6 +110,14 @@ local function via_assert(): integer
   assert(r, "make failed")
   return r.x
 end
+local function via_assert_expression(): integer
+  -- the shape a Lua programmer writes first (whilp/cosmic#1065):
+  -- assert DECLARES that it strips nil, so it narrows composed with a
+  -- fallible call, not only as a statement above the use
+  local r = assert(make())
+  local r2 = assert(make())
+  return r.x + r2.x
+end
 local function via_eq_nil(): integer
   local r = make()
   if r == nil then
@@ -123,8 +132,8 @@ local function via_ne_nil_boolean(): integer
   end
   return 0
 end
-print(early() + positive() + arr() + via_assert() + via_eq_nil()
-  + via_ne_nil_boolean())
+print(early() + positive() + arr() + via_assert() + via_assert_expression()
+  + via_eq_nil() + via_ne_nil_boolean())
 ]]))
   local result = teal.check_file(path)
   assert(result.ok, "guards must narrow a nil union (carried tl patch): "

--- a/docs/decisions/d21-carried-tl-patch.md
+++ b/docs/decisions/d21-carried-tl-patch.md
@@ -21,8 +21,10 @@
   CI's pinned-release fetch. Patches ride archive pins only: editing a
   formatless pin's single output would fail its own digest forever.
   The first cargo is the tl narrowing patch (`3p/tl/tl_patch.tl`:
-  truthiness, then `assert(x)` and `== nil`/`~= nil`), with its own
-  canary test (`cosmic/teal_test.tl`) so a lost patch fails as one
+  truthiness, then `assert(x)` and `== nil`/`~= nil`, and — whilp/cosmic#1065 —
+  a one-line declaration change making `assert` strip nil, so it
+  narrows in expression position and not only as a statement), with its
+  own canary test (`cosmic/teal_test.tl`) so a lost patch fails as one
   named test, not a hundred downstream type errors.
 - **rejected:** forking tl for one edit (a compiler of maintenance for
   a function of change); waiting for upstream (unbounded, and the scar

--- a/docs/guides/checking.md
+++ b/docs/guides/checking.md
@@ -89,6 +89,21 @@ assert(sock, "connect failed")
 local _sent, _serr = sock:send("hello") -- narrowed, method call included
 ```
 
+`assert` also narrows as an EXPRESSION, because it declares that it
+strips the nil — so composing it with a fallible call yields the plain
+type, and there is nothing cosmic-specific to learn first:
+
+```teal
+local sqlite = require("cosmic.sqlite")
+
+local db = assert(sqlite.open(":memory:")) -- Database, not Database | nil
+assert(db:exec("CREATE TABLE t (x TEXT)"))
+```
+
+that is the same narrowing `check.must` gives, in the primitive you
+already know. `check.must` remains the one to reach for in tests and
+examples, where the callee's own error string is the failure message.
+
 `~= nil` is exact, so it also narrows unions containing `boolean`,
 which truthiness and `assert` deliberately skip (`false` is falsy, so
 truthy does not mean "not nil" there):

--- a/docs/guides/gotchas.md
+++ b/docs/guides/gotchas.md
@@ -115,7 +115,9 @@ end
 a guard on a plain variable narrows it: truthiness (`if r then`, `if
 not r then return end`), `assert(r, "msg")`, and `== nil` / `~= nil`
 comparisons all narrow `T | nil` for every `T` (the carried tl patch,
-`3p/tl/tl_patch.tl`):
+`3p/tl/tl_patch.tl`) — and `assert` narrows in expression position too,
+so `local db = assert(sqlite.open(p))` is `Database`, not
+`Database | nil`:
 
 ```teal
 local sqlite = require("cosmic.sqlite")


### PR DESCRIPTION
Fixes #1065. Two commits — the second is an unrelated fix this PR's testing surfaced, riding along because the branch is shared.

## 1. `assert` strips nil

One line, carried in `3p/tl/tl_patch.tl` (plus its `tl.tl` twin, as the ast-cache edits do):

```diff
-assert: function<A, B>(A, ? B, ...: any): A --[[special_function]]
+assert: function<A, B>(A | nil, ? B, ...: any): A --[[special_function]]
```

After #942 `assert` narrowed as a *statement* (`assert(d)` then `d:exec(...)`) but not as an *expression*: `local db = assert(sqlite.open(p))` handed back `Database | nil` and failed at the first method call. Both shapes narrow now; the statement form is untouched.

### Route (D05 preference order)

1. **Pin bump — no.** tl master still declares `assert` exactly as 0.24.8 does (`teal/default/stdlib.d.tl` line 371), and 0.24.8 is the newest release. Master has also split the single `tl.tl` into modules behind a new API, so there is nothing to bump to.
2. **Upstream — still owed.** This is the usual D21 debt: submit the declaration change, delete the edit when a pin lands it. Not done in this PR — opening a PR against `teal-language/tl` is a separate, outward-facing step.
3. **Carry it — what this PR does.** The anchor must match exactly once, so a pin bump that moves it fails the fetch loudly.

### Blast radius, measured

A stdlib signature change is global, so it was checked rather than assumed:

- `--make ci` → `ci: PASS (5 stages)`, 195 files, **no call site changed anywhere in the tree**
- `_make/fixtures_test.tl` (the fixture projects) passes
- probes over the shapes that could have regressed — a `boolean, string` effect, a union without `nil`, `any`, `boolean | nil`, a generic call, a plain string, `assert(f(), "msg")` — behave identically before and after; only the `| nil` cases change, and only by narrowing

### Regression coverage

The carried patch's canary in `cosmic/teal_test.tl` gains the expression shapes (`local r = assert(make())`), so a pin bump that drops the patch fails there as one named test.

### Docs

`checking.md` gains the expression-position section, `gotchas.md`'s `record-fields-dont-narrow` says `assert` narrows composed with a fallible call, D21 records the new edit, and `AGENTS.md` states the rule. `check.must`'s doc comment loses its stale rationale — it is no longer the only way past a `T | nil` in a test; what it still buys is the callee's own error string and passing `false` through.

## 2. The fixpoint gate could not pass on any tree

`COSMIC_FIXPOINT=1 --make test _make/fixpoint_test.tl` failed on this branch **and on a clean `main`**:

```
gen2: --make build should succeed:
make: _build/workflows_test.tl declares `reads: .github/workflows`, which does not exist
```

`copy_tree` pruned every dot-entry, which was a fine proxy for "generated" until a test declared a read under `.github`. The model validates that declared reads exist, so the copy failed the build it exists to measure — and since the gate is opt-in, nothing noticed. It now prunes `.git` and `o/` instead. Both generations build and gen2 == gen3 byte for byte.