### PR TITLE
the pin advance: spend the narrowing the new release carries (#942)

### DIFF
--- a/_cli/build/init_test.tl
+++ b/_cli/build/init_test.tl
@@ -92,8 +92,8 @@ local function test_compile_unchanged_restamps_without_rewriting()
   assert(fs.set_mode(out, tonumber("444", 8) as integer)) -- cast: octal is integral
   code = run_driver("compile", test_bin, src, out)
   assert(code == 0, "second compile failed")
-  local st2 = fs.stat(out)
-  local t2 = (st2 as fs.Stat):modify_time() -- cast: record union after guard
+  local st2 = assert(fs.stat(out))
+  local t2 = st2:modify_time()
   assert(t2.secs > t1.secs or (t2.secs == t1.secs and t2.nsecs >= t1.nsecs),
     "unchanged compile must bring the output up to date")
   assert(fs.read(out) == body, "and must not rewrite its contents")
@@ -182,7 +182,7 @@ local function test_list_write_if_changed()
   local t1 = st1:modify_time()
   code = run_driver("write-list", out, "a.tl", "b.tl")
   assert(code == 0, "unchanged list must succeed")
-  local t2 = (fs.stat(out) as fs.Stat):modify_time() -- cast: record union after guard
+  local t2 = assert(fs.stat(out)):modify_time()
   assert(t1.secs == t2.secs and t1.nsecs == t2.nsecs,
     "unchanged list must not rewrite the stamp")
   code = run_driver("write-list", out, "a.tl")

--- a/_cli/build/steps.tl
+++ b/_cli/build/steps.tl
@@ -99,7 +99,7 @@ local function do_assert_marker(args: {string}): integer
       if name ~= "." and name ~= ".." then
         local p = fs.join(d, name)
         local st = fs.stat(p)
-        if st and (st as fs.Stat):is_dir() then -- cast: record union after guard
+        if st and st:is_dir() then
           if scan(p) then return true end
         else
           local content = fs.read(p)

--- a/bin/cosmic.pin
+++ b/bin/cosmic.pin
@@ -4,5 +4,5 @@
 # `*_pin.tl` — those are resolved by `cosmic --make fetch`, which needs a
 # cosmic to run, which is the thing this pin provides. Bump both fields
 # together; the sha is what is verified before anything is executed.
-url = https://github.com/whilp/cosmic/releases/download/2026-08-08-8abaf1f/cosmic-lua
-sha256 = 15230db4b257d31c3cf07435c869a1c4b292a380d3f17ba4ac27c92fcc431137
+url = https://github.com/whilp/cosmic/releases/download/2026-08-10-ea92a15/cosmic-lua
+sha256 = 59ec6bba474ca495c47b61a45fed4131916eca8f21e044e26305cb0980432f0d

--- a/cosmic/sandbox/landlock.tl
+++ b/cosmic/sandbox/landlock.tl
@@ -216,8 +216,7 @@ local function restrict(opts?: RestrictOptions): boolean, string
     -- (READ, RW, ...). A rule left with no grantable bits is skipped —
     -- landlock denies by default, so granting nothing needs no rule.
     local st = unix.fstat(pfd)
-    -- cast: record union after guard
-    if st and not unix.S_ISDIR((st as unix.Stat):mode()) then
+    if st and not unix.S_ISDIR(st:mode()) then
       access = access & FILE_BITS
     end
     if access ~= 0 then

--- a/cosmic/shm_test.tl
+++ b/cosmic/shm_test.tl
@@ -285,7 +285,7 @@ test_memory_wait_retries_eintr_until_deadline()
 -- returns an error instead of touching freed memory, and wake wakes
 -- nothing.
 local function test_memory_close()
-  local mem = assert(shm.open(64)) as shm.Memory -- cast: record union after guard
+  local mem = assert(shm.open(64))
   assert(mem:store(0, 7))
   mem:close()
   mem:close() -- the second, correct call is a quiet no-op, not a false

--- a/cosmic/url_test.tl
+++ b/cosmic/url_test.tl
@@ -220,7 +220,7 @@ test_parse_empty_url()
 local function test_parse_invalid_port()
   local result, err = url.parse("http://example.com:99999/")
   assert(result == nil, "port 99999 must be rejected, got port " ..
-    tostring(result and (result as url.Url).port)) -- cast: record union after guard
+    tostring(result ~= nil and result.port))
   assert(err ~= nil and err:find("invalid port") ~= nil,
     "expected invalid-port error, got '" .. tostring(err) .. "'")
 end

--- a/docs/guides/checking.md
+++ b/docs/guides/checking.md
@@ -102,6 +102,10 @@ if st and st:is_dir() then
 end
 ```
 
+that fact rides the CONDITION: in value position — `tostring(x and
+x.port)` — the left operand is not read in boolean context, so write
+`x ~= nil and x.port` there, which is exact and needs no context.
+
 `assert` also narrows as an EXPRESSION, because it declares that it
 strips the nil — so composing it with a fallible call yields the plain
 type, and there is nothing cosmic-specific to learn first:


### PR DESCRIPTION
Collects the debt #1071 left. `bin/cosmic.pin` moves to `2026-08-10-ea92a15` — the first release built from a main that carries both `narrow-assert-decl` (#1070) and `narrow-and-operand` (#1071) — and the six casts that were waiting on it go.

- assert-expression: `_cli/build/init_test.tl:96,185`, `cosmic/shm_test.tl:288`
- `x and x.field`: `_cli/build/steps.tl:102`, `cosmic/sandbox/landlock.tl:219`, `cosmic/url_test.tl:223`

**One of them taught something #1071 could not.** `url_test`'s guard is inside a `tostring(...)` argument, and the truthiness fact rides the CONDITION — in value position the left operand of `and` is not read in boolean context, so it does not narrow there. That is the edit's deliberate scope (where a VALUE is expected, `e1` is the expression's own falsy result and keeps its type), and `~= nil` is exact and needs no context, so the site now says what it means: `tostring(result ~= nil and result.port)`. `guide.checking` draws the same line, since the distinction is invisible until you hit it.

What remains uncollectable is unchanged and documented: a guard whose block ends in `error(...)` or `unix.exit(...)` still does not narrow below itself, because only a `return` marks a block terminal — `cosmic/check.tl:257`, `cosmic/searcher.tl:85,221`, `_perf/perf_test.tl:24`, `cosmic/quicksand/proxy.tl`.

## Gate

`bin/cosmic --make ci` from a cold tree on the new pin: `ci: PASS (5 stages)`, 195 checks, coverage ratchet ok. The pin's sha256 was verified against the release's own `SHA256SUMS` and by hashing the downloaded artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XXNpXy6tuWYUA7Yw1mtQNT

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXNpXy6tuWYUA7Yw1mtQNT)_